### PR TITLE
Fix Grid style issues

### DIFF
--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -13,7 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies.
  */
-import { Button, Card, FormattedHeader, Modal, NewspackLogo, PluginInstaller } from '../';
+import { Button, Card, FormattedHeader, Modal, NewspackLogo, PluginInstaller, Grid } from '../';
 import { buttonProps } from '../../../shared/js/';
 import './style.scss';
 
@@ -195,7 +195,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 				return <Redirect from="/plugin-requirements" to="/" />;
 			}
 			return (
-				<Fragment>
+				<Grid>
 					<Route
 						path="/"
 						render={ routeProps => (
@@ -213,7 +213,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 							</Card>
 						) }
 					/>
-				</Fragment>
+				</Grid>
 			);
 		};
 

--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -7,7 +7,6 @@
 }
 
 .newspack-dashboard-tier {
-	display: flex;
 	justify-content: center;
 	padding-bottom: 1em;
 	position: relative;
@@ -16,11 +15,14 @@
 	&::after {
 		content: '';
 		height: 1px;
-		max-width: 745px;
-		width: 100%;
+		width: 50%;
 		background-color: $muriel-gray-50;
 		position: absolute;
 		bottom: 0;
+		margin-left: auto;
+		margin-right: auto;
+		left: 0;
+		right: 0;
 	}
 
 	&:last-of-type::after {
@@ -28,13 +30,11 @@
 	}
 }
 
-.newspack-dashboard-card {
-	margin: 1em;
-	max-width: 330px;
-	width: 100%;
+.newspack-dashboard-card.muriel-grid-item {
+	grid-column: auto / span 4;
+	margin-bottom: 0;
 	text-align: center;
 	position: relative;
-	box-sizing: border-box;
 	box-shadow: 0px 1px 3px rgba( 0, 0, 0, 0.2 ), 0px 2px 2px rgba( 0, 0, 0, 0.12 ),
 		0px 0px 2px rgba( 0, 0, 0, 0.14 );
 
@@ -91,16 +91,32 @@
 	}
 }
 
-@media ( max-width: 600px ) {
+@media screen and ( min-width: 661px ) {
+	.newspack-dashboard-tier.items-2 {
+		.newspack-dashboard-card.muriel-grid-item:first-of-type {
+			grid-column-start: 3;
+		}
+	}
+}
+
+@media screen and ( min-width: 661px ) and ( max-width: 1040px ) {
+	.newspack-dashboard-card.muriel-grid-item {
+		grid-column: auto / span 2;
+
+		&:first-of-type {
+			grid-column: 2 / span 2;
+		}
+	}
+}
+
+@media screen and ( max-width: 660px ) {
+	.newspack-dashboard-card.muriel-grid-item {
+		grid-column: 1 / span 4;
+		margin-bottom: .5em;
+		margin-top: .5em;
+	}
+
 	.newspack_dashboard__header {
 		margin-right: 14px;
-	}
-
-	.newspack-dashboard-tier {
-		display: block;
-	}
-
-	.newspack-dashboard-card {
-		max-width: calc( 100% - 3em );
 	}
 }

--- a/assets/wizards/dashboard/views/tier.js
+++ b/assets/wizards/dashboard/views/tier.js
@@ -6,6 +6,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -22,8 +23,9 @@ class Tier extends Component {
 	render() {
 		const { items } = this.props;
 
+		const classes = classnames( 'newspack-dashboard-tier', 'muriel-grid-container', 'items-' + items.length );
 		return (
-			<div className="newspack-dashboard-tier">
+			<div className={ classes }>
 				{ items.map( card => (
 					<DashboardCard { ...card } key={ card.slug } />
 				) ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes a couple lingering style issues from the Muriel Grid implementation:
- Align/size dashboard cards to the grid
- Align/size the required plugins installer to the grid

### How to test the changes in this Pull Request:

1. `npm run clean; npm run build:webpack`
2. Go to dashboard. Verify things look nice at all breakpoints. Verify things match to grid at all breakpoints.
3. Go to a wizard with a required plugin that you don't have active. Verify the required plugins screen matches the grid nicely.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->