### PR TITLE
Donations: Fix typo in dependency reference

### DIFF
--- a/assets/wizards/donations/index.js
+++ b/assets/wizards/donations/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import DonationSettingsScreen from './views/DonationSettingsScreen';
+import DonationSettingsScreen from './views/donationSettingsScreen';
 import { withWizard } from '../../components/src';
 import './style.scss';
 


### PR DESCRIPTION
The build can fail with the following error due to the uppercase D:

> ERROR in ./assets/wizards/donations/index.js
Module not found: Error: Can't resolve './views/DonationSettingsScreen' in '/home/philipjohn/vagrants/newspack/www/newspack/public_html/wp-content/plugins/newspack-plugin/assets/wizards/donations'
 @ ./assets/wizards/donations/index.js 23:0-68 190:31-53

This change fixes that by making sure the reference has a lowercase 'd'