### PR TITLE
Build: Simplify style build stack

### DIFF
--- a/assets/src/components/card/index.js
+++ b/assets/src/components/card/index.js
@@ -7,6 +7,11 @@
  */
 import { Component } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 class Card extends Component {
 	/**
 	 * Render.

--- a/assets/src/components/checkboxInput/index.js
+++ b/assets/src/components/checkboxInput/index.js
@@ -11,6 +11,7 @@ import { CheckboxControl } from '@wordpress/components';
  * Internal dependencies
  */
 import InfoButton from '../../components/infoButton';
+import './style.scss';
 
 class CheckboxInput extends CheckboxControl {
 

--- a/assets/src/components/infoButton/index.js
+++ b/assets/src/components/infoButton/index.js
@@ -7,6 +7,11 @@
  */
 import { Tooltip } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 class InfoButton extends Tooltip {
 
 	/**

--- a/assets/src/wizards/subscriptions/index.js
+++ b/assets/src/wizards/subscriptions/index.js
@@ -8,6 +8,7 @@ import { Component, Fragment, render } from '@wordpress/element';
  */
 import CheckboxInput from '../../components/checkboxInput';
 import Card from '../../components/card';
+import './style.scss';
 
 /**
  * Subscriptions wizard stub for example purposes.

--- a/includes/wizards/class-subscriptions-wizard.php
+++ b/includes/wizards/class-subscriptions-wizard.php
@@ -56,7 +56,7 @@ class Subscriptions_Wizard extends Wizard {
 		wp_register_style(
 			'newspack-subscriptions-wizard',
 			Newspack::plugin_url() . '/assets/dist/subscriptions.css',
-			null,
+			[ 'wp-components' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/subscriptions.css' )
 		);
 		wp_style_add_data( 'newspack-subscriptions-wizard', 'rtl', 'replace' );

--- a/includes/wizards/class-subscriptions-wizard.php
+++ b/includes/wizards/class-subscriptions-wizard.php
@@ -45,19 +45,19 @@ class Subscriptions_Wizard extends Wizard {
 			return;
 		}
 
-		wp_enqueue_script( 
-			'newspack-subscriptions-wizard', 
-			Newspack::plugin_url() . '/assets/dist/subscriptions.js', 
-			[ 'wp-components' ], 
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/subscriptions.js' ), 
-			true 
+		wp_enqueue_script(
+			'newspack-subscriptions-wizard',
+			Newspack::plugin_url() . '/assets/dist/subscriptions.js',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/subscriptions.js' ),
+			true
 		);
 
 		wp_register_style(
 			'newspack-subscriptions-wizard',
-			Newspack::plugin_url() . '/assets/dist/subscriptions-style.css',
-			[ 'newspack-components' ],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/subscriptions-style.css' )
+			Newspack::plugin_url() . '/assets/dist/subscriptions.css',
+			null,
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/subscriptions.css' )
 		);
 		wp_style_add_data( 'newspack-subscriptions-wizard', 'rtl', 'replace' );
 		wp_enqueue_style( 'newspack-subscriptions-wizard' );

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -67,14 +67,5 @@ class Wizard {
 		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
 			return;
 		}
-
-		wp_register_style(
-			'newspack-components',
-			Newspack::plugin_url() . '/assets/dist/components.css',
-			[ 'wp-components' ],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/components.css' )
-		);
-		wp_style_add_data( 'newspack-components', 'rtl', 'replace' );
-		wp_enqueue_style( 'newspack-components' );
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,13 +11,6 @@ const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.
 const path = require( 'path' );
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 
-// Get files for components stylesheet.
-const adminComponentsDir = path.join( __dirname, 'assets', 'src', 'components' );
-const adminComponentsStyles = fs
-  .readdirSync( adminComponentsDir )
-  .filter( adminComponent => fs.existsSync( path.join( __dirname, 'assets', 'src', 'components', adminComponent, 'style.scss' ) ) );
-const adminComponentsStyleFiles = adminComponentsStyles.map( adminComponent => path.join( __dirname, 'assets', 'src', 'components', adminComponent, 'style.scss' ) );
-
 const wizardsDir = path.join( __dirname, 'assets', 'src', 'wizards' );
 
 // Get files for wizards scripts.
@@ -29,23 +22,10 @@ wizardsScripts.forEach( function( wizard ) {
 	wizardsScriptFiles[ wizard ] = path.join( __dirname, 'assets', 'src', 'wizards', wizard, 'index.js' );
 } );
 
-// Get files for wizards styles.
-const wizardsStyles = fs
-  .readdirSync( wizardsDir )
-  .filter( wizard => fs.existsSync( path.join( __dirname, 'assets', 'src', 'wizards', wizard, 'style.scss' ) ) );
-const wizardsStyleFiles = {}
-wizardsStyles.forEach( function( wizard ) {
-	wizardsStyleFiles[ wizard + '-style' ] = path.join( __dirname, 'assets', 'src', 'wizards', wizard, 'style.scss' );
-} );
-
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
-		entry: {
-			...wizardsScriptFiles,
-			...wizardsStyleFiles,
-			components: adminComponentsStyleFiles
-		},
+		entry: wizardsScriptFiles,
 		module: {
 			rules: [
 				{


### PR DESCRIPTION
Having extra entry points for style files is a bit weird TBH :grimacing: `calypso-build` supports `import`ing SASS files out of the box, so this PR suggests using that technique instead.

Can be a first step towards dropping the webpack config altogether (which ironically will make adding back a babel config less messy. And adding a babel config is one way to fix failing tests).