### PR TITLE
Functionality for enabling/disabling modules in PWA wizard where possible

### DIFF
--- a/includes/configuration_managers/class-progressive-wp-configuration-manager.php
+++ b/includes/configuration_managers/class-progressive-wp-configuration-manager.php
@@ -33,6 +33,8 @@ class Progressive_WP_Configuration_Manager extends Configuration_Manager {
 		'site_icon',
 		'firebase-serverkey',
 		'firebase-senderid',
+		'installable-mode',
+		'offline-page',
 	];
 
 	/**
@@ -122,6 +124,26 @@ class Progressive_WP_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function firebase_credentials_set( $set ) {
 		update_option( 'pwp_firebase_credentials_set', $set ? 'yes' : 'no' );
+	}
+
+	/**
+	 * Determine whether a module is enabled.
+	 *
+	 * @param string Module slug.
+	 * @return bool Whether the module is enabled or not.
+	 */
+	public function is_module_enabled( $module ) {
+		switch ( $module ) {
+			case 'add_to_homescreen':
+				return 'none' !== $this->get( 'installable-mode' );
+			case 'offline_usage':
+				$setting = $this->get( 'offline-page' );
+				return 'page' === get_post_type( $setting );
+			case 'push_notifications':
+				return 'yes' === get_option( 'pwp_firebase_credentials_set', 'no' );
+			default:
+				return false;
+		}
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds the ability to persistently enable/disable the Add to Homescreen and Push Notification features of the PWA wizard. It's not really possible to disable the offline support feature as far as I can tell.

### How to test the changes in this Pull Request:

1. Disable the Add to Homepage toggle when going through the wizard. Observe it persists on refresh. Go to `/wp-admin/admin.php?page=progressive-wordpress`, and observe it's marked 'disabled'. Do the same thing for the toggle 'enabled'.
2. The toggle on the Offline Usage screen doesn't do anything.
3. Enable/Disable the toggle for Push Notifications screen like in step 1.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->