### PR TITLE
Loading UI and use loading UI in Subscriptions wizards

### DIFF
--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -30,7 +30,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 			this.state = {
 				complete: null,
 				error: null,
-				loading: 0,
+				loading: requiredPlugins ? 1 : 0,
 			};
 			this.wrappedComponentRef = createRef();
 		}
@@ -137,6 +137,9 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		 * Called when plugin installation is complete. Updates state and calls onWizardReady on the wrapped component.
 		 */
 		pluginInstallationStatus = ( { complete } ) => {
+			if ( this.state.loading ) {
+				this.doneLoading();
+			}
 			const instance = this.wrappedComponentRef.current;
 			this.setState( { complete }, () => {
 				complete && instance && instance.onWizardReady && instance.onWizardReady();
@@ -196,7 +199,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 					<Route
 						path="/"
 						render={ routeProps => (
-							<Card noBackground>
+							<Card noBackground className='muriel-wizardScreen muriel-wizardScreen__no-background'>
 								{ complete !== null && (
 									<FormattedHeader
 										headerText={ __( 'Required plugin' ) }

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -149,7 +149,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		startLoading = () => {
 			this.setState( state => ( {
 				loading: state.loading + 1
-			} ), () => { console.log( this.state.loading + ' items loading' ); } );
+			} ) );
 		}
 
 		/**
@@ -158,7 +158,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		doneLoading = () => {
 			this.setState( state => ( {
 				loading: state.loading - 1
-			} ), () => { console.log( this.state.loading + ' items loading' ); } );
+			} ) );
 			
 		}
 

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -165,7 +165,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		/**
 		 * Replacement for core apiFetch that automatically manages wizard loading UI.
 		 */
-		apiFetch = args => {
+		wizardApiFetch = args => {
 			this.startLoading();
 			return new Promise( ( resolve, reject ) => {
 				apiFetch( args )
@@ -234,7 +234,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 							setError={ this.setError }
 							startLoading={ this.startLoading }
 							doneLoading={ this.doneLoading }
-							apiFetch={ this.apiFetch }
+							wizardApiFetch={ this.wizardApiFetch }
 							ref={ this.wrappedComponentRef }
 							{ ...this.props }
 						/>

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -34,6 +34,12 @@
 			background-color: $primary-color;
 			animation: loading 2s linear infinite;
 		}
+
+		&.muriel-wizardScreen__no-background {
+			&:after {
+				background: #f1f1f1; /* WP admin bg color */
+			}
+		}
 	}
 
 	.muriel-button {

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -1,4 +1,58 @@
+@import '../../../shared/scss/muriel-component';
+
 .newspack-wizard .newspack-logo {
 	display: block;
 	margin: 2em auto 0 auto;
+}
+
+.muriel-wizardScreen__loading {
+	.muriel-wizardScreen {
+		position: relative;
+
+		&:after {
+			display: block;
+			content: '';
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			background: $muriel-white;
+			opacity: 0.8;
+			z-index: 102; /* Toggle arrows from Select components are at z-index: 101 */
+		}
+
+		&:before {
+			display: block;
+			position: absolute;
+			content: "";
+			z-index: 103;
+			left: 0;
+			top: 0;
+			width: 10%;
+			height: 4px;
+			background-color: $primary-color;
+			animation: loading 2s linear infinite;
+		}
+	}
+
+	.muriel-button {
+		opacity: 0.3;
+	}
+
+	&::after {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+	}
+}
+
+@keyframes loading {
+    from { left: 0; width: 10%; }
+    50% { width: 30%; }
+    75% { width: 20%; }
+    to { left: 90%; width: 10% }
 }

--- a/assets/wizards/subscriptions/index.js
+++ b/assets/wizards/subscriptions/index.js
@@ -48,8 +48,8 @@ class SubscriptionsWizard extends Component {
 	 * Get the latest subscriptions info.
 	 */
 	refreshSubscriptions( callback ) {
-		const { setError, apiFetch } = this.props;
-		return apiFetch( { path: '/newspack/v1/wizard/subscriptions' } )
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( { path: '/newspack/v1/wizard/subscriptions' } )
 			.then( subscriptions => {
 				const result = subscriptions.reduce( ( result, value ) => {
 					result[ value.id ] = value;
@@ -76,11 +76,11 @@ class SubscriptionsWizard extends Component {
 	 * Save the fields to a susbcription.
 	 */
 	saveSubscription( subscription ) {
-		const { setError, apiFetch } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		const { id, name, image, price, frequency } = subscription;
 		const image_id = image ? image.id : 0;
 		return new Promise( ( resolve, reject ) => {
-			apiFetch( {
+			wizardApiFetch( {
 				path: '/newspack/v1/wizard/subscriptions',
 				method: 'post',
 				data: {
@@ -106,9 +106,9 @@ class SubscriptionsWizard extends Component {
 	 * @param int id Subscription ID.
 	 */
 	deleteSubscription( id ) {
-		const { setError, apiFetch } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		if ( confirm( __( 'Are you sure you want to delete this subscription?' ) ) ) {
-			apiFetch( {
+			wizardApiFetch( {
 				path: '/newspack/v1/wizard/subscriptions/' + id,
 				method: 'delete',
 			} )
@@ -125,9 +125,9 @@ class SubscriptionsWizard extends Component {
 	 * Get the latest info about the choosePrice setting.
 	 */
 	refreshChoosePrice() {
-		const { apiFetch } = this.props;
+		const { wizardApiFetch } = this.props;
 
-		apiFetch( { path: '/newspack/v1/wizard/subscriptions/choose-price' } ).then( choosePrice => {
+		wizardApiFetch( { path: '/newspack/v1/wizard/subscriptions/choose-price' } ).then( choosePrice => {
 			this.setState( {
 				choosePrice: !! choosePrice,
 			} );
@@ -138,14 +138,14 @@ class SubscriptionsWizard extends Component {
 	 * Enable/Disable Name-Your-Price for Newspack subscriptions.
 	 */
 	toggleChoosePrice() {
-		const { apiFetch } = this.props;
+		const { wizardApiFetch } = this.props;
 
 		this.setState(
 			{
 				choosePrice: ! this.state.choosePrice,
 			},
 			() => {
-				apiFetch( {
+				wizardApiFetch( {
 					path: '/newspack/v1/wizard/subscriptions/choose-price',
 					method: 'post',
 					data: {
@@ -162,9 +162,9 @@ class SubscriptionsWizard extends Component {
 	 * Mark this wizard as complete.
 	 */
 	markWizardComplete() {
-		const { setError, apiFetch } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		return new Promise( ( resolve, reject ) => {
-			apiFetch( {
+			wizardApiFetch( {
 				path: '/newspack/v1/wizards/subscriptions/complete',
 				method: 'post',
 				data: {},

--- a/assets/wizards/subscriptions/index.js
+++ b/assets/wizards/subscriptions/index.js
@@ -6,7 +6,6 @@
  * WordPress dependencies
  */
 import { Component, render } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -49,7 +48,7 @@ class SubscriptionsWizard extends Component {
 	 * Get the latest subscriptions info.
 	 */
 	refreshSubscriptions( callback ) {
-		const { setError } = this.props;
+		const { setError, apiFetch } = this.props;
 		return apiFetch( { path: '/newspack/v1/wizard/subscriptions' } )
 			.then( subscriptions => {
 				const result = subscriptions.reduce( ( result, value ) => {
@@ -77,7 +76,7 @@ class SubscriptionsWizard extends Component {
 	 * Save the fields to a susbcription.
 	 */
 	saveSubscription( subscription ) {
-		const { setError } = this.props;
+		const { setError, apiFetch } = this.props;
 		const { id, name, image, price, frequency } = subscription;
 		const image_id = image ? image.id : 0;
 		return new Promise( ( resolve, reject ) => {
@@ -107,7 +106,7 @@ class SubscriptionsWizard extends Component {
 	 * @param int id Subscription ID.
 	 */
 	deleteSubscription( id ) {
-		const { setError } = this.props;
+		const { setError, apiFetch } = this.props;
 		if ( confirm( __( 'Are you sure you want to delete this subscription?' ) ) ) {
 			apiFetch( {
 				path: '/newspack/v1/wizard/subscriptions/' + id,
@@ -126,6 +125,8 @@ class SubscriptionsWizard extends Component {
 	 * Get the latest info about the choosePrice setting.
 	 */
 	refreshChoosePrice() {
+		const { apiFetch } = this.props;
+
 		apiFetch( { path: '/newspack/v1/wizard/subscriptions/choose-price' } ).then( choosePrice => {
 			this.setState( {
 				choosePrice: !! choosePrice,
@@ -137,6 +138,8 @@ class SubscriptionsWizard extends Component {
 	 * Enable/Disable Name-Your-Price for Newspack subscriptions.
 	 */
 	toggleChoosePrice() {
+		const { apiFetch } = this.props;
+
 		this.setState(
 			{
 				choosePrice: ! this.state.choosePrice,
@@ -159,7 +162,7 @@ class SubscriptionsWizard extends Component {
 	 * Mark this wizard as complete.
 	 */
 	markWizardComplete() {
-		const { setError } = this.props;
+		const { setError, apiFetch } = this.props;
 		return new Promise( ( resolve, reject ) => {
 			apiFetch( {
 				path: '/newspack/v1/wizards/subscriptions/complete',

--- a/assets/wizards/subscriptionsOnboarding/index.js
+++ b/assets/wizards/subscriptionsOnboarding/index.js
@@ -6,7 +6,6 @@
  * WordPress dependencies
  */
 import { Component, Fragment, render } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -69,7 +68,8 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Get information used for populating complex dropdown menus.
 	 */
 	refreshFieldOptions() {
-		const { setError } = this.props;
+		const { setError, apiFetch } = this.props;
+
 		apiFetch( { path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/fields' } )
 			.then( fields => {
 				setError();
@@ -86,7 +86,7 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Get the latest saved info about business location.
 	 */
 	refreshLocationInfo() {
-		const { setError } = this.props;
+		const { setError, apiFetch } = this.props;
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/location',
 		} )
@@ -105,7 +105,7 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Save the current location info.
 	 */
 	saveLocation() {
-		const { setError } = this.props;
+		const { setError, apiFetch } = this.props;
 		return new Promise( ( resolve, reject ) => {
 			apiFetch( {
 				path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/location',
@@ -127,7 +127,7 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Get the latest saved Stripe settings.
 	 */
 	refreshStripeInfo() {
-		const { setError } = this.props;
+		const { setError, apiFetch } = this.props;
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/stripe-settings',
 		} )
@@ -146,7 +146,7 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Save the current Stripe settings.
 	 */
 	saveStripeSettings() {
-		const { setError } = this.props;
+		const { setError, apiFetch } = this.props;
 		return new Promise( ( resolve, reject ) => {
 			apiFetch( {
 				path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/stripe-settings',
@@ -168,7 +168,7 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Mark this wizard as complete.
 	 */
 	markWizardComplete() {
-		const { setError } = this.props;
+		const { setError, apiFetch } = this.props;
 		return new Promise( ( resolve, reject ) => {
 			apiFetch( {
 				path: '/newspack/v1/wizards/subscriptions-onboarding/complete',

--- a/assets/wizards/subscriptionsOnboarding/index.js
+++ b/assets/wizards/subscriptionsOnboarding/index.js
@@ -68,9 +68,8 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Get information used for populating complex dropdown menus.
 	 */
 	refreshFieldOptions() {
-		const { setError, apiFetch } = this.props;
-
-		apiFetch( { path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/fields' } )
+		const { setError, wizardApiFetch } = this.props;
+		wizardApiFetch( { path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/fields' } )
 			.then( fields => {
 				setError();
 				this.setState( {
@@ -86,8 +85,8 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Get the latest saved info about business location.
 	 */
 	refreshLocationInfo() {
-		const { setError, apiFetch } = this.props;
-		apiFetch( {
+		const { setError, wizardApiFetch } = this.props;
+		wizardApiFetch( {
 			path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/location',
 		} )
 			.then( location => {
@@ -105,9 +104,9 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Save the current location info.
 	 */
 	saveLocation() {
-		const { setError, apiFetch } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		return new Promise( ( resolve, reject ) => {
-			apiFetch( {
+			wizardApiFetch( {
 				path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/location',
 				method: 'post',
 				data: {
@@ -127,8 +126,8 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Get the latest saved Stripe settings.
 	 */
 	refreshStripeInfo() {
-		const { setError, apiFetch } = this.props;
-		apiFetch( {
+		const { setError, wizardApiFetch } = this.props;
+		wizardApiFetch( {
 			path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/stripe-settings',
 		} )
 			.then( stripeSettings => {
@@ -146,9 +145,9 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Save the current Stripe settings.
 	 */
 	saveStripeSettings() {
-		const { setError, apiFetch } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		return new Promise( ( resolve, reject ) => {
-			apiFetch( {
+			wizardApiFetch( {
 				path: '/newspack/v1/wizard/newspack-subscriptions-onboarding-wizard/stripe-settings',
 				method: 'post',
 				data: {
@@ -168,9 +167,9 @@ class SubscriptionsOnboardingWizard extends Component {
 	 * Mark this wizard as complete.
 	 */
 	markWizardComplete() {
-		const { setError, apiFetch } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		return new Promise( ( resolve, reject ) => {
-			apiFetch( {
+			wizardApiFetch( {
 				path: '/newspack/v1/wizards/subscriptions-onboarding/complete',
 				method: 'post',
 				data: {},

--- a/assets/wizards/subscriptionsOnboarding/views/locationSetup.js
+++ b/assets/wizards/subscriptionsOnboarding/views/locationSetup.js
@@ -42,7 +42,7 @@ class LocationSetup extends Component {
 				<SelectControl
 					label={ __( 'Where is your business based?' ) }
 					value={ countrystate }
-					options={ countrystateFields }
+					options={ countrystateFields && countrystateFields.length ? countrystateFields : [ {} ] }
 					onChange={ value => this.handleOnChange( 'countrystate', value ) }
 				/>
 				<TextControl
@@ -68,7 +68,7 @@ class LocationSetup extends Component {
 				<SelectControl
 					label={ 'Which currency does your business use?' }
 					value={ currency }
-					options={ currencyFields }
+					options={ currencyFields && currencyFields.length ? currencyFields : [ {} ] }
 					onChange={ value => this.handleOnChange( 'currency', value ) }
 				/>
 			</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #76 .

This PR adds functionality for handling loading to the `withWizard` component. While loading the screen is overlayed with an element that prevents users from clicking on anything and a loading UI is displayed. I've implemented this UI based on the [Material design guidelines for indeterminate progress bars](https://material.io/design/components/progress-indicators.html#) and the Muriel designs for progress bars. They're currently not available as a stand-alone component, but if that's desired let me know.

To make usage simple, I've defined a new `apiFetch` method on `withWizard` that automatically handles loading UI. Usage is the same as `apiFetch`, you just load up `apiFetch` from `withWizard` instead of `@wordpress/api-fetch`. It can handle multiple concurrent API calls, and will stop loading once they are all resolved. @jeffersonrabb please let me know if you see any issues in the `apiFetch` wrapper method in `withWizard` or with this approach.

I've updated the two Subscriptions wizards to use this api/loading style for demonstration purposes. After this is merged I'll update the other wizards in a separate PR.

### Screenshot

![localhost_wp-admin_admin php_page=newspack-subscriptions-onboarding-wizard (2)](https://user-images.githubusercontent.com/7317227/60618399-f603c280-9d8a-11e9-812e-35f13d346851.png)

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. Use Subscriptions Onboarding and Subscriptions wizards.
3. Observe loading UI. Test that buttons/etc. are blocked from being clicked on while loading is happening. Other than that, things should work as normal.

### Question

![localhost_wp-admin_admin php_page=newspack-subscriptions-wizard (3)](https://user-images.githubusercontent.com/7317227/60618400-f603c280-9d8a-11e9-9238-a9a89f06af22.png)

@sonjaleix Does this look OK? I wasn't able to come up with a really nice-looking way of doing the loading on screens that don't have the card background. Do you have a better suggestion?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->