### PR TITLE
Handoff Banner Style Change

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -50,6 +50,7 @@
 		background: none;
 		border: none;
 		color: $muriel-gray-300;
+		cursor: pointer;
 		text-decoration: underline;
 		&:hover {
 			text-decoration: none;

--- a/assets/wizards/handoff-banner/style.scss
+++ b/assets/wizards/handoff-banner/style.scss
@@ -6,11 +6,11 @@
 	background-size: 32px 32px;
 	box-shadow: 0 2px 2px #cccccc;
 	display: flex;
-	margin: 0 0 0 -20px;
+	margin: 20px 0 0 0;
 	min-height: 52px;
 	padding: 0;
 	position: relative;
-	width: calc( 100% + 20px );
+	width: calc( 100% - 20px );
 	.jetpack-pagestyles & {
 		margin-left: 0;
 		width: 100%;

--- a/assets/wizards/handoff-banner/style.scss
+++ b/assets/wizards/handoff-banner/style.scss
@@ -1,4 +1,9 @@
 #newspack-handoff-banner {
+	display: block;
+	padding: 0;
+	position: relative;
+}
+.newspack-handoff-banner {
 	background-color: white;
 	background-image: url( './newspack-mark.svg' );
 	background-position: 20px center;
@@ -9,17 +14,7 @@
 	margin: 20px 0 0 0;
 	min-height: 52px;
 	padding: 0;
-	position: relative;
 	width: calc( 100% - 20px );
-	.jetpack-pagestyles & {
-		margin: 20px;
-		width: calc( 100% - 40px );
-	}
-}
-.newspack-handoff-banner {
-	display: flex;
-	padding: 0;
-	width: 100%;
 	p {
 		align-self: center;
 		flex-grow: 1;
@@ -31,10 +26,14 @@
 			margin-right: 20px;
 		}
 	}
-	@media only screen and (max-width: 660px) {
+	@media only screen and ( max-width: 660px ) {
 		justify-content: flex-end;
 		p {
 			display: none;
 		}
+	}
+	.jetpack-pagestyles & {
+		margin: 20px;
+		width: calc( 100% - 40px );
 	}
 }

--- a/assets/wizards/handoff-banner/style.scss
+++ b/assets/wizards/handoff-banner/style.scss
@@ -1,7 +1,11 @@
 #newspack-handoff-banner {
 	display: block;
+	margin: 20px 0 0 0;
 	padding: 0;
 	position: relative;
+	&.has-help-tabs {
+		margin-top: 40px;
+	}
 }
 .newspack-handoff-banner {
 	background-color: white;
@@ -11,7 +15,7 @@
 	background-size: 32px 32px;
 	box-shadow: 0 2px 2px #cccccc;
 	display: flex;
-	margin: 20px 0 0 0;
+	margin: 0;
 	min-height: 52px;
 	padding: 0;
 	width: calc( 100% - 20px );

--- a/assets/wizards/handoff-banner/style.scss
+++ b/assets/wizards/handoff-banner/style.scss
@@ -12,8 +12,8 @@
 	position: relative;
 	width: calc( 100% - 20px );
 	.jetpack-pagestyles & {
-		margin-left: 0;
-		width: 100%;
+		margin: 20px;
+		width: calc( 100% - 40px );
 	}
 }
 .newspack-handoff-banner {

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -32,11 +32,18 @@ class Handoff_Banner {
 	 * @return void.
 	 */
 	public function insert_handoff_banner() {
+		$classes        = [];
+		$screen         = get_current_screen();
+		$help_tab_count = count( $screen->get_help_tabs() );
+		$is_jetpack     = strrpos( $screen->base, 'jetpack' );
+		if ( $help_tab_count > 0 && false === $is_jetpack ) {
+			$classes[] = 'has-help-tabs';
+		}
 		if ( ! $this->needs_handoff_return_ui() ) {
 			return;
 		}
 		$newspack_handoff_return_url = get_option( NEWSPACK_HANDOFF_RETURN_URL );
-		echo sprintf( "<div id='newspack-handoff-banner' data-primary_button_url='%s'></div>", esc_attr( $newspack_handoff_return_url ) );
+		echo sprintf( "<div id='newspack-handoff-banner' data-primary_button_url='%s' class='%s'></div>", esc_attr( $newspack_handoff_return_url ), esc_attr( implode( ' ', $classes ) ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Per a suggestion from @sonjaleix this PR adds margins around the Handoff banner based on this screenshot:

<img width="1440" alt="Screenshot 2019-06-20 16 52 40" src="https://user-images.githubusercontent.com/1477002/60194755-effc6780-9807-11e9-93fd-8df1546ec624.png">

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Navigate to `Newspack->Components Demo`
3. Click any of the `Handoff` buttons.
4. Observe the new banner styles. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->