### PR TITLE
Fix #226: Prevent conflictive function from being called by users below admin level.

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -56,7 +56,6 @@ final class Newspack {
 	 * e.g. include_once NEWSPACK_ABSPATH . 'includes/foo.php';
 	 */
 	private function includes() {
-		include_once ABSPATH . 'wp-includes/pluggable.php';
 		include_once NEWSPACK_ABSPATH . 'includes/util.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-plugin-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -56,6 +56,7 @@ final class Newspack {
 	 * e.g. include_once NEWSPACK_ABSPATH . 'includes/foo.php';
 	 */
 	private function includes() {
+		include_once ABSPATH . 'wp-includes/pluggable.php';
 		include_once NEWSPACK_ABSPATH . 'includes/util.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-plugin-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -38,7 +38,9 @@ class Setup_Wizard extends Wizard {
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
 		if ( ! get_option( NEWSPACK_SETUP_COMPLETE ) ) {
 			add_action( 'current_screen', [ $this, 'redirect_to_setup' ] );
+		if ( current_user_can( 'install_plugins' ) ) {
 			add_action( 'admin_menu', [ $this, 'hide_non_setup_menu_items' ], 1000 );
+		}
 		}
 	}
 

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -38,9 +38,8 @@ class Setup_Wizard extends Wizard {
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
 		if ( ! get_option( NEWSPACK_SETUP_COMPLETE ) ) {
 			add_action( 'current_screen', [ $this, 'redirect_to_setup' ] );
-		if ( current_user_can( 'install_plugins' ) ) {
 			add_action( 'admin_menu', [ $this, 'hide_non_setup_menu_items' ], 1000 );
-		}
+
 		}
 	}
 
@@ -125,6 +124,9 @@ class Setup_Wizard extends Wizard {
 	 */
 	public function hide_non_setup_menu_items() {
 		global $submenu;
+		if ( ! current_user_can( $this->capability ) ) {
+			return;
+		}
 		foreach ( $submenu['newspack'] as $key => $value ) {
 			if ( 'newspack-setup-wizard' !== $value[2] ) {
 				unset( $submenu['newspack'][ $key ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is my first contribution, so please let me know if I’m making mistakes in the process. I’ll try to be as descriptive as possible.

The issue #226 is caused by the following:
class_wizard.php, on line 58, inside add_page() function is creating the submenu only for admin users, since the calling class “class-setup-wizard.php” is sending a capability of “install_plugins”.

The current code (class-setup-wizard.php) is trying to call the “hide_non_setup_menu_items()” function from all type of users, but only the admin users have the submenu created. This means that the $submenu global (which is declared inside the add_submenu_page() function from wp_admin/inclues/plugin.php) only exists for admins, hence the notice generated for users below admin level. (“Notice: Undefined index: newspack”…)

The solution I propose with this PR is to only call the hide_non_setup_menu_items() for users with admin capabilities. This can be accomplished by wrapping the function call inside a current_user_can(‘install_plugins’) conditional.

Two other possible solutions are the following:
1. Add the submenu to users with lower than admin level, by modifying the “$capability” parameter in the add_page() function. This changes the architecture of the plugin, which is out of my scope, but technically, it solves the notice issue.
2. Wrap the calling of hide_non_setup_menu_items() function in an “if(sset($submenu[‘newspack’]))” conditional. 
(I prefer the method proposed in this PR since I don’t think one should call a method that you already know won’t do anything; and I would also prefer to leave the hide_non_setup_menu_items() function unchanged. But again, technically, I think this is a viable option for the Notice issue).

Closes #226  .

### How to test the changes in this Pull Request:

(These are basically the same steps proposed in the issue to replicate the error):
1. Create a non admin user (For example: editor)
2. Log into the dashboard
3. No notices appear

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?