### PR TITLE
Alternate Plugin Installer UI

### DIFF
--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { ActionCard, Button } from '../';
+import { ActionCard, Button, ProgressBar } from '../';
 import './style.scss';
 
 const PLUGIN_STATE_NONE = 0;
@@ -35,7 +35,10 @@ class PluginInstaller extends Component {
 
 	componentDidMount = () => {
 		const { plugins } = this.props;
-		this.retrievePluginInfo( plugins );
+		this.retrievePluginInfo( plugins ).then( () => {
+			const { asProgressBar } = this.props;
+			if ( asProgressBar ) this.installAllPlugins();
+		} );
 	};
 
 	componentDidUpdate = prevProps => {
@@ -46,17 +49,19 @@ class PluginInstaller extends Component {
 	};
 
 	retrievePluginInfo = plugins => {
-		apiFetch( { path: '/newspack/v1/plugins/' } ).then( response => {
-			const pluginInfo = Object.keys( response ).reduce( ( result, slug ) => {
-				if ( plugins.indexOf( slug ) === -1 ) return result;
-				result[ slug ] = {
-					...response[ slug ],
-					installationStatus:
-						response[ slug ].Status === 'active' ? PLUGIN_STATE_ACTIVE : PLUGIN_STATE_NONE,
-				};
-				return result;
-			}, {} );
-			this.updatePluginInfo( pluginInfo );
+		return new Promise( ( resolve, reject ) => {
+			apiFetch( { path: '/newspack/v1/plugins/' } ).then( response => {
+				const pluginInfo = Object.keys( response ).reduce( ( result, slug ) => {
+					if ( plugins.indexOf( slug ) === -1 ) return result;
+					result[ slug ] = {
+						...response[ slug ],
+						installationStatus:
+							response[ slug ].Status === 'active' ? PLUGIN_STATE_ACTIVE : PLUGIN_STATE_NONE,
+					};
+					return result;
+				}, {} );
+				this.updatePluginInfo( pluginInfo ).then( () => resolve() );
+			} );
 		} );
 	};
 
@@ -126,15 +131,18 @@ class PluginInstaller extends Component {
 	};
 
 	updatePluginInfo = pluginInfo => {
-		const { onComplete } = this.props;
-		this.setState( { pluginInfo }, () => {
-			const { pluginInfo } = this.state;
-			const isDone = Object.values( pluginInfo ).every( plugin => {
-				return 'active' === plugin.Status;
+		return new Promise( ( resolve, reject ) => {
+			const { onComplete } = this.props;
+			this.setState( { pluginInfo }, () => {
+				const { pluginInfo } = this.state;
+				const isDone = Object.values( pluginInfo ).every( plugin => {
+					return 'active' === plugin.Status;
+				} );
+				if ( isDone && onComplete ) {
+					onComplete( pluginInfo );
+				}
+				resolve();
 			} );
-			if ( isDone && onComplete ) {
-				onComplete( pluginInfo );
-			}
 		} );
 	};
 
@@ -142,13 +150,21 @@ class PluginInstaller extends Component {
 	 * Render.
 	 */
 	render() {
-		const { canUninstall } = this.props;
+		const { asProgressBar, canUninstall } = this.props;
 		const { pluginInfo } = this.state;
 		const slugs = Object.keys( pluginInfo );
 		const needsInstall = slugs.some( slug => {
 			const plugin = pluginInfo[ slug ];
 			return plugin.Status !== 'active' && plugin.installationStatus === PLUGIN_STATE_NONE;
 		} );
+		if ( asProgressBar ) {
+			const completed = slugs.reduce(
+				( completed, slug ) =>
+					'active' === pluginInfo[ slug ].Status ? completed + 1 : completed,
+				0
+			);
+			return slugs.length > 0 && <ProgressBar completed={ completed } total={ slugs.length } />;
+		}
 		return (
 			<div>
 				{ pluginInfo &&

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -203,6 +203,8 @@ class PluginInstaller extends Component {
 								notificationLevel="error"
 							/>
 						);
+					} ) }
+					{ pluginInfo && slugs.length > 0 && (
 						<Button
 							disabled={ ! needsInstall }
 							isPrimary
@@ -210,8 +212,8 @@ class PluginInstaller extends Component {
 							onClick={ this.installAllPlugins }
 						>
 							{ __( 'Use All' ) }
-						</Button>;
-					} ) }
+						</Button>
+					) }
 			</div>
 		);
 	}

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -203,15 +203,15 @@ class PluginInstaller extends Component {
 								notificationLevel="error"
 							/>
 						);
+						<Button
+							disabled={ ! needsInstall }
+							isPrimary
+							className="is-centered"
+							onClick={ this.installAllPlugins }
+						>
+							{ __( 'Use All' ) }
+						</Button>;
 					} ) }
-				<Button
-					disabled={ ! needsInstall }
-					isPrimary
-					className="is-centered"
-					onClick={ this.installAllPlugins }
-				>
-					{ __( 'Use All' ) }
-				</Button>
 			</div>
 		);
 	}

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -48,6 +48,7 @@ class ComponentsDemo extends Component {
 			selectValue1: '2nd',
 			selectValue2: '',
 			modalShown: false,
+			showPluginInstallerWithProgressBar: false,
 		};
 	}
 
