### PR TITLE
Fix Tertiary Button Focus State 

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -46,6 +46,13 @@
 		}
 	}
 
+	&.is-tertiary {
+		&:focus:enabled {
+			background-color: inherit;
+			box-shadow: none;
+		}
+	}
+
 	&.is-link {
 		background: none;
 		border: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes white background and outline when tertiary buttons are clicked.

Closes #151 .

### How to test the changes in this Pull Request:

1. Go to any wizard.
2. Click and hold the button at the bottom that returns to the checklist or dashboard.
3. Verify there is no longer a white background and border on this button.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->