### PR TITLE
Style number/password/etc. inputs

### DIFF
--- a/assets/src/components/text-control/style.scss
+++ b/assets/src/components/text-control/style.scss
@@ -30,7 +30,7 @@
 		color: $muriel-gray-500;
 	}
 
-	input[type="text"] {
+	input {
 		position: absolute;
 		width: -webkit-calc(100% - 16px - 20px);
 		width:    -moz-calc(100% - 16px - 20px);
@@ -51,7 +51,7 @@
 		label {
 			display: none;
 		}
-		input[type="text"] {
+		input {
 			top: 17px;
 			color: $muriel-gray-800;
 		}
@@ -60,7 +60,7 @@
 	&.with-value {
 		label {
 		}
-		input[type="text"] {
+		input {
 			top: 25px;
 			color: $muriel-gray-800;
 		}
@@ -70,7 +70,7 @@
 		label {
 			display: none;
 		}
-		input[type="text"] {
+		input {
 			top: 17px;
 			color: $muriel-gray-500;
 		}
@@ -80,7 +80,7 @@
 		label {
 			display: none;
 		}
-		input[type="text"] {
+		input {
 			top: 17px;
 			color: $muriel-gray-200;
 

--- a/assets/src/wizards/componentsDemo/index.js
+++ b/assets/src/wizards/componentsDemo/index.js
@@ -38,6 +38,7 @@ class ComponentsDemo extends Component {
 			checklistProgress: 0,
 			inputTextValue1: 'Input value',
 			inputTextValue2: '',
+			inputNumValue: 0,
 			image: null,
 			selectValue1: '2nd',
 			selectValue2: '',
@@ -64,6 +65,7 @@ class ComponentsDemo extends Component {
 			checklistProgress,
 			inputTextValue1,
 			inputTextValue2,
+			inputNumValue,
 			selectValue1,
 			selectValue2,
 		} = this.state;
@@ -162,6 +164,12 @@ class ComponentsDemo extends Component {
 						label={ __( 'Text Input empty' ) }
 						value={ inputTextValue2 }
 						onChange={ value => this.setState( { inputTextValue2: value } ) }
+					/>
+					<TextControl
+						type='number'
+						label={ __( 'Number Input' ) }
+						value={ inputNumValue }
+						onChange={ value => this.setState( { inputNumValue: value } ) }
 					/>
 					<TextControl label={ __( 'Text Input disabled' ) } disabled />
 				</Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Related #64 

The styles in the stylesheet were only getting applied to inputs with the 'text' type. I've removed the restriction, so all types of inputs (number, password, etc.) will get the styles.

Here is what the input looked like before the change:
<img width="466" alt="Screen Shot 2019-05-21 at 2 12 14 PM" src="https://user-images.githubusercontent.com/7317227/58131525-c4b4a600-7bd3-11e9-8374-fa3fcd96b86f.png">

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. Go to Components Demo and observe number input there is styled:
<img width="461" alt="Screen Shot 2019-05-21 at 2 18 01 PM" src="https://user-images.githubusercontent.com/7317227/58131558-d7c77600-7bd3-11e9-851d-0471b308fb15.png">


### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->