### PR TITLE
Enable alternate Donation form checkout locations.

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -377,7 +377,7 @@ class Donations {
 		);
 
 		// Redirect to checkout.
-		\wp_safe_redirect( \wc_get_page_permalink( 'checkout' ) );
+		\wp_safe_redirect( apply_filters( 'newspack_donation_checkout_url', \wc_get_page_permalink( 'checkout' ), $donation_value, $donation_frequency ) );
 		exit;
 	}
 

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -311,7 +311,7 @@ class Donations {
 	/**
 	 * Remove all donation products from the cart.
 	 */
-	protected static function remove_donations_from_cart() {
+	public static function remove_donations_from_cart() {
 		$donation_settings = self::get_donation_settings();
 		if ( ! $donation_settings['created'] ) {
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR makes 2 small changes necessary for NRH checkout support:
- Adds a filter for modifying the checkout page redirect.
- Makes the `remove_donations_from_cart` method public because it's handy and useful for other integrations (like NRH checkout integration).

### How to test the changes in this Pull Request:

1. Add the following code somewhere:
```
add_filter( 'newspack_donation_checkout_url', function($url){ return site_url(); } );
```
2. Use the Donate block, observe you get redirected to the home page upon form submission.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->