### PR TITLE
Action Card Toggle Control

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { Component } from '@wordpress/element';
-import { Dashicon, Spinner } from '@wordpress/components';
+import { Dashicon, Spinner, ToggleControl } from '@wordpress/components';
 import { Button, Card } from '../';
 
 /**
@@ -45,6 +45,8 @@ class ActionCard extends Component {
 			onClick,
 			onSecondaryActionClick,
 			isWaiting,
+			toggleChecked,
+			toggleOnChange,
 		} = this.props;
 		const classes = murielClassnames( 'newspack-action-card', simple && 'is_clickable', className );
 		const notificationClasses = classnames(
@@ -59,7 +61,13 @@ class ActionCard extends Component {
 		return (
 			<Card className={ classes } onClick={ simple && onClick }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
-					{ image && (
+					{ toggleOnChange && (
+						<ToggleControl
+							checked={ toggleChecked }
+							onChange={ toggleOnChange }
+						/>
+					) }
+					{ image && ! toggleOnChange && (
 						<div className="newspack-action-card__region newspack-action-card__region-left">
 							<a href={ imageLink }>
 								<div
@@ -113,6 +121,10 @@ class ActionCard extends Component {
 			</Card>
 		);
 	}
+}
+
+ActionCard.defaultProps = {
+	toggleChecked: false,
 }
 
 export default ActionCard;

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -5,13 +5,13 @@
 @import '../../../shared/scss/muriel-component';
 
 .newspack-action-card {
-
 	/* General styles */
 
 	color: $muriel-gray-300;
 	font-size: 14px;
 
-	h1, h2 {
+	h1,
+	h2 {
 		font-weight: normal;
 		margin: 0;
 		padding: 0;
@@ -86,9 +86,19 @@
 		background-repeat: no-repeat;
 		background-size: cover;
 		border: 1px solid $muriel-gray-400;
- 		border-radius: 50%;
- 		height: 32px;
- 		width: 32px;
+		border-radius: 50%;
+		height: 32px;
+		width: 32px;
+	}
+
+	/* ToggleControl */
+
+	.components-toggle-control {
+		align-self: center;
+		margin-right: 1em;
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
 	}
 
 	/* Buttons */
@@ -110,5 +120,4 @@
 	&:hover button.newspack-action-card__secondary_button {
 		visibility: visible;
 	}
-
 }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -79,20 +79,19 @@ class ComponentsDemo extends Component {
 			selectValue2,
 			modalShown,
 			showPluginInstallerWithProgressBar,
+			actionCardToggleChecked,
 		} = this.state;
 
 		return (
 			<Fragment>
-				<NewspackLogo width='250' className='newspack-components-demo_logo' />
+				<NewspackLogo width="250" className="newspack-components-demo_logo" />
 				<FormattedHeader
 					headerText={ __( 'Newspack Components' ) }
 					subHeaderText={ __( 'Temporary demo of Newspack components' ) }
 				/>
 				<Grid>
 					<Card>
-						<FormattedHeader
-							headerText={ __( 'Handoff Buttons' ) }
-						/>
+						<FormattedHeader headerText={ __( 'Handoff Buttons' ) } />
 						<Handoff
 							className="is-centered"
 							modalTitle="Manage AMP"
@@ -168,7 +167,12 @@ class ComponentsDemo extends Component {
 							] }
 							canUninstall
 							onStatus={ ( { complete, pluginInfo } ) => {
-								console.log( complete ? 'All plugins installed successfully' : 'Plugin installation incomplete', pluginInfo );
+								console.log(
+									complete
+										? 'All plugins installed successfully'
+										: 'Plugin installation incomplete',
+									pluginInfo
+								);
 							} }
 						/>
 					</Card>
@@ -176,7 +180,12 @@ class ComponentsDemo extends Component {
 						<PluginInstaller
 							plugins={ [ 'woocommerce', 'amp', 'wordpress-seo' ] }
 							onStatus={ ( { complete, pluginInfo } ) => {
-								console.log( complete ? 'All plugins installed successfully' : 'Plugin installation incomplete', pluginInfo );
+								console.log(
+									complete
+										? 'All plugins installed successfully'
+										: 'Plugin installation incomplete',
+									pluginInfo
+								);
 							} }
 						/>
 					</Card>
@@ -232,7 +241,11 @@ class ComponentsDemo extends Component {
 						}
 						notificationLevel="warning"
 					/>
-					<ActionCard title="Example Six" description="Static text, no button" actionText="Active" />
+					<ActionCard
+						title="Example Six"
+						description="Static text, no button"
+						actionText="Active"
+					/>
 					<ActionCard
 						title="Example Seven"
 						description="Static text, secondary action button."
@@ -251,6 +264,16 @@ class ComponentsDemo extends Component {
 						} }
 						image="//s1.wp.com/wp-content/themes/h4/landing/marketing/pages/hp-jan-2019/media/man-with-shadow.jpg"
 						imageLink="https://wordpress.com"
+					/>
+					<ActionCard
+						title="Example Nine"
+						description="Action Card with Toggle Control."
+						actionText={ actionCardToggleChecked && "Set Up" }
+						onClick={ () => {
+							console.log( 'Set Up' );
+						} }
+						toggleOnChange={ checked => this.setState( { actionCardToggleChecked: checked } ) }
+						toggleChecked={ actionCardToggleChecked }
 					/>
 					<FormattedHeader headerText={ __( 'Checklist' ) } />
 					<Checklist progressBarText={ __( 'Your setup list' ) } className="muriel-grid-item">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds an optional toggle to the left side of `ActionCard`. This is a UI pattern @sonjaleix has been using instead of checklists. The first use is in the Advertising wizard. 

There are two new `ActionCard` props:

- `toggleChecked`: The state of the toggle.
- `toggleOnChange`: An `onChange` handler for the toggle. The `ToggleControl` will only be rendered if `toggleOnChange` is set.

Note that `toggleOnChange` takes precedence over `image`. If both are set, the toggle will be rendered and the image will not. 

<img width="689" alt="Screen Shot 2019-07-20 at 7 46 57 AM" src="https://user-images.githubusercontent.com/1477002/61578311-c5c65e80-aac2-11e9-8de9-7a7210469634.png">

<img width="697" alt="Screen Shot 2019-07-20 at 7 47 03 AM" src="https://user-images.githubusercontent.com/1477002/61578312-ca8b1280-aac2-11e9-8fed-85cf30ddde1e.png">

### How to test the changes in this Pull Request:

1. `npm ci && npm run clean && npm run build:webpack`
2. Navigate to Components Demo and observe the new example `ActionCard` with toggle.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->