### PR TITLE
Reset Newspack

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -40,6 +40,7 @@ final class Newspack {
 	public function __construct() {
 		$this->define_constants();
 		$this->includes();
+		add_action( 'admin_menu', [ $this, 'remove_all_newspack_options' ], 1 );
 	}
 
 	/**
@@ -83,6 +84,20 @@ final class Newspack {
 	 */
 	public static function plugin_url() {
 		return untrailingslashit( plugins_url( '/', NEWSPACK_PLUGIN_FILE ) );
+	}
+
+	/**
+	 * Reset Newspack by removing all newspack prefixed options. Triggered by the query param reset_newspack_settings=1
+	 */
+	public function remove_all_newspack_options() {
+		if ( filter_input( INPUT_GET, 'reset_newspack_settings', FILTER_SANITIZE_STRING ) === '1' ) {
+			$all_options = wp_load_alloptions();
+			foreach ( $all_options as $key => $value ) {
+				if ( strpos( $key, 'newspack' ) === 0 || strpos( $key, '_newspack' ) === 0 ) {
+					delete_option( $key );
+				}
+			}
+		}
 	}
 }
 Newspack::instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With testing beginning of Newspack onboarding flows it's useful to have a temporary way to reset all Newspack options. This branch introduces a way to  do this by adding `&reset_newspack_settings=1` to a wp-admin URL.   

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Go through the Set Up Wizard completely, which sets an option that unlocks the Dashboard. Populate some of the fields along the way.
3. On the dashboard, add `&reset_newspack_settings=1` to the end of the URL and load the page.
4. Verify this deletes all Newspack options, which then returns you to the Set Up Wizard and makes the dashboard inaccessible again. As you go through Set Up any fields you had populated should be blank again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->