### PR TITLE
React Router

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -34,6 +34,7 @@ class ActionCard extends Component {
 			className,
 			title,
 			description,
+			href,
 			notification,
 			notificationLevel,
 			actionText,
@@ -72,13 +73,13 @@ class ActionCard extends Component {
 					</div>
 					{ actionText && (
 						<div className="newspack-action-card__region newspack-action-card__region-right">
-							{ actionText && onClick && (
-								<Button isLink onClick={ onClick } className="newspack-action-card__primary_button">
+							{ actionText && ( !! onClick || !! href ) && (
+								<Button isLink href={ href } onClick={ onClick } className="newspack-action-card__primary_button">
 									{ actionText }
 								</Button>
 							) }
 
-							{ actionText && ! onClick && (
+							{ actionText && ( ! onClick && ! href ) && (
 								<div className="newspack-action-card__container">
 									{ isWaiting && <Spinner /> }
 									{ actionText }

--- a/assets/wizards/subscriptions/views/editSubscriptionScreen.js
+++ b/assets/wizards/subscriptions/views/editSubscriptionScreen.js
@@ -41,7 +41,7 @@ class EditSubscriptionScreen extends Component {
 	 * Render.
 	 */
 	render() {
-		const { subscription, onClickSave, onClickCancel } = this.props;
+		const { subscription, onClickSave } = this.props;
 		const { id, name, price, frequency } = subscription;
 		let { image } = subscription;
 		if ( ! image || '0' === image.id ) {
@@ -93,8 +93,7 @@ class EditSubscriptionScreen extends Component {
 					</Button>
 					<Button
 						className="newspack-edit-subscription-screen__cancel isLink is-centered is-tertiary"
-						href="#"
-						onClick={ () => onClickCancel() }
+						href="#/"
 					>
 						{ __( 'Cancel' ) }
 					</Button>

--- a/assets/wizards/subscriptions/views/manageSubscriptionsScreen.js
+++ b/assets/wizards/subscriptions/views/manageSubscriptionsScreen.js
@@ -24,7 +24,6 @@ class ManageSubscriptionsScreen extends Component {
 		const {
 			subscriptions,
 			choosePrice,
-			onClickEditSubscription,
 			onClickDeleteSubscription,
 			onClickChoosePrice,
 		} = this.props;
@@ -53,7 +52,7 @@ class ManageSubscriptionsScreen extends Component {
 							title={ name }
 							description={ display_price }
 							actionText={ __( 'Edit' ) }
-							onClick={ () => onClickEditSubscription( subscription ) }
+							href={ `#edit/${ id }`}
 							secondaryActionText={ __( 'Delete' ) }
 							onSecondaryActionClick={ () => onClickDeleteSubscription( subscription ) }
 						/>
@@ -74,15 +73,7 @@ class ManageSubscriptionsScreen extends Component {
 				<Button
 					isPrimary
 					className="is-centered"
-					onClick={ () =>
-						onClickEditSubscription( {
-							id: 0,
-							name: '',
-							image: null,
-							price: '',
-							frequency: 'month',
-						} )
-					}
+					href="#/create"
 				>
 					{ buttonText }
 				</Button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6272,6 +6272,12 @@
       "integrity": "sha1-dJ/9gDtYTVC9ZOc6ehqRhz6djPs=",
       "dev": true
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
@@ -6407,6 +6413,20 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
+    },
+    "history": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.9.0.tgz",
+      "integrity": "sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^2.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^0.4.0"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -8155,6 +8175,17 @@
       "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
       "dev": true
     },
+    "mini-create-react-context": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.0",
+        "gud": "^1.0.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.6.0.tgz",
@@ -9163,6 +9194,23 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -10134,6 +10182,50 @@
         "prop-types": "^15.5.8"
       }
     },
+    "react-router": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
+      "integrity": "sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.3.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.0.1.tgz",
+      "integrity": "sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.0.1",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-test-renderer": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
@@ -10516,6 +10608,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==",
       "dev": true
     },
     "resolve-url": {
@@ -11979,6 +12077,18 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "dev": true
     },
+    "tiny-invariant": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
+      "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g==",
+      "dev": true
+    },
+    "tiny-warning": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
+      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==",
+      "dev": true
+    },
     "tinycolor2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
@@ -12430,6 +12540,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==",
+      "dev": true
     },
     "vendors": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "postcss-cli": "^6.0.1",
     "postcss-focus-within": "^3.0.0",
     "prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.16.4/wp-prettier-1.16.4.tgz",
+    "react-router-dom": "^5.0.1",
     "rtlcss": "^2.4.0",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR introduces React Router (https://reacttraining.com/react-router/), replacing all existing approaches to screen navigation in wizards. This branch is fully merged into `add/react-router+plugin-requirements`, so this PR need not be merged on its own. I'm opening it mostly so the implementation of routing can be assessed without distractions. 

To test, try out the Subscription and Subscription Onboarding wizards, which should function exactly as before. Note the changing URL as you use them.

Also note the use of URL Parameters in the Subscriptions Wizard (e.g. paths like `/wp-admin/admin.php?page=newspack-subscriptions-wizard#/edit/282`), and programmatic routing after a new subscription is saved for the first time (the URL should change from `/create` to `/edit/{id}`).

I opted to use hash routing (`<HashRouter/>`) to avoid conflicting with wp-admin paths—the only part of the URL that will change is to the right of the #.