### PR TITLE
Couple small tweaks to Subscriptions Onboarding wizard

### DIFF
--- a/assets/wizards/subscriptionsOnboarding/index.js
+++ b/assets/wizards/subscriptionsOnboarding/index.js
@@ -309,7 +309,6 @@ class SubscriptionsOnboardingWizard extends Component {
 						location={ location }
 						onChange={ location => this.setState( { location } ) }
 						onClickContinue={ () => this.saveLocation() }
-						onClickSkip={ () => this.nextWizardStep() }
 					/>
 				</Fragment>
 			);
@@ -323,7 +322,6 @@ class SubscriptionsOnboardingWizard extends Component {
 						stripeSettings={ stripeSettings }
 						onChange={ stripeSettings => this.setState( { stripeSettings } ) }
 						onClickFinish={ () => this.saveStripeSettings() }
-						onClickCancel={ () => this.nextWizardStep() }
 					/>
 				</Fragment>
 			);

--- a/assets/wizards/subscriptionsOnboarding/style.scss
+++ b/assets/wizards/subscriptionsOnboarding/style.scss
@@ -21,3 +21,14 @@
 .newspack-payment-setup-screen__api-keys-heading {
 	margin-top: 3em;
 }
+
+.newspack-payment-setup-screen__api-tip {
+	margin-top: -3em;
+	margin-bottom: 2em;
+	font-style: italic;
+	text-align: right;
+}
+
+.newspack-payment-setup-screen__api-keys-instruction {
+	margin-bottom: 1.5em;
+}

--- a/assets/wizards/subscriptionsOnboarding/views/locationSetup.js
+++ b/assets/wizards/subscriptionsOnboarding/views/locationSetup.js
@@ -81,13 +81,6 @@ class LocationSetup extends Component {
 					<Button isPrimary className='is-centered' onClick={ () => onClickContinue() }>
 						{ __( 'Continue' ) }
 					</Button>
-					<Button
-						className='isLink is-centered is-tertiary'
-						href='#'
-						onClick={ () => onClickSkip() }
-					>
-						{ __( 'Skip' ) }
-					</Button>
 				</Card>
 			</div>
 		);

--- a/assets/wizards/subscriptionsOnboarding/views/paymentSetup.js
+++ b/assets/wizards/subscriptionsOnboarding/views/paymentSetup.js
@@ -77,11 +77,15 @@ class PaymentSetup extends Component {
 								tooltip='Test mode will not capture real payments. Use it for testing your purchase flow.'
 							/>
 							<div className='newspack-payment-setup-screen__api-keys-heading'>
-								<h4 className='newspack-payment-setup-screen__api-heading'>
-									<a href='https://stripe.com/docs/keys#api-keys' target='_blank'>
-										{ __( 'Get your API keys from your Stripe account' ) }
-									</a>
+								<h4 className='newspack-payment-setup-screen__api-keys-instruction'>
+									{ __( 'Get your API keys from your Stripe account' ) }
 								</h4>
+								<p className='newspack-payment-setup-screen__api-tip'>
+									<a href='https://stripe.com/docs/keys#api-keys' target='_blank'>
+										{ __( 'Learn how' ) }
+									</a>
+								</p>
+
 								{ testMode && (
 									<Fragment>
 										<TextControl

--- a/assets/wizards/subscriptionsOnboarding/views/paymentSetup.js
+++ b/assets/wizards/subscriptionsOnboarding/views/paymentSetup.js
@@ -127,13 +127,6 @@ class PaymentSetup extends Component {
 					<Button isPrimary className='is-centered' onClick={ () => onClickFinish() }>
 						{ __( 'Finish' ) }
 					</Button>
-					<Button
-						className='isLink is-centered is-tertiary'
-						href='#'
-						onClick={ () => onClickCancel() }
-					>
-						{ __( 'Cancel' ) }
-					</Button>
 				</Card>
 			</div>
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR addresses some of the feedback brought up in https://github.com/Automattic/newspack-plugin/pull/86#issuecomment-500985705 and https://github.com/Automattic/newspack-plugin/pull/86#pullrequestreview-248192737.

Specifically, the following changes are implemented:
- Removed the Skip and Cancel links from the wizard.
- Adjust the link to the Stripe API info so it displays more like a tip:

<img width="562" alt="Screen Shot 2019-06-12 at 11 36 33 AM" src="https://user-images.githubusercontent.com/7317227/59377448-1d74eb80-8d07-11e9-99c5-39f7d1e7b0bb.png">

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. Go to the Subscriptions Onboarding wizard (first item in Memberships checklist). Observe the skip/cancel links are removed, and the Stripe settings screen should look like the above screenshot.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->