### PR TITLE
Checklist completion

### DIFF
--- a/assets/wizards/checklist/index.js
+++ b/assets/wizards/checklist/index.js
@@ -28,6 +28,27 @@ class ChecklistScreen extends Component {
 	}
 
 	/**
+	 * When the checklist is first loaded, set the progress.
+	 * This counts from the first element until the first non-complete element to determine progress.
+	 * This will prevent issues if e.g. a wizard further down the list is complete.
+	 */
+	componentDidMount() {
+		const { steps } = this.props;
+		let numComplete = 0;
+		for ( let i = 0; i < steps.length; ++i ) {
+			if ( steps[i].completed ) {
+				++numComplete;
+			} else {
+				break;
+			}
+		}
+
+		this.setState( {
+			checklistProgress: numComplete,
+		} );
+	}
+
+	/**
 	 * Mark a checklist item as skipped.
 	 * @todo Make this permanent using an API call.
 	 */
@@ -53,7 +74,7 @@ class ChecklistScreen extends Component {
 							title={ step.name }
 							description={ step.description }
 							buttonText={ __( 'Do it' ) }
-							completedTitle={ __( 'All set!' ) }
+							completedTitle={ step.name }
 							completed={ step.completed || checklistProgress > index }
 							onDismiss={ () => this.dismissCheckListItem( index ) }
 							active={ checklistProgress === index }

--- a/assets/wizards/subscriptions/index.js
+++ b/assets/wizards/subscriptions/index.js
@@ -155,6 +155,26 @@ class SubscriptionsWizard extends Component {
 		);
 	}
 
