### PR TITLE
Action Card Component

### DIFF
--- a/assets/src/components/action-card/index.js
+++ b/assets/src/components/action-card/index.js
@@ -48,11 +48,11 @@ class ActionCard extends Component {
 			notification,
 			notificationLevel,
 			actionText,
-			secondaryActionText,
+			deletionText,
 			image,
 			imageLink,
 			onClick,
-			onSecondaryClick,
+			onDeletionClick,
 		} = this.props;
 		const classes = murielClassnames( 'newspack-action-card', className );
 		const notificationClasses = classnames(
@@ -86,7 +86,7 @@ class ActionCard extends Component {
 								'newspack-action-card__region',
 								'newspack-action-card__region-right',
 								'button' === actionType &&
-									secondaryActionText &&
+									deletionText &&
 									'newspack-action-card__region-right__double-button'
 							) }
 						>
@@ -95,13 +95,13 @@ class ActionCard extends Component {
 									{ actionText }
 								</Button>
 							) }
-							{ 'button' === actionType && secondaryActionText && (
+							{ 'button' === actionType && deletionText && (
 								<Button
 									isLink
-									onClick={ onSecondaryClick }
-									className="newspack-action-card__secondary_button"
+									onClick={ onDeletionClick }
+									className="newspack-action-card__deletion_button"
 								>
-									{ secondaryActionText }
+									{ deletionText }
 								</Button>
 							) }
 							{ 'spinner' === actionType && (

--- a/assets/src/components/action-card/index.js
+++ b/assets/src/components/action-card/index.js
@@ -56,7 +56,6 @@ class ActionCard extends Component {
 			imageLink,
 			onClick,
 			onSecondaryClick,
-			onImageClick,
 		} = this.props;
 		const classes = murielClassnames( 'newspack-action-card', className );
 		const notificationClasses = classnames(
@@ -73,7 +72,6 @@ class ActionCard extends Component {
 							<a href={ imageLink }>
 								<div
 									className="newspack-action-card__image"
-									onClick={ onImageClick }
 									style={ this.backgroundImageStyles( image ) }
 								/>
 							</a>

--- a/assets/src/components/action-card/index.js
+++ b/assets/src/components/action-card/index.js
@@ -22,17 +22,6 @@ import './style.scss';
 import classnames from 'classnames';
 
 class ActionCard extends Component {
-	actionTypeFromProps = props => {
-		const { isButton, isSpinner } = props;
-		if ( isButton ) {
-			return 'button';
-		}
-		if ( isSpinner ) {
-			return 'spinner';
-		}
-		return 'none';
-	};
-
 	backgroundImageStyles = url => {
 		return url ? { backgroundImage: `url(${ url })` } : {};
 	};
@@ -53,6 +42,7 @@ class ActionCard extends Component {
 			imageLink,
 			onClick,
 			onSecondaryActionClick,
+			isWaiting,
 		} = this.props;
 		const classes = murielClassnames( 'newspack-action-card', className );
 		const notificationClasses = classnames(
@@ -60,9 +50,9 @@ class ActionCard extends Component {
 			'notice',
 			`notice-${ notificationLevel }`,
 			'notice-alt',
-			'update-message',
+			'update-message'
 		);
-		const actionType = this.actionTypeFromProps( this.props );
+		const hasSecondaryAction = secondaryActionText && onSecondaryActionClick;
 		return (
 			<Card className={ classes }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
@@ -81,21 +71,21 @@ class ActionCard extends Component {
 						<h2>{ description }</h2>
 					</div>
 					{ actionText && (
-						<div
-							className={ classnames(
-								'newspack-action-card__region',
-								'newspack-action-card__region-right',
-								'button' === actionType &&
-									secondaryActionText &&
-									'newspack-action-card__region-right__double-button'
-							) }
-						>
-							{ 'button' === actionType && (
+						<div className="newspack-action-card__region newspack-action-card__region-right">
+							{ actionText && onClick && (
 								<Button isLink onClick={ onClick } className="newspack-action-card__primary_button">
 									{ actionText }
 								</Button>
 							) }
-							{ 'button' === actionType && secondaryActionText && (
+
+							{ actionText && ! onClick && (
+								<div className="newspack-action-card__container">
+									{ isWaiting && <Spinner /> }
+									{ actionText }
+								</div>
+							) }
+
+							{ secondaryActionText && onSecondaryActionClick && (
 								<Button
 									isLink
 									onClick={ onSecondaryActionClick }
@@ -103,15 +93,6 @@ class ActionCard extends Component {
 								>
 									{ secondaryActionText }
 								</Button>
-							) }
-							{ 'spinner' === actionType && (
-								<div className="newspack-action-card__action-type__spinner">
-									<Spinner />
-									{ actionText }
-								</div>
-							) }
-							{ 'none' === actionType && (
-								<p className="newspack-action-card__action-type__none">{ actionText }</p>
 							) }
 						</div>
 					) }

--- a/assets/src/components/action-card/index.js
+++ b/assets/src/components/action-card/index.js
@@ -65,7 +65,7 @@ class ActionCard extends Component {
 		const actionType = this.actionTypeFromProps( this.props );
 		return (
 			<Card className={ classes }>
-				<div className="newspack-action-card__upper">
+				<div className="newspack-action-card__region newspack-action-card__region-top">
 					{ image && (
 						<div className="newspack-action-card__region newspack-action-card__region-left">
 							<a href={ imageLink }>
@@ -107,7 +107,7 @@ class ActionCard extends Component {
 							{ 'spinner' === actionType && (
 								<div className="newspack-action-card__action-type__spinner">
 									<Spinner />
-									<p>{ actionText }</p>
+									{ actionText }
 								</div>
 							) }
 							{ 'none' === actionType && (

--- a/assets/src/components/action-card/index.js
+++ b/assets/src/components/action-card/index.js
@@ -23,12 +23,9 @@ import classnames from 'classnames';
 
 class ActionCard extends Component {
 	actionTypeFromProps = props => {
-		const { isButton, isExternalLink, isSpinner } = props;
+		const { isButton, isSpinner } = props;
 		if ( isButton ) {
 			return 'button';
-		}
-		if ( isExternalLink ) {
-			return 'external_link';
 		}
 		if ( isSpinner ) {
 			return 'spinner';
@@ -61,7 +58,9 @@ class ActionCard extends Component {
 		const notificationClasses = classnames(
 			'newspack-action-card__notification',
 			'notice',
-			`notice-${ notificationLevel }`
+			`notice-${ notificationLevel }`,
+			'notice-alt',
+			'update-message',
 		);
 		const actionType = this.actionTypeFromProps( this.props );
 		return (

--- a/assets/src/components/action-card/index.js
+++ b/assets/src/components/action-card/index.js
@@ -1,0 +1,132 @@
+/**
+ * Action cards.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Component } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
+import { Button, Card } from '../';
+
+/**
+ * Internal dependencies
+ */
+import murielClassnames from '../../shared/js/muriel-classnames';
+import './style.scss';
+
+/**
+ * External dependencies
+ */
+
+import classnames from 'classnames';
+
+class ActionCard extends Component {
+	actionTypeFromProps = props => {
+		const { isButton, isExternalLink, isSpinner } = props;
+		if ( isButton ) {
+			return 'button';
+		}
+		if ( isExternalLink ) {
+			return 'external_link';
+		}
+		if ( isSpinner ) {
+			return 'spinner';
+		}
+		return 'none';
+	};
+
+	backgroundImageStyles = url => {
+		return url ? { backgroundImage: `url(${ url })` } : {};
+	};
+
+	/**
+	 * Render.
+	 */
+	render( props ) {
+		const {
+			className,
+			title,
+			description,
+			notification,
+			notificationLevel,
+			actionText,
+			secondaryActionText,
+			image,
+			imageLink,
+			onClick,
+			onSecondaryClick,
+			onImageClick,
+		} = this.props;
+		const classes = murielClassnames( 'newspack-action-card', className );
+		const notificationClasses = classnames(
+			'newspack-action-card__notification',
+			'notice',
+			`notice-${ notificationLevel }`
+		);
+		const actionType = this.actionTypeFromProps( this.props );
+		return (
+			<Card className={ classes }>
+				<div className="newspack-action-card__upper">
+					{ image && (
+						<div className="newspack-action-card__region newspack-action-card__region-left">
+							<a href={ imageLink }>
+								<div
+									className="newspack-action-card__image"
+									onClick={ onImageClick }
+									style={ this.backgroundImageStyles( image ) }
+								/>
+							</a>
+						</div>
+					) }
+					<div className="newspack-action-card__region newspack-action-card__region-center">
+						<h1>{ title }</h1>
+						<h2>{ description }</h2>
+					</div>
+					{ actionText && (
+						<div
+							className={ classnames(
+								'newspack-action-card__region',
+								'newspack-action-card__region-right',
+								'button' === actionType &&
+									secondaryActionText &&
+									'newspack-action-card__region-right__double-button'
+							) }
+						>
+							{ 'button' === actionType && (
+								<Button isLink onClick={ onClick } className="newspack-action-card__primary_button">
+									{ actionText }
+								</Button>
+							) }
+							{ 'button' === actionType && secondaryActionText && (
+								<Button
+									isLink
+									onClick={ onSecondaryClick }
+									className="newspack-action-card__secondary_button"
+								>
+									{ secondaryActionText }
+								</Button>
+							) }
+							{ 'spinner' === actionType && (
+								<div className="newspack-action-card__action-type__spinner">
+									<Spinner />
+									<p>{ actionText }</p>
+								</div>
+							) }
+							{ 'none' === actionType && (
+								<p className="newspack-action-card__action-type__none">{ actionText }</p>
+							) }
+						</div>
+					) }
+				</div>
+				{ notification && (
+					<div className={ notificationClasses }>
+						<p>{ notification }</p>
+					</div>
+				) }
+			</Card>
+		);
+	}
+}
+
+export default ActionCard;

--- a/assets/src/components/action-card/index.js
+++ b/assets/src/components/action-card/index.js
@@ -48,11 +48,11 @@ class ActionCard extends Component {
 			notification,
 			notificationLevel,
 			actionText,
-			deletionText,
+			secondaryActionText,
 			image,
 			imageLink,
 			onClick,
-			onDeletionClick,
+			onSecondaryActionClick,
 		} = this.props;
 		const classes = murielClassnames( 'newspack-action-card', className );
 		const notificationClasses = classnames(
@@ -86,7 +86,7 @@ class ActionCard extends Component {
 								'newspack-action-card__region',
 								'newspack-action-card__region-right',
 								'button' === actionType &&
-									deletionText &&
+									secondaryActionText &&
 									'newspack-action-card__region-right__double-button'
 							) }
 						>
@@ -95,13 +95,13 @@ class ActionCard extends Component {
 									{ actionText }
 								</Button>
 							) }
-							{ 'button' === actionType && deletionText && (
+							{ 'button' === actionType && secondaryActionText && (
 								<Button
 									isLink
-									onClick={ onDeletionClick }
-									className="newspack-action-card__deletion_button"
+									onClick={ onSecondaryActionClick }
+									className="newspack-action-card__secondary_button"
 								>
-									{ deletionText }
+									{ secondaryActionText }
 								</Button>
 							) }
 							{ 'spinner' === actionType && (

--- a/assets/src/components/action-card/style.scss
+++ b/assets/src/components/action-card/style.scss
@@ -1,0 +1,92 @@
+/**
+ * Button styles,
+ */
+
+@import '../../shared/scss/muriel-component';
+
+.newspack-action-card {
+	.newspack-action-card__upper {
+		display: flex;
+	}
+	.newspack-action-card__region {
+		display: flex;
+		flex-grow: 0;
+		flex-direction: column;
+		align-items: flex-start;
+		margin: 0;
+	}
+	.newspack-action-card__region-left {
+		margin-right: 1.5em;
+	}
+	.newspack-action-card__region-center {
+		flex-grow: 1;
+	}
+	.newspack-action-card__region-right {
+		align-items: flex-end;
+		justify-content: center;
+		margin-left: 1.5em;
+		p {
+			margin: 0;
+		}
+		.newspack-action-card__action-type__none {
+			color: $muriel-gray-300;
+		}
+		.newspack-action-card__action-type__spinner {
+			display: flex;
+			align-items: center;
+			color: $muriel-gray-300;
+			.components-spinner {
+				margin-top: 0;
+				margin-bottom: 0;
+			}
+		}
+		&.newspack-action-card__region-right__double-button {
+			justify-content: flex-start;
+		}
+	}
+	.newspack-action-card__notification {
+		margin: 14px 0 0 0;
+	}
+	.newspack-action-card__none {
+		color: $muriel-gray-300;
+	}
+	h1, h2 {
+		margin: 0;
+		padding: 0;
+		font-weight: normal;
+	}
+	h1 {
+		font-size: 16px;
+		color: $muriel-gray-900;
+		line-height: 21px;
+	}
+	h2 {
+		color: $muriel-gray-600;
+		font-size: 14px;
+		line-height: 16px;
+	}
+	.newspack-action-card__image {
+		background-position: center;
+		background-repeat: no-repeat;
+		background-size: cover;
+ 		border-radius: 50%;
+ 		height: 32px;
+ 		width: 32px;
+ 		border: 1px solid $muriel-gray-400;
+	}
+	.newspack-action-card__primary_button {
+		&.is-link {
+			color: $muriel-blue-500;
+		}
+	}
+	.newspack-action-card__secondary_button {
+		display: none;
+		&.is-link {
+			color: $muriel-gray-300;
+			text-decoration: none;
+		}
+	}
+	&:hover .newspack-action-card__secondary_button {
+		display: block;
+	}
+}

--- a/assets/src/components/action-card/style.scss
+++ b/assets/src/components/action-card/style.scss
@@ -83,13 +83,13 @@
 		}
 	}
 	.newspack-action-card__secondary_button {
-		display: none;
+		visibility: hidden;
 		&.is-link {
 			color: $muriel-red-300;
 		}
 	}
 	&:hover .newspack-action-card__secondary_button {
-		display: block;
+		visibility: visible;
 	}
 }
 

--- a/assets/src/components/action-card/style.scss
+++ b/assets/src/components/action-card/style.scss
@@ -82,14 +82,13 @@
 			color: $muriel-blue-500;
 		}
 	}
-	.newspack-action-card__secondary_button {
+	.newspack-action-card__deletion_button {
 		display: none;
 		&.is-link {
-			color: $muriel-gray-300;
-			text-decoration: none;
+			color: $muriel-red-300;
 		}
 	}
-	&:hover .newspack-action-card__secondary_button {
+	&:hover .newspack-action-card__deletion_button {
 		display: block;
 	}
 }

--- a/assets/src/components/action-card/style.scss
+++ b/assets/src/components/action-card/style.scss
@@ -46,6 +46,9 @@
 	}
 	.newspack-action-card__notification {
 		margin: 14px 0 0 0;
+		p:before {
+			margin-right: 6px;
+		}
 	}
 	.newspack-action-card__none {
 		color: $muriel-gray-300;
@@ -90,3 +93,4 @@
 		display: block;
 	}
 }
+

--- a/assets/src/components/action-card/style.scss
+++ b/assets/src/components/action-card/style.scss
@@ -5,32 +5,62 @@
 @import '../../shared/scss/muriel-component';
 
 .newspack-action-card {
-	.newspack-action-card__upper {
-		display: flex;
+
+	/* General styles */
+
+	color: $muriel-gray-300;
+
+	h1, h2 {
+		font-weight: normal;
+		margin: 0;
+		padding: 0;
 	}
+
+	h1 {
+		color: $muriel-gray-900;
+		font-size: 16px;
+
+		line-height: 21px;
+	}
+
+	h2 {
+		color: $muriel-gray-600;
+		font-size: 14px;
+		line-height: 16px;
+	}
+
+	/* Regions */
+
 	.newspack-action-card__region {
-		display: flex;
-		flex-grow: 0;
-		flex-direction: column;
 		align-items: flex-start;
+		display: flex;
+		flex-direction: column;
+		flex-grow: 0;
 		margin: 0;
 	}
+
+	.newspack-action-card__region-top {
+		display: flex;
+		flex-direction: row;
+	}
+
 	.newspack-action-card__region-left {
 		margin-right: 1.5em;
 	}
+
 	.newspack-action-card__region-center {
 		flex-grow: 1;
 	}
+
 	.newspack-action-card__region-right {
 		align-items: flex-end;
 		justify-content: center;
 		margin-left: 1.5em;
-		p {
-			margin: 0;
-		}
+
 		.newspack-action-card__action-type__none {
 			color: $muriel-gray-300;
 		}
+
 		.newspack-action-card__action-type__spinner {
 			display: flex;
 			align-items: center;
@@ -40,34 +70,23 @@
 				margin-bottom: 0;
 			}
 		}
+
 		&.newspack-action-card__region-right__double-button {
 			justify-content: flex-start;
 		}
 	}
+
+	/* Notifications */
+
 	.newspack-action-card__notification {
 		margin: 14px 0 0 0;
 		p:before {
 			margin-right: 6px;
 		}
 	}
-	.newspack-action-card__none {
-		color: $muriel-gray-300;
-	}
-	h1, h2 {
-		margin: 0;
-		padding: 0;
-		font-weight: normal;
-	}
-	h1 {
-		font-size: 16px;
-		color: $muriel-gray-900;
-		line-height: 21px;
-	}
-	h2 {
-		color: $muriel-gray-600;
-		font-size: 14px;
-		line-height: 16px;
-	}
+
+	/* Image */
+
 	.newspack-action-card__image {
 		background-position: center;
 		background-repeat: no-repeat;
@@ -77,19 +96,21 @@
  		width: 32px;
  		border: 1px solid $muriel-gray-400;
 	}
-	.newspack-action-card__primary_button {
-		&.is-link {
-			color: $muriel-blue-500;
-		}
+
+	/* Buttons */
+
+	button.is-link {
+		color: $muriel-blue-500;
 	}
-	.newspack-action-card__secondary_button {
+
+	button.newspack-action-card__secondary_button {
 		visibility: hidden;
 		&.is-link {
 			color: $muriel-red-300;
 		}
 	}
-	&:hover .newspack-action-card__secondary_button {
+
+	&:hover button.newspack-action-card__secondary_button {
 		visibility: visible;
 	}
 }
-

--- a/assets/src/components/action-card/style.scss
+++ b/assets/src/components/action-card/style.scss
@@ -99,7 +99,10 @@
 	button.newspack-action-card__secondary_button {
 		visibility: hidden;
 		&.is-link {
-			color: $muriel-red-300;
+			color: $muriel-hot-red-600;
+			&:hover {
+				color: $muriel-hot-red-500;
+			}
 		}
 	}
 

--- a/assets/src/components/action-card/style.scss
+++ b/assets/src/components/action-card/style.scss
@@ -82,13 +82,13 @@
 			color: $muriel-blue-500;
 		}
 	}
-	.newspack-action-card__deletion_button {
+	.newspack-action-card__secondary_button {
 		display: none;
 		&.is-link {
 			color: $muriel-red-300;
 		}
 	}
-	&:hover .newspack-action-card__deletion_button {
+	&:hover .newspack-action-card__secondary_button {
 		display: block;
 	}
 }

--- a/assets/src/components/action-card/style.scss
+++ b/assets/src/components/action-card/style.scss
@@ -9,6 +9,7 @@
 	/* General styles */
 
 	color: $muriel-gray-300;
+	font-size: 14px;
 
 	h1, h2 {
 		font-weight: normal;
@@ -19,7 +20,6 @@
 	h1 {
 		color: $muriel-gray-900;
 		font-size: 16px;
-
 		line-height: 21px;
 	}
 
@@ -54,26 +54,19 @@
 
 	.newspack-action-card__region-right {
 		align-items: flex-end;
-		justify-content: center;
+		align-self: center;
 		margin-left: 1.5em;
+	}
 
-		.newspack-action-card__action-type__none {
-			color: $muriel-gray-300;
-		}
+	/* Spinner */
 
-		.newspack-action-card__action-type__spinner {
-			display: flex;
-			align-items: center;
-			color: $muriel-gray-300;
-			.components-spinner {
-				margin-top: 0;
-				margin-bottom: 0;
-			}
-		}
+	.newspack-action-card__container {
+		display: flex;
+	}
 
-		&.newspack-action-card__region-right__double-button {
-			justify-content: flex-start;
-		}
+	.components-spinner {
+		margin-top: 0;
+		margin-bottom: 0;
 	}
 
 	/* Notifications */
@@ -91,10 +84,10 @@
 		background-position: center;
 		background-repeat: no-repeat;
 		background-size: cover;
+		border: 1px solid $muriel-gray-400;
  		border-radius: 50%;
  		height: 32px;
  		width: 32px;
- 		border: 1px solid $muriel-gray-400;
 	}
 
 	/* Buttons */

--- a/assets/src/components/index.js
+++ b/assets/src/components/index.js
@@ -1,3 +1,4 @@
+export { default as ActionCard } from './action-card';
 export { default as Button } from './button';
 export { default as Card } from './card';
 export { default as CheckboxControl } from './checkbox-control';

--- a/assets/src/wizards/componentsDemo/index.js
+++ b/assets/src/wizards/componentsDemo/index.js
@@ -79,52 +79,54 @@ class ComponentsDemo extends Component {
 					subHeaderText={ __( 'Temporary demo of Newspack components' ) }
 				/>
 				<ActionCard
-					title="WooCommerce"
-					description="Version: 3.6.3"
+					title="Example One"
+					description="Has an action button."
 					actionText="Install"
 					onClick={ () => { console.log( 'Install clicked' ) } }
 				/>
 				<ActionCard
-					title={ __( 'WooCommerce' ) }
-					description="Version: 3.6.3"
+					title="Example Two"
+					description="Has action button and secondary button (visible on hover)."
 					actionText={ __( 'Edit' ) }
 					secondaryActionText={ __( 'Delete' ) }
-					onClick={ () => { console.log( 'Install clicked' ) } }
+					onClick={ () => { console.log( 'Edit clicked' ) } }
 					onSecondaryActionClick={ () => { console.log( 'Delete clicked' ) } }
 				/>
 				<ActionCard
-					title="WooCommerce"
-					description="Version: 3.6.3"
+					title="Example Three"
+					description="Waiting/in-progress state, no action button."
 					actionText="Installing..."
 					isWaiting
 				/>
 				<ActionCard
-					title="WooCommerce"
-					description="Version: 3.6.3"
+					title="Example Four"
+					description="Error notification"
 					notification={ <Fragment>Plugin cannot be installed <a href='#'>Retry</a> | <a href='#'>Documentation</a></Fragment> }
 					notificationLevel="error"
 				/>
 				<ActionCard
-					title="WooCommerce"
-					description="Version: 3.6.3"
+					title="Example Five"
+					description="Warning notification, action button"
+					actionText="Install"
+					onClick={ () => { console.log( 'Install clicked' ) } }
 					notification={ <Fragment>There is a new version available. <a href='#'>View details</a> or <a href='#'>update now</a></Fragment> }
 					notificationLevel="warning"
 				/>
 				<ActionCard
-					title="WooCommerce"
-					description="Version: 3.6.3"
+					title="Example Six"
+					description="Static text, no button"
 					actionText="Active"
 				/>
 				<ActionCard
-					title="WooCommerce"
-					description="Version: 3.6.3"
+					title="Example Seven"
+					description="Static text, secondary action button."
 					actionText="Active"
 					secondaryActionText={ __( 'Delete' ) }
 					onSecondaryActionClick={ () => { console.log( 'Delete clicked' ) } }
 				/>
 				<ActionCard
-					title="WooCommerce"
-					description="Version: 3.6.3"
+					title="Example Eight"
+					description="Image with link and action button."
 					actionText="Set Up"
 					onClick={ () => { console.log( 'Set Up' ) } }
 					image="//s1.wp.com/wp-content/themes/h4/landing/marketing/pages/hp-jan-2019/media/man-with-shadow.jpg"

--- a/assets/src/wizards/componentsDemo/index.js
+++ b/assets/src/wizards/componentsDemo/index.js
@@ -89,10 +89,10 @@ class ComponentsDemo extends Component {
 					title={ __( 'WooCommerce' ) }
 					description="Version: 3.6.3"
 					actionText={ __( 'Edit' ) }
-					deletionText={ __( 'Delete' ) }
+					secondaryActionText={ __( 'Delete' ) }
 					isButton
 					onClick={ () => { console.log( 'Install clicked' ) } }
-					onDeletionClick={ () => { console.log( 'Delete clicked' ) } }
+					onSecondaryActionClick={ () => { console.log( 'Delete clicked' ) } }
 				/>
 				<ActionCard
 					title="WooCommerce"

--- a/assets/src/wizards/componentsDemo/index.js
+++ b/assets/src/wizards/componentsDemo/index.js
@@ -88,11 +88,11 @@ class ComponentsDemo extends Component {
 				<ActionCard
 					title={ __( 'WooCommerce' ) }
 					description="Version: 3.6.3"
-					actionText={ __( 'Install' ) }
-					secondaryActionText={ __( 'Delete' ) }
+					actionText={ __( 'Edit' ) }
+					deletionText={ __( 'Delete' ) }
 					isButton
 					onClick={ () => { console.log( 'Install clicked' ) } }
-					onSecondaryClick={ () => { console.log( 'Delete clicked' ) } }
+					onDeletionClick={ () => { console.log( 'Delete clicked' ) } }
 				/>
 				<ActionCard
 					title="WooCommerce"

--- a/assets/src/wizards/componentsDemo/index.js
+++ b/assets/src/wizards/componentsDemo/index.js
@@ -82,7 +82,6 @@ class ComponentsDemo extends Component {
 					title="WooCommerce"
 					description="Version: 3.6.3"
 					actionText="Install"
-					isButton
 					onClick={ () => { console.log( 'Install clicked' ) } }
 				/>
 				<ActionCard
@@ -90,7 +89,6 @@ class ComponentsDemo extends Component {
 					description="Version: 3.6.3"
 					actionText={ __( 'Edit' ) }
 					secondaryActionText={ __( 'Delete' ) }
-					isButton
 					onClick={ () => { console.log( 'Install clicked' ) } }
 					onSecondaryActionClick={ () => { console.log( 'Delete clicked' ) } }
 				/>
@@ -98,7 +96,7 @@ class ComponentsDemo extends Component {
 					title="WooCommerce"
 					description="Version: 3.6.3"
 					actionText="Installing..."
-					isSpinner
+					isWaiting
 				/>
 				<ActionCard
 					title="WooCommerce"
@@ -120,9 +118,15 @@ class ComponentsDemo extends Component {
 				<ActionCard
 					title="WooCommerce"
 					description="Version: 3.6.3"
+					actionText="Active"
+					secondaryActionText={ __( 'Delete' ) }
+					onSecondaryActionClick={ () => { console.log( 'Delete clicked' ) } }
+				/>
+				<ActionCard
+					title="WooCommerce"
+					description="Version: 3.6.3"
 					actionText="Set Up"
 					onClick={ () => { console.log( 'Set Up' ) } }
-					isButton
 					image="//s1.wp.com/wp-content/themes/h4/landing/marketing/pages/hp-jan-2019/media/man-with-shadow.jpg"
 					imageLink="https://wordpress.com"
 				/>

--- a/assets/src/wizards/componentsDemo/index.js
+++ b/assets/src/wizards/componentsDemo/index.js
@@ -7,11 +7,13 @@
  */
 import { Component, Fragment, render } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import {
+	ActionCard,
 	ImageUpload,
 	CheckboxControl,
 	Card,
@@ -75,6 +77,54 @@ class ComponentsDemo extends Component {
 				<FormattedHeader
 					headerText={ __( 'Newspack Components' ) }
 					subHeaderText={ __( 'Temporary demo of Newspack components' ) }
+				/>
+				<ActionCard
+					title="WooCommerce"
+					description="Version: 3.6.3"
+					actionText="Install"
+					isButton
+					onClick={ () => { console.log( 'Install clicked' ) } }
+				/>
+				<ActionCard
+					title={ __( 'WooCommerce' ) }
+					description="Version: 3.6.3"
+					actionText={ __( 'Install' ) }
+					secondaryActionText={ __( 'Delete' ) }
+					isButton
+					onClick={ () => { console.log( 'Install clicked' ) } }
+					onSecondaryClick={ () => { console.log( 'Delete clicked' ) } }
+				/>
+				<ActionCard
+					title="WooCommerce"
+					description="Version: 3.6.3"
+					actionText="Installing..."
+					isSpinner
+				/>
+				<ActionCard
+					title="WooCommerce"
+					description="Version: 3.6.3"
+					notification={ <Fragment>Plugin cannot be installed <a href='#'>Retry</a> | <a href='#'>Documentation</a></Fragment> }
+					notificationLevel="error"
+				/>
+				<ActionCard
+					title="WooCommerce"
+					description="Version: 3.6.3"
+					notification={ <Fragment>There is a new version available. <a href='#'>View details</a> or <a href='#'>update now</a></Fragment> }
+					notificationLevel="warning"
+				/>
+				<ActionCard
+					title="WooCommerce"
+					description="Version: 3.6.3"
+					actionText="Active"
+				/>
+				<ActionCard
+					title="WooCommerce"
+					description="Version: 3.6.3"
+					actionText="Set Up"
+					onClick={ () => { console.log( 'Set Up' ) } }
+					isButton
+					image="//s1.wp.com/wp-content/themes/h4/landing/marketing/pages/hp-jan-2019/media/man-with-shadow.jpg"
+					imageLink="https://wordpress.com"
 				/>
 				<Checklist progressBarText={ __( 'Your setup list' ) }>
 					<Task

--- a/assets/src/wizards/componentsDemo/index.js
+++ b/assets/src/wizards/componentsDemo/index.js
@@ -101,14 +101,14 @@ class ComponentsDemo extends Component {
 				<ActionCard
 					title="Example Four"
 					description="Error notification"
+					actionText="Install"
+					onClick={ () => { console.log( 'Install clicked' ) } }
 					notification={ <Fragment>Plugin cannot be installed <a href='#'>Retry</a> | <a href='#'>Documentation</a></Fragment> }
 					notificationLevel="error"
 				/>
 				<ActionCard
 					title="Example Five"
 					description="Warning notification, action button"
-					actionText="Install"
-					onClick={ () => { console.log( 'Install clicked' ) } }
 					notification={ <Fragment>There is a new version available. <a href='#'>View details</a> or <a href='#'>update now</a></Fragment> }
 					notificationLevel="warning"
 				/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a new component, `ActionCard`, which can be used any time there is a series of similar items in a wizard. The initial use case will be for the plugin installer, but it's designed to be swapped in to Subscriptions Wizard, Ad Wizards, and many others. The `ActionCard` component takes the following parameters:

`title`: Primary text  display.
`description`: Secondary text display.
`notification`: Optional notification text.
`notificationLevel`: The severity/type of notification (error|warning)
`actionText`: Text for the action button on the right  side.
`secondaryActionText`: Text for the secondary action  button (e.g. Delete)
`image`: Optional path for image to be displayed at the far left.
`imageLink`: Optional URL to link the image to.
`onClick`: Click handler for primary button.
~~`onSecondaryClick`~~ `onSecondaryActionClick`: Click handler for secondary button.
~~`isButton`: Signifies button(s) on the right side (`secondaryActionText`, `onClick`, and  `onSecondaryActionClick` are only meaningful if `isButton` is true)~~
~~`isSpinner`~~ `isWaiting` Signifies waiting state for the component, with a spinner.

Some questions for discussion:

1) Is `ActionCard` the best name for this component? This is loosely similar to the iOS [UITableViewCell](https://developer.apple.com/documentation/uikit/uitableviewcell), which is semantically quite different.
~~2) Is it problematic that `isButton` and `isSpinner` could both be true on the same instance of this component? Would it be preferable to have a prop called `actionCardStyle` which could be button|spinner|static?~~ 
_Update: Refactored in such a way that button state is inferred from the available parameters, leaving only `isWaiting` to be explicitly set._
~~3) The vertical alignment of the right edge is top-aligned if there are primary and secondary buttons, but in no other cases. Is this odd?~~
_Update: By switching from `display: none` to `visibility: hidden` the spacing issue goes away._ 

### How to test the changes in this Pull Request:

1. Check out the branch.
2. `npm ci && npm run clean && npm run build:webpack`
3. Navigate to Newspack->Components Demo, observe seven examples of different `ActionCard` configurations.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->