### PR TITLE
Switch newspack-gam to newspack-ads.

### DIFF
--- a/assets/wizards/googleAdManager/index.js
+++ b/assets/wizards/googleAdManager/index.js
@@ -219,6 +219,6 @@ class GoogleAdManagerWizard extends Component {
 }
 
 render(
-	createElement( withWizard( GoogleAdManagerWizard, [ 'newspack-gam' ] ) ),
+	createElement( withWizard( GoogleAdManagerWizard, [ 'newspack-ads' ] ) ),
 	document.getElementById( 'newspack-google-ad-manager-wizard' )
 );

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -31,15 +31,15 @@ class Plugin_Manager {
 				'Author'      => 'Automattic',
 				'PluginURI'   => 'https://newspack.blog',
 				'AuthorURI'   => 'https://automattic.com',
-				'Download'    => 'https://github.com/Automattic/newspack-gam/releases/latest/download/newspack-gam.zip',
+				'Download'    => 'https://github.com/Automattic/newspack-blocks/releases/latest/download/newspack-blocks.zip',
 			],
-			'newspack-gam'                  => [
-				'Name'        => esc_html__( 'Newspack Google Ad Manager', 'newspack' ),
-				'Description' => esc_html__( 'Google Ad Manager integration.' ),
+			'newspack-ads'                  => [
+				'Name'        => esc_html__( 'Newspack Ads', 'newspack' ),
+				'Description' => esc_html__( 'Ads integration.' ),
 				'Author'      => 'Automattic',
 				'PluginURI'   => 'https://newspack.blog',
 				'AuthorURI'   => 'https://automattic.com',
-				'Download'    => 'https://github.com/Automattic/newspack-blocks/releases/latest/download/newspack-blocks.zip',
+				'Download'    => 'https://github.com/Automattic/newspack-ads/releases/latest/download/newspack-ads.zip',
 			],
 			'jetpack'                       => [
 				'Name'        => __( 'Jetpack', 'newspack' ),

--- a/includes/configuration_managers/class-configuration-managers.php
+++ b/includes/configuration_managers/class-configuration-managers.php
@@ -36,9 +36,9 @@ class Configuration_Managers {
 			'filename'   => 'class-progressive-wp-configuration-manager.php',
 			'class_name' => 'Progressive_WP_Configuration_Manager',
 		],
-		'newspack-gam'    => [
-			'filename'   => 'class-newspack-gam-configuration-manager.php',
-			'class_name' => 'Newspack_GAM_Configuration_Manager',
+		'newspack-ads'    => [
+			'filename'   => 'class-newspack-ads-configuration-manager.php',
+			'class_name' => 'Newspack_Ads_Configuration_Manager',
 		],
 	];
 

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Site Kit plugin configuration manager.
+ * Newspack Ads Configuration Manager
  *
  * @package Newspack
  */
@@ -12,34 +12,34 @@ defined( 'ABSPATH' ) || exit;
 require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
 
 /**
- * Provide an interface for configuring and querying the configuration of Google Site Kit.
+ * Provide an interface for configuring and querying the configuration of Newspack Ads.
  */
-class Newspack_GAM_Configuration_Manager extends Configuration_Manager {
+class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 
 	/**
 	 * The slug of the plugin.
 	 *
 	 * @var string
 	 */
-	public $slug = 'newspack-gam';
+	public $slug = 'newspack-ads';
 
 	/**
 	 * Get whether the Site Kit plugin is active and set up.
 	 *
-	 * @return bool Whether Newspack Google Ad Manager is installed and activated.
+	 * @return bool Whether Newspack Ads is installed and activated.
 	 */
 	public function is_configured() {
-		return class_exists( 'Newspack_GAM_Model' );
+		return class_exists( 'Newspack_Ads_Model' );
 	}
 
 	/**
 	 * Get the ad units from our saved option.
 	 *
-	 * @return array | WP_Error Array of ad units or WP_Error if Newspack Google Ad Manager isn't installed and activated.
+	 * @return array | WP_Error Array of ad units or WP_Error if Newspack Ads isn't installed and activated.
 	 */
 	public function get_ad_units() {
 		return $this->is_configured() ?
-			\Newspack_GAM_Model::get_ad_units() :
+			\Newspack_Ads_Model::get_ad_units() :
 			$this->unconfigured_error();
 	}
 
@@ -51,7 +51,7 @@ class Newspack_GAM_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_ad_unit( $id ) {
 		return $this->is_configured() ?
-			\Newspack_GAM_Model::get_ad_unit( $id ) :
+			\Newspack_Ads_Model::get_ad_unit( $id ) :
 			$this->unconfigured_error();
 	}
 
@@ -63,7 +63,7 @@ class Newspack_GAM_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function add_ad_unit( $ad_unit ) {
 		return $this->is_configured() ?
-			\Newspack_GAM_Model::add_ad_unit( $ad_unit ) :
+			\Newspack_Ads_Model::add_ad_unit( $ad_unit ) :
 			$this->unconfigured_error();
 	}
 
@@ -75,7 +75,7 @@ class Newspack_GAM_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function update_ad_unit( $ad_unit ) {
 		return $this->is_configured() ?
-			\Newspack_GAM_Model::update_ad_unit( $ad_unit ) :
+			\Newspack_Ads_Model::update_ad_unit( $ad_unit ) :
 			$this->unconfigured_error();
 	}
 
@@ -87,7 +87,7 @@ class Newspack_GAM_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function delete_ad_unit( $id ) {
 		return $this->is_configured() ?
-			\Newspack_GAM_Model::delete_ad_unit( $id ) :
+			\Newspack_Ads_Model::delete_ad_unit( $id ) :
 			$this->unconfigured_error();
 	}
 
@@ -99,7 +99,7 @@ class Newspack_GAM_Configuration_Manager extends Configuration_Manager {
 	private function unconfigured_error() {
 		return new \WP_Error(
 			'newspack_missing_required_plugin',
-			esc_html__( 'The Newspack Google Ad Manager plugin is not installed and activated. Install and/or activate it to access this feature.', 'newspack' ),
+			esc_html__( 'The Newspack Ads plugin is not installed and activated. Install and/or activate it to access this feature.', 'newspack' ),
 			[
 				'status' => 400,
 				'level'  => 'fatal',
@@ -108,8 +108,7 @@ class Newspack_GAM_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
-	 * Configure Site Kit for Newspack use.
-	 * This can't actually do anything, since Site Kit is partially set up in Google.
+	 * Configure Newspack Ads for Newspack use.
 	 *
 	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
 	 */

--- a/includes/wizards/class-google-ad-manager-wizard.php
+++ b/includes/wizards/class-google-ad-manager-wizard.php
@@ -143,7 +143,7 @@ class Google_Ad_Manager_Wizard extends Wizard {
 	 * @return WP_REST_Response containing ad units info.
 	 */
 	public function api_get_adunits() {
-		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-gam' );
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
 		return \rest_ensure_response( $configuration_manager->get_ad_units() );
 	}
 
@@ -154,7 +154,7 @@ class Google_Ad_Manager_Wizard extends Wizard {
 	 * @return WP_REST_Response containing ad unit info.
 	 */
 	public function api_get_adunit( $request ) {
-		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-gam' );
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
 
 		$params = $request->get_params();
 		$id     = $params['id'];
@@ -169,7 +169,7 @@ class Google_Ad_Manager_Wizard extends Wizard {
 	 * @return WP_REST_Response Updated ad unit info.
 	 */
 	public function api_save_adunit( $request ) {
-		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-gam' );
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
 
 		$params = $request->get_params();
 		$adunit = [
@@ -194,7 +194,7 @@ class Google_Ad_Manager_Wizard extends Wizard {
 	 * @return WP_REST_Response Boolean Delete success.
 	 */
 	public function api_delete_adunit( $request ) {
-		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-gam' );
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
 
 		$params = $request->get_params();
 		$id     = $params['id'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/Automattic/newspack-ads/pull/4 the `newspack-gam` plugin has been renamed `newspack-ads`. This PR implements this name change in the Newspack Plugin.

### How to test the changes in this Pull Request:

Complete testing instructions found here: https://github.com/Automattic/newspack-ads/pull/4

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->