### PR TITLE
Mighty Blue

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -28,20 +28,20 @@
 
 	&.is-primary {
 		border: none;
-		background-color: $muriel-hot-pink-500;
+		background-color: $primary_color;
 		box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
 		color: $muriel-white;
 		text-shadow: none;
 
 		&:hover,
 		&:focus:enabled {
-			background-color: $muriel-hot-pink-400;
+			background-color: $primary_color_lighter;
 			color: $muriel-gray-0;
 			box-shadow: inherit;
 		}
 
 		&:active:enabled {
-			background-color: $muriel-hot-pink-700;
+			background-color: $primary_color_darker;
 			color: $muriel-white;
 		}
 	}

--- a/assets/components/src/checkbox-control/style.scss
+++ b/assets/components/src/checkbox-control/style.scss
@@ -14,8 +14,8 @@
 		border-radius: 3px;
 
 		&:checked {
-			background-color: $muriel-hot-pink-500;
-			border-color: $muriel-hot-pink-500;
+			background-color: $primary_color;
+			border-color: $primary_color;
 
 			&:before {
 				font-size: 30px;

--- a/assets/components/src/image-upload/style.scss
+++ b/assets/components/src/image-upload/style.scss
@@ -6,7 +6,7 @@
 
 .muriel-image-upload {
 	button {
-		color: $muriel-hot-pink-500;
+		color: $primary_color;
 		font-size: 16px;
 		padding: 0;
 		vertical-align: middle;

--- a/assets/components/src/progress-bar/style.scss
+++ b/assets/components/src/progress-bar/style.scss
@@ -2,6 +2,8 @@
  * Progress bar styles.
  */
 
+@import '../../../shared/scss/muriel-component';
+
 .muriel-progress-bar {
 	margin: 16px 0;
 	position: relative;
@@ -22,7 +24,7 @@
 
 	.muriel-progress-bar__bar {
 		height: 4px;
-		background-color: $muriel-hot-pink-500;
+		background-color: $primary_color;
 		-webkit-transition: width 0.25s; /* Safari */
   		transition: width 0.25s;
 

--- a/assets/shared/scss/_muriel-component.scss
+++ b/assets/shared/scss/_muriel-component.scss
@@ -1,8 +1,8 @@
 $primary_color: #2A7DE1;
 
 /* TODO: Update $primary_color_lighter and $primary_color_darker */
-$primary_color_lighter: #{ $muriel-hot-pink-400 };
-$primary_color_darker: #{ $muriel-hot-pink-700 };
+$primary_color_lighter: #4f8cdd;
+$primary_color_darker: #3166ae;
 .muriel-component {
 	margin-top: 14px;
 	margin-bottom: 14px;

--- a/assets/shared/scss/_muriel-component.scss
+++ b/assets/shared/scss/_muriel-component.scss
@@ -1,3 +1,8 @@
+$primary_color: #2A7DE1;
+
+/* TODO: Update $primary_color_lighter and $primary_color_darker */
+$primary_color_lighter: #{ $muriel-hot-pink-400 };
+$primary_color_darker: #{ $muriel-hot-pink-700 };
 .muriel-component {
 	margin-top: 14px;
 	margin-bottom: 14px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR switches to the Newspack color scheme for components. 

Primary: `#2a7de1`
Hover: `#4f8cdd`
Active: `#3166ae`

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Navigate to Components Demo (`/wp-admin/admin.php?page=newspack-components-demo`)
3. Observe color changes on `<Button>`, `<ImageUpload>`, `<ProgressBar>`, and `<CheckboxControl>` components.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->