### PR TITLE
Muriel Grid WIP

### DIFF
--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -28,7 +28,7 @@
 			width: 642px;
 		}
 	}
-	@media screen and ( max-width: 375px ) {
+	@media screen and ( max-width: 660px ) {
 		max-width: calc( 342px - 20px );
 		padding: 10px;
 		&.muriel-card__no-background {

--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -29,10 +29,18 @@
 		}
 	}
 	@media screen and ( max-width: 660px ) {
-		max-width: calc( 342px - 20px );
+		max-width: calc( 100% - 68px );
 		padding: 10px;
+		margin-left: 24px;
+		margin-right: 24px;
 		&.muriel-card__no-background {
-			width: 342px;
+			width: calc( 100% - 48px );
+		}
+		.muriel-card {
+			margin-left: 0;
+			margin-right: 0;
+			max-width: calc( 100% - 20px );
+			width: 100%;
 		}
 	}
 }

--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -7,12 +7,32 @@
 .muriel-card {
 	background: $muriel-white;
 	border-radius: 3px;
-	box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.25);
+	box-shadow: 0px 1px 1px rgba( 0, 0, 0, 0.25 );
 	margin: 0 auto 10px auto;
-	max-width: 440px;
-	padding: 24px;
+
+	max-width: calc( 682px - 62px );
+	padding: 31px;
+
 	&.muriel-card__no-background {
 		background: none;
 		box-shadow: none;
+		padding-left: 0;
+		padding-right: 0;
+		max-width: 682px;
+	}
+	@media screen and ( max-width: 1024px ) {
+		max-width: calc( 642px - 58px );
+		padding-left: 29px;
+		padding-right: 29px;
+		&.muriel-card__no-background {
+			width: 642px;
+		}
+	}
+	@media screen and ( max-width: 375px ) {
+		max-width: calc( 342px - 20px );
+		padding: 10px;
+		&.muriel-card__no-background {
+			width: 342px;
+		}
 	}
 }

--- a/assets/components/src/checklist/index.js
+++ b/assets/components/src/checklist/index.js
@@ -13,7 +13,7 @@ import { Dashicon } from '@wordpress/components';
  * Internal dependencies.
  */
 import murielClassnames from '../../../shared/js/muriel-classnames';
-import { Button, ProgressBar } from '../';
+import { Button, Card, ProgressBar } from '../';
 import './style.scss';
 
 class Checklist extends Component {
@@ -41,28 +41,30 @@ class Checklist extends Component {
 			return completedCount + ( child.props.completed ? 1 : 0 );
 		}, 0 );
 		return (
-			<div className={ classes } { ...otherProps }>
-				<div className="muriel-checklist__header">
-					<div className="muriel-checklist__header-main">
-						<ProgressBar
-							completed={ completedCount }
-							total={ Children.count( children ) }
-							displayFraction
-							label={ progressBarText }
-						/>
+			<Card noBackground className={ classes } { ...otherProps }>
+				<div className="muriel-checklist__wrapper">
+					<div className="muriel-checklist__header">
+						<div className="muriel-checklist__header-main">
+							<ProgressBar
+								completed={ completedCount }
+								total={ Children.count( children ) }
+								displayFraction
+								label={ progressBarText }
+							/>
+						</div>
+						<div className="muriel-checklist__header-secondary">
+							<label htmlFor="muriel-checklist__header-action">{ completedLabel }</label>
+							<Button
+								id="muriel-checklist__header-action"
+								onClick={ () => this.setState( { hideCompleted: ! hideCompleted } ) }
+							>
+								<Dashicon icon={ completedIcon } />
+							</Button>
+						</div>
 					</div>
-					<div className="muriel-checklist__header-secondary">
-						<label htmlFor="muriel-checklist__header-action">{ completedLabel }</label>
-						<Button
-							id="muriel-checklist__header-action"
-							onClick={ () => this.setState( { hideCompleted: ! hideCompleted } ) }
-						>
-							<Dashicon icon={ completedIcon } />
-						</Button>
-					</div>
+					<div className="muriel-checklist__tasks">{ children }</div>
 				</div>
-				<div className="muriel-checklist__tasks">{ children }</div>
-			</div>
+			</Card>
 		);
 	}
 }

--- a/assets/components/src/checklist/style.scss
+++ b/assets/components/src/checklist/style.scss
@@ -1,4 +1,4 @@
-.muriel-checklist {
+.muriel-checklist .muriel-checklist__wrapper {
 	background-color: $muriel-white;
 	margin: 14px auto;
 	max-width: 1040px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements the Muriel grid through width and padding styles in the `Card` component at a variety of breakpoints. Because  all Newspack Wizards are contained in `Card`s this effectively enforces the grid for all of our UI. The one exception was the `Checklist` component, which is why this PR contains changes to wrap it in a `Card` like everything else. 

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run  build:webpack`
2. Navigate to `Newspack->Components Demo` 
3. Verify correct widths of all elements at all breakpoints (0-660px, 660px-1024px, 1024px+). 

Note: the Muriel Grid Chrome extension is useful for testing: https://chrome.google.com/webstore/detail/muriel-grid/heabkjiofmaphebjodoflpglpkdojpmg?hl=en

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->