### PR TITLE
Minor tweaks

### DIFF
--- a/assets/src/components/checkboxInput/style.scss
+++ b/assets/src/components/checkboxInput/style.scss
@@ -7,18 +7,18 @@
 	input[type="checkbox"] {
 		width: 22px;
 		height: 22px;
-		border: 2px solid #636D75;
+		border: 2px solid $muriel-gray-500;
 		border-radius: 3px;
 
 		&:checked {
-			background-color: #D52C82;
-			border-color: #D52C82;
+			background-color: $muriel-hot-pink-500;
+			border-color: $muriel-hot-pink-500;
 
 			&:before {
 				font-size: 30px;
 				margin-left: -7px;
 				margin-top: -4px;
-				color: #FFF;
+				color: $muriel-white;
 			}
 		}
 	}

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -60,7 +60,6 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 
-		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-subscriptions-wizard.php';
 	}
 

--- a/includes/wizards/class-subscriptions-wizard.php
+++ b/includes/wizards/class-subscriptions-wizard.php
@@ -9,6 +9,8 @@ namespace Newspack;
 
 defined( 'ABSPATH' ) || exit;
 
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
 /**
  * Easy interface for managing subscriptions.
  */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,17 +26,6 @@ const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
 		entry: wizardsScriptFiles,
-		module: {
-			rules: [
-				{
-					test: /.scss$/,
-					use: [
-						MiniCssExtractPlugin.loader,
-						'css-loader'
-					]
-				}
-			]
-		},
 		'output-path': path.join( __dirname, 'assets', 'dist' ),
 	}
 );


### PR DESCRIPTION
This PR implements the suggestions from https://github.com/Automattic/newspack-plugin/pull/25#pullrequestreview-232478568 . The PR was merged since those were non-blocking suggestions, and I'm opening this PR before I forget about them.

Specifically:
- Use sass color variables instead of literal colors.
- Move inclusion of Wizard class to classes that extend it instead of the main Newspack class.
- Remove unnecessary module from webpack config.

The `package.json` dependencies mentioned in the review, we will re-approach down the line as part of a bigger dependency clean-up effort. There are some other dependencies @jeffersonrabb has mentioned we may be able to remove, but including unnecessary dependencies doesn't affect our product at the moment, so let's investigate that later.