### PR TITLE
Install The Newspack Theme

### DIFF
--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -23,7 +23,7 @@ import './style.scss';
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { pickBy, includes, forEach } from 'lodash';
 
-const REQUIRED_PLUGINS = [ 'jetpack', 'amp', 'pwa', 'wordpress-seo', 'google-site-kit' ];
+const REQUIRED_PLUGINS = [ 'jetpack', 'amp', 'pwa', 'wordpress-seo', 'google-site-kit', 'newspack-theme' ];
 
 /**
  * Wizard for setting up ability to take payments.
@@ -174,7 +174,7 @@ class SetupWizard extends Component {
 						exact
 						render={ routeProps => (
 							<Welcome
-								buttonText={ __( 'Install core plugins' ) }
+								buttonText={ __( 'Install core plugins and Newspack theme' ) }
 								buttonAction={ {
 									href: '#/about',
 									onClick: () => this.updateProfile(),
@@ -184,7 +184,7 @@ class SetupWizard extends Component {
 								profile={ profile }
 								notice=<p>
 									{ __(
-										'Clicking “Get Started” will install core Newspack plugins in the background.'
+										'Clicking “Get Started” will install core Newspack plugins and the theme in the background.'
 									) }
 								</p>
 							/>

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -188,10 +188,7 @@ class Plugin_Manager {
 				}
 			}
 			if ( 'newspack-theme' === $plugin_slug ) {
-				$theme      = wp_get_theme();
-				$plugin_uri = $theme->get( 'ThemeURI' );
-				$theme_slug = explode( '/', $plugin_uri );
-				if ( end( $theme_slug ) === $plugin_slug ) {
+				if ( 'newspack-theme' === get_stylesheet() ) {
 					$status = 'active';
 				}
 			}

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -156,6 +156,11 @@ class Plugin_Manager {
 				'Author'      => 'Newspack',
 				'Download'    => 'wporg',
 			],
+			'newspack-theme'                => [
+				'Name'        => 'Newspack Theme',
+				'Description' => 'The Newspack theme.',
+				'Author'      => 'Newspack',
+			],
 		];
 
 		$default_info = [
@@ -180,6 +185,14 @@ class Plugin_Manager {
 					$status = 'active';
 				} else {
 					$status = 'inactive';
+				}
+			}
+			if ( 'newspack-theme' === $plugin_slug ) {
+				$theme      = wp_get_theme();
+				$plugin_uri = $theme->get( 'ThemeURI' );
+				$theme_slug = explode( '/', $plugin_uri );
+				if ( end( $theme_slug ) === $plugin_slug ) {
+					$status = 'active';
 				}
 			}
 			$managed_plugins[ $plugin_slug ]['Status']      = $status;
@@ -230,6 +243,9 @@ class Plugin_Manager {
 	 * @return bool True on success. False on failure or if plugin was already activated.
 	 */
 	public static function activate( $plugin ) {
+		if ( 'newspack-theme' === $plugin ) {
+			return newspack_install_activate_theme();
+		}
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
@@ -306,7 +322,9 @@ class Plugin_Manager {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		return array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'reduce_plugin_info' ) );
+		$plugins = array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'reduce_plugin_info' ) );
+		$themes  = array_reduce( array_keys( wp_get_themes() ), array( __CLASS__, 'reduce_plugin_info' ) );
+		return array_merge( $plugins, $themes );
 	}
 
 	/**
@@ -315,7 +333,7 @@ class Plugin_Manager {
 	 * @return array of 'plugin_slug => []' entries for all installed plugins.
 	 */
 	public static function get_installed_plugins_info() {
-		$plugins = get_plugins();
+		$plugins = array_merge( get_plugins(), wp_get_themes() );
 
 		$installed_plugins_info = [];
 		foreach ( self::get_installed_plugins() as $key => $path ) {

--- a/includes/configuration_managers/class-configuration-managers.php
+++ b/includes/configuration_managers/class-configuration-managers.php
@@ -43,7 +43,11 @@ class Configuration_Managers {
 		'woocommerce'     => [
 			'filename'   => 'class-woocommerce-configuration-manager.php',
 			'class_name' => 'WooCommerce_Configuration_Manager',
-		]
+		],
+		'newspack-theme'  => [
+			'filename'   => 'class-newspack-theme-configuration-manager.php',
+			'class_name' => 'Newspack_Theme_Configuration_Manager',
+		],
 	];
 
 	/**

--- a/includes/configuration_managers/class-newspack-theme-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-theme-configuration-manager.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Newspack Theme plugin configuration manager.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
+
+/**
+ * Provide an interface for configuring and querying the configuration of AMP.
+ */
+class Newspack_Theme_Configuration_Manager extends Configuration_Manager {
+
+	/**
+	 * Configure Newspack Theme for Newspack use.
+	 *
+	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
+	 */
+	public function configure() {
+		set_theme_mod( 'theme_colors', 'default' );
+		return true;
+	}
+}

--- a/includes/util.php
+++ b/includes/util.php
@@ -41,7 +41,7 @@ function newspack_string_to_bool( $string ) {
  */
 function newspack_install_activate_theme() {
 	$theme_slug = 'newspack-theme';
-	$theme_url  = 'https://github.com/Automattic/newspack-theme/archive/master.zip';
+	$theme_url  = 'https://github.com/Automattic/newspack-theme/releases/latest/download/newspack-theme.zip';
 
 	$theme_object = wp_get_theme( $theme_slug );
 	if ( ! $theme_object->exists() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the Newspack Theme to the list of plugins and takes care of handling it as an unusual case. The theme is installed as part of the Setup Wizard. The PR also includes a stub of a configuration manager for the theme, which at present only sets the colors to be default (which is  the theme default anyway). This configuration manager will eventually be the main interface between the Site  Design wizard and the Theme. The PR also contains some minor UI/text changes to the Setup Wizard to indicate that the theme is being installed as well as plugins.

### How to test the changes in this Pull Request:

1. Check out this branch, run `npm run build:webpack`
2. Deactivate and delete the theme.
3. Run through the Setup Wizard. 
4. Verify that the theme has been installed and is the active theme. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->