@@ -75,6 +76,7 @@ class ComponentsDemo extends Component {
 			selectValue1,
 			selectValue2,
 			modalShown,
+			showPluginInstallerWithProgressBar,
 		} = this.state;
 
 		return (
@@ -129,6 +131,22 @@ class ComponentsDemo extends Component {
 								{ __( 'Also dismiss' ) }
 							</Button>
 						</Modal>
+					) }
+				</Card>
+				<Card>
+					<FormattedHeader headerText={ __( 'Plugin installer: Progress Bar' ) } />
+					<Button
+						onClick={ () => this.setState( { showPluginInstallerWithProgressBar: true } ) }
+						className="is-centered"
+						isPrimary
+					>
+						{ __( 'Show Plugin Installer w/Progress Bar' ) }
+					</Button>
+					{ showPluginInstallerWithProgressBar && (
+						<PluginInstaller
+							plugins={ [ 'woocommerce', 'amp', 'wordpress-seo', 'google-site-kit' ] }
+							asProgressBar
+						/>
 					) }
 				</Card>
 				<Card noBackground>

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -139,6 +139,18 @@ class ComponentsDemo extends Component {
 							'amp',
 							'wordpress-seo',
 							'google-site-kit',
+						] }
+						asProgressBar
+					/>
+				</Card>
+				<Card noBackground>
+					<FormattedHeader headerText={ __( 'Plugin installer' ) } />
+					<PluginInstaller
+						plugins={ [
+							'woocommerce',
+							'amp',
+							'wordpress-seo',
+							'google-site-kit',
 							'woocommerce-subscriptions',
 							'fake-plugin',
 						] }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -139,18 +139,6 @@ class ComponentsDemo extends Component {
 							'amp',
 							'wordpress-seo',
 							'google-site-kit',
-						] }
-						asProgressBar
-					/>
-				</Card>
-				<Card noBackground>
-					<FormattedHeader headerText={ __( 'Plugin installer' ) } />
-					<PluginInstaller
-						plugins={ [
-							'woocommerce',
-							'amp',
-							'wordpress-seo',
-							'google-site-kit',
 							'woocommerce-subscriptions',
 							'fake-plugin',
 						] }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Setup Wizard installs plugins using different UI from the normal `PluginInstaller` component. It uses a `ProgressBar`, and installation begins automatically rather than requiring a `Button` click. To avoid code duplication, this PR brings this UI and functionality to the `PluginInstaller` component if it has the `asProgressBar` prop. Also, the `Use All` `Button` is hidden until plugin data has been retrieved, which will remove the flash of incorrect UI that appears in cases where the component determines that all plugin requirements have been met and hides itself.

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Deactivate and remove these plugins: WooCommerce, AMP, Yoast, Site Kit
3. Navigate to `Newspack->Components Demo`
4. Click `Show Plugin Installer w/Progress Bar`.
5. Observe a `ProgressBar` appears and fills in as the four plugins are installed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->