### PR TITLE
Add/plugin configurator

### DIFF
--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -164,6 +164,25 @@ class Plugins_Controller extends WP_REST_Controller {
 				'schema' => [ $this, 'get_item_schema' ],
 			]
 		);
+
+		// Register newspack/v1/plugins/some-plugin/configure.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->resource_name . '/(?P<slug>[\a-z]+)\/configure',
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'configure_item' ],
+					'permission_callback' => [ $this, 'configure_item_permissions_check' ],
+					'args'                => [
+						'slug' => [
+							'sanitize_callback' => [ $this, 'sanitize_plugin_slug' ],
+						],
+					],
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
 	}
 
 	/**
@@ -307,6 +326,43 @@ class Plugins_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Configure a managed plugin (installing and activating it if needed).
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function configure_item( $request ) {
+		$slug = $request['slug'];
+
+		$is_valid_plugin = $this->validate_managed_plugin( $slug );
+		if ( is_wp_error( $is_valid_plugin ) ) {
+			return $is_valid_plugin;
+		}
+
+		$result = Plugin_Manager::activate( $slug );
+		if ( is_wp_error( $result ) ) {
+			/* If the plugin is already installed and active, simply proceed to configuration */
+			if ( 'newspack_plugin_already_active' !== $result->get_error_code() ) {
+				return $result;
+			}
+		}
+
+		$managed_plugins = Plugin_Manager::get_managed_plugins();
+
+		$plugin = $managed_plugins[ $slug ];
+
+		$configurer = isset( $plugin['Configurer'] ) ? $plugin['Configurer'] : null;
+		if ( $configurer ) {
+			require_once NEWSPACK_ABSPATH . 'includes/configuration_managers/' . $configurer['filename'];
+			$classname        = 'Newspack\\' . $configurer['class_name'];
+			$configurer_class = new $classname();
+			$configurer_class->configure();
+		}
+
+		return rest_ensure_response( $plugin );
+	}
+
+	/**
 	 * Check capabilities when getting plugins info.
 	 *
 	 * @param WP_REST_Request $request API request object.
@@ -423,6 +479,26 @@ class Plugins_Controller extends WP_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function handoff_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return new WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				[
+					'status' => $this->authorization_status_code(),
+				]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check capabilities when configuring a plugin.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return bool|WP_Error
+	 */
+	public function configure_item_permissions_check( $request ) {
 		if ( ! current_user_can( 'install_plugins' ) ) {
 			return new WP_Error(
 				'newspack_rest_forbidden',

--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -356,7 +356,10 @@ class Plugins_Controller extends WP_REST_Controller {
 			require_once NEWSPACK_ABSPATH . 'includes/configuration_managers/' . $configurer['filename'];
 			$classname        = 'Newspack\\' . $configurer['class_name'];
 			$configurer_class = new $classname();
-			$configurer_class->configure();
+			$result           = $configurer_class->configure();
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
 		}
 
 		return rest_ensure_response( $plugin );

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -33,6 +33,10 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://automattic.com/',
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=jetpack',
+				'Configurer'  => [
+					'filename'   => 'class-jetpack-configuration-manager.php',
+					'class_name' => 'Jetpack_Configuration_Manager',
+				],
 			],
 			'amp'                           => [
 				'Name'        => __( 'AMP', 'newspack' ),
@@ -42,6 +46,10 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://github.com/ampproject/amp-wp/graphs/contributors',
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=amp-options',
+				'Configurer'  => [
+					'filename'   => 'class-amp-configuration-manager.php',
+					'class_name' => 'AMP_Configuration_Manager',
+				],
 			],
 			'woocommerce-gateway-stripe'    => [
 				'Name'        => __( 'WooCommerce Stripe Gateway', 'newspack' ),

--- a/includes/configuration_managers/class-amp-configuration-manager.php
+++ b/includes/configuration_managers/class-amp-configuration-manager.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
 
 /**
- * Common functionality for admin wizards. Override this class.
+ * Provide an interface for configuring and querying the configuration of AMP.
  */
 class AMP_Configuration_Manager extends Configuration_Manager {
 
@@ -24,9 +24,9 @@ class AMP_Configuration_Manager extends Configuration_Manager {
 	public $slug = 'amp';
 
 	/**
-	 * Get this wizard's name.
+	 * Configure AMP for Newspack use.
 	 *
-	 * @return string The wizard name.
+	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
 	 */
 	public function configure() {
 		$active = $this->is_active();

--- a/includes/configuration_managers/class-amp-configuration-manager.php
+++ b/includes/configuration_managers/class-amp-configuration-manager.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * AMP plugin configuration manager.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
+
+/**
+ * Common functionality for admin wizards. Override this class.
+ */
+class AMP_Configuration_Manager extends Configuration_Manager {
+
+	/**
+	 * The slug of the plugin.
+	 *
+	 * @var string
+	 */
+	public $slug = 'amp';
+
+	/**
+	 * Get this wizard's name.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function configure() {
+		if ( ! $this->is_active() ) {
+			return;
+		}
+		if ( class_exists( 'AMP_Options_Manager' ) ) {
+			\AMP_Options_Manager::update_option( 'theme_support', \AMP_Theme_Support::STANDARD_MODE_SLUG );
+		}
+		$this->set_newspack_has_configured( true );
+		return true;
+	}
+}

--- a/includes/configuration_managers/class-amp-configuration-manager.php
+++ b/includes/configuration_managers/class-amp-configuration-manager.php
@@ -29,8 +29,9 @@ class AMP_Configuration_Manager extends Configuration_Manager {
 	 * @return string The wizard name.
 	 */
 	public function configure() {
-		if ( ! $this->is_active() ) {
-			return;
+		$active = $this->is_active();
+		if ( ! $active || is_wp_error( $active ) ) {
+			return $active;
 		}
 		if ( class_exists( 'AMP_Options_Manager' ) ) {
 			\AMP_Options_Manager::update_option( 'theme_support', \AMP_Theme_Support::STANDARD_MODE_SLUG );

--- a/includes/configuration_managers/class-configuration-manager.php
+++ b/includes/configuration_managers/class-configuration-manager.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Plugin configuration manager, abstract class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error;
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Provide an interface for configuring and querying the configuration of Newspack-managed plugins.
+ */
+abstract class Configuration_Manager {
+	/**
+	 * The slug of the plugin.
+	 *
+	 * @var string
+	 */
+	protected $slug = '';
+
+	/**
+	 * Retrieve data for this plugin.
+	 *
+	 * @var object
+	 */
+	protected function get_plugin_data() {
+		$managed_plugins = Plugin_Manager::get_managed_plugins();
+		try {
+			$plugin = $managed_plugins[ $this->slug ];
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_plugin_not_found', __( 'The plugin is not found.', 'newspack' ) );
+		}
+		return $plugin;
+	}
+
+	/**
+	 * Determines whether the plugin is installed and activated.
+	 *
+	 * @return bool Plugin activation state.
+	 */
+	public function is_active() {
+		$plugin = $this->get_plugin_data();
+		$status = isset( $plugin['Status'] ) ? $plugin['Status'] : null;
+		return 'active' === $status;
+	}
+
+	/**
+	 * Determines whether the plugin is installed (but not necessarily activated);
+	 *
+	 * @return bool Plugin installation state.
+	 */
+	public function is_installed() {
+		$plugin = $this->get_plugin_data();
+		$status = isset( $plugin['Status'] ) ? $plugin['Status'] : null;
+		return 'uninstalled' !== $status;
+	}
+
+	/**
+	 * Option name to determine if plugin has ever been configured by Newspack.s
+	 *
+	 * @return string
+	 */
+	public function has_configured_option_key() {
+		return 'newspack_has_configured_plugin_' . $this->slug;
+	}
+
+	/**
+	 * Sets an option indicating that Newspack has configured this plugin at least once.
+	 *
+	 * @param bool $value Has plugin been configured.
+	 * @return void
+	 */
+	public function set_newspack_has_configured( $value ) {
+		update_option( $this->has_configured_option_key(), boolval( $value ) );
+	}
+
+	/**
+	 * Determines whether the plugin is ready for use. This will mean different things for different plugins.
+	 *
+	 * @return bool Plugin ready state.
+	 */
+	public function is_configured() {
+		return $this->is_active() && get_option( $this->has_configured_option_key() );
+	}
+
+	/**
+	 * Configure the plugin. Meant to be called immediately after installation/activation.
+	 *
+	 * @return void
+	 */
+	abstract public function configure();
+
+}

--- a/includes/configuration_managers/class-configuration-manager.php
+++ b/includes/configuration_managers/class-configuration-manager.php
@@ -28,21 +28,22 @@ abstract class Configuration_Manager {
 	 */
 	protected function get_plugin_data() {
 		$managed_plugins = Plugin_Manager::get_managed_plugins();
-		try {
-			$plugin = $managed_plugins[ $this->slug ];
-		} catch ( Exception $e ) {
-			return new WP_Error( 'newspack_plugin_not_found', __( 'The plugin is not found.', 'newspack' ) );
+		if ( empty( $managed_plugins[ $this->slug ] ) ) {
+			return new WP_Error( 'newspack_plugin_not_newspack_managed', __( 'The plugin is not managed by Newspack.', 'newspack' ) );
 		}
-		return $plugin;
+		return $managed_plugins[ $this->slug ];
 	}
 
 	/**
 	 * Determines whether the plugin is installed and activated.
 	 *
-	 * @return bool Plugin activation state.
+	 * @return bool||WP_Error Plugin activation state or WP_Error.
 	 */
 	public function is_active() {
 		$plugin = $this->get_plugin_data();
+		if ( is_wp_error( $plugin ) ) {
+			return $plugin;
+		}
 		$status = isset( $plugin['Status'] ) ? $plugin['Status'] : null;
 		return 'active' === $status;
 	}
@@ -50,16 +51,19 @@ abstract class Configuration_Manager {
 	/**
 	 * Determines whether the plugin is installed (but not necessarily activated);
 	 *
-	 * @return bool Plugin installation state.
+	 * @return bool||WP_Error Plugin installation state or WP_Error.
 	 */
 	public function is_installed() {
 		$plugin = $this->get_plugin_data();
+		if ( is_wp_error( $plugin ) ) {
+			return $plugin;
+		}
 		$status = isset( $plugin['Status'] ) ? $plugin['Status'] : null;
 		return 'uninstalled' !== $status;
 	}
 
 	/**
-	 * Option name to determine if plugin has ever been configured by Newspack.s
+	 * Option name to determine if plugin has ever been configured by Newspack.
 	 *
 	 * @return string
 	 */

--- a/includes/configuration_managers/class-jetpack-configuration-manager.php
+++ b/includes/configuration_managers/class-jetpack-configuration-manager.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack plugin configuration manager.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
+
+/**
+ * Common functionality for admin wizards. Override this class.
+ */
+class Jetpack_Configuration_Manager extends Configuration_Manager {
+
+	/**
+	 * The slug of the plugin.
+	 *
+	 * @var string
+	 */
+	public $slug = 'jetpack';
+
+	/**
+	 * Get this wizard's name.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function configure() {
+		return true;
+	}
+
+	/**
+	 * Is Jetpack installed and connected?
+	 *
+	 * @return bool Plugin ready state.
+	 */
+	public function is_configured() {
+		if ( $this->is_active() && class_exists( 'Jetpack' ) && \Jetpack::is_active() ) {
+			return true;
+		}
+		return false;
+	}
+}
+
+
+

--- a/includes/configuration_managers/class-jetpack-configuration-manager.php
+++ b/includes/configuration_managers/class-jetpack-configuration-manager.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
 
 /**
- * Common functionality for admin wizards. Override this class.
+ * Provide an interface for configuring and querying the configuration of Jetpack.
  */
 class Jetpack_Configuration_Manager extends Configuration_Manager {
 
@@ -24,9 +24,9 @@ class Jetpack_Configuration_Manager extends Configuration_Manager {
 	public $slug = 'jetpack';
 
 	/**
-	 * Get this wizard's name.
+	 * Configure AMP for Newspack use.
 	 *
-	 * @return string The wizard name.
+	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
 	 */
 	public function configure() {
 		return true;

--- a/tests/unit-tests/api-plugins-controller.php
+++ b/tests/unit-tests/api-plugins-controller.php
@@ -83,6 +83,10 @@ class Newspack_Test_Plugins_Controller extends WP_UnitTestCase {
 			'Slug'        => 'jetpack',
 			'Status'      => 'uninstalled',
 			'Version'     => '',
+			'Configurer'  => [
+				'filename'   => 'class-jetpack-configuration-manager.php',
+				'class_name' => 'Jetpack_Configuration_Manager',
+			],
 		];
 		$this->assertEquals( $expected_jetpack_info, $data['jetpack'] );
 	}

--- a/tests/unit-tests/plugin-manager.php
+++ b/tests/unit-tests/plugin-manager.php
@@ -68,6 +68,10 @@ class Newspack_Test_Plugin_Manager extends WP_UnitTestCase {
 			'DomainPath'  => '',
 			'Version'     => '',
 			'Status'      => 'uninstalled',
+			'Configurer'  => [
+				'filename'   => 'class-jetpack-configuration-manager.php',
+				'class_name' => 'Jetpack_Configuration_Manager',
+			],
 		];
 		$this->assertEquals( $expected_jetpack_info, $managed_plugins['jetpack'] );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces the `Configuration_Manager` abstract class and two subclasses, for AMP and Jetpack. Ultimately, there will be a subclass for every plugin that requires any configuration. Currently the AMP Configuration Manager switches to AMP strict mode when `configure()` is called. The Jetpack Configuration Manager shows how `is_configured()` can be used to determine if Jetpack has been connected. 

This also introduces a new endpoint: `newspack/v1/plugins/{plugin-slug}/configure`. This endpoint will install and activate the plugin, then if a configuration class has been specified it will be loaded and `configure()` called. If the plugin is already active, this endpoint won't fail like `/activate` does. Instead the error will be ignored and the plugin configured normally.

### How to test the changes in this Pull Request:

Testing can be a little tricky. In one approach, you could throw some PHP somewhere and try the calls out. This might look like this:

```
require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-jetpack-configuration-manager.php'; 
$config_manager = new Jetpack_Configuration_Manager();
if ( $config_manager->is_configured() ) { 
  echo '<h1>Jetpack Configured</h1>';
}
```

The `<h1>` will be shown only if Jetpack is installed and connected.

Alternatively, edit the `PluginInstaller` component and change the `activate` endpoint to `configure` here: https://github.com/Automattic/newspack-plugin/blob/master/assets/components/src/plugin-installer/index.js#L78. Run the build script, then go to the Components Demo and try installing AMP. To verify the change, go into the AMP dashboard and switch the mode to Reader or Transitional. Then delete AMP. Go to Components Demo and install AMP. It should  install and activate normally, and after this is done you should see that the mode has been changed to Standard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->