### PR TITLE
Fix Ad Unit Titles

### DIFF
--- a/includes/wizards/class-google-ad-manager-wizard.php
+++ b/includes/wizards/class-google-ad-manager-wizard.php
@@ -245,7 +245,7 @@ class Google_Ad_Manager_Wizard extends Wizard {
 				$query->the_post();
 				$ad_units[] = [
 					'id'   => \get_the_ID(),
-					'name' => \get_the_title(),
+					'name' => html_entity_decode( \get_the_title() ),
 					'code' => \get_post_meta( get_the_ID(), 'newspack_ad_code', true ),
 				];
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes mangled Ad Unit titles when there's an `x` in them, e.g. "Ad Unit 300x60" 

Closes https://github.com/Automattic/newspack-blocks/issues/51

Before:

<img width="1515" alt="Screen Shot 2019-07-10 at 3 08 41 PM" src="https://user-images.githubusercontent.com/1477002/60997550-1270a380-a325-11e9-9728-e73ffc9cfcb0.png">

After:

<img width="1515" alt="Screen Shot 2019-07-10 at 3 09 05 PM" src="https://user-images.githubusercontent.com/1477002/60997561-169cc100-a325-11e9-91ff-11b11e09dad1.png">

### How to test the changes in this Pull Request:

1. On `master` branch, navigate to Google Ad Manager Widget, and create an Ad Unit. Name it "Ad Unit 300x200" and Save.
2. Observe that the title contains raw ASCII code.
3. Switch to this branch, run `npm ci && npm run clean && npm run build:webpack`
4. Refresh the page. Observe the title displays correctly.

This fix will also apply to the Ad Unit Select control in the Google Ad Manager block: https://github.com/Automattic/newspack-blocks/pull/39

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->