### PR TITLE
Notification/Modal component

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -6,6 +6,7 @@ export { default as Checklist } from './checklist';
 export { default as FormattedHeader } from './formatted-header';
 export { default as InfoButton } from './info-button';
 export { default as ImageUpload } from './image-upload';
+export { default as Modal } from './modal';
 export { default as PluginInstaller } from './plugin-installer';
 export { default as ProgressBar } from './progress-bar';
 export { default as SelectControl } from './select-control';

--- a/assets/components/src/modal/index.js
+++ b/assets/components/src/modal/index.js
@@ -1,0 +1,37 @@
+/**
+ * Muriel-styled Modal notice.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { Modal as BaseComponent } from '@wordpress/components';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import murielClassnames from '../../../shared/js/muriel-classnames';
+import './style.scss';
+
+class Modal extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { className, overlayClassName, ...otherProps } = this.props;
+		const classes = murielClassnames( 'muriel-modal', className );
+		const overlayClasses = murielClassnames( 'muriel-modal-overlay', overlayClassName );
+
+		return (
+			<BaseComponent className={ classes } overlayClassName={ overlayClasses } { ...otherProps } />
+		);
+	}
+}
+
+export default Modal;

--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -1,0 +1,52 @@
+.muriel-modal-overlay {
+	margin: 0!important;
+	background: rgba(43, 45, 47, 0.4);
+}
+
+.muriel-modal {
+	border-radius: 3px;
+	overflow: hidden;
+
+	.components-modal__content {
+		padding: 0 2em 2em;
+	}
+
+	.components-modal__header {
+		border: none;
+		display: block;
+		height: 1em;
+		font-size: 16px;
+		margin-top: 2em;
+		margin-bottom: 1em;
+
+		button.components-icon-button {
+			padding: 0;
+			position: absolute;
+			top: -30px;
+			right: -8px;
+
+			svg {
+				width: 30px;
+				height: 30px;
+			}
+
+			&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
+			&:not(:disabled):not([aria-disabled="true"]):not(.is-default):active {
+				border: none;
+				box-shadow: none;
+			}
+		}
+	}
+
+	.components-modal__header-heading {
+		font-weight: 500;
+	}
+
+	.muriel-button {
+		margin-bottom: 0;
+
+		&:first-of-type {
+			margin-left: 0;
+		}
+	}
+}

--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -1,5 +1,5 @@
 .muriel-modal-overlay {
-	margin: 0!important;
+	margin: 0 !important;
 	background: rgba(43, 45, 47, 0.4);
 }
 

--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -18,6 +18,7 @@
 		font-size: 16px;
 		margin-top: 2em;
 		margin-bottom: 1em;
+		position: relative;
 
 		button.components-icon-button {
 			padding: 0;
@@ -47,6 +48,26 @@
 
 		&:first-of-type {
 			margin-left: 0;
+		}
+	}
+}
+
+@media (max-width: 600px) {
+	.muriel-modal {
+		top: auto;
+
+		.components-modal__content {
+			height: auto;
+		}
+	}
+}
+
+// Reset unneccessary IE-specific style tweak from core styles.
+@supports(-ms-ime-align: auto) {
+	.muriel-modal {
+		.components-modal__header {
+			position: relative;
+			width: auto;
 		}
 	}
 }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -8,7 +8,6 @@
 import { Component, Fragment, render } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
 
 /**
  * Internal dependencies

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -8,6 +8,7 @@
 import { Component, Fragment, render } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -25,6 +26,7 @@ import {
 	Checklist,
 	Task,
 	SelectControl,
+	Modal,
 } from '../../components/src';
 import './style.scss';
 
@@ -45,6 +47,7 @@ class ComponentsDemo extends Component {
 			image: null,
 			selectValue1: '2nd',
 			selectValue2: '',
+			modalShown: false,
 		};
 	}
 
@@ -71,6 +74,7 @@ class ComponentsDemo extends Component {
 			inputNumValue,
 			selectValue1,
 			selectValue2,
+			modalShown,
 		} = this.state;
 
 		return (
@@ -79,7 +83,32 @@ class ComponentsDemo extends Component {
 					headerText={ __( 'Newspack Components' ) }
 					subHeaderText={ __( 'Temporary demo of Newspack components' ) }
 				/>
+				<Card>
+					<FormattedHeader
+						headerText={ __( 'Notice/Modal' ) }
+					/>
+					<Button className="is-centered" isTertiary onClick={ () => this.setState( { modalShown: true } ) } >
+						{ __( 'Open modal' ) }
+					</Button>
+					{ modalShown && (
+						<Modal
+							title="This is the modal title"
+							onRequestClose={ () => this.setState( { modalShown: false } ) }
+						>
+							<p>{ __( 'Based on industry research, we advise to test the modal component, and continuing this sentence so we can see how the text wraps is one good way of doing that.' ) }</p>
+							<Button isPrimary onClick={ () => this.setState( { modalShown: false } ) } >
+								{ __( 'Dismiss' ) }
+							</Button>
+							<Button isDefault onClick={ () => this.setState( { modalShown: false } ) } >
+								{ __( 'Also dismiss' ) }
+							</Button>
+						</Modal>
+					) }
+				</Card>
 				<Card noBackground>
+					<FormattedHeader
+						headerText={ __( 'Plugin installer' ) }
+					/>
 					<PluginInstaller
 						plugins={ [ 'woocommerce', 'amp', 'wordpress-seo', 'fake-plugin' ] }
 						canUninstall
@@ -93,6 +122,9 @@ class ComponentsDemo extends Component {
 						} }
 					/>
 				</Card>
+				<FormattedHeader
+					headerText={ __( 'Action cards' ) }
+				/>
 				<ActionCard
 					title="Example One"
 					description="Has an action button."
@@ -163,6 +195,9 @@ class ComponentsDemo extends Component {
 					} }
 					image="//s1.wp.com/wp-content/themes/h4/landing/marketing/pages/hp-jan-2019/media/man-with-shadow.jpg"
 					imageLink="https://wordpress.com"
+				/>
+				<FormattedHeader
+					headerText={ __( 'Checklist' ) }
 				/>
 				<Checklist progressBarText={ __( 'Your setup list' ) }>
 					<Task


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #77  .

This adds a Muriel-style wrapper for the core Modal component:

<img width="726" alt="Screen Shot 2019-06-04 at 12 19 06 PM" src="https://user-images.githubusercontent.com/7317227/58907749-be3e2800-86c3-11e9-8ae3-934200dcfe2f.png">

I've also added a couple headers to the components demo page to organize it a little.

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. Click the button on the Components Demo screen to test the modal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->