### PR TITLE
Tweak Subscriptions and Ad Manager wizard buttons to better match designs.

### DIFF
--- a/assets/wizards/googleAdManager/index.js
+++ b/assets/wizards/googleAdManager/index.js
@@ -5,14 +5,14 @@
 /**
  * WordPress dependencies
  */
-import { Component, render } from '@wordpress/element';
+import { Component, render, Fragment } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { withWizard } from '../../components/src';
+import { withWizard, Button } from '../../components/src';
 import ManageAdUnitsScreen from './views/manageAdUnitsScreen';
 import EditAdUnitScreen from './views/editAdUnitsScreen';
 
@@ -140,27 +140,36 @@ class GoogleAdManagerWizard extends Component {
 						path="/"
 						exact
 						render={ routeProps => (
-							<ManageAdUnitsScreen
-								headerText={
-									Object.values( adUnits ).length
-										? __( 'Any more ad units to add?' )
-										: __( 'Add your first ad unit.' )
-								}
-								subHeaderText={ __(
-									'Paste your ad code from Google Ad Manager and give it a descriptive name.'
-								) }
-								adUnits={ Object.values( adUnits ) }
-								onClickDeleteAdUnit={ adUnit =>
-									this.deleteAdUnit( adUnit.id )
-								}
-								buttonText={
-									adUnits.length
-										? __( 'Add another ad unit' )
-										: __( 'Add an ad unit' )
-								}
-								buttonAction="#/create"
-								noBackground
-							/>
+							<Fragment>
+								<ManageAdUnitsScreen
+									headerText={
+										Object.values( adUnits ).length
+											? __( 'Any more ad units to add?' )
+											: __( 'Add your first ad unit.' )
+									}
+									subHeaderText={ __(
+										'Paste your ad code from Google Ad Manager and give it a descriptive name.'
+									) }
+									adUnits={ Object.values( adUnits ) }
+									onClickDeleteAdUnit={ adUnit =>
+										this.deleteAdUnit( adUnit.id )
+									}
+									buttonText={
+										adUnits.length
+											? __( 'Add another ad unit' )
+											: __( 'Add an ad unit' )
+									}
+									buttonAction="#/create"
+									noBackground
+								/>
+								<Button
+									isTertiary
+									className='is-centered'
+									href={ newspack_urls[ 'checklists' ][ 'advertising' ] }
+								>
+									{ __( 'Back to checklist' ) }
+								</Button>
+							</Fragment>
 						) }
 					/>
 					<Route
@@ -179,6 +188,7 @@ class GoogleAdManagerWizard extends Component {
 											);
 										} )
 									}
+									noBackground
 								/>
 							);
 						} }
@@ -205,6 +215,7 @@ class GoogleAdManagerWizard extends Component {
 											);
 										} )
 									}
+									noBackground
 								/>
 							);
 						} }
