### PR TITLE
Bump calypso-build to 1.0.0-rc.3. Remove file-loader and Babel config.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-	extends: require.resolve( '@automattic/calypso-build/babel.config.js' ),
-	presets: [ require( '@automattic/calypso-build/babel/wordpress-element' ) ],
-
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,14 @@
   "requires": true,
   "dependencies": {
     "@automattic/calypso-build": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@automattic/calypso-build/-/calypso-build-1.0.0-beta.4.tgz",
-      "integrity": "sha512-YepaQ6lAqOv0hwmUSEuoCgkP6v2O0CT5NbdAvtytsMP7bvVpeBI6zLrd+riJ8wxdp9I3ID1KoOzHUhEzdEf4ow==",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@automattic/calypso-build/-/calypso-build-1.0.0-rc.3.tgz",
+      "integrity": "sha512-W7tEgys5hm8ZOjaFgu+SVFJLaqZspj3AkPEdk7GrXe2u6zfRTVGZHRFnMHLeIX3E6xab8//gC23VQAvwUW7tlA==",
       "dev": true,
       "requires": {
         "@automattic/calypso-color-schemes": "^1.0.0",
         "@automattic/wordpress-external-dependencies-plugin": "^1.0.0",
+        "@babel/core": "7.4.0",
         "@babel/plugin-proposal-class-properties": "7.4.0",
         "@babel/plugin-proposal-export-default-from": "7.2.0",
         "@babel/plugin-proposal-export-namespace-from": "7.2.0",
@@ -20,25 +21,52 @@
         "@babel/plugin-transform-runtime": "7.4.0",
         "@babel/preset-env": "7.4.2",
         "@babel/preset-react": "7.0.0",
+        "@babel/preset-typescript": "7.3.3",
         "@wordpress/babel-plugin-import-jsx-pragma": "2.1.0",
+        "@wordpress/browserslist-config": "2.3.0",
         "autoprefixer": "9.4.4",
         "babel-loader": "8.0.5",
         "browserslist": "4.5.4",
         "caniuse-api": "3.0.0",
         "css-loader": "2.1.1",
         "duplicate-package-checker-webpack-plugin": "3.0.0",
-        "mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
+        "file-loader": "3.0.1",
+        "mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
         "node-sass": "4.11.0",
         "postcss-custom-properties": "8.0.9",
         "postcss-loader": "3.0.0",
         "sass-loader": "7.1.0",
         "terser-webpack-plugin": "1.2.3",
         "thread-loader": "2.1.2",
+        "typescript": "3.4.3",
         "webpack": "4.29.6",
+        "webpack-cli": "3.3.0",
         "webpack-filter-warnings-plugin": "1.2.1",
         "webpack-rtl-plugin": "1.8.0"
       },
       "dependencies": {
+        "@babel/core": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
+          "integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.0",
+            "@babel/helpers": "^7.4.0",
+            "@babel/parser": "^7.4.0",
+            "@babel/template": "^7.4.0",
+            "@babel/traverse": "^7.4.0",
+            "@babel/types": "^7.4.0",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.11",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
         "autoprefixer": {
           "version": "9.4.4",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.4.tgz",
@@ -64,10 +92,55 @@
             "node-releases": "^1.1.13"
           }
         },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "electron-to-chromium": {
-          "version": "1.3.127",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.127.tgz",
-          "integrity": "sha512-1o25iFRf/dbgauTWalEzmD1EmRN3a2CzP/K7UVpYLEBduk96LF0FyUdCcf4Ry2mAWJ1VxyblFjC93q6qlLwA2A==",
+          "version": "1.3.130",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.130.tgz",
+          "integrity": "sha512-UY2DI+gsnqGtQJqO8wXN0DnpJY+29FwJafACj0h18ZShn5besKnrRq6+lXWUbKzdxw92QQcnTqRLgNByOKXcUg==",
+          "dev": true
+        },
+        "findup-sync": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "dev": true,
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "node-releases": {
@@ -77,6 +150,21 @@
           "dev": true,
           "requires": {
             "semver": "^5.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         },
         "webpack": {
@@ -109,6 +197,25 @@
             "terser-webpack-plugin": "^1.1.0",
             "watchpack": "^1.5.0",
             "webpack-sources": "^1.3.0"
+          }
+        },
+        "webpack-cli": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.0.tgz",
+          "integrity": "sha512-t1M7G4z5FhHKJ92WRKwZ1rtvi7rHc0NZoZRbSkol0YKl4HvcC8+DsmGDmK7MmZxHSAetHagiOsjOB6MmzC2TUw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "cross-spawn": "^6.0.5",
+            "enhanced-resolve": "^4.1.0",
+            "findup-sync": "^2.0.0",
+            "global-modules": "^1.0.0",
+            "import-local": "^2.0.0",
+            "interpret": "^1.1.0",
+            "loader-utils": "^1.1.0",
+            "supports-color": "^5.5.0",
+            "v8-compile-cache": "^2.0.2",
+            "yargs": "^12.0.5"
           }
         }
       }
