### PR TITLE
Performance Wizard

### DIFF
--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -25,13 +25,18 @@ export default function withWizardScreen( WrappedComponent, config ) {
 				headerText,
 				subHeaderText,
 				noBackground,
+				noCard,
 			} = this.props;
 			const classes = murielClassnames(
 				'muriel-wizardScreen',
 				className,
 				noBackground ? 'muriel-wizardScreen__no-background' : ''
 			);
-			const retrievedButtonProps = buttonProps( buttonAction );
+			const content = (
+				<div className="muriel-wizardScreen__content">
+					<WrappedComponent { ...this.props } />
+				</div>
+			);
 			return (
 				<Fragment>
 					<Card noBackground>
@@ -39,11 +44,12 @@ export default function withWizardScreen( WrappedComponent, config ) {
 							<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 						) }
 					</Card>
-					<Card className={ classes } noBackground={ noBackground }>
-						<div className="muriel-wizardScreen__content">
-							<WrappedComponent { ...this.props } />
-						</div>
-					</Card>
+					{ !! noCard && content }
+					{ ! noCard && (
+						<Card className={ classes } noBackground={ noBackground }>
+							{ content }
+						</Card>
+					) }
 					{ buttonText && buttonAction && !! retrievedButtonProps.plugin && (
 						<Handoff
 							isPrimary

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -37,6 +37,7 @@ export default function withWizardScreen( WrappedComponent, config ) {
 					<WrappedComponent { ...this.props } />
 				</div>
 			);
+			const retrievedButtonProps = buttonProps( buttonAction );
 			return (
 				<Fragment>
 					<Card noBackground>

--- a/assets/shared/scss/_muriel-component.scss
+++ b/assets/shared/scss/_muriel-component.scss
@@ -11,3 +11,7 @@ $primary_color_darker: #3166ae;
  		margin-right: auto;
  	}
 }
+.newspack-plugin-description {
+	color: $muriel-gray-400;
+	font-style: italic;
+}

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -1,0 +1,68 @@
+/**
+ * Performance Wizard.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment, render } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { withWizard } from '../../components/src';
+
+/**
+ * External dependencies
+ */
+import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
+
+/**
+ * Wizard for configuring PWA features.
+ */
+class PerformanceWizard extends Component {
+	/**
+	 * Constructor.
+	 */
+	constructor() {
+		super( ...arguments );
+		this.state = {};
+	}
+
+	/**
+	 * wizardReady will be called when all plugin requirements are met.
+	 */
+	onWizardReady = () => {
+		// TK
+	};
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const { pluginRequirements } = this.props;
+		return (
+			<HashRouter hashType="slash">
+				<Switch>
+					{ pluginRequirements }
+					<Route
+						path="/"
+						exact
+						render={ routeProps => ( <p>TK</p> ) }
+					/>
+					<Redirect to="/" />
+				</Switch>
+			</HashRouter>
+		);
+	}
+}
+
+render(
+	createElement( withWizard( PerformanceWizard, [ 'pwa', 'progressive-wp' ] ), {
+		buttonText: __( 'Back to dashboard' ),
+		buttonAction: newspack_urls[ 'dashboard' ],
+	} ),
+	document.getElementById( 'newspack-performance-wizard' )
+);

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -56,17 +56,19 @@ class PerformanceWizard extends Component {
 	updateSettings() {
 		const { setError } = this.props;
 		const { settings } = this.state;
-		return apiFetch( {
-			path: '/newspack/v1/wizard/performance',
-			method: 'POST',
-			data: { settings },
-		} )
-			.then( settings => {
-				this.setState( { settings } );
+		return new Promise( ( resolve, reject ) => {
+			apiFetch( {
+				path: '/newspack/v1/wizard/performance',
+				method: 'POST',
+				data: { settings },
 			} )
-			.catch( error => {
-				setError( error );
-			} );
+				.then( settings => {
+					this.setState( { settings } ).then( () => resolve() );
+				} )
+				.catch( error => {
+					setError( error ).then( () => reject() );
+				} );
+		} );
 	}
 
 	updateSetting = ( key, value ) => {

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -90,8 +90,8 @@ class PerformanceWizard extends Component {
 						render={ routeProps => (
 							<Intro
 								noCard
-								headerText={ __( 'Progressive Web App (PWA)' ) }
-								subHeaderText={ __( 'Optimizing your news site for better performance.' ) }
+								headerText={ __( 'Performance options' ) }
+								subHeaderText={ __( 'Optimizing your news site for better performance and increased user engagement.' ) }
 								buttonText={ __( 'Configure advanced options' ) }
 								buttonAction="#/add-to-homescreen"
 							/>

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -31,9 +31,7 @@ class PerformanceWizard extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
-			settings: {
-				'add_to_homescreen': false,
-			},
+			settings: {},
 		};
 	}
 
@@ -41,8 +39,35 @@ class PerformanceWizard extends Component {
 	 * wizardReady will be called when all plugin requirements are met.
 	 */
 	onWizardReady = () => {
-		// TK
+		this.getSettings();
 	};
+
+	getSettings() {
+		const { setError } = this.props;
+		return apiFetch( { path: '/newspack/v1/wizard/performance' } )
+			.then( settings => {
+				this.setState( { settings } );
+			} )
+			.catch( error => {
+				this.setError( error );
+			} );
+	}
+
+	updateSettings() {
+		const { setError } = this.props;
+		const { settings } = this.state;
+		return apiFetch( {
+			path: '/newspack/v1/wizard/performance',
+			method: 'POST',
+			data: { settings },
+		} )
+			.then( settings => {
+				this.setState( { settings } );
+			} )
+			.catch( error => {
+				this.setError( error );
+			} );
+	}
 
 	updateSetting = ( key, value ) => {
 		const { settings } = this.state;
@@ -81,7 +106,7 @@ class PerformanceWizard extends Component {
 									'Encourage your users to add your news site to their homescreen.'
 								) }
 								buttonText={ __( 'Continue' ) }
-								buttonAction="#/offline-usage"
+								buttonAction={ () => this.updateSettings() }
 								settings={ settings }
 								updateSetting={ this.updateSetting }
 							/>
@@ -96,7 +121,7 @@ class PerformanceWizard extends Component {
 									'Make your website reliable. Even on flaky internet connections.'
 								) }
 								buttonText={ __( 'Continue' ) }
-								buttonAction="#/push-notifications"
+								buttonAction={ () => this.updateSettings() }
 								settings={ settings }
 								updateSetting={ this.updateSetting }
 							/>
@@ -109,7 +134,7 @@ class PerformanceWizard extends Component {
 								headerText={ __( 'Enable Push Notifications' ) }
 								subHeaderText={ __( 'Keep your users engaged by sending push notifications.' ) }
 								buttonText={ __( 'Continue' ) }
-								buttonAction="#/"
+								buttonAction={ () => this.updateSettings() }
 								settings={ settings }
 								updateSetting={ this.updateSetting }
 							/>

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -106,7 +106,10 @@ class PerformanceWizard extends Component {
 									'Encourage your users to add your news site to their homescreen.'
 								) }
 								buttonText={ __( 'Continue' ) }
-								buttonAction={ () => this.updateSettings() }
+								buttonAction={ {
+									onClick: () => this.updateSettings(),
+									href: '#/offline-usage',
+								} }
 								settings={ settings }
 								updateSetting={ this.updateSetting }
 							/>
@@ -121,7 +124,10 @@ class PerformanceWizard extends Component {
 									'Make your website reliable. Even on flaky internet connections.'
 								) }
 								buttonText={ __( 'Continue' ) }
-								buttonAction={ () => this.updateSettings() }
+								buttonAction={ {
+									onClick: () => this.updateSettings(),
+									href: '#/push-notifications',
+								} }
 								settings={ settings }
 								updateSetting={ this.updateSetting }
 							/>
@@ -134,7 +140,11 @@ class PerformanceWizard extends Component {
 								headerText={ __( 'Enable Push Notifications' ) }
 								subHeaderText={ __( 'Keep your users engaged by sending push notifications.' ) }
 								buttonText={ __( 'Continue' ) }
-								buttonAction={ () => this.updateSettings() }
+								buttonAction={ () =>
+									this.updateSettings().then(
+										() => ( window.location = newspack_urls[ 'dashboard' ] )
+									)
+								}
 								settings={ settings }
 								updateSetting={ this.updateSetting }
 							/>

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -29,7 +29,11 @@ class PerformanceWizard extends Component {
 	 */
 	constructor() {
 		super( ...arguments );
-		this.state = {};
+		this.state = {
+			settings: {
+				'add_to_homescreen': false,
+			},
+		};
 	}
 
 	/**
@@ -39,11 +43,17 @@ class PerformanceWizard extends Component {
 		// TK
 	};
 
+	updateSetting = ( key, value ) => {
+		const { settings } = this.state;
+		this.setState( { settings: { ...settings, [ key ]: value } } );
+	};
+
 	/**
 	 * Render.
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
+		const { settings } = this.state;
 		return (
 			<HashRouter hashType="slash">
 				<Switch>
@@ -66,9 +76,13 @@ class PerformanceWizard extends Component {
 						render={ routeProps => (
 							<AddToHomeScreen
 								headerText={ __( 'Enable Add to Homescreen' ) }
-								subHeaderText={ __( 'Encourage your users to add your news site to their homescreen.' ) }
+								subHeaderText={ __(
+									'Encourage your users to add your news site to their homescreen.'
+								) }
 								buttonText={ __( 'Continue' ) }
 								buttonAction="#/offline-usage"
+								settings={ settings }
+								updateSetting={ this.updateSetting }
 							/>
 						) }
 					/>
@@ -77,9 +91,13 @@ class PerformanceWizard extends Component {
 						render={ routeProps => (
 							<OfflineUsage
 								headerText={ __( 'Enable Offline Usage' ) }
-								subHeaderText={ __( 'Make your website reliable. Even on flaky internet connections.' ) }
+								subHeaderText={ __(
+									'Make your website reliable. Even on flaky internet connections.'
+								) }
 								buttonText={ __( 'Continue' ) }
 								buttonAction="#/push-notifications"
+								settings={ settings }
+								updateSetting={ this.updateSetting }
 							/>
 						) }
 					/>
@@ -91,6 +109,8 @@ class PerformanceWizard extends Component {
 								subHeaderText={ __( 'Keep your users engaged by sending push notifications.' ) }
 								buttonText={ __( 'Continue' ) }
 								buttonAction="#/"
+								settings={ settings }
+								updateSetting={ this.updateSetting }
 							/>
 						) }
 					/>

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { withWizard } from '../../components/src';
 import { AddToHomeScreen, Intro, OfflineUsage, PushNotifications } from './views';
+import './style.scss';
 
 /**
  * External dependencies

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { withWizard } from '../../components/src';
+import { Intro } from './views';
 
 /**
  * External dependencies
@@ -50,7 +51,15 @@ class PerformanceWizard extends Component {
 					<Route
 						path="/"
 						exact
-						render={ routeProps => ( <p>TK</p> ) }
+						render={ routeProps => (
+							<Intro
+								noCard
+								headerText={ __( 'Progressive Web App (PWA)' ) }
+								subHeaderText={ __( 'Optimizing your news site for better performance.' ) }
+								buttonText={ __( 'Configure advanced options' ) }
+								buttonAction="#/configure"
+							/>
+						) }
 					/>
 					<Redirect to="/" />
 				</Switch>

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { withWizard } from '../../components/src';
-import { Intro } from './views';
+import { AddToHomeScreen, Intro, OfflineUsage, PushNotifications } from './views';
 
 /**
  * External dependencies
@@ -57,7 +57,40 @@ class PerformanceWizard extends Component {
 								headerText={ __( 'Progressive Web App (PWA)' ) }
 								subHeaderText={ __( 'Optimizing your news site for better performance.' ) }
 								buttonText={ __( 'Configure advanced options' ) }
-								buttonAction="#/configure"
+								buttonAction="#/add-to-homescreen"
+							/>
+						) }
+					/>
+					<Route
+						path="/add-to-homescreen"
+						render={ routeProps => (
+							<AddToHomeScreen
+								headerText={ __( 'Enable Add to Homescreen' ) }
+								subHeaderText={ __( 'Encourage your users to add your news site to their homescreen.' ) }
+								buttonText={ __( 'Continue' ) }
+								buttonAction="#/offline-usage"
+							/>
+						) }
+					/>
+					<Route
+						path="/offline-usage"
+						render={ routeProps => (
+							<OfflineUsage
+								headerText={ __( 'Enable Offline Usage' ) }
+								subHeaderText={ __( 'Make your website reliable. Even on flaky internet connections.' ) }
+								buttonText={ __( 'Continue' ) }
+								buttonAction="#/push-notifications"
+							/>
+						) }
+					/>
+					<Route
+						path="/push-notifications"
+						render={ routeProps => (
+							<PushNotifications
+								headerText={ __( 'Enable Push Notifications' ) }
+								subHeaderText={ __( 'Keep your users engaged by sending push notifications.' ) }
+								buttonText={ __( 'Continue' ) }
+								buttonAction="#/"
 							/>
 						) }
 					/>

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -70,7 +70,7 @@ class PerformanceWizard extends Component {
 				data: { settings: submitSettings },
 			} )
 				.then( settings => {
-					this.setState( { settings }, () => resolve() );
+					setError().then( () => this.setState( { settings }, () => resolve() ) );
 				} )
 				.catch( error => {
 					setError( error ).then( () => reject() );

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -53,14 +53,21 @@ class PerformanceWizard extends Component {
 			} );
 	}
 
-	updateSettings() {
+	updateSettings( ...fields ) {
 		const { setError } = this.props;
 		const { settings } = this.state;
+		const submitSettings = Object.keys( settings ).reduce(
+			( submitSettings, key ) =>
+				fields.indexOf( key ) > -1
+					? { ...submitSettings, [ key ]: settings[ key ] }
+					: submitSettings,
+			{}
+		);
 		return new Promise( ( resolve, reject ) => {
 			apiFetch( {
 				path: '/newspack/v1/wizard/performance',
 				method: 'POST',
-				data: { settings },
+				data: { settings: submitSettings },
 			} )
 				.then( settings => {
 					this.setState( { settings }, () => resolve() );
@@ -111,7 +118,9 @@ class PerformanceWizard extends Component {
 								) }
 								buttonText={ __( 'Continue' ) }
 								buttonAction={ () =>
-									this.updateSettings().then( () => routeProps.history.push( '/offline-usage' ) )
+									this.updateSettings( 'add_to_homescreen', 'site_icon' ).then( () =>
+										routeProps.history.push( '/offline-usage' )
+									)
 								}
 								settings={ settings }
 								updateSetting={ this.updateSetting }
@@ -128,7 +137,7 @@ class PerformanceWizard extends Component {
 								) }
 								buttonText={ __( 'Continue' ) }
 								buttonAction={ () =>
-									this.updateSettings().then( () =>
+									this.updateSettings( 'offline_usage' ).then( () =>
 										routeProps.history.push( '/push-notifications' )
 									)
 								}
@@ -145,9 +154,11 @@ class PerformanceWizard extends Component {
 								subHeaderText={ __( 'Keep your users engaged by sending push notifications.' ) }
 								buttonText={ __( 'Continue' ) }
 								buttonAction={ () =>
-									this.updateSettings().then(
-										() => ( window.location = newspack_urls[ 'dashboard' ] )
-									)
+									this.updateSettings(
+										'push_notifications',
+										'push_notification_server_key',
+										'push_notification_sender_id'
+									).then( () => ( window.location = newspack_urls[ 'dashboard' ] ) )
 								}
 								settings={ settings }
 								updateSetting={ this.updateSetting }

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -63,7 +63,7 @@ class PerformanceWizard extends Component {
 				data: { settings },
 			} )
 				.then( settings => {
-					this.setState( { settings } ).then( () => resolve() );
+					this.setState( { settings }, () => resolve() );
 				} )
 				.catch( error => {
 					setError( error ).then( () => reject() );

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -49,7 +49,7 @@ class PerformanceWizard extends Component {
 				this.setState( { settings } );
 			} )
 			.catch( error => {
-				this.setError( error );
+				setError( error );
 			} );
 	}
 
@@ -65,7 +65,7 @@ class PerformanceWizard extends Component {
 				this.setState( { settings } );
 			} )
 			.catch( error => {
-				this.setError( error );
+				setError( error );
 			} );
 	}
 
@@ -91,7 +91,9 @@ class PerformanceWizard extends Component {
 							<Intro
 								noCard
 								headerText={ __( 'Performance options' ) }
-								subHeaderText={ __( 'Optimizing your news site for better performance and increased user engagement.' ) }
+								subHeaderText={ __(
+									'Optimizing your news site for better performance and increased user engagement.'
+								) }
 								buttonText={ __( 'Configure advanced options' ) }
 								buttonAction="#/add-to-homescreen"
 							/>
@@ -106,10 +108,9 @@ class PerformanceWizard extends Component {
 									'Encourage your users to add your news site to their homescreen.'
 								) }
 								buttonText={ __( 'Continue' ) }
-								buttonAction={ {
-									onClick: () => this.updateSettings(),
-									href: '#/offline-usage',
-								} }
+								buttonAction={ () =>
+									this.updateSettings().then( () => routeProps.history.push( '/offline-usage' ) )
+								}
 								settings={ settings }
 								updateSetting={ this.updateSetting }
 							/>
@@ -124,10 +125,11 @@ class PerformanceWizard extends Component {
 									'Make your website reliable. Even on flaky internet connections.'
 								) }
 								buttonText={ __( 'Continue' ) }
-								buttonAction={ {
-									onClick: () => this.updateSettings(),
-									href: '#/push-notifications',
-								} }
+								buttonAction={ () =>
+									this.updateSettings().then( () =>
+										routeProps.history.push( '/push-notifications' )
+									)
+								}
 								settings={ settings }
 								updateSetting={ this.updateSetting }
 							/>

--- a/assets/wizards/performance/style.scss
+++ b/assets/wizards/performance/style.scss
@@ -7,3 +7,17 @@
 		margin-left: 2em;
 	}
 }
+.newspack-performance-wizard__info-block {
+	color:  $muriel-gray-300;
+	position: relative;
+	padding-left: 3em;
+	strong {
+		color: $muriel-gray-600;
+	}
+	&:before {
+		position: absolute;
+		top: 0;
+		left: 0;
+		color: $muriel-gray-500;
+	}
+}

--- a/assets/wizards/performance/style.scss
+++ b/assets/wizards/performance/style.scss
@@ -1,0 +1,9 @@
+.newspack-performance-wizard {
+	.newspack-performance-wizard_indented-block {
+		margin-left: 50px;
+	}
+	ul {
+		list-style-type: disc;
+		margin-left: 2em;
+	}
+}

--- a/assets/wizards/performance/views/add-to-homescreen/index.js
+++ b/assets/wizards/performance/views/add-to-homescreen/index.js
@@ -7,11 +7,13 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { withWizardScreen } from '../../../../components/src';
+import { CheckboxControl, ImageUpload, withWizardScreen } from '../../../../components/src';
+import './style.scss';
 
 /**
  * Description and controls for the Add To Homescreen feature.
@@ -21,7 +23,7 @@ class AddToHomeScreen extends Component {
 	 * Render.
 	 */
 	render() {
-		const { pluginRequirements } = this.props;
+		const { updateSetting, settings } = this.props;
 		return (
 			<Fragment>
 				<p>
@@ -29,6 +31,23 @@ class AddToHomeScreen extends Component {
 						'With this feature you are able to display an "add to homescreen" prompt. This way your news site gets a prominent place on the users home screen right next to the native apps.'
 					) }
 				</p>
+				<ToggleControl
+					label={ __( 'Enable “Add to Homescreen” button' ) }
+					onChange={ checked => updateSetting( 'add_to_homescreen', checked ) }
+					checked={ settings.add_to_homescreen }
+					tooltip={ __(
+						'The mobile browser will show a mini-infobar which opens the install prompt'
+					) }
+				/>
+				{ settings.add_to_homescreen && (
+					<div className="newspack-performance-wizard_site_icon_container">
+						<p><em>{ __( 'Site icons should be square and at least 512 × 512 pixels.' ) }</em></p>
+						<ImageUpload
+							image={ settings.site_icon }
+							onChange={ image => updateSetting( 'site_icon', image ) }
+						/>
+					</div>
+				) }
 			</Fragment>
 		);
 	}

--- a/assets/wizards/performance/views/add-to-homescreen/index.js
+++ b/assets/wizards/performance/views/add-to-homescreen/index.js
@@ -13,7 +13,6 @@ import { ToggleControl } from '@wordpress/components';
  * Internal dependencies
  */
 import { CheckboxControl, ImageUpload, withWizardScreen } from '../../../../components/src';
-import './style.scss';
 
 /**
  * Description and controls for the Add To Homescreen feature.
@@ -40,7 +39,7 @@ class AddToHomeScreen extends Component {
 					) }
 				/>
 				{ settings.add_to_homescreen && (
-					<div className="newspack-performance-wizard_site_icon_container">
+					<div className="newspack-performance-wizard_indented-block">
 						<p><em>{ __( 'Site icons should be square and at least 512 × 512 pixels.' ) }</em></p>
 						<ImageUpload
 							image={ settings.site_icon }

--- a/assets/wizards/performance/views/add-to-homescreen/index.js
+++ b/assets/wizards/performance/views/add-to-homescreen/index.js
@@ -1,0 +1,37 @@
+/**
+ * Performance Wizard Add To Homescreen screen.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { withWizardScreen } from '../../../../components/src';
+
+/**
+ * Description and controls for the Add To Homescreen feature.
+ */
+class AddToHomeScreen extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { pluginRequirements } = this.props;
+		return (
+			<Fragment>
+				<p>
+					{ __(
+						'With this feature you are able to display an "add to homescreen" prompt. This way your news site gets a prominent place on the users home screen right next to the native apps.'
+					) }
+				</p>
+			</Fragment>
+		);
+	}
+}
+
+export default withWizardScreen( AddToHomeScreen, {} );

--- a/assets/wizards/performance/views/add-to-homescreen/style.scss
+++ b/assets/wizards/performance/views/add-to-homescreen/style.scss
@@ -1,3 +1,0 @@
-.newspack-performance-wizard_site_icon_container {
-	margin-left: 50px;
-}

--- a/assets/wizards/performance/views/add-to-homescreen/style.scss
+++ b/assets/wizards/performance/views/add-to-homescreen/style.scss
@@ -1,0 +1,3 @@
+.newspack-performance-wizard_site_icon_container {
+	margin-left: 50px;
+}

--- a/assets/wizards/performance/views/index.js
+++ b/assets/wizards/performance/views/index.js
@@ -1,0 +1,1 @@
+export { default as Intro } from './intro'

--- a/assets/wizards/performance/views/index.js
+++ b/assets/wizards/performance/views/index.js
@@ -1,1 +1,4 @@
 export { default as Intro } from './intro'
+export { default as AddToHomeScreen } from './add-to-homescreen'
+export { default as PushNotifications } from './push-notifications'
+export { default as OfflineUsage } from './offline-usage'

--- a/assets/wizards/performance/views/intro/index.js
+++ b/assets/wizards/performance/views/intro/index.js
@@ -1,5 +1,5 @@
 /**
- * Performance Wizard.
+ * Performance Wizard Intro screen
  */
 
 /**
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { Card, withWizardScreen } from '../../../../components/src';
 
 /**
- * Wizard for configuring PWA features.
+ * Intro screen for Performnance Wizard
  */
 class Intro extends Component {
 	/**

--- a/assets/wizards/performance/views/intro/index.js
+++ b/assets/wizards/performance/views/intro/index.js
@@ -1,0 +1,64 @@
+/**
+ * Performance Wizard.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Card, withWizardScreen } from '../../../../components/src';
+
+/**
+ * Wizard for configuring PWA features.
+ */
+class Intro extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { pluginRequirements } = this.props;
+		return (
+			<Fragment>
+				<Card>
+					<p>
+						{ __(
+							'Newspack utilizes PWA to automatically optomizing and configuring your news site to perform better. It improves:'
+						) }
+					</p>
+					<h2>{ __( 'Speed' ) }</h2>
+					<p>{ __( 'Will work reliably, no matter the network conditions.' ) }</p>
+					<h2>{ __( 'Security' ) }</h2>
+					<p>
+						{ __(
+							'Served from a secure origin through HTTPS, which will protect the integrity of your news site.'
+						) }
+					</p>
+					<h2>{ __( 'User Experience' ) }</h2>
+					<p>
+						{ __( 'Feels like a natural app on the device, with an immersive user experience.' ) }
+					</p>
+				</Card>
+				<Card>
+					<h2>{ __( 'Advanced Options' ) }</h2>
+					<p>
+						{ __(
+							'Increase engagement with your audience by implementing the following advanced options:'
+						) }
+					</p>
+					<ul>
+						<li>{ __( 'Add to homescreen' ) }</li>
+						<li>{ __( 'Offline usage' ) }</li>
+						<li>{ __( 'Push notifications' ) }</li>
+					</ul>
+				</Card>
+			</Fragment>
+		);
+	}
+}
+
+export default withWizardScreen( Intro, {} );

--- a/assets/wizards/performance/views/intro/index.js
+++ b/assets/wizards/performance/views/intro/index.js
@@ -7,6 +7,7 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -35,7 +36,6 @@ class Intro extends Component {
 						<strong>{ __( 'Offline usage' ) }</strong>
 						{ __( ', and ' ) }
 						<strong>{ __( 'Push notifications' ) }</strong>.
-
 					</p>
 				</Card>
 				<Card>
@@ -48,19 +48,23 @@ class Intro extends Component {
 						</p>
 						<p>
 							<strong>{ __( 'Speed: ' ) }</strong>
-							{ __(
-								'Will work reliably, no matter the network conditions.'
-							) }<br />
+							{ __( 'Will work reliably, no matter the network conditions.' ) }
+							<br />
 							<strong>{ __( 'Security: ' ) }</strong>
-							{ __(
-								'Served through HTTPS to protect the integrity of your news site.'
-							) }<br />
+							{ __( 'Served through HTTPS to protect the integrity of your news site.' ) }
+							<br />
 							<strong>{ __( 'User experience:  ' ) }</strong>
-							{ __(
-								'Feels like a native app on the device.'
-							) }
+							{ __( 'Feels like a native app on the device.' ) }
 						</p>
 					</div>
+					<p className="newspack-plugin-description">
+						{ __(
+							'Basic PWA options have been automatically set up for you. Advanced options are available in the Progressive WP dashboard.'
+						) }
+						<ExternalLink href="/wp-admin/admin.php?page=progressive-wordpress">
+							{ __( 'Configure advanced options', 'newspack' ) }
+						</ExternalLink>
+					</p>
 				</Card>
 			</Fragment>
 		);

--- a/assets/wizards/performance/views/intro/index.js
+++ b/assets/wizards/performance/views/intro/index.js
@@ -25,36 +25,42 @@ class Intro extends Component {
 		return (
 			<Fragment>
 				<Card>
+					<h3>{ __( 'Increase user engagement' ) }</h3>
 					<p>
 						{ __(
-							'Newspack utilizes PWA to automatically optomizing and configuring your news site to perform better. It improves:'
+							'Engage with your audience more by implementing the following advanced features (optional): '
 						) }
-					</p>
-					<h2>{ __( 'Speed' ) }</h2>
-					<p>{ __( 'Will work reliably, no matter the network conditions.' ) }</p>
-					<h2>{ __( 'Security' ) }</h2>
-					<p>
-						{ __(
-							'Served from a secure origin through HTTPS, which will protect the integrity of your news site.'
-						) }
-					</p>
-					<h2>{ __( 'User Experience' ) }</h2>
-					<p>
-						{ __( 'Feels like a natural app on the device, with an immersive user experience.' ) }
+						<strong>{ __( 'Add to home screen' ) }</strong>
+						{ __( ', ' ) }
+						<strong>{ __( 'Offline usage' ) }</strong>
+						{ __( ', and ' ) }
+						<strong>{ __( 'Push notifications' ) }</strong>.
+
 					</p>
 				</Card>
 				<Card>
-					<h2>{ __( 'Advanced Options' ) }</h2>
-					<p>
-						{ __(
-							'Increase engagement with your audience by implementing the following advanced options:'
-						) }
-					</p>
-					<ul>
-						<li>{ __( 'Add to homescreen' ) }</li>
-						<li>{ __( 'Offline usage' ) }</li>
-						<li>{ __( 'Push notifications' ) }</li>
-					</ul>
+					<h3>{ __( 'Automatic performance enhancements' ) }</h3>
+					<div className="newspack-performance-wizard__info-block dashicons-before dashicons-info">
+						<p>
+							{ __(
+								'Newspack utilizes Progressive Web App (PWA) to automatically optimize and configure your news site to perform better. It automatically improves:'
+							) }
+						</p>
+						<p>
+							<strong>{ __( 'Speed: ' ) }</strong>
+							{ __(
+								'Will work reliably, no matter the network conditions.'
+							) }<br />
+							<strong>{ __( 'Security: ' ) }</strong>
+							{ __(
+								'Served through HTTPS to protect the integrity of your news site.'
+							) }<br />
+							<strong>{ __( 'User experience:  ' ) }</strong>
+							{ __(
+								'Feels like a native app on the device.'
+							) }
+						</p>
+					</div>
 				</Card>
 			</Fragment>
 		);

--- a/assets/wizards/performance/views/offline-usage/index.js
+++ b/assets/wizards/performance/views/offline-usage/index.js
@@ -1,0 +1,37 @@
+/**
+ * Performance Wizard Offline Usage screen.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { withWizardScreen } from '../../../../components/src';
+
+/**
+ * Description and controls for the Offline Usage feature.
+ */
+class OfflineUsage extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { pluginRequirements } = this.props;
+		return (
+			<Fragment>
+				<p>
+					{ __(
+						"No connection? No problem. We pre-cache all critical assets of your website, as well as all visited resources. So if there's no internet connection it will serve the resources from the local storage."
+					) }
+				</p>
+			</Fragment>
+		);
+	}
+}
+
+export default withWizardScreen( OfflineUsage, {} );

--- a/assets/wizards/performance/views/offline-usage/index.js
+++ b/assets/wizards/performance/views/offline-usage/index.js
@@ -7,6 +7,7 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -21,7 +22,7 @@ class OfflineUsage extends Component {
 	 * Render.
 	 */
 	render() {
-		const { pluginRequirements } = this.props;
+		const { settings, updateSetting } = this.props;
 		return (
 			<Fragment>
 				<p>
@@ -29,6 +30,11 @@ class OfflineUsage extends Component {
 						"No connection? No problem. We pre-cache all critical assets of your website, as well as all visited resources. So if there's no internet connection it will serve the resources from the local storage."
 					) }
 				</p>
+				<ToggleControl
+					label={ __( 'Enable Offline Usage' ) }
+					onChange={ checked => updateSetting( 'offline_usage', checked ) }
+					checked={ settings.offline_usage }
+				/>
 			</Fragment>
 		);
 	}

--- a/assets/wizards/performance/views/push-notifications/index.js
+++ b/assets/wizards/performance/views/push-notifications/index.js
@@ -1,0 +1,37 @@
+/**
+ * Performance Wizard Push Notifications screen.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { withWizardScreen } from '../../../../components/src';
+
+/**
+ * Description and controls for the Push Notification feature.
+ */
+class PushNotifications extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { pluginRequirements } = this.props;
+		return (
+			<Fragment>
+				<p>
+					{ __(
+						'You just published new content and you want to let everyone know? Why not send a push notification? We has an integrated connection to Firebase that lets you manage registered devices and send push notifications to all or selected devices!'
+					) }
+				</p>
+			</Fragment>
+		);
+	}
+}
+
+export default withWizardScreen( PushNotifications, {} );

