### PR TITLE
ActionCards Checklist Style

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -37,16 +37,16 @@ class ActionCard extends Component {
 			href,
 			notification,
 			notificationLevel,
-			actionIcon,
 			actionText,
 			secondaryActionText,
 			image,
 			imageLink,
+			simple,
 			onClick,
 			onSecondaryActionClick,
 			isWaiting,
 		} = this.props;
-		const classes = murielClassnames( 'newspack-action-card', className );
+		const classes = murielClassnames( 'newspack-action-card', simple && 'is_clickable', className );
 		const notificationClasses = classnames(
 			'newspack-action-card__notification',
 			'notice',
@@ -55,14 +55,9 @@ class ActionCard extends Component {
 			'update-message'
 		);
 		const hasSecondaryAction = secondaryActionText && onSecondaryActionClick;
-		let actionDisplay;
-		if ( actionIcon ) {
-			actionDisplay = <Dashicon icon={ actionIcon } />;
-		} else if ( actionText ) {
-			actionDisplay = actionText;
-		}
+		const actionDisplay = ( simple && <Dashicon icon="arrow-right-alt2" /> ) || actionText;
 		return (
-			<Card className={ classes }>
+			<Card className={ classes } onClick={ simple && onClick }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
 					{ image && (
 						<div className="newspack-action-card__region newspack-action-card__region-left">
@@ -81,7 +76,12 @@ class ActionCard extends Component {
 					{ actionDisplay && (
 						<div className="newspack-action-card__region newspack-action-card__region-right">
 							{ actionDisplay && ( !! onClick || !! href ) && (
-								<Button isLink href={ href } onClick={ onClick } className="newspack-action-card__primary_button">
+								<Button
+									isLink
+									href={ href }
+									onClick={ onClick }
+									className="newspack-action-card__primary_button"
+								>
 									{ actionDisplay }
 								</Button>
 							) }

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { Component } from '@wordpress/element';
-import { Spinner } from '@wordpress/components';
+import { Dashicon, Spinner } from '@wordpress/components';
 import { Button, Card } from '../';
 
 /**
@@ -37,6 +37,7 @@ class ActionCard extends Component {
 			href,
 			notification,
 			notificationLevel,
+			actionIcon,
 			actionText,
 			secondaryActionText,
 			image,
@@ -54,6 +55,12 @@ class ActionCard extends Component {
 			'update-message'
 		);
 		const hasSecondaryAction = secondaryActionText && onSecondaryActionClick;
+		let actionDisplay;
+		if ( actionIcon ) {
+			actionDisplay = <Dashicon icon={ actionIcon } />;
+		} else if ( actionText ) {
+			actionDisplay = actionText;
+		}
 		return (
 			<Card className={ classes }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
@@ -71,18 +78,18 @@ class ActionCard extends Component {
 						<h1>{ title }</h1>
 						<h2>{ description }</h2>
 					</div>
-					{ actionText && (
+					{ actionDisplay && (
 						<div className="newspack-action-card__region newspack-action-card__region-right">
-							{ actionText && ( !! onClick || !! href ) && (
+							{ actionDisplay && ( !! onClick || !! href ) && (
 								<Button isLink href={ href } onClick={ onClick } className="newspack-action-card__primary_button">
-									{ actionText }
+									{ actionDisplay }
 								</Button>
 							) }
 
-							{ actionText && ( ! onClick && ! href ) && (
+							{ actionDisplay && ( ! onClick && ! href ) && (
 								<div className="newspack-action-card__container">
 									{ isWaiting && <Spinner /> }
-									{ actionText }
+									{ actionDisplay }
 								</div>
 							) }
 

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -110,4 +110,5 @@
 	&:hover button.newspack-action-card__secondary_button {
 		visibility: visible;
 	}
+
 }

--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -13,6 +13,10 @@
 	max-width: calc( 682px - 62px );
 	padding: 31px;
 
+	&.is_clickable {
+		cursor: pointer;
+	}
+
 	&.muriel-card__no-background {
 		background: none;
 		box-shadow: none;

--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -15,6 +15,9 @@
 
 	&.is_clickable {
 		cursor: pointer;
+		&:hover {
+			box-shadow: 0px 5px 5px rgba( 0, 0, 0, 0.2 ), 0px 3px 14px rgba( 0, 0, 0, 0.12 ), 0px 8px 10px rgba( 0, 0, 0, 0.14 );
+		}
 	}
 
 	&.muriel-card__no-background {

--- a/assets/wizards/checklist/index.js
+++ b/assets/wizards/checklist/index.js
@@ -81,7 +81,7 @@ class ChecklistScreen extends Component {
 						<ActionCard
 							title={ step.name }
 							description={ step.description }
-							actionIcon="arrow-right-alt2"
+							simple
 							onClick={ () => ( window.location = step.url ) }
 						/>
 					) )

--- a/assets/wizards/checklist/index.js
+++ b/assets/wizards/checklist/index.js
@@ -11,7 +11,15 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Button, FormattedHeader, Checklist, NewspackLogo, Task } from '../../components/src';
+import {
+	ActionCard,
+	Button,
+	Card,
+	FormattedHeader,
+	Checklist,
+	NewspackLogo,
+	Task,
+} from '../../components/src';
 import './style.scss';
 
 /**
@@ -37,7 +45,7 @@ class ChecklistScreen extends Component {
 		const { steps } = this.props;
 		let numComplete = 0;
 		for ( let i = 0; i < steps.length; ++i ) {
-			if ( steps[i].completed ) {
+			if ( steps[ i ].completed ) {
 				++numComplete;
 			} else {
 				break;
@@ -62,28 +70,39 @@ class ChecklistScreen extends Component {
 	 * Render.
 	 */
 	render() {
-		const { name, description, steps, dashboardURL } = this.props;
+		const { name, description, listStyle, steps, dashboardURL } = this.props;
 		const { checklistProgress } = this.state;
-
 		return (
 			<Fragment>
 				<NewspackLogo compact width="50" className="newspack-logo" />
 				<FormattedHeader headerText={ name } subHeaderText={ description } />
-				<Checklist progressBarText={ __( 'Your setup list' ) }>
-					{ steps.map( ( step, index ) => (
-						<Task
-							key={ index }
+				{ 'actionCards' === listStyle && (
+					steps.map( ( step, index ) => (
+						<ActionCard
 							title={ step.name }
 							description={ step.description }
-							buttonText={ __( 'Do it' ) }
-							completedTitle={ step.name }
-							completed={ step.completed || checklistProgress > index }
-							onDismiss={ () => this.dismissCheckListItem( index ) }
-							active={ checklistProgress === index }
+							actionIcon="arrow-right-alt2"
 							onClick={ () => ( window.location = step.url ) }
 						/>
-					) ) }
-				</Checklist>
+					) )
+				) }
+				{ 'actionCards' !== listStyle && (
+					<Checklist progressBarText={ __( 'Your setup list' ) }>
+						{ steps.map( ( step, index ) => (
+							<Task
+								key={ index }
+								title={ step.name }
+								description={ step.description }
+								buttonText={ __( 'Do it' ) }
+								completedTitle={ step.name }
+								completed={ step.completed || checklistProgress > index }
+								onDismiss={ () => this.dismissCheckListItem( index ) }
+								active={ checklistProgress === index }
+								onClick={ () => ( window.location = step.url ) }
+							/>
+						) ) }
+					</Checklist>
+				) }
 				<Button
 					className="is-centered"
 					isTertiary

--- a/includes/class-checklists.php
+++ b/includes/class-checklists.php
@@ -44,6 +44,7 @@ class Checklists {
 			'advertising'    => [
 				'name'        => esc_html__( 'Advertising', 'newspack' ),
 				'description' => esc_html__( 'Display advertising', 'newspack' ),
+				'style'       => 'actionCards',
 				'wizards'     => [
 					'google-adsense',
 				],
@@ -98,6 +99,21 @@ class Checklists {
 
 		return false;
 
+	}
+
+	/**
+	 * Get a checklist's style.
+	 *
+	 * @param string $checklist_slug The checklist slug, as registered in the self::$checklists variable.
+	 * @return string | bool The list style
+	 */
+	public static function get_style( $checklist_slug ) {
+		$checklist = self::get_checklist( $checklist_slug );
+		if ( $checklist ) {
+			return isset( $checklist['style'] ) ? $checklist['style'] : null;
+		}
+
+		return false;
 	}
 
 	/**
@@ -202,6 +218,7 @@ class Checklists {
 			'description'  => self::get_description( $checklist_slug ),
 			'steps'        => [],
 			'dashboardURL' => Wizards::get_url( 'dashboard' ),
+			'listStyle'    => self::get_style( $checklist_slug ),
 		];
 
 		foreach ( $checklist['wizards'] as $wizard_slug ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR establishes an alternate, simpler style for checklists. A simple checklist is just a collection of `ActionCard`s, each of which is fully clickable. The cards also have a right-pointing arrow instead of action text. This is meant to be used for checklist screens where the idea of completing items in order doesn't apply. 

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Navigate to the Advertising checklist.
3. There will be only one item in the checklist. 
4. Observe the new style, verify the entire card is clickable, verify hover state.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->