### PR TITLE
Show Feature Areas In Admin Menu

### DIFF
--- a/includes/class-checklists.php
+++ b/includes/class-checklists.php
@@ -59,7 +59,6 @@ class Checklists {
 
 		add_action( 'admin_menu', 'Newspack\Checklists::add_page' );
 		add_action( 'admin_enqueue_scripts', 'Newspack\Checklists::enqueue_scripts_and_styles' );
-		add_action( 'admin_head', 'Newspack\Checklists::hide_from_menus' );
 	}
 
 	/**
@@ -166,7 +165,7 @@ class Checklists {
 	 * Register and add the page that the checklists will live on.
 	 */
 	public static function add_page() {
-		add_submenu_page( 'newspack', 'Checklist', 'Checklist', 'manage_options', 'newspack-checklist', 'Newspack\Checklists::render_checklist' );
+		add_submenu_page( null, 'Checklist', 'Checklist', 'manage_options', 'newspack-checklist', 'Newspack\Checklists::render_checklist' );
 	}
 
 	/**
@@ -177,20 +176,6 @@ class Checklists {
 		<div id="newspack-checklist" class="newspack-checklist">
 		</div>
 		<?php
-	}
-
-	/**
-	 * Hide a link to the submenu page from the Newspack menu.
-	 */
-	public static function hide_from_menus() {
-		global $submenu;
-
-		$newspack_menu = $submenu['newspack'];
-		foreach ( $newspack_menu as $key => $menu_item ) {
-			if ( 'newspack-checklist' === $menu_item[2] ) {
-				unset( $submenu['newspack'][ $key ] );
-			}
-		}
 	}
 
 	/**

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -37,9 +37,7 @@ class Components_Demo extends Wizard {
 		parent::__construct();
 
 		// Only show a link to the Components Demo if WP_DEBUG is enabled.
-		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
-			add_action( 'admin_head', array( $this, 'hide_from_menus' ) );
-		}
+		$this->hidden = ! defined( 'WP_DEBUG' ) || ! WP_DEBUG;
 	}
 
 	/**

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -31,6 +31,13 @@ class Components_Demo extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Priority setting for ordering admin submenu items.
+	 *
+	 * @var int.
+	 */
+	protected $menu_priority = 100;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -31,13 +31,6 @@ class Components_Demo extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Display a link to this wizard in the Newspack submenu.
-	 *
-	 * @var bool
-	 */
-	protected $hidden = false;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -163,6 +163,14 @@ class Dashboard extends Wizard {
 			$icon,
 			3
 		);
