### PR TITLE
Tabbed Navigation

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -13,6 +13,7 @@ export { default as NewspackLogo } from './newspack-logo';
 export { default as PluginInstaller } from './plugin-installer';
 export { default as ProgressBar } from './progress-bar';
 export { default as SelectControl } from './select-control';
+export { default as TabbedNavigation } from './tabbed-navigation';
 export { default as Task } from './task';
 export { default as TextControl } from './text-control';
 export { default as withWizard } from './with-wizard';

--- a/assets/components/src/tabbed-navigation/index.js
+++ b/assets/components/src/tabbed-navigation/index.js
@@ -1,0 +1,52 @@
+/**
+ * Tabbed Navigation
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import murielClassnames from '../../../shared/js/muriel-classnames';
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+import { NavLink } from 'react-router-dom';
+
+/**
+ * Internal dependencies.
+ */
+import './style.scss';
+
+/**
+ * Progress bar.
+ */
+class TabbedNavigation extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { items, className } = this.props;
+		const classes = murielClassnames( 'muriel-tabbed-navigation', 'muriel-grid-item', className );
+		return (
+			<div className={ classes }>
+				<ul>
+					{ items.map( ( item, key ) => (
+						<li key={ key }>
+							<NavLink to={ item.path } exact={ item.exact } activeClassName="selected">
+								{ item.label }
+							</NavLink>
+						</li>
+					) ) }
+				</ul>
+			</div>
+		);
+	}
+}
+
+export default TabbedNavigation;

--- a/assets/components/src/tabbed-navigation/style.scss
+++ b/assets/components/src/tabbed-navigation/style.scss
@@ -1,0 +1,32 @@
+/**
+ * Progress bar styles.
+ */
+
+@import '../../../shared/scss/muriel-component';
+
+.muriel-tabbed-navigation {
+	margin-bottomn: 0;
+	box-shadow: none;
+	background: transparent;
+	padding: 0;
+	ul {
+		margin: 0;
+		border-bottom: 1px solid $muriel-gray-100;
+	}
+	a {
+		color: black;
+		display: inline-block;
+		font-size: 12px;
+		margin: 0;
+		padding: 0 2em 1em 2em;
+		text-decoration: none;
+		&.selected {
+			border-bottom: 2px solid $primary_color;
+		}
+	}
+	li {
+		margin: 0;
+		padding: 0;
+		display: inline-block;
+	}
+}

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -10,7 +10,7 @@ import { Component, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies.
  */
-import { Button, Card, FormattedHeader, Handoff, Grid } from '../';
+import { Button, Card, FormattedHeader, Handoff, Grid, TabbedNavigation } from '../';
 import { murielClassnames, buttonProps } from '../../../shared/js/';
 import './style.scss';
 
@@ -26,6 +26,7 @@ export default function withWizardScreen( WrappedComponent, config ) {
 				subHeaderText,
 				noBackground,
 				noCard,
+				tabbedNavigation,
 			} = this.props;
 			const classes = murielClassnames(
 				'muriel-wizardScreen',
@@ -46,6 +47,11 @@ export default function withWizardScreen( WrappedComponent, config ) {
 								<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 							) }
 						</Card>
+						{ tabbedNavigation && (
+							<Card noBackground>
+								<TabbedNavigation items={ tabbedNavigation } />
+							</Card>
+						) }
 					</Grid>
 					{ !! noCard && content }
 					{ ! noCard && (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR creates a `<TabbedNavigation>` component and implements it in `withWizardScreen`. This will be a common navigation style used in most (if not all) wizards.

<img width="1325" alt="Screen Shot 2019-07-20 at 1 15 56 PM" src="https://user-images.githubusercontent.com/1477002/61581793-b5c57380-aaf0-11e9-8391-e32b2e7ab1d5.png">

### How to test the changes in this Pull Request:

Tabbed Navigation isn't actually used in any Wizards in this PR, so the best way to test is to add the following prop to both Wizard Screens in the Subscription Onboarding wizard and give it a try. You should see results like the screenshot above:

```
tabbedNavigation={ [
  {
    label: __( 'Step 1' ),
    path: '/',
    exact: true,
  },
  {
    label: __( 'Step 2' ),
    path: '/stripe',
  },
] }
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->