### PR TITLE
TextControl's CSS width changed from hard-coded px to percentage-based

### DIFF
--- a/assets/src/components/button/button.test.js
+++ b/assets/src/components/button/button.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Button from './';
+
+describe( 'Button', () => {
+	describe( 'basic rendering', () => {
+		it( 'should render a Button element with a value of "Continue"', () => {
+			const button = shallow( <Button isPrimary>Continue</Button> );
+			expect( button.render().hasClass( 'muriel-button' ) ).toBe( true );
+		} );
+	} );
+	describe( 'rendering default', () => {
+		it( 'should render a Button element with a class of is-default', () => {
+			const button = shallow( <Button isDefault>Continue</Button> );
+			expect( button.render().hasClass( 'is-default' ) ).toBe( true );
+		} );
+	} );
+	describe( 'rendering primary', () => {
+		it( 'should render a Button element with a class of is-primary', () => {
+			const button = shallow( <Button isPrimary>Continue</Button> );
+			expect( button.render().hasClass( 'is-primary' ) ).toBe( true );
+		} );
+	} );
+	describe( 'rendering tertiary', () => {
+		it( 'should render a Button element with a class of is-tertiary', () => {
+			const button = shallow( <Button isTertiary>Continue</Button> );
+			expect( button.render().hasClass( 'is-tertiary' ) ).toBe( true );
+		} );
+	} );
+	describe( 'rendering centered primary', () => {
+		it( 'should render a Button element with a class of is-primary and class of is-centered', () => {
+			const button = shallow( <Button isPrimary className="is-centered">Continue</Button> );
+			expect( button.render().hasClass( 'is-primary' ) ).toBe( true );
+			expect( button.render().hasClass( 'is-centered' ) ).toBe( true );
+		} );
+	} );
+} );

--- a/assets/src/components/button/index.js
+++ b/assets/src/components/button/index.js
@@ -1,0 +1,28 @@
+/**
+ * Muriel-styled buttons.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Component } from '@wordpress/element';
+import { Button as BaseComponent } from '@wordpress/components';
+
+import classnames from 'classnames';
+
+import './style.scss';
+
+class Button extends Component {
+
+	/**
+	 * Render.
+	 */
+	render( props ) {
+		const { className, ...otherProps } = this.props;
+		return (
+			<BaseComponent className={ classnames( 'muriel-button', className ) } { ...otherProps } />
+		);
+	}
+}
+
+export default Button;

--- a/assets/src/components/button/style.scss
+++ b/assets/src/components/button/style.scss
@@ -1,0 +1,53 @@
+/**
+ * Button styles,
+ */
+
+.muriel-button {
+	text-align: center;
+	font-size: 14px;
+	line-height: 18px;
+	font-weight: 500;
+	color: $muriel-gray-700;
+
+	&.is-button {
+		display: inline-block;
+		background-color: $muriel-white;
+		border-color: #CCCCCC;
+		border-radius: 3px;
+		height: auto;
+		padding: 7px 25px;
+		margin: 14px 7px;
+
+		&:active:enabled {
+			border-width: 2px 1px 1px;
+		}
+	}
+
+	&.is-primary {
+		border: none;
+		background-color: $muriel-hot-pink-500;
+		box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
+		color: $muriel-white;
+		text-shadow: none;
+
+		&:hover,
+		&:focus:enabled {
+			background-color: $muriel-hot-pink-400;
+			color: $muriel-gray-0;
+			box-shadow: inherit;
+		}
+
+		&:active:enabled {
+			background-color: $muriel-hot-pink-700;
+			color: $muriel-white;
+		}
+	}
+
+	&.is-centered {
+		display: block;
+		width: 100%;
+		max-width: 310px;
+		margin: 14px auto;
+	}
+
+}

--- a/assets/src/components/textControl/index.js
+++ b/assets/src/components/textControl/index.js
@@ -36,10 +36,13 @@ const TextControl = withFocusOutside(
 		}
 
 		/**
-		 * Handle component onClick.
+		 * Handle component onClick; also executes the props' onChange handler (the parent's original onClick).
 		 */
