### PR TITLE
Add 'return to checklist' links where needed

### DIFF
--- a/assets/wizards/subscriptions/views/manageSubscriptionsScreen.js
+++ b/assets/wizards/subscriptions/views/manageSubscriptionsScreen.js
@@ -86,6 +86,13 @@ class ManageSubscriptionsScreen extends Component {
 				>
 					{ buttonText }
 				</Button>
+				<Button
+					className='is-centered'
+					isTertiary
+					onClick={ () => ( window.location = newspack_urls['checklists']['memberships'] ) }
+				>
+					{ __( "I'm done adding" ) }
+				</Button>
 			</div>
 		);
 	}

--- a/assets/wizards/subscriptions/views/manageSubscriptionsScreen.js
+++ b/assets/wizards/subscriptions/views/manageSubscriptionsScreen.js
@@ -89,7 +89,7 @@ class ManageSubscriptionsScreen extends Component {
 				<Button
 					className='is-centered'
 					isTertiary
-					onClick={ () => ( window.location = newspack_urls['checklists']['memberships'] ) }
+					href={ newspack_urls['checklists']['memberships'] }
 				>
 					{ __( "I'm done adding" ) }
 				</Button>

--- a/assets/wizards/subscriptionsOnboarding/index.js
+++ b/assets/wizards/subscriptionsOnboarding/index.js
@@ -297,7 +297,7 @@ class SubscriptionsOnboardingWizard extends Component {
 						<Button
 							className='is-centered'
 							isTertiary
-							onClick={ () => ( window.location = newspack_urls['checklists']['memberships'] ) }
+							href={ newspack_urls['checklists']['memberships'] }
 						>
 							{ __( 'Back to checklist') }
 						</Button>

--- a/assets/wizards/subscriptionsOnboarding/index.js
+++ b/assets/wizards/subscriptionsOnboarding/index.js
@@ -294,6 +294,13 @@ class SubscriptionsOnboardingWizard extends Component {
 							plugins={ REQUIRED_PLUGINS }
 							onComplete={ () => this.setState( { pluginRequirementsMet: true } ) }
 						/>
+						<Button
+							className='is-centered'
+							isTertiary
+							onClick={ () => ( window.location = newspack_urls['checklists']['memberships'] ) }
+						>
+							{ __( 'Back to checklist') }
+						</Button>
 					</Card>
 				</Fragment>
 			);
@@ -329,12 +336,9 @@ class SubscriptionsOnboardingWizard extends Component {
 			);
 		}
 
-		return (
-			<h3>
-				Wizard complete. TODO: This should redirect to the checklist instead of displaying this
-				message.
-			</h3>
-		);
+		// Redirect to Memberships checklist if all steps are complete.
+		window.location = newspack_urls['checklists']['memberships'];
+		return null;
 	}
 }
 render(

--- a/includes/class-checklists.php
+++ b/includes/class-checklists.php
@@ -119,6 +119,20 @@ class Checklists {
 	}
 
 	/**
+	 * Get all the URLs for all the checklists.
+	 *
+	 * @return array of slug => URL pairs.
+	 */
+	public static function get_urls() {
+		$urls = [];
+		foreach ( self::$checklists as $slug => $checklist ) {
+			$urls[ $slug ] = self::get_url( $slug );
+		}
+
+		return $urls;
+	}
+
+	/**
 	 * Get a checklist's status. Valid stati are: 'enabled', 'disabled', 'completed'.
 	 *
 	 * @todo Make this actually check for whether a checklist is completed.

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -64,6 +64,20 @@ class Wizards {
 	}
 
 	/**
+	 * Get all the URLs for all the wizards.
+	 *
+	 * @return array of slug => URL pairs.
+	 */
+	public static function get_urls() {
+		$urls = [];
+		foreach ( self::$wizards as $slug => $wizard ) {
+			$urls[ $slug ] = $wizard->get_url();
+		}
+
+		return $urls;
+	}
+
+	/**
 	 * Get a wizard's name.
 	 *
 	 * @param string $wizard_slug The wizard to get name for. Use slug from self::$wizards.

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -71,6 +71,19 @@ abstract class Wizard {
 		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
 			return;
 		}
+
+		// This script is just used for making newspack data available in JS vars.
+		// It should not actually load a JS file.
+		wp_register_script( 'newspack_data', '', [], '1.0', false );
+
+		$urls = [
+			'checklists' => Checklists::get_urls(),
+			'wizards'    => Wizards::get_urls(),
+			'dashboard'  => Wizards::get_url( 'dashboard' ),
+		];
+
+		wp_localize_script( 'newspack_data', 'newspack_urls', $urls );
+		wp_enqueue_script( 'newspack_data' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #98 .

This PR adds links back to the checklist in the following places:
- Plugin installer
- Subscription management screen
- Automatic redirect when finished with Subscriptions Onboarding wizard

It also makes URLs for checklists/wizards/dashboard available in a JS variable for future wizards to use.

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. Deactivate WooCommerce, go to Subscriptions Onboarding wizard. Verify the link to return to the checklist works.
3. Go through the Subscriptions Onboarding wizard. Verify you are redirected to the checklist when the wizard is completed.
4. Verify the "I'm done adding" link takes you back to the checklist.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->