### PR TITLE
Remove js from phpcs check

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -30,7 +30,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<config name="testVersion" value="5.6-"/>
 
-	<arg name="extensions" value="php,js"/>
+	<arg name="extensions" value="php"/>
 
 	<!-- Show sniff codes in all reports -->
 	<arg value="s"/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Related #64 

- Removes the JS check from PHPCS. 
- We have prettier working nicely, and having two linters for JS code style seems excessive. Keeping rules for the two linters in sync would be difficult (so the lint rules don't conflict) .
- PHPCS is not designed to handle React. The linter cannot handle code like `<div foo={ bar }>` and our codebase generates hundreds of lines of errors similar to the following:
```
FILE:newspack/wp-content/plugins/newspack-plugin/assets/src/wizards/componentsDemo/index.js
------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 330 ERRORS AND 75 WARNINGS AFFECTING 129 LINES
------------------------------------------------------------------------------------------------------------------------------------------------------------
  47 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 12 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  53 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 12 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  72 | ERROR   | [x] Expected 1 space after "<"; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
  72 | ERROR   | [x] Expected 1 space before ">"; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
  73 | ERROR   | [x] Expected 1 space after "<"; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
  74 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 19 spaces but found 0 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  74 | ERROR   | [x] Expected 1 space before "="; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
  74 | ERROR   | [x] Expected 1 space after "="; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
  75 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 16 spaces but found 0 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  75 | ERROR   | [x] Expected 1 space before "="; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
  75 | ERROR   | [x] Expected 1 space after "="; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
  76 | ERROR   | [x] Expected 1 space after "/"; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
  76 | ERROR   | [x] Expected 1 space before ">"; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
...
```


### How to test the changes in this Pull Request:

1. `composer install` if phpcs isn't already installed.
2. `vendor/bin/phpcs`. You should just have one warning about `@package` tag in the main plugin file.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->