### PR TITLE
Tweak notice and menu priorities

### DIFF
--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -23,7 +23,7 @@ class Handoff_Banner {
 	public function __construct() {
 		add_action( 'current_screen', [ $this, 'persist_current_url' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_styles' ], 1 );
-		add_action( 'admin_notices', [ $this, 'insert_handoff_banner' ], 1 );
+		add_action( 'admin_notices', [ $this, 'insert_handoff_banner' ], -10000 );
 	}
 
 	/**

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -147,7 +147,8 @@ class Dashboard extends Wizard {
 			$this->capability,
 			$this->slug,
 			[ $this, 'render_wizard' ],
-			$icon
+			$icon,
+			3
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adjusts the priorities of the Newspack menu and notice to make the menu item higher up and the notice not be blocked by Site Kit:

![localhost_wp-admin_admin php_page=googlesitekit-splash (1)](https://user-images.githubusercontent.com/7317227/60209013-99def280-980e-11e9-971c-18f1659590b4.png)

`3` is the best menu position, so there isn't a way of getting above Jetpack since we're after them alphabetically.

The disclaimer about the Site Kit priority tweak is that they could theoretically change their priority to `-10001` and we could have a notice priority arms race on our hands. :)

### How to test the changes in this Pull Request:

1. Observe Newspack is up near the top of the admin menu.
2. Click the 'Manage Site Kit' handoff in the Components Demo. Observe our notice is present on Site Kit admin pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->