### PR TITLE
Configure Plugins After Install

### DIFF
--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -80,7 +80,7 @@ class PluginInstaller extends Component {
 	installPlugin = slug => {
 		this.setInstallationStatus( slug, PLUGIN_STATE_INSTALLING );
 		const params = {
-			path: `/newspack/v1/plugins/${ slug }/activate/`,
+			path: `/newspack/v1/plugins/${ slug }/configure/`,
 			method: 'post',
 		};
 		return apiFetch( params )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR switches the endpoint `PluginInstaller` uses from `/newspack/v1/plugins/{plugin-slug}/activate` to `/newspack/v1/plugins/{plugin-slug}/configure`. The configure endpoint will install, activate, and finally run the plugin's Configuration Manager's `configure()` method. At this point, the only actual change here is that AMP will be initially set to `Standard` mode on installation.

### How to test the changes in this Pull Request:

1. If AMP is installed, go to AMP's settings page and set Mode to "Reader" or "Transitional". 
2. From the plugins page, uninstall AMP.
3. Go to Newspack->Set Up and run through the wizard. 
4. Return to the AMP settings page and verify that mode is now "Standard."

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->