+		add_submenu_page(
+			$this->slug,
+			__( 'Dashboard' ),
+			__( 'Dashboard' ),
+			$this->capability,
+			$this->slug,
+			[ $this, 'render_wizard' ]
+		);
 	}
 
 	/**

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -31,13 +31,6 @@ class Dashboard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Display a link to this wizard in the Newspack submenu.
-	 *
-	 * @var bool
-	 */
-	protected $hidden = false;
-
-	/**
 	 * Priority setting for ordering admin submenu items. Dashboard must come first.
 	 *
 	 * @var int.
@@ -162,8 +155,8 @@ class Dashboard extends Wizard {
 	public function add_page() {
 		$icon = 'data:image/svg+xml;base64,PHN2ZyBpZD0iZjU0YWJkZjgtZTI5Ny00YTRmLWJjZTYtOTFiZmY5NjZkNTdlIiBkYXRhLW5hbWU9IkxheWVyIDEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDIyMiAyMjIiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuYjMxM2MzYWQtYzkyNC00ZjI3LTg1MzktOThiYTBiNjhmNGJjIHsKICAgICAgICBmaWxsOiAjMmE3ZGUxOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8dGl0bGU+bmV3c3BhY2stbWFyazwvdGl0bGU+CiAgPHBhdGggY2xhc3M9ImIzMTNjM2FkLWM5MjQtNGYyNy04NTM5LTk4YmEwYjY4ZjRiYyIgZD0iTTI2MS41LDEzMUExMTEsMTExLDAsMSwwLDM3Mi42LDI0MiwxMTEsMTExLDAsMCwwLDI2MS41LDEzMVpNMjE2LjEsMjg3LjRWMjU3LjJsMzAuMywzMC4yWm02MC42LDAtNjAuNi02MC41VjE5Ni42TDMwNywyODcuNFpNMzA3LDI0NkgyOTUuOGwtNy4yLTcuMkgzMDdabTAtMjEuMkgyNzQuN2wtNy4yLTcuMUgzMDdabTAtMjEuMUgyNTMuNmwtNy4yLTcuMUgzMDdaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTUwLjUgLTEzMSkiLz4KPC9zdmc+Cg==';
 		add_menu_page(
-			__( 'Newspack', 'newspack' ),
-			__( 'Newspack', 'newspack' ),
+			$this->get_name(),
+			$this->get_name(),
 			$this->capability,
 			$this->slug,
 			[ $this, 'render_wizard' ],

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -38,6 +38,13 @@ class Dashboard extends Wizard {
 	protected $hidden = false;
 
 	/**
+	 * Priority setting for ordering admin submenu items. Dashboard must come first.
+	 *
+	 * @var int.
+	 */
+	protected $menu_priority = 1;
+
+	/**
 	 * Initialize.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -163,10 +163,11 @@ class Dashboard extends Wizard {
 			$icon,
 			3
 		);
+		$first_subnav_title = get_option( NEWSPACK_SETUP_COMPLETE ) ? __( 'Dashboard' ) : __( 'Setup' );
 		add_submenu_page(
 			$this->slug,
-			__( 'Dashboard' ),
-			__( 'Dashboard' ),
+			$first_subnav_title,
+			$first_subnav_title,
 			$this->capability,
 			$this->slug,
 			[ $this, 'render_wizard' ]

--- a/includes/wizards/class-donations-wizard.php
+++ b/includes/wizards/class-donations-wizard.php
@@ -33,6 +33,13 @@ class Donations_Wizard extends Wizard {
 	protected $capability = 'edit_products';
 
 	/**
+	 * Whether the wizard should be displayed in the Newspack submenu.
+	 *
+	 * @var bool.
+	 */
+	protected $hidden = true;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-google-analytics-wizard.php
+++ b/includes/wizards/class-google-analytics-wizard.php
@@ -32,6 +32,13 @@ class Google_Analytics_Wizard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Whether the wizard should be displayed in the Newspack submenu.
+	 *
+	 * @var bool.
+	 */
+	protected $hidden = true;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-mailchimp-wizard.php
+++ b/includes/wizards/class-mailchimp-wizard.php
@@ -32,6 +32,13 @@ class Mailchimp_Wizard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Whether the wizard should be displayed in the Newspack submenu.
+	 *
+	 * @var bool.
+	 */
+	protected $hidden = true;
+
+	/**
 	 * Get the name for this wizard.
 	 *
 	 * @return string The wizard name.

--- a/includes/wizards/class-newsletter-block-wizard.php
+++ b/includes/wizards/class-newsletter-block-wizard.php
@@ -32,6 +32,13 @@ class Newsletter_Block_Wizard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Whether the wizard should be displayed in the Newspack submenu.
+	 *
+	 * @var bool.
+	 */
+	protected $hidden = true;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -83,7 +90,7 @@ class Newsletter_Block_Wizard extends Wizard {
 
 	/**
 	 * Get the Jetpack-Mailchimp connection settings.
-	 * 
+	 *
 	 * @see jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
 	 * @return WP_REST_Response with the info.
 	 */

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -30,6 +30,7 @@ class Performance_Wizard extends Wizard {
 	 * @var string
 	 */
 	protected $capability = 'install_plugins';
+
 	/**
 	 * Constructor.
 	 */

--- a/includes/wizards/class-reader-revenue-onboarding-wizard.php
+++ b/includes/wizards/class-reader-revenue-onboarding-wizard.php
@@ -34,6 +34,13 @@ class Reader_Revenue_Onboarding_Wizard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Whether the wizard should be displayed in the Newspack submenu.
+	 *
+	 * @var bool.
+	 */
+	protected $hidden = true;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -35,8 +35,11 @@ class Setup_Wizard extends Wizard {
 	 */
 	public function __construct() {
 		parent::__construct();
-		add_action( 'current_screen', [ $this, 'redirect_to_setup' ] );
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+		if ( ! get_option( NEWSPACK_SETUP_COMPLETE ) ) {
+			add_action( 'current_screen', [ $this, 'redirect_to_setup' ] );
+			add_action( 'admin_menu', [ $this, 'hide_non_setup_menu_items' ], 1000 );
+		}
 	}
 
 	/**
@@ -116,12 +119,21 @@ class Setup_Wizard extends Wizard {
 	}
 
 	/**
+	 * Hide all menu items besides setup if setup is incomplete.
+	 */
+	public function hide_non_setup_menu_items() {
+		global $submenu;
+		foreach ( $submenu['newspack'] as $key => $value ) {
+			if ( 'newspack-setup-wizard' !== $value[2] ) {
+				unset( $submenu['newspack'][ $key ] );
+			}
+		}
+	}
+
+	/**
 	 * If initial setup is incomplete, redirect to Setup Wizard.
 	 */
 	public function redirect_to_setup() {
-		if ( get_option( NEWSPACK_SETUP_COMPLETE ) ) {
-			return;
-		}
 		$screen = get_current_screen();
 		if ( $screen && 'toplevel_page_newspack' === $screen->id ) {
 			$setup_url = Wizards::get_url( 'setup' );

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -31,13 +31,6 @@ class Setup_Wizard extends Wizard {
 	protected $capability = 'install_plugins';
 
 	/**
-	 * Display a link to this wizard in the Newspack submenu.
-	 *
-	 * @var bool
-	 */
-	protected $hidden = false;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-subscriptions-wizard.php
+++ b/includes/wizards/class-subscriptions-wizard.php
@@ -26,6 +26,14 @@ class Subscriptions_Wizard extends Wizard {
 	 * @var string
 	 */
 	protected $capability = 'edit_products';
+
+	/**
+	 * Whether the wizard should be displayed in the Newspack submenu.
+	 *
+	 * @var bool.
+	 */
+	protected $hidden = true;
+
 	/**
 	 * Constructor.
 	 */

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -35,7 +35,7 @@ abstract class Wizard {
 	 *
 	 * @var bool.
 	 */
-	protected $hidden = true;
+	protected $hidden = false;
 
 	/**
 	 * Initialize.

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -38,10 +38,17 @@ abstract class Wizard {
 	protected $hidden = false;
 
 	/**
+	 * Priority setting for ordering admin submenu items.
+	 *
+	 * @var int.
+	 */
+	protected $menu_priority = 1;
+
+	/**
 	 * Initialize.
 	 */
 	public function __construct() {
-		add_action( 'admin_menu', [ $this, 'add_page' ] );
+		add_action( 'admin_menu', [ $this, 'add_page' ], $this->menu_priority );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 	}
 

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -42,7 +42,7 @@ abstract class Wizard {
 	 *
 	 * @var int.
 	 */
-	protected $menu_priority = 1;
+	protected $menu_priority = 2;
 
 	/**
 	 * Initialize.

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -43,17 +43,20 @@ abstract class Wizard {
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_page' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
-
-		if ( $this->hidden ) {
-			add_action( 'admin_head', array( $this, 'hide_from_menus' ) );
-		}
 	}
 
 	/**
 	 * Add an admin page for the wizard to live on.
 	 */
 	public function add_page() {
-		add_submenu_page( 'newspack', $this->get_name(), $this->get_name(), $this->capability, $this->slug, [ $this, 'render_wizard' ] );
+		add_submenu_page(
+			$this->hidden ? null : 'newspack',
+			$this->get_name(),
+			$this->get_name(),
+			$this->capability,
+			$this->slug,
+			[ $this, 'render_wizard' ]
+		);
 	}
 
 	/**
@@ -139,20 +142,6 @@ abstract class Wizard {
 		}
 
 		return ! empty( $value );
-	}
-
-	/**
-	 * Hide menu items from view so the pages exist, but the menu items do not.
-	 */
-	public function hide_from_menus() {
-		global $submenu;
-
-		$newspack_menu = $submenu['newspack'];
-		foreach ( $newspack_menu as $key => $menu_item ) {
-			if ( $menu_item[2] === $this->slug ) {
-				unset( $submenu['newspack'][ $key ] );
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adjusts and refactors the admin menu in a variety of ways:

- All unified wizards are now included. As of now this is only Performance and Advertising, but soon it will be all feature areas.
- The first item has been renamed "Dashboard" to avoid the duplication of Newspack.
- If Setup has not been completed the submenu will show only Setup.

<img width="1376" alt="Screen Shot 2019-07-27 at 8 19 05 AM" src="https://user-images.githubusercontent.com/1477002/61995011-de012500-b050-11e9-80f6-7f63cde5e515.png">

Note: Because of these changes, when viewing a Checklist page or an older non-unified Wizard (e.g. Reader Revenue), the Newspack admin menu will not be illuminated and the submenu will not be shown. We shouldn't worry about this problem since both of these structures will be removed shortly. Example:

<img width="1376" alt="Screen Shot 2019-07-27 at 8 19 10 AM" src="https://user-images.githubusercontent.com/1477002/61995138-15240600-b052-11e9-8ce6-4ace4b192346.png">

Closes #197.

### How to test the changes in this Pull Request:

1. Checkout the branch (no npm build necessary)
2. Click on Newspack in the admin menu. You should see Dashboard, Setup, Advertising, Performance and Components demo.
3. Verify all links work. 
4. From the dashboard, verify all links work, and verify all links from the checklists continue to work. As noted, the menu will not appear to be selected when on a checklist or non-unified Wizard
5. Reset your Newspack settings by adding `&reset_newspack_settings=1` to the end of any Newspack admin URL, then click Newspack in the admin menu.
6. You should now see only Setup in the submenu. 
7. Go through the Setup Wizard, and verify that the submenu items become visible once Setup is complete.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->