+	/**
+	 * Mark this wizard as complete.
+	 */
+	markWizardComplete() {
+		const { setError } = this.props;
+		return new Promise( ( resolve, reject ) => {
+			apiFetch( {
+				path: '/newspack/v1/wizards/subscriptions/complete',
+				method: 'post',
+				data: {},
+			} )
+				.then( response => {
+					setError().then( () => resolve() );
+				} )
+				.catch( error => {
+					setError( error ).then( () => reject() );
+				} );
+		} );
+	}
+
 	onSubscriptionChange = subscription => {
 		this.setState( prevState => ( {
 			subscriptions: {
@@ -216,7 +236,7 @@ class SubscriptionsWizard extends Component {
 										this.saveSubscription( subscription ).then( newSubscription => {
 											return this.refreshSubscriptions().then( () =>
 												routeProps.history.push( '/' )
-											);
+											).then( () => this.markWizardComplete() );
 										} )
 									}
 								/>
@@ -244,7 +264,7 @@ class SubscriptionsWizard extends Component {
 										this.saveSubscription( subscription ).then( newSubscription => {
 											return this.refreshSubscriptions().then( () =>
 												routeProps.history.push( '/' )
-											);
+											).then( () => this.markWizardComplete() );
 										} )
 									}
 								/>

--- a/assets/wizards/subscriptionsOnboarding/index.js
+++ b/assets/wizards/subscriptionsOnboarding/index.js
@@ -165,6 +165,26 @@ class SubscriptionsOnboardingWizard extends Component {
 	}
 
 	/**
+	 * Mark this wizard as complete.
+	 */
+	markWizardComplete() {
+		const { setError } = this.props;
+		return new Promise( ( resolve, reject ) => {
+			apiFetch( {
+				path: '/newspack/v1/wizards/subscriptions-onboarding/complete',
+				method: 'post',
+				data: {},
+			} )
+				.then( response => {
+					setError().then( () => resolve() );
+				} )
+				.catch( error => {
+					setError( error ).then( () => reject() );
+				} );
+		} );
+	}
+
+	/**
 	 * Render.
 	 */
 	render() {
@@ -208,9 +228,12 @@ class SubscriptionsOnboardingWizard extends Component {
 									onChange={ stripeSettings => this.setState( { stripeSettings } ) }
 									buttonText={ __( 'Finish' ) }
 									buttonAction={ () =>
-										this.saveStripeSettings().then(
-											() => ( window.location = newspack_urls[ 'checklists' ][ 'reader-revenue' ] )
-										)
+										this.saveStripeSettings()
+											.then( () => this.markWizardComplete()
+												.then(
+													() => ( window.location = newspack_urls[ 'checklists' ][ 'reader-revenue' ] )
+												)
+											)
 									}
 								/>
 							</Fragment>

--- a/includes/api/class-wizards-controller.php
+++ b/includes/api/class-wizards-controller.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Wizard management API endpoints.
+ *
+ * @package Newspack\API
+ */
+
+namespace Newspack\API;
+
+use \WP_REST_Controller;
+use \WP_Error;
+use Newspack\Wizards;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API endpoints for managing wizards.
+ */
+class Wizards_Controller extends WP_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = '/newspack/v1';
+
+	/**
+	 * Endpoint resource.
+	 *
+	 * @var string
+	 */
+	protected $resource_name = 'wizards';
+
+	/**
+	 * Register the routes.
+	 */
+	public function register_routes() {
+		// Register newspack/v1/wizards/some-wizard endpoint.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->resource_name . '/(?P<slug>[\a-z]+)',
+			[
+				[
+					'methods'             => 'GET',
+					'callback'            => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => [
+						'slug' => [
+							'sanitize_callback' => [ $this, 'sanitize_wizard_slug' ],
+						],
+					],
+				],
+			]
+		);
+
+		// Register newspack/v1/wizards/some-wizard/complete endpoint.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->resource_name . '/(?P<slug>[\a-z]+)\/complete',
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'complete_item' ],
+					'permission_callback' => [ $this, 'complete_item_permissions_check' ],
+					'args'                => [
+						'slug' => [
+							'sanitize_callback' => [ $this, 'sanitize_wizard_slug' ],
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get info about one wizard.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) {
+		$slug = $request['slug'];
+
+		$is_valid_wizard = $this->validate_wizard( $slug );
+		if ( is_wp_error( $is_valid_wizard ) ) {
+			return $is_valid_wizard;
+		}
+
+		$wizard = Wizards::get_wizard( $slug );
+		$response = [
+			'name' => $wizard->get_name(),
+			'url'  => $wizard->get_url(),
+			'description' => $wizard->get_description(),
+			'completed' => $wizard->is_completed(),
+		];
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Mark a wizard as completed.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function complete_item( $request ) {
+		$slug = $request['slug'];
+
+		$is_valid_wizard = $this->validate_wizard( $slug );
+		if ( is_wp_error( $is_valid_wizard ) ) {
+			return $is_valid_wizard;
+		}
+
+		$wizard = Wizards::get_wizard( $slug );
+		$wizard->set_completed();
+
+		return rest_ensure_response( true );
+	}
+
+	/**
+	 * Check capabilities when getting plugin info.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return bool|WP_Error
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot view this resource.', 'newspack' ),
+				[
+					'status' => $this->authorization_status_code(),
+				]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check capabilities when completing a wizard.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return bool|WP_Error
+	 */
+	public function complete_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				[
+					'status' => $this->authorization_status_code(),
+				]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check that a wizard slug is valid.
+	 *
+	 * @param string $slug The plugin slug.
+	 * @return bool|WP_Error
+	 */
+	protected function validate_wizard( $slug ) {
+		if ( ! Wizards::get_wizard( $slug ) ) {
+			return new WP_Error(
+				'newspack_rest_invalid_wizard',
+				esc_html__( 'Resource does not exist.', 'newspack' ),
+				[
+					'status' => 404,
+				]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Sanitize the slug for a wizard.
+	 *
+	 * @param string $slug The wizard slug.
+	 * @return string
+	 */
+	public function sanitize_wizard_slug( $slug ) {
+		return sanitize_title( $slug );
+	}
+
+	/**
+	 * Get the appropriate status code for errors.
+	 *
+	 * @return int
+	 */
+	public function authorization_status_code() {
+		$status = 401;
+		if ( is_user_logged_in() ) {
+			$status = 403;
+		}
+
+		return $status;
+	}
+}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -8,6 +8,7 @@
 namespace Newspack;
 
 use Newspack\Api\Plugins_Controller;
+use Newspack\Api\Wizards_Controller;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -21,9 +22,13 @@ class API {
 	 */
 	public function __construct() {
 		include_once 'api/class-plugins-controller.php';
+		include_once 'api/class-wizards-controller.php';
 
 		$plugins_api = new Plugins_Controller();
 		add_action( 'rest_api_init', [ $plugins_api, 'register_routes' ] );
+
+		$wizards_api = new Wizards_Controller();
+		add_action( 'rest_api_init', [ $wizards_api, 'register_routes' ] );
 	}
 }
 new API();

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -9,6 +9,8 @@ namespace Newspack;
 
 defined( 'ABSPATH' ) || exit;
 
+define( 'NEWSPACK_WIZARD_COMPLETED_OPTION_PREFIX', 'newspack_wizard_completed_' );
+
 /**
  * Common functionality for admin wizards. Override this class.
  */
@@ -146,11 +148,19 @@ abstract class Wizard {
 	/**
 	 * Whether this wizard has been completed.
 	 *
-	 * @todo This needs to actually handle completion.
 	 * @return bool
 	 */
 	public function is_completed() {
-		return false;
+		return (bool) get_option( NEWSPACK_WIZARD_COMPLETED_OPTION_PREFIX . $this->slug, false );
+	}
+
+	/**
+	 * Mark whether this wizard has been completed.
+	 *
+	 * @param bool $completed Whether the wizard has been completed (default: true).
+	 */
+	public function set_completed( $completed = true ) {
+		update_option( NEWSPACK_WIZARD_COMPLETED_OPTION_PREFIX . $this->slug, (bool) $completed );
 	}
 
 	/**

--- a/tests/unit-tests/api-wizards-controller.php
+++ b/tests/unit-tests/api-wizards-controller.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Tests the wizards API functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\API\Wizards_Controller;
+
+/**
+ * Test wizards API endpoints functionality.
+ */
+class Newspack_Test_Wizards_Controller extends WP_UnitTestCase {
+
+	/**
+	 * Route we're testing.
+	 *
+	 * @var string
+	 */
+	protected $api_route = '/newspack/v1/wizards/subscriptions-onboarding';
+
+	/**
+	 * Set up stuff for testing API requests.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		do_action( 'rest_api_init' );
+
+		$this->administrator = $this->factory->user->create( [ 'role' => 'administrator' ] );
+	}
+
+	/**
+	 * Test that the routes are registered.
+	 */
+	public function test_register_route() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/newspack/v1/wizards/(?P<slug>[\a-z]+)', $routes );
+	}
+
+	/**
+	 * Test unauthorized users can't retrieve wizards info.
+	 */
+	public function test_get_wizard_unauthorized() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'GET', $this->api_route );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test retrieving plugins info.
+	 */
+	public function test_get_wizard_authorized() {
+		wp_set_current_user( $this->administrator );
+		$request  = new WP_REST_Request( 'GET', $this->api_route );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( 'Subscriptions Onboarding', $data['name'] );
+	}
+
+	/**
+	 * Test that marking a wizard as complete works.
+	 */
+	public function test_set_wizard_completion() {
+		wp_set_current_user( $this->administrator );
+
+		// Before setting completed.
+		$request  = new WP_REST_Request( 'GET', $this->api_route );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( false, $data['completed'] );
+
+		// Set completed.
+		$request  = new WP_REST_Request( 'POST', $this->api_route . '/complete' );
+		$this->server->dispatch( $request );
+
+		// Verify it saved.
+		$request  = new WP_REST_Request( 'GET', $this->api_route );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( true, $data['completed'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds functionality for marking a wizard complete, and endpoints also. I've updated the Checklist to handle this and added completion tracking for the 2 subscription wizards. In the API there is a `newspack/v1/wizards/{slug}` endpoint for getting a wizard's info/status and a `newspack/v1/wizards/{slug}/complete` endpoint for marking a wizard as complete.

![localhost_wp-admin_admin php_page=newspack-checklist checklist=reader-revenue](https://user-images.githubusercontent.com/7317227/60463417-c9bc3a80-9c00-11e9-89b9-424609d9f57d.png)

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. Go to the Reader Revenue checklist.
3. Go through the Subscriptions Onboarding wizard. After the last Save, observe it gets marked complete in the checklist.
4. Go through the Subscriptions wizard. Save at least one subscription. Observe it gets marked complete in the checklist.


### Next step

 After this milestone's work is complete I'd like to consolidate the existing and new endpoints into one simple namespace. Currently there are e.g. these endpoints
```
newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/fields
newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/location
newspack/v1/wizards/subscriptions-onboarding
newspack/v1/wizards/subscriptions-onboarding/complete
```

It would better if there was e.g.
```
newspack/v1/wizards/subscriptions-onboarding/fields
newspack/v1/wizards/subscriptions-onboarding/location
newspack/v1/wizards/subscriptions-onboarding
newspack/v1/wizards/subscriptions-onboarding/complete
```

This change is going to touch a lot of files, though, so it's not part of this PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->