### PR TITLE
Performance Wizard UI Improvements

### DIFF
--- a/assets/components/src/button/button.test.js
+++ b/assets/components/src/button/button.test.js
@@ -30,8 +30,7 @@ describe( 'Button', () => {
 	describe( 'rendering centered primary', () => {
 		it( 'should render a Button element with a class of is-primary and class of is-centered', () => {
 			const button = shallow( <Button isPrimary className="is-centered">Continue</Button> );
-			expect( button.render().hasClass( 'is-primary' ) ).toBe( true );
-			expect( button.render().hasClass( 'is-centered' ) ).toBe( true );
+			expect( button.render().hasClass( 'muriel-button-is-centered-wrapper' ) ).toBe( true );
 		} );
 	} );
 } );

--- a/assets/components/src/button/index.js
+++ b/assets/components/src/button/index.js
@@ -16,15 +16,18 @@ import murielClassnames from '../../../shared/js/muriel-classnames';
 import './style.scss';
 
 class Button extends Component {
-
 	/**
 	 * Render.
 	 */
 	render( props ) {
 		const { className, ...otherProps } = this.props;
 		const classes = murielClassnames( 'muriel-button', className );
-		return (
-			<BaseComponent className={ classes } { ...otherProps } />
+		const isCentered = classes.indexOf( 'is-centered' ) > -1; // TODO: Replace with a prop
+		const renderedButton = <BaseComponent className={ classes } { ...otherProps } />;
+		return isCentered ? (
+			<div className="muriel-button-is-centered-wrapper">{ renderedButton }</div>
+		) : (
+			renderedButton
 		);
 	}
 }

--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -17,7 +17,7 @@
 		border-color: #CCCCCC;
 		border-radius: 3px;
 		height: auto;
-		padding: 7px 25px;
+		padding: 16px 32px;
 		margin: 14px 7px;
 		text-decoration: none;
 
@@ -66,8 +66,7 @@
 
 	&.is-centered {
 		display: block;
-		width: 100%;
-		max-width: 310px;
+		width: fit-content;
 	}
 
 }

--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -12,7 +12,6 @@
 	color: $muriel-gray-700;
 
 	&.is-button {
-		display: inline-block;
 		background-color: $muriel-white;
 		border-color: #CCCCCC;
 		border-radius: 3px;
@@ -63,9 +62,7 @@
 			text-decoration: none;
 		}
 	}
-
-	&.is-centered {
-		display: block;
-	}
-
+}
+.muriel-button-is-centered-wrapper {
+	text-align: center;
 }

--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -66,7 +66,6 @@
 
 	&.is-centered {
 		display: block;
-		width: fit-content;
 	}
 
 }

