### PR TITLE
Fix: Checkbox input should extend Component, not CheckboxControl.

### DIFF
--- a/assets/src/components/checkboxInput/index.js
+++ b/assets/src/components/checkboxInput/index.js
@@ -5,6 +5,7 @@
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { CheckboxControl } from '@wordpress/components';
 
 /**
@@ -13,7 +14,7 @@ import { CheckboxControl } from '@wordpress/components';
 import InfoButton from '../../components/infoButton';
 import './style.scss';
 
-class CheckboxInput extends CheckboxControl {
+class CheckboxInput extends Component {
 
 	/**
 	 * Render.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The restyled components should extend `Component`, not the component we  are restyling. I think it was a happy accident that extending `CheckboxControl` actually worked in this case, but we run into trouble when doing the same with other components, e.g. `Button`.

### How to test the changes in this Pull Request:

1. Execute `npm run build:webpack`
2. Observe that the checkbox components in `Newspack/Subscriptions` look and act as they did before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->