### PR TITLE
Move <Grid> wrapper inside the plugin requirements route's render.

### DIFF
--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -41,7 +41,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 				const instance = this.wrappedComponentRef.current;
 				instance && instance.onWizardReady && instance.onWizardReady();
 			}
-		}
+		};
 
 		/**
 		 * Set the error. Called by Wizards when an error occurs.
@@ -151,19 +151,18 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		 */
 		startLoading = () => {
 			this.setState( state => ( {
-				loading: state.loading + 1
+				loading: state.loading + 1,
 			} ) );
-		}
+		};
 
 		/**
 		 * End loading.
 		 */
 		doneLoading = () => {
 			this.setState( state => ( {
-				loading: state.loading - 1
+				loading: state.loading - 1,
 			} ) );
-			
-		}
+		};
 
 		/**
 		 * Replacement for core apiFetch that automatically manages wizard loading UI.
@@ -181,7 +180,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 						reject( error );
 					} );
 			} );
-		}
+		};
 
 		/**
 		 * Render a Route that checks for plugin installation requirements, and redirects to '/' when all are done.
@@ -195,11 +194,11 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 				return <Redirect from="/plugin-requirements" to="/" />;
 			}
 			return (
-				<Grid>
-					<Route
-						path="/"
-						render={ routeProps => (
-							<Card noBackground className='muriel-wizardScreen muriel-wizardScreen__no-background'>
+				<Route
+					path="/"
+					render={ routeProps => (
+						<Grid>
+							<Card noBackground className="muriel-wizardScreen muriel-wizardScreen__no-background">
 								{ complete !== null && (
 									<FormattedHeader
 										headerText={ __( 'Required plugin' ) }
@@ -211,9 +210,9 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 									onStatus={ status => this.pluginInstallationStatus( status ) }
 								/>
 							</Card>
-						) }
-					/>
-				</Grid>
+						</Grid>
+					) }
+				/>
 			);
 		};
 
@@ -228,8 +227,12 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 			return (
 				<Fragment>
 					{ this.getError() }
-					<NewspackLogo width={ fullLogo ? 240 : 50 } compact={ ! fullLogo } className="newspack-logo" />
-					<div className={ !! loading ? 'muriel-wizardScreen__loading' : '' } >
+					<NewspackLogo
+						width={ fullLogo ? 240 : 50 }
+						compact={ ! fullLogo }
+						className="newspack-logo"
+					/>
+					<div className={ !! loading ? 'muriel-wizardScreen__loading' : '' }>
 						<WrappedComponent
 							pluginRequirements={ requiredPlugins && this.pluginRequirements() }
 							clearError={ this.clearError }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This addresses a React warning. In `withWizard` the plugin requirements `<Route>` is wrapped by a `<Grid>` component, which leads to this warning in the console:

```
react-dom.165d5c53.js:500 Warning: React does not recognize the `computedMatch` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `computedmatch` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by Grid)
    in Grid (created by _temp)
    in Switch (created by GoogleAdManagerWizard)
    in Router (created by HashRouter)
    in HashRouter (created by GoogleAdManagerWizard)
    in GoogleAdManagerWizard (created by _temp)
    in div (created by _temp)
    in _temp
```

This PR moves the `<Grid>` component into the `<Route>`'s render method, resolving the issue.

### How to test the changes in this Pull Request:

1. On `master` branch, navigate to any Wizard. 
2. Observe the React warning in the Javascript console.
3. Branch switch to `fix/plugin-requirements-grid-wrap` and execute `npm run build:webpack`
4. Refresh the page and observe the error goes away.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->