### PR TITLE
Subscriptions Wizard

### DIFF
--- a/assets/src/wizards/subscriptions/index.js
+++ b/assets/src/wizards/subscriptions/index.js
@@ -1,0 +1,157 @@
+/**
+ * Subscriptions Wizard.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, render } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import ManageSubscriptionsScreen from './views/manageSubscriptionsScreen';
+import EditSubscriptionScreen from './views/editSubscriptionScreen';
+import './style.scss';
+
+/**
+ * Subscriptions wizard for managing and setting up subscriptions.
+ */
+class SubscriptionsWizard extends Component {
+	/**
+	 * Constructor.
+	 */
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			subscriptions: [],
+			editing: false,
+			choosePrice: false,
+		};
+	}
+
+	/**
+	 * Get info when wizard is first loaded.
+	 */
+	componentDidMount() {
+		this.refreshSubscriptions();
+		this.refreshChoosePrice();
+	}
+
+	/**
+	 * Get the latest subscriptions info.
+	 */
+	refreshSubscriptions() {
+		apiFetch( { path: '/newspack/v1/wizard/subscriptions' } ).then( subscriptions => {
+			this.setState( {
+				subscriptions: subscriptions,
+			} );
+		} );
+	}
+
+	/**
+	 * Save the fields to a susbcription.
+	 */
+	saveSubscription( subscription ) {
+		const { id, name, image, price, frequency } = subscription;
+		const image_id = image ? image.id : 0;
+
+		apiFetch( {
+			path: '/newspack/v1/wizard/subscriptions',
+			method: 'post',
+			data: {
+				id: id,
+				name: name,
+				image_id: image_id,
+				price: price,
+				frequency: frequency,
+			},
+		} ).then( response => {
+			this.setState( {
+				editing: false,
+			} );
+			this.refreshSubscriptions();
+		} );
+	}
+
+	/**
+	 * Delete a subscription.
+	 *
+	 * @param int id Subscription ID.
+	 */
+	deleteSubscription( id ) {
+		if ( confirm( __( 'Are you sure you want to delete this subscription?' ) ) ) {
+			apiFetch( {
+				path: '/newspack/v1/wizard/subscriptions/' + id,
+				method: 'delete',
+			} ).then( response => {
+				this.refreshSubscriptions();
+			} );
+		}
+	}
+
+	/**
+	 * Get the latest info about the choosePrice setting.
+	 */
+	refreshChoosePrice() {
+		apiFetch( { path: '/newspack/v1/wizard/subscriptions/choose-price' } ).then( choosePrice => {
+			this.setState( {
+				choosePrice: !! choosePrice,
+			} );
+		} );
+	}
+
+	/**
+	 * Enable/Disable Name-Your-Price for Newspack subscriptions.
+	 */
+	toggleChoosePrice() {
+		this.setState(
+			{
+				choosePrice: ! this.state.choosePrice,
+			},
+			() => {
+				apiFetch( {
+					path: '/newspack/v1/wizard/subscriptions/choose-price',
+					method: 'post',
+					data: {
+						enabled: this.state.choosePrice,
+					},
+				} ).then( response => {
+					this.refreshSubscriptions();
+				} );
+			}
+		);
+	}
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const { subscriptions, editing, choosePrice } = this.state;
+
+		if ( !! editing ) {
+			return (
+				<EditSubscriptionScreen
+					subscription={ editing }
+					onChange={ subscription => { this.setState( { editing: subscription } ); } }
+					onClickSave={ subscription => this.saveSubscription( subscription ) }
+					onClickCancel={ () => this.setState( { editing: false } ) }
+				/>
+			);
+		} else {
+			return (
+				<ManageSubscriptionsScreen
+					subscriptions={ subscriptions }
+					choosePrice={ choosePrice }
+					onClickEditSubscription={ subscription => this.setState( { editing: subscription } ) }
+					onClickDeleteSubscription={ subscription => this.deleteSubscription( subscription.id ) }
+					onClickChoosePrice={ () => this.toggleChoosePrice() }
+				/>
+			);
+		}
+	}
+}
+
+render( <SubscriptionsWizard />, document.getElementById( 'newspack-subscriptions-wizard' ) );

