### PR TITLE
Dashboard + Checklist + Cohesiveness 

### DIFF
--- a/assets/wizards/checklist/index.js
+++ b/assets/wizards/checklist/index.js
@@ -1,0 +1,78 @@
+/**
+ * Checklist.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment, render } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Button, FormattedHeader, Checklist, Task } from '../../components/src';
+
+/**
+ * Renders any checklist.
+ */
+class ChecklistScreen extends Component {
+	/**
+	 * Constructor.
+	 */
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			checklistProgress: 0,
+		};
+	}
+
+	/**
+	 * Mark a checklist item as skipped.
+	 * @todo Make this permanent using an API call.
+	 */
+	dismissCheckListItem = index => {
+		const { checklistProgress } = this.state;
+		this.setState( { checklistProgress: Math.max( checklistProgress, index + 1 ) } );
+	};
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const { name, description, steps, dashboardURL } = this.props;
+		const { checklistProgress } = this.state;
+
+		return (
+			<Fragment>
+				<FormattedHeader headerText={ name } subHeaderText={ description } />
+				<Checklist progressBarText={ __( 'Your setup list' ) }>
+					{ steps.map( ( step, index ) => (
+						<Task
+							key={ index }
+							title={ step.name }
+							description={ step.description }
+							buttonText={ __( 'Do it' ) }
+							completedTitle={ __( 'All set!' ) }
+							completed={ step.completed || checklistProgress > index }
+							onDismiss={ () => this.dismissCheckListItem( index ) }
+							active={ checklistProgress === index }
+							onClick={ () => ( window.location = step.url ) }
+						/>
+					) ) }
+				</Checklist>
+				<Button
+					className="is-centered"
+					isTertiary
+					onClick={ () => ( window.location = dashboardURL ) }
+				>
+					{ __( "I'm done setting up" ) }
+				</Button>
+			</Fragment>
+		);
+	}
+}
+render(
+	<ChecklistScreen { ...newspack_checklist } />,
+	document.getElementById( 'newspack-checklist' )
+);

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -7,9 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	FormattedHeader,
-} from '../../components/src';
+import { FormattedHeader } from '../../components/src';
 import Tier from './views/tier';
 import './style.scss';
 
@@ -17,16 +15,23 @@ import './style.scss';
  * The Newspack dashboard.
  */
 class Dashboard extends Component {
+	/**
+	 * Render.
+	 */
 	render() {
 		const { items } = this.props;
-		console.log( items );
-		return ( 
+
+		return (
 			<Fragment>
-				<FormattedHeader 
+				<FormattedHeader
 					headerText={ __( 'Welcome to the Newspack Dashboard' ) }
-					subHeaderText={ __( "Here we'll guide you through the setup and launch of your news site" ) } 
+					subHeaderText={ __(
+						"Here we'll guide you through the setup and launch of your news site"
+					) }
 				/>
-				{ items.map( ( tier, index ) => <Tier items={ tier } key={ index } /> ) }
+				{ items.map( ( tier, index ) => (
+					<Tier items={ tier } key={ index } />
+				) ) }
 			</Fragment>
 		);
 	}

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment, render } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormattedHeader,
+} from '../../components/src';
+import Tier from './views/tier';
+import './style.scss';
+
+/**
+ * The Newspack dashboard.
+ */
+class Dashboard extends Component {
+	render() {
+		const { items } = this.props;
+		console.log( items );
+		return ( 
+			<Fragment>
+				<FormattedHeader 
+					headerText={ __( 'Welcome to the Newspack Dashboard' ) }
+					subHeaderText={ __( "Here we'll guide you through the setup and launch of your news site" ) } 
+				/>
+				{ items.map( ( tier, index ) => <Tier items={ tier } key={ index } /> ) }
+			</Fragment>
+		);
+	}
+}
+render( <Dashboard items={ newspack_dashboard } />, document.getElementById( 'newspack' ) );

--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -1,0 +1,55 @@
+.newspack-dashboard-tier {
+	display: flex;
+	justify-content: center;
+	padding-bottom: 1em;
+	position: relative;
+	padding-top: 1em;
+
+	&::after {
+		content: '';
+		height: 1px;
+		max-width: 745px;
+		width: 100%;
+	 	background-color: $muriel-gray-50;
+	 	position: absolute;
+	 	bottom: 0;
+	}
+
+	&:last-of-type::after {
+		display: none;
+	}
+}
+
+.newspack-dashboard-card {
+	margin: 1em;
+	max-width: 330px;
+	width: 100%;
+	text-align: center;
+
+	a, .newspack-dashboard-card__disabled-link {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-decoration: none;
+	}
+
+	img {
+		max-width: 104px;
+		height: auto;
+	}
+
+	h3 {
+		font-size: 16px;
+		color: $muriel-gray-900;
+	}
+
+	h4 {
+		font-size: 14px;
+		color: $muriel-gray-500;
+		font-weight: normal;
+	}
+
+	&.disabled {
+		opacity: 0.6;
+	}
+}

--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -25,11 +25,13 @@
 	max-width: 330px;
 	width: 100%;
 	text-align: center;
+	position: relative;
 
 	a, .newspack-dashboard-card__disabled-link {
 		display: flex;
-		flex-direction: column;
+		height: 100%;
 		align-items: center;
+		justify-content: center;
 		text-decoration: none;
 	}
 
@@ -51,5 +53,27 @@
 
 	&.disabled {
 		opacity: 0.6;
+	}
+
+	&.completed {
+		background: none;
+		border: 1px solid rgba(0, 0, 0, .1);
+	}
+
+	.newspack-dashboard-card__completed-icon {
+		fill: $muriel-hot-green-500;
+		position: absolute;
+		top: 40px;
+		right: 80px;
+	}
+}
+
+@media (max-width: 600px) {
+	.newspack-dashboard-tier {
+		display: block;
+	}
+
+	.newspack-dashboard-card {
+		max-width: calc(100% - 6em);
 	}
 }

