### PR TITLE
Newspack Logo In Admin Menu

### DIFF
--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -140,12 +140,14 @@ class Dashboard extends Wizard {
 	 * Add an admin page for the wizard to live on.
 	 */
 	public function add_page() {
-		add_menu_page( 
-			__( 'Newspack', 'newspack' ), 
-			__( 'Newspack', 'newspack' ), 
-			$this->capability, 
-			$this->slug, 
-			[ $this, 'render_wizard' ] 
+		$icon = 'data:image/svg+xml;base64,PHN2ZyBpZD0iZjU0YWJkZjgtZTI5Ny00YTRmLWJjZTYtOTFiZmY5NjZkNTdlIiBkYXRhLW5hbWU9IkxheWVyIDEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDIyMiAyMjIiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuYjMxM2MzYWQtYzkyNC00ZjI3LTg1MzktOThiYTBiNjhmNGJjIHsKICAgICAgICBmaWxsOiAjMmE3ZGUxOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8dGl0bGU+bmV3c3BhY2stbWFyazwvdGl0bGU+CiAgPHBhdGggY2xhc3M9ImIzMTNjM2FkLWM5MjQtNGYyNy04NTM5LTk4YmEwYjY4ZjRiYyIgZD0iTTI2MS41LDEzMUExMTEsMTExLDAsMSwwLDM3Mi42LDI0MiwxMTEsMTExLDAsMCwwLDI2MS41LDEzMVpNMjE2LjEsMjg3LjRWMjU3LjJsMzAuMywzMC4yWm02MC42LDAtNjAuNi02MC41VjE5Ni42TDMwNywyODcuNFpNMzA3LDI0NkgyOTUuOGwtNy4yLTcuMkgzMDdabTAtMjEuMkgyNzQuN2wtNy4yLTcuMUgzMDdabTAtMjEuMUgyNTMuNmwtNy4yLTcuMUgzMDdaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTUwLjUgLTEzMSkiLz4KPC9zdmc+Cg==';
+		add_menu_page(
+			__( 'Newspack', 'newspack' ),
+			__( 'Newspack', 'newspack' ),
+			$this->capability,
+			$this->slug,
+			[ $this, 'render_wizard' ],
+			$icon
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR simply adds the Newspack logo to the admin menu.

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Observe gear icon has been replaced by Newspack icon as pictured here:

<img width="164" alt="Screen Shot 2019-06-13 at 9 42 16 AM" src="https://user-images.githubusercontent.com/1477002/59437434-9899d880-8dbf-11e9-9cab-5b4456c1e8f3.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->