### PR TITLE
Standardize naming conventions

### DIFF
--- a/assets/src/components/card/card.test.js
+++ b/assets/src/components/card/card.test.js
@@ -6,7 +6,7 @@ describe( 'Card', () => {
 	describe( 'basic rendering', () => {
 		it( 'should render a Card element with only one class', () => {
 			const card = shallow( <Card /> );
-			expect( card.hasClass( 'newspack-card' ) ).toBe( true );
+			expect( card.hasClass( 'muriel-card' ) ).toBe( true );
 		} );
 	} );
 } );

--- a/assets/src/components/card/index.js
+++ b/assets/src/components/card/index.js
@@ -17,7 +17,7 @@ class Card extends Component {
 	 * Render.
 	 */
 	render() {
-		return <div className="newspack-card" { ...this.props } />
+		return <div className="muriel-card" { ...this.props } />
 	}
 }
 

--- a/assets/src/components/card/style.scss
+++ b/assets/src/components/card/style.scss
@@ -2,7 +2,7 @@
  * Card styles.
  */
 
-.newspack-card {
+.muriel-card {
 	background: $muriel-white;
 	border-radius: 3px;
 	box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.25);

--- a/assets/src/components/checkboxControl/index.js
+++ b/assets/src/components/checkboxControl/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl as BaseComponent } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ import { CheckboxControl } from '@wordpress/components';
 import InfoButton from '../../components/infoButton';
 import './style.scss';
 