--- a/assets/components/src/image-upload/index.js
+++ b/assets/components/src/image-upload/index.js
@@ -76,7 +76,7 @@ class ImageUpload extends Component {
 	 * Render.
 	 */
 	render = () => {
-		const { className, image } = this.props;
+		const { className, image, uploadPrompt } = this.props;
 		return (
 			<Fragment>
 				{ !! image && (
@@ -92,12 +92,15 @@ class ImageUpload extends Component {
 				{ ! image && (
 					<div className={ murielClassnames( 'muriel-image-upload', 'no-image', className ) }>
 						<Button className="add-image" onClick={ this.openModal }>
-							{ __( 'Add an image' ) }
+							{ uploadPrompt }
 						</Button>
 					</div>
 				) }
 			</Fragment>
 		);
 	}
+}
+ImageUpload.defaultProps = {
+	uploadPrompt: __( 'Add an image' ),
 }
 export default ImageUpload;

--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -12,6 +12,7 @@ export { default as Modal } from './modal';
 export { default as NewspackLogo } from './newspack-logo';
 export { default as PluginInstaller } from './plugin-installer';
 export { default as ProgressBar } from './progress-bar';
+export { default as SecondaryNavigation } from './secondary-navigation';
 export { default as SelectControl } from './select-control';
 export { default as TabbedNavigation } from './tabbed-navigation';
 export { default as Task } from './task';

--- a/assets/components/src/plugin-installer/style.scss
+++ b/assets/components/src/plugin-installer/style.scss
@@ -1,3 +1,5 @@
+@import '../../../shared/scss/muriel-component';
+
 .newspack-plugin-installer__checkbox-row {
 	position: relative;
 	.components-spinner,
@@ -6,6 +8,15 @@
 		top: 0;
 		right: 0;
 	}
+}
+.newspack_plugin-installer__icon {
+	background-color: $primary_color;
+	border: 1px solid $primary_color;
+	border-radius: 16px;
+	width: 16px;
+	height: 16px;
+	color: $muriel-white;
+	margin-right: 12px;
 }
 .newspack-plugin-installer_waiting {
 	text-align: center;

--- a/assets/components/src/secondary-navigation/index.js
+++ b/assets/components/src/secondary-navigation/index.js
@@ -1,0 +1,52 @@
+/**
+ * Tabbed Navigation
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import murielClassnames from '../../../shared/js/muriel-classnames';
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+import { NavLink } from 'react-router-dom';
+
+/**
+ * Internal dependencies.
+ */
+import './style.scss';
+
+/**
+ * Progress bar.
+ */
+class SecondaryNavigation extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { items, className } = this.props;
+		const classes = murielClassnames( 'muriel-secondary-navigation', 'muriel-grid-item', className );
+		return (
+			<div className={ classes }>
+				<ul>
+					{ items.map( ( item, key ) => (
+						<li key={ key }>
+							<NavLink to={ item.path } exact={ item.exact } activeClassName="selected">
+								{ item.label }
+							</NavLink>
+						</li>
+					) ) }
+				</ul>
+			</div>
+		);
+	}
+}
+
+export default SecondaryNavigation;

--- a/assets/components/src/secondary-navigation/style.scss
+++ b/assets/components/src/secondary-navigation/style.scss
@@ -1,0 +1,34 @@
+/**
+ * Secondary Navigation Styles
+ */
+
+@import '../../../shared/scss/muriel-component';
+
+.muriel-secondary-navigation {
+	font-size: 14px;
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 14px 0 0 0;
+	}
+	li {
+		display: inline-block;
+		margin: 0;
+		& + li::before {
+			color: black;
+			content: '|';
+			margin: 0 6px;
+		}
+	}
+	a {
+		color: $primary_color;
+		text-decoration: none;
+		&:hover {
+			text-decoration: underline;
+		}
+		&.selected {
+			font-weight: bold;
+			color: black;
+		}
+	}
+}

--- a/assets/components/src/tabbed-navigation/style.scss
+++ b/assets/components/src/tabbed-navigation/style.scss
@@ -1,5 +1,5 @@
 /**
- * Progress bar styles.
+ * Tabbed Navigation Styles.
  */
 
 @import '../../../shared/scss/muriel-component';

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { Button, Card, FormattedHeader, Handoff, Grid, TabbedNavigation } from '../';
+import { Button, Card, FormattedHeader, Handoff, Grid, SecondaryNavigation, TabbedNavigation } from '../';
 import { murielClassnames, buttonProps } from '../../../shared/js/';
 import './style.scss';
 