--- a/assets/wizards/dashboard/views/dashboardCard.js
+++ b/assets/wizards/dashboard/views/dashboardCard.js
@@ -12,9 +12,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import {
-	Card,
-} from '../../../components/src';
+import { Card } from '../../../components/src';
 
 /**
  * One card in the dashboard.
@@ -28,29 +26,29 @@ class DashboardCard extends Component {
 		const classes = classnames( 'newspack-dashboard-card', slug, status );
 
 		const contents = (
-			<div className='newspack-dashboard-card__contents'>
-				{ !! image && (
-					<img src={ image } />
-				) }
+			<div className="newspack-dashboard-card__contents">
+				{ !! image && <img src={ image } /> }
 				<h3>{ name }</h3>
 				<h4>{ description }</h4>
 			</div>
-		)
+		);
 
 		if ( 'disabled' === status ) {
 			return (
-				<Card className={ classes } >
-					<div className='newspack-dashboard-card__disabled-link'>
-						{ contents }
-					</div>
+				<Card className={ classes }>
+					<div className="newspack-dashboard-card__disabled-link">{ contents }</div>
 				</Card>
 			);
 		} else {
 			return (
-				<Card className={ classes } >
-					<a href={ url } >
+				<Card className={ classes }>
+					<a href={ url }>
 						{ 'completed' === status && (
-							<Dashicon icon='yes-alt' size='24' className='newspack-dashboard-card__completed-icon' />
+							<Dashicon
+								icon="yes-alt"
+								size="24"
+								className="newspack-dashboard-card__completed-icon"
+							/>
 						) }
 						{ contents }
 					</a>

--- a/assets/wizards/dashboard/views/dashboardCard.js
+++ b/assets/wizards/dashboard/views/dashboardCard.js
@@ -1,0 +1,59 @@
+/**
+ * Subscription Management Screens.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import {
+	Card,
+} from '../../../components/src';
+
+/**
+ * One card in the dashboard.
+ */
+class DashboardCard extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { name, description, slug, url, image, enabled } = this.props;
+		const classes = classnames( 'newspack-dashboard-card', slug, enabled ? 'enabled' : 'disabled' );
+
+		const contents = (
+			<Fragment>
+				{ !! image && (
+					<img src={ image } />
+				) }
+				<h3>{ name }</h3>
+				<h4>{ description }</h4>
+			</Fragment>
+		)
+
+		if ( enabled ) {
+			return (
+				<Card className={ classes } >
+					<a href={ url } >
+						{ contents }
+					</a>
+				</Card>
+			);
+		} else {
+			return (
+				<Card className={ classes } >
+					<div className='newspack-dashboard-card__disabled-link'>
+						{ contents }
+					</div>
+				</Card>
+
+			);
+		}
+	}
+}
+export default DashboardCard;

--- a/assets/wizards/dashboard/views/dashboardCard.js
+++ b/assets/wizards/dashboard/views/dashboardCard.js
@@ -6,6 +6,7 @@
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
+import { Dashicon } from '@wordpress/components';
 import classnames from 'classnames';
 
 /**
@@ -23,35 +24,37 @@ class DashboardCard extends Component {
 	 * Render.
 	 */
 	render() {
-		const { name, description, slug, url, image, enabled } = this.props;
-		const classes = classnames( 'newspack-dashboard-card', slug, enabled ? 'enabled' : 'disabled' );
+		const { name, description, slug, url, image, status } = this.props;
+		const classes = classnames( 'newspack-dashboard-card', slug, status );
 
 		const contents = (
-			<Fragment>
+			<div className='newspack-dashboard-card__contents'>
 				{ !! image && (
 					<img src={ image } />
 				) }
 				<h3>{ name }</h3>
 				<h4>{ description }</h4>
-			</Fragment>
+			</div>
 		)
 
-		if ( enabled ) {
-			return (
-				<Card className={ classes } >
-					<a href={ url } >
-						{ contents }
-					</a>
-				</Card>
-			);
-		} else {
+		if ( 'disabled' === status ) {
 			return (
 				<Card className={ classes } >
 					<div className='newspack-dashboard-card__disabled-link'>
 						{ contents }
 					</div>
 				</Card>
-
+			);
+		} else {
+			return (
+				<Card className={ classes } >
+					<a href={ url } >
+						{ 'completed' === status && (
+							<Dashicon icon='yes-alt' size='24' className='newspack-dashboard-card__completed-icon' />
+						) }
+						{ contents }
+					</a>
+				</Card>
 			);
 		}
 	}

--- a/assets/wizards/dashboard/views/tier.js
+++ b/assets/wizards/dashboard/views/tier.js
@@ -24,7 +24,9 @@ class Tier extends Component {
 
 		return (
 			<div className="newspack-dashboard-tier">
-				{ items.map( card => <DashboardCard { ...card } key={ card.slug } /> ) }
+				{ items.map( card => (
+					<DashboardCard { ...card } key={ card.slug } />
+				) ) }
 			</div>
 		);
 	}

--- a/assets/wizards/dashboard/views/tier.js
+++ b/assets/wizards/dashboard/views/tier.js
@@ -1,0 +1,32 @@
+/**
+ * One tier of the dashboard.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DashboardCard from './dashboardCard';
+
+/**
+ * One tier of the dashboard.
+ */
+class Tier extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { items } = this.props;
+
+		return (
+			<div className="newspack-dashboard-tier">
+				{ items.map( card => <DashboardCard { ...card } key={ card.slug } /> ) }
+			</div>
+		);
+	}
+}
+export default Tier;