-class CheckboxInput extends Component {
+class CheckboxControl extends Component {
 
 	/**
 	 * Render.
@@ -22,8 +22,8 @@ class CheckboxInput extends Component {
 	render() {
 		const { tooltip } = this.props;
 		return (
-			<div className="newspack-checkbox">
-				<CheckboxControl { ...this.props } />
+			<div className="muriel-checkbox">
+				<BaseComponent { ...this.props } />
 				{ tooltip && (
 					<InfoButton text={ tooltip } />
 				) }
@@ -32,4 +32,4 @@ class CheckboxInput extends Component {
 	}
 }
 
-export default CheckboxInput;
+export default CheckboxControl;

--- a/assets/src/components/checkboxControl/style.scss
+++ b/assets/src/components/checkboxControl/style.scss
@@ -1,7 +1,7 @@
 /**
  * Checkbox styles.
  */
-.newspack-checkbox {
+.muriel-checkbox {
 	display: block;
 	position: relative;
 	input[type="checkbox"] {

--- a/assets/src/components/formattedHeader/formattedHeader.test.js
+++ b/assets/src/components/formattedHeader/formattedHeader.test.js
@@ -6,16 +6,16 @@ describe( 'FormattedHeader', () => {
 	describe( 'basic rendering', () => {
 		it( 'should render a FormattedHeader element with a subheader', () => {
 			const header = shallow( <FormattedHeader headerText="header text" subHeaderText="subheader text" /> );
-			expect( header.hasClass( 'newspack-formatted-header' ) ).toBe( true );
+			expect( header.hasClass( 'muriel-formatted-header' ) ).toBe( true );
 			expect( header.hasClass( 'has-subheader' ) ).toBe( true );
-			expect( header.find( '.newspack-formatted-header__subtitle' ) ).toHaveLength( 1 );
+			expect( header.find( '.muriel-formatted-header__subtitle' ) ).toHaveLength( 1 );
 		} );
 
 		it( 'should render a FormattedHeader element with no subheader', () => {
 			const header = shallow( <FormattedHeader headerText="header text" /> );
-			expect( header.hasClass( 'newspack-formatted-header' ) ).toBe( true );
+			expect( header.hasClass( 'muriel-formatted-header' ) ).toBe( true );
 			expect( header.hasClass( 'has-subheader' ) ).toBe( false );
-			expect( header.find( '.newspack-formatted-header__subtitle' ) ).toHaveLength( 0 );
+			expect( header.find( '.muriel-formatted-header__subtitle' ) ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/assets/src/components/formattedHeader/index.js
+++ b/assets/src/components/formattedHeader/index.js
@@ -24,15 +24,15 @@ class FormattedHeader extends Component {
 	render() {
 		const { headerText, subHeaderText } = this.props;
 		const classes = classnames(
-			'newspack-formatted-header',
+			'muriel-formatted-header',
 			!! subHeaderText ? 'has-subheader' : null
 		);
 
 		return (
 			<header className={ classes }>
-				<h1 className="newspack-formatted-header__title">{ headerText }</h1>
+				<h1 className="muriel-formatted-header__title">{ headerText }</h1>
 				{ subHeaderText && (
-					<h2 className="newspack-formatted-header__subtitle">{ subHeaderText }</h2>
+					<h2 className="muriel-formatted-header__subtitle">{ subHeaderText }</h2>
 				) }
 			</header>
 		);

--- a/assets/src/components/formattedHeader/style.scss
+++ b/assets/src/components/formattedHeader/style.scss
@@ -2,11 +2,11 @@
  * Formatted Header styles.
  */
 
-.newspack-formatted-header {
+.muriel-formatted-header {
 	text-align: center;
 	margin-bottom: 24px;
 
-	.newspack-formatted-header__title {
+	.muriel-formatted-header__title {
 		font-size: 24px;
 		line-height: 32px;
 		letter-spacing: -0.5px;
@@ -14,7 +14,7 @@
 		margin: .5em 0;
 	}
 
-	.newspack-formatted-header__subtitle {
+	.muriel-formatted-header__subtitle {
 		font-size: 14px;
 		line-height: 16px;
 		font-weight: 500;

--- a/assets/src/components/infoButton/index.js
+++ b/assets/src/components/infoButton/index.js
@@ -5,6 +5,7 @@
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { Tooltip } from '@wordpress/components';
 
 /**
@@ -12,13 +13,13 @@ import { Tooltip } from '@wordpress/components';
  */
 import './style.scss';
 
-class InfoButton extends Tooltip {
+class InfoButton extends Component {
 
 	/**
 	 * Render.
 	 */
 	render() {
-		return <Tooltip { ...this.props }><div className="newspack-info-button" /></Tooltip>
+		return <Tooltip { ...this.props }><div className="muriel-info-button" /></Tooltip>
 	}
 }
 

--- a/assets/src/components/infoButton/style.scss
+++ b/assets/src/components/infoButton/style.scss
@@ -2,7 +2,7 @@
  * Info Button styles
  */
 
-.newspack-info-button {
+.muriel-info-button {
 	background-image: url( 'info_24px.svg' );
 	position: absolute;
 	width: 24px;

--- a/assets/src/components/textControl/index.js
+++ b/assets/src/components/textControl/index.js
@@ -5,11 +5,11 @@
 /**
  * WordPress dependencies
  */
-import { TextControl, withFocusOutside } from '@wordpress/components';
+import { TextControl as BaseComponent, withFocusOutside } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import './style.scss';
 
-const InputText = withFocusOutside(
+const TextControl = withFocusOutside(
 
 	class extends Component {
 
@@ -64,8 +64,8 @@ const InputText = withFocusOutside(
 			const className= this.getClassName( disabled, isEmpty, isActive );
 
 			return (
-				<TextControl
-					className={ "newspack-input-text " + className }
+				<BaseComponent
+					className={ "muriel-input-text " + className }
 					placeholder={ label }
 					{ ...this.props }
 					onClick={ () => this.handleOnClick() }
@@ -75,4 +75,4 @@ const InputText = withFocusOutside(
 	}
 );
 
-export default InputText;
+export default TextControl;

--- a/assets/src/components/textControl/style.scss
+++ b/assets/src/components/textControl/style.scss
@@ -2,7 +2,7 @@
  * Text/Number Input styles.
  */
 
-.newspack-input-text {
+.muriel-input-text {
 	position: relative;
 	width: 440px;
 	height: 56px;

--- a/assets/src/wizards/subscriptions/index.js
+++ b/assets/src/wizards/subscriptions/index.js
@@ -10,10 +10,10 @@ import { Component, Fragment, render } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import CheckboxInput from '../../components/checkboxInput';
+import CheckboxControl from '../../components/checkboxControl';
 import Card from '../../components/card';
 import FormattedHeader from '../../components/formattedHeader';
-import InputText from '../../components/InputText';
+import TextControl from '../../components/textControl';
 import './style.scss';
 
 /**
@@ -48,11 +48,11 @@ class SubscriptionsWizard extends Component {
 					<FormattedHeader
 						headerText="Checkboxes"
 					/>
-					<CheckboxInput
+					<CheckboxControl
 				        label="Checkbox is tested?"
 				        onChange={ function(){ console.log( 'Yep, it\'s tested' ); } }
 					/>
-					<CheckboxInput
+					<CheckboxControl
 				        label="Checkbox w/Tooltip"
 				        onChange={ function(){ console.log( 'Yep, it\'s tested' ); } }
 				        tooltip="This is tooltip text"
@@ -62,17 +62,17 @@ class SubscriptionsWizard extends Component {
 					<FormattedHeader
 						headerText="Text Inputs"
 					/>
-					<InputText
+					<TextControl
 						label="Text Input with value"
 						value={ inputTextValue1 }
 						onChange={ value => this.setState( { inputTextValue1: value } ) }
 					/>
-					<InputText
+					<TextControl
 						label="Text Input empty"
 						value={ inputTextValue2 }
 						onChange={ value => this.setState( { inputTextValue2: value } ) }
 					/>
-					<InputText
+					<TextControl
 						label="Text Input disabled"
 						disabled
 					/>


### PR DESCRIPTION
This PR standardizes the naming conventions for the components following these rules:
- Use the same JS class name as the Gutenberg component for Murielized components when applicable.
- Use the `muriel-` prefix for HTML classes.

In addition to making it easier to offer these components as stand-alone components in the future, this should make naming things easier and won't require getting creative with component names.

To test:
1. `npm ci`, `npm run build:webpack`, `npm run test`.
2. Go to the Subscriptions page. Observe nothing is broken or unstyled.