@@ -28,6 +28,7 @@ export default function withWizardScreen( WrappedComponent, config ) {
 				noBackground,
 				noCard,
 				tabbedNavigation,
+				secondaryNavigation,
 				footer,
 				secondaryButtonText,
 				secondaryButtonAction,
@@ -55,6 +56,7 @@ export default function withWizardScreen( WrappedComponent, config ) {
 						{ tabbedNavigation && (
 							<Card noBackground>
 								<TabbedNavigation items={ tabbedNavigation } />
+								{ secondaryNavigation && <SecondaryNavigation items={ secondaryNavigation } /> }
 							</Card>
 						) }
 					</Grid>

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -89,6 +89,32 @@ class PerformanceWizard extends Component {
 	render() {
 		const { pluginRequirements } = this.props;
 		const { settings } = this.state;
+		const tabbedNavigation = [
+			{
+				label: __( 'AMP' ),
+				path: '/',
+				exact: true,
+			},
+			{
+				label: __( 'Advanced PWA Features' ),
+				path: '/pwa/',
+			},
+		];
+		const secondaryNavigation = [
+			{
+				label: __( 'Add to home screen' ),
+				path: '/pwa/',
+				exact: true
+			},
+			{
+				label: __( 'Offline usage' ),
+				path: '/pwa/offline-usage',
+			},
+			{
+				label: __( 'Push notifications' ),
+				path: '/pwa/push-notifications',
+			},
+		]
 		return (
 			<HashRouter hashType="slash">
 				<Switch>
@@ -105,11 +131,13 @@ class PerformanceWizard extends Component {
 								) }
 								buttonText={ __( 'Configure advanced options' ) }
 								buttonAction="#/add-to-homescreen"
+								tabbedNavigation={ tabbedNavigation }
 							/>
 						) }
 					/>
 					<Route
-						path="/add-to-homescreen"
+						path="/pwa"
+						exact
 						render={ routeProps => (
 							<AddToHomeScreen
 								headerText={ __( 'Enable Add to Homescreen' ) }
@@ -124,11 +152,13 @@ class PerformanceWizard extends Component {
 								}
 								settings={ settings }
 								updateSetting={ this.updateSetting }
+								tabbedNavigation={ tabbedNavigation }
+								secondaryNavigation={ secondaryNavigation }
 							/>
 						) }
 					/>
 					<Route
-						path="/offline-usage"
+						path="/pwa/offline-usage"
 						render={ routeProps => (
 							<OfflineUsage
 								headerText={ __( 'Enable Offline Usage' ) }
@@ -143,11 +173,13 @@ class PerformanceWizard extends Component {
 								}
 								settings={ settings }
 								updateSetting={ this.updateSetting }
+								tabbedNavigation={ tabbedNavigation }
+								secondaryNavigation={ secondaryNavigation }
 							/>
 						) }
 					/>
 					<Route
-						path="/push-notifications"
+						path="/pwa/push-notifications"
 						render={ routeProps => (
 							<PushNotifications
 								headerText={ __( 'Enable Push Notifications' ) }
@@ -162,6 +194,8 @@ class PerformanceWizard extends Component {
 								}
 								settings={ settings }
 								updateSetting={ this.updateSetting }
+								tabbedNavigation={ tabbedNavigation }
+								secondaryNavigation={ secondaryNavigation }
 							/>
 						) }
 					/>

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -105,7 +105,7 @@ class PerformanceWizard extends Component {
 		];
 		const secondaryNavigation = [
 			{
-				label: __( 'Add to home screen' ),
+				label: __( 'Add to homescreen' ),
 				path: '/pwa/',
 				exact: true,
 			},

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -131,7 +131,6 @@ class PerformanceWizard extends Component {
 						exact
 						render={ routeProps => (
 							<Intro
-								noCard
 								headerText={ headerText }
 								subHeaderText={ subHeaderText }
 								tabbedNavigation={ tabbedNavigation }

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -78,9 +78,11 @@ class PerformanceWizard extends Component {
 		} );
 	}
 
-	updateSetting = ( key, value ) => {
+	updateSetting = ( key, value, commit ) => {
 		const { settings } = this.state;
-		this.setState( { settings: { ...settings, [ key ]: value } } );
+		this.setState( { settings: { ...settings, [ key ]: value } }, () => {
+			commit && this.updateSettings( key );
+		} );
 	};
 
 	/**

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -104,7 +104,7 @@ class PerformanceWizard extends Component {
 			{
 				label: __( 'Add to home screen' ),
 				path: '/pwa/',
-				exact: true
+				exact: true,
 			},
 			{
 				label: __( 'Offline usage' ),
@@ -114,7 +114,11 @@ class PerformanceWizard extends Component {
 				label: __( 'Push notifications' ),
 				path: '/pwa/push-notifications',
 			},
-		]
+		];
+		const headerText = __( 'Performance' );
+		const subHeaderText = __(
+			'Users engage more with an optimized website. Increase user engagement even further by setting up advanced PWA features.'
+		);
 		return (
 			<HashRouter hashType="slash">
 				<Switch>
@@ -125,10 +129,8 @@ class PerformanceWizard extends Component {
 						render={ routeProps => (
 							<Intro
 								noCard
-								headerText={ __( 'Performance options' ) }
-								subHeaderText={ __(
-									'Optimizing your news site for better performance and increased user engagement.'
-								) }
+								headerText={ headerText }
+								subHeaderText={ subHeaderText }
 								buttonText={ __( 'Configure advanced options' ) }
 								buttonAction="#/add-to-homescreen"
 								tabbedNavigation={ tabbedNavigation }
@@ -140,10 +142,8 @@ class PerformanceWizard extends Component {
 						exact
 						render={ routeProps => (
 							<AddToHomeScreen
-								headerText={ __( 'Enable Add to Homescreen' ) }
-								subHeaderText={ __(
-									'Encourage your users to add your news site to their homescreen.'
-								) }
+								headerText={ headerText }
+								subHeaderText={ subHeaderText }
 								buttonText={ __( 'Continue' ) }
 								buttonAction={ () =>
 									this.updateSettings( 'add_to_homescreen', 'site_icon' ).then( () =>
@@ -161,10 +161,8 @@ class PerformanceWizard extends Component {
 						path="/pwa/offline-usage"
 						render={ routeProps => (
 							<OfflineUsage
-								headerText={ __( 'Enable Offline Usage' ) }
-								subHeaderText={ __(
-									'Make your website reliable. Even on flaky internet connections.'
-								) }
+								headerText={ headerText }
+								subHeaderText={ subHeaderText }
 								buttonText={ __( 'Continue' ) }
 								buttonAction={ () =>
 									this.updateSettings( 'offline_usage' ).then( () =>
@@ -182,8 +180,8 @@ class PerformanceWizard extends Component {
 						path="/pwa/push-notifications"
 						render={ routeProps => (
 							<PushNotifications
-								headerText={ __( 'Enable Push Notifications' ) }
-								subHeaderText={ __( 'Keep your users engaged by sending push notifications.' ) }
+								headerText={ headerText }
+								subHeaderText={ subHeaderText }
 								buttonText={ __( 'Continue' ) }
 								buttonAction={ () =>
 									this.updateSettings(

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -133,8 +133,6 @@ class PerformanceWizard extends Component {
 								noCard
 								headerText={ headerText }
 								subHeaderText={ subHeaderText }
-								buttonText={ __( 'Configure advanced options' ) }
-								buttonAction="#/add-to-homescreen"
 								tabbedNavigation={ tabbedNavigation }
 							/>
 						) }
@@ -146,12 +144,8 @@ class PerformanceWizard extends Component {
 							<AddToHomeScreen
 								headerText={ headerText }
 								subHeaderText={ subHeaderText }
-								buttonText={ __( 'Continue' ) }
-								buttonAction={ () =>
-									this.updateSettings( 'add_to_homescreen', 'site_icon' ).then( () =>
-										routeProps.history.push( '/offline-usage' )
-									)
-								}
+								buttonText={ settings.add_to_homescreen && __( 'Save' ) }
+								buttonAction={ () => this.updateSettings( 'add_to_homescreen', 'site_icon' ) }
 								settings={ settings }
 								updateSetting={ this.updateSetting }
 								tabbedNavigation={ tabbedNavigation }
@@ -165,12 +159,6 @@ class PerformanceWizard extends Component {
 							<OfflineUsage
 								headerText={ headerText }
 								subHeaderText={ subHeaderText }
-								buttonText={ __( 'Continue' ) }
-								buttonAction={ () =>
-									this.updateSettings( 'offline_usage' ).then( () =>
-										routeProps.history.push( '/push-notifications' )
-									)
-								}
 								settings={ settings }
 								updateSetting={ this.updateSetting }
 								tabbedNavigation={ tabbedNavigation }
@@ -184,13 +172,13 @@ class PerformanceWizard extends Component {
 							<PushNotifications
 								headerText={ headerText }
 								subHeaderText={ subHeaderText }
-								buttonText={ __( 'Continue' ) }
+								buttonText={ settings.push_notifications && __( 'Save' ) }
 								buttonAction={ () =>
 									this.updateSettings(
 										'push_notifications',
 										'push_notification_server_key',
 										'push_notification_sender_id'
-									).then( () => ( window.location = newspack_urls[ 'dashboard' ] ) )
+									)
 								}
 								settings={ settings }
 								updateSetting={ this.updateSetting }

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -63,6 +63,7 @@ class PerformanceWizard extends Component {
 					: submitSettings,
 			{}
 		);
+		console.log( submitSettings );
 		return new Promise( ( resolve, reject ) => {
 			wizardApiFetch( {
 				path: '/newspack/v1/wizard/performance',
@@ -144,7 +145,7 @@ class PerformanceWizard extends Component {
 							<AddToHomeScreen
 								headerText={ headerText }
 								subHeaderText={ subHeaderText }
-								buttonText={ settings.add_to_homescreen && __( 'Save' ) }
+								buttonText={ __( 'Save' ) }
 								buttonAction={ () => this.updateSettings( 'add_to_homescreen', 'site_icon' ) }
 								settings={ settings }
 								updateSetting={ this.updateSetting }
@@ -172,7 +173,7 @@ class PerformanceWizard extends Component {
 							<PushNotifications
 								headerText={ headerText }
 								subHeaderText={ subHeaderText }
-								buttonText={ settings.push_notifications && __( 'Save' ) }
+								buttonText={ __( 'Save' ) }
 								buttonAction={ () =>
 									this.updateSettings(
 										'push_notifications',

--- a/assets/wizards/performance/style.scss
+++ b/assets/wizards/performance/style.scss
@@ -6,6 +6,13 @@
 		list-style-type: disc;
 		margin-left: 2em;
 	}
+	h4 {
+		display: flex;
+		svg {
+			margin-right: 6px;
+			color: $muriel-gray-200;
+		}
+	}
 }
 .newspack-performance-wizard__info-block {
 	color:  $muriel-gray-300;

--- a/assets/wizards/performance/style.scss
+++ b/assets/wizards/performance/style.scss
@@ -1,4 +1,4 @@
-.newspack-performance-wizard {
+.newspack-performance-wizard .muriel-wizardScreen__content {
 	.newspack-performance-wizard_indented-block {
 		margin-left: 50px;
 	}

--- a/assets/wizards/performance/views/add-to-homescreen/index.js
+++ b/assets/wizards/performance/views/add-to-homescreen/index.js
@@ -25,6 +25,7 @@ class AddToHomeScreen extends Component {
 		const { updateSetting, settings } = this.props;
 		return (
 			<Fragment>
+				<h4>{ __( 'Encourage your users to add your news site to their homescreen. ' ) }</h4>
 				<p>
 					{ __(
 						'With this feature you are able to display an "add to homescreen" prompt. This way your news site gets a prominent place on the users home screen right next to the native apps.'
@@ -40,10 +41,13 @@ class AddToHomeScreen extends Component {
 				/>
 				{ settings.add_to_homescreen && (
 					<div className="newspack-performance-wizard_indented-block">
-						<p><em>{ __( 'Site icons should be square and at least 512 × 512 pixels.' ) }</em></p>
+						<p>
+							<em>{ __( 'Site icons should be square and at least 512 × 512 pixels.' ) }</em>
+						</p>
 						<ImageUpload
 							image={ settings.site_icon }
 							onChange={ image => updateSetting( 'site_icon', image ) }
+							uploadPrompt={ __( 'Add site icon' ) }
 						/>
 					</div>
 				) }

--- a/assets/wizards/performance/views/add-to-homescreen/index.js
+++ b/assets/wizards/performance/views/add-to-homescreen/index.js
@@ -32,8 +32,8 @@ class AddToHomeScreen extends Component {
 				</p>
 				<ToggleControl
 					label={ __( 'Enable “Add to Homescreen” button' ) }
-					onChange={ checked => updateSetting( 'add_to_homescreen', checked, true ) }
-					checked={ settings.add_to_homescreen }
+					onChange={ checked => updateSetting( 'add_to_homescreen', checked ) }
+					checked={ settings.add_to_homescreen || false }
 					tooltip={ __(
 						'The mobile browser will show a mini-infobar which opens the install prompt'
 					) }

--- a/assets/wizards/performance/views/add-to-homescreen/index.js
+++ b/assets/wizards/performance/views/add-to-homescreen/index.js
@@ -28,11 +28,11 @@ class AddToHomeScreen extends Component {
 				<h4>{ __( 'Encourage your users to add your news site to their homescreen. ' ) }</h4>
 				<p>
 					{ __(
-						'With this feature you are able to display an "add to homescreen" prompt. This way your news site gets a prominent place on the users home screen right next to the native apps.'
+						'With this feature you are able to display an "add to homescreen" prompt. This way your news site gets a prominent place on the users homescreen right next to the native apps.'
 					) }
 				</p>
 				<ToggleControl
-					label={ __( 'Enable “Add to Homescreen” button' ) }
+					label={ __( 'Enable “Add to homescreen” button' ) }
 					onChange={ checked => updateSetting( 'add_to_homescreen', checked ) }
 					checked={ settings.add_to_homescreen || false }
 					tooltip={ __(

--- a/assets/wizards/performance/views/add-to-homescreen/index.js
+++ b/assets/wizards/performance/views/add-to-homescreen/index.js
@@ -32,7 +32,7 @@ class AddToHomeScreen extends Component {
 				</p>
 				<ToggleControl
 					label={ __( 'Enable “Add to Homescreen” button' ) }
-					onChange={ checked => updateSetting( 'add_to_homescreen', checked ) }
+					onChange={ checked => updateSetting( 'add_to_homescreen', checked, true ) }
 					checked={ settings.add_to_homescreen }
 					tooltip={ __(
 						'The mobile browser will show a mini-infobar which opens the install prompt'

--- a/assets/wizards/performance/views/intro/index.js
+++ b/assets/wizards/performance/views/intro/index.js
@@ -7,7 +7,7 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
+import { Dashicon, ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -24,49 +24,27 @@ class Intro extends Component {
 	render() {
 		const { pluginRequirements } = this.props;
 		return (
-			<Grid>
-				<Card>
-					<h3>{ __( 'Increase user engagement' ) }</h3>
-					<p>
-						{ __(
-							'Engage with your audience more by implementing the following advanced features (optional): '
-						) }
-						<strong>{ __( 'Add to home screen' ) }</strong>
-						{ __( ', ' ) }
-						<strong>{ __( 'Offline usage' ) }</strong>
-						{ __( ', and ' ) }
-						<strong>{ __( 'Push notifications' ) }</strong>.
-					</p>
-				</Card>
-				<Card>
-					<h3>{ __( 'Automatic performance enhancements' ) }</h3>
-					<div className="newspack-performance-wizard__info-block dashicons-before dashicons-info">
-						<p>
-							{ __(
-								'Newspack utilizes Progressive Web App (PWA) to automatically optimize and configure your news site to perform better. It automatically improves:'
-							) }
-						</p>
-						<p>
-							<strong>{ __( 'Speed: ' ) }</strong>
-							{ __( 'Will work reliably, no matter the network conditions.' ) }
-							<br />
-							<strong>{ __( 'Security: ' ) }</strong>
-							{ __( 'Served through HTTPS to protect the integrity of your news site.' ) }
-							<br />
-							<strong>{ __( 'User experience:  ' ) }</strong>
-							{ __( 'Feels like a native app on the device.' ) }
-						</p>
-					</div>
-					<p className="newspack-plugin-description">
-						{ __(
-							'Basic PWA options have been automatically set up for you. Advanced options are available in the Progressive WP dashboard.'
-						) }
-						<ExternalLink href="/wp-admin/admin.php?page=progressive-wordpress">
-							{ __( 'Configure advanced options', 'newspack' ) }
-						</ExternalLink>
-					</p>
-				</Card>
-			</Grid>
+			<Fragment>
+				<h4><Dashicon icon="info" /> { __( 'Your site performance has been enhanced automatically' ) }</h4>
+				<p>
+					{ __( 'Newspack utilizes ' ) }
+					<ExternalLink href="#">{ __( 'Progressive Web App' ) }</ExternalLink>
+					{ __(
+						'(PWA) to automatically optimizing and configuring your news site to perform better. It automatically improves:'
+					) }
+				</p>
+				<p>
+					<strong>{ __( 'Speed:' ) }</strong>{' '}
+					{ __( 'Will work reliably, no matter the network conditions.' ) }
+					<br />
+					<strong>{ __( 'Security:' ) }</strong>{' '}
+					{ __( 'Served through HTTPS to protect the integrity of your news site.' ) }
+					<br />
+					<strong>{ __( 'User Experience:' ) }</strong>{' '}
+					{ __( 'Feels like a native app on the device.' ) }
+					<br />
+				</p>
+			</Fragment>
 		);
 	}
 }

--- a/assets/wizards/performance/views/offline-usage/index.js
+++ b/assets/wizards/performance/views/offline-usage/index.js
@@ -5,9 +5,8 @@
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -24,18 +23,11 @@ class OfflineUsage extends Component {
 	render() {
 		const { settings, updateSetting } = this.props;
 		return (
-			<Fragment>
-				<p>
-					{ __(
-						"No connection? No problem. We pre-cache all critical assets of your website, as well as all visited resources. So if there's no internet connection it will serve the resources from the local storage."
-					) }
-				</p>
-				<ToggleControl
-					label={ __( 'Enable Offline Usage' ) }
-					onChange={ checked => updateSetting( 'offline_usage', checked, true ) }
-					checked={ settings.offline_usage }
-				/>
-			</Fragment>
+			<p>
+				{ __(
+					"No connection? No problem. We pre-cache all critical assets of your website, as well as all visited resources. So if there's no internet connection it will serve the resources from the local storage."
+				) }
+			</p>
 		);
 	}
 }

--- a/assets/wizards/performance/views/offline-usage/index.js
+++ b/assets/wizards/performance/views/offline-usage/index.js
@@ -32,7 +32,7 @@ class OfflineUsage extends Component {
 				</p>
 				<ToggleControl
 					label={ __( 'Enable Offline Usage' ) }
-					onChange={ checked => updateSetting( 'offline_usage', checked ) }
+					onChange={ checked => updateSetting( 'offline_usage', checked, true ) }
 					checked={ settings.offline_usage }
 				/>
 			</Fragment>

--- a/assets/wizards/performance/views/offline-usage/index.js
+++ b/assets/wizards/performance/views/offline-usage/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -23,11 +23,14 @@ class OfflineUsage extends Component {
 	render() {
 		const { settings, updateSetting } = this.props;
 		return (
-			<p>
-				{ __(
-					"No connection? No problem. We pre-cache all critical assets of your website, as well as all visited resources. So if there's no internet connection it will serve the resources from the local storage."
-				) }
-			</p>
+			<Fragment>
+				<h4>{ __( 'Make your website reliable. Even on flaky internet connections.' ) }</h4>
+				<p>
+					{ __(
+						"No connection? No problem. We pre-cache all critical assets of your website, as well as all visited resources. So if there's no internet connection it will serve the resources from the local storage."
+					) }
+				</p>
+			</Fragment>
 		);
 	}
 }

--- a/assets/wizards/performance/views/push-notifications/index.js
+++ b/assets/wizards/performance/views/push-notifications/index.js
@@ -32,8 +32,8 @@ class PushNotifications extends Component {
 				</p>
 				<ToggleControl
 					label={ __( 'Enable Push Notifications' ) }
-					onChange={ checked => updateSetting( 'push_notifications', checked, true ) }
-					checked={ settings.push_notifications }
+					onChange={ checked => updateSetting( 'push_notifications', checked ) }
+					checked={ settings.push_notifications || false }
 				/>
 				{ settings.push_notifications && (
 					<Fragment>

--- a/assets/wizards/performance/views/push-notifications/index.js
+++ b/assets/wizards/performance/views/push-notifications/index.js
@@ -32,7 +32,7 @@ class PushNotifications extends Component {
 				</p>
 				<ToggleControl
 					label={ __( 'Enable Push Notifications' ) }
-					onChange={ checked => updateSetting( 'push_notifications', checked ) }
+					onChange={ checked => updateSetting( 'push_notifications', checked, true ) }
 					checked={ settings.push_notifications }
 				/>
 				{ settings.push_notifications && (

--- a/assets/wizards/performance/views/push-notifications/index.js
+++ b/assets/wizards/performance/views/push-notifications/index.js
@@ -25,6 +25,7 @@ class PushNotifications extends Component {
 		const { settings, updateSetting } = this.props;
 		return (
 			<Fragment>
+				<h4>{ __( 'Keep your users engaged by sending push notifications.' ) }</h4>
 				<p>
 					{ __(
 						'You just published new content and you want to let everyone know? Why not send a push notification? We have an integrated connection to Firebase that lets you manage registered devices and send push notifications to all or selected devices!'
@@ -42,7 +43,9 @@ class PushNotifications extends Component {
 							<ul>
 								<li>
 									{ __( 'Go to ' ) }
-									<ExternalLink href="https://console.firebase.google.com/">{ __( 'Firebase Console' ) }</ExternalLink>
+									<ExternalLink href="https://console.firebase.google.com/">
+										{ __( 'Firebase Console' ) }
+									</ExternalLink>
 								</li>
 								<li>{ __( 'Click "create new project"' ) }</li>
 								<li>{ __( 'Follow the instructions to create your project' ) }</li>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This updates the UI for the Performance Wizard based on feedback in https://github.com/Automattic/newspack-plugin/issues/180. This is the first wizard with both tabbed and secondary navigation. As it stands currently, Offline Usage features are always going to be on, so I removed the toggle and left the description only. 

<details>
<img width="1312" alt="Screen Shot 2019-07-29 at 7 17 22 AM" src="https://user-images.githubusercontent.com/1477002/62044513-247d8d80-b1d1-11e9-83bb-da02a942a486.png">

<img width="1312" alt="Screen Shot 2019-07-29 at 7 17 27 AM" src="https://user-images.githubusercontent.com/1477002/62044522-29dad800-b1d1-11e9-8cdb-0c870b1a7d4b.png">

<img width="1312" alt="Screen Shot 2019-07-29 at 7 17 29 AM" src="https://user-images.githubusercontent.com/1477002/62044532-2fd0b900-b1d1-11e9-8290-0d605a64c5a4.png">

<img width="1312" alt="Screen Shot 2019-07-29 at 7 17 36 AM" src="https://user-images.githubusercontent.com/1477002/62044886-f64c7d80-b1d1-11e9-823d-e017fe9be91c.png">

<img width="1312" alt="Screen Shot 2019-07-29 at 7 17 38 AM" src="https://user-images.githubusercontent.com/1477002/62044994-3449a180-b1d2-11e9-8164-1a6231010abe.png">

</details>

Blocked by:

https://github.com/Automattic/newspack-plugin/pull/217
https://github.com/Automattic/newspack-plugin/pull/216
https://github.com/Automattic/newspack-plugin/pull/215

Closes #180.

### How to test the changes in this Pull Request:

1. `npm run build:webpack`
2. Navigate to the Performance Wizard
3. Compare to screenshots above and visual feedback in https://github.com/Automattic/newspack-plugin/issues/180.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->