### PR TITLE
Add API Fetch Dependency To Wizards

### DIFF
--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -90,7 +90,7 @@ class Components_Demo extends Wizard {
 		wp_enqueue_script(
 			'newspack-components-demo',
 			Newspack::plugin_url() . '/assets/dist/componentsDemo.js',
-			[ 'wp-components' ],
+			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/componentsDemo.js' ),
 			true
 		);

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -178,7 +178,7 @@ class Dashboard extends Wizard {
 		wp_register_script(
 			'newspack-dashboard',
 			Newspack::plugin_url() . '/assets/dist/dashboard.js',
-			[ 'wp-components' ],
+			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/dashboard.js' ),
 			true
 		);

--- a/includes/wizards/class-donations-wizard.php
+++ b/includes/wizards/class-donations-wizard.php
@@ -167,7 +167,7 @@ class Donations_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-donations-wizard',
 			Newspack::plugin_url() . '/assets/dist/donations.js',
-			[ 'wp-components' ],
+			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/donations.js' ),
 			true
 		);

--- a/includes/wizards/class-google-ad-manager-wizard.php
+++ b/includes/wizards/class-google-ad-manager-wizard.php
@@ -215,7 +215,7 @@ class Google_Ad_Manager_Wizard extends Wizard {
 		\wp_enqueue_script(
 			'newspack-google-ad-manager-wizard',
 			Newspack::plugin_url() . '/assets/dist/googleAdManager.js',
-			[ 'wp-components' ],
+			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/googleAdManager.js' ),
 			true
 		);

--- a/includes/wizards/class-google-adsense-wizard.php
+++ b/includes/wizards/class-google-adsense-wizard.php
@@ -136,7 +136,7 @@ class Google_AdSense_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-google-adsense-wizard',
 			Newspack::plugin_url() . '/assets/dist/googleAdSense.js',
-			[ 'wp-components' ],
+			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/googleAdSense.js' ),
 			true
 		);

--- a/includes/wizards/class-google-analytics-wizard.php
+++ b/includes/wizards/class-google-analytics-wizard.php
@@ -136,7 +136,7 @@ class Google_Analytics_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-google-analytics-wizard',
 			Newspack::plugin_url() . '/assets/dist/googleAnalytics.js',
-			[ 'wp-components' ],
+			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/googleAnalytics.js' ),
 			true
 		);

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -192,7 +192,7 @@ class Performance_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-performance-wizard',
 			Newspack::plugin_url() . '/assets/dist/performance.js',
-			[ 'wp-components' ],
+			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/performance.js' ),
 			true
 		);

--- a/includes/wizards/class-reader-revenue-onboarding-wizard.php
+++ b/includes/wizards/class-reader-revenue-onboarding-wizard.php
@@ -519,7 +519,7 @@ class Reader_Revenue_Onboarding_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-reader-revenue-onboarding-wizard',
 			Newspack::plugin_url() . '/assets/dist/readerRevenueOnboarding.js',
-			[ 'wp-components' ],
+			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/readerRevenueOnboarding.js' ),
 			true
 		);

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -108,7 +108,7 @@ class Setup_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-setup-wizard',
 			Newspack::plugin_url() . '/assets/dist/setup.js',
-			[ 'wp-components' ],
+			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/setup.js' ),
 			true
 		);

--- a/includes/wizards/class-subscriptions-wizard.php
+++ b/includes/wizards/class-subscriptions-wizard.php
@@ -395,7 +395,7 @@ class Subscriptions_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-subscriptions-wizard',
 			Newspack::plugin_url() . '/assets/dist/subscriptions.js',
-			[ 'wp-components' ],
+			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/subscriptions.js' ),
 			true
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With the Gutenberg plugin installed, `wp-api-fetch` is not always loaded which causes Newspack wizards to fail. The bug can be hard to see since other other plugins load it, so the recommended testing flow involves removing all plugins except Newspack and Gutenberg. 

Closes #198 .

### How to test the changes in this Pull Request:

1. Keeping Newspack on `master`, install the Gutenberg plugin and disable all other plugins except for Newspack & Gutenberg.
2. Navigate to any Wizard. You should see a Javascript error and the wizard freezes on the loading screen. 
3. Switch Newspack to `fix/api-fetch-dependency`
4. Try all wizards. They should all load successfully.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->