### PR TITLE
Fix AdSense handoff issues

### DIFF
--- a/includes/configuration_managers/class-site-kit-configuration-manager.php
+++ b/includes/configuration_managers/class-site-kit-configuration-manager.php
@@ -6,8 +6,6 @@
  */
 
 namespace Newspack;
-use Google\Site_Kit\Modules\AdSense;
-use Google\Site_Kit\Context;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/configuration_managers/class-site-kit-configuration-manager.php
+++ b/includes/configuration_managers/class-site-kit-configuration-manager.php
@@ -86,7 +86,7 @@ class Site_Kit_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function activate_module( $module ) {
 		$sitekit_active_modules = get_option( 'googlesitekit-active-modules', [] );
-		if ( ! in_array( $module, $sitekit_adsense_active ) ) {
+		if ( ! in_array( $module, $sitekit_active_modules ) ) {
 			$sitekit_active_modules[] = $module;
 			update_option( 'googlesitekit-active-modules', $sitekit_active_modules );
 		}

--- a/includes/configuration_managers/class-site-kit-configuration-manager.php
+++ b/includes/configuration_managers/class-site-kit-configuration-manager.php
@@ -6,6 +6,8 @@
  */
 
 namespace Newspack;
+use Google\Site_Kit\Modules\AdSense;
+use Google\Site_Kit\Context;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -77,6 +79,37 @@ class Site_Kit_Configuration_Manager extends Configuration_Manager {
 		}
 
 		return ! empty( get_user_meta( $user_id, $wpdb->prefix . 'googlesitekit_site_verified_meta', true ) );
+	}
+
+	/**
+	 * Activate a module if it isn't already active.
+	 *
+	 * @param string $module The module slug. See `get_module_info` for valid slugs.
+	 */
+	public function activate_module( $module ) {
+		$sitekit_active_modules = get_option( 'googlesitekit-active-modules', [] );
+		if ( ! in_array( $module, $sitekit_adsense_active ) ) {
+			$sitekit_active_modules[] = $module;
+			update_option( 'googlesitekit-active-modules', $sitekit_active_modules );
+		}
+	}
+
+	/**
+	 * Deactivate a module if it possible.
+	 *
+	 * @param string $module The module slug. See `get_module_info` for valid slugs.
+	 */
+	public function deactivate_module( $module ) {
+		$sitekit_active_modules = get_option( 'googlesitekit-active-modules', [] );
+		$updated_modules        = [];
+
+		foreach ( $sitekit_active_modules as $active_module ) {
+			if ( $module !== $active_module ) {
+				$updated_modules[] = $active_module;
+			}
+		}
+
+		update_option( 'googlesitekit-active-modules', $updated_modules );
 	}
 
 	/**

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -279,6 +279,12 @@ class Advertising_Wizard extends Wizard {
 		} else {
 			update_option( self::NEWSPACK_ADVERTISING_SERVICE_PREFIX . $service, true );
 		}
+
+		if ( 'google_adsense' === $service ) {
+			$sitekit_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'google-site-kit' );
+			$sitekit_manager->activate_module( 'adsense' );
+		}
+
 		return \rest_ensure_response( $this->retrieve_data() );
 	}
 
@@ -296,6 +302,12 @@ class Advertising_Wizard extends Wizard {
 		} else {
 			update_option( self::NEWSPACK_ADVERTISING_SERVICE_PREFIX . $service, false );
 		}
+
+		if ( 'google_adsense' === $service ) {
+			$sitekit_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'google-site-kit' );
+			$sitekit_manager->deactivate_module( 'adsense' );
+		}
+
 		return \rest_ensure_response( $this->retrieve_data() );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #211 

The underlying issue was that Site Kit keeps a list of active (but not necessarily configured) modules, and only registers/loads the settings screen for active modules. I've added methods to the Site Kit configuration manager to allow us to programmatically activate/deactivate Site Kit modules, and updated the wizard to use these.

### How to test the changes in this Pull Request:

1. In the advertising wizard, enable the AdSense toggle and click configure. Follow the handoff to the AdSense settings, which should now load correctly.
2. Disable the AdSense toggle in the advertising wizard. Go to the Site Kit connected services and observe AdSense is not in the list any more.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->