### PR TITLE
Update 'once' donation price logic

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -236,8 +236,8 @@ class Donations {
 		if ( $args['imageID'] ) {
 			$once_product->set_image_id( $args['imageID'] );
 		}
-		$once_product->set_regular_price( $default_price );
-		$once_product->update_meta_data( '_suggested_price', $default_price );
+		$once_product->set_regular_price( 12 * $default_price );
+		$once_product->update_meta_data( '_suggested_price', 12 * $default_price );
 		$once_product->update_meta_data( '_hide_nyp_minimum', 'yes' );
 		$once_product->update_meta_data( '_min_price', wc_format_decimal( 1.0 ) );
 		$once_product->update_meta_data( '_nyp', 'yes' );
@@ -283,6 +283,7 @@ class Donations {
 				continue;
 			}
 
+			$yearly_price = 12 * $default_price;
 			$child_product->set_status( 'publish' );
 			$child_product->set_image_id( $args['imageID'] );
 			$child_product->set_regular_price( $default_price );
@@ -291,7 +292,6 @@ class Donations {
 				if ( 'year' === $child_product->get_meta( '_subscription_period', true ) ) {
 					/* translators: %s: Product name */
 					$child_product->set_name( sprintf( __( '%s: Yearly', 'newspack' ), $args['name'] ) );
-					$yearly_price = 12 * $default_price;
 					$child_product->update_meta_data( '_subscription_price', \wc_format_decimal( $yearly_price ) );
 					$child_product->update_meta_data( '_suggested_price', \wc_format_decimal( $yearly_price ) );
 					$child_product->set_regular_price( $yearly_price );
@@ -303,6 +303,8 @@ class Donations {
 			} else {
 				/* translators: %s: Product name */
 				$child_product->set_name( sprintf( __( '%s: One-Time', 'newspack' ), $args['name'] ) );
+				$child_product->set_regular_price( $yearly_price );
+				$child_product->update_meta_data( '_suggested_price', $yearly_price );
 			}
 			$child_product->save();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #242  . See that issue for backstory.

This PR makes it so that the created/updated price for the 'once' frequency is 12 * the monthly frequency.

### How to test the changes in this Pull Request:

1. [Check out the companion PR to this](https://github.com/Automattic/newspack-blocks/pull/69).
2. Re-save the donation settings, or save them the first time if you haven't saved them yet.
3. Go to the Donate landing page, observe Once tab in the editor is 12 * monthly price. Go to Donate landing page in the frontend, observe Once tab in the frontend is 12 * monthly price. Click to make a one-time donation, observe the correct value gets added to the cart.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->