### PR TITLE
Action Card: Handoff Functionality

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -7,7 +7,7 @@
  */
 import { Component } from '@wordpress/element';
 import { Dashicon, Spinner, ToggleControl } from '@wordpress/components';
-import { Button, Card } from '../';
+import { Button, Card, Handoff } from '../';
 
 /**
  * Internal dependencies
@@ -35,6 +35,8 @@ class ActionCard extends Component {
 			className,
 			title,
 			description,
+			handoff,
+			editLink,
 			href,
 			notification,
 			notificationLevel,
@@ -63,10 +65,7 @@ class ActionCard extends Component {
 			<Card className={ classes } onClick={ simple && onClick }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
 					{ toggleOnChange && (
-						<ToggleControl
-							checked={ toggleChecked }
-							onChange={ toggleOnChange }
-						/>
+						<ToggleControl checked={ toggleChecked } onChange={ toggleOnChange } />
 					) }
 					{ image && ! toggleOnChange && (
 						<div className="newspack-action-card__region newspack-action-card__region-left">
@@ -79,12 +78,19 @@ class ActionCard extends Component {
 						</div>
 					) }
 					<div className="newspack-action-card__region newspack-action-card__region-center">
-						<h1>{ [ title, badge && <span className='newspack-action-card-badge'>{ badge }</span> ] }</h1>
+						<h1>
+							{ [ title, badge && <span className="newspack-action-card-badge">{ badge }</span> ] }
+						</h1>
 						<h2>{ description }</h2>
 					</div>
 					{ actionDisplay && (
 						<div className="newspack-action-card__region newspack-action-card__region-right">
-							{ actionDisplay && ( !! onClick || !! href ) && (
+							{ handoff && (
+								<Handoff plugin={ handoff } editLink={ editLink } compact isLink>
+									{ actionDisplay }
+								</Handoff>
+							) }
+							{ ( !! onClick || !! href ) && ! handoff && (
 								<Button
 									isLink
 									href={ href }
@@ -95,7 +101,7 @@ class ActionCard extends Component {
 								</Button>
 							) }
 
-							{ actionDisplay && ( ! onClick && ! href ) && (
+							{ ! handoff && ( ! onClick && ! href ) && (
 								<div className="newspack-action-card__container">
 									{ isWaiting && <Spinner /> }
 									{ actionDisplay }
@@ -126,6 +132,6 @@ class ActionCard extends Component {
 
 ActionCard.defaultProps = {
 	toggleChecked: false,
-}
+};
 
 export default ActionCard;

--- a/assets/components/src/handoff/index.js
+++ b/assets/components/src/handoff/index.js
@@ -59,10 +59,10 @@ class Handoff extends Component {
 		apiFetch( {
 			path: '/newspack/v1/plugins/' + plugin + '/handoff',
 			method: 'POST',
-			data: { 
-				editLink, 
+			data: {
+				editLink,
 				handoffReturnUrl: window && window.location.href,
-				showOnBlockEditor: showOnBlockEditor ? true : false 
+				showOnBlockEditor: showOnBlockEditor ? true : false,
 			},
 		} ).then( response => {
 			window.location.href = response.HandoffLink;
@@ -73,7 +73,7 @@ class Handoff extends Component {
 	 * Render.
 	 */
 	render( props ) {
-		const { className, children, useModal, onReady, ...otherProps } = this.props;
+		const { className, children, compact, useModal, onReady, ...otherProps } = this.props;
 		const { pluginInfo, showModal } = this.state;
 		const {
 			modalBody,
@@ -89,7 +89,7 @@ class Handoff extends Component {
 				{ Name && 'active' === Status && (
 					<Button
 						className={ classes }
-						isDefault
+						isDefault={ ! otherProps.isLink }
 						{ ...otherProps }
 						onClick={ () =>
 							useModal ? this.setState( { showModal: true } ) : this.goToPlugin( Slug )
@@ -104,10 +104,10 @@ class Handoff extends Component {
 					</Button>
 				) }
 				{ ! Name && (
-					<Button className={ classes } isDefault { ...otherProps }>
+					<Button className={ classes } isDefault={ ! otherProps.isLink } { ...otherProps }>
 						<Fragment>
 							{ __( 'Retrieving Plugin Info' ) }
-							<Spinner />
+							{ ! compact && <Spinner /> }
 						</Fragment>
 					</Button>
 				) }
@@ -132,6 +132,6 @@ class Handoff extends Component {
 
 Handoff.defaultProps = {
 	onReady: () => {},
-}
+};
 
 export default Handoff;

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -297,6 +297,19 @@ class ComponentsDemo extends Component {
 							console.log( 'Install clicked' );
 						} }
 					/>
+					<ActionCard
+						title="Handoff"
+						description="An example of an action card with Handoff."
+						actionText="Configure"
+						handoff="jetpack"
+					/>
+					<ActionCard
+						title="Handoff"
+						description="An example of an action card with Handoff and EditLink."
+						actionText="Configure"
+						handoff="jetpack"
+						editLink="admin.php?page=jetpack#/settings"
+					/>
 					<FormattedHeader headerText={ __( 'Checklist' ) } />
 					<Checklist progressBarText={ __( 'Your setup list' ) } className="muriel-grid-item">
 						<Task


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds Handoff support to Action Cards, allowing the primary button to be configured as a handoff link to another plugin. The `ActionCard` component now takes optional `handoff` and `editLink` parameters. `handoff` should be the slug of the plugin to handoff to, and `editLink` optionally allows setting the exact URL to go to which is useful if you wish to target a specific page within the plugin's dashboard.

<img width="785" alt="Screen Shot 2019-08-28 at 12 35 59 AM" src="https://user-images.githubusercontent.com/1477002/63826204-0029e380-c92c-11e9-8c3f-ae0a340bf7d7.png">

### How to test the changes in this Pull Request:

1. Check out the theme, run `npm run build:webpack`
2. Navigate to `Components Demo` (`/wp-admin/admin.php?page=newspack-components-demo`)
3. Observe two new `ActionCard` examples, as shown in the screenshot above. 
4. Clicking `Configure` in the first should lead to Jetpack's main dashboard.
5. Clicking `Configure` in the second should lead to the Jetpack Setting page.
6. In both cases the Handoff banner should be visible (and functional) at the top of the page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->