### PR TITLE
Use jsdom environment when running jest tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "setupFilesAfterEnv": [
       "<rootDir>/assets/src/setupTests.js"
     ],
-    "testEnvironment": "jsdom",
     "testMatch": [
       "<rootDir>/**/src/**/*test.js?(x)",
       "!**/.eslintrc.*"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "setupFilesAfterEnv": [
       "<rootDir>/assets/src/setupTests.js"
     ],
-    "testEnvironment": "node",
+    "testEnvironment": "jsdom",
     "testMatch": [
       "<rootDir>/**/src/**/*test.js?(x)",
       "!**/.eslintrc.*"


### PR DESCRIPTION
Updates master with [the change from this PR](https://github.com/Automattic/newspack-plugin/pull/29#issuecomment-490535220), so everyone has access to working unit tests before that PR is merged.

The previous version used the `node` environment, which simulates a node server. This caused issues because browser variables like `window` were not defined and some Gutenberg components expect that variable. The default `jsdom` environment simulates a browser, and meets our needs much better.

To test:
1. Run unit tests.
2. Check out #29 and run unit tests.