### PR TITLE
Wizard and WizardScreen components for managing common wizard tasks

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -12,3 +12,5 @@ export { default as ProgressBar } from './progress-bar';
 export { default as SelectControl } from './select-control';
 export { default as Task } from './task';
 export { default as TextControl } from './text-control';
+export { default as Wizard } from './wizard';
+export { default as WizardScreen } from './wizardScreen';

--- a/assets/components/src/wizard/index.js
+++ b/assets/components/src/wizard/index.js
@@ -116,7 +116,7 @@ class Wizard extends Component {
 				<p>
 					<strong>{ message }</strong>
 				</p>
-				<Button isPrimary onClick={ () => this.setState( { modalShown: false } ) }>
+				<Button isPrimary onClick={ () => ( window.location = newspack_urls[ 'dashboard' ] ) }>
 					{ __( 'Return to dashboard' ) }
 				</Button>
 			</Modal>

--- a/assets/components/src/wizard/index.js
+++ b/assets/components/src/wizard/index.js
@@ -13,18 +13,29 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { PluginInstaller, Card, FormattedHeader, Modal, Button } from '../';
-import './style.scss';
 
+/**
+ * Manages a bunch of WizardScreen components into a cohesive wizard.
+ * Handles required plugins, errors, screen switching, etc.
+ */
 class Wizard extends Component {
+	/**
+	 * Constructor.
+	 */
 	constructor( props ) {
 		super( ...arguments );
 
 		const { requiredPlugins } = props;
 		this.state = {
 			pluginRequirementsMet: requiredPlugins ? false : true,
-		}
+		};
 	}
 
+	/**
+	 * Get the screen that is currently displayed.
+	 *
+	 * @return Component|false
+	 */
 	getActiveWizardScreen() {
 		const { children, activeScreen } = this.props;
 
@@ -40,6 +51,9 @@ class Wizard extends Component {
 		return activeComponent || false;
 	}
 
+	/**
+	 * Handler that fires when the plugin requirements have been met.
+	 */
 	handlePluginRequirementsMet() {
 		this.setState( {
 			pluginRequirementsMet: true,
@@ -54,26 +68,28 @@ class Wizard extends Component {
 	/**
 	 * Render any errors that need rendering.
 	 *
-	 * @return null | React object
+	 * @return null | Component
 	 */
 	getError() {
 		const { error } = this.props;
 		if ( ! error ) {
 			return null;
 		}
-		const { level } = error;
+
+		const parsedError = this.parseError( error );
+		const { level } = parsedError;
 		if ( 'fatal' === level ) {
-			return this.getFatalError( error );
+			return this.getFatalError( parsedError );
 		}
 
-		return this.getErrorNotice( error );
+		return this.getErrorNotice( parsedError );
 	}
 
 	/**
 	 * Get a notice-level error.
 	 *
 	 * @param Error object already parsed by parseError
-	 * @return React object
+	 * @return Component
 	 */
 	getErrorNotice( error ) {
 		const { message } = error;
@@ -95,20 +111,20 @@ class Wizard extends Component {
 		return (
 			<Modal
 				title={ __( 'Unrecoverable error' ) }
-				onRequestClose={ () => console.log( 'Redirect to checklist now' ) }
+				onRequestClose={ () => ( window.location = newspack_urls[ 'dashboard' ] ) }
 			>
 				<p>
 					<strong>{ message }</strong>
 				</p>
 				<Button isPrimary onClick={ () => this.setState( { modalShown: false } ) }>
-					{ __( 'Return to checklist' ) }
+					{ __( 'Return to dashboard' ) }
 				</Button>
 			</Modal>
 		);
 	}
 
 	/**
-	 * Parse an error caught by an API request.
+	 * Get all the relevant info out of a raw API error response.
 	 *
 	 * @param Raw error object
 	 * @return Error object with relevant fields and defaults
@@ -129,18 +145,8 @@ class Wizard extends Component {
 	}
 
 	/**
-	 * Go to the next wizard step.
+	 * Render.
 	 */
-	nextWizardStep() {
-		const { wizardStep, error } = this.state;
-
-		if ( ! error ) {
-			this.setState( {
-				wizardStep: wizardStep + 1,
-			} );
-		}
-	}
-
 	render() {
 		const { pluginRequirementsMet, wizardStep } = this.state;
 		const { requiredPlugins, requiredPluginsCancelText, onRequiredPluginsCancel } = this.props;
@@ -160,7 +166,11 @@ class Wizard extends Component {
 							onComplete={ () => this.handlePluginRequirementsMet() }
 						/>
 						{ requiredPluginsCancelText && (
-							<Button isTertiary className='is-centered' onClick={ () => onRequiredPluginsCancel() }>
+							<Button
+								isTertiary
+								className="is-centered"
+								onClick={ () => onRequiredPluginsCancel() }
+							>
 								{ requiredPluginsCancelText }
 							</Button>
 						) }

--- a/assets/components/src/wizard/index.js
+++ b/assets/components/src/wizard/index.js
@@ -1,0 +1,223 @@
+/**
+ * Multi-Screen Wizard.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment, cloneElement } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { PluginInstaller, Card, FormattedHeader, Modal, Button } from '../';
+import './style.scss';
+
+//const REQUIRED_PLUGINS = [ 'woocommerce' ];
+
+class Wizard extends Component {
+	constructor( props ) {
+		super( ...arguments );
+
+		const { requiredPlugins } = props;
+		this.state = {
+			pluginRequirementsMet: requiredPlugins ? false : true,
+			wizardScreen: false,
+			error: false,
+		}
+	}
+
+	getActiveWizardScreen() {
+		const { wizardScreen } = this.state;
+		const { children } = this.props;
+
+		const active = children.find( function( child ) {
+			const { identifier } = child.props;
+			if ( ! identifier ) {
+				return false;
+			}
+
+			// If no wizardScreen is active, return the first wizardScreen.
+			if ( ! wizardScreen ) {
+				return true;
+			}
+
+			return identifier === wizardScreen;
+		} );
+
+		return active || false;
+	}
+
+	getActiveWizardScreenIdentifier() {
+		const active = this.getActiveWizardScreen();
+		if ( ! active ) {
+			return false;
+		}
+
+		return active.props.identifier;
+	}
+
+	prepareWizardScreen( wizardScreen ) {
+		const { props } = wizardScreen;
+		if ( ! props ) {
+			return wizardScreen;
+		}
+
+		const newProps = {};
+		const { onCompleteButtonClicked, onSubCompleteButtonClicked } = props;
+		if ( 'string' === typeof onCompleteButtonClicked ) {
+			newProps.onCompleteButtonClicked = () => this.setState( { wizardScreen: onCompleteButtonClicked } );
+		}
+
+		if ( 'string' === typeof onSubCompleteButtonClicked ) {
+			newProps.onSubCompleteButtonClicked = () => this.setState( { wizardScreen: onSubCompleteButtonClicked } );
+		}
+
+		return cloneElement( wizardScreen, newProps );
+	}
+
+	componentDidMount() {
+		this.setState( {
+			wizardStep: this.getActiveWizardScreenIdentifier(),
+		} );
+	}
+
+	/**
+	 * Get the saved data for populating the forms when wizard is first loaded.
+	 */
+	componentDidUpdate( prevProps, prevState ) {
+		const { error, pluginRequirementsMet } = this.state;
+
+		if ( error ) {
+			return;
+		}
+
+		if ( ! prevState.pluginRequirementsMet && this.state.pluginRequirementsMet ) {
+			// Get initial info.
+		}
+	}
+
+	/**
+	 * Render any errors that need rendering.
+	 *
+	 * @return null | React object
+	 */
+	getError() {
+		const { error } = this.state;
+		if ( ! error ) {
+			return null;
+		}
+		const { level } = error;
+		if ( 'fatal' === level ) {
+			return this.getFatalError( error );
+		}
+
+		return this.getErrorNotice( error );
+	}
+
+	/**
+	 * Get a notice-level error.
+	 *
+	 * @param Error object already parsed by parseError
+	 * @return React object
+	 */
+	getErrorNotice( error ) {
+		const { message } = error;
+		return (
+			<div className="notice notice-error notice-alt update-message">
+				<p>{ message }</p>
+			</div>
+		);
+	}
+
+	/**
+	 * Get a fatal-level error.
+	 *
+	 * @param Error object already parsed by parseError
+	 * @return React object
+	 */
+	getFatalError( error ) {
+		const { message } = error;
+		return (
+			<Modal
+				title={ __( 'Unrecoverable error' ) }
+				onRequestClose={ () => console.log( 'Redirect to checklist now' ) }
+			>
+				<p>
+					<strong>{ message }</strong>
+				</p>
+				<Button isPrimary onClick={ () => this.setState( { modalShown: false } ) }>
+					{ __( 'Return to checklist' ) }
+				</Button>
+			</Modal>
+		);
+	}
+
+	/**
+	 * Parse an error caught by an API request.
+	 *
+	 * @param Raw error object
+	 * @return Error object with relevant fields and defaults
+	 */
+	parseError( error ) {
+		const { data, message, code } = error;
+		let level = 'fatal';
+		if ( !! data && 'level' in data ) {
+			level = data.level;
+		} else if ( 'rest_invalid_param' === code ) {
+			level = 'notice';
+		}
+
+		return {
+			message,
+			level,
+		};
+	}
+
+	/**
+	 * Go to the next wizard step.
+	 */
+	nextWizardStep() {
+		const { wizardStep, error } = this.state;
+
+		if ( ! error ) {
+			this.setState( {
+				wizardStep: wizardStep + 1,
+			} );
+		}
+	}
+
+	render() {
+		const { pluginRequirementsMet, wizardStep } = this.state;
+		const { requiredPlugins } = this.props;
+		const error = this.getError();
+
+		if ( ! pluginRequirementsMet ) {
+			return (
+				<Fragment>
+					{ error }
+					<Card noBackground>
+						<FormattedHeader
+							headerText={ __( 'Required plugin' ) }
+							subHeaderText={ __( 'This feature requires the following plugin.' ) }
+						/>
+						<PluginInstaller
+							plugins={ requiredPlugins }
+							onComplete={ () => this.setState( { pluginRequirementsMet: true } ) }
+						/>
+					</Card>
+				</Fragment>
+			);
+		}
+
+		return (
+			<Fragment>
+				{ error }
+				{ this.prepareWizardScreen( this.getActiveWizardScreen() ) }
+			</Fragment>
+		);
+	}
+}
+export default Wizard;

--- a/assets/components/src/wizardScreen/index.js
+++ b/assets/components/src/wizardScreen/index.js
@@ -5,14 +5,10 @@ import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 
-import { PluginInstaller, Card, FormattedHeader, Modal, Button } from '../';
+import { Card, Button } from '../';
 import murielClassnames from '../../../shared/js/muriel-classnames';
 
 class WizardScreen extends Component {
-	constructor( props ) {
-		super( ...arguments );
-	}
-
 	render() {
 		const {
 			identifier,

--- a/assets/components/src/wizardScreen/index.js
+++ b/assets/components/src/wizardScreen/index.js
@@ -1,14 +1,27 @@
 /**
+ * One screen from a Wizard.
+ */
+
+/**
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-
+/**
+ * Internal dependencies.
+ */
 import { Card, Button } from '../';
 import murielClassnames from '../../../shared/js/muriel-classnames';
+import './style.scss';
 
+/**
+ * One Wizard screen.
+ */
 class WizardScreen extends Component {
+	/**
+	 * Render.
+	 */
 	render() {
 		const {
 			identifier,
@@ -20,26 +33,28 @@ class WizardScreen extends Component {
 			className,
 			noBackground,
 		} = this.props;
-		const classes = murielClassnames(
-			'muriel-wizardScreen',
-			className,
-			identifier
-		);
+		const classes = murielClassnames( 'muriel-wizardScreen', className, identifier, noBackground ? 'muriel-wizardScreen__no-background' : '' );
 
 		return (
 			<Fragment>
 				<Card className={ classes } noBackground={ noBackground }>
-					<div className='muriel-wizardScreen__content'>
-						{ children }
-					</div>
+					<div className="muriel-wizardScreen__content">{ children }</div>
 					{ completeButtonText && (
-						<Button isPrimary className='is-centered' onClick={ () => onCompleteButtonClicked( identifier ) }>
+						<Button
+							isPrimary
+							className="is-centered muriel-wizardScreen__completeButton"
+							onClick={ () => onCompleteButtonClicked( identifier ) }
+						>
 							{ completeButtonText }
 						</Button>
 					) }
 				</Card>
 				{ subCompleteButtonText && (
-					<Button isTertiary className='is-centered' onClick={ () => onSubCompleteButtonClicked( identifier ) }>
+					<Button
+						isTertiary
+						className="is-centered muriel-wizardScreen__subCompleteButton"
+						onClick={ () => onSubCompleteButtonClicked( identifier ) }
+					>
 						{ subCompleteButtonText }
 					</Button>
 				) }

--- a/assets/components/src/wizardScreen/index.js
+++ b/assets/components/src/wizardScreen/index.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+
+import { PluginInstaller, Card, FormattedHeader, Modal, Button } from '../';
+import murielClassnames from '../../../shared/js/muriel-classnames';
+
+class WizardScreen extends Component {
+	constructor( props ) {
+		super( ...arguments );
+	}
+
+	render() {
+		const {
+			identifier,
+			completeButtonText,
+			onCompleteButtonClicked,
+			subCompleteButtonText,
+			onSubCompleteButtonClicked,
+			children,
+			className,
+			noBackground,
+		} = this.props;
+		const classes = murielClassnames(
+			'muriel-wizardScreen',
+			className,
+			identifier
+		);
+
+		return (
+			<Fragment>
+				<Card className={ classes } noBackground={ noBackground }>
+					<div className='muriel-wizardScreen__content'>
+						{ children }
+					</div>
+					{ completeButtonText && (
+						<Button isPrimary className='is-centered' onClick={ () => onCompleteButtonClicked( identifier ) }>
+							{ completeButtonText }
+						</Button>
+					) }
+				</Card>
+				{ subCompleteButtonText && (
+					<Button isTertiary className='is-centered' onClick={ () => onSubCompleteButtonClicked( identifier ) }>
+						{ subCompleteButtonText }
+					</Button>
+				) }
+			</Fragment>
+		);
+	}
+}
+export default WizardScreen;

--- a/assets/components/src/wizardScreen/style.scss
+++ b/assets/components/src/wizardScreen/style.scss
@@ -1,0 +1,10 @@
+.muriel-wizardScreen {
+	&.muriel-wizardScreen__no-background {
+		padding-bottom: 0;
+		padding-top: 1em;
+	}
+}
+
+.muriel-component.muriel-wizardScreen__completeButton {
+	margin-bottom: 0;
+}

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -49,6 +49,7 @@ class ComponentsDemo extends Component {
 			selectValue1: '2nd',
 			selectValue2: '',
 			modalShown: false,
+			activeWizardScreen: 'test-wizard-1',
 		};
 	}
 
@@ -76,8 +77,8 @@ class ComponentsDemo extends Component {
 			selectValue1,
 			selectValue2,
 			modalShown,
+			activeWizardScreen,
 		} = this.state;
-
 
 		return (
 			<Fragment>
@@ -85,11 +86,16 @@ class ComponentsDemo extends Component {
 					headerText={ __( 'Newspack Components' ) }
 					subHeaderText={ __( 'Temporary demo of Newspack components' ) }
 				/>
-				<Wizard>
+				<Wizard 
+					activeScreen={ activeWizardScreen } 
+					requiredPlugins={ [ 'jetpack' ] }
+					requiredPluginsCancelText={ __( 'Back to checklist' ) }
+					onRequiredPluginsCancel={ () => console.log( 'Checklist' ) }
+				>
 					<WizardScreen
 						identifier='test-wizard-1'
 						completeButtonText={ __( 'Continue to 2' ) }
-						onCompleteButtonClicked='test-wizard-2'
+						onCompleteButtonClicked={ () => this.setState( { activeWizardScreen: 'test-wizard-2' } ) }
 						subCompleteButtonText={ __( 'Back to checklist' ) }
 						onSubCompleteButtonClicked={ () => console.log( 'Checklist' ) }
 					>
@@ -102,9 +108,9 @@ class ComponentsDemo extends Component {
 					<WizardScreen
 						identifier='test-wizard-2'
 						completeButtonText={ __( 'Continue to 3' ) }
-						onCompleteButtonClicked='test-wizard-3'
+						onCompleteButtonClicked={ () => this.setState( { activeWizardScreen: 'test-wizard-3' } ) }
 						subCompleteButtonText={ __( 'Back to 1' ) }
-						onSubCompleteButtonClicked='test-wizard-1'
+						onSubCompleteButtonClicked={ () => this.setState( { activeWizardScreen: 'test-wizard-1' } ) }
 					>
 						<FormattedHeader
 							headerText={ __( 'WizardScreen Component 2' ) }
@@ -125,6 +131,7 @@ class ComponentsDemo extends Component {
 						<div>Content and whatnot can go here.</div>
 					</WizardScreen>
 				</Wizard>
+				<hr/>
 				<Card>
 					<FormattedHeader
 						headerText={ __( 'Notice/Modal' ) }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -103,7 +103,6 @@ class ComponentsDemo extends Component {
 							headerText={ __( 'WizardScreen Component 1' ) }
 							subHeaderText={ __( 'This is #1 wizard screen' ) }
 						/>
-						<div>Content and whatnot can go here.</div>
 					</WizardScreen>
 					<WizardScreen
 						identifier='test-wizard-2'
@@ -116,19 +115,17 @@ class ComponentsDemo extends Component {
 							headerText={ __( 'WizardScreen Component 2' ) }
 							subHeaderText={ __( 'This is #2 wizard screen' ) }
 						/>
-						<div>Content and whatnot can go here.</div>
 					</WizardScreen>
 					<WizardScreen
 						noBackground
 						identifier='test-wizard-3'
 						completeButtonText={ __( 'Finish' ) }
-						onCompleteButtonClicked={ () => console.log( 'Checklist' ) }
+						onCompleteButtonClicked={ () => this.setState( { activeWizardScreen: 'test-wizard-1' } ) }
 					>
 						<FormattedHeader
 							headerText={ __( 'WizardScreen Component 3' ) }
 							subHeaderText={ __( 'This is #3 wizard screen' ) }
 						/>
-						<div>Content and whatnot can go here.</div>
 					</WizardScreen>
 				</Wizard>
 				<hr/>

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -26,6 +26,8 @@ import {
 	Task,
 	SelectControl,
 	Modal,
+	Wizard,
+	WizardScreen,
 } from '../../components/src';
 import './style.scss';
 
@@ -76,12 +78,53 @@ class ComponentsDemo extends Component {
 			modalShown,
 		} = this.state;
 
+
 		return (
 			<Fragment>
 				<FormattedHeader
 					headerText={ __( 'Newspack Components' ) }
 					subHeaderText={ __( 'Temporary demo of Newspack components' ) }
 				/>
+				<Wizard>
+					<WizardScreen
+						identifier='test-wizard-1'
+						completeButtonText={ __( 'Continue to 2' ) }
+						onCompleteButtonClicked='test-wizard-2'
+						subCompleteButtonText={ __( 'Back to checklist' ) }
+						onSubCompleteButtonClicked={ () => console.log( 'Checklist' ) }
+					>
+						<FormattedHeader
+							headerText={ __( 'WizardScreen Component 1' ) }
+							subHeaderText={ __( 'This is #1 wizard screen' ) }
+						/>
+						<div>Content and whatnot can go here.</div>
+					</WizardScreen>
+					<WizardScreen
+						identifier='test-wizard-2'
+						completeButtonText={ __( 'Continue to 3' ) }
+						onCompleteButtonClicked='test-wizard-3'
+						subCompleteButtonText={ __( 'Back to 1' ) }
+						onSubCompleteButtonClicked='test-wizard-1'
+					>
+						<FormattedHeader
+							headerText={ __( 'WizardScreen Component 2' ) }
+							subHeaderText={ __( 'This is #2 wizard screen' ) }
+						/>
+						<div>Content and whatnot can go here.</div>
+					</WizardScreen>
+					<WizardScreen
+						noBackground
+						identifier='test-wizard-3'
+						completeButtonText={ __( 'Finish' ) }
+						onCompleteButtonClicked={ () => console.log( 'Checklist' ) }
+					>
+						<FormattedHeader
+							headerText={ __( 'WizardScreen Component 3' ) }
+							subHeaderText={ __( 'This is #3 wizard screen' ) }
+						/>
+						<div>Content and whatnot can go here.</div>
+					</WizardScreen>
+				</Wizard>
 				<Card>
 					<FormattedHeader
 						headerText={ __( 'Notice/Modal' ) }

--- a/assets/wizards/subscriptions/index.js
+++ b/assets/wizards/subscriptions/index.js
@@ -14,12 +14,15 @@ import { __ } from '@wordpress/i18n';
  */
 import ManageSubscriptionsScreen from './views/manageSubscriptionsScreen';
 import EditSubscriptionScreen from './views/editSubscriptionScreen';
-import {
-	FormattedHeader,
-	Wizard,
-	WizardScreen,
-} from '../../components/src';
+import { FormattedHeader, Wizard, WizardScreen } from '../../components/src';
 import './style.scss';
+
+const REQUIRED_PLUGINS = [
+	'woocommerce',
+	'woocommerce-subscriptions',
+	'woocommerce-name-your-price',
+	'woocommerce-one-page-checkout',
+];
 
 /**
  * Subscriptions wizard for managing and setting up subscriptions.
@@ -50,11 +53,17 @@ class SubscriptionsWizard extends Component {
 	 * Get the latest subscriptions info.
 	 */
 	refreshSubscriptions() {
-		apiFetch( { path: '/newspack/v1/wizard/subscriptions' } ).then( subscriptions => {
-			this.setState( {
-				subscriptions: subscriptions,
+		apiFetch( { path: '/newspack/v1/wizard/subscriptions' } )
+			.then( subscriptions => {
+				this.setState( {
+					subscriptions: subscriptions,
+				} );
+			} )
+			.catch( error => {
+				this.setState( {
+					error,
+				} );
 			} );
-		} );
 	}
 
 	/**
@@ -74,16 +83,22 @@ class SubscriptionsWizard extends Component {
 				price,
 				frequency,
 			},
-		} ).then( response => {
-			this.setState(
-				{
-					editing: false,
-				},
-				() => {
-					this.refreshSubscriptions();
-				}
-			);
-		} );
+		} )
+			.then( response => {
+				this.setState(
+					{
+						editing: false,
+					},
+					() => {
+						this.refreshSubscriptions();
+					}
+				);
+			} )
+			.catch( error => {
+				this.setState( {
+					error,
+				} );
+			} );
 	}
 
 	/**
@@ -96,9 +111,15 @@ class SubscriptionsWizard extends Component {
 			apiFetch( {
 				path: '/newspack/v1/wizard/subscriptions/' + id,
 				method: 'delete',
-			} ).then( response => {
-				this.refreshSubscriptions();
-			} );
+			} )
+				.then( response => {
+					this.refreshSubscriptions();
+				} )
+				.catch( error => {
+					this.setState( {
+						error,
+					} );
+				} );
 		}
 	}
 
@@ -106,11 +127,17 @@ class SubscriptionsWizard extends Component {
 	 * Get the latest info about the choosePrice setting.
 	 */
 	refreshChoosePrice() {
-		apiFetch( { path: '/newspack/v1/wizard/subscriptions/choose-price' } ).then( choosePrice => {
-			this.setState( {
-				choosePrice: !! choosePrice,
+		apiFetch( { path: '/newspack/v1/wizard/subscriptions/choose-price' } )
+			.then( choosePrice => {
+				this.setState( {
+					choosePrice: !! choosePrice,
+				} );
+			} )
+			.catch( error => {
+				this.setState( {
+					error,
+				} );
 			} );
-		} );
 	}
 
 	/**
@@ -128,9 +155,15 @@ class SubscriptionsWizard extends Component {
 					data: {
 						enabled: this.state.choosePrice,
 					},
-				} ).then( response => {
-					this.refreshSubscriptions();
-				} );
+				} )
+					.then( response => {
+						this.refreshSubscriptions();
+					} )
+					.catch( error => {
+						this.setState( {
+							error,
+						} );
+					} );
 			}
 		);
 	}
@@ -174,41 +207,47 @@ class SubscriptionsWizard extends Component {
 			<Fragment>
 				{ heading && <FormattedHeader headerText={ heading } subHeaderText={ subHeading } /> }
 				<Wizard
-					requiredPlugins={ [ 'woocommerce' ] }
+					requiredPlugins={ REQUIRED_PLUGINS }
 					activeScreen={ currentScreen }
 					requiredPluginsCancelText={ __( 'Back to checklist' ) }
-					onRequiredPluginsCancel={ () => window.location = newspack_urls['checklists']['memberships'] }
+					onRequiredPluginsCancel={ () =>
+						( window.location = newspack_urls[ 'checklists' ][ 'memberships' ] )
+					}
 					onPluginRequirementsMet={ () => this.onWizardReady() }
 					error={ error }
 				>
 					<WizardScreen
-						identifier='manage-subscriptions'
+						identifier="manage-subscriptions"
 						completeButtonText={ buttonText }
-						onCompleteButtonClicked={ () => this.setState( 
-							{
+						onCompleteButtonClicked={ () =>
+							this.setState( {
 								editing: {
 									id: 0,
 									name: '',
 									image: null,
 									price: '',
 									frequency: 'month',
-								}
-							} 
-						) }
+								},
+							} )
+						}
 						subCompleteButtonText={ subButtonText }
-						onSubCompleteButtonClicked={ () => window.location = newspack_urls['checklists']['memberships'] }
+						onSubCompleteButtonClicked={ () =>
+							( window.location = newspack_urls[ 'checklists' ][ 'memberships' ] )
+						}
 						noBackground
 					>
 						<ManageSubscriptionsScreen
 							subscriptions={ subscriptions }
 							choosePrice={ choosePrice }
 							onClickEditSubscription={ subscription => this.setState( { editing: subscription } ) }
-							onClickDeleteSubscription={ subscription => this.deleteSubscription( subscription.id ) }
+							onClickDeleteSubscription={ subscription =>
+								this.deleteSubscription( subscription.id )
+							}
 							onClickChoosePrice={ () => this.toggleChoosePrice() }
 						/>
 					</WizardScreen>
 					<WizardScreen
-						identifier='edit-subscription'
+						identifier="edit-subscription"
 						completeButtonText={ buttonText }
 						onCompleteButtonClicked={ () => this.saveSubscription() }
 						subCompleteButtonText={ subButtonText }

--- a/assets/wizards/subscriptions/style.scss
+++ b/assets/wizards/subscriptions/style.scss
@@ -2,12 +2,6 @@
  * Subscriptions Wizard styles.
  */
 
-#newspack-subscriptions-wizard {
-	header.muriel-formatted-header {
-		margin-bottom: 32px;
-	}
-}
-
 /**
  * Subscription management screen.
  */

--- a/assets/wizards/subscriptions/style.scss
+++ b/assets/wizards/subscriptions/style.scss
@@ -12,27 +12,10 @@
  * Subscription management screen.
  */
 .newspack-manage-subscriptions-screen {
-	max-width: 440px;
-	margin-left: auto;
-	margin-right: auto;
-
-	button.is-primary {
-		margin-top: 3em;
+	.newspack-manage-subscriptions-screen__choose-price {
+		margin-top: 2em;
 		margin-bottom: 2em;
 	}
-}
-
-.newspack-manage-subscriptions-screen__finished {
-	display: block;
-	text-align: center;
-}
-
-.newspack-manage-subscriptions-screen__finished {
-	text-decoration: none;
-}
-
-.newspack-manage-subscriptions-screen__choose-price {
-	margin-top: 2em;
 }
 
 /**
@@ -45,7 +28,7 @@
 	}
 
 	button.is-primary {
-		margin-bottom: 2em;
+		margin-top: 2em;
 	}
 }
 

--- a/assets/wizards/subscriptions/views/editSubscriptionScreen.js
+++ b/assets/wizards/subscriptions/views/editSubscriptionScreen.js
@@ -12,9 +12,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import {
-	Card,
-	FormattedHeader,
-	Button,
 	TextControl,
 	ImageUpload,
 	SelectControl,
@@ -41,64 +38,43 @@ class EditSubscriptionScreen extends Component {
 	 * Render.
 	 */
 	render() {
-		const { subscription, onClickSave, onClickCancel } = this.props;
+		const { subscription } = this.props;
 		const { id, name, price, frequency } = subscription;
 		let { image } = subscription;
 		if ( ! image || '0' === image.id ) {
 			image = null;
 		}
 
-		const editing_existing_subscription = !! id;
-		const heading = editing_existing_subscription
-			? __( 'Edit subscription' )
-			: __( 'Add a subscription' );
-		const subHeading = editing_existing_subscription
-			? __( 'You are editing an existing subscription' )
-			: __( 'You are adding a new subscription' );
-
 		return (
 			<div className="newspack-edit-subscription-screen">
-				<FormattedHeader headerText={ heading } subHeaderText={ subHeading } />
-				<Card>
+				<TextControl
+					label={ __( 'What is this product called? e.g. Valued Donor' ) }
+					value={ name }
+					onChange={ value => this.handleOnChange( 'name', value ) }
+				/>
+				<ImageUpload
+					image={ image }
+					onChange={ value => this.handleOnChange( 'image', value ) }
+				/>
+				<div className="newspack-edit-subscription-screen__price-settings">
 					<TextControl
-						label={ __( 'What is this product called? e.g. Valued Donor' ) }
-						value={ name }
-						onChange={ value => this.handleOnChange( 'name', value ) }
+						type="number"
+						step="0.01"
+						label={ __( 'Price' ) }
+						value={ price }
+						onChange={ value => this.handleOnChange( 'price', value ) }
 					/>
-					<ImageUpload
-						image={ image }
-						onChange={ value => this.handleOnChange( 'image', value ) }
+					<SelectControl
+						label={ __( 'Frequency' ) }
+						value={ frequency }
+						options={ [
+							{ value: 'month', label: __( 'per month' ) },
+							{ value: 'year', label: __( 'per year' ) },
+							{ value: 'once', label: __( 'once' ) },
+						] }
+						onChange={ value => this.handleOnChange( 'frequency', value ) }
 					/>
-					<div className="newspack-edit-subscription-screen__price-settings">
-						<TextControl
-							type="number"
-							step="0.01"
-							label={ __( 'Price' ) }
-							value={ price }
-							onChange={ value => this.handleOnChange( 'price', value ) }
-						/>
-						<SelectControl
-							label={ __( 'Frequency' ) }
-							value={ frequency }
-							options={ [
-								{ value: 'month', label: __( 'per month' ) },
-								{ value: 'year', label: __( 'per year' ) },
-								{ value: 'once', label: __( 'once' ) },
-							] }
-							onChange={ value => this.handleOnChange( 'frequency', value ) }
-						/>
-					</div>
-					<Button isPrimary className="is-centered" onClick={ () => onClickSave( subscription ) }>
-						{ __( 'Save' ) }
-					</Button>
-					<Button
-						className="newspack-edit-subscription-screen__cancel isLink is-centered is-tertiary"
-						href="#"
-						onClick={ () => onClickCancel() }
-					>
-						{ __( 'Cancel' ) }
-					</Button>
-				</Card>
+				</div>
 			</div>
 		);
 	}

--- a/assets/wizards/subscriptions/views/manageSubscriptionsScreen.js
+++ b/assets/wizards/subscriptions/views/manageSubscriptionsScreen.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, CheckboxControl, FormattedHeader } from '../../../components/src';
+import { ActionCard, CheckboxControl } from '../../../components/src';
 
 /**
  * Subscriptions management screen.
@@ -29,19 +29,8 @@ class ManageSubscriptionsScreen extends Component {
 			onClickChoosePrice,
 		} = this.props;
 
-		const headerText = subscriptions.length
-			? __( 'Any more subscriptions to add?' )
-			: __( 'Add your first subscription' );
-		const buttonText = subscriptions.length
-			? __( 'Add another subscription' )
-			: __( 'Add a subscription' );
-
 		return (
 			<div className="newspack-manage-subscriptions-screen">
-				<FormattedHeader
-					headerText={ headerText }
-					subHeaderText={ __( 'Subscriptions can provide a stable, recurring source of revenue' ) }
-				/>
 				{ subscriptions.map( subscription => {
 					const { id, image, name, display_price, url } = subscription;
 
@@ -71,28 +60,6 @@ class ManageSubscriptionsScreen extends Component {
 						checked={ choosePrice }
 					/>
 				) }
-				<Button
-					isPrimary
-					className="is-centered"
-					onClick={ () =>
-						onClickEditSubscription( {
-							id: 0,
-							name: '',
-							image: null,
-							price: '',
-							frequency: 'month',
-						} )
-					}
-				>
-					{ buttonText }
-				</Button>
-				<Button
-					className='is-centered'
-					isTertiary
-					href={ newspack_urls['checklists']['memberships'] }
-				>
-					{ __( "I'm done adding" ) }
-				</Button>
 			</div>
 		);
 	}

--- a/assets/wizards/subscriptionsOnboarding/views/locationSetup.js
+++ b/assets/wizards/subscriptionsOnboarding/views/locationSetup.js
@@ -34,7 +34,7 @@ class LocationSetup extends Component {
 	 * Render.
 	 */
 	render() {
-		const { location, onClickContinue, onClickSkip, countrystateFields, currencyFields } = this.props;
+		const { location, countrystateFields, currencyFields } = this.props;
 		const { countrystate, address1, address2, city, postcode, currency } = location;
 
 		return (
@@ -78,9 +78,6 @@ class LocationSetup extends Component {
 						options={ currencyFields }
 						onChange={ value => this.handleOnChange( 'currency', value ) }
 					/>
-					<Button isPrimary className='is-centered' onClick={ () => onClickContinue() }>
-						{ __( 'Continue' ) }
-					</Button>
 				</Card>
 			</div>
 		);

--- a/assets/wizards/subscriptionsOnboarding/views/locationSetup.js
+++ b/assets/wizards/subscriptionsOnboarding/views/locationSetup.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Card, FormattedHeader, Button, TextControl, SelectControl } from '../../../components/src';
+import { TextControl, SelectControl } from '../../../components/src';
 
 /**
  * Location Setup Screen.
@@ -39,46 +39,38 @@ class LocationSetup extends Component {
 
 		return (
 			<div className='newspack-location-setup-screen'>
-				<FormattedHeader
-					headerText={ __( 'About your publication' ) }
-					subHeaderText={ __(
-						'This information is required for accepting payments'
-					) }
+				<SelectControl
+					label={ __( 'Where is your business based?' ) }
+					value={ countrystate }
+					options={ countrystateFields }
+					onChange={ value => this.handleOnChange( 'countrystate', value ) }
 				/>
-				<Card>
-					<SelectControl
-						label={ __( 'Where is your business based?' ) }
-						value={ countrystate }
-						options={ countrystateFields }
-						onChange={ value => this.handleOnChange( 'countrystate', value ) }
-					/>
-					<TextControl
-						label={ __( 'Address' ) }
-						value={ address1 }
-						onChange={ value => this.handleOnChange( 'address1', value ) }
-					/>
-					<TextControl
-						label={ __( 'Address line 2' ) }
-						value={ address2 }
-						onChange={ value => this.handleOnChange( 'address2', value ) }
-					/>
-					<TextControl
-						label={ __( 'City' ) }
-						value={ city }
-						onChange={ value => this.handleOnChange( 'city', value ) }
-					/>
-					<TextControl
-						label={ __( 'Postcode / Zip' ) }
-						value={ postcode }
-						onChange={ value => this.handleOnChange( 'postcode', value ) }
-					/>
-					<SelectControl
-						label={ 'Which currency does your business use?' }
-						value={ currency }
-						options={ currencyFields }
-						onChange={ value => this.handleOnChange( 'currency', value ) }
-					/>
-				</Card>
+				<TextControl
+					label={ __( 'Address' ) }
+					value={ address1 }
+					onChange={ value => this.handleOnChange( 'address1', value ) }
+				/>
+				<TextControl
+					label={ __( 'Address line 2' ) }
+					value={ address2 }
+					onChange={ value => this.handleOnChange( 'address2', value ) }
+				/>
+				<TextControl
+					label={ __( 'City' ) }
+					value={ city }
+					onChange={ value => this.handleOnChange( 'city', value ) }
+				/>
+				<TextControl
+					label={ __( 'Postcode / Zip' ) }
+					value={ postcode }
+					onChange={ value => this.handleOnChange( 'postcode', value ) }
+				/>
+				<SelectControl
+					label={ 'Which currency does your business use?' }
+					value={ currency }
+					options={ currencyFields }
+					onChange={ value => this.handleOnChange( 'currency', value ) }
+				/>
 			</div>
 		);
 	}

--- a/assets/wizards/subscriptionsOnboarding/views/paymentSetup.js
+++ b/assets/wizards/subscriptionsOnboarding/views/paymentSetup.js
@@ -43,7 +43,7 @@ class PaymentSetup extends Component {
 	 * Render.
 	 */
 	render() {
-		const { stripeSettings, onClickFinish, onClickCancel, onChange } = this.props;
+		const { stripeSettings, onChange } = this.props;
 		const {
 			enabled,
 			testMode,
@@ -128,9 +128,6 @@ class PaymentSetup extends Component {
 							) }
 						</em>
 					) }
-					<Button isPrimary className='is-centered' onClick={ () => onClickFinish() }>
-						{ __( 'Finish' ) }
-					</Button>
 				</Card>
 			</div>
 		);

--- a/assets/wizards/subscriptionsOnboarding/views/paymentSetup.js
+++ b/assets/wizards/subscriptionsOnboarding/views/paymentSetup.js
@@ -13,9 +13,6 @@ import { ToggleControl } from '@wordpress/components';
  * Internal dependencies
  */
 import {
-	Card,
-	FormattedHeader,
-	Button,
 	TextControl,
 	SelectControl,
 	CheckboxControl,
@@ -55,80 +52,74 @@ class PaymentSetup extends Component {
 
 		return (
 			<div className='newspack-payment-setup-screen'>
-				<FormattedHeader
-					headerText={ __( 'Set up Stripe' ) }
-					subHeaderText={ __( 'Stripe is the recommended gateway for accepting payments' ) }
+				<ToggleControl
+					label={ __( 'Enable Stripe' ) }
+					checked={ enabled }
+					onChange={ value => this.handleOnChange( 'enabled', value ) }
 				/>
-				<Card>
-					<ToggleControl
-						label={ __( 'Enable Stripe' ) }
-						checked={ enabled }
-						onChange={ value => this.handleOnChange( 'enabled', value ) }
-					/>
-					{ enabled && (
-						<Fragment>
-							<h3 className='newspack-payment-setup-screen__settings-heading'>
-								{ __( 'Stripe settings' ) }
-							</h3>
-							<CheckboxControl
-								label={ __( 'Use Stripe in test mode' ) }
-								checked={ testMode }
-								onChange={ value => this.handleOnChange( 'testMode', value ) }
-								tooltip='Test mode will not capture real payments. Use it for testing your purchase flow.'
-							/>
-							<div className='newspack-payment-setup-screen__api-keys-heading'>
-								<h4 className='newspack-payment-setup-screen__api-keys-instruction'>
-									{ __( 'Get your API keys from your Stripe account' ) }
-								</h4>
-								<p className='newspack-payment-setup-screen__api-tip'>
-									<a href='https://stripe.com/docs/keys#api-keys' target='_blank'>
-										{ __( 'Learn how' ) }
-									</a>
-								</p>
+				{ enabled && (
+					<Fragment>
+						<h3 className='newspack-payment-setup-screen__settings-heading'>
+							{ __( 'Stripe settings' ) }
+						</h3>
+						<CheckboxControl
+							label={ __( 'Use Stripe in test mode' ) }
+							checked={ testMode }
+							onChange={ value => this.handleOnChange( 'testMode', value ) }
+							tooltip='Test mode will not capture real payments. Use it for testing your purchase flow.'
+						/>
+						<div className='newspack-payment-setup-screen__api-keys-heading'>
+							<h4 className='newspack-payment-setup-screen__api-keys-instruction'>
+								{ __( 'Get your API keys from your Stripe account' ) }
+							</h4>
+							<p className='newspack-payment-setup-screen__api-tip'>
+								<a href='https://stripe.com/docs/keys#api-keys' target='_blank'>
+									{ __( 'Learn how' ) }
+								</a>
+							</p>
 
-								{ testMode && (
-									<Fragment>
-										<TextControl
-											type='password'
-											value={ testPublishableKey }
-											label={ __( 'Test Publishable Key' ) }
-											onChange={ value => this.handleOnChange( 'testPublishableKey', value ) }
-										/>
-										<TextControl
-											type='password'
-											value={ testSecretKey }
-											label={ __( 'Test Secret Key' ) }
-											onChange={ value => this.handleOnChange( 'testSecretKey', value ) }
-										/>
-									</Fragment>
-								) }
-								{ ! testMode && (
-									<Fragment>
-										<TextControl
-											type='password'
-											value={ publishableKey }
-											label={ __( 'Publishable Key' ) }
-											onChange={ value => this.handleOnChange( 'publishableKey', value ) }
-										/>
-										<TextControl
-											type='password'
-											value={ secretKey }
-											label={ __( 'Secret Key' ) }
-											onChange={ value => this.handleOnChange( 'secretKey', value ) }
-										/>
-									</Fragment>
-								) }
-							</div>
-						</Fragment>
-					) }
-					{ ! enabled && (
-						<em>
-							{ __(
-								'Other gateways can be enabled and set up in the WooCommerce payment gateway settings.'
+							{ testMode && (
+								<Fragment>
+									<TextControl
+										type='password'
+										value={ testPublishableKey }
+										label={ __( 'Test Publishable Key' ) }
+										onChange={ value => this.handleOnChange( 'testPublishableKey', value ) }
+									/>
+									<TextControl
+										type='password'
+										value={ testSecretKey }
+										label={ __( 'Test Secret Key' ) }
+										onChange={ value => this.handleOnChange( 'testSecretKey', value ) }
+									/>
+								</Fragment>
 							) }
-						</em>
-					) }
-				</Card>
+							{ ! testMode && (
+								<Fragment>
+									<TextControl
+										type='password'
+										value={ publishableKey }
+										label={ __( 'Publishable Key' ) }
+										onChange={ value => this.handleOnChange( 'publishableKey', value ) }
+									/>
+									<TextControl
+										type='password'
+										value={ secretKey }
+										label={ __( 'Secret Key' ) }
+										onChange={ value => this.handleOnChange( 'secretKey', value ) }
+									/>
+								</Fragment>
+							) }
+						</div>
+					</Fragment>
+				) }
+				{ ! enabled && (
+					<em>
+						{ __(
+							'Other gateways can be enabled and set up in the WooCommerce payment gateway settings.'
+						) }
+					</em>
+				) }
 			</div>
 		);
 	}

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -25,7 +25,7 @@ class Plugin_Manager {
 	 */
 	public static function get_managed_plugins() {
 		$managed_plugins = [
-			'jetpack'                    => [
+			'jetpack'                       => [
 				'Name'        => __( 'Jetpack', 'newspack' ),
 				'Description' => esc_html__( 'Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.', 'newspack' ),
 				'Author'      => 'Automattic',
@@ -33,7 +33,7 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://automattic.com/',
 				'Download'    => 'wporg',
 			],
-			'amp'                        => [
+			'amp'                           => [
 				'Name'        => __( 'AMP', 'newspack' ),
 				'Description' => esc_html__( 'Enable AMP on your WordPress site, the WordPress way.', 'newspack' ),
 				'Author'      => 'WordPress.com VIP, XWP, Google, and contributors',
@@ -41,14 +41,14 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://github.com/ampproject/amp-wp/graphs/contributors',
 				'Download'    => 'wporg',
 			],
-			'woocommerce-gateway-stripe' => [
+			'woocommerce-gateway-stripe'    => [
 				'Name'        => __( 'WooCommerce Stripe Gateway', 'newspack' ),
 				'Description' => esc_html__( 'Take credit card payments on your store using Stripe.', 'newspack' ),
 				'Author'      => 'WooCommerce',
 				'PluginURI'   => 'https://woocommerce.com/',
 				'AuthorURI'   => 'https://woocommerce.com/',
 			],
-			'woocommerce'                => [
+			'woocommerce'                   => [
 				'Name'        => __( 'WooCommerce', 'newspack' ),
 				'Description' => esc_html__( 'An eCommerce toolkit that helps you sell anything. Beautifully.', 'newspack' ),
 				'Author'      => 'WordPress.com VIP, XWP, Google, and contributors',
@@ -56,14 +56,38 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://woocommerce.com',
 				'Download'    => 'wporg',
 			],
-			'wordpress-seo'              => [
+			'woocommerce-subscriptions'     => [
+				'Name'        => __( 'WooCommerce Subscriptions', 'newspack' ),
+				'Description' => esc_html__( 'An eCommerce toolkit that helps you sell anything. Beautifully.', 'newspack' ),
+				'Author'      => 'Prospress Inc.',
+				'PluginURI'   => 'https://woocommerce.com/products/woocommerce-subscriptions/',
+				'AuthorURI'   => 'https://prospress.com',
+				'Download'    => 'wporg', // @todo add premium plugin handling.
+			],
+			'woocommerce-name-your-price'   => [
+				'Name'        => __( 'WooCommerce Name Your Price', 'newspack' ),
+				'Description' => esc_html__( 'WooCommerce Name Your Price allows customers to set their own price for products or donations.', 'newspack' ),
+				'Author'      => 'Kathy Darling',
+				'PluginURI'   => 'http://www.woocommerce.com/products/name-your-price/',
+				'AuthorURI'   => 'http://kathyisawesome.com',
+				'Download'    => 'wporg', // @todo add premium plugin handling.
+			],
+			'woocommerce-one-page-checkout' => [
+				'Name'        => __( 'WooCommerce One Page Checkout', 'newspack' ),
+				'Description' => esc_html__( 'Super fast sales with WooCommerce. Add to cart, checkout & pay all on the one page!', 'newspack' ),
+				'Author'      => 'Prospress Inc.',
+				'PluginURI'   => 'https://woocommerce.com/products/woocommerce-one-page-checkout/',
+				'AuthorURI'   => 'http://prospress.com/',
+				'Download'    => 'wporg', // @todo add premium plugin handling.
+			],
+			'wordpress-seo'                 => [
 				'Name'        => 'Yoast SEO',
 				'Description' => 'The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more.',
 				'Author'      => 'Team Yoast',
 				'AuthorURI'   => 'https://yoa.st/1uk',
 				'Download'    => 'wporg',
 			],
-			'fake-plugin'                => [
+			'fake-plugin'                   => [
 				'Name'        => 'Fake Plugin',
 				'Description' => 'This is a made-up plugin, meant to error out.',
 				'Author'      => 'Newspack',

--- a/includes/wizards/class-subscriptions-wizard.php
+++ b/includes/wizards/class-subscriptions-wizard.php
@@ -7,7 +7,7 @@
 
 namespace Newspack;
 
-use \WC_Subscriptions_Product, \WC_Product_Simple, \WC_Product_Subscription, \WC_Name_Your_Price_Helpers;
+use \WP_Error, \WC_Subscriptions_Product, \WC_Product_Simple, \WC_Product_Subscription, \WC_Name_Your_Price_Helpers;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -173,11 +173,36 @@ class Subscriptions_Wizard extends Wizard {
 	}
 
 	/**
+	 * Check whether required lugins are installed and active.
+	 *
+	 * @return bool | WP_Error True on success, WP_Error on failure.
+	 */
+	protected function check_required_plugins_installed() {
+		if ( ! function_exists( 'WC' ) || ! class_exists( 'WC_Subscriptions_Product' ) || ! class_exists( 'WC_Name_Your_Price_Helpers' ) ) {
+			return new WP_Error(
+				'newspack_missing_required_plugin',
+				esc_html__( 'The required plugins are not installed and activated. Install and/or activate them to access this feature.', 'newspack' ),
+				[
+					'status' => 400,
+					'level'  => 'fatal',
+				]
+			);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Get the Newspack subscriptions.
 	 *
 	 * @return WP_REST_Response containing subscriptions info.
 	 */
 	public function api_get_subscriptions() {
+		$required_plugins_installed = $this->check_required_plugins_installed();
+		if ( is_wp_error( $required_plugins_installed ) ) {
+			return rest_ensure_response( $required_plugins_installed );
+		}
+
 		$products = wc_get_products(
 			[
 				'limit'                           => -1,
@@ -200,6 +225,11 @@ class Subscriptions_Wizard extends Wizard {
 	 * @return WP_REST_Response containing subscription info.
 	 */
 	public function api_get_subscription( $request ) {
+		$required_plugins_installed = $this->check_required_plugins_installed();
+		if ( is_wp_error( $required_plugins_installed ) ) {
+			return rest_ensure_response( $required_plugins_installed );
+		}
+
 		$params  = $request->get_params();
 		$id      = $params['id'];
 		$product = wc_get_product( $params['id'] );
@@ -223,6 +253,11 @@ class Subscriptions_Wizard extends Wizard {
 	 * @return array of information about the product.
 	 */
 	protected function get_product_data_for_api( $product ) {
+		$required_plugins_installed = $this->check_required_plugins_installed();
+		if ( is_wp_error( $required_plugins_installed ) ) {
+			return rest_ensure_response( $required_plugins_installed );
+		}
+
 		return [
 			'id'            => $product->get_id(),
 			'name'          => $product->get_name(),
@@ -244,6 +279,11 @@ class Subscriptions_Wizard extends Wizard {
 	 * @return WP_REST_Response Updated product info.
 	 */
 	public function api_save_subscription( $request ) {
+		$required_plugins_installed = $this->check_required_plugins_installed();
+		if ( is_wp_error( $required_plugins_installed ) ) {
+			return rest_ensure_response( $required_plugins_installed );
+		}
+
 		$params   = $request->get_params();
 		$defaults = [
 			'id'        => 0,
@@ -298,6 +338,11 @@ class Subscriptions_Wizard extends Wizard {
 	 * @return WP_REST_Response Boolean delete success.
 	 */
 	public function api_delete_subscription( $request ) {
+		$required_plugins_installed = $this->check_required_plugins_installed();
+		if ( is_wp_error( $required_plugins_installed ) ) {
+			return rest_ensure_response( $required_plugins_installed );
+		}
+
 		$params  = $request->get_params();
 		$id      = $params['id'];
 		$product = wc_get_product( $params['id'] );
@@ -314,6 +359,11 @@ class Subscriptions_Wizard extends Wizard {
 	 * @return WP_REST_Response Boolean whether it's enabled.
 	 */
 	public function api_get_choose_price() {
+		$required_plugins_installed = $this->check_required_plugins_installed();
+		if ( is_wp_error( $required_plugins_installed ) ) {
+			return rest_ensure_response( $required_plugins_installed );
+		}
+
 		return rest_ensure_response( $this->get_choose_price() );
 	}
 
@@ -345,6 +395,11 @@ class Subscriptions_Wizard extends Wizard {
 	 * @return WP_REST_Response The updated setting.
 	 */
 	public function api_set_choose_price( $request ) {
+		$required_plugins_installed = $this->check_required_plugins_installed();
+		if ( is_wp_error( $required_plugins_installed ) ) {
+			return rest_ensure_response( $required_plugins_installed );
+		}
+
 		$params   = $request->get_params();
 		$enabled  = $params['enabled'];
 		$setting  = $enabled ? 'yes' : '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds `Wizard` and `WizardScreen` components and migrates the `Subscriptions` and `SubscriptionsOnboarding` wizards to use those components. These components should let us build wizards without needing to re-implement a bunch of common functionality each time.

- The `WizardScreen` component renders one screen of a wizard, with optional primary button and optional tertiary button.
- The `Wizard` component manages a collection of child `WizardScreen` components, displays the correct wizard screen, displays errors if necessary, and handles required plugins.

Here is an example of a super simple 3-screen wizard (taken from the components demo):
```
<Wizard 
	activeScreen={ activeWizardScreen } 
	requiredPlugins={ [ 'jetpack' ] }
	requiredPluginsCancelText={ __( 'Back to checklist' ) }
	onRequiredPluginsCancel={ () => console.log( 'Checklist' ) }
>
	<WizardScreen
		identifier='test-wizard-1'
		completeButtonText={ __( 'Continue to 2' ) }
		onCompleteButtonClicked={ () => this.setState( { activeWizardScreen: 'test-wizard-2' } ) }
		subCompleteButtonText={ __( 'Back to checklist' ) }
		onSubCompleteButtonClicked={ () => console.log( 'Checklist' ) }
	>
		<FormattedHeader
			headerText={ __( 'WizardScreen Component 1' ) }
			subHeaderText={ __( 'This is #1 wizard screen' ) }
		/>
	</WizardScreen>
	<WizardScreen
		identifier='test-wizard-2'
		completeButtonText={ __( 'Continue to 3' ) }
		onCompleteButtonClicked={ () => this.setState( { activeWizardScreen: 'test-wizard-3' } ) }
		subCompleteButtonText={ __( 'Back to 1' ) }
		onSubCompleteButtonClicked={ () => this.setState( { activeWizardScreen: 'test-wizard-1' } ) }
	>
		<FormattedHeader
			headerText={ __( 'WizardScreen Component 2' ) }
			subHeaderText={ __( 'This is #2 wizard screen' ) }
		/>
	</WizardScreen>
	<WizardScreen
		noBackground
		identifier='test-wizard-3'
		completeButtonText={ __( 'Finish' ) }
		onCompleteButtonClicked={ () => this.setState( { activeWizardScreen: 'test-wizard-1' } ) }
	>
		<FormattedHeader
			headerText={ __( 'WizardScreen Component 3' ) }
			subHeaderText={ __( 'This is #3 wizard screen' ) }
		/>
	</WizardScreen>
</Wizard>
```
The `FormattedHeader` components are the screen contents; the children of the `WizardScreen` are the screen contents.

If there are changes required for this to be merged and people are blocked, feel free to push commits to this branch and handle them without me, since I'll be gone next week. I won't be offended. :)

This should hopefully be the last of the large, overarching PRs. After this is merged, we should be able to just have regular, single-focused PRs. 🤞 

### Next steps:
- We need to add handling for premium plugins to the `Plugin_Manager` class, so we have graceful failures when required premium plugins are missing. Currently, the plugin manager will try and download the plugins from .org and will probably crash (I haven't really tested what happens if you don't have e.g. WooCommerce Subscriptions installed at all with the required plugin handling)
- (Optional) We can easily set up a multi-page components demo now, with each component having its own `WizardScreen`. That would probably be preferable to our current giganto long list.

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. Try the wizard in the Components Demo.
3. Try the Subscriptions and Subscriptions Onboarding wizards and verify things work well and look normal.

When reviewing the code, it's probably going to be super confusing to look at the diff for the Subscription and Subscription Onboarding wizards on GitHub. I'd advise looking at `wizards/subscriptions/index.js` and `wizards/subscriptionsOnboarding/index.js` to see what things look like using the new components.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->