@@ -219,11 +230,7 @@ class GoogleAdManagerWizard extends Component {
 
 render(
 	createElement(
-		withWizard( GoogleAdManagerWizard ),
-		{
-			buttonText: __( 'Back to checklist' ),
-			buttonAction: newspack_urls[ 'checklists' ][ 'advertising' ],
-		}
+		withWizard( GoogleAdManagerWizard )
 	),
 	document.getElementById( 'newspack-google-ad-manager-wizard' )
 );

--- a/assets/wizards/googleAdManager/views/editAdUnitsScreen.js
+++ b/assets/wizards/googleAdManager/views/editAdUnitsScreen.js
@@ -46,16 +46,18 @@ class EditAdUnitScreen extends Component {
 		const editing_existing_ad_unit = !! id;
 		return (
 			<Fragment>
-				<TextControl
-					label={ __( 'What is this ad unit called?' ) }
-					value={ name }
-					onChange={ value => this.handleOnChange( 'name', value ) }
-				/>
-				<TextareaControl
-					label={ __( 'Paste the ad code from Google Ad Manager here' ) }
-					value={ code }
-					onChange={ value => this.handleOnChange( 'code', value ) }
-				/>
+				<Card>
+					<TextControl
+						label={ __( 'What is this ad unit called?' ) }
+						value={ name }
+						onChange={ value => this.handleOnChange( 'name', value ) }
+					/>
+					<TextareaControl
+						label={ __( 'Paste the ad code from Google Ad Manager here' ) }
+						value={ code }
+						onChange={ value => this.handleOnChange( 'code', value ) }
+					/>
+				</Card>
 				<Button isPrimary className="is-centered" onClick={ () => onClickSave( adUnit ) }>
 					{ __( 'Save' ) }
 				</Button>

--- a/assets/wizards/subscriptions/index.js
+++ b/assets/wizards/subscriptions/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { Component, render } from '@wordpress/element';
+import { Component, render, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  */
 import ManageSubscriptionsScreen from './views/manageSubscriptionsScreen';
 import EditSubscriptionScreen from './views/editSubscriptionScreen';
-import { withWizard } from '../../components/src';
+import { withWizard, Button } from '../../components/src';
 import './style.scss';
 
 /**
@@ -201,29 +201,38 @@ class SubscriptionsWizard extends Component {
 						path="/"
 						exact
 						render={ routeProps => (
-							<ManageSubscriptionsScreen
-								headerText={
-									Object.values( subscriptions ).length
-										? __( 'Any more subscriptions to add?' )
-										: __( 'Add your first subscription' )
-								}
-								subHeaderText={ __(
-									'Subscriptions can provide a stable, recurring source of revenue'
-								) }
-								subscriptions={ Object.values( subscriptions ) }
-								choosePrice={ choosePrice }
-								onClickDeleteSubscription={ subscription =>
-									this.deleteSubscription( subscription.id )
-								}
-								onClickChoosePrice={ () => this.toggleChoosePrice() }
-								buttonText={
-									subscriptions.length
-										? __( 'Add another subscription' )
-										: __( 'Add a subscription' )
-								}
-								buttonAction="#/create"
-								noBackground
-							/>
+							<Fragment>
+								<ManageSubscriptionsScreen
+									headerText={
+										Object.values( subscriptions ).length
+											? __( 'Any more subscriptions to add?' )
+											: __( 'Add your first subscription' )
+									}
+									subHeaderText={ __(
+										'Subscriptions can provide a stable, recurring source of revenue'
+									) }
+									subscriptions={ Object.values( subscriptions ) }
+									choosePrice={ choosePrice }
+									onClickDeleteSubscription={ subscription =>
+										this.deleteSubscription( subscription.id )
+									}
+									onClickChoosePrice={ () => this.toggleChoosePrice() }
+									buttonText={
+										subscriptions.length
+											? __( 'Add another subscription' )
+											: __( 'Add a subscription' )
+									}
+									buttonAction="#/create"
+									noBackground
+								/>
+								<Button 
+									isTertiary 
+									className='is-centered' 
+									href={ newspack_urls[ 'checklists' ][ 'reader-revenue' ] }
+								>
+									{ __( 'Back to checklist' ) }
+								</Button>
+							</Fragment>
 						) }
 					/>
 					<Route
@@ -242,6 +251,7 @@ class SubscriptionsWizard extends Component {
 											).then( () => this.markWizardComplete() );
 										} )
 									}
+									noBackground
 								/>
 							);
 						} }
@@ -270,6 +280,7 @@ class SubscriptionsWizard extends Component {
 											).then( () => this.markWizardComplete() );
 										} )
 									}
+									noBackground
 								/>
 							);
 						} }
@@ -288,11 +299,7 @@ render(
 			'woocommerce-subscriptions',
 			'woocommerce-name-your-price',
 			'woocommerce-one-page-checkout',
-		] ),
-		{
-			buttonText: __( 'Back to checklist' ),
-			buttonAction: newspack_urls[ 'checklists' ][ 'reader-revenue' ],
-		}
+		] )
 	),
 	document.getElementById( 'newspack-subscriptions-wizard' )
 );

--- a/assets/wizards/subscriptions/views/editSubscriptionScreen.js
+++ b/assets/wizards/subscriptions/views/editSubscriptionScreen.js
@@ -52,34 +52,36 @@ class EditSubscriptionScreen extends Component {
 		const editing_existing_subscription = !! id;
 		return (
 			<div className="newspack-edit-subscription-screen">
-				<TextControl
-					label={ __( 'What is this product called? e.g. Valued Donor' ) }
-					value={ name }
-					onChange={ value => this.handleOnChange( 'name', value ) }
-				/>
-				<ImageUpload
-					image={ image }
-					onChange={ value => this.handleOnChange( 'image', value ) }
-				/>
-				<div className="newspack-edit-subscription-screen__price-settings">
+				<Card>
 					<TextControl
-						type="number"
-						step="0.01"
-						label={ __( 'Price' ) }
-						value={ price }
-						onChange={ value => this.handleOnChange( 'price', value ) }
+						label={ __( 'What is this product called? e.g. Valued Donor' ) }
+						value={ name }
+						onChange={ value => this.handleOnChange( 'name', value ) }
 					/>
-					<SelectControl
-						label={ __( 'Frequency' ) }
-						value={ frequency }
-						options={ [
-							{ value: 'month', label: __( 'per month' ) },
-							{ value: 'year', label: __( 'per year' ) },
-							{ value: 'once', label: __( 'once' ) },
-						] }
-						onChange={ value => this.handleOnChange( 'frequency', value ) }
+					<ImageUpload
+						image={ image }
+						onChange={ value => this.handleOnChange( 'image', value ) }
 					/>
-				</div>
+					<div className="newspack-edit-subscription-screen__price-settings">
+						<TextControl
+							type="number"
+							step="0.01"
+							label={ __( 'Price' ) }
+							value={ price }
+							onChange={ value => this.handleOnChange( 'price', value ) }
+						/>
+						<SelectControl
+							label={ __( 'Frequency' ) }
+							value={ frequency }
+							options={ [
+								{ value: 'month', label: __( 'per month' ) },
+								{ value: 'year', label: __( 'per year' ) },
+								{ value: 'once', label: __( 'once' ) },
+							] }
+							onChange={ value => this.handleOnChange( 'frequency', value ) }
+						/>
+					</div>
+				</Card>
 				<Button isPrimary className="is-centered" onClick={ () => onClickSave( subscription ) }>
 					{ __( 'Save' ) }
 				</Button>


### PR DESCRIPTION
### All Submissions:

*  [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #136  .

This PR updates the Subscriptions and Ad Manager wizards to match the changes in #136: When editing there are "Save" and "Cancel" buttons, and when managing there are "Add" and "Back to checklist" buttons.

![localhost_wp-admin_admin php_page=newspack-subscriptions-wizard (6)](https://user-images.githubusercontent.com/7317227/60988551-af691780-a2f8-11e9-9061-bac149d494c4.png)
![localhost_wp-admin_admin php_page=newspack-subscriptions-wizard (5)](https://user-images.githubusercontent.com/7317227/60988548-ae37ea80-a2f8-11e9-87d3-1725fc973069.png)

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. Go to Subscriptions and Ad Manager wizards and verify things look good and still work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->