### PR TITLE
Ad Picker Improvements

### DIFF
--- a/assets/wizards/advertising/views/placements/ad-picker/index.js
+++ b/assets/wizards/advertising/views/placements/ad-picker/index.js
@@ -21,9 +21,8 @@ class AdPicker extends Component {
 	adUnitsForSelect = adUnits => {
 		return [
 			{
-				label: __( 'Select an ad unit' ),
+				label: __( '- Select an ad unit -' ),
 				value: null,
-				disabled: true,
 			},
 			...Object.values( adUnits ).map( adUnit => {
 				return {
@@ -37,9 +36,8 @@ class AdPicker extends Component {
 	adServicesForSelect = services => {
 		return [
 			{
-				label: __( 'Select an ad provider' ),
+				label: __( '- Select an ad provider -' ),
 				value: null,
-				disabled: true,
 			},
 			...Object.keys( services )
 				.map(

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -410,10 +410,28 @@ class Advertising_Wizard extends Wizard {
 	private function retrieve_data() {
 		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
 
+		$services   = $this->get_services();
+		$placements = $this->get_placements();
+		$ad_units   = $configuration_manager->get_ad_units();
+
+		/* If there is only one enabled service, select it for all placements */
+		$enabled_services = array_filter(
+			$services,
+			function ( $service ) {
+				return ! empty( $service['enabled'] ) && $service['enabled'];
+			}
+		);
+
+		if ( 1 === count( $enabled_services ) ) {
+			$only_service = array_keys( $enabled_services )[0];
+			foreach ( $placements as &$placement ) {
+				$placement['service'] = $only_service;
+			}
+		}
 		return array(
-			'services'   => $this->get_services(),
-			'placements' => $this->get_placements(),
-			'ad_units'   => $configuration_manager->get_ad_units(),
+			'services'   => $services,
+			'placements' => $placements,
+			'ad_units'   => $ad_units,
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR addresses a situation where only one Ad Service is enabled and because of this the service cannot be selected, making it impossible to view the Ad Unit select. This addresses the problem in two ways:

- If only one Ad Service is enabled, the data returned by the API will have that service automatically selected for all placements.
- The first item in the Select form elements is no longer disabled. This means it is possible to make a selection when there is only one item. It also means the Ad Unit can be unset, which was previously impossible.

### How to test the changes in this Pull Request:

1. `npm run build:webpack`
2. Navigate to Advertising Wizard.
3. Turn on only Google Ad Manager. 
4. Click Global Settings tab, switch on one or more placements.
5. Observe that the Ad Provider select is automatically set to Google Ad Manager and the Ad Unit select is visible.
6. Switch on a second Ad Service.
7. On Global Settings switch on another placement.
8. Observe that the select has two elements and a selection can be made normally.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->