--- a/includes/class-checklists.php
+++ b/includes/class-checklists.php
@@ -34,16 +34,16 @@ class Checklists {
 		 */
 		self::$checklists = [
 			'memberships'    => [
-				'name'        => __( 'Memberships', 'newspack' ),
-				'description' => __( 'Subscriptions, donations, and paywall', 'newspack' ),
+				'name'        => esc_html__( 'Memberships', 'newspack' ),
+				'description' => esc_html__( 'Subscriptions, donations, and paywall', 'newspack' ),
 				'wizards'     => [
 					'subscriptions-onboarding',
 					'subscriptions',
 				],
 			],
 			'temporary-demo' => [
-				'name'        => __( 'Demo checklist', 'newspack' ),
-				'description' => __( 'A demo checklist', 'newspack' ),
+				'name'        => esc_html__( 'Demo checklist', 'newspack' ),
+				'description' => esc_html__( 'A demo checklist', 'newspack' ),
 				'wizards'     => [
 					'subscriptions',
 					'components-demo',
@@ -112,7 +112,7 @@ class Checklists {
 	public static function get_url( $checklist_slug ) {
 		$checklist = self::get_checklist( $checklist_slug );
 		if ( $checklist ) {
-			return admin_url( 'admin.php?page=newspack-checklist&checklist=' . $checklist_slug );
+			return esc_url( admin_url( 'admin.php?page=newspack-checklist&checklist=' . $checklist_slug ), null, 'link' );
 		}
 
 		return false;
@@ -181,7 +181,6 @@ class Checklists {
 
 		/**
 		 * The following information is placed into the `newspack_checklist` js variable on a checklist's page:
-		 *
 		 * name         => String name of the checklist.
 		 * description  => String description of the checklist. 
 		 * steps        => Array of wizards. See $checklist_data['steps'] below.
@@ -202,7 +201,6 @@ class Checklists {
 
 			/**
 			 * One checklist step has the following info:
-			 *
 			 * name        => String name of the step.
 			 * description => String description of the step.
 			 * url         => String URL of the wizard.

--- a/includes/class-checklists.php
+++ b/includes/class-checklists.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Newspack Checklist manager.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages the checklists.
+ */
+class Checklists {
+
+	/**
+	 * Information about all of the checklists.
+	 * See `init` for structure of the data.
+	 *
+	 * @var array
+	 */
+	protected static $checklists = [];
+
+	/**
+	 * Initialize the data and hooks.
+	 */
+	public static function init() {
+		/**
+		 * One checklist has the following information:
+		 *     name: The checklist name.
+		 *     description: The checklist description.
+		 *     wizards: An array of wizard slugs in desired order, corresponding to slugs registered in Wizards class.
+		 */
+		self::$checklists = [
+			'memberships'    => [
+				'name'        => __( 'Memberships', 'newspack' ),
+				'description' => __( 'Subscriptions, donations, and paywall', 'newspack' ),
+				'wizards'     => [
+					'subscriptions',
+					'components-demo',
+				],
+			],
+			'temporary-demo' => [
+				'name'        => __( 'Demo checklist', 'newspack' ),
+				'description' => __( 'A demo checklist', 'newspack' ),
+				'wizards'     => [
+					'subscriptions',
+					'components-demo',
+					'components-demo',
+					'dashboard',
+				],
+			],
+		];
+
+		add_action( 'admin_menu', 'Newspack\Checklists::add_page' );
+		add_action( 'admin_enqueue_scripts', 'Newspack\Checklists::enqueue_scripts_and_styles' );
+		add_action( 'admin_head', 'Newspack\Checklists::hide_from_menus' );
+	}
+
+	/**
+	 * Get a checklist's raw info.
+	 *
+	 * @param string $checklist_slug The checklist slug, as registered in the self::$checklists variable.
+	 * @return array | bool The info on success, false on failure.
+	 */
+	public static function get_checklist( $checklist_slug ) {
+		if ( isset( self::$checklists[ $checklist_slug ] ) ) {
+			return self::$checklists[ $checklist_slug ];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get a checklist's name.
+	 *
+	 * @param string $checklist_slug The checklist slug, as registered in the self::$checklists variable.
+	 * @return string | bool The info on success, false on failure.
+	 */
+	public static function get_name( $checklist_slug ) {
+		$checklist = self::get_checklist( $checklist_slug );
+		if ( $checklist ) {
+			return $checklist['name'];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get a checklist's description.
+	 *
+	 * @param string $checklist_slug The checklist slug, as registered in the self::$checklists variable.
+	 * @return string | bool The info on success, false on failure.
+	 */
+	public static function get_description( $checklist_slug ) {
+		$checklist = self::get_checklist( $checklist_slug );
+		if ( $checklist ) {
+			return $checklist['description'];
+		}
+
+		return false;
+
+	}
+
+	/**
+	 * Get a checklist's URL.
+	 *
+	 * @param string $checklist_slug The checklist slug, as registered in the self::$checklists variable.
+	 * @return string | bool The URL on success, false on failure.
+	 */
+	public static function get_url( $checklist_slug ) {
+		$checklist = self::get_checklist( $checklist_slug );
+		if ( $checklist ) {
+			return admin_url( 'admin.php?page=newspack-checklist&checklist=' . $checklist_slug );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get a checklist's status. Valid stati are: 'enabled', 'disabled', 'completed'.
+	 *
+	 * @todo Make this actually check for whether a checklist is completed.
+	 * @param string $checklist_slug The checklist slug, as registered in the self::$checklists variable.
+	 * @return string | bool The info on success, false on failure.
+	 */
+	public static function get_status( $checklist_slug ) {
+		return 'enabled';
+	}
+
+	/**
+	 * Register and add the page that the checklists will live on.
+	 */
+	public static function add_page() {
+		add_submenu_page( 'newspack', 'Checklist', 'Checklist', 'manage_options', 'newspack-checklist', 'Newspack\Checklists::render_checklist' );
+	}
+
+	/**
+	 * Render a container for the checklist to render in.
+	 */
+	public static function render_checklist() {
+		?>
+		<div id="newspack-checklist">
+		</div>
+		<?php
+	}
+
+	/**
+	 * Hide a link to the submenu page from the Newspack menu.
+	 */
+	public static function hide_from_menus() {
+		global $submenu;
+
+		$newspack_menu = $submenu['newspack'];
+		foreach ( $newspack_menu as $key => $menu_item ) {
+			if ( 'newspack-checklist' === $menu_item[2] ) {
+				unset( $submenu['newspack'][ $key ] );
+			}
+		}
+	}
+
+	/**
+	 * Load up the scripts when appropriate. 
+	 * Prepare all of the information about the requested checklist into a 'newspack_checklist' variable.
+	 */
+	public static function enqueue_scripts_and_styles() {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== 'newspack-checklist' ) {
+			return;
+		}
+
+		$checklist_slug = filter_input( INPUT_GET, 'checklist', FILTER_SANITIZE_STRING );
+		if ( ! $checklist_slug ) {
+			wp_die( esc_html__( 'No checklist found.', 'newspack' ) );
+		}
+
+		$checklist = self::get_checklist( $checklist_slug );
+		if ( ! $checklist ) {
+			wp_die( esc_html__( 'No checklist found.', 'newspack' ) );
+		}
+
+		$checklist_data = [
+			'name'         => self::get_name( $checklist_slug ),
+			'description'  => self::get_description( $checklist_slug ),
+			'steps'        => [],
+			'dashboardURL' => Wizards::get_url( 'dashboard' ),
+		];
+
+		foreach ( $checklist['wizards'] as $wizard_slug ) {
+			$wizard = Wizards::get_wizard( $wizard_slug );
+			if ( ! $wizard ) {
+				continue;
+			}
+
+			$checklist_data['steps'][] = [
+				'name'        => $wizard->get_name(),
+				'description' => $wizard->get_description(),
+				'url'         => $wizard->get_url(),
+				'length'      => $wizard->get_length(),
+				'completed'   => $wizard->is_completed(),
+			];
+		}
+
+		wp_register_script(
+			'newspack-checklist',
+			Newspack::plugin_url() . '/assets/dist/checklist.js',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/checklist.js' ),
+			true
+		);
+		wp_localize_script( 'newspack-checklist', 'newspack_checklist', $checklist_data );
+		wp_enqueue_script( 'newspack-checklist' );
+
+		wp_register_style(
+			'newspack-checklist',
+			Newspack::plugin_url() . '/assets/dist/checklist.css',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/checklist.css' )
+		);
+		wp_style_add_data( 'newspack-checklist', 'rtl', 'replace' );
+		wp_enqueue_style( 'newspack-checklist' );
+	}
+}
+Checklists::init();

--- a/includes/class-checklists.php
+++ b/includes/class-checklists.php
@@ -179,6 +179,14 @@ class Checklists {
 			wp_die( esc_html__( 'No checklist found.', 'newspack' ) );
 		}
 
+		/**
+		 * The following information is placed into the `newspack_checklist` js variable on a checklist's page:
+		 *
+		 * name         => String name of the checklist.
+		 * description  => String description of the checklist. 
+		 * steps        => Array of wizards. See $checklist_data['steps'] below.
+		 * dashboardURL => String link to the main dashboard, so the checklist can return to the dashboard when needed.
+		 */
 		$checklist_data = [
 			'name'         => self::get_name( $checklist_slug ),
 			'description'  => self::get_description( $checklist_slug ),
@@ -192,6 +200,15 @@ class Checklists {
 				continue;
 			}
 
+			/**
+			 * One checklist step has the following info:
+			 *
+			 * name        => String name of the step.
+			 * description => String description of the step.
+			 * url         => String URL of the wizard.
+			 * length      => String textual description of how long the wizard is expected to take.
+			 * completed   => Boolean whether the wizard has been completed.
+			 */
 			$checklist_data['steps'][] = [
 				'name'        => $wizard->get_name(),
 				'description' => $wizard->get_description(),

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -40,7 +40,6 @@ final class Newspack {
 	public function __construct() {
 		$this->define_constants();
 		$this->includes();
-		$this->init_hooks();
 	}
 
 	/**
@@ -68,13 +67,6 @@ final class Newspack {
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-wizards.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-checklists.php';
-	}
-
-	/**
-	 * Hook into actions and filters.
-	 * e.g. add_action( 'foo', 'bar' );
-	 */
-	private function init_hooks() {
 	}
 
 	/**

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -60,9 +60,12 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 
-		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-dashboard.php';
-		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-components-demo.php';
-		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-subscriptions-wizard.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-dashboard.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-subscriptions-wizard.php';
+
+		include_once NEWSPACK_ABSPATH . 'includes/class-wizards.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-checklists.php';
 	}
 
 	/**

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -60,6 +60,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 
+		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-dashboard.php';
 		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-components-demo.php';
 		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-subscriptions-wizard.php';
 	}
@@ -69,14 +70,6 @@ final class Newspack {
 	 * e.g. add_action( 'foo', 'bar' );
 	 */
 	private function init_hooks() {
-		add_action( 'admin_menu', [ $this, 'register_admin_wizard_container' ], 1 );
-	}
-
-	/**
-	 * Register the top-level Newspack section.
-	 */
-	public function register_admin_wizard_container() {
-		add_menu_page( __( 'Newspack', 'newspack' ), __( 'Newspack', 'newspack' ), 'manage_options', 'newspack', function() { echo 'TODO: A dashboard page here or something.'; } ); // phpcs:ignore
 	}
 
 	/**

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Newspack Wizards manager.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages the wizards.
+ */
+class Wizards {
+
+	/**
+	 * Information about all of the wizards.
+	 * See `init` for structure of the data.
+	 *
+	 * @var array
+	 */
+	protected static $wizards = [];
+
+	/**
+	 * Initialize and register all of the wizards.
+	 */
+	public static function init() {
+		self::$wizards = [
+			'dashboard'       => new Dashboard(),
+			'subscriptions'   => new Subscriptions_Wizard(),
+			'components-demo' => new Components_Demo(),
+		];
+	}
+
+	/**
+	 * Get a wizard's object.
+	 *
+	 * @param string $wizard_slug The wizard to get. Use slug from self::$wizards.
+	 * @return Wizard | bool The wizard on success, false on failure.
+	 */
+	public static function get_wizard( $wizard_slug ) {
+		if ( isset( self::$wizards[ $wizard_slug ] ) ) {
+			return self::$wizards[ $wizard_slug ];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get a wizard's URL.
+	 *
+	 * @param string $wizard_slug The wizard to get URL for. Use slug from self::$wizards.
+	 * @return string | bool The URL on success, false on failure.
+	 */
+	public static function get_url( $wizard_slug ) {
+		$wizard = self::get_wizard( $wizard_slug );
+		if ( $wizard ) {
+			return $wizard->get_url();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get a wizard's name.
+	 *
+	 * @param string $wizard_slug The wizard to get name for. Use slug from self::$wizards.
+	 * @return string | bool The name on success, false on failure.
+	 */
+	public static function get_name( $wizard_slug ) {
+		$wizard = self::get_wizard( $wizard_slug );
+		if ( $wizard ) {
+			return $wizard->get_name();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get a wizard's description.
+	 *
+	 * @param string $wizard_slug The wizard to get description for. Use slug from self::$wizards.
+	 * @return string | bool The description on success, false on failure.
+	 */
+	public static function get_description( $wizard_slug ) {
+		$wizard = self::get_wizard( $wizard_slug );
+		if ( $wizard ) {
+			return $wizard->get_description();
+		}
+
+		return false;
+	}
+}
+Wizards::init();

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -43,7 +43,7 @@ class Components_Demo extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return __( 'Components demo', 'newspack' );
+		return esc_html__( 'Components demo', 'newspack' );
 	}
 
 	/**
@@ -52,7 +52,7 @@ class Components_Demo extends Wizard {
 	 * @return string The wizard description.
 	 */
 	public function get_description() {
-		return __( 'A temporary demo of components used to build Newspack', 'newspack' );
+		return esc_html__( 'A temporary demo of components used to build Newspack', 'newspack' );
 	}
 
 	/**
@@ -61,7 +61,7 @@ class Components_Demo extends Wizard {
 	 * @return string A description of the expected duration (e.g. '10 minutes').
 	 */
 	public function get_length() {
-		return __( '2 minutes', 'newspack' );
+		return esc_html__( '2 minutes', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -17,13 +17,6 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Components_Demo extends Wizard {
 
 	/**
-	 * The name of this wizard.
-	 *
-	 * @var string
-	 */
-	protected $name = 'Components Demo';
-
-	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -36,6 +29,40 @@ class Components_Demo extends Wizard {
 	 * @var string
 	 */
 	protected $capability = 'manage_options';
+
+	/**
+	 * Display a link to this wizard in the Newspack submenu.
+	 *
+	 * @var bool
+	 */
+	protected $hidden = false;
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return __( 'Components demo', 'newspack' );
+	}
+
+	/**
+	 * Get the description of this wizard.
+	 *
+	 * @return string The wizard description.
+	 */
+	public function get_description() {
+		return __( 'A temporary demo of components used to build Newspack', 'newspack' );
+	}
+
+	/**
+	 * Get the duration of this wizard.
+	 *
+	 * @return string A description of the expected duration (e.g. '10 minutes').
+	 */
+	public function get_length() {
+		return __( '2 minutes', 'newspack' );
+	}
 
 	/**
 	 * Enqueue Subscriptions Wizard scripts and styles.
@@ -66,4 +93,3 @@ class Components_Demo extends Wizard {
 		wp_enqueue_style( 'newspack-components-demo' );
 	}
 }
-new Components_Demo();

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -115,7 +115,7 @@ class Dashboard extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return __( 'Newspack', 'newspack' );
+		return esc_html__( 'Newspack', 'newspack' );
 	}
 
 	/**
@@ -124,7 +124,7 @@ class Dashboard extends Wizard {
 	 * @return string The wizard description.
 	 */
 	public function get_description() {
-		return __( 'The Newspack hub', 'newspack' );
+		return esc_html__( 'The Newspack hub', 'newspack' );
 	}
 
 	/**
@@ -133,7 +133,7 @@ class Dashboard extends Wizard {
 	 * @return string A description of the expected duration (e.g. '10 minutes').
 	 */
 	public function get_length() {
-		return __( '1 day', 'newspack' );
+		return esc_html__( '1 day', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -44,9 +44,11 @@ class Dashboard extends Wizard {
 		add_action( 'admin_menu', [ $this, 'add_page' ], 1 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 
-		// Temporary filter to demonstrate disabling a card.
+		// Temporary filter to demonstrate card status.
 		// @todo remove this and do it properly in the checklist class.
-		add_filter( 'newspack_dashboard_enabled_syndication', '__return_false' );
+		add_filter( 'newspack_dashboard_status_syndication', function() { return 'disabled'; } );
+		add_filter( 'newspack_dashboard_status_onboarding', function() { return 'completed'; } );
+		add_filter( 'newspack_dashboard_status_newsletter', function() { return 'completed'; } );
 	}
 
 	protected function get_dashboard() {
@@ -99,8 +101,9 @@ class Dashboard extends Wizard {
 
 		foreach ( $dashboard as &$tier ) {
 			foreach ( $tier as &$card ) {
-				// The checklist hooks into this filter to selectively disable tasks that have uncompleted prerequisites.
-				$card['enabled'] = apply_filters( 'newspack_dashboard_enabled_' . $card['slug'], true );
+				// The checklist hooks into this filter to manage card statuses.
+				// Valid status are: 'enabled', 'disabled', 'completed'.
+				$card['status'] = apply_filters( 'newspack_dashboard_status_' . $card['slug'], 'enabled' );
 			}
 		}
 

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Newspack dashboard.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Common functionality for admin wizards. Override this class.
+ */
+class Dashboard extends Wizard {
+
+	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Newspack';
+
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack';
+
+	/**
+	 * The capability required to access this.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Initialize.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', [ $this, 'add_page' ], 1 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
+
+		// Temporary filter to demonstrate disabling a card.
+		// @todo remove this and do it properly in the checklist class.
+		add_filter( 'newspack_dashboard_enabled_syndication', '__return_false' );
+	}
+
+	protected function get_dashboard() {
+		$dashboard = [
+			[
+				[
+					'name'        => __( 'Onboarding', 'newspack' ),
+					'slug'        => 'onboarding',
+					'description' => __( 'Lay the groundwork', 'newspack' ),
+					'image'       => 'https://ps.w.org/gutenberg/assets/icon-256x256.jpg?rev=1776042',
+					'url'         => '#',
+				],
+			],
+			[
+				[
+					'name'        => __( 'Memberships', 'newspack' ),
+					'slug'        => 'memberships',
+					'description' => __( 'Set up subscriptions, donations, and paywall', 'newspack' ),
+					'image'       => 'https://ps.w.org/gutenberg/assets/icon-256x256.jpg?rev=1776042',
+					'url'         => '#',
+				],
+				[
+					'name'        => __( 'Setup newsletter', 'newspack' ),
+					'slug'        => 'newsletter',
+					'description' => __( 'Reach your audience', 'newspack' ),
+					'url'         => '#',
+				],
+			],
+			[
+				[
+					'name'        => __( 'Analytics', 'newspack' ),
+					'slug'        => 'analytics',
+					'description' => __( 'Learn about your audience', 'newspack' ),
+					'url'         => '#',
+				],
+				[
+					'name'        => __( 'Engage your audience', 'newspack' ),
+					'slug'        => 'engagement',
+					'description' => __( 'Set up social and commenting integrations', 'newspack' ),
+					'url'         => '#',
+				],
+				[
+					'name'        => __( 'Syndicate your content', 'newspack' ),
+					'slug'        => 'syndication',
+					'description' => __( 'Cross post your articles to other outlets', 'newspack' ),
+					'url'         => '#',
+				]
+			],
+		];
+
+		foreach ( $dashboard as &$tier ) {
+			foreach ( $tier as &$card ) {
+				// The checklist hooks into this filter to selectively disable tasks that have uncompleted prerequisites.
+				$card['enabled'] = apply_filters( 'newspack_dashboard_enabled_' . $card['slug'], true );
+			}
+		}
+
+		return $dashboard;
+	}
+
+	/**
+	 * Add an admin page for the wizard to live on.
+	 */
+	public function add_page() {
+		add_menu_page( 
+			__( 'Newspack', 'newspack' ), 
+			__( 'Newspack', 'newspack' ), 
+			$this->capability, 
+			$this->slug, 
+			[ $this, 'render_wizard'] 
+		);
+	}
+
+	/**
+	 * Load up common JS/CSS for wizards.
+	 */
+	public function enqueue_scripts_and_styles() {
+		parent::enqueue_scripts_and_styles();
+		wp_enqueue_media();
+
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+			return;
+		}
+
+		wp_register_script(
+			'newspack-dashboard',
+			Newspack::plugin_url() . '/assets/dist/dashboard.js',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/dashboard.js' ),
+			true
+		);
+		wp_localize_script( 'newspack-dashboard', 'newspack_dashboard', $this->get_dashboard() );
+		wp_enqueue_script( 'newspack-dashboard' );
+
+		wp_register_style(
+			'newspack-dashboard',
+			Newspack::plugin_url() . '/assets/dist/dashboard.css',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/dashboard.css' )
+		);
+		wp_style_add_data( 'newspack-dashboard', 'rtl', 'replace' );
+		wp_enqueue_style( 'newspack-dashboard' );
+	}
+}
+new Dashboard();

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -17,13 +17,6 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Dashboard extends Wizard {
 
 	/**
-	 * The name of this wizard.
-	 *
-	 * @var string
-	 */
-	protected $name = 'Newspack';
-
-	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -38,43 +31,54 @@ class Dashboard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Display a link to this wizard in the Newspack submenu.
+	 *
+	 * @var bool
+	 */
+	protected $hidden = false;
+
+	/**
 	 * Initialize.
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_page' ], 1 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
-
-		// Temporary filter to demonstrate card status.
-		// @todo remove this and do it properly in the checklist class.
-		add_filter( 'newspack_dashboard_status_syndication', function() { return 'disabled'; } );
-		add_filter( 'newspack_dashboard_status_onboarding', function() { return 'completed'; } );
-		add_filter( 'newspack_dashboard_status_newsletter', function() { return 'completed'; } );
 	}
 
+	/**
+	 * Get the information required to build the dashboard.
+	 * Each tier of the dashboard is an array.
+	 * Each card within the tier is an array of [slug, name, url, description, image, status].
+	 *
+	 * @return array
+	 */
 	protected function get_dashboard() {
 		$dashboard = [
 			[
 				[
-					'name'        => __( 'Onboarding', 'newspack' ),
 					'slug'        => 'onboarding',
-					'description' => __( 'Lay the groundwork', 'newspack' ),
-					'image'       => 'https://ps.w.org/gutenberg/assets/icon-256x256.jpg?rev=1776042',
-					'url'         => '#',
+					'name'        => Checklists::get_name( 'temporary-demo' ),
+					'url'         => Checklists::get_url( 'temporary-demo' ),
+					'description' => Checklists::get_description( 'temporary-demo' ),
+					'status'      => 'completed',
+					'image'       => 'https://ps.w.org/gutenberg/assets/icon-256x256.jpg?rev=1776042', // Temporary for demo purposes.
 				],
 			],
 			[
 				[
-					'name'        => __( 'Memberships', 'newspack' ),
 					'slug'        => 'memberships',
-					'description' => __( 'Set up subscriptions, donations, and paywall', 'newspack' ),
-					'image'       => 'https://ps.w.org/gutenberg/assets/icon-256x256.jpg?rev=1776042',
-					'url'         => '#',
+					'name'        => Checklists::get_name( 'memberships' ),
+					'url'         => Checklists::get_url( 'memberships' ),
+					'description' => Checklists::get_description( 'memberships' ),
+					'status'      => Checklists::get_status( 'memberships' ),
+					'image'       => 'https://ps.w.org/gutenberg/assets/icon-256x256.jpg?rev=1776042', // Temporary for demo purposes.
 				],
 				[
 					'name'        => __( 'Setup newsletter', 'newspack' ),
 					'slug'        => 'newsletter',
 					'description' => __( 'Reach your audience', 'newspack' ),
-					'url'         => '#',
+					'status'      => 'completed',
+					'url'         => '#todo',
 				],
 			],
 			[
@@ -82,32 +86,54 @@ class Dashboard extends Wizard {
 					'name'        => __( 'Analytics', 'newspack' ),
 					'slug'        => 'analytics',
 					'description' => __( 'Learn about your audience', 'newspack' ),
-					'url'         => '#',
+					'status'      => 'disabled',
+					'url'         => '#todo',
 				],
 				[
 					'name'        => __( 'Engage your audience', 'newspack' ),
 					'slug'        => 'engagement',
 					'description' => __( 'Set up social and commenting integrations', 'newspack' ),
-					'url'         => '#',
+					'status'      => 'disabled',
+					'url'         => '#todo',
 				],
 				[
 					'name'        => __( 'Syndicate your content', 'newspack' ),
 					'slug'        => 'syndication',
 					'description' => __( 'Cross post your articles to other outlets', 'newspack' ),
-					'url'         => '#',
-				]
+					'status'      => 'disabled',
+					'url'         => '#todo',
+				],
 			],
 		];
 
-		foreach ( $dashboard as &$tier ) {
-			foreach ( $tier as &$card ) {
-				// The checklist hooks into this filter to manage card statuses.
-				// Valid status are: 'enabled', 'disabled', 'completed'.
-				$card['status'] = apply_filters( 'newspack_dashboard_status_' . $card['slug'], 'enabled' );
-			}
-		}
-
 		return $dashboard;
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return __( 'Newspack', 'newspack' );
+	}
+
+	/**
+	 * Get the description of this wizard.
+	 *
+	 * @return string The wizard description.
+	 */
+	public function get_description() {
+		return __( 'The Newspack hub', 'newspack' );
+	}
+
+	/**
+	 * Get the duration of this wizard.
+	 *
+	 * @return string A description of the expected duration (e.g. '10 minutes').
+	 */
+	public function get_length() {
+		return __( '1 day', 'newspack' );
 	}
 
 	/**
@@ -119,16 +145,15 @@ class Dashboard extends Wizard {
 			__( 'Newspack', 'newspack' ), 
 			$this->capability, 
 			$this->slug, 
-			[ $this, 'render_wizard'] 
+			[ $this, 'render_wizard' ] 
 		);
 	}
 
 	/**
-	 * Load up common JS/CSS for wizards.
+	 * Load up JS/CSS.
 	 */
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
-		wp_enqueue_media();
 
 		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
 			return;
@@ -154,4 +179,3 @@ class Dashboard extends Wizard {
 		wp_enqueue_style( 'newspack-dashboard' );
 	}
 }
-new Dashboard();

--- a/includes/wizards/class-subscriptions-onboarding-wizard.php
+++ b/includes/wizards/class-subscriptions-onboarding-wizard.php
@@ -46,7 +46,7 @@ class Subscriptions_Onboarding_Wizard extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return __( 'Subscriptions Onboarding', 'newspack' );
+		return esc_html__( 'Subscriptions Onboarding', 'newspack' );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class Subscriptions_Onboarding_Wizard extends Wizard {
 	 * @return string The wizard description.
 	 */
 	public function get_description() {
-		return __( 'Set up general settings and the Stripe payment gateway', 'newspack' );
+		return esc_html__( 'Set up general settings and the Stripe payment gateway', 'newspack' );
 	}
 
 	/**
@@ -64,7 +64,7 @@ class Subscriptions_Onboarding_Wizard extends Wizard {
 	 * @return string The wizard length.
 	 */
 	public function get_length() {
-		return __( '10 minutes', 'newspack' );
+		return esc_html__( '10 minutes', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-subscriptions-wizard.php
+++ b/includes/wizards/class-subscriptions-wizard.php
@@ -48,7 +48,7 @@ class Subscriptions_Wizard extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return __( 'Subscriptions', 'newspack' );
+		return esc_html__( 'Subscriptions', 'newspack' );
 	}
 
 	/**
@@ -57,7 +57,7 @@ class Subscriptions_Wizard extends Wizard {
 	 * @return string The wizard description.
 	 */
 	public function get_description() {
-		return __( 'Create and manage subscription plans for consistent memberships revenue', 'newspack' );
+		return esc_html__( 'Create and manage subscription plans for consistent memberships revenue', 'newspack' );
 	}
 
 	/**
@@ -66,7 +66,7 @@ class Subscriptions_Wizard extends Wizard {
 	 * @return string The wizard length.
 	 */
 	public function get_length() {
-		return __( '10 minutes', 'newspack' );
+		return esc_html__( '10 minutes', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-subscriptions-wizard.php
+++ b/includes/wizards/class-subscriptions-wizard.php
@@ -19,13 +19,6 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Subscriptions_Wizard extends Wizard {
 
 	/**
-	 * The name of this wizard.
-	 *
-	 * @var string
-	 */
-	protected $name = 'Subscriptions';
-
-	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -47,6 +40,33 @@ class Subscriptions_Wizard extends Wizard {
 
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
 		add_filter( 'woocommerce_product_data_store_cpt_get_products_query', [ $this, 'handle_only_get_newspack_subscriptions_query' ], 10, 2 );
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return __( 'Subscriptions', 'newspack' );
+	}
+
+	/**
+	 * Get the description of this wizard.
+	 *
+	 * @return string The wizard description.
+	 */
+	public function get_description() {
+		return __( 'Create and manage subscription plans for consistent memberships revenue', 'newspack' );
+	}
+
+	/**
+	 * Get the expected duration of this wizard.
+	 *
+	 * @return string The wizard length.
+	 */
+	public function get_length() {
+		return __( '10 minutes', 'newspack' );
 	}
 
 	/**
@@ -389,4 +409,3 @@ class Subscriptions_Wizard extends Wizard {
 		wp_enqueue_style( 'newspack-subscriptions-wizard' );
 	}
 }
-new Subscriptions_Wizard();

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -12,14 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Common functionality for admin wizards. Override this class.
  */
-class Wizard {
-
-	/**
-	 * The name of this wizard. Override this.
-	 *
-	 * @var string
-	 */
-	protected $name = '';
+abstract class Wizard {
 
 	/**
 	 * The slug of this wizard. Override this.
@@ -36,18 +29,29 @@ class Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Whether the wizard should be displayed in the Newspack submenu.
+	 * 
+	 * @var bool.
+	 */
+	protected $hidden = true;
+
+	/**
 	 * Initialize.
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_page' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
+
+		if ( $this->hidden ) {
+			add_action( 'admin_head', array( $this, 'hide_from_menus' ) );
+		}
 	}
 
 	/**
 	 * Add an admin page for the wizard to live on.
 	 */
 	public function add_page() {
-		add_submenu_page( 'newspack', $this->name, $this->name, $this->capability, $this->slug, [ $this, 'render_wizard' ] );
+		add_submenu_page( 'newspack', $this->get_name(), $this->get_name(), $this->capability, $this->slug, [ $this, 'render_wizard' ] );
 	}
 
 	/**
@@ -87,4 +91,58 @@ class Wizard {
 		}
 		return true;
 	}
+
+	/**
+	 * Hide menu items from view so the pages exist, but the menu items do not.
+	 */
+	public function hide_from_menus() {
+		global $submenu;
+
+		$newspack_menu = $submenu['newspack'];
+		foreach ( $newspack_menu as $key => $menu_item ) {
+			if ( $menu_item[2] === $this->slug ) {
+				unset( $submenu['newspack'][ $key ] );
+			}
+		}
+	}
+
+	/**
+	 * Get the URL for this wizard.
+	 *
+	 * @return string
+	 */
+	public function get_url() {
+		return admin_url( 'admin.php?page=' . $this->slug );
+	}
+
+	/**
+	 * Whether this wizard has been completed.
+	 *
+	 * @todo This needs to actually handle completion.
+	 * @return bool
+	 */
+	public function is_completed() {
+		return false;
+	}
+
+	/**
+	 * Get this wizard's name.
+	 *
+	 * @return string The wizard name.
+	 */
+	abstract public function get_name();
+
+	/**
+	 * Get the description of this wizard.
+	 *
+	 * @return string The wizard description.
+	 */
+	abstract public function get_description();
+
+	/**
+	 * Get the duration of this wizard.
+	 *
+	 * @return string A description of the expected duration (e.g. '10 minutes').
+	 */
+	abstract public function get_length();
 }

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -127,7 +127,7 @@ abstract class Wizard {
 	 * @return string
 	 */
 	public function get_url() {
-		return admin_url( 'admin.php?page=' . $this->slug );
+		return esc_url( admin_url( 'admin.php?page=' . $this->slug ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #56 .

Sorry for YAGPR (Yet Another Giganto Pull Request 😄). The components are somewhat woven together, and I didn't feel that the architecture could be properly evaluated or communicated if it was split into a bunch of smaller PRs.

This pull request implements dashboard and checklist handling and ties everything together into one (mostly) functional application.

Architecture:
- The Dashboard is a stand-alone area that can render anything into a card (checklists, links, etc.). Under the hood, it's just a 1-screen wizard. See `assets/wizards/dashboard` and `includes/wizards/class-dashboard.php`.
- Checklists are managed and rendered in a centralized way, so we don't need to make a bunch of different independent checklist handlers. Checklists are defined and routed in  `includes/class-checklists.php`. Checklists are rendered in `assets/wizards/checklist`.
- Wizards contain all of the info in their classes (name, description, etc.). They are managed and initialized in `includes/class-wizards.php`. The `Wizards` class provides a central location for retrieving wizards and their info.

Screenshots in details:
<details>

<img width="1449" alt="Screen Shot 2019-06-10 at 11 20 32 AM" src="https://user-images.githubusercontent.com/7317227/59218291-c2ab8a80-8b74-11e9-8e90-57b266323125.png">
<img width="205" alt="Screen Shot 2019-06-10 at 11 20 40 AM" src="https://user-images.githubusercontent.com/7317227/59218292-c2ab8a80-8b74-11e9-947e-64a49b2df311.png">
<img width="1169" alt="Screen Shot 2019-06-10 at 11 21 00 AM" src="https://user-images.githubusercontent.com/7317227/59218294-c3442100-8b74-11e9-8a68-73bfa535468c.png">
<img width="1119" alt="Screen Shot 2019-06-10 at 11 21 14 AM" src="https://user-images.githubusercontent.com/7317227/59218295-c3442100-8b74-11e9-930b-e239d6317acf.png">

</details>

### How to test the changes in this Pull Request:

1. `npm ci; npm run clean; npm run build:webpack`
2. Go to WP Admin > Newspack. Observe most wizards don't have links in the submenu any more.
3. On the dashboard, observe things look good, with a mix of statuses on the cards.
4. Click the "Demo Checklist" or "Memberships" cards. Observe you are taken to the appropriate checklist.
5. Click the "Skip" in the checklist to skip an item or "Do it" to go to the appropriate wizard. Click "I'm done setting up" to return to the dashboard.

The main thing not done in this PR is making the checklist item completion permanent; that'll be done in a future PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->