@@ -611,6 +718,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
+      "integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
@@ -930,6 +1046,16 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.4.tgz",
+      "integrity": "sha512-rwDvjaMTx09WC0rXGBRlYSSkEHOKRrecY6hEr3SVIPKII8DVWXtapNAfAyMC0dovuO+zYArcAuKeu3q9DNRfzA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-typescript": "^7.2.0"
+      }
+    },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
@@ -1005,6 +1131,16 @@
         "@babel/plugin-transform-react-jsx": "^7.0.0",
         "@babel/plugin-transform-react-jsx-self": "^7.0.0",
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz",
+      "integrity": "sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.3.2"
       }
     },
     "@babel/runtime": {
@@ -3209,26 +3345,26 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.5",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
-          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+          "version": "4.5.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+          "integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000960",
-            "electron-to-chromium": "^1.3.124",
-            "node-releases": "^1.1.14"
+            "caniuse-lite": "^1.0.30000963",
+            "electron-to-chromium": "^1.3.127",
+            "node-releases": "^1.1.17"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30000963",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
-          "integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
+          "version": "1.0.30000966",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
+          "integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.127",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.127.tgz",
-          "integrity": "sha512-1o25iFRf/dbgauTWalEzmD1EmRN3a2CzP/K7UVpYLEBduk96LF0FyUdCcf4Ry2mAWJ1VxyblFjC93q6qlLwA2A==",
+          "version": "1.3.130",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.130.tgz",
+          "integrity": "sha512-UY2DI+gsnqGtQJqO8wXN0DnpJY+29FwJafACj0h18ZShn5besKnrRq6+lXWUbKzdxw92QQcnTqRLgNByOKXcUg==",
           "dev": true
         },
         "node-releases": {
@@ -4831,7 +4967,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4855,13 +4992,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4878,19 +5017,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5021,7 +5163,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5035,6 +5178,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5051,6 +5195,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5059,13 +5204,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5086,6 +5233,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5174,7 +5322,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5188,6 +5337,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5283,7 +5433,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5325,6 +5476,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5346,6 +5498,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5394,13 +5547,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11629,6 +11784,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
+      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://newspack.blog",
   "devDependencies": {
-    "@automattic/calypso-build": "^1.0.0-beta.1",
+    "@automattic/calypso-build": "^1.0.0-rc.3",
     "@babel/core": "^7.4.0",
     "@wordpress/blocks": "^6.2.0",
     "@wordpress/browserslist-config": "^2.2.2",
@@ -18,7 +18,6 @@
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "eslint": "^5.16.0",
-    "file-loader": "^3.0.1",
     "grunt": "^0.4.5",
     "grunt-wp-i18n": "^0.5.4",
     "grunt-wp-readme-to-markdown": "^1.0.0",
@@ -57,7 +56,7 @@
   "scripts": {
     "build:style-plugins-screen": "node-sass assets/plugins-screen/plugins-screen.scss assets/plugins-screen/plugins-screen.css --output-style expanded && postcss -r assets/plugins-screen/plugins-screen.css",
     "build:style-plugins-screen-rtl": "rtlcss assets/plugins-screen/plugins-screen.css assets/plugins-screen/plugins-screen-rtl.css",
-    "build:webpack": "webpack",
+    "build:webpack": "calypso-build --config='./webpack.config.js'",
     "build": "run-p \"build:*\"",
     "clean": "rm -rf dist/",
     "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Mirroring changes in https://github.com/Automattic/newspack-blocks/pull/7, this PR bumps `@automattic/calypso-build` to 1.0.0-rc.3, removes an unnecessary dependency (`file-loader`), and removes the Babel config file. 

Closes # .

### How to test the changes in this Pull Request:

`npm ci && npm run build:webpack`

Verify no errors, then navigate to `/admin.php?page=newspack-subscriptions-wizard` and verify two `Card` components one with a simple checkbox and one with a checkbox with tooltip. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->