### PR TITLE
Plugin Installer UI Improvements

### DIFF
--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -215,7 +215,7 @@ class PluginInstaller extends Component {
 							className="is-centered"
 							onClick={ this.installAllPlugins }
 						>
-							{ __( 'Use All' ) }
+							{ __( 'Install' ) }
 						</Button>
 					) }
 			</div>

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -9,6 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -161,7 +162,7 @@ class PluginInstaller extends Component {
 						if ( installationStatus === PLUGIN_STATE_INSTALLING ) {
 							actionText = __( 'Setting up...' );
 						} else if ( Status === 'active' ) {
-							actionText = __( 'In Use' );
+							actionText = <Dashicon icon="yes" className="newspack_plugin-installer__icon" />;
 						}
 						const onClick = isButton ? () => this.installPlugin( slug ) : null;
 						return (

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -187,8 +187,6 @@ class PluginInstaller extends Component {
 							actionText = __( 'Deactivating' );
 						} else if ( Status === 'active' ) {
 							actionText = __( 'In Use' );
-						} else {
-							actionText = __( 'Use' );
 						}
 						const onClick = isButton ? () => this.installPlugin( slug ) : null;
 						return (

--- a/assets/components/src/plugin-installer/style.scss
+++ b/assets/components/src/plugin-installer/style.scss
@@ -1,3 +1,5 @@
+@import '../../../shared/scss/muriel-component';
+
 .newspack-plugin-installer__checkbox-row {
 	position: relative;
 	.components-spinner,
@@ -6,6 +8,15 @@
 		top: 0;
 		right: 0;
 	}
+}
+.newspack_plugin-installer__icon {
+	background-color: $primary_color;
+	border: 1px solid $primary_color;
+	border-radius: 16px;
+	width: 16px;
+	height: 16px;
+	color: $muriel-white;
+	margin-right: 12px;
 }
 .newspack-plugin-installer_waiting {
 	text-align: center;

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -3,7 +3,7 @@
 		padding-bottom: 0;
 		padding-top: 0;
 	}
-	p {
+	.muriel-wizardScreen__content p {
 		margin: 0 0 1em 0;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR contains a series of UI improvements to the `PluginInstaller` component, described in https://github.com/Automattic/newspack-plugin/issues/187.

- Individual plugin install links have been removed. Now, the only action is the `Install` button at the bottom, which installs all of them.
- Uninstall UI has been removed. (@sonjaleix this was not requested in the issue but I assumed that the thinking would be identical as for removing individual plugin installation UI)
- Blue checkbox UI indicates success, replacing the words "In Use."

<img width="765" alt="Screen Shot 2019-07-27 at 12 13 37 PM" src="https://user-images.githubusercontent.com/1477002/61996968-9d150a80-b068-11e9-8862-0225510382f4.png">

Closes #187.

### How to test the changes in this Pull Request:

1. `npm run build:webpack`
2. Navigate to Components Demo page and try out the example Plugin Installer.
3. Go to WordPress plugins page and deactivate or uninstall some of the plugins in the example, and try it again.
4. Bonus: Uninstall other required plugins and try various Wizards to verify they work just like before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->