### PR TITLE
Subscriptions Wizard w/ActionCard

### DIFF
--- a/assets/src/wizards/subscriptions/style.scss
+++ b/assets/src/wizards/subscriptions/style.scss
@@ -27,67 +27,6 @@
 	text-align: center;
 }
 
-.newspack-manage-subscriptions-screen__subscription-card {
-	display: flex;
-	justify-content: space-between;
-
-	img {
- 		border-radius: 50%;
- 		height: 32px;
- 		width: auto;
- 		border: 1px solid $muriel-gray-400;
- 		margin-right: 1.5em;
- 		margin-top: 2px;
-	}
-
-	&:hover {
-		.delete-subscription {
-			visibility: visible;
-		}
-	}
-}
-
-.newspack-manage-subscriptions-screen__subscription-card__product-actions {
-	a {
-		display: block;
-		text-decoration: none;
-	}
-
-	.edit-subscription {
-		color: $muriel-hot-pink-400;
-		font-size: 16px;
-		margin-bottom: .25em;
-
-		&:hover {
-			color: $muriel-hot-pink-700;
-		}
-	}
-
-	.delete-subscription {
-		visibility: hidden;
-		color: $muriel-gray-100;
-
-		&:hover {
-			color: $muriel-gray-400;
-		}
-	}
-}
-
-.newspack-manage-subscriptions-screen__subscription-card__product-info {
-	width: 100%;
-
-	.product-name {
-		color: $muriel-gray-900;
-		font-size: 16px;
-		font-weight: 500;
-		margin-bottom: .25em;
-	}
-
-	.product-price {
-		color: $muriel-gray-400;
-	}
-}
-
 .newspack-manage-subscriptions-screen__finished {
 	text-decoration: none;
 }

--- a/assets/src/wizards/subscriptions/views/manageSubscriptionsScreen.js
+++ b/assets/src/wizards/subscriptions/views/manageSubscriptionsScreen.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Card, FormattedHeader, Button, CheckboxControl } from '../../../components';
+import { ActionCard, Button, CheckboxControl, FormattedHeader } from '../../../components';
 
 /**
  * Subscriptions management screen.
@@ -46,31 +46,17 @@ class ManageSubscriptionsScreen extends Component {
 					const { id, image, name, display_price, url } = subscription;
 
 					return (
-						<Card className="newspack-manage-subscriptions-screen__subscription-card" key={ id }>
-							<a href={ url } target="_blank">
-								<img src={ image ? image.url : '' } />
-							</a>
-							<div className="newspack-manage-subscriptions-screen__subscription-card__product-info">
-								<div className="product-name">{ name }</div>
-								<div className="product-price">{ display_price }</div>
-							</div>
-							<div className="newspack-manage-subscriptions-screen__subscription-card__product-actions">
-								<a
-									className="edit-subscription"
-									href="#"
-									onClick={ () => onClickEditSubscription( subscription ) }
-								>
-									{ __( 'Edit' ) }
-								</a>
-								<a
-									className="delete-subscription"
-									href="#"
-									onClick={ () => onClickDeleteSubscription( subscription ) }
-								>
-									{ __( 'Delete' ) }
-								</a>
-							</div>
-						</Card>
+						<ActionCard
+							key={ id }
+							imageLink={ url }
+							image={ image.url }
+							title={ name }
+							description={ display_price }
+							actionText={ __( 'Edit' ) }
+							onClick={ () => onClickEditSubscription( subscription ) }
+							secondaryActionText={ __( 'Delete' ) }
+							onSecondaryActionClick={ () => onClickDeleteSubscription( subscription ) }
+						/>
 					);
 				} ) }
 				{ !! subscriptions.length && (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements the new `ActionCard` component in the Subscriptions Wizard. This is simply a UI swap, and there should be no change to existing functionality.

Closes # .

### How to test the changes in this Pull Request:

1. You'll need the required plugins installed (WooCommerce, WooCommerce Name Your Price, WooCommerce Subscriptions).
2. Checkout this branch.
3. `npm ci && npm run clean && npm run build:webpack`
4. Navigate to Newspack->Subscriptions (`/wp-admin/admin.php?page=newspack-subscriptions-wizard`). 
5. Add several subscriptions (if you don't have already). 
6. Verify that you see the title, price, and image on the list page.
7. Verify that Edit and Delete buttons work as expected.  

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->