### PR TITLE
Style 'help' text for checkboxes

### DIFF
--- a/assets/src/components/checkbox-control/style.scss
+++ b/assets/src/components/checkbox-control/style.scss
@@ -30,4 +30,11 @@
 		margin-left: 28px;
 		font-size: 16px;
 	}
+
+	.components-base-control__help {
+		margin-left: 54px;
+		font-style: normal;
+		margin-top: 0;
+		color: $muriel-gray-600;
+	}
 }

--- a/assets/src/wizards/componentsDemo/index.js
+++ b/assets/src/wizards/componentsDemo/index.js
@@ -139,6 +139,13 @@ class ComponentsDemo extends Component {
 						} }
 						tooltip="This is tooltip text"
 					/>
+					<CheckboxControl
+						label={ __( 'Checkbox w/Help' ) }
+						onChange={ function() {
+							console.log( "Yep, it's tested" );
+						} }
+						help="This is help text"
+					/>
 				</Card>
 				<Card>
 					<FormattedHeader headerText={ __( 'Image Uploader' ) } />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Related #64 

This PR adds styling for the 'help' text on checkboxes.

Here is the design for this:
<img width="473" alt="Screen Shot 2019-05-21 at 10 20 05 AM" src="https://user-images.githubusercontent.com/7317227/58117626-db4b0500-7bb3-11e9-9be2-770133655660.png">

Without the CSS in this PR, here is what it would look like:
<img width="272" alt="Screen Shot 2019-05-21 at 10 25 30 AM" src="https://user-images.githubusercontent.com/7317227/58117636-e00fb900-7bb3-11e9-8371-d85d80184bdc.png">

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. Go to Components Demo. Examine the new 'Checkbox w/Help' element I've added:
<img width="262" alt="Screen Shot 2019-05-21 at 10 33 20 AM" src="https://user-images.githubusercontent.com/7317227/58117670-f4ec4c80-7bb3-11e9-883c-8517ea5f0851.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->