--- a/assets/src/wizards/subscriptions/index.js
+++ b/assets/src/wizards/subscriptions/index.js
@@ -62,17 +62,21 @@ class SubscriptionsWizard extends Component {
 			path: '/newspack/v1/wizard/subscriptions',
 			method: 'post',
 			data: {
-				id: id,
-				name: name,
-				image_id: image_id,
-				price: price,
-				frequency: frequency,
+				id,
+				name,
+				image_id,
+				price,
+				frequency,
 			},
 		} ).then( response => {
-			this.setState( {
-				editing: false,
-			} );
-			this.refreshSubscriptions();
+			this.setState(
+				{
+					editing: false,
+				},
+				() => {
+					this.refreshSubscriptions();
+				}
+			);
 		} );
 	}
 
@@ -135,7 +139,7 @@ class SubscriptionsWizard extends Component {
 			return (
 				<EditSubscriptionScreen
 					subscription={ editing }
-					onChange={ subscription => { this.setState( { editing: subscription } ); } }
+					onChange={ subscription => this.setState( { editing: subscription } ) }
 					onClickSave={ subscription => this.saveSubscription( subscription ) }
 					onClickCancel={ () => this.setState( { editing: false } ) }
 				/>

--- a/assets/src/wizards/subscriptions/style.scss
+++ b/assets/src/wizards/subscriptions/style.scss
@@ -1,0 +1,134 @@
+/**
+ * Subscriptions Wizard styles.
+ */
+
+#newspack-subscriptions-wizard {
+	header.muriel-formatted-header {
+		margin-bottom: 32px;
+	}
+}
+
+/**
+ * Subscription management screen.
+ */
+.newspack-manage-subscriptions-screen {
+	max-width: 440px;
+	margin-left: auto;
+	margin-right: auto;
+
+	.newspack-manage-subscriptions-screen__finished {
+		display: block;
+		text-align: center;
+	}
+
+	.newspack-manage-subscriptions-screen__subscription-card {
+		display: flex;
+		justify-content: space-between;
+
+		.newspack-manage-subscriptions-screen__subscription-card__product-actions {
+			a {
+				display: block;
+				text-decoration: none;
+			}
+
+			.edit-subscription {
+				color: $muriel-hot-pink-400;
+				font-size: 16px;
+				margin-bottom: .25em;
+
+				&:hover {
+					color: $muriel-hot-pink-700;
+				}
+			}
+
+			.delete-subscription {
+				visibility: hidden;
+				color: $muriel-gray-100;
+
+				&:hover {
+					color: $muriel-gray-400;
+				}
+			}
+		}
+
+		.newspack-manage-subscriptions-screen__subscription-card__product-info {
+			width: 100%;
+
+			.product-name {
+				color: $muriel-gray-900;
+				font-size: 16px;
+				font-weight: 500;
+				margin-bottom: .25em;
+			}
+
+			.product-price {
+				color: $muriel-gray-400;
+			}
+		}
+
+		img {
+	 		border-radius: 50%;
+	 		height: 32px;
+	 		width: auto;
+	 		border: 1px solid $muriel-gray-400;
+	 		margin-right: 1.5em;
+	 		margin-top: 2px;
+		}
+
+		&:hover {
+			.delete-subscription {
+				visibility: visible;
+			}
+		}
+	}
+
+	button.is-primary {
+		margin-top: 3em;
+		margin-bottom: 2em;
+	}
+
+	.newspack-manage-subscriptions-screen__finished {
+		text-decoration: none;
+	}
+
+	.newspack-manage-subscriptions-screen__choose-price {
+		margin-top: 2em;
+	}
+}
+
+/**
+ * Subscription editing screen.
+ */
+.newspack-edit-subscription-screen {
+	.newspack-edit-subscription-screen__price-settings {
+		display: flex;
+		justify-content: space-between;
+
+		& > div {
+			width: 50%;
+
+			&:first-of-type {
+				margin-right: .5em;
+			}
+
+			&:last-of-type {
+				margin-left: .5em;
+			}
+		}
+	}
+
+	.muriel-image-upload {
+		margin-top: 3em;
+		margin-bottom: 2em;
+	}
+
+	button.is-primary {
+		margin-bottom: 2em;
+	}
+
+	.newspack-edit-subscription-screen__cancel {
+		display: block;
+		text-align: center;
+		text-decoration: none;
+	}
+}

--- a/assets/src/wizards/subscriptions/style.scss
+++ b/assets/src/wizards/subscriptions/style.scss
@@ -16,107 +16,90 @@
 	margin-left: auto;
 	margin-right: auto;
 
-	.newspack-manage-subscriptions-screen__finished {
-		display: block;
-		text-align: center;
-	}
-
-	.newspack-manage-subscriptions-screen__subscription-card {
-		display: flex;
-		justify-content: space-between;
-
-		.newspack-manage-subscriptions-screen__subscription-card__product-actions {
-			a {
-				display: block;
-				text-decoration: none;
-			}
-
-			.edit-subscription {
-				color: $muriel-hot-pink-400;
-				font-size: 16px;
-				margin-bottom: .25em;
-
-				&:hover {
-					color: $muriel-hot-pink-700;
-				}
-			}
-
-			.delete-subscription {
-				visibility: hidden;
-				color: $muriel-gray-100;
-
-				&:hover {
-					color: $muriel-gray-400;
-				}
-			}
-		}
-
-		.newspack-manage-subscriptions-screen__subscription-card__product-info {
-			width: 100%;
-
-			.product-name {
-				color: $muriel-gray-900;
-				font-size: 16px;
-				font-weight: 500;
-				margin-bottom: .25em;
-			}
-
-			.product-price {
-				color: $muriel-gray-400;
-			}
-		}
-
-		img {
-	 		border-radius: 50%;
-	 		height: 32px;
-	 		width: auto;
-	 		border: 1px solid $muriel-gray-400;
-	 		margin-right: 1.5em;
-	 		margin-top: 2px;
-		}
-
-		&:hover {
-			.delete-subscription {
-				visibility: visible;
-			}
-		}
-	}
-
 	button.is-primary {
 		margin-top: 3em;
 		margin-bottom: 2em;
 	}
+}
 
