### PR TITLE
Set Up Wizard Loading Fixes

### DIFF
--- a/assets/components/src/wizard-pagination/index.js
+++ b/assets/components/src/wizard-pagination/index.js
@@ -31,12 +31,12 @@ class WizardPagination extends Component {
 		return (
 			<Fragment>
 				<a className="newspack-wizard-pagination__navigation" onClick={ () => history.goBack() }>
-					<span class="dashicons dashicons-arrow-left-alt" /> { __( 'Back' ) }
+					<span className="dashicons dashicons-arrow-left-alt" /> { __( 'Back' ) }
 				</a>
 				{ currentIndex > 0 && (
 					<div className="newspack-wizard-pagination__pagination">
 						{ __( 'Page' ) } { currentIndex } { __( 'of' ) } { routes.length }{' '}
-						<span class="dashicons dashicons-arrow-right-alt" />
+						<span className="dashicons dashicons-arrow-right-alt" />
 					</div>
 				) }
 			</Fragment>

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -246,13 +246,13 @@ class SetupWizard extends Component {
 						<Redirect to="/" />
 					</Switch>
 					<Route
-						path={ [ '/about', '/newsroom', '/configure-plugins' ] }
+						path={ [ '/about', '/newsroom' ] }
 						render={ routeProps => (
 							<div className="newspack-setup-wizard_plugin-installer">
 								<PluginInstaller
 									asProgressBar
 									plugins={ REQUIRED_PLUGINS }
-									onStatus={ installationComplete => this.setState( { installationComplete } ) }
+									onStatus={ status => this.setState( { installationComplete: status.complete } ) }
 								/>
 								{ ! installationComplete && (
 									<p className="newspack-setup-wizard_progress_bar_explainer">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes a bug that caused the Set Up Wizard's `PluginLoader` to incorrectly report completion. The loading bar will also be hidden on the fourth screen (which is only accessible after all plugins are loaded.)

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Delete some plugins, and run the Set Up Wizard.
3. Verify that the button on the third screen remains disabled until plugins are loaded, and becomes enabled after they are done.
4. On the fourth screen, verify there is no loading bar anymore.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->