### PR TITLE
Shared Component Styles

### DIFF
--- a/assets/src/components/card/index.js
+++ b/assets/src/components/card/index.js
@@ -10,6 +10,11 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import murielClassnames from '../../shared/js/muriel-classnames';
+
+/**
+ * Internal dependencies
+ */
 import './style.scss';
 
 class Card extends Component {
@@ -17,7 +22,9 @@ class Card extends Component {
 	 * Render.
 	 */
 	render() {
-		return <div className="muriel-card" { ...this.props } />
+		const { className, ...otherProps } = this.props;
+		const classes = murielClassnames( 'muriel-card', className );
+		return <div className={ classes } { ...otherProps } />
 	}
 }
 

--- a/assets/src/components/card/style.scss
+++ b/assets/src/components/card/style.scss
@@ -2,6 +2,8 @@
  * Card styles.
  */
 
+@import '../../shared/scss/muriel-component';
+
 .muriel-card {
 	background: $muriel-white;
 	border-radius: 3px;

--- a/assets/src/components/checkboxControl/index.js
+++ b/assets/src/components/checkboxControl/index.js
@@ -11,6 +11,7 @@ import { CheckboxControl as BaseComponent } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import murielClassnames from '../../shared/js/muriel-classnames';
 import InfoButton from '../../components/infoButton';
 import './style.scss';
 
@@ -20,13 +21,12 @@ class CheckboxControl extends Component {
 	 * Render.
 	 */
 	render() {
-		const { tooltip } = this.props;
+		const { className, tooltip, ...otherProps } = this.props;
+		const classes = murielClassnames( 'muriel-checkbox', className );
 		return (
-			<div className="muriel-checkbox">
-				<BaseComponent { ...this.props } />
-				{ tooltip && (
-					<InfoButton text={ tooltip } />
-				) }
+			<div className={ classes }>
+				<BaseComponent { ...otherProps } />
+				{ tooltip && <InfoButton text={ tooltip } /> }
 			</div>
 		);
 	}

--- a/assets/src/components/checkboxControl/style.scss
+++ b/assets/src/components/checkboxControl/style.scss
@@ -1,6 +1,9 @@
 /**
  * Checkbox styles.
  */
+
+@import '../../shared/scss/muriel-component';
+
 .muriel-checkbox {
 	display: block;
 	position: relative;

--- a/assets/src/components/formattedHeader/index.js
+++ b/assets/src/components/formattedHeader/index.js
@@ -3,14 +3,14 @@
  */
 
 /**
- * External dependencies.
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies.
  */
 import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import murielClassnames from '../../shared/js/muriel-classnames';
 
 /**
  * Internal dependencies.
@@ -22,12 +22,8 @@ class FormattedHeader extends Component {
 	 * Render.
 	 */
 	render() {
-		const { headerText, subHeaderText } = this.props;
-		const classes = classnames(
-			'muriel-formatted-header',
-			!! subHeaderText ? 'has-subheader' : null
-		);
-
+		const { className, headerText, subHeaderText } = this.props;
+		const classes = murielClassnames( 'muriel-formatted-header', className, !! subHeaderText ? 'has-subheader' : null );
 		return (
 			<header className={ classes }>
 				<h1 className="muriel-formatted-header__title">{ headerText }</h1>

--- a/assets/src/components/formattedHeader/style.scss
+++ b/assets/src/components/formattedHeader/style.scss
@@ -2,6 +2,8 @@
  * Formatted Header styles.
  */
 
+@import '../../shared/scss/muriel-component';
+
 .muriel-formatted-header {
 	text-align: center;
 	margin-bottom: 24px;

--- a/assets/src/components/imageUpload/index.js
+++ b/assets/src/components/imageUpload/index.js
@@ -9,6 +9,11 @@ import { Component, Fragment } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { data } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import murielClassnames from '../../shared/js/muriel-classnames';
 import './style.scss';
 
 /**
@@ -71,12 +76,11 @@ class ImageUpload extends Component {
 	 * Render.
 	 */
 	render = () => {
-		const { image } = this.props;
-
+		const { className, image } = this.props;
 		return (
 			<Fragment>
 				{ !! image && (
-				<div className="muriel-image-upload has-image">
+				<div className={ murielClassnames( 'muriel-image-upload', 'has-image', className ) }>
 					<div className="image-preview">
 						<img src={ image.url } />
 					</div>
@@ -86,7 +90,7 @@ class ImageUpload extends Component {
 				</div>
 				) }
 				{ ! image && (
-					<div className="muriel-image-upload no-image">
+					<div className={ murielClassnames( 'muriel-image-upload', 'no-image', className ) }>
 						<Button className="add-image" onClick={ this.openModal }>
 							{ __( 'Add an image' ) }
 						</Button>

--- a/assets/src/components/imageUpload/style.scss
+++ b/assets/src/components/imageUpload/style.scss
@@ -2,6 +2,8 @@
  * Image uploader styles.
  */
 
+@import '../../shared/scss/muriel-component';
+
 .muriel-image-upload {
 	button {
 		color: $muriel-hot-pink-500;

--- a/assets/src/components/infoButton/index.js
+++ b/assets/src/components/infoButton/index.js
@@ -11,6 +11,7 @@ import { Tooltip } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import murielClassnames from '../../shared/js/muriel-classnames';
 import './style.scss';
 
 class InfoButton extends Component {
@@ -19,7 +20,8 @@ class InfoButton extends Component {
 	 * Render.
 	 */
 	render() {
-		return <Tooltip { ...this.props }><div className="muriel-info-button" /></Tooltip>
+		const { className, ...otherProps } = this.props;
+		return <Tooltip { ...otherProps }><div className={ murielClassnames( 'muriel-info-button', className ) } /></Tooltip>
 	}
 }
 

--- a/assets/src/components/infoButton/style.scss
+++ b/assets/src/components/infoButton/style.scss
@@ -2,6 +2,8 @@
  * Info Button styles
  */
 
+@import '../../shared/scss/muriel-component';
+
 .muriel-info-button {
 	background-image: url( 'info_24px.svg' );
 	position: absolute;

--- a/assets/src/components/textControl/index.js
+++ b/assets/src/components/textControl/index.js
@@ -7,6 +7,11 @@
  */
 import { TextControl as BaseComponent, withFocusOutside } from '@wordpress/components';
 import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import murielClassnames from '../../shared/js/muriel-classnames';
 import './style.scss';
 
 const TextControl = withFocusOutside(
@@ -58,16 +63,16 @@ const TextControl = withFocusOutside(
 		 */
 		render() {
 			const { isFocused } = this.state;
-			const { label, value, disabled } = this.props;
+			const { className, ...otherProps } = this.props;
+			const { label, value, disabled } = otherProps;
 			const isEmpty = ! value;
 			const isActive = isFocused && ! disabled;
-			const className= this.getClassName( disabled, isEmpty, isActive );
 
 			return (
 				<BaseComponent
-					className={ "muriel-input-text " + className }
+					className={ murielClassnames( "muriel-input-text", className, this.getClassName( disabled, isEmpty, isActive ) ) }
 					placeholder={ label }
-					{ ...this.props }
+					{ ...otherProps }
 					onClick={ () => this.handleOnClick() }
 				/>
 			);

--- a/assets/src/components/textControl/style.scss
+++ b/assets/src/components/textControl/style.scss
@@ -2,6 +2,8 @@
  * Text/Number Input styles.
  */
 
+@import '../../shared/scss/muriel-component';
+
 .muriel-input-text {
 	position: relative;
 	width: 440px;

--- a/assets/src/shared/js/muriel-classnames.js
+++ b/assets/src/shared/js/muriel-classnames.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import classnames from 'classnames';
+
+export default function murielClassnames( ...classNames ) {
+	return classnames( 'muriel-component', classNames );
+}

--- a/assets/src/shared/scss/_muriel-component.scss
+++ b/assets/src/shared/scss/_muriel-component.scss
@@ -1,0 +1,8 @@
+.muriel-component {
+	margin-top: 14px;
+	margin-bottom: 14px;
+ 	&.is-centered {
+ 		margin-left: auto;
+ 		margin-right: auto;
+ 	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

- Utility that combines component classNames, adding "muriel-component" to each
- If className is set on the component itself, it will be included in React rendering. 
- Global stylesheet for all components.
- Normalized top/bottom margins for all components.
- `is-centered` class

Closes #44

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Navigate to `/admin.php?page=newspack-subscriptions-wizard`.
3. Observe that all components look and behave as before.
4. Observe vertical space between Text Inputs.
5. Edit `/assets/wizards/subscriptions/index.js`. Try adding `className` attributes to any of the components and in browser web inspector observe that the classes are set on the rendered components.  

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->