### PR TITLE
Switch to using shared Muriel styles and murielClassnames()

### DIFF
--- a/assets/src/components/button/index.js
+++ b/assets/src/components/button/index.js
@@ -8,7 +8,10 @@
 import { Component } from '@wordpress/element';
 import { Button as BaseComponent } from '@wordpress/components';
 
-import classnames from 'classnames';
+/**
+ * Internal dependencies
+ */
+import murielClassnames from '../../shared/js/muriel-classnames';
 
 import './style.scss';
 
@@ -19,8 +22,9 @@ class Button extends Component {
 	 */
 	render( props ) {
 		const { className, ...otherProps } = this.props;
+		const classes = murielClassnames( 'muriel-button', className );
 		return (
-			<BaseComponent className={ classnames( 'muriel-button', className ) } { ...otherProps } />
+			<BaseComponent className={ classes } { ...otherProps } />
 		);
 	}
 }

--- a/assets/src/components/button/style.scss
+++ b/assets/src/components/button/style.scss
@@ -2,6 +2,8 @@
  * Button styles,
  */
 
+@import '../../shared/scss/muriel-component';
+
 .muriel-button {
 	text-align: center;
 	font-size: 14px;
@@ -47,7 +49,6 @@
 		display: block;
 		width: 100%;
 		max-width: 310px;
-		margin: 14px auto;
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We're now using `murielClassnames()` as introduced in #57 and we don't need to set the margin in our component styles for the button because the shared component styles handle that.

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Navigate to `/admin.php?page=newspack-subscriptions-wizard`
3. Observe that all components look and behave as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->