### PR TITLE
Unsupported Plugin Notification

### DIFF
--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -248,11 +248,8 @@ class Admin_Plugins_Screen {
 
 		$message = __( 'Newspack found unsupported plugins: ' ) . '<strong>' . implode( $unsupported_plugin_names, ', ' ) . '.</strong>';
 		?>
-		<div class="notice notice-warning is-dismissible">
+		<div class="notice notice-warning">
 			<p><?php echo wp_kses_post( $message ); ?></p>
-			<button type="button" class="notice-dismiss">
-				<span class="screen-reader-text"><?php echo esc_html__( 'Dismiss.', 'newspack' ); ?></span>
-			</button>
 		</div>
 		<?php
 	}

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -191,6 +191,25 @@ class Plugin_Manager {
 	}
 
 	/**
+	 * Get info about all the unmanaged plugins that are installed.
+	 *
+	 * @return array of plugin info.
+	 */
+	public static function get_unmanaged_plugins() {
+		$plugins_info      = self::get_installed_plugins_info();
+		$managed_plugins   = self::get_managed_plugins();
+		$ignore            = [ 'newspack-plugin' ];
+		$unmanaged_plugins = [];
+		foreach ( $plugins_info as $slug => $info ) {
+			if ( ! isset( $managed_plugins[ $slug ] ) && ! in_array( $slug, $ignore ) && is_plugin_active( $info['Path'] ) ) {
+				$unmanaged_plugins[ $slug ] = $info;
+			}
+		}
+		return $unmanaged_plugins;
+	}
+
+
+	/**
 	 * Determine whether plugin installation is allowed in the current environment.
 	 *
 	 * @return bool
@@ -288,6 +307,22 @@ class Plugin_Manager {
 		}
 
 		return array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'reduce_plugin_info' ) );
+	}
+
+	/**
+	 * Get a list of all installed plugins, with complete info for each.
+	 *
+	 * @return array of 'plugin_slug => []' entries for all installed plugins.
+	 */
+	public static function get_installed_plugins_info() {
+		$plugins = get_plugins();
+
+		$installed_plugins_info = [];
+		foreach ( self::get_installed_plugins() as $key => $path ) {
+			$installed_plugins_info[ $key ]         = $plugins[ $path ];
+			$installed_plugins_info[ $key ]['Path'] = $path;
+		}
+		return $installed_plugins_info;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a dismiss-able warning-level notification to Newspack dashboard pages listing unsupported plugins that are installed and active. 

### How to test the changes in this Pull Request:

1. Install and activate one or more plugins that are not supported by Newspack. 
2. Navigate to any page within the Newspack dashboard.
3. Observe notification about these plugins:
<img width="1089" alt="Screen Shot 2019-08-13 at 1 35 41 PM" src="https://user-images.githubusercontent.com/1477002/62963775-9fe55e80-bdcf-11e9-8c0b-3805883f2bb4.png">
4. When no unsupported plugins are active, observe that the notification is not displayed.
5. Observe the notification is not displayed on non-Newspack pages.
6. Plugin names should be links to the plugin's page if one is available.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->