### PR TITLE
Fix Set Up Wizard Plugin Installer Completion Event

### DIFF
--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -252,7 +252,7 @@ class SetupWizard extends Component {
 								<PluginInstaller
 									asProgressBar
 									plugins={ REQUIRED_PLUGINS }
-									onComplete={ () => this.setState( { installationComplete: true } ) }
+									onStatus={ installationComplete => this.setState( { installationComplete } ) }
 								/>
 								{ ! installationComplete && (
 									<p className="newspack-setup-wizard_progress_bar_explainer">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Following the merge of https://github.com/Automattic/newspack-plugin/pull/140 the Set Up Wizard will no longer advance to the fourth screen. This is because 140 changes `PluginInstaller`'s completion even from `onComplete` to `onStatus`, but the Set Up Wizard did not implement this change.

### How to test the changes in this Pull Request:

1. On `master`, try the Set Up Wizard. Observe you cannot advance to the fourth screen with the Jetpack and Site Kit cards. The Plugin Installer progress bar will fill all the way but the button will remain disabled.
2. Branch switch to `fix/set-up-loading-issiue` and repeat the Wizard. This time you should be able to advance to the fourth screen. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->