--- a/assets/wizards/performance/views/push-notifications/index.js
+++ b/assets/wizards/performance/views/push-notifications/index.js
@@ -27,7 +27,7 @@ class PushNotifications extends Component {
 			<Fragment>
 				<p>
 					{ __(
-						'You just published new content and you want to let everyone know? Why not send a push notification? We has an integrated connection to Firebase that lets you manage registered devices and send push notifications to all or selected devices!'
+						'You just published new content and you want to let everyone know? Why not send a push notification? We have an integrated connection to Firebase that lets you manage registered devices and send push notifications to all or selected devices!'
 					) }
 				</p>
 				<ToggleControl

--- a/assets/wizards/performance/views/push-notifications/index.js
+++ b/assets/wizards/performance/views/push-notifications/index.js
@@ -7,7 +7,7 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { ToggleControl } from '@wordpress/components';
+import { ToggleControl, ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -40,7 +40,10 @@ class PushNotifications extends Component {
 						<div className="newspack-performance-wizard_indented-block">
 							<p>{ __( 'This plugin uses Firebase Cloud Messaging as a messaging service.' ) }</p>
 							<ul>
-								<li>{ __( 'Go to Firebase Console' ) }</li>
+								<li>
+									{ __( 'Go to ' ) }
+									<ExternalLink href="https://console.firebase.google.com/">{ __( 'Firebase Console' ) }</ExternalLink>
+								</li>
 								<li>{ __( 'Click "create new project"' ) }</li>
 								<li>{ __( 'Follow the instructions to create your project' ) }</li>
 								<li>{ __( 'Now navigate to Project setting page' ) }</li>

--- a/assets/wizards/performance/views/push-notifications/index.js
+++ b/assets/wizards/performance/views/push-notifications/index.js
@@ -7,11 +7,12 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { withWizardScreen } from '../../../../components/src';
+import { TextControl, withWizardScreen } from '../../../../components/src';
 
 /**
  * Description and controls for the Push Notification feature.
@@ -21,7 +22,7 @@ class PushNotifications extends Component {
 	 * Render.
 	 */
 	render() {
-		const { pluginRequirements } = this.props;
+		const { settings, updateSetting } = this.props;
 		return (
 			<Fragment>
 				<p>
@@ -29,6 +30,39 @@ class PushNotifications extends Component {
 						'You just published new content and you want to let everyone know? Why not send a push notification? We has an integrated connection to Firebase that lets you manage registered devices and send push notifications to all or selected devices!'
 					) }
 				</p>
+				<ToggleControl
+					label={ __( 'Enable Push Notifications' ) }
+					onChange={ checked => updateSetting( 'push_notifications', checked ) }
+					checked={ settings.push_notifications }
+				/>
+				{ settings.push_notifications && (
+					<Fragment>
+						<div className="newspack-performance-wizard_indented-block">
+							<p>{ __( 'This plugin uses Firebase Cloud Messaging as a messaging service.' ) }</p>
+							<ul>
+								<li>{ __( 'Go to Firebase Console' ) }</li>
+								<li>{ __( 'Click "create new project"' ) }</li>
+								<li>{ __( 'Follow the instructions to create your project' ) }</li>
+								<li>{ __( 'Now navigate to Project setting page' ) }</li>
+								<li>
+									{ __(
+										'Navigate to Cloud Messaging Tab to get the “Server Key” and “Sender Id”'
+									) }
+								</li>
+							</ul>
+						</div>
+						<TextControl
+							label={ __( 'Server Key' ) }
+							value={ settings.push_notification_server_key }
+							onChange={ value => updateSetting( 'push_notification_server_key', value ) }
+						/>
+						<TextControl
+							label={ __( 'Sender ID' ) }
+							value={ settings.push_notification_sender_id }
+							onChange={ value => updateSetting( 'push_notification_sender_id', value ) }
+						/>
+					</Fragment>
+				) }
 			</Fragment>
 		);
 	}

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -67,6 +67,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-subscriptions-onboarding-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-subscriptions-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-google-adsense-wizard.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-performance-wizard.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-wizards.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-checklists.php';

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -117,6 +117,22 @@ class Plugin_Manager {
 				'Author'      => 'Gutenberg Team',
 				'Download'    => 'wporg',
 			],
+			'pwa'                           => [
+				'Name'        => 'PWA',
+				'Description' => 'Feature plugin to bring Progressive Web App (PWA) capabilities to Core',
+				'Author'      => 'PWA Plugin Contributors',
+				'AuthorURI'   => 'https://github.com/xwp/pwa-wp/graphs/contributors',
+				'PluginURI'   => 'https://github.com/xwp/pwa-wp',
+				'Download'    => 'wporg',
+			],
+			'progressive-wp'                => [
+				'Name'        => 'Progressive WordPress (PWA)',
+				'Description' => 'Turn your website into a Progressive Web App and make it installable, offline ready and send push notifications.',
+				'Author'      => 'Nico Martin',
+				'AuthorURI'   => 'https://nicomartin.ch',
+				'PluginURI'   => 'https://github.com/SayHelloGmbH/progressive-wordpress',
+				'Download'    => 'wporg',
+			],
 			'fake-plugin'                   => [
 				'Name'        => 'Fake Plugin',
 				'Description' => 'This is a made-up plugin, meant to error out.',

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -33,6 +33,7 @@ class Wizards {
 			'subscriptions'            => new Subscriptions_Wizard(),
 			'google-adsense'           => new Google_AdSense_Wizard(),
 			'components-demo'          => new Components_Demo(),
+			'performance'              => new Performance_Wizard(),
 		];
 	}
 

--- a/includes/configuration_managers/class-configuration-manager.php
+++ b/includes/configuration_managers/class-configuration-manager.php
@@ -91,6 +91,17 @@ abstract class Configuration_Manager {
 	}
 
 	/**
+	 * Construct the function name to get or update a setting.
+	 *
+	 * @param string $setting The name of the setting.
+	 * @param string $prefix The prefix of the function. get|update. Default is get.
+	 * @return string Function name.
+	 */
+	public function setting_to_function_name( $setting, $prefix = 'get' ) {
+		return sprintf( '%s_%s', $prefix, str_replace( '-', '_', $setting ) );
+	}
+
+	/**
 	 * Configure the plugin. Meant to be called immediately after installation/activation.
 	 *
 	 * @return void

--- a/includes/configuration_managers/class-configuration-managers.php
+++ b/includes/configuration_managers/class-configuration-managers.php
@@ -32,6 +32,10 @@ class Configuration_Managers {
 			'filename'   => 'class-sitekit-configuration-manager.php',
 			'class_name' => 'SiteKit_Configuration_Manager',
 		],
+		'progressive-wp'  => [
+			'filename'   => 'class-progressive-wp-configuration-manager.php',
+			'class_name' => 'Progressive_WP_Configuration_Manager',
+		],
 	];
 
 	/**

--- a/includes/configuration_managers/class-progressive-wp-configuration-manager.php
+++ b/includes/configuration_managers/class-progressive-wp-configuration-manager.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * AMP plugin configuration manager.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error;
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
+
+/**
+ * Provide an interface for configuring and querying the configuration of AMP.
+ */
+class Progressive_WP_Configuration_Manager extends Configuration_Manager {
+
+	/**
+	 * The slug of the plugin.
+	 *
+	 * @var string
+	 */
+	public $slug = 'progressive-wp';
+
+	/**
+	 * List of retrievable fields.
+	 *
+	 * @var array
+	 */
+	public $fields = [
+		'site_icon',
+	];
+
+	/**
+	 * Configure AMP for Newspack use.
+	 *
+	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
+	 */
+	public function configure() {
+		return true;
+	}
+
+	/**
+	 * Retrieve one value
+	 *
+	 * @param string $field The key of the value.
+	 * @var string || WP_Error
+	 */
+	public function get( $field = '' ) {
+		if ( ! in_array( $field, $this->fields ) ) {
+			return new WP_Error( 'newspack_field_not_found', 'Field could not be retrieved' );
+		}
+		$method = sprintf( 'get_%s', $field );
+		return $this->{ $method }();
+	}
+
+	/**
+	 * Retrieve Site Icon
+	 *
+	 * @var string
+	 */
+	public function get_site_icon() {
+		$site_icon = get_option( 'site_icon' );
+		if ( ! $site_icon ) {
+			return null;
+		}
+		$url = wp_get_attachment_image_src( $site_icon );
+		return [
+			'id'  => $site_icon,
+			'url' => $url[0],
+		];
+	}
+
+	/**
+	 * Update Site Icon
+	 *
+	 * @param string $site_icon The site icon.
+	 */
+	public function update_site_icon( $site_icon ) {
+		if ( ! empty( $site_icon['id'] ) ) {
+			update_option( 'site_icon', intval( $site_icon['id'] ) );
+		}
+	}
+
+}

--- a/includes/configuration_managers/class-progressive-wp-configuration-manager.php
+++ b/includes/configuration_managers/class-progressive-wp-configuration-manager.php
@@ -115,4 +115,13 @@ class Progressive_WP_Configuration_Manager extends Configuration_Manager {
 		}
 	}
 
+	/**
+	 * Update Progressive WP's Firebase Credentials Set option
+	 *
+	 * @param bool $set Whether Firebase credentials are set.
+	 */
+	public function firebase_credentials_set( $set ) {
+		update_option( 'pwp_firebase_credentials_set', $set ? 'yes' : 'no' );
+	}
+
 }

