### PR TITLE
Plugin management endpoints

### DIFF
--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -53,7 +53,7 @@ class Plugins_Controller extends WP_REST_Controller {
 		// Register newspack/v1/plugins/some-plugin endpoint.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->resource_name . '/(?P<slug>[\a-zA-Z]+)',
+			'/' . $this->resource_name . '/(?P<slug>[\a-z]+)',
 			[
 				[
 					'methods'             => 'GET',
@@ -72,7 +72,7 @@ class Plugins_Controller extends WP_REST_Controller {
 		// Register newspack/v1/plugins/some-plugin/activate endpoint.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->resource_name . '/(?P<slug>[\a-zA-Z]+)\/activate',
+			'/' . $this->resource_name . '/(?P<slug>[\a-z]+)\/activate',
 			[
 				[
 					'methods'             => 'POST',
@@ -91,7 +91,7 @@ class Plugins_Controller extends WP_REST_Controller {
 		// Register newspack/v1/plugins/some-plugin/deactivate endpoint.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->resource_name . '/(?P<slug>[\a-zA-Z]+)\/deactivate',
+			'/' . $this->resource_name . '/(?P<slug>[\a-z]+)\/deactivate',
 			[
 				[
 					'methods'             => 'POST',
@@ -110,7 +110,7 @@ class Plugins_Controller extends WP_REST_Controller {
 		// Register newspack/v1/plugins/some-plugin/install endpoint.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->resource_name . '/(?P<slug>[\a-zA-Z]+)\/install',
+			'/' . $this->resource_name . '/(?P<slug>[\a-z]+)\/install',
 			[
 				[
 					'methods'             => 'POST',
@@ -129,7 +129,7 @@ class Plugins_Controller extends WP_REST_Controller {
 		// Register newspack/v1/plugins/some-plugin/uninstall endpoint.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->resource_name . '/(?P<slug>[\a-zA-Z]+)\/uninstall',
+			'/' . $this->resource_name . '/(?P<slug>[\a-z]+)\/uninstall',
 			[
 				[
 					'methods'             => 'POST',

--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Plugin management API endpoints.
+ *
+ * @package Newspack\API
+ */
+
+namespace Newspack\API;
+
+use \WP_Error;
+use Newspack\Plugin_Manager;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API endpoints for managing plugins.
+ */
+class Plugins_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = '/newspack/v1';
+
+	/**
+	 * Endpoint resource.
+	 *
+	 * @var string
+	 */
+	protected $resource_name = 'plugins';
+
+	/**
+	 * Register the routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->resource_name,
+			[
+				[
+					'methods'             => 'GET',
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Get info about all managed plugins.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_items( $request ) {
+		return rest_ensure_response( Plugin_Manager::get_managed_plugins() );
+	}
+
+	/**
+	 * Check capabilities when getting plugins info.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return bool|WP_Error
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				esc_html__( 'You cannot view this resource.', 'newspack' ),
+				[
+					'status' => $this->authorization_status_code(),
+				]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the appropriate status code for errors.
+	 *
+	 * @return int
+	 */
+	public function authorization_status_code() {
+		$status = 401;
+		if ( is_user_logged_in() ) {
+			$status = 403;
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Get the REST schema for the endpoints.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		return [];
+	}
+}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Newspack API setup.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Newspack\Api\Plugins_Controller;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages the API as a whole.
+ */
+class API {
+
+	/**
+	 * Load up and register the endpoints.
+	 */
+	public function __construct() {
+		include_once 'api/class-plugins-controller.php';
+
+		$plugins_api = new Plugins_Controller();
+		add_action( 'rest_api_init', [ $plugins_api, 'register_routes' ] );
+	}
+}
+new API();

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -57,6 +57,7 @@ final class Newspack {
 	 */
 	private function includes() {
 		include_once NEWSPACK_ABSPATH . 'includes/class-plugin-manager.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 	}
 
 	/**

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -27,13 +27,11 @@ class Plugin_Manager {
 		$managed_plugins = [
 			'jetpack' => [
 				'name'     => __( 'Jetpack', 'newspack' ),
-				'wporg'    => true,
-				'download' => 'jetpack',
+				'download' => 'wporg',
 			],
 			'amp'     => [
 				'name'     => __( 'AMP', 'newspack' ),
-				'wporg'    => true,
-				'download' => 'amp',
+				'download' => 'wporg',
 			],
 		];
 

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -17,6 +17,44 @@ defined( 'ABSPATH' ) || exit;
 class Plugin_Manager {
 
 	/**
+	 * Get info about all the managed plugins and their status.
+	 *
+	 * @todo Define what the structure of this looks like better and load it up from a config or something.
+	 *
+	 * @return array of plugins info.
+	 */
+	public static function get_managed_plugins() {
+		$managed_plugins = [
+			'jetpack' => [
+				'name'     => __( 'Jetpack', 'newspack' ),
+				'wporg'    => true,
+				'download' => 'jetpack',
+			],
+			'amp'     => [
+				'name'     => __( 'AMP', 'newspack' ),
+				'wporg'    => true,
+				'download' => 'amp',
+			],
+		];
+
+		// Add plugin status info.
+		$installed_plugins = self::get_installed_plugins();
+		foreach ( $managed_plugins as $plugin_slug => $managed_plugin ) {
+			$status = 'uninstalled';
+			if ( isset( $installed_plugins[ $plugin_slug ] ) ) {
+				if ( is_plugin_active( $installed_plugins[ $plugin_slug ] ) ) {
+					$status = 'active';
+				} else {
+					$status = 'inactive';
+				}
+			}
+			$managed_plugins[ $plugin_slug ]['status'] = $status;
+		}
+
+		return $managed_plugins;
+	}
+
+	/**
 	 * Determine whether plugin installation is allowed in the current environment.
 	 *
 	 * @return bool

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -145,6 +145,10 @@ class Plugin_Manager {
 	 * @return array of 'plugin_slug => plugin_file_path' entries for all installed plugins.
 	 */
 	public static function get_installed_plugins() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		return array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'reduce_plugin_info' ) );
 	}
 
@@ -222,6 +226,10 @@ class Plugin_Manager {
 
 		// Deactivate plugin before uninstalling.
 		self::deactivate( $plugin_file );
+
+		if ( ! function_exists( 'request_filesystem_credentials' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
 
 		$success = (bool) delete_plugins( [ $plugin_file ] );
 		if ( $success ) {

--- a/tests/unit-tests/api-plugins-controller.php
+++ b/tests/unit-tests/api-plugins-controller.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Tests the plugins API functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\API\Plugins_Controller;
+
+/**
+ * Test plugin API endpoints functionality.
+ */
+class Newspack_Test_Plugins_Controller extends WP_UnitTestCase {
+
+	/**
+	 * Plugin slug/folder.
+	 *
+	 * @var string
+	 */
+	protected $api_namespace = '/newspack/v1';
+
+	/**
+	 * Set up stuff for testing API requests.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		do_action( 'rest_api_init' );
+
+		$this->administrator = $this->factory->user->create( [ 'role' => 'administrator' ] );
+	}
+
+	/**
+	 * Test that the routes are all registered.
+	 */
+	public function test_register_route() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( $this->api_namespace . '/plugins', $routes );
+	}
+
+	/**
+	 * Test retrieving the plugins as an unauthorized user.
+	 */
+	public function test_get_plugins_unauthorized() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'GET', $this->api_namespace . '/plugins' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test retrieving the plugins as an authorized user.
+	 */
+	public function test_get_plugins_authorized() {
+		wp_set_current_user( $this->administrator );
+		$request  = new WP_REST_Request( 'GET', $this->api_namespace . '/plugins' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'jetpack', $data );
+
+		$expected_jetpack_info = [
+			'name'     => 'Jetpack',
+			'wporg'    => true,
+			'download' => 'jetpack',
+			'status'   => 'uninstalled',
+		];
+		$this->assertEquals( $expected_jetpack_info, $data['jetpack'] );
+	}
+}

--- a/tests/unit-tests/api-plugins-controller.php
+++ b/tests/unit-tests/api-plugins-controller.php
@@ -6,6 +6,7 @@
  */
 
 use Newspack\API\Plugins_Controller;
+use Newspack\Plugin_Manager;
 
 /**
  * Test plugin API endpoints functionality.
@@ -31,6 +32,11 @@ class Newspack_Test_Plugins_Controller extends WP_UnitTestCase {
 		do_action( 'rest_api_init' );
 
 		$this->administrator = $this->factory->user->create( [ 'role' => 'administrator' ] );
+
+		// Delete any lingering managed plugins.
+		foreach ( Plugin_Manager::get_managed_plugins() as $slug => $plugin ) {
+			Plugin_Manager::uninstall( $slug );
+		}
 	}
 
 	/**
@@ -42,7 +48,7 @@ class Newspack_Test_Plugins_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test retrieving the plugins as an unauthorized user.
+	 * Test unauthorized users can't retrieve plugins info.
 	 */
 	public function test_get_plugins_unauthorized() {
 		wp_set_current_user( 0 );
@@ -52,7 +58,7 @@ class Newspack_Test_Plugins_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test retrieving the plugins as an authorized user.
+	 * Test retrieving plugins info.
 	 */
 	public function test_get_plugins_authorized() {
 		wp_set_current_user( $this->administrator );
@@ -65,10 +71,170 @@ class Newspack_Test_Plugins_Controller extends WP_UnitTestCase {
 
 		$expected_jetpack_info = [
 			'name'     => 'Jetpack',
-			'wporg'    => true,
-			'download' => 'jetpack',
+			'download' => 'wporg',
 			'status'   => 'uninstalled',
 		];
 		$this->assertEquals( $expected_jetpack_info, $data['jetpack'] );
+	}
+
+	/**
+	 * Test unauthorized users can't retrieve plugin info.
+	 */
+	public function test_get_plugin_unauthorized() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'GET', $this->api_namespace . '/plugins/jetpack' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test retrieving one plugin's info.
+	 */
+	public function test_get_plugin_authorized() {
+		wp_set_current_user( $this->administrator );
+
+		$request  = new WP_REST_Request( 'GET', $this->api_namespace . '/plugins/jetpack' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$expected_data = [
+			'name'     => 'Jetpack',
+			'download' => 'wporg',
+			'status'   => 'uninstalled',
+		];
+		$this->assertEquals( $expected_data, $response->get_data() );
+
+		$request  = new WP_REST_Request( 'GET', $this->api_namespace . '/plugins/this-dont-exist' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test unauthorized users can't activate/deactivate plugins.
+	 */
+	public function test_activate_deactivate_plugin_unauthorized() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/activate' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/deactivate' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test activating/deactivating plugins.
+	 */
+	public function test_activate_deactivate_plugin_authorized() {
+		wp_set_current_user( $this->administrator );
+
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/activate' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$expected_data = [
+			'name'     => 'AMP',
+			'download' => 'wporg',
+			'status'   => 'active',
+		];
+		$this->assertEquals( $expected_data, $response->get_data() );
+
+		// Activating the plugin again should fail.
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/activate' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 500, $response->get_status() );
+
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/deactivate' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$expected_data = [
+			'name'     => 'AMP',
+			'download' => 'wporg',
+			'status'   => 'inactive',
+		];
+		$this->assertEquals( $expected_data, $response->get_data() );
+
+		// Dectivating the plugin again should fail.
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/deactivate' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 500, $response->get_status() );
+
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/this-dont-exist/activate' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+
+		// Should not be able to activate plugins that aren't managed.
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/hello-dolly/activate' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test unauthorized users can't install/uninstall plugins.
+	 */
+	public function test_install_uninstall_unauthorized() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/install' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+
+	}
+
+	/**
+	 * Test installing/uninstalling plugins.
+	 */
+	public function test_install_uninstall_authorized() {
+		wp_set_current_user( $this->administrator );
+
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/install' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$expected_data = [
+			'name'     => 'AMP',
+			'download' => 'wporg',
+			'status'   => 'inactive',
+		];
+		$this->assertEquals( $expected_data, $response->get_data() );
+
+		// Installing the plugin again should fail.
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/install' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 500, $response->get_status() );
+
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/uninstall' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$expected_data = [
+			'name'     => 'AMP',
+			'download' => 'wporg',
+			'status'   => 'uninstalled',
+		];
+		$this->assertEquals( $expected_data, $response->get_data() );
+
+		// Uninstalling the plugin again should fail.
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/amp/uninstall' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 500, $response->get_status() );
+
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/this-dont-exist/install' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+
+		// Should not be able to install plugins that aren't managed.
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/plugins/hello-dolly/install' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test the schema.
+	 */
+	public function test_schema() {
+		$request  = new WP_REST_Request( 'OPTIONS', $this->api_namespace . '/plugins' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$schema = $response->get_data();
+		$this->assertEquals( 'string', $schema['schema']['properties']['name']['type'] );
 	}
 }

--- a/tests/unit-tests/plugin-manager.php
+++ b/tests/unit-tests/plugin-manager.php
@@ -47,6 +47,23 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test Plugin_Manager::get_managed_plugins.
+	 */
+	public function test_get_managed_plugins() {
+		$managed_plugins = Plugin_Manager::get_managed_plugins();
+
+		$this->assertArrayHasKey( 'jetpack', $managed_plugins );
+
+		$expected_jetpack_info = [
+			'name'     => 'Jetpack',
+			'wporg'    => true,
+			'download' => 'jetpack',
+			'status'   => 'uninstalled',
+		];
+		$this->assertEquals( $expected_jetpack_info, $managed_plugins['jetpack'] );
+	}
+
+	/**
 	 * Test the plugin-slug parser.
 	 */
 	public function test_get_plugin_slug() {

--- a/tests/unit-tests/plugin-manager.php
+++ b/tests/unit-tests/plugin-manager.php
@@ -56,8 +56,7 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 
 		$expected_jetpack_info = [
 			'name'     => 'Jetpack',
-			'wporg'    => true,
-			'download' => 'jetpack',
+			'download' => 'wporg',
 			'status'   => 'uninstalled',
 		];
 		$this->assertEquals( $expected_jetpack_info, $managed_plugins['jetpack'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #4.

This PR adds the following REST API endpoints for users with the correct capabilities:
- GET `newspack/v1/plugins`
- GET `newspack/v1/plugins/{some-plugin}`
- POST `newspack/v1/plugins/{some-plugin}/activate`
- POST `newspack/v1/plugins/{some-plugin}/deactivate`
- POST `newspack/v1/plugins/{some-plugin}/install`
- POST `newspack/v1/plugins/{some-plugin}/uninstall`

The GET endpoints retrieve info about plugins and their installation status. The POST endpoints can be used to activate/deactivate/etc. a plugin. See the unit tests for usage.

I've also added a minimal way to get information about the managed plugins, since that was required for the GET endpoints. See my comment below, and please let me know if there's a better way you know (loading from a config file?).

### How to test the changes in this Pull Request:

1. Run/examine unit tests.
2. Examine source code.

Sorry about the length of this PR; the way endpoints are registered and handled is very verbose in WP. Most of the relevant logic is in the `Plugins_Controller::{something}_item` methods. It should all be straightforward and [following the controller design pattern recommended for REST API endpoints.](https://developer.wordpress.org/rest-api/extending-the-rest-api/controller-classes/#controllers)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->