### PR TITLE
Fix #119: Disable Install button on premium plugins.

### DIFF
--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -99,7 +99,7 @@ class Admin_Plugins_Screen {
 			unset( $actions['activate'] );
 			unset( $actions['delete'] );
 			if ( current_user_can( 'install_plugins' ) ) {
-				if ( $plugin_data['Is_Premium'] == 'YES' ) {
+				if ( empty( $plugin_data['Download'] ) ) {
 					$actions['install'] = 'Premium';
 				} else {
 					$actions['install'] = '<a href="' .

--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -100,7 +100,7 @@ class Admin_Plugins_Screen {
 			unset( $actions['delete'] );
 			if ( current_user_can( 'install_plugins' ) ) {
 				if ( empty( $plugin_data['Download'] ) ) {
-					$actions['install'] = 'Premium';
+					$actions['install'] = __( 'Premium', 'newspack' );
 				} else {
 					$actions['install'] = '<a href="' .
 						wp_nonce_url( 'plugins.php?action=newspack_install_plugin&plugin=' . urlencode( $plugin_slug ), 'newspack-install-plugin_' . $plugin_slug, 'install_nonce' ) .

--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -99,14 +99,18 @@ class Admin_Plugins_Screen {
 			unset( $actions['activate'] );
 			unset( $actions['delete'] );
 			if ( current_user_can( 'install_plugins' ) ) {
-				$actions['install'] = '<a href="' .
-					wp_nonce_url( 'plugins.php?action=newspack_install_plugin&plugin=' . urlencode( $plugin_slug ), 'newspack-install-plugin_' . $plugin_slug, 'install_nonce' ) .
-					'" class="edit" aria-label="' .
-					/* translators: %s - plugin name */
-					esc_attr( sprintf( __( 'Install %s', 'newspack' ), $plugin_data['Name'] ) ) .
-					'">' .
-					__( 'Install', 'newspack' ) .
-					'</a>';
+				if ( $plugin_data['Is_Premium'] == 'YES' ) {
+					$actions['install'] = 'Premium';
+				} else {
+					$actions['install'] = '<a href="' .
+						wp_nonce_url( 'plugins.php?action=newspack_install_plugin&plugin=' . urlencode( $plugin_slug ), 'newspack-install-plugin_' . $plugin_slug, 'install_nonce' ) .
+						'" class="edit" aria-label="' .
+						/* translators: %s - plugin name */
+						esc_attr( sprintf( __( 'Install %s', 'newspack' ), $plugin_data['Name'] ) ) .
+						'">' .
+						__( 'Install', 'newspack' ) .
+						'</a>';
+				}
 			}
 		}
 

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -83,7 +83,7 @@ class Plugin_Manager {
 				'Author'      => 'Prospress Inc.',
 				'PluginURI'   => 'https://woocommerce.com/products/woocommerce-subscriptions/',
 				'AuthorURI'   => 'https://prospress.com',
-				'Is_Premium'  => 'YES',
+
 			],
 			'woocommerce-name-your-price'   => [
 				'Name'        => __( 'WooCommerce Name Your Price', 'newspack' ),
@@ -169,7 +169,6 @@ class Plugin_Manager {
 			'DomainPath'  => '',
 			'Download'    => '',
 			'Status'      => '',
-			'Is_Premium'  => 'NO',
 		];
 
 		// Add plugin status info and fill in defaults.

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -83,6 +83,7 @@ class Plugin_Manager {
 				'Author'      => 'Prospress Inc.',
 				'PluginURI'   => 'https://woocommerce.com/products/woocommerce-subscriptions/',
 				'AuthorURI'   => 'https://prospress.com',
+				'Is_Premium'  => 'YES',
 			],
 			'woocommerce-name-your-price'   => [
 				'Name'        => __( 'WooCommerce Name Your Price', 'newspack' ),
@@ -168,6 +169,7 @@ class Plugin_Manager {
 			'DomainPath'  => '',
 			'Download'    => '',
 			'Status'      => '',
+			'Is_Premium'  => 'NO',
 		];
 
 		// Add plugin status info and fill in defaults.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The solution I propose is to add a flag to the premium plugins in the $managed_plugins array (class-plugin-manager.php) and use that flag to disable the Install button (class-admin-plugins-screen.php) on plugins marked as premium.

Closes #119  .

### How to test the changes in this Pull Request:

Follow the same steps proposed in the issue to reproduce the bug:
1. Uninstall WooCommerce Subscriptions (if it was already installed). 
2. Go to Plugins screen.
3. The WooCommerce Subscriptions Install button should be disabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?