--- a/includes/configuration_managers/class-progressive-wp-configuration-manager.php
+++ b/includes/configuration_managers/class-progressive-wp-configuration-manager.php
@@ -31,6 +31,8 @@ class Progressive_WP_Configuration_Manager extends Configuration_Manager {
 	 */
 	public $fields = [
 		'site_icon',
+		'firebase-serverkey',
+		'firebase-senderid',
 	];
 
 	/**
@@ -45,15 +47,44 @@ class Progressive_WP_Configuration_Manager extends Configuration_Manager {
 	/**
 	 * Retrieve one value
 	 *
-	 * @param string $field The key of the value.
+	 * @param string $setting The key of the value.
 	 * @var string || WP_Error
 	 */
-	public function get( $field = '' ) {
-		if ( ! in_array( $field, $this->fields ) ) {
-			return new WP_Error( 'newspack_field_not_found', 'Field could not be retrieved' );
+	public function get( $setting = '' ) {
+		if ( ! in_array( $setting, $this->fields ) ) {
+			return new WP_Error( 'newspack_field_not_found', 'Setting could not be retrieved' );
 		}
-		$method = sprintf( 'get_%s', $field );
-		return $this->{ $method }();
+		$method = $this->setting_to_function_name( $setting, 'get' );
+		if ( method_exists( $this, $method ) ) {
+			return $this->{ $method }();
+		}
+		if ( function_exists( 'pwp_settings' ) ) {
+			return pwp_settings()->get_setting( $setting );
+		}
+		return null;
+	}
+
+	/**
+	 * Update one setting value
+	 *
+	 * @param string $setting The setting name.
+	 * @param string $value The setting value.
+	 * @var null || WP_Error
+	 */
+	public function update( $setting = '', $value = '' ) {
+		if ( ! in_array( $setting, $this->fields ) ) {
+			return new WP_Error( 'newspack_field_not_found', 'Field could not be updated' );
+		}
+		$method = $this->setting_to_function_name( $setting, 'update' );
+		if ( method_exists( $this, $method ) ) {
+			return $this->{ $method }( $value );
+		}
+		if ( function_exists( 'pwp_settings' ) ) {
+			$options = get_option( 'pwp-settings' );
+
+			$options[ $setting ] = $value;
+			update_option( 'pwp-settings', $options );
+		}
 	}
 
 	/**

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -78,7 +78,7 @@ class Dashboard extends Wizard {
 					'name'        => esc_html__( 'Performance', 'newspack' ),
 					'url'         => admin_url( 'admin.php?page=newspack-performance-wizard' ),
 					'description' => esc_html__( 'Page Speed, AMP, Progressive Web App', 'newspack' ),
-					'image'       => Newspack::plugin_url() . '/assets/wizards/dashboard/performance-icon.png',
+					'image'       => Newspack::plugin_url() . '/assets/wizards/dashboard/performance-icon.svg',
 				],
 				[
 					'slug'        => 'advertising',

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -76,10 +76,9 @@ class Dashboard extends Wizard {
 				[
 					'slug'        => 'performance',
 					'name'        => esc_html__( 'Performance', 'newspack' ),
-					'url'         => '#',
+					'url'         => admin_url( 'admin.php?page=newspack-performance-wizard' ),
 					'description' => esc_html__( 'Page Speed, AMP, Progressive Web App', 'newspack' ),
-					'image'       => Newspack::plugin_url() . '/assets/wizards/dashboard/performance-icon.svg',
-					'status'      => 'disabled',
+					'image'       => Newspack::plugin_url() . '/assets/wizards/dashboard/performance-icon.png',
 				],
 				[
 					'slug'        => 'advertising',

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -102,20 +102,36 @@ class Performance_Wizard extends Wizard {
 	 */
 	public function api_update_settings( $request ) {
 		if ( empty( $request['settings'] ) ) {
-			return new WP_Error( 'newspack_invalid_update', 'Invalid update' );
+			return new WP_Error( 'newspack_invalid_update', __( 'Invalid update' ) );
 		}
 		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'progressive-wp' );
 		if ( is_wp_error( $configuration_manager ) ) {
 			return $configuration_manager;
 		}
 		$settings = $request['settings'];
-		if ( ! empty( $settings['site_icon'] ) ) {
+		if ( isset( $settings['push_notifications'] ) && $settings['push_notifications'] ) {
+			$push_notification_server_key = isset( $settings['push_notification_server_key'] ) ? trim( $settings['push_notification_server_key'] ) : null;
+			$push_notification_sender_id  = isset( $settings['push_notification_sender_id'] ) ? trim( $settings['push_notification_sender_id'] ) : null;
+			if ( ! $push_notification_server_key || ! $push_notification_sender_id ) {
+				return new WP_Error(
+					'newspack_incomplete_firebase_fields',
+					__( 'Firebase Server Key and Sender ID must be set in order to use Push Notifications.' ),
+					[
+						'status' => 400,
+						'level'  => 'notice',
+					]
+				);
+			}
+		}
+
+
+		if ( isset( $settings['site_icon'] ) ) {
 			$configuration_manager->update( 'site_icon', $settings['site_icon'] );
 		}
-		if ( ! empty( $settings['push_notification_server_key'] ) ) {
+		if ( isset( $settings['push_notification_server_key'] ) ) {
 			$configuration_manager->update( 'firebase-serverkey', $settings['push_notification_server_key'] );
 		}
-		if ( ! empty( $settings['push_notification_sender_id'] ) ) {
+		if ( isset( $settings['push_notification_sender_id'] ) ) {
 			$configuration_manager->update( 'firebase-senderid', $settings['push_notification_sender_id'] );
 		}
 		return rest_ensure_response( $this->get_settings() );

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Performance Wizard
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Easy interface for setting up general store info.
+ */
+class Performance_Wizard extends Wizard {
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-performance-wizard';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return esc_html__( 'Performance', 'newspack' );
+	}
+
+	/**
+	 * Get the description of this wizard.
+	 *
+	 * @return string The wizard description.
+	 */
+	public function get_description() {
+		return esc_html__( 'Set up and maintain Progressive Web App functionality.', 'newspack' );
+	}
+
+	/**
+	 * Get the expected duration of this wizard.
+	 *
+	 * @return string The wizard length.
+	 */
+	public function get_length() {
+		return esc_html__( '10 minutes', 'newspack' );
+	}
+
+	/**
+	 * Enqueue Subscriptions Wizard scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		parent::enqueue_scripts_and_styles();
+		wp_enqueue_media();
+
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'newspack-performance-wizard',
+			Newspack::plugin_url() . '/assets/dist/performance.js',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/performance.js' ),
+			true
+		);
+
+		wp_register_style(
+			'newspack-performance-wizard',
+			Newspack::plugin_url() . '/assets/dist/performance.css',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/performance.css' )
+		);
+		wp_style_add_data( 'newspack-performance-wizard', 'rtl', 'replace' );
+		wp_enqueue_style( 'newspack-performance-wizard' );
+	}
+}

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -121,6 +121,8 @@ class Performance_Wizard extends Wizard {
 						'level'  => 'notice',
 					]
 				);
+			} else {
+				$configuration_manager->firebase_credentials_set( true );
 			}
 		}
 

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -108,7 +108,13 @@ class Performance_Wizard extends Wizard {
 		}
 		$settings = $request['settings'];
 		if ( ! empty( $settings['site_icon'] ) ) {
-			$configuration_manager->update_site_icon( $settings['site_icon'] );
+			$configuration_manager->update( 'site_icon', $settings['site_icon'] );
+		}
+		if ( ! empty( $settings['push_notification_server_key'] ) ) {
+			$configuration_manager->update( 'firebase-serverkey', $settings['push_notification_server_key'] );
+		}
+		if ( ! empty( $settings['push_notification_sender_id'] ) ) {
+			$configuration_manager->update( 'firebase-senderid', $settings['push_notification_sender_id'] );
 		}
 		return rest_ensure_response( $this->get_settings() );
 	}
@@ -124,8 +130,8 @@ class Performance_Wizard extends Wizard {
 			'site_icon'                    => $configuration_manager->get( 'site_icon' ),
 			'offline_usage'                => true,
 			'push_notifications'           => true,
-			'push_notification_server_key' => 'boo',
-			'push_notification_sender_id'  => 'hoo',
+			'push_notification_server_key' => $configuration_manager->get( 'firebase-serverkey' ),
+			'push_notification_sender_id'  => $configuration_manager->get( 'firebase-senderid' ),
 		];
 	}
 

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -101,10 +101,12 @@ class Performance_Wizard extends Wizard {
 	 * @param WP_REST_Request $request Full details about the request.
 	 */
 	public function api_update_settings( $request ) {
-		require_once NEWSPACK_ABSPATH . 'includes/configuration_managers/class-progressive-wp-configuration-manager.php';
-		$configuration_manager = new Progressive_WP_Configuration_Manager();
 		if ( empty( $request['settings'] ) ) {
 			return new WP_Error( 'newspack_invalid_update', 'Invalid update' );
+		}
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'progressive-wp' );
+		if ( is_wp_error( $configuration_manager ) ) {
+			return $configuration_manager;
 		}
 		$settings = $request['settings'];
 		if ( ! empty( $settings['site_icon'] ) ) {
@@ -123,8 +125,10 @@ class Performance_Wizard extends Wizard {
 	 * Get all settings
 	 */
 	public function get_settings() {
-		require_once NEWSPACK_ABSPATH . 'includes/configuration_managers/class-progressive-wp-configuration-manager.php';
-		$configuration_manager = new Progressive_WP_Configuration_Manager();
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'progressive-wp' );
+		if ( is_wp_error( $configuration_manager ) ) {
+			return $configuration_manager;
+		}
 		return [
 			'add_to_homescreen'            => true,
 			'site_icon'                    => $configuration_manager->get( 'site_icon' ),

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -126,6 +126,18 @@ class Performance_Wizard extends Wizard {
 
 
 		if ( isset( $settings['site_icon'] ) ) {
+			$height = isset( $settings['site_icon']['height'] ) ? $settings['site_icon']['height'] : 0;
+			$width  = isset( $settings['site_icon']['width'] ) ? $settings['site_icon']['width'] : 0;
+			if ( $height !== $width ) {
+				return new WP_Error(
+					'newspack_site_icon_not_square',
+					__( 'Site icon images must be square.' ),
+					[
+						'status' => 400,
+						'level'  => 'notice',
+					]
+				);
+			}
 			$configuration_manager->update( 'site_icon', $settings['site_icon'] );
 		}
 		if ( isset( $settings['push_notification_server_key'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR introduces the Performance Wizard. This wizard names [Progressive WP](https://wordpress.org/plugins/progressive-wp/) and [PWA](https://wordpress.org/plugins/pwa/) as dependencies, and configures Progressive WP for Save To Homescreen, Offline Usage, and Push Notification features. In addition to normal Wizard activity, this adds a few other things:

- `withWizardScreen` has a `noCard` option. In this option the screen is not wrapped in a `Card` which allows for multi-Card layouts like the first screen of the wizard.
- The configuration manager updates another plugin's options, that are serialized in a single option.
- The configuration manager gets and updates one field which is part of core—the Site Icon.

Note: Newspack does not yet have a Muriel-ized Toggle control, so I'm using the default WordPress one. I'll file an issue and we can create one shortly and swap it in. This is why the Tooltips from @sonjaleix's designs are missing. 

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Navigate to the Performance Wizard.
3. Verify PWA and Progressive WP plugins are installed and activated successfully.
4. On the `Add To Homescreen` screen, verify that the Site Icon you see is the one uploaded in the Customizer. 
5. Replace the Site Icon and verify that the change persists to the Customizer as well as this Wizard.
6. On the `Push Notifications` screen, update Server Key and Sender ID fields. 
7. Verify that these fields are persisted.
8. Go to the Progressive WP dashboard, then the Push Notifications section, and verify that the values you input are present there as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->