### PR TITLE
Secondary Navigation

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -12,6 +12,7 @@ export { default as Modal } from './modal';
 export { default as NewspackLogo } from './newspack-logo';
 export { default as PluginInstaller } from './plugin-installer';
 export { default as ProgressBar } from './progress-bar';
+export { default as SecondaryNavigation } from './secondary-navigation';
 export { default as SelectControl } from './select-control';
 export { default as TabbedNavigation } from './tabbed-navigation';
 export { default as Task } from './task';

--- a/assets/components/src/secondary-navigation/index.js
+++ b/assets/components/src/secondary-navigation/index.js
@@ -1,0 +1,52 @@
+/**
+ * Tabbed Navigation
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import murielClassnames from '../../../shared/js/muriel-classnames';
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+import { NavLink } from 'react-router-dom';
+
+/**
+ * Internal dependencies.
+ */
+import './style.scss';
+
+/**
+ * Progress bar.
+ */
+class SecondaryNavigation extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { items, className } = this.props;
+		const classes = murielClassnames( 'muriel-secondary-navigation', 'muriel-grid-item', className );
+		return (
+			<div className={ classes }>
+				<ul>
+					{ items.map( ( item, key ) => (
+						<li key={ key }>
+							<NavLink to={ item.path } exact={ item.exact } activeClassName="selected">
+								{ item.label }
+							</NavLink>
+						</li>
+					) ) }
+				</ul>
+			</div>
+		);
+	}
+}
+
+export default SecondaryNavigation;

--- a/assets/components/src/secondary-navigation/style.scss
+++ b/assets/components/src/secondary-navigation/style.scss
@@ -1,0 +1,34 @@
+/**
+ * Secondary Navigation Styles
+ */
+
+@import '../../../shared/scss/muriel-component';
+
+.muriel-secondary-navigation {
+	font-size: 14px;
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 14px 0 0 0;
+	}
+	li {
+		display: inline-block;
+		margin: 0;
+		& + li::before {
+			color: black;
+			content: '|';
+			margin: 0 6px;
+		}
+	}
+	a {
+		color: $primary_color;
+		text-decoration: none;
+		&:hover {
+			text-decoration: underline;
+		}
+		&.selected {
+			font-weight: bold;
+			color: black;
+		}
+	}
+}

--- a/assets/components/src/tabbed-navigation/style.scss
+++ b/assets/components/src/tabbed-navigation/style.scss
@@ -1,5 +1,5 @@
 /**
- * Progress bar styles.
+ * Tabbed Navigation Styles.
  */
 
 @import '../../../shared/scss/muriel-component';

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { Button, Card, FormattedHeader, Handoff, Grid, TabbedNavigation } from '../';
+import { Button, Card, FormattedHeader, Handoff, Grid, SecondaryNavigation, TabbedNavigation } from '../';
 import { murielClassnames, buttonProps } from '../../../shared/js/';
 import './style.scss';
 
@@ -28,6 +28,7 @@ export default function withWizardScreen( WrappedComponent, config ) {
 				noBackground,
 				noCard,
 				tabbedNavigation,
+				secondaryNavigation,
 				footer,
 				secondaryButtonText,
 				secondaryButtonAction,
@@ -55,6 +56,7 @@ export default function withWizardScreen( WrappedComponent, config ) {
 						{ tabbedNavigation && (
 							<Card noBackground>
 								<TabbedNavigation items={ tabbedNavigation } />
+								{ secondaryNavigation && <SecondaryNavigation items={ secondaryNavigation } /> }
 							</Card>
 						) }
 					</Grid>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds `SecondaryNavigation` component for second row of navigation which will be necessary in certain Wizards. 

This work is based on the following mockup:

<img width="704" alt="Screen Shot 2019-07-27 at 11 37 54 AM" src="https://user-images.githubusercontent.com/1477002/61996522-24f81600-b063-11e9-9875-070671759bd5.png">

Screenshot of actual implementation:

<img width="1376" alt="Screen Shot 2019-07-27 at 11 36 53 AM" src="https://user-images.githubusercontent.com/1477002/61996533-3c370380-b063-11e9-8def-750168ab65cf.png">

@sonjaleix I chose the name Secondary Navigation arbitrarily—is there a better name?

### How to test the changes in this Pull Request:

As with the [Tabbed Navigation PR](https://github.com/Automattic/newspack-plugin/pull/194), there isn't a use in an existing Wizard, so the best testing strategy is to add a secondary navigation to one Wizard and try it out.

1. Check out the branch. 
2. In `assets/wizards/advertising/index.js`, add the following attribute to the `<Placements>` element:
```
 secondaryNavigation={ [
	{
		label: __( 'First Page' ),
		path: '/google_ad_manager',
	},
	{
		label: __( 'Selected Page' ),
		path: '/ad-placements',
	},
	{
		label: __( 'Third Page' ),
		path: '/google_ad_managerv',
	},
] }
```
3. Run `npm run build:webpack` and navigate to `/wp-admin/admin.php?page=newspack-advertising-wizard#/ad-placements`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->