### PR TITLE
Dashboard Hover State

### DIFF
--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -18,9 +18,9 @@
 		height: 1px;
 		max-width: 745px;
 		width: 100%;
-	 	background-color: $muriel-gray-50;
-	 	position: absolute;
-	 	bottom: 0;
+		background-color: $muriel-gray-50;
+		position: absolute;
+		bottom: 0;
 	}
 
 	&:last-of-type::after {
@@ -35,9 +35,11 @@
 	text-align: center;
 	position: relative;
 	box-sizing: border-box;
-	box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2), 0px 2px 2px rgba(0, 0, 0, 0.12), 0px 0px 2px rgba(0, 0, 0, 0.14);
+	box-shadow: 0px 1px 3px rgba( 0, 0, 0, 0.2 ), 0px 2px 2px rgba( 0, 0, 0, 0.12 ),
+		0px 0px 2px rgba( 0, 0, 0, 0.14 );
 
-	a, .newspack-dashboard-card__disabled-link {
+	a,
+	.newspack-dashboard-card__disabled-link {
 		display: flex;
 		height: 100%;
 		align-items: center;
@@ -73,7 +75,7 @@
 
 	&.completed {
 		background: none;
-		border: 1px solid rgba(0, 0, 0, .1);
+		border: 1px solid rgba( 0, 0, 0, 0.1 );
 	}
 
 	.newspack-dashboard-card__completed-icon {
@@ -82,9 +84,14 @@
 		top: 40px;
 		right: 80px;
 	}
+
+	&:not( .disabled ):hover {
+		box-shadow: 0px 5px 5px rgba( 0, 0, 0, 0.2 ), 0px 3px 14px rgba( 0, 0, 0, 0.12 ),
+			0px 8px 10px rgba( 0, 0, 0, 0.14 );
+	}
 }
 
-@media (max-width: 600px) {
+@media ( max-width: 600px ) {
 	.newspack_dashboard__header {
 		margin-right: 14px;
 	}
@@ -94,6 +101,6 @@
 	}
 
 	.newspack-dashboard-card {
-		max-width: calc(100% - 3em);
+		max-width: calc( 100% - 3em );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds hover state to non-disabled dashboard cards.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #144.

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Navigate to Newspack dashboard.
3. Hover over Reader Revenue and Advertising cards. Verify and assess hover state.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->