### PR TITLE
Replace React and ReactDOM with @wordpress/element

### DIFF
--- a/assets/src/wizards/subscriptions/index.js
+++ b/assets/src/wizards/subscriptions/index.js
@@ -1,16 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { Component, render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import CheckboxInput from '../../components/checkboxInput';
 
 /**
  * Subscriptions wizard stub for example purposes.
  */
-class SubscriptionsWizard extends React.Component {
+class SubscriptionsWizard extends Component {
 
 	/**
 	 * Render the example stub.
 	 */
 	render() {
 		return(
-			<CheckboxInput 
+			<CheckboxInput
 		        label="Checkbox is tested?"
 		        onChange={ function(){ console.log( 'Yep, it\'s tested' ); } }
 			/>
@@ -18,7 +26,7 @@ class SubscriptionsWizard extends React.Component {
 	}
 }
 
-ReactDOM.render(
+render(
   <SubscriptionsWizard />,
   document.getElementById( 'newspack-subscriptions-wizard' )
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The [@wordpress/element](https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-element/) package is wrapper for React and ReactDOM. In this Pull Request use of React and ReactDOM are replaced with the package.

### How to test the changes in this Pull Request:

1. As per usual run `npm ci && npm run build:webpack`
2. Verify there are no  errors.
3. In a test environment with the Newspack plugin installed, navigate to Newspack->Subscriptions, and verify that the page loads with a single checkbox component.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->