### PR TITLE
Sprinkle some loading throughout the wizards

### DIFF
--- a/assets/wizards/googleAdManager/index.js
+++ b/assets/wizards/googleAdManager/index.js
@@ -47,8 +47,8 @@ class GoogleAdManagerWizard extends Component {
 	 * Get the latest adUnits info.
 	 */
 	refreshAdUnits() {
-		const { setError } = this.props;
-		return apiFetch( { path: '/newspack/v1/wizard/adunits' } )
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( { path: '/newspack/v1/wizard/adunits' } )
 			.then( adUnits => {
 				const result = adUnits.reduce( ( result, value ) => {
 					result[ value.id ] = value;
@@ -75,10 +75,10 @@ class GoogleAdManagerWizard extends Component {
 	 * Save the fields to an ad unit.
 	 */
 	saveAdUnit( adUnit ) {
-		const { setError } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		const { id, name, code } = adUnit;
 		return new Promise( ( resolve, reject ) => {
-			apiFetch( {
+			wizardApiFetch( {
 				path: '/newspack/v1/wizard/adunits',
 				method: 'post',
 				data: {
@@ -102,9 +102,9 @@ class GoogleAdManagerWizard extends Component {
 	 * @param int id Ad Unit ID.
 	 */
 	deleteAdUnit( id ) {
-		const { setError } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		if ( confirm( __( 'Are you sure you want to delete this ad unit?' ) ) ) {
-			apiFetch( {
+			wizardApiFetch( {
 				path: '/newspack/v1/wizard/adunits/' + id,
 				method: 'delete',
 			} )

--- a/assets/wizards/googleAdSense/index.js
+++ b/assets/wizards/googleAdSense/index.js
@@ -6,6 +6,7 @@
  * WordPress dependencies
  */
 import { Component, render, Fragment } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { Dashicon } from '@wordpress/components';
 
@@ -81,9 +82,9 @@ class GoogleAdSenseWizard extends Component {
 	 * Mark this wizard as complete.
 	 */
 	markWizardComplete() {
-		const { setError, wizardApiFetch } = this.props;
+		const { setError } = this.props;
 		return new Promise( ( resolve, reject ) => {
-			wizardApiFetch( {
+			apiFetch( {
 				path: '/newspack/v1/wizards/google-adsense/complete',
 				method: 'post',
 				data: {},

--- a/assets/wizards/googleAdSense/index.js
+++ b/assets/wizards/googleAdSense/index.js
@@ -6,7 +6,6 @@
  * WordPress dependencies
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { Dashicon } from '@wordpress/components';
 
@@ -14,6 +13,7 @@ import { Dashicon } from '@wordpress/components';
  * Internal dependencies
  */
 import { withWizard, FormattedHeader, Handoff } from '../../components/src';
+import AdSenseSetup from './views/adSenseSetup';
 import './style.scss';
 
 /**
@@ -57,8 +57,8 @@ class GoogleAdSenseWizard extends Component {
 	 * Get whether AdSense setup is complete.
 	 */
 	refreshComplete() {
-		const { setError } = this.props;
-		return apiFetch( { path: '/newspack/v1/wizard/newspack-google-adsense-wizard/adsense-setup-complete' } )
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( { path: '/newspack/v1/wizard/newspack-google-adsense-wizard/adsense-setup-complete' } )
 			.then( complete => {
 				return new Promise( resolve => {
 					this.setState(
@@ -81,9 +81,9 @@ class GoogleAdSenseWizard extends Component {
 	 * Mark this wizard as complete.
 	 */
 	markWizardComplete() {
-		const { setError } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		return new Promise( ( resolve, reject ) => {
-			apiFetch( {
+			wizardApiFetch( {
 				path: '/newspack/v1/wizards/google-adsense/complete',
 				method: 'post',
 				data: {},
@@ -111,25 +111,12 @@ class GoogleAdSenseWizard extends Component {
 						path="/"
 						exact
 						render={ routeProps => (
-							<Fragment>
-								<FormattedHeader
-									headerText={ __( 'Google AdSense' ) }
-									subHeaderText={ __( 'Connect to your AdSense account using the Site Kit plugin, then enable Auto Ads.' ) }
-								/>
-								{ complete && (
-									<div className='newspack-google-adsense-wizard__success'>
-										<Dashicon icon="yes-alt" />
-										<h4>{ __( 'AdSense is set up' ) }</h4>
-									</div>
-								) }
-								<Handoff
-									plugin='google-site-kit'
-									editLink='admin.php?page=googlesitekit-module-adsense'
-									className='is-centered'
-									isPrimary={ ! complete }
-									isDefault={ !! complete }
-								>{ complete ? __( 'AdSense Settings' ) : __( 'Set up Google AdSense' ) }</Handoff>
-							</Fragment>
+							<AdSenseSetup
+								headerText={ __( 'Google AdSense' ) }
+								subHeaderText={ __( 'Connect to your AdSense account using the Site Kit plugin, then enable Auto Ads.' ) }
+								complete={ complete }
+								noBackground
+							/>
 						) }
 					/>
 				</Switch>

--- a/assets/wizards/googleAdSense/views/adSenseSetup.js
+++ b/assets/wizards/googleAdSense/views/adSenseSetup.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Dashicon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { withWizardScreen, Handoff } from '../../../components/src';
+
+/**
+ * Screen for handing off to Site Kit AdSense setup.
+ */
+class AdSenseSetup extends Component {
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const { complete } = this.props;
+
+		return(
+			<Fragment>
+				{ complete && (
+					<div className='newspack-google-adsense-wizard__success'>
+						<Dashicon icon="yes-alt" />
+						<h4>{ __( 'AdSense is set up' ) }</h4>
+					</div>
+				) }
+				<Handoff
+					plugin='google-site-kit'
+					editLink='admin.php?page=googlesitekit-module-adsense'
+					className='is-centered'
+					isPrimary={ ! complete }
+					isDefault={ !! complete }
+				>{ complete ? __( 'AdSense Settings' ) : __( 'Set up Google AdSense' ) }</Handoff>
+			</Fragment>
+		);
+	}
+}
+
+export default withWizardScreen( AdSenseSetup );

--- a/assets/wizards/googleAnalytics/index.js
+++ b/assets/wizards/googleAnalytics/index.js
@@ -14,6 +14,7 @@ import { Dashicon } from '@wordpress/components';
  * Internal dependencies
  */
 import { withWizard, FormattedHeader, Handoff } from '../../components/src';
+import GoogleAnalyticsSetup from './views/googleAnalyticsSetup';
 import './style.scss';
 
 /**
@@ -57,8 +58,8 @@ class GoogleAnalyticsWizard extends Component {
 	 * Get whether Analytics setup is complete.
 	 */
 	refreshComplete() {
-		const { setError } = this.props;
-		return apiFetch( { path: '/newspack/v1/wizard/newspack-google-analytics-wizard/analytics-setup-complete' } )
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( { path: '/newspack/v1/wizard/newspack-google-analytics-wizard/analytics-setup-complete' } )
 			.then( complete => {
 				return new Promise( resolve => {
 					this.setState(
@@ -111,25 +112,12 @@ class GoogleAnalyticsWizard extends Component {
 						path="/"
 						exact
 						render={ routeProps => (
-							<Fragment>
-								<FormattedHeader
-									headerText={ __( 'Google Analytics' ) }
-									subHeaderText={ __( 'Connect to your Google Analytics account using the Site Kit plugin.' ) }
-								/>
-								{ complete && (
-									<div className='newspack-google-analytics-wizard__success'>
-										<Dashicon icon="yes-alt" />
-										<h4>{ __( 'Google Analytics is set up' ) }</h4>
-									</div>
-								) }
-								<Handoff
-									plugin='google-site-kit'
-									editLink='admin.php?page=googlesitekit-module-analytics'
-									className='is-centered'
-									isPrimary={ ! complete }
-									isDefault={ !! complete }
-								>{ complete ? __( 'Google Analytics Settings' ) : __( 'Set up Google Analytics' ) }</Handoff>
-							</Fragment>
+							<GoogleAnalyticsSetup
+								headerText={ __( 'Google Analytics' ) }
+								subHeaderText={ __( 'Connect to your Google Analytics account using the Site Kit plugin.' ) }
+								complete={ complete }
+								noBackground
+							/>
 						) }
 					/>
 				</Switch>

--- a/assets/wizards/googleAnalytics/views/googleAnalyticsSetup.js
+++ b/assets/wizards/googleAnalytics/views/googleAnalyticsSetup.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Dashicon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { withWizardScreen, Handoff } from '../../../components/src';
+
+/**
+ * Screen for handing off to Site Kit AdSense setup.
+ */
+class GoogleAnalyticsSetup extends Component {
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const { complete } = this.props;
+
+		return(
+			<Fragment>
+				{ complete && (
+					<div className='newspack-google-analytics-wizard__success'>
+						<Dashicon icon="yes-alt" />
+						<h4>{ __( 'Google Analytics is set up' ) }</h4>
+					</div>
+				) }
+				<Handoff
+					plugin='google-site-kit'
+					editLink='admin.php?page=googlesitekit-module-analytics'
+					className='is-centered'
+					isPrimary={ ! complete }
+					isDefault={ !! complete }
+				>{ complete ? __( 'Google Analytics Settings' ) : __( 'Set up Google Analytics' ) }</Handoff>
+			</Fragment>
+		);
+	}
+}
+
+export default withWizardScreen( GoogleAnalyticsSetup );

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -43,8 +43,8 @@ class PerformanceWizard extends Component {
 	};
 
 	getSettings() {
-		const { setError } = this.props;
-		return apiFetch( { path: '/newspack/v1/wizard/performance' } )
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( { path: '/newspack/v1/wizard/performance' } )
 			.then( settings => {
 				this.setState( { settings } );
 			} )
@@ -54,7 +54,7 @@ class PerformanceWizard extends Component {
 	}
 
 	updateSettings( ...fields ) {
-		const { setError } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		const { settings } = this.state;
 		const submitSettings = Object.keys( settings ).reduce(
 			( submitSettings, key ) =>
@@ -64,7 +64,7 @@ class PerformanceWizard extends Component {
 			{}
 		);
 		return new Promise( ( resolve, reject ) => {
-			apiFetch( {
+			wizardApiFetch( {
 				path: '/newspack/v1/wizard/performance',
 				method: 'POST',
 				data: { settings: submitSettings },

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -51,11 +51,11 @@ class SetupWizard extends Component {
 	};
 
 	updateProfile = () => {
-		const { setError } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		const { profile } = this.state;
 		const params = { path: '/newspack/v1/profile/', method: 'POST', data: { profile } };
 		return new Promise( ( resolve, reject ) => {
-			apiFetch( params )
+			wizardApiFetch( params )
 				.then( response => {
 					const { profile } = response;
 					this.setState( { profile }, () => resolve( response ) );
@@ -69,10 +69,10 @@ class SetupWizard extends Component {
 	};
 
 	retrieveProfile = () => {
-		const { setError } = this.props;
+		const { setError, wizardApiFetch } = this.props;
 		const params = { path: '/newspack/v1/profile/', method: 'GET' };
 		return new Promise( ( resolve, reject ) => {
-			apiFetch( params )
+			wizardApiFetch( params )
 				.then( response => {
 					const { profile, currencies, countries } = response;
 					this.setState( { profile, currencies, countries }, () => resolve( response ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR updates the existing wizards that don't have loading handling yet to use `withWizard`'s loading handling. As part of this work, I had to do some minor refactoring around the Site Kit handoff wizards to make them official wizardScreens instead of loose conglomerations of components. 

There should be loading UI in all the wizards where needed after this PR.

### How to test the changes in this Pull Request:

Go through the following wizards and observe loading UI when a screen loads or is saved:
1. AdSense wizard
2. Ad Manager wizard
3. Analytics wizard
4. Performance wizard
5. Setup wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->