### PR TITLE
Improved handling for plugins that Newspack can't install

### DIFF
--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -99,7 +99,7 @@ class ComponentsDemo extends Component {
 					/>
 					<Handoff
 						className="is-centered"
-						plugin="google-site-kit-wp"
+						plugin="google-site-kit"
 					/>
 					<Handoff
 						className="is-centered"
@@ -133,7 +133,7 @@ class ComponentsDemo extends Component {
 						headerText={ __( 'Plugin installer' ) }
 					/>
 					<PluginInstaller
-						plugins={ [ 'woocommerce', 'amp', 'wordpress-seo', 'google-site-kit-wp', 'fake-plugin' ] }
+						plugins={ [ 'woocommerce', 'amp', 'wordpress-seo', 'google-site-kit', 'woocommerce-subscriptions', 'fake-plugin' ] }
 						canUninstall
 					/>
 				</Card>

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -133,7 +133,7 @@ class ComponentsDemo extends Component {
 						headerText={ __( 'Plugin installer' ) }
 					/>
 					<PluginInstaller
-						plugins={ [ 'woocommerce', 'amp', 'wordpress-seo', 'fake-plugin' ] }
+						plugins={ [ 'woocommerce', 'amp', 'wordpress-seo', 'google-site-kit-wp', 'fake-plugin' ] }
 						canUninstall
 					/>
 				</Card>

--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -209,11 +209,7 @@ class Plugins_Controller extends WP_REST_Controller {
 		}
 
 		$managed_plugins = Plugin_Manager::get_managed_plugins();
-		if ( 'wporg' === $managed_plugins[ $slug ]['Download'] ) {
-			$result = Plugin_Manager::activate( $slug );
-		} else {
-			$result = Plugin_Manager::activate( $managed_plugins[ $slug ]['Download'] );
-		}
+		$result = Plugin_Manager::activate( $slug );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -66,7 +66,6 @@ class Plugin_Manager {
 				'Author'      => 'Prospress Inc.',
 				'PluginURI'   => 'https://woocommerce.com/products/woocommerce-subscriptions/',
 				'AuthorURI'   => 'https://prospress.com',
-				'Download'    => 'wporg', // @todo add premium plugin handling.
 			],
 			'woocommerce-name-your-price'   => [
 				'Name'        => __( 'WooCommerce Name Your Price', 'newspack' ),
@@ -74,7 +73,6 @@ class Plugin_Manager {
 				'Author'      => 'Kathy Darling',
 				'PluginURI'   => 'http://www.woocommerce.com/products/name-your-price/',
 				'AuthorURI'   => 'http://kathyisawesome.com',
-				'Download'    => 'wporg', // @todo add premium plugin handling.
 			],
 			'woocommerce-one-page-checkout' => [
 				'Name'        => __( 'WooCommerce One Page Checkout', 'newspack' ),
@@ -82,7 +80,6 @@ class Plugin_Manager {
 				'Author'      => 'Prospress Inc.',
 				'PluginURI'   => 'https://woocommerce.com/products/woocommerce-one-page-checkout/',
 				'AuthorURI'   => 'http://prospress.com/',
-				'Download'    => 'wporg', // @todo add premium plugin handling.
 			],
 			'wordpress-seo'                 => [
 				'Name'        => 'Yoast SEO',
@@ -92,12 +89,13 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=wpseo_dashboard',
 			],
-			'google-site-kit-wp'            => [
+			'google-site-kit'            => [
 				'Name'        => 'Google Site Kit',
 				'Description' => 'Site Kit is is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.',
 				'Author'      => 'Google',
 				'AuthorURI'   => 'https://opensource.google.com',
 				'PluginURI'   => 'https://sitekit.withgoogle.com/',
+				'Download'    => 'https://sitekit.withgoogle.com/service/download/google-site-kit.zip',
 				'EditPath'    => 'admin.php?page=googlesitekit-dashboard',
 			],
 			'fake-plugin'                   => [

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -307,7 +307,7 @@ class Plugin_Manager {
 	 * Install a plugin by slug.
 	 *
 	 * @param string $plugin_slug The slug for the plugin.
-	 * @return bool True on success. False on failure.
+	 * @return Mixed True on success. WP_Error on failure.
 	 */
 	protected static function install_from_slug( $plugin_slug ) {
 		// Quick check to make sure plugin directory doesn't already exist.
@@ -338,7 +338,7 @@ class Plugin_Manager {
 			);
 		}
 
-		// If the plugin has a URL as it's Download, install it from there.
+		// If the plugin has a URL as its Download, install it from there.
 		if ( wp_http_validate_url( $managed_plugins[ $plugin_slug ]['Download'] ) ) {
 			return self::install_from_url( $managed_plugins[ $plugin_slug ]['Download'] );
 		}

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -89,7 +89,7 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=wpseo_dashboard',
 			],
-			'google-site-kit'            => [
+			'google-site-kit'               => [
 				'Name'        => 'Google Site Kit',
 				'Description' => 'Site Kit is is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.',
 				'Author'      => 'Google',

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -73,7 +73,7 @@ class Plugin_Manager {
 				'Description' => 'Site Kit is is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.',
 				'Author'      => 'Google',
 				'AuthorURI'   => 'https://opensource.google.com',
-				'Download'    => 'preinstall',
+				'PluginURI'   => 'https://sitekit.withgoogle.com/',
 				'EditPath'    => 'admin.php?page=googlesitekit-dashboard',
 			],
 			'fake-plugin'                => [
@@ -262,7 +262,7 @@ class Plugin_Manager {
 		if ( wp_http_validate_url( $plugin ) ) {
 			return self::install_from_url( $plugin );
 		} else {
-			return self::install_from_wporg( $plugin );
+			return self::install_from_slug( $plugin );
 		}
 	}
 
@@ -304,22 +304,50 @@ class Plugin_Manager {
 	}
 
 	/**
-	 * Install a plugin from the WordPress.org plugin repo.
+	 * Install a plugin by slug.
 	 *
 	 * @param string $plugin_slug The slug for the plugin.
 	 * @return bool True on success. False on failure.
 	 */
-	protected static function install_from_wporg( $plugin_slug ) {
+	protected static function install_from_slug( $plugin_slug ) {
 		// Quick check to make sure plugin directory doesn't already exist.
 		$plugin_directory = WP_PLUGIN_DIR . '/' . $plugin_slug;
 		if ( is_dir( $plugin_directory ) ) {
 			return new WP_Error( 'newspack_plugin_already_installed', __( 'The plugin directory already exists.', 'newspack' ) );
 		}
 
+		$managed_plugins = self::get_managed_plugins();
+		if ( ! isset( $managed_plugins[ $plugin_slug ] ) ) {
+			return new WP_Error(
+				'newspack_plugin_failed_install',
+				__( 'Plugin not found.', 'newspack' )
+			);
+		}
+
+		// Return a useful error if we are unable to get download info for the plugin.
+		if ( empty( $managed_plugins[ $plugin_slug ]['Download'] ) ) {
+			$error_message = __( 'Newspack can not install this plugin. You will need to get it from the plugin\'s site and install it manually.', 'newspack' );
+			if ( ! empty( $managed_plugins[ $plugin_slug ]['PluginURI'] ) ) {
+				/* translators: %s: plugin URL */
+				$error_message = sprintf( __( 'Newspack can not install this plugin. You will need to get it from %s and install it manually.', 'newspack' ), esc_url( $managed_plugins[ $plugin_slug ]['PluginURI'] ) );
+			}
+
+			return new WP_Error(
+				'newspack_plugin_failed_install',
+				$error_message
+			);
+		}
+
+		// If the plugin has a URL as it's Download, install it from there.
+		if ( wp_http_validate_url( $managed_plugins[ $plugin_slug ]['Download'] ) ) {
+			return self::install_from_url( $managed_plugins[ $plugin_slug ]['Download'] );
+		}
+
 		if ( ! function_exists( 'plugins_api' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 		}
 
+		// Check WP.org for a download link, and install it from WP.org.
 		$plugin_info = plugins_api(
 			'plugin_information',
 			[

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -49,6 +49,7 @@ class Plugin_Manager {
 				'Author'      => 'WooCommerce',
 				'PluginURI'   => 'https://woocommerce.com/',
 				'AuthorURI'   => 'https://woocommerce.com/',
+				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=wc-settings&tab=checkout&section=stripe',
 			],
 			'woocommerce'                   => [

--- a/tests/unit-tests/plugin-manager.php
+++ b/tests/unit-tests/plugin-manager.php
@@ -17,21 +17,21 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	protected $plugin_slug = 'hello-dolly';
+	protected $plugin_slug = 'amp';
 
 	/**
 	 * Plugin file path.
 	 *
 	 * @var string
 	 */
-	protected $plugin_file = 'hello-dolly/hello.php';
+	protected $plugin_file = 'amp/amp.php';
 
 	/**
 	 * URL to plugin download.
 	 *
 	 * @var string
 	 */
-	protected $plugin_url = 'https://downloads.wordpress.org/plugin/hello-dolly.1.6.zip';
+	protected $plugin_url = 'https://downloads.wordpress.org/plugin/amp.1.2.0.zip';
 
 	/**
 	 * Compatibility checks and clean up.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR improves the handling for plugins that can't be installed by Newspack because the plugin URL's aren't public. This could be premium plugins, Site Kit, etc. Attempting to install one of those plugins through the API or Plugin_Manager will fail and provide a useful error about where to get the plugin.

Plugins without `Download` info in the `Plugin_Manager` are plugins that cannot be installed. Information about where to get the plugin is pulled from the plugin's `PluginURI` info.

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. In the Components Demo, try and install Site Kit. Observe it fails with a useful error:
![localhost_wp-admin_admin php_page=newspack-components-demo](https://user-images.githubusercontent.com/7317227/60066447-11503d00-96bc-11e9-9a11-8c3e57acebb9.png)

In the future once the plugin installer component is fine-tuned to be more user friendly, we can probably hide the "Use" button and just display a "This plugin can't be installed" message instead, so the user doesn't need the installation to fail before finding out.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->