### PR TITLE
Wizard Pagination

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -16,3 +16,4 @@ export { default as Task } from './task';
 export { default as TextControl } from './text-control';
 export { default as withWizard } from './with-wizard';
 export { default as withWizardScreen } from './with-wizard-screen';
+export { default as WizardPagination } from './wizard-pagination';

--- a/assets/components/src/wizard-pagination/index.js
+++ b/assets/components/src/wizard-pagination/index.js
@@ -1,0 +1,47 @@
+/**
+ * Wizard pagination
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { withRouter } from 'react-router-dom';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+class WizardPagination extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { history, location, routes } = this.props;
+		const currentIndex = parseInt( routes.indexOf( location.pathname ) ) + 1;
+		if ( ! routes || ! history || ! location ) {
+			return;
+		}
+		return (
+			<Fragment>
+				<a className="newspack-wizard-pagination__navigation" onClick={ () => history.goBack() }>
+					<span class="dashicons dashicons-arrow-left-alt" /> { __( 'Back' ) }
+				</a>
+				{ currentIndex > 0 && (
+					<div className="newspack-wizard-pagination__pagination">
+						{ __( 'Page' ) } { currentIndex } { __( 'of' ) } { routes.length }{' '}
+						<span class="dashicons dashicons-arrow-right-alt" />
+					</div>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+export default withRouter( WizardPagination );

--- a/assets/components/src/wizard-pagination/style.scss
+++ b/assets/components/src/wizard-pagination/style.scss
@@ -1,0 +1,14 @@
+.newspack-wizard {
+	position: relative;
+}
+.newspack-wizard-pagination__navigation {
+	position: absolute;
+	top: 1em;
+	left: 0;
+	cursor: pointer;
+}
+.newspack-wizard-pagination__pagination {
+	position: absolute;
+	top: 1em;
+	right: 1em;
+}

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -14,7 +14,7 @@ import { Spinner } from '@wordpress/components';
  * Internal dependencies
  */
 import { About, ConfigurePlugins, Newsroom, Welcome } from './views/';
-import { Card, PluginInstaller, withWizard } from '../../components/src';
+import { Card, PluginInstaller, withWizard, WizardPagination } from '../../components/src';
 import './style.scss';
 
 /**
@@ -149,6 +149,7 @@ class SetupWizard extends Component {
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
+					<WizardPagination routes={ [ '/', '/about', '/newsroom', '/configure-plugins' ] } />
 					<Switch>
 						<Route
 							path="/"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds the `WizardPagination` component and uses it in the Set Up Wizard. The component will render a BACK button in the upper left corner and "Page {n} of {total}" UI in the upper right corner. 

<img width="1269" alt="Screen Shot 2019-07-01 at 11 17 02 AM" src="https://user-images.githubusercontent.com/1477002/60447645-e13ff700-9bf1-11e9-8020-eab7b6291906.png">

`WizardPagination` should be added anywhere within a `HashRouter`. The use of `withRouter` will cause errors if used outside of a router. The component requires one prop: `routes`. This should be an array of the page routes, in order. In an earlier iteration (https://github.com/Automattic/newspack-plugin/pull/113) I played with deriving the array of routes programmatically, but recent work on the plugin requirements handling illustrated that there will be `Routes` found that should not be included in pagination, so I opted to specify them manually.

One UI question for @sonjaleix: the presence of a right arrow by the pagination suggests clicking to advance is possible. This would be quite complex to build in, since Wizards often have additional logic attached to their next buttons, so simply advancing to the next route would be bad.

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Navigate to `/wp-admin/admin.php?page=newspack-setup-wizard`
3. Step through the Set Up Wizard.
4. Observe the pagination advancing as you go.
5. Click the BACK button and verify you return to the previous route (or to the dashboard when on page 1.)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->