### PR TITLE
Action Button Below Card

### DIFF
--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -31,13 +31,15 @@ export default function withWizardScreen( WrappedComponent, config ) {
 				noBackground ? 'muriel-wizardScreen__no-background' : ''
 			);
 			return (
-				<Card className={ classes } noBackground={ noBackground }>
-					{ headerText && (
-						<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
-					) }
-					<div className="muriel-wizardScreen__content">
-						<WrappedComponent { ...this.props } />
-					</div>
+				<Fragment>
+					<Card className={ classes } noBackground={ noBackground }>
+						{ headerText && (
+							<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+						) }
+						<div className="muriel-wizardScreen__content">
+							<WrappedComponent { ...this.props } />
+						</div>
+					</Card>
 					{ buttonText && buttonAction && (
 						<Button
 							isPrimary
@@ -47,7 +49,7 @@ export default function withWizardScreen( WrappedComponent, config ) {
 							{ buttonText }
 						</Button>
 					) }
-				</Card>
+				</Fragment>
 			);
 		}
 	};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The action button has been moved outside the `<Card>` in Wizard Screens.

Closes #129 .

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. View any Wizards and verify that the button appears where it should.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->