### PR TITLE
Plugin management utility class

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -5,6 +5,8 @@
  * @package Newspack
  */
 
+namespace Newspack;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -54,7 +56,7 @@ final class Newspack {
 	 * e.g. include_once NEWSPACK_ABSPATH . 'includes/foo.php';
 	 */
 	private function includes() {
-
+		include_once NEWSPACK_ABSPATH . 'includes/class-plugin-manager.php';
 	}
 
 	/**

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -82,13 +82,19 @@ class Plugin_Manager {
 	/**
 	 * Deactivate a plugin.
 	 *
-	 * @param string $plugin_file The path to the plugin file. e.g. 'newspack/newspack.php'.
+	 * @param string $plugin The plugin slug (e.g. 'newspack') or path to the plugin file. e.g. ('newspack/newspack.php').
 	 * @return bool True on success. False on failure.
 	 */
-	public static function deactivate( $plugin_file ) {
+	public static function deactivate( $plugin ) {
 		$installed_plugins = self::get_installed_plugins();
-		if ( ! in_array( $plugin_file, $installed_plugins ) ) {
+		if ( ! in_array( $plugin, $installed_plugins ) && ! isset( $installed_plugins[ $plugin ] ) ) {
 			return new WP_Error( 'newspack_plugin_not_installed', __( 'The plugin is not installed.', 'newspack' ) );
+		}
+
+		if ( isset( $installed_plugins[ $plugin ] ) ) {
+			$plugin_file = $installed_plugins[ $plugin ];
+		} else {
+			$plugin_file = $plugin;
 		}
 
 		if ( ! is_plugin_active( $plugin_file ) ) {
@@ -158,17 +164,23 @@ class Plugin_Manager {
 	/**
 	 * Uninstall a plugin.
 	 *
-	 * @param string $plugin_file The path to the plugin file. e.g. 'newspack/newspack.php'.
+	 * @param string $plugin The plugin slug (e.g. 'newspack') or path to the plugin file. e.g. ('newspack/newspack.php').
 	 * @return bool True on success. False on failure.
 	 */
-	public static function uninstall( $plugin_file ) {
+	public static function uninstall( $plugin ) {
 		if ( ! self::can_install_plugins() ) {
 			return new WP_Error( 'newspack_plugin_failed_uninstall', __( 'Plugins cannot be uninstalled.', 'newspack' ) );
 		}
 
 		$installed_plugins = self::get_installed_plugins();
-		if ( ! in_array( $plugin_file, $installed_plugins ) ) {
+		if ( ! in_array( $plugin, $installed_plugins ) && ! isset( $installed_plugins[ $plugin ] ) ) {
 			return new WP_Error( 'newspack_plugin_failed_uninstall', __( 'The plugin is not installed.', 'newspack' ) );
+		}
+
+		if ( isset( $installed_plugins[ $plugin ] ) ) {
+			$plugin_file = $installed_plugins[ $plugin ];
+		} else {
+			$plugin_file = $plugin;
 		}
 
 		// Deactivate plugin before uninstalling.

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -41,14 +41,9 @@ class Plugin_Manager {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugin_slug = $plugin;
-
-		// if it's a url, parse the slug from the URL.
-		if ( wp_http_validate_url( $plugin ) ) {
-			$plugin_slug = self::get_plugin_slug_from_url( $plugin );
-			if ( ! $plugin_slug ) {
-				return new WP_Error( 'newspack_invalid_plugin', __( 'Invalid plugin URL.', 'newspack' ) );
-			}
+		$plugin_slug = self::get_plugin_slug( $plugin );
+		if ( ! $plugin_slug ) {
+			return new WP_Error( 'newspack_invalid_plugin', __( 'Invalid plugin.', 'newspack' ) );
 		}
 
 		$installed_plugins = self::get_installed_plugins();
@@ -118,18 +113,24 @@ class Plugin_Manager {
 	}
 
 	/**
-	 * Parse a plugin slug from the URL to download a plugin.
+	 * Parse a plugin slug from the slug or URL to download a plugin.
 	 *
-	 * @param string $url The URL to a plugin zip file.
+	 * @param string $plugin A plugin slug or the URL to a plugin zip file.
 	 * @return string|bool Parsed slug on success. False on failure.
 	 */
-	public static function get_plugin_slug_from_url( $url ) {
-		if ( ! is_string( $url ) ) {
+	public static function get_plugin_slug( $plugin ) {
+		if ( ! is_string( $plugin ) || empty( $plugin ) ) {
 			return false;
 		}
 
-		$url = wp_http_validate_url( $url );
-		if ( ! $url || ! stripos( $url, '.zip' ) ) {
+		$url = wp_http_validate_url( $plugin );
+
+		// A plugin slug was passed in, so just return it.
+		if ( ! $url ) {
+			return $plugin;
+		}
+
+		if ( ! stripos( $url, '.zip' ) ) {
 			return false;
 		}
 

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -20,7 +20,8 @@ class Plugin_Manager {
 	 * @return bool
 	 */
 	public static function can_install_plugins() {
-		if ( ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT ) || ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) ) {
+		if ( ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT ) ||
+			( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) ) {
 			return false;
 		}
 
@@ -98,11 +99,7 @@ class Plugin_Manager {
 	 * @return array of 'plugin_slug => plugin_file_path' entries for all installed plugins.
 	 */
 	public static function get_installed_plugins() {
-		$installed_plugins = array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'reduce_plugin_info' ) );
-		if ( empty( $installed_plugins ) ) {
-			$installed_plugins = [];
-		}
-		return $installed_plugins;
+		return array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'reduce_plugin_info' ) );
 	}
 
 	/**
@@ -112,6 +109,10 @@ class Plugin_Manager {
 	 * @return string|bool Parsed slug on success. False on failure.
 	 */
 	public static function get_plugin_slug_from_url( $url ) {
+		if ( ! is_string( $url ) ) {
+			return false;
+		}
+
 		$url = wp_http_validate_url( $url );
 		if ( ! $url || ! stripos( $url, '.zip' ) ) {
 			return false;

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Newspack setup
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * General purpose class for managing installation/activation of plugins.
+ */
+class Plugin_Manager {
+
+	/**
+	 * Determine whether plugin installation is allowed in the current environment.
+	 *
+	 * @return bool
+	 */
+	public static function can_install_plugins() {
+		if ( ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT ) || ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Activate a plugin, installing it first if necessary.
+	 *
+	 * @param string $plugin The plugin slug or URL to the plugin.
+	 * @return bool True on success. False on failure or if plugin was already activated.
+	 */
+	public static function activate( $plugin ) {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$plugin_slug = $plugin;
+
+		// if it's a url, parse the slug from the URL.
+		if ( wp_http_validate_url( $plugin ) ) {
+			$plugin_slug = self::get_plugin_slug_from_url( $plugin );
+			if ( ! $plugin_slug ) {
+				return false;
+			}
+		}
+
+		$installed_plugins = self::get_installed_plugins();
+
+		// Install the plugin if it's not installed already.
+		$plugin_installed = isset( $installed_plugins[ $plugin_slug ] );
+		if ( ! $plugin_installed ) {
+			$plugin_installed = self::install( $plugin );
+		}
+		if ( ! $plugin_installed ) {
+			return false;
+		}
+
+		// Refresh the installed plugin list if the plugin isn't present because we just installed it.
+		if ( ! isset( $installed_plugins[ $plugin_slug ] ) ) {
+			$installed_plugins = self::get_installed_plugins();
+		}
+
+		if ( is_plugin_active( $installed_plugins[ $plugin_slug ] ) ) {
+			return false;
+		}
+
+		$activated = activate_plugin( $installed_plugins[ $plugin_slug ] );
+		if ( is_wp_error( $activated ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Deactivate a plugin.
+	 *
+	 * @param string $plugin_file The path to the plugin file. e.g. 'newspack/newspack.php'.
+	 * @return bool True on success. False on failure.
+	 */
+	public static function deactivate( $plugin_file ) {
+		$installed_plugins = self::get_installed_plugins();
+		if ( ! in_array( $plugin_file, $installed_plugins ) ) {
+			return false;
+		}
+
+		deactivate_plugins( $plugin_file );
+		return true;
+	}
+
+	/**
+	 * Get a simple list of all installed plugins.
+	 *
+	 * @return array of 'plugin_slug => plugin_file_path' entries for all installed plugins.
+	 */
+	public static function get_installed_plugins() {
+		$installed_plugins = array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'reduce_plugin_info' ) );
+		if ( empty( $installed_plugins ) ) {
+			$installed_plugins = [];
+		}
+		return $installed_plugins;
+	}
+
+	/**
+	 * Parse a plugin slug from the URL to download a plugin.
+	 *
+	 * @param string $url The URL to a plugin zip file.
+	 * @return string|bool Parsed slug on success. False on failure.
+	 */
+	public static function get_plugin_slug_from_url( $url ) {
+		$url = wp_http_validate_url( $url );
+		if ( ! $url || ! stripos( $url, '.zip' ) ) {
+			return false;
+		}
+
+		$result = preg_match_all( '/\/([^\.\/*]+)/', $url, $matches );
+		if ( ! $result ) {
+			return false;
+		}
+
+		$group = end( $matches );
+		$slug  = end( $group );
+		return $slug;
+	}
+
+	/**
+	 * Installs a plugin.
+	 *
+	 * @param string $plugin Plugin slug or URL to plugin zip file.
+	 * @return bool True on success. False on failure.
+	 */
+	public static function install( $plugin ) {
+		if ( ! self::can_install_plugins() ) {
+			return false;
+		}
+
+		if ( wp_http_validate_url( $plugin ) ) {
+			return self::install_from_url( $plugin );
+		} else {
+			return self::install_from_wporg( $plugin );
+		}
+	}
+
+	/**
+	 * Uninstall a plugin.
+	 *
+	 * @param string $plugin_file The path to the plugin file. e.g. 'newspack/newspack.php'.
+	 * @return bool True on success. False on failure.
+	 */
+	public static function uninstall( $plugin_file ) {
+		if ( ! self::can_install_plugins() ) {
+			return false;
+		}
+
+		$success = (bool) delete_plugins( [ $plugin_file ] );
+		if ( $success ) {
+			wp_clean_plugins_cache();
+		}
+		return $success;
+	}
+
+	/**
+	 * Install a plugin from the WordPress.org plugin repo.
+	 *
+	 * @param string $plugin_slug The slug for the plugin.
+	 * @return bool True on success. False on failure.
+	 */
+	protected static function install_from_wporg( $plugin_slug ) {
+		// Quick check to make sure plugin directory doesn't already exist.
+		$plugin_directory = WP_PLUGIN_DIR . '/' . $plugin_slug;
+		if ( is_dir( $plugin_directory ) ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'plugins_api' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		}
+
+		$plugin_info = plugins_api(
+			'plugin_information',
+			[
+				'slug'   => $plugin_slug,
+				'fields' => [
+					'short_description' => false,
+					'sections'          => false,
+					'requires'          => false,
+					'rating'            => false,
+					'ratings'           => false,
+					'downloaded'        => false,
+					'last_updated'      => false,
+					'added'             => false,
+					'tags'              => false,
+					'compatibility'     => false,
+					'homepage'          => false,
+					'donate_link'       => false,
+				],
+			]
+		);
+
+		if ( is_wp_error( $plugin_info ) ) {
+			return false;
+		}
+
+		return self::install_from_url( $plugin_info->download_link );
+	}
+
+	/**
+	 * Install a plugin from an arbitrary URL.
+	 *
+	 * @param string $plugin_url The URL to the plugin zip file.
+	 * @return bool True on success. False on failure.
+	 */
+	protected static function install_from_url( $plugin_url ) {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		WP_Filesystem();
+
+		$skin     = new \Automatic_Upgrader_Skin();
+		$upgrader = new \WP_Upgrader( $skin );
+
+		$download = $upgrader->download_package( $plugin_url );
+		if ( is_wp_error( $download ) ) {
+			return false;
+		}
+
+		$working_dir = $upgrader->unpack_package( $download );
+		if ( is_wp_error( $working_dir ) ) {
+			return false;
+		}
+
+		$result = $upgrader->install_package(
+			[
+				'source'        => $working_dir,
+				'destination'   => WP_PLUGIN_DIR,
+				'clear_working' => true,
+				'hook_extra'    => [
+					'type'   => 'plugin',
+					'action' => 'install',
+				],
+			]
+		);
+		if ( is_wp_error( $result ) ) {
+			return false;
+		}
+
+		wp_clean_plugins_cache();
+		return true;
+	}
+
+	/**
+	 * Reduce get_plugins() info to form 'folder => file'.
+	 *
+	 * @param array  $plugins Associative array of plugin files to paths.
+	 * @param string $key Plugin relative path. Example: newspack/newspack.php.
+	 * @return array
+	 */
+	private static function reduce_plugin_info( $plugins, $key ) {
+		$path               = explode( '/', $key );
+		$folder             = current( $path );
+		$plugins[ $folder ] = $key;
+		return $plugins;
+	}
+}

--- a/tests/unit-tests/core.php
+++ b/tests/unit-tests/core.php
@@ -5,6 +5,8 @@
  * @package Newspack\Tests
  */
 
+use Newspack\Newspack;
+
 /**
  * Test base/util functionality.
  */

--- a/tests/unit-tests/plugin-manager.php
+++ b/tests/unit-tests/plugin-manager.php
@@ -95,6 +95,20 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test error handling when activating/deactivating.
+	 */
+	public function test_activate_deactivate_errors() {
+		$this->assertTrue( is_wp_error( Plugin_manager::activate( 'non-existant-plugin' ) ) );
+		$this->assertTrue( is_wp_error( Plugin_manager::deactivate( 'non-existant-plugin' ) ) );
+
+		$this->assertTrue( is_wp_error( Plugin_manager::activate( 'https://downloads.wordpress.org/plugin/non-existant-plugin.zip' ) ) );
+		$this->assertTrue( is_wp_error( Plugin_manager::deactivate( 'https://downloads.wordpress.org/plugin/non-existant-plugin.zip' ) ) );
+
+		$this->assertTrue( is_wp_error( Plugin_manager::activate( 'https://example.org/not-a-zip' ) ) );
+		$this->assertTrue( is_wp_error( Plugin_manager::deactivate( 'https://example.org/not-a-zip' ) ) );
+	}
+
+	/**
 	 * Test that activating/deactivating an installed plugin activates/deactivates the plugin.
 	 */
 	public function test_activate_deactivate_installed() {
@@ -103,11 +117,20 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 		$this->assertTrue( Plugin_Manager::activate( $this->plugin_slug ) );
 		$this->assertTrue( is_plugin_active( $this->plugin_file ) );
 
+		// If the plugin is already activated, activating it by slug should fail.
+		$this->assertTrue( is_wp_error( Plugin_manager::activate( $this->plugin_slug ) ) );
+
 		$this->assertTrue( Plugin_manager::deactivate( $this->plugin_file ) );
 		$this->assertFalse( is_plugin_active( $this->plugin_file ) );
 
+		// If the plugin is already deactivated, deactivating should fail.
+		$this->assertTrue( is_wp_error( Plugin_manager::deactivate( $this->plugin_file ) ) );
+
 		$this->assertTrue( Plugin_Manager::activate( $this->plugin_url ) );
 		$this->assertTrue( is_plugin_active( $this->plugin_file ) );
+
+		// If the plugin is already activated, activating it by url should fail.
+		$this->assertTrue( is_wp_error( Plugin_manager::activate( $this->plugin_url ) ) );
 	}
 
 	/**
@@ -116,6 +139,9 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 	public function test_plugin_install_uninstall_wporg() {
 		$this->assertTrue( Plugin_Manager::install( $this->plugin_slug ) );
 		$this->assertTrue( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+
+		// If the plugin is already installed, installing it by slug should fail.
+		$this->assertTrue( is_wp_error( Plugin_manager::install( $this->plugin_slug ) ) );
 
 		$this->assertTrue( Plugin_Manager::uninstall( $this->plugin_file ) );
 		$this->assertFalse( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
@@ -128,7 +154,24 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 		$this->assertTrue( Plugin_Manager::install( $this->plugin_url ) );
 		$this->assertTrue( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
 
+		// If the plugin is already installed, installing it by URL should fail.
+		$this->assertTrue( is_wp_error( Plugin_manager::install( $this->plugin_url ) ) );
+
 		$this->assertTrue( Plugin_Manager::uninstall( $this->plugin_file ) );
 		$this->assertFalse( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+	}
+
+	/**
+	 * Test error handling when installing/uninstalling.
+	 */
+	public function test_plugin_install_uninstall_errors() {
+		$this->assertTrue( is_wp_error( Plugin_manager::install( 'non-existant-plugin' ) ) );
+		$this->assertTrue( is_wp_error( Plugin_manager::uninstall( 'non-existant-plugin' ) ) );
+
+		$this->assertTrue( is_wp_error( Plugin_manager::install( 'https://downloads.wordpress.org/plugin/non-existant-plugin.zip' ) ) );
+		$this->assertTrue( is_wp_error( Plugin_manager::uninstall( 'https://downloads.wordpress.org/plugin/non-existant-plugin.zip' ) ) );
+
+		$this->assertTrue( is_wp_error( Plugin_manager::install( 'https://example.org/not-a-zip' ) ) );
+		$this->assertTrue( is_wp_error( Plugin_manager::uninstall( 'https://example.org/not-a-zip' ) ) );
 	}
 }

--- a/tests/unit-tests/plugin-manager.php
+++ b/tests/unit-tests/plugin-manager.php
@@ -56,6 +56,10 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly' ) );
 		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly.tar' ) );
 		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 'hello-dolly' ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( '' ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( true ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( new WP_Error() ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 20 ) );
 	}
 
 	/**

--- a/tests/unit-tests/plugin-manager.php
+++ b/tests/unit-tests/plugin-manager.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Tests the plugin management functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Plugin_Manager;
+
+/**
+ * Test plugin management functionality.
+ */
+class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
+
+	/**
+	 * Plugin slug/folder.
+	 *
+	 * @var string
+	 */
+	protected $plugin_slug = 'hello-dolly';
+
+	/**
+	 * Plugin file path.
+	 *
+	 * @var string
+	 */
+	protected $plugin_file = 'hello-dolly/hello.php';
+
+	/**
+	 * URL to plugin download.
+	 *
+	 * @var string
+	 */
+	protected $plugin_url = 'https://downloads.wordpress.org/plugin/hello-dolly.1.6.zip';
+
+	/**
+	 * Compatibility checks and clean up.
+	 */
+	public function setUp() {
+		// These tests can't run on environments where we can't install plugins e.g. VIP Go.
+		if ( ! Plugin_Manager::can_install_plugins() ) {
+			$this->markTestSkipped( 'Plugin installation is not allowed in the environment' );
+		}
+
+		// Clean up any lingering plugin installs that may exist from a previous test.
+		Plugin_Manager::uninstall( $this->plugin_file );
+	}
+
+	/**
+	 * Test the plugin-slug-from-URL parser.
+	 */
+	public function test_get_plugin_slug_from_url() {
+		$this->assertEquals( 'hello-dolly', Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly.1.6.zip' ) );
+		$this->assertEquals( 'hello-dolly', Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly.zip/' ) );
+		$this->assertEquals( 'hello-dolly', Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly.zip?foo=blah&1' ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly' ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly.tar' ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 'hello-dolly' ) );
+	}
+
+	/**
+	 * Test that activating an uninstalled plugin from a slug will install and activate the plugin.
+	 * Deactivating the plugin will not uninstall the plugin.
+	 */
+	public function test_activate_deactivate_wporg_uninstalled() {
+		$this->assertFalse( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+
+		$this->assertTrue( Plugin_Manager::activate( $this->plugin_slug ) );
+		$this->assertTrue( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+		$this->assertTrue( is_plugin_active( $this->plugin_file ) );
+
+		$this->assertTrue( Plugin_manager::deactivate( $this->plugin_file ) );
+		$this->assertTrue( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+		$this->assertFalse( is_plugin_active( $this->plugin_file ) );
+	}
+
+	/**
+	 * Test that activating an uninstalled plugin from an URL will install and activate the plugin.
+	 * Deactivating the plugin will not uninstall the plugin.
+	 */
+	public function test_activate_deactivate_url_uninstalled() {
+		$this->assertFalse( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+
+		$this->assertTrue( Plugin_Manager::activate( $this->plugin_url ) );
+		$this->assertTrue( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+		$this->assertTrue( is_plugin_active( $this->plugin_file ) );
+
+		$this->assertTrue( Plugin_manager::deactivate( $this->plugin_file ) );
+		$this->assertTrue( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+		$this->assertFalse( is_plugin_active( $this->plugin_file ) );
+	}
+
+	/**
+	 * Test that activating/deactivating an installed plugin activates/deactivates the plugin.
+	 */
+	public function test_activate_deactivate_installed() {
+		Plugin_Manager::install( $this->plugin_slug );
+
+		$this->assertTrue( Plugin_Manager::activate( $this->plugin_slug ) );
+		$this->assertTrue( is_plugin_active( $this->plugin_file ) );
+
+		$this->assertTrue( Plugin_manager::deactivate( $this->plugin_file ) );
+		$this->assertFalse( is_plugin_active( $this->plugin_file ) );
+
+		$this->assertTrue( Plugin_Manager::activate( $this->plugin_url ) );
+		$this->assertTrue( is_plugin_active( $this->plugin_file ) );
+	}
+
+	/**
+	 * Test that plugins install/uninstall from WordPress.org by slug.
+	 */
+	public function test_plugin_install_uninstall_wporg() {
+		$this->assertTrue( Plugin_Manager::install( $this->plugin_slug ) );
+		$this->assertTrue( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+
+		$this->assertTrue( Plugin_Manager::uninstall( $this->plugin_file ) );
+		$this->assertFalse( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+	}
+
+	/**
+	 * Test that plugins install/uninstall from a URL.
+	 */
+	public function test_plugin_install_uninstall_url() {
+		$this->assertTrue( Plugin_Manager::install( $this->plugin_url ) );
+		$this->assertTrue( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+
+		$this->assertTrue( Plugin_Manager::uninstall( $this->plugin_file ) );
+		$this->assertFalse( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
+	}
+}

--- a/tests/unit-tests/plugin-manager.php
+++ b/tests/unit-tests/plugin-manager.php
@@ -47,19 +47,19 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the plugin-slug-from-URL parser.
+	 * Test the plugin-slug parser.
 	 */
-	public function test_get_plugin_slug_from_url() {
-		$this->assertEquals( 'hello-dolly', Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly.1.6.zip' ) );
-		$this->assertEquals( 'hello-dolly', Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly.zip/' ) );
-		$this->assertEquals( 'hello-dolly', Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly.zip?foo=blah&1' ) );
-		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly' ) );
-		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 'https://downloads.wordpress.org/plugin/hello-dolly.tar' ) );
-		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 'hello-dolly' ) );
-		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( '' ) );
-		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( true ) );
-		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( new WP_Error() ) );
-		$this->assertEquals( false, Plugin_Manager::get_plugin_slug_from_url( 20 ) );
+	public function test_get_plugin_slug() {
+		$this->assertEquals( 'hello-dolly', Plugin_Manager::get_plugin_slug( 'https://downloads.wordpress.org/plugin/hello-dolly.1.6.zip' ) );
+		$this->assertEquals( 'hello-dolly', Plugin_Manager::get_plugin_slug( 'https://downloads.wordpress.org/plugin/hello-dolly.zip/' ) );
+		$this->assertEquals( 'hello-dolly', Plugin_Manager::get_plugin_slug( 'https://downloads.wordpress.org/plugin/hello-dolly.zip?foo=blah&1' ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug( 'https://downloads.wordpress.org/plugin/hello-dolly' ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug( 'https://downloads.wordpress.org/plugin/hello-dolly.tar' ) );
+		$this->assertEquals( 'hello-dolly', Plugin_Manager::get_plugin_slug( 'hello-dolly' ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug( '' ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug( true ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug( new WP_Error() ) );
+		$this->assertEquals( false, Plugin_Manager::get_plugin_slug( 20 ) );
 	}
 
 	/**

--- a/tests/unit-tests/plugin-manager.php
+++ b/tests/unit-tests/plugin-manager.php
@@ -114,23 +114,30 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 	public function test_activate_deactivate_installed() {
 		Plugin_Manager::install( $this->plugin_slug );
 
+		// Activate by slug.
 		$this->assertTrue( Plugin_Manager::activate( $this->plugin_slug ) );
 		$this->assertTrue( is_plugin_active( $this->plugin_file ) );
 
 		// If the plugin is already activated, activating it by slug should fail.
 		$this->assertTrue( is_wp_error( Plugin_manager::activate( $this->plugin_slug ) ) );
 
-		$this->assertTrue( Plugin_manager::deactivate( $this->plugin_file ) );
+		// Deactivate by slug.
+		$this->assertTrue( Plugin_manager::deactivate( $this->plugin_slug ) );
 		$this->assertFalse( is_plugin_active( $this->plugin_file ) );
 
 		// If the plugin is already deactivated, deactivating should fail.
 		$this->assertTrue( is_wp_error( Plugin_manager::deactivate( $this->plugin_file ) ) );
 
+		// Activate by URL.
 		$this->assertTrue( Plugin_Manager::activate( $this->plugin_url ) );
 		$this->assertTrue( is_plugin_active( $this->plugin_file ) );
 
 		// If the plugin is already activated, activating it by url should fail.
 		$this->assertTrue( is_wp_error( Plugin_manager::activate( $this->plugin_url ) ) );
+
+		// Deactivate by file.
+		$this->assertTrue( Plugin_manager::deactivate( $this->plugin_file ) );
+		$this->assertFalse( is_plugin_active( $this->plugin_file ) );
 	}
 
 	/**
@@ -143,7 +150,8 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 		// If the plugin is already installed, installing it by slug should fail.
 		$this->assertTrue( is_wp_error( Plugin_manager::install( $this->plugin_slug ) ) );
 
-		$this->assertTrue( Plugin_Manager::uninstall( $this->plugin_file ) );
+		// Uninstall by slug.
+		$this->assertTrue( Plugin_Manager::uninstall( $this->plugin_slug ) );
 		$this->assertFalse( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
 	}
 
@@ -157,6 +165,7 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 		// If the plugin is already installed, installing it by URL should fail.
 		$this->assertTrue( is_wp_error( Plugin_manager::install( $this->plugin_url ) ) );
 
+		// Uninstall by file.
 		$this->assertTrue( Plugin_Manager::uninstall( $this->plugin_file ) );
 		$this->assertFalse( file_exists( WP_PLUGIN_DIR . '/' . $this->plugin_file ) );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #3 .

I've developed a class to handle general plugin management tasks: install/uninstall, activate/deactivate, etc. The class is designed so that we can just use it without having to worry about whether the underlying host is VIP Go or a different host:
- It handles installation from both WordPress.org repos and from URLs.
- The class is designed to work in all environments, including VIP Go.
- The `activate` method will install a plugin first if needed (when possible), so the idea is to just use `activate` in the OBW and that will automatically handle installation and activation of plugins.
- The class checks to make sure plugins installation is allowed in order to prevent issues with VIP Go. If plugin installation is not allowed, it gracefully falls back to only managing activation of existing plugins.
- There are also some general purpose methods that will probably come in handy.
- I've introduced namespaces. Since we're supporting PHP 5.6+, we can take advantage of this and not have to prefix all our classes/function names.

Questions (these can be adressed in follow-up PRs or down the road if we encounter a situation):
- Do we need bulk plugin install functionality? Activation should be quick enough to activate a bunch of plugins in one session, but install won't be.
- Do we need background install functionality? This would prevent the need for "loading" screens while something is installing but introduce UI/development complexity as plugins may not be available to use right away.
- How (and whether) should we integrate VIP Go-specific functionality like [wpcom_vip_load_plugin](https://vip.wordpress.com/functions/wpcom_vip_load_plugin/)?

### How to test the changes in this Pull Request:

1. Run/examine unit tests to see usage.
2. Examine code.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->