### PR TITLE
Improved Plugin Loading Flow

### DIFF
--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -165,6 +165,12 @@ class PluginInstaller extends Component {
 		}
 		return (
 			<div>
+				{ ! pluginInfo.length && (
+					<div className="newspack-plugin-installer_waiting">
+						<p>{ __( 'Retrieving plugin information...') }</p>
+						<Spinner />
+					</div>
+				) }
 				{ pluginInfo &&
 					slugs.length > 0 &&
 					slugs.map( slug => {

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -29,7 +29,7 @@ class PluginInstaller extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
-			pluginInfo: [],
+			pluginInfo: {},
 		};
 	}
 
@@ -165,7 +165,7 @@ class PluginInstaller extends Component {
 		}
 		return (
 			<div>
-				{ ! pluginInfo.length && (
+				{ ( ! pluginInfo || ! Object.keys( pluginInfo ).length )  && (
 					<div className="newspack-plugin-installer_waiting">
 						<p>{ __( 'Retrieving plugin information...') }</p>
 						<Spinner />

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -132,15 +132,13 @@ class PluginInstaller extends Component {
 
 	updatePluginInfo = pluginInfo => {
 		return new Promise( ( resolve, reject ) => {
-			const { onComplete } = this.props;
+			const { onStatus } = this.props;
 			this.setState( { pluginInfo }, () => {
 				const { pluginInfo } = this.state;
-				const isDone = Object.values( pluginInfo ).every( plugin => {
+				const complete = Object.values( pluginInfo ).every( plugin => {
 					return 'active' === plugin.Status;
 				} );
-				if ( isDone && onComplete ) {
-					onComplete( pluginInfo );
-				}
+				onStatus( { complete, pluginInfo } );
 				resolve();
 			} );
 		} );
@@ -217,6 +215,10 @@ class PluginInstaller extends Component {
 			</div>
 		);
 	}
+}
+
+PluginInstaller.defaultProps = {
+	onStatus: () => {},
 }
 
 export default PluginInstaller;

--- a/assets/components/src/plugin-installer/style.scss
+++ b/assets/components/src/plugin-installer/style.scss
@@ -7,3 +7,9 @@
 		right: 0;
 	}
 }
+.newspack-plugin-installer_waiting {
+	text-align: center;
+	.components-spinner {
+		float: none;
+	}
+}

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -25,7 +25,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		constructor( props ) {
 			super( props );
 			this.state = {
-				complete: false,
+				complete: null,
 				error: null,
 			};
 			this.wrappedComponentRef = createRef();
@@ -154,10 +154,12 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 						path="/"
 						render={ routeProps => (
 							<Card noBackground>
-								<FormattedHeader
-									headerText={ __( 'Required plugin' ) }
-									subHeaderText={ __( 'This feature requires the following plugin.' ) }
-								/>
+								{ complete !== null && (
+									<FormattedHeader
+										headerText={ __( 'Required plugin' ) }
+										subHeaderText={ __( 'This feature requires the following plugin.' ) }
+									/>
+								) }
 								<PluginInstaller
 									plugins={ requiredPlugins }
 									onStatus={ status => this.pluginInstallationStatus( status ) }

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -31,12 +31,6 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 			this.wrappedComponentRef = createRef();
 		}
 
-		componentDidMount() {
-			if ( ! requiredPlugins ) {
-				this.pluginInstallationComplete();
-			}
-		}
-
 		/**
 		 * Set the error. Called by Wizards when an error occurs.
 		 *
@@ -182,7 +176,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 				<Fragment>
 					{ this.getError() }
 					<WrappedComponent
-						pluginRequirements={ this.pluginRequirements() }
+						pluginRequirements={ requiredPlugins && this.pluginRequirements() }
 						clearError={ this.clearError }
 						getError={ this.getError }
 						setError={ this.setError }

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -151,7 +151,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 			return (
 				<Fragment>
 					<Route
-						path="/plugin-requirements"
+						path="/"
 						render={ routeProps => (
 							<Card noBackground>
 								<FormattedHeader
@@ -165,7 +165,6 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 							</Card>
 						) }
 					/>
-					<Redirect to="/plugin-requirements" />
 				</Fragment>
 			);
 		};

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -25,7 +25,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		constructor( props ) {
 			super( props );
 			this.state = {
-				pluginRequirementsMet: false,
+				complete: false,
 				error: null,
 			};
 			this.wrappedComponentRef = createRef();
@@ -130,10 +130,10 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		/**
 		 * Called when plugin installation is complete. Updates state and calls onWizardReady on the wrapped component.
 		 */
-		pluginInstallationComplete = () => {
+		pluginInstallationStatus = ( { complete } ) => {
 			const instance = this.wrappedComponentRef.current;
-			this.setState( { pluginRequirementsMet: true }, () => {
-				instance && instance.onWizardReady && instance.onWizardReady();
+			this.setState( { complete }, () => {
+				complete && instance && instance.onWizardReady && instance.onWizardReady();
 			} );
 		};
 
@@ -143,9 +143,9 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		 * @return void
 		 */
 		pluginRequirements = () => {
-			const { pluginRequirementsMet } = this.state;
+			const { complete } = this.state;
 			/* After all plugins are loaded, redirect to / (this could be configurable) */
-			if ( pluginRequirementsMet ) {
+			if ( complete ) {
 				return <Redirect from="/plugin-requirements" to="/" />;
 			}
 			return (
@@ -160,7 +160,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 								/>
 								<PluginInstaller
 									plugins={ requiredPlugins }
-									onStatus={ ( { complete, pluginInfo } ) => complete && this.pluginInstallationComplete() }
+									onStatus={ status => this.pluginInstallationStatus( status ) }
 								/>
 							</Card>
 						) }

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -160,7 +160,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 								/>
 								<PluginInstaller
 									plugins={ requiredPlugins }
-									onComplete={ () => this.pluginInstallationComplete() }
+									onStatus={ ( { complete, pluginInfo } ) => complete && this.pluginInstallationComplete() }
 								/>
 							</Card>
 						) }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -163,13 +163,16 @@ class ComponentsDemo extends Component {
 							'fake-plugin',
 						] }
 						canUninstall
+						onStatus={ ( { complete, pluginInfo } ) => {
+							console.log( complete ? 'All plugins installed successfully' : 'Plugin installation incomplete', pluginInfo );
+						} }
 					/>
 				</Card>
 				<Card noBackground>
 					<PluginInstaller
 						plugins={ [ 'woocommerce', 'amp', 'wordpress-seo' ] }
-						onComplete={ pluginInfo => {
-							console.log( 'All plugins installed successfully', pluginInfo );
+						onStatus={ ( { complete, pluginInfo } ) => {
+							console.log( complete ? 'All plugins installed successfully' : 'Plugin installation incomplete', pluginInfo );
 						} }
 					/>
 				</Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the plugin installer loading UI in a few ways:

1) Previously wizards with required plugins always defaulted to the `/` route after plugin installation. This has been reworked here so that a wizard can begin  on a deeper route but still perform plugin installation check.
2) Even if all plugins have been installed, there will be a flash of the "Required plugins" header before the initial plugin data is retrieved. Replacing `onComplete` with a more sophisticated `onStatus` event makes it possible to hide this header.
3) "Retrieving plugin information" UI with `Spinner` added to `PluginInstaller`.

### How to test the changes in this Pull Request:

1. On `master` branch navigate directly to `/wp-admin/admin.php?page=newspack-subscriptions-onboarding-wizard#/stripe`. Observe a flash of the `Required plugins` header. Observe that after plugin requirements are satisfied, the Wizard redirects to the `/` route.
2. Switch to `fix/plugin-loading-flow`, and run `npm ci && npm run clean && npm run build:webpack`
3. Navigate again to `/wp-admin/admin.php?page=newspack-subscriptions-onboarding-wizard#/stripe`
4. Observe the headers are suppressed, "Retrieving plugin information" UI is shown, and the Wizard ultimately lands on the correct route.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->