### PR TITLE
Handoff: Edit Link and Button Text Overrides

### DIFF
--- a/assets/components/src/handoff/index.js
+++ b/assets/components/src/handoff/index.js
@@ -44,28 +44,39 @@ class Handoff extends Component {
 	textForPlugin = pluginInfo => {
 		const defaults = {
 			modalBody: null,
-			modalTitle: pluginInfo.Name && `${ __( 'Manage' ) } ${pluginInfo.Name}`,
-			primaryButton: pluginInfo.Name && `${ __( 'Manage' ) } ${pluginInfo.Name}`,
+			modalTitle: pluginInfo.Name && `${ __( 'Manage' ) } ${ pluginInfo.Name }`,
+			primaryButton: pluginInfo.Name && `${ __( 'Manage' ) } ${ pluginInfo.Name }`,
 			primaryModalButton: __( 'Manage' ),
 			dismissModalButton: __( 'Dismiss' ),
-		}
+		};
 		return assign( defaults, this.props );
 	};
 
 	goToPlugin = plugin => {
-		apiFetch( { path: '/newspack/v1/plugins/' + plugin + '/handoff', method: 'POST' } ).then( response => {
+		const { handoffLink } = this.props;
+		apiFetch( {
+			path: '/newspack/v1/plugins/' + plugin + '/handoff',
+			method: 'POST',
+			data: { handoffLink },
+		} ).then( response => {
 			window.location.href = response.HandoffLink;
 		} );
-	}
+	};
 
 	/**
 	 * Render.
 	 */
 	render( props ) {
-		const { className, ...otherProps } = this.props;
+		const { className, children, ...otherProps } = this.props;
 		const classes = murielClassnames( 'muriel-button', className );
 		const { pluginInfo, showModal } = this.state;
-		const { modalBody, modalTitle, primaryButton, primaryModalButton, dismissModalButton } = this.textForPlugin( pluginInfo );
+		const {
+			modalBody,
+			modalTitle,
+			primaryButton,
+			primaryModalButton,
+			dismissModalButton,
+		} = this.textForPlugin( pluginInfo );
 		const { Name, Slug, Status } = pluginInfo;
 		return (
 			<Fragment>
@@ -76,16 +87,11 @@ class Handoff extends Component {
 						{ ...otherProps }
 						onClick={ () => this.setState( { showModal: true } ) }
 					>
-						{ primaryButton }
+						{ children ? children : primaryButton }
 					</Button>
 				) }
 				{ Name && 'active' !== Status && (
-					<Button
-						className={ classes }
-						isDefault
-						disabled
-						{ ...otherProps }
-					>
+					<Button className={ classes } isDefault disabled { ...otherProps }>
 						{ Name + __( ' not installed' ) }
 					</Button>
 				) }

--- a/assets/components/src/handoff/index.js
+++ b/assets/components/src/handoff/index.js
@@ -53,11 +53,11 @@ class Handoff extends Component {
 	};
 
 	goToPlugin = plugin => {
-		const { handoffLink } = this.props;
+		const { editLink } = this.props;
 		apiFetch( {
 			path: '/newspack/v1/plugins/' + plugin + '/handoff',
 			method: 'POST',
-			data: { handoffLink },
+			data: { editLink },
 		} ).then( response => {
 			window.location.href = response.HandoffLink;
 		} );

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -84,33 +84,32 @@ class ComponentsDemo extends Component {
 					subHeaderText={ __( 'Temporary demo of Newspack components' ) }
 				/>
 				<Card>
-					<FormattedHeader
-						headerText={ __( 'Handoff Buttons' ) }
-					/>
+					<FormattedHeader headerText={ __( 'Handoff Buttons' ) } />
 					<Handoff
 						className="is-centered"
 						modalTitle="Manage AMP"
 						modalBody="Click to go to the AMP dashboard. There will be a notification bar at the top with a link to return to Newspack."
 						plugin="amp"
 					/>
+					<Handoff className="is-centered" plugin="jetpack" />
+					<Handoff className="is-centered" plugin="google-site-kit" />
+					<Handoff className="is-centered" plugin="woocommerce" />
 					<Handoff
 						className="is-centered"
-						plugin="jetpack"
-					/>
-					<Handoff
-						className="is-centered"
-						plugin="google-site-kit"
-					/>
-					<Handoff
-						className="is-centered"
-						plugin="woocommerce"
-					/>
+						plugin="wordpress-seo"
+						isPrimary
+						editLink="/wp-admin/admin.php?page=wpseo_dashboard#top#features"
+					>
+						{ __( 'Specific Yoast Page' ) }
+					</Handoff>
 				</Card>
 				<Card>
-					<FormattedHeader
-						headerText={ __( 'Notice/Modal' ) }
-					/>
-					<Button className="is-centered" isTertiary onClick={ () => this.setState( { modalShown: true } ) } >
+					<FormattedHeader headerText={ __( 'Notice/Modal' ) } />
+					<Button
+						className="is-centered"
+						isTertiary
+						onClick={ () => this.setState( { modalShown: true } ) }
+					>
 						{ __( 'Open modal' ) }
 					</Button>
 					{ modalShown && (
@@ -118,22 +117,31 @@ class ComponentsDemo extends Component {
 							title="This is the modal title"
 							onRequestClose={ () => this.setState( { modalShown: false } ) }
 						>
-							<p>{ __( 'Based on industry research, we advise to test the modal component, and continuing this sentence so we can see how the text wraps is one good way of doing that.' ) }</p>
-							<Button isPrimary onClick={ () => this.setState( { modalShown: false } ) } >
+							<p>
+								{ __(
+									'Based on industry research, we advise to test the modal component, and continuing this sentence so we can see how the text wraps is one good way of doing that.'
+								) }
+							</p>
+							<Button isPrimary onClick={ () => this.setState( { modalShown: false } ) }>
 								{ __( 'Dismiss' ) }
 							</Button>
-							<Button isDefault onClick={ () => this.setState( { modalShown: false } ) } >
+							<Button isDefault onClick={ () => this.setState( { modalShown: false } ) }>
 								{ __( 'Also dismiss' ) }
 							</Button>
 						</Modal>
 					) }
 				</Card>
 				<Card noBackground>
-					<FormattedHeader
-						headerText={ __( 'Plugin installer' ) }
-					/>
+					<FormattedHeader headerText={ __( 'Plugin installer' ) } />
 					<PluginInstaller
-						plugins={ [ 'woocommerce', 'amp', 'wordpress-seo', 'google-site-kit', 'woocommerce-subscriptions', 'fake-plugin' ] }
+						plugins={ [
+							'woocommerce',
+							'amp',
+							'wordpress-seo',
+							'google-site-kit',
+							'woocommerce-subscriptions',
+							'fake-plugin',
+						] }
 						canUninstall
 					/>
 				</Card>
@@ -145,9 +153,7 @@ class ComponentsDemo extends Component {
 						} }
 					/>
 				</Card>
-				<FormattedHeader
-					headerText={ __( 'Action cards' ) }
-				/>
+				<FormattedHeader headerText={ __( 'Action cards' ) } />
 				<ActionCard
 					title="Example One"
 					description="Has an action button."
@@ -219,9 +225,7 @@ class ComponentsDemo extends Component {
 					image="//s1.wp.com/wp-content/themes/h4/landing/marketing/pages/hp-jan-2019/media/man-with-shadow.jpg"
 					imageLink="https://wordpress.com"
 				/>
-				<FormattedHeader
-					headerText={ __( 'Checklist' ) }
-				/>
+				<FormattedHeader headerText={ __( 'Checklist' ) } />
 				<Checklist progressBarText={ __( 'Your setup list' ) }>
 					<Task
 						title={ __( 'Set up membership' ) }

--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -303,7 +303,14 @@ class Plugins_Controller extends WP_REST_Controller {
 		}
 
 		Handoff_Banner::register_handoff_for_plugin( $slug );
-		return $this->get_item( $request );
+		$managed_plugins = Plugin_Manager::get_managed_plugins();
+
+		$response = $managed_plugins[ $slug ];
+		if ( isset( $request['editLink'] ) ) {
+			$response['HandoffLink'] = $request['editLink'];
+		}
+
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -97,7 +97,7 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://opensource.google.com',
 				'PluginURI'   => 'https://sitekit.withgoogle.com/',
 				'Download'    => 'https://sitekit.withgoogle.com/service/download/google-site-kit.zip',
-				'EditPath'    => 'admin.php?page=googlesitekit-dashboard',
+				'EditPath'    => 'admin.php?page=googlesitekit-splash',
 			],
 			'fake-plugin'                   => [
 				'Name'        => 'Fake Plugin',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

@philipjohn has noted that in some cases a `Handoff`s will need to go to a specific page within a plugin's dashboard, e.g. the AdSense area of Google Site Kit. This PR addresses this concern by supporting an optional `editLink` prop which will override the default link. Also, if the `<Handoff>` element has content, this will be used in place of the default `Manage {Plugin Name}`. 

For example:

```
<Handoff
	className="is-centered"
	plugin="wordpress-seo"
	isPrimary
	editLink="/wp-admin/admin.php?page=wpseo_dashboard#top#features"
>
	{ __( 'Specific Yoast Page' ) }
</Handoff>
```

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Install Yoast SEO plugin.
3. Navigate to `Newspack->Components Demo` (`/wp-admin/admin.php?page=newspack-components-demo`
4. Observe "Specific Yoast Button" in the "Handoff Buttons" area. Unlike the others, it should have Primary Button styling, and the button text is custom.
5. Click the button. Observe normal interstitial modal, then redirect to `/wp-admin/admin.php?page=wpseo_dashboard#top#features` as specified on the component.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->