-	.newspack-manage-subscriptions-screen__finished {
+.newspack-manage-subscriptions-screen__finished {
+	display: block;
+	text-align: center;
+}
+
+.newspack-manage-subscriptions-screen__subscription-card {
+	display: flex;
+	justify-content: space-between;
+
+	img {
+ 		border-radius: 50%;
+ 		height: 32px;
+ 		width: auto;
+ 		border: 1px solid $muriel-gray-400;
+ 		margin-right: 1.5em;
+ 		margin-top: 2px;
+	}
+
+	&:hover {
+		.delete-subscription {
+			visibility: visible;
+		}
+	}
+}
+
+.newspack-manage-subscriptions-screen__subscription-card__product-actions {
+	a {
+		display: block;
 		text-decoration: none;
 	}
 
-	.newspack-manage-subscriptions-screen__choose-price {
-		margin-top: 2em;
+	.edit-subscription {
+		color: $muriel-hot-pink-400;
+		font-size: 16px;
+		margin-bottom: .25em;
+
+		&:hover {
+			color: $muriel-hot-pink-700;
+		}
 	}
+
+	.delete-subscription {
+		visibility: hidden;
+		color: $muriel-gray-100;
+
+		&:hover {
+			color: $muriel-gray-400;
+		}
+	}
+}
+
+.newspack-manage-subscriptions-screen__subscription-card__product-info {
+	width: 100%;
+
+	.product-name {
+		color: $muriel-gray-900;
+		font-size: 16px;
+		font-weight: 500;
+		margin-bottom: .25em;
+	}
+
+	.product-price {
+		color: $muriel-gray-400;
+	}
+}
+
+.newspack-manage-subscriptions-screen__finished {
+	text-decoration: none;
+}
+
+.newspack-manage-subscriptions-screen__choose-price {
+	margin-top: 2em;
 }
 
 /**
  * Subscription editing screen.
  */
 .newspack-edit-subscription-screen {
-	.newspack-edit-subscription-screen__price-settings {
-		display: flex;
-		justify-content: space-between;
-
-		& > div {
-			width: 50%;
-
-			&:first-of-type {
-				margin-right: .5em;
-			}
-
-			&:last-of-type {
-				margin-left: .5em;
-			}
-		}
-	}
-
 	.muriel-image-upload {
 		margin-top: 3em;
 		margin-bottom: 2em;
@@ -125,10 +108,21 @@
 	button.is-primary {
 		margin-bottom: 2em;
 	}
+}
 
-	.newspack-edit-subscription-screen__cancel {
-		display: block;
-		text-align: center;
-		text-decoration: none;
+.newspack-edit-subscription-screen__price-settings {
+	display: flex;
+	justify-content: space-between;
+
+	& > div {
+		width: 50%;
+
+		&:first-of-type {
+			margin-right: .5em;
+		}
+
+		&:last-of-type {
+			margin-left: .5em;
+		}
 	}
 }

--- a/assets/src/wizards/subscriptions/views/editSubscriptionScreen.js
+++ b/assets/src/wizards/subscriptions/views/editSubscriptionScreen.js
@@ -1,0 +1,107 @@
+/**
+ * New/Edit Subscription Screen.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	Card,
+	FormattedHeader,
+	Button,
+	TextControl,
+	ImageUpload,
+	SelectControl,
+} from '../../../components';
+
+/**
+ * New/Edit Subscription Screen.
+ */
+class EditSubscriptionScreen extends Component {
+	/**
+	 * Handle an update to a subscription field.
+	 *
+	 * @param string key Subscription field
+	 * @param mixed  value New value for field
+	 *
+	 */
+	handleOnChange( key, value ) {
+		const { subscription, onChange } = this.props;
+		subscription[ key ] = value;
+		onChange( subscription );
+	}
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const { subscription, onClickSave, onClickCancel } = this.props;
+		const { id, name, price, frequency } = subscription;
+		let { image } = subscription;
+		if ( ! image || '0' === image.id ) {
+			image = null;
+		}
+
+		const editing_existing_subscription = !! id;
+		const heading = editing_existing_subscription
+			? __( 'Edit subscription' )
+			: __( 'Add a subscription' );
+		const subHeading = editing_existing_subscription
+			? __( 'You are editing an existing subscription' )
+			: __( 'You are adding a new subscription' );
+
+		return (
+			<div className="newspack-edit-subscription-screen">
+				<FormattedHeader headerText={ heading } subHeaderText={ subHeading } />
+				<Card>
+					<TextControl
+						label={ __( 'What is this product called? e.g. Valued Donor' ) }
+						value={ name }
+						onChange={ value => this.handleOnChange( 'name', value ) }
+					/>
+					<ImageUpload
+						image={ image }
+						onChange={ value => this.handleOnChange( 'image', value ) }
+					/>
+					<div className="newspack-edit-subscription-screen__price-settings">
+						<TextControl
+							type="number"
+							step="0.01"
+							label={ __( 'Price' ) }
+							value={ price }
+							onChange={ value => this.handleOnChange( 'price', value ) }
+						/>
+						<SelectControl
+							label={ __( 'Frequency' ) }
+							value={ frequency }
+							options={ [
+								{ value: 'month', label: __( 'per month' ) },
+								{ value: 'year', label: __( 'per year' ) },
+								{ value: 'once', label: __( 'once' ) },
+							] }
+							onChange={ value => this.handleOnChange( 'frequency', value ) }
+						/>
+					</div>
+					<Button isPrimary className="is-centered" onClick={ () => onClickSave( subscription ) }>
+						{ __( 'Save' ) }
+					</Button>
+					<a
+						className="newspack-edit-subscription-screen__cancel"
+						href="#"
+						onClick={ () => onClickCancel() }
+					>
+						{ __( 'Cancel' ) }
+					</a>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default EditSubscriptionScreen;

--- a/assets/src/wizards/subscriptions/views/editSubscriptionScreen.js
+++ b/assets/src/wizards/subscriptions/views/editSubscriptionScreen.js
@@ -91,13 +91,13 @@ class EditSubscriptionScreen extends Component {
 					<Button isPrimary className="is-centered" onClick={ () => onClickSave( subscription ) }>
 						{ __( 'Save' ) }
 					</Button>
-					<a
-						className="newspack-edit-subscription-screen__cancel"
+					<Button
+						className="newspack-edit-subscription-screen__cancel isLink is-centered is-tertiary"
 						href="#"
 						onClick={ () => onClickCancel() }
 					>
 						{ __( 'Cancel' ) }
-					</a>
+					</Button>
 				</Card>
 			</div>
 		);

--- a/assets/src/wizards/subscriptions/views/manageSubscriptionsScreen.js
+++ b/assets/src/wizards/subscriptions/views/manageSubscriptionsScreen.js
@@ -1,0 +1,108 @@
+/**
+ * Subscription Management Screens.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Card, FormattedHeader, Button, CheckboxControl } from '../../../components';
+
+/**
+ * Subscriptions management screen.
+ */
+class ManageSubscriptionsScreen extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const {
+			subscriptions,
+			choosePrice,
+			onClickEditSubscription,
+			onClickDeleteSubscription,
+			onClickChoosePrice,
+		} = this.props;
+
+		const headerText = subscriptions.length
+			? __( 'Any more subscriptions to add?' )
+			: __( 'Add your first subscription' );
+		const buttonText = subscriptions.length
+			? __( 'Add another subscription' )
+			: __( 'Add a subscription' );
+
+		return (
+			<div className="newspack-manage-subscriptions-screen">
+				<FormattedHeader
+					headerText={ headerText }
+					subHeaderText={ __( 'Subscriptions can provide a stable, recurring source of revenue' ) }
+				/>
+				{ subscriptions.map( subscription => {
+					const { id, image, name, display_price, url } = subscription;
+
+					return (
+						<Card className="newspack-manage-subscriptions-screen__subscription-card" key={ id }>
+							<a href={ url } target="_blank">
+								<img src={ image ? image.url : '' } />
+							</a>
+							<div className="newspack-manage-subscriptions-screen__subscription-card__product-info">
+								<div className="product-name">{ name }</div>
+								<div className="product-price">{ display_price }</div>
+							</div>
+							<div className="newspack-manage-subscriptions-screen__subscription-card__product-actions">
+								<a
+									className="edit-subscription"
+									href="#"
+									onClick={ () => onClickEditSubscription( subscription ) }
+								>
+									{ __( 'Edit' ) }
+								</a>
+								<a
+									className="delete-subscription"
+									href="#"
+									onClick={ () => onClickDeleteSubscription( subscription ) }
+								>
+									{ __( 'Delete' ) }
+								</a>
+							</div>
+						</Card>
+					);
+				} ) }
+				{ !! subscriptions.length && (
+					<CheckboxControl
+						className="newspack-manage-subscriptions-screen__choose-price"
+						label={ __( 'Allow members to specify donation amount' ) }
+						onChange={ () => onClickChoosePrice() }
+						tooltip={ __(
+							'Enabling this makes the subscription price a "Recommended price" and allows subscribers to set the subscription price when purchasing.'
+						) }
+						help={ __( 'Mostly used for donations' ) }
+						checked={ choosePrice }
+					/>
+				) }
+				<Button
+					isPrimary
+					className="is-centered"
+					onClick={ () =>
+						onClickEditSubscription( {
+							id: 0,
+							name: '',
+							image: null,
+							price: '',
+							frequency: 'month',
+						} )
+					}
+				>
+					{ buttonText }
+				</Button>
+			</div>
+		);
+	}
+}
+
+export default ManageSubscriptionsScreen;

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -61,6 +61,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 
 		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-components-demo.php';
+		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-subscriptions-wizard.php';
 	}
 
 	/**

--- a/includes/wizards/class-subscriptions-wizard.php
+++ b/includes/wizards/class-subscriptions-wizard.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * Newspack subscriptions setup and management.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WC_Subscriptions_Product, \WC_Product_Simple, \WC_Product_Subscription, \WC_Name_Your_Price_Helpers;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Easy interface for managing subscriptions.
+ */
+class Subscriptions_Wizard extends Wizard {
+
+	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Subscriptions';
+
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-subscriptions-wizard';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'edit_products';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+		add_filter( 'woocommerce_product_data_store_cpt_get_products_query', [ $this, 'handle_only_get_newspack_subscriptions_query' ], 10, 2 );
+	}
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public function register_api_endpoints() {
+		// Get all Newspack subscriptions.
+		register_rest_route(
+			'newspack/v1/wizard/',
+			'/subscriptions/',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'api_get_subscriptions' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		// Get one subscription.
+		register_rest_route(
+			'newspack/v1/wizard/',
+			'/subscriptions/(?P<id>\d+)',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'api_get_subscription' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'id' => [
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+
+		// Save a subscription.
+		register_rest_route(
+			'newspack/v1/wizard/',
+			'/subscriptions/',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ $this, 'api_save_subscription' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'id'        => [
+						'sanitize_callback' => 'absint',
+					],
+					'image'     => [
+						'sanitize_callback' => 'absint',
+					],
+					'name'      => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'price'     => [
+						'sanitize_callback' => 'wc_format_decimal',
+					],
+					'frequency' => [
+						'sanitize_callback' => 'sanitize_title',
+					],
+				],
+			]
+		);
+
+		// Delete a subscription.
+		register_rest_route(
+			'newspack/v1/wizard/',
+			'/subscriptions/(?P<id>\d+)',
+			[
+				'methods'             => 'DELETE',
+				'callback'            => [ $this, 'api_delete_subscription' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'id' => [
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+
+		// Get NYP status.
+		register_rest_route(
+			'newspack/v1/wizard/',
+			'/subscriptions/choose-price/',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'api_get_choose_price' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		// Enable/Disable NYP for Newspack subscriptions.
+		register_rest_route(
+			'newspack/v1/wizard/',
+			'/subscriptions/choose-price/',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ $this, 'api_set_choose_price' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'enabled' => [
+						'sanitize_callback' => 'wc_string_to_bool',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get the Newspack subscriptions.
+	 *
+	 * @return WP_REST_Response containing subscriptions info.
+	 */
+	public function api_get_subscriptions() {
+		$products = wc_get_products(
+			[
+				'limit'                           => -1,
+				'only_get_newspack_subscriptions' => true,
+			]
+		);
+
+		$response = [];
+		foreach ( $products as $product ) {
+			$response[] = $this->get_product_data_for_api( $product );
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Get one subscription.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response containing subscription info.
+	 */
+	public function api_get_subscription( $request ) {
+		$params  = $request->get_params();
+		$id      = $params['id'];
+		$product = wc_get_product( $params['id'] );
+		if ( ! $product ) {
+			return new WP_Error(
+				'newspack_rest_invalid_product',
+				esc_html__( 'Resource does not exist.', 'newspack' ),
+				[
+					'status' => 404,
+				]
+			);
+		}
+
+		return rest_ensure_response( $this->get_product_data_for_api( $product ) );
+	}
+
+	/**
+	 * Get information about one product, suitable for the API.
+	 *
+	 * @param WC_Product $product Product to get info for.
+	 * @return array of information about the product.
+	 */
+	protected function get_product_data_for_api( $product ) {
+		return [
+			'id'            => $product->get_id(),
+			'name'          => $product->get_name(),
+			'price'         => $product->get_regular_price(),
+			'display_price' => wp_strip_all_tags( html_entity_decode( $product->get_price_html() ) ),
+			'url'           => $product->get_permalink(),
+			'frequency'     => WC_Subscriptions_Product::get_period( $product ) ? WC_Subscriptions_Product::get_period( $product ) : 'once',
+			'image'         => [
+				'id'  => $product->get_image_id(),
+				'url' => $product->get_image_id() ? current( wp_get_attachment_image_src( $product->get_image_id(), 'woocommerce_thumbnail' ) ) : wc_placeholder_img_src( 'woocommerce_thumbnail' ),
+			],
+		];
+	}
+
+	/**
+	 * Save a subscription.
+	 *
+	 * @param WP_REST_Request $request Product info.
+	 * @return WP_REST_Response Updated product info.
+	 */
+	public function api_save_subscription( $request ) {
+		$params   = $request->get_params();
+		$defaults = [
+			'id'        => 0,
+			'name'      => '',
+			'image_id'  => 0,
+			'price'     => 0.0,
+			'frequency' => 'once',
+		];
+		$args     = wp_parse_args( $params, $defaults );
+
+		if ( 'once' === $args['frequency'] ) {
+			$product = new \WC_Product_Simple( $args['id'] );
+		} else {
+			$product = new \WC_Product_Subscription( $args['id'] );
+		}
+
+		$product->set_name( $args['name'] );
+		$product->set_virtual( true );
+		$product->set_image_id( $args['image_id'] );
+		$product->set_regular_price( $args['price'] );
+
+		// Set one-page checkout 'on' for this product.
+		$product->update_meta_data( '_wcopc', 'yes' );
+
+		// Set 'Name your price' settings.
+		$product->update_meta_data( '_suggested_price', $args['price'] );
+		$product->update_meta_data( '_hide_nyp_minimum', 'yes' );
+		$product->update_meta_data( '_min_price', wc_format_decimal( 1.0 ) );
+		if ( $this->get_choose_price() ) {
+			$product->update_meta_data( '_nyp', 'yes' );
+		}
+
+		// Mark product as created through the Subscription Wizard.
+		$product->update_meta_data( 'newspack_created_subscription', 1 );
+
+		// Add subscription info.
+		if ( 'once' !== $args['frequency'] ) {
+			$product->update_meta_data( '_subscription_price', wc_format_decimal( $args['price'] ) );
+			$product->update_meta_data( '_subscription_period', 'month' === $args['frequency'] ? 'month' : 'year' );
+			$product->update_meta_data( '_subscription_period_interval', 1 );
+		}
+
+		$product->save();
+
+		return rest_ensure_response( $this->get_product_data_for_api( $product ) );
+	}
+
+	/**
+	 * Delete a subscription.
+	 *
+	 * @param WP_REST_Request $request Request with ID of product to delete.
+	 * @return WP_REST_Response Boolean delete success.
+	 */
+	public function api_delete_subscription( $request ) {
+		$params  = $request->get_params();
+		$id      = $params['id'];
+		$product = wc_get_product( $params['id'] );
+		if ( ! $product ) {
+			return rest_ensure_response( false );
+		}
+
+		return rest_ensure_response( $product->delete( true ) );
+	}
+
+	/**
+	 * Get whether choose price is enabled through the API.
+	 *
+	 * @return WP_REST_Response Boolean whether it's enabled.
+	 */
+	public function api_get_choose_price() {
+		return rest_ensure_response( $this->get_choose_price() );
+	}
+
+	/**
+	 * Get whether choose price is enabled.
+	 *
+	 * @return bool
+	 */
+	protected function get_choose_price() {
+		// Check one product to determine whether NYP is enabled, and generalize to all products.
+		$products = wc_get_products(
+			[
+				'limit'                           => 1,
+				'only_get_newspack_subscriptions' => true,
+			]
+		);
+
+		if ( empty( $products ) ) {
+			return false;
+		}
+
+		return (bool) WC_Name_Your_Price_Helpers::is_nyp( $products[0] );
+	}
+
+	/**
+	 * Set choose price to true/false for all Newspack subscriptions.
+	 *
+	 * @param WP_REST_Request $request Enable or disable.
+	 * @return WP_REST_Response The updated setting.
+	 */
+	public function api_set_choose_price( $request ) {
+		$params   = $request->get_params();
+		$enabled  = $params['enabled'];
+		$setting  = $enabled ? 'yes' : '';
+		$products = wc_get_products(
+			[
+				'limit'                           => -1,
+				'only_get_newspack_subscriptions' => true,
+			]
+		);
+
+		foreach ( $products as $product ) {
+			$product->update_meta_data( '_nyp', $setting );
+			$product->save();
+		}
+
+		return $this->api_get_choose_price();
+	}
+
+	/**
+	 * Hook into wc_get_products to handle filtering by only products created through the Newspack Subscriptions Wizard.
+	 *
+	 * @param array $query WP_Query args.
+	 * @param array $query_vars Args passed into wc_get_products.
+	 */
+	public function handle_only_get_newspack_subscriptions_query( $query, $query_vars ) {
+		if ( ! empty( $query_vars['only_get_newspack_subscriptions'] ) ) {
+			$query['meta_query'][] = [
+				'key'   => 'newspack_created_subscription',
+				'value' => 1,
+			];
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Enqueue Subscriptions Wizard scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		parent::enqueue_scripts_and_styles();
+		wp_enqueue_media();
+
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'newspack-subscriptions-wizard',
+			Newspack::plugin_url() . '/assets/dist/subscriptions.js',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/subscriptions.js' ),
+			true
+		);
+
+		wp_register_style(
+			'newspack-subscriptions-wizard',
+			Newspack::plugin_url() . '/assets/dist/subscriptions.css',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/subscriptions.css' )
+		);
+		wp_style_add_data( 'newspack-subscriptions-wizard', 'rtl', 'replace' );
+		wp_enqueue_style( 'newspack-subscriptions-wizard' );
+	}
+}
+new Subscriptions_Wizard();

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -68,4 +68,23 @@ class Wizard {
 			return;
 		}
 	}
+
+	/**
+	 * Check capabilities for using API.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return bool|WP_Error
+	 */
+	public function api_permissions_check( $request ) {
+		if ( ! current_user_can( $this->capability ) ) {
+			return new \WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				[
+					'status' => 403,
+				]
+			);
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #53 .
Supersedes #15.
Supersedes #64 .

This implementation of the subscriptions wizard does so with all of the state pulled up into the main wizard class, as per @jeffersonrabb's suggestion. I think it was a good suggestion, and this seems easier to maintain and follow the code logic.

### How to test the changes in this Pull Request:

1. `npm ci; npm run clean; npm run build:webpack`
2. Go to Newspack > Subscriptions and use the wizard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->