### PR TITLE
Ad Manager: Parse out ad dimensions from the ad code

### DIFF
--- a/includes/wizards/class-google-ad-manager-wizard.php
+++ b/includes/wizards/class-google-ad-manager-wizard.php
@@ -243,10 +243,13 @@ class Google_Ad_Manager_Wizard extends Wizard {
 		if ( $query->have_posts() ) {
 			while ( $query->have_posts() ) {
 				$query->the_post();
+				$ad_code = \get_post_meta( get_the_ID(), 'newspack_ad_code', true );
 				$ad_units[] = [
-					'id'   => \get_the_ID(),
-					'name' => \get_the_title(),
-					'code' => \get_post_meta( get_the_ID(), 'newspack_ad_code', true ),
+					'id'     => \get_the_ID(),
+					'name'   => \get_the_title(),
+					'code'   => $ad_code,
+					'width'  => $this->_extract_ad_width( $ad_code ),
+					'height' => $this->_extract_ad_height( $ad_code ),
 				];
 			}
 		}
@@ -259,11 +262,15 @@ class Google_Ad_Manager_Wizard extends Wizard {
 	 */
 	private function _get_ad_unit( $id ) {
 		$ad_unit = \get_post( $id );
+
 		if ( is_a( $ad_unit, 'WP_Post' ) ) {
+			$ad_code = \get_post_meta( $ad_unit->ID, 'newspack_ad_code', true );
 			return [
-				'id' => $ad_unit->ID,
-				'name' => $ad_unit->post_title,
-				'code' => \get_post_meta( $ad_unit->ID, 'newspack_ad_code', true ),
+				'id'     => $ad_unit->ID,
+				'name'   => $ad_unit->post_title,
+				'code'   => $ad_code,
+				'width'  => $this->_extract_ad_width( $ad_code ),
+				'height' => $this->_extract_ad_height( $ad_code ),
 			];
 		} else {
 			return new WP_Error(
@@ -316,9 +323,11 @@ class Google_Ad_Manager_Wizard extends Wizard {
 		\add_post_meta( $ad_unit_post, 'newspack_ad_code', $ad_unit['code'] );
 
 		return [
-			'id' => $ad_unit_post,
-			'name' => $ad_unit['name'],
-			'code' => $ad_unit['code'],
+			'id'     => $ad_unit_post,
+			'name'   => $ad_unit['name'],
+			'code'   => $ad_unit['code'],
+			'width'  => $ad_unit['width'],
+			'height' => $ad_unit['height'],
 		];
 
 	}
@@ -349,9 +358,11 @@ class Google_Ad_Manager_Wizard extends Wizard {
 		\update_post_meta( $ad_unit['id'], 'newspack_ad_code', $ad_unit['code'] );
 
 		return [
-			'id' => $ad_unit['id'],
-			'name' => $ad_unit['name'],
-			'code' => $ad_unit['code'],
+			'id'     => $ad_unit['id'],
+			'name'   => $ad_unit['name'],
+			'code'   => $ad_unit['code'],
+			'width'  => $ad_unit['width'],
+			'height' => $ad_unit['height'],
 		];
 
 	}
@@ -389,10 +400,14 @@ class Google_Ad_Manager_Wizard extends Wizard {
 			);
 		}
 
-		$sanitised_ad_unit = [
-			'name' => \esc_html( $ad_unit['name'] ),
-			'code' => $ad_unit['code'], // esc_js( $ad_unit['code'] ), @todo If a `script` tag goes here, esc_js is the wrong function to use.
+		// Extract the width and height out of the ad code.
 
+
+		$sanitised_ad_unit = [
+			'name'   => \esc_html( $ad_unit['name'] ),
+			'code'   => $ad_unit['code'], // esc_js( $ad_unit['code'] ), @todo If a `script` tag goes here, esc_js is the wrong function to use.
+			'width'  => $this->_extract_ad_width( $ad_unit['code'] ),
+			'height' => $this->_extract_ad_height( $ad_unit['code'] ),
 		];
 
 		if ( isset( $ad_unit['id'] ) ) {

--- a/includes/wizards/class-google-ad-manager-wizard.php
+++ b/includes/wizards/class-google-ad-manager-wizard.php
@@ -404,6 +404,48 @@ class Google_Ad_Manager_Wizard extends Wizard {
 	}
 
 	/**
+	 * Extract the value of the width parameter from given ad code.
+	 * @param  string   $ad_code The full ad code
+	 * @return int|null          The value, or null on failure.
+	 */
+	private function _extract_ad_width( $ad_code ) {
+		$width = null;
+
+		$search = preg_match(
+			'/width=([0-9]+)\s/',
+			$ad_code,
+			$matches
+		);
+
+		if ( isset( $matches[1] ) ) {
+			$width = $matches[1];
+		}
+
+		return $width;
+	}
+
+	/**
+	 * Extract the value of the height parameter from given ad code.
+	 * @param  string   $ad_code The full ad code
+	 * @return int|null          The value, or null on failure.
+	 */
+	private function _extract_ad_height( $ad_code ) {
+		$height = null;
+
+		$search = preg_match(
+			'/height=([0-9]+)\s/',
+			$ad_code,
+			$matches
+		);
+
+		if ( isset( $matches[1] ) ) {
+			$height = $matches[1];
+		}
+
+		return $height;
+	}
+
+	/**
 	 * Enqueue Subscriptions Wizard scripts and styles.
 	 */
 	public function enqueue_scripts_and_styles() {

--- a/tests/unit-tests/ad-manager-wizard.php
+++ b/tests/unit-tests/ad-manager-wizard.php
@@ -34,6 +34,12 @@ class Newspack_Test_Ad_Manager_Wizard extends WP_UnitTestCase {
 
 		$this->delete_ad_unit = $reflection->getMethod( '_delete_ad_unit' );
 		$this->delete_ad_unit->setAccessible( true );
+
+		$this->extract_ad_width = $reflection->getMethod( '_extract_ad_width' );
+		$this->extract_ad_width->setAccessible( true );
+
+		$this->extract_ad_height = $reflection->getMethod( '_extract_ad_height' );
+		$this->extract_ad_height->setAccessible( true );
 	}
 
 	/**
@@ -117,5 +123,41 @@ class Newspack_Test_Ad_Manager_Wizard extends WP_UnitTestCase {
 			$this->assertTrue( $unit['name'] === $unit1['name'] || $unit['name'] === $unit2['name'] );
 			$this->assertTrue( $unit['code'] === $unit1['code'] || $unit['code'] === $unit2['code'] );
 		}
+	}
+
+	public function test_extract_ad_width() {
+		$unit1_code = '<amp-ad width=300 height=250
+    type="doubleclick"
+    data-slot="/000000000000/test_ad">
+</amp-ad>';
+		$unit2_code = '<amp-ad width=468 height=60
+    type="doubleclick"
+    data-slot="/00000000000/test_ad"
+    data-multi-size="320x50">
+</amp-ad>';
+
+		$unit1_width = $this->extract_ad_width->invokeArgs( $this->wizard, [ $unit1_code ] );
+		$unit2_width = $this->extract_ad_width->invokeArgs( $this->wizard, [ $unit2_code ] );
+
+		$this->assertEquals( 300, $unit1_width );
+		$this->assertEquals( 468, $unit2_width );
+	}
+
+	public function test_extract_ad_height() {
+		$unit1_code = '<amp-ad width=300 height=250
+    type="doubleclick"
+    data-slot="/000000000000/test_ad">
+</amp-ad>';
+		$unit2_code = '<amp-ad width=468 height=60
+    type="doubleclick"
+    data-slot="/00000000000/test_ad"
+    data-multi-size="320x50">
+</amp-ad>';
+
+		$unit1_height = $this->extract_ad_height->invokeArgs( $this->wizard, [ $unit1_code ] );
+		$unit2_height = $this->extract_ad_height->invokeArgs( $this->wizard, [ $unit2_code ] );
+
+		$this->assertEquals( 250, $unit1_height );
+		$this->assertEquals( 60, $unit2_height );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds new methods to extract the width and height parameters from ad code, and then includes those values in API responses. This lays the groundwork for the GAM block to dynamically resize itself based on the chosen ad unit, as per https://github.com/Automattic/newspack-blocks/pull/39#issuecomment-508550604

### How to test the changes in this Pull Request:

1. Apply the patch
2. Use real ad codes (copy from the included unit tests) to add ads in the wizard
3. Verify that the API responses include correct width and height parameters (add a `console.log(result);' on line 58 of index.js).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
