### PR TITLE
Formatted header component

### DIFF
--- a/assets/src/components/formattedHeader/formattedHeader.test.js
+++ b/assets/src/components/formattedHeader/formattedHeader.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import FormattedHeader from './';
+
+describe( 'FormattedHeader', () => {
+	describe( 'basic rendering', () => {
+		it( 'should render a FormattedHeader element with a subheader', () => {
+			const header = shallow( <FormattedHeader headerText="header text" subHeaderText="subheader text" /> );
+			expect( header.hasClass( 'newspack-formatted-header' ) ).toBe( true );
+			expect( header.hasClass( 'has-subheader' ) ).toBe( true );
+			expect( header.find( '.newspack-formatted-header__subtitle' ) ).toHaveLength( 1 );
+		} );
+
+		it( 'should render a FormattedHeader element with no subheader', () => {
+			const header = shallow( <FormattedHeader headerText="header text" /> );
+			expect( header.hasClass( 'newspack-formatted-header' ) ).toBe( true );
+			expect( header.hasClass( 'has-subheader' ) ).toBe( false );
+			expect( header.find( '.newspack-formatted-header__subtitle' ) ).toHaveLength( 0 );
+		} );
+	} );
+} );

--- a/assets/src/components/formattedHeader/index.js
+++ b/assets/src/components/formattedHeader/index.js
@@ -1,0 +1,34 @@
+/**
+ * Formatted header for titling screens/sections.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+class FormattedHeader extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { headerText, subHeaderText } = this.props;
+		const classes = 'newspack-formatted-header' + ( !! subHeaderText ? ' has-subheader' : '' );
+
+		return (
+			<header className={ classes }>
+				<h1 className="newspack-formatted-header__title">{ headerText }</h1>
+				{ subHeaderText && (
+					<p className="newspack-formatted-header__subtitle">{ subHeaderText }</p>
+				) }
+			</header>
+		);
+	}
+}
+
+export default FormattedHeader;

--- a/assets/src/components/formattedHeader/index.js
+++ b/assets/src/components/formattedHeader/index.js
@@ -30,9 +30,9 @@ class FormattedHeader extends Component {
 
 		return (
 			<header className={ classes }>
-				<h2 className="newspack-formatted-header__title">{ headerText }</h2>
+				<h1 className="newspack-formatted-header__title">{ headerText }</h1>
 				{ subHeaderText && (
-					<p className="newspack-formatted-header__subtitle">{ subHeaderText }</p>
+					<h2 className="newspack-formatted-header__subtitle">{ subHeaderText }</h2>
 				) }
 			</header>
 		);

--- a/assets/src/components/formattedHeader/index.js
+++ b/assets/src/components/formattedHeader/index.js
@@ -3,12 +3,17 @@
  */
 
 /**
- * WordPress dependencies
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies.
  */
 import { Component } from '@wordpress/element';
 
 /**
- * Internal dependencies
+ * Internal dependencies.
  */
 import './style.scss';
 
@@ -18,11 +23,14 @@ class FormattedHeader extends Component {
 	 */
 	render() {
 		const { headerText, subHeaderText } = this.props;
-		const classes = 'newspack-formatted-header' + ( !! subHeaderText ? ' has-subheader' : '' );
+		const classes = classnames(
+			'newspack-formatted-header',
+			!! subHeaderText ? 'has-subheader' : null
+		);
 
 		return (
 			<header className={ classes }>
-				<h1 className="newspack-formatted-header__title">{ headerText }</h1>
+				<h2 className="newspack-formatted-header__title">{ headerText }</h2>
 				{ subHeaderText && (
 					<p className="newspack-formatted-header__subtitle">{ subHeaderText }</p>
 				) }

--- a/assets/src/components/formattedHeader/style.scss
+++ b/assets/src/components/formattedHeader/style.scss
@@ -18,5 +18,6 @@
 		font-size: 14px;
 		line-height: 16px;
 		font-weight: 500;
+		margin: 0;
 	}
 }

--- a/assets/src/components/formattedHeader/style.scss
+++ b/assets/src/components/formattedHeader/style.scss
@@ -1,0 +1,21 @@
+/**
+ * Formatted Header styles.
+ */
+
+.newspack-formatted-header {
+	text-align: center;
+	margin-bottom: 32px;
+
+	.newspack-formatted-header__title {
+		font-size: 24px;
+		line-height: 32px;
+		letter-spacing: -0.5px;
+		font-weight: normal;
+	}
+
+	.newspack-formatted-header__subtitle {
+		font-size: 14px;
+		line-height: 16px;
+		font-weight: 500;
+	}
+}

--- a/assets/src/components/formattedHeader/style.scss
+++ b/assets/src/components/formattedHeader/style.scss
@@ -4,13 +4,14 @@
 
 .newspack-formatted-header {
 	text-align: center;
-	margin-bottom: 32px;
+	margin-bottom: 24px;
 
 	.newspack-formatted-header__title {
 		font-size: 24px;
 		line-height: 32px;
 		letter-spacing: -0.5px;
 		font-weight: normal;
+		margin: .5em 0;
 	}
 
 	.newspack-formatted-header__subtitle {

--- a/assets/src/wizards/subscriptions/index.js
+++ b/assets/src/wizards/subscriptions/index.js
@@ -1,4 +1,8 @@
 /**
+ * Subscriptions Wizard.
+ */
+
+/**
  * WordPress dependencies
  */
 import { Component, Fragment, render } from '@wordpress/element';
@@ -8,6 +12,7 @@ import { Component, Fragment, render } from '@wordpress/element';
  */
 import CheckboxInput from '../../components/checkboxInput';
 import Card from '../../components/card';
+import FormattedHeader from '../../components/formattedHeader';
 import './style.scss';
 
 /**
@@ -21,13 +26,18 @@ class SubscriptionsWizard extends Component {
 	render() {
 		return(
 			<Fragment>
+				<FormattedHeader
+					headerText="Newspack Components"
+					subHeaderText="Temporary demo of Newspack components"
+				/>
 				<Card>
+					<FormattedHeader
+						headerText="Checkboxes"
+					/>
 					<CheckboxInput
 				        label="Checkbox is tested?"
 				        onChange={ function(){ console.log( 'Yep, it\'s tested' ); } }
 					/>
-				</Card>
-				<Card>
 					<CheckboxInput
 				        label="Checkbox w/Tooltip"
 				        onChange={ function(){ console.log( 'Yep, it\'s tested' ); } }

--- a/assets/src/wizards/subscriptions/style.scss
+++ b/assets/src/wizards/subscriptions/style.scss
@@ -2,9 +2,4 @@
  * Temporary styles for example purposes.
  */
 #newspack-subscriptions-wizard {
-	background-color: #FFF;
-	box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.25);
-	border-radius: 3px;
-	padding: 24px;
-	box-sizing: border-box;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #18 .

Adds the FormattedHeader component. The code is strongly influenced by [the Calypso component of the same name.](https://github.com/Automattic/wp-calypso/blob/master/client/components/formatted-header/index.jsx) I've also made a couple tweaks to the Subscriptions demo page, for better demoing.

I'll remove the Do Not Merge label and add tests to this as soon as the tests are working again. :)

### How to test the changes in this Pull Request:

1. `npm ci` `npm run build:webpack`
2. Navigate to the Subscriptions screen.
<img width="566" alt="Screen Shot 2019-05-07 at 11 34 17 AM" src="https://user-images.githubusercontent.com/7317227/57324895-b5a30380-70bd-11e9-8268-c6117f754ca1.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->