-		handleOnClick = () => {
+		handleOnClick = ( onClick ) => {
 			this.setState( { isFocused: true } );
+			if (typeof onClick === "function") {
+				onClick();
+			}
 		};
 
 		/**
@@ -63,7 +66,7 @@ const TextControl = withFocusOutside(
 		 */
 		render() {
 			const { isFocused } = this.state;
-			const { className, ...otherProps } = this.props;
+			const { className, onClick, ...otherProps } = this.props;
 			const { label, value, disabled } = otherProps;
 			const isEmpty = ! value;
 			const isActive = isFocused && ! disabled;
@@ -72,8 +75,8 @@ const TextControl = withFocusOutside(
 				<BaseComponent
 					className={ murielClassnames( "muriel-input-text", className, this.getClassName( disabled, isEmpty, isActive ) ) }
 					placeholder={ label }
+					onClick={ () => this.handleOnClick( onClick ) }
 					{ ...otherProps }
-					onClick={ () => this.handleOnClick() }
 				/>
 			);
 		}

--- a/assets/src/components/textControl/style.scss
+++ b/assets/src/components/textControl/style.scss
@@ -6,7 +6,8 @@
 
 .muriel-input-text {
 	position: relative;
-	width: 440px;
+	width: 100%;
+	max-width: 440px;
 	height: 56px;
 
 	border: 1px solid $muriel-gray-200;
@@ -17,7 +18,10 @@
 
 	label {
 		position: absolute;
-		width: 408px;
+		width: -webkit-calc(100% - 16px - 16px);
+		width:    -moz-calc(100% - 16px - 16px);
+		width:         calc(100% - 16px - 16px);
+		max-width: 408px;
 		height: 21px;
 		top: 9px;
 		right: 16px;
@@ -30,7 +34,10 @@
 
 	input[type="text"] {
 		position: absolute;
-		width: 408px;
+		width: -webkit-calc(100% - 16px - 20px);
+		width:    -moz-calc(100% - 16px - 20px);
+		width:         calc(100% - 16px - 20px);
+		max-width: 408px;
 		height: 24px;
 		right: 20px;
 		left: 16px;

--- a/assets/src/components/textControl/style.scss
+++ b/assets/src/components/textControl/style.scss
@@ -7,7 +7,6 @@
 .muriel-input-text {
 	position: relative;
 	width: 100%;
-	max-width: 440px;
 	height: 56px;
 
 	border: 1px solid $muriel-gray-200;
@@ -21,7 +20,6 @@
 		width: -webkit-calc(100% - 16px - 16px);
 		width:    -moz-calc(100% - 16px - 16px);
 		width:         calc(100% - 16px - 16px);
-		max-width: 408px;
 		height: 21px;
 		top: 9px;
 		right: 16px;
@@ -37,7 +35,6 @@
 		width: -webkit-calc(100% - 16px - 20px);
 		width:    -moz-calc(100% - 16px - 20px);
 		width:         calc(100% - 16px - 20px);
-		max-width: 408px;
 		height: 24px;
 		right: 20px;
 		left: 16px;

--- a/assets/src/wizards/subscriptions/index.js
+++ b/assets/src/wizards/subscriptions/index.js
@@ -10,9 +10,10 @@ import { Component, Fragment, render } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import ImageUpload from '../../components/ImageUpload';
+import ImageUpload from '../../components/imageUpload';
 import CheckboxControl from '../../components/checkboxControl';
 import Card from '../../components/card';
+import Button from '../../components/button';
 import FormattedHeader from '../../components/formattedHeader';
 import TextControl from '../../components/textControl';
 import ProgressBar from '../../components/progressBar';
@@ -92,6 +93,9 @@ class SubscriptionsWizard extends Component {
 						label="Text Input disabled"
 						disabled
 					/>
+					<Button isPrimary className="is-centered">Continue</Button>
+					<Button isDefault className="is-centered">Continue</Button>
+					<Button isTertiary className="is-centered">Continue</Button>
 				</Card>
 				<Card>
 					<FormattedHeader
@@ -102,6 +106,10 @@ class SubscriptionsWizard extends Component {
 					<ProgressBar completed="0" total="5" displayFraction />
 					<ProgressBar completed="3" total="8" label="Progress made" displayFraction />
 				</Card>
+
+				<Button isPrimary>Continue</Button>
+				<Button isDefault>Continue</Button>
+				<Button isTertiary>Continue</Button>
 			</Fragment>
 		);
 	}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@wordpress/browserslist-config": "^2.2.2",
     "@wordpress/components": "^7.3.1",
     "@wordpress/element": "^2.3.0",
+    "@wordpress/components": "^7.3.1",
     "autoprefixer": "^9.1.5",
     "chokidar-cli": "^1.2.1",
     "classnames": "^2.2.6",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updated the TextControl's CSS width from hard-coded pixel value to a percentage-based value.

### How to test the changes in this Pull Request:

The TextControl are demoed in the Subscription Wizzard. One can change the value of `.muriel-card`'s `max-width` value by using the Inspector, and check that the component styling changes accordingly and behaves properly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->