### PR TITLE
Only show Components Demo if WP_DEBUG is enabled

### DIFF
--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -43,6 +43,7 @@ class Components_Demo extends Wizard {
 	public function __construct() {
 		parent::__construct();
 
+		// Only show a link to the Components Demo if WP_DEBUG is enabled.
 		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
 			add_action( 'admin_head', array( $this, 'hide_from_menus' ) );
 		}

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -38,6 +38,17 @@ class Components_Demo extends Wizard {
 	protected $hidden = false;
 
 	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			add_action( 'admin_head', array( $this, 'hide_from_menus' ) );
+		}
+	}
+
+	/**
 	 * Get the name for this wizard.
 	 *
 	 * @return string The wizard name.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR makes it so that the Components Demo link in the admin menu is only visible if `WP_DEBUG` is enabled.

### How to test the changes in this Pull Request:

1. In your `wp-config.php` add `define('WP_DEBUG', true);` if it's not already there. You should see a link to the Components Demo in the admin menu.
2. Change `WP_DEBUG` to `false`. You should not see a link to the Components Demo in the admin menu.
3. Delete the `WP_DEBUG` line entirely. You should not see a link to the Components Demo in the admin menu.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->