### PR TITLE
Fix/concurrent plugin installation

### DIFF
--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -80,10 +80,11 @@ class PluginInstaller extends Component {
 		};
 		return apiFetch( params )
 			.then( response => {
-				let { pluginInfo } = this.state;
-				pluginInfo[ slug ] = response;
-				pluginInfo[ slug ].installationStatus = PLUGIN_STATE_ACTIVE;
-				this.updatePluginInfo( pluginInfo );
+				const { pluginInfo } = this.state;
+				this.updatePluginInfo( {
+					...pluginInfo,
+					[ slug ]: { ...response, installationStatus: PLUGIN_STATE_ACTIVE },
+				} );
 			} )
 			.catch( error => {
 				this.setInstallationStatus( slug, PLUGIN_STATE_ERROR, error.message );
@@ -99,10 +100,11 @@ class PluginInstaller extends Component {
 		};
 		return apiFetch( params )
 			.then( response => {
-				let { pluginInfo } = this.state;
-				pluginInfo[ slug ] = response;
-				pluginInfo[ slug ].installationStatus = PLUGIN_STATE_NONE;
-				this.updatePluginInfo( pluginInfo );
+				const { pluginInfo } = this.state;
+				this.updatePluginInfo( {
+					...pluginInfo,
+					[ slug ]: { ...response, installationStatus: PLUGIN_STATE_NONE },
+				} );
 			} )
 			.catch( error => {
 				this.setInstallationStatus( slug, PLUGIN_STATE_ERROR, error.message );

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -11,11 +11,6 @@ import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
- * External dependencies.
- */
-import { forEach, includes, pickBy } from 'lodash';
-
-/**
  * Internal dependencies.
  */
 import { ActionCard, Button } from '../';
@@ -52,11 +47,15 @@ class PluginInstaller extends Component {
 
 	retrievePluginInfo = plugins => {
 		apiFetch( { path: '/newspack/v1/plugins/' } ).then( response => {
-			const pluginInfo = pickBy( response, ( value, key ) => includes( plugins, key ) );
-			forEach( pluginInfo, plugin => {
-				plugin.installationStatus =
-					plugin.Status === 'active' ? PLUGIN_STATE_ACTIVE : PLUGIN_STATE_NONE;
-			} );
+			const pluginInfo = Object.keys( response ).reduce( ( result, slug ) => {
+				if ( plugins.indexOf( slug ) === -1 ) return result;
+				result[ slug ] = {
+					...response[ slug ],
+					installationStatus:
+						response[ slug ].Status === 'active' ? PLUGIN_STATE_ACTIVE : PLUGIN_STATE_NONE,
+				};
+				return result;
+			}, {} );
 			this.updatePluginInfo( pluginInfo );
 		} );
 	};

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -110,17 +110,17 @@ class PluginInstaller extends Component {
 			} );
 	};
 
-	setChecked = ( slug, value ) => {
-		let { pluginInfo } = this.state;
-		pluginInfo[ slug ].checked = value;
-		this.updatePluginInfo( pluginInfo );
+	setChecked = ( slug, checked ) => {
+		const { pluginInfo } = this.state;
+		this.updatePluginInfo( { ...pluginInfo, [ slug ]: { ...pluginInfo[ slug ], checked } } );
 	};
 
-	setInstallationStatus = ( slug, value, notification = null ) => {
-		let { pluginInfo } = this.state;
-		pluginInfo[ slug ].installationStatus = value;
-		pluginInfo[ slug ].notification = notification;
-		this.updatePluginInfo( pluginInfo );
+	setInstallationStatus = ( slug, installationStatus, notification = null ) => {
+		const { pluginInfo } = this.state;
+		this.updatePluginInfo( {
+			...pluginInfo,
+			[ slug ]: { ...pluginInfo[ slug ], installationStatus, notification },
+		} );
 	};
 
 	updatePluginInfo = pluginInfo => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In the original version of the `PluginInstaller` component, clicking "Use All" kicks off all plugin installations simultaneously. Frequently these concurrent installations fail with `Could not copy file` error. Noting that I've never seen this issue when installing plugins one by one, this PR changes `PluginInstaller` to install them one at a time, sequentially.

The approach to sequentially handling multiple Promises is based on https://hackernoon.com/functional-javascript-resolving-promises-sequentially-7aac18c4431e.

The PR also contains some other refactoring to remove the `lodash` dependency and generally adopt a more modern approach.

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. To start with a clean slate, deactivate and delete the plugins that the Components Demo `PluginInstaller` examples use: WooCommerce, AMP, Yoast SEO, Google Site Kit, WooCommerce Subscriptions.
3. Navigate to `Components Demo` (`/wp-admin/admin.php?page=newspack-components-demo`)
4. Click `Use All` on the larger `PluginInstaller` example.
5. Observe that the installations occur one at a time from top to bottom. All should succeed except WooCommerce Subscriptions (`Newspack can not install this plugin. You will need to get it from...`), and Fake Plugin (`Plugin not found`).
6. Verify all other aspects of the `PluginInstaller` components work as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->