### PR TITLE
Site Design Wizard: Stub

### DIFF
--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -23,7 +23,16 @@ import './style.scss';
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { pickBy, includes, forEach } from 'lodash';
 
-const REQUIRED_PLUGINS = [ 'jetpack', 'amp', 'pwa', 'gutenberg', 'wordpress-seo', 'google-site-kit', 'newspack-blocks', 'newspack-theme' ];
+const REQUIRED_PLUGINS = [
+	'jetpack',
+	'amp',
+	'pwa',
+	'gutenberg',
+	'wordpress-seo',
+	'google-site-kit',
+	'newspack-blocks',
+	'newspack-theme',
+];
 
 /**
  * Wizard for setting up ability to take payments.

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -60,7 +60,7 @@ class Dashboard extends Wizard {
 				'url'         => admin_url( 'customize.php' ),
 				'description' => esc_html__( 'Branding, color, typography, layouts', 'newspack' ),
 				'image'       => Newspack::plugin_url() . '/assets/wizards/dashboard/site-design-icon.svg',
-				'status'      => true,
+				'status'      => 'enabled',
 			],
 			[
 				'slug'        => 'reader-revenue',

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -57,10 +57,10 @@ class Dashboard extends Wizard {
 			[
 				'slug'        => 'site-design',
 				'name'        => esc_html__( 'Site Design', 'newspack' ),
-				'url'         => '#',
+				'url'         => admin_url( 'customize.php' ),
 				'description' => esc_html__( 'Branding, color, typography, layouts', 'newspack' ),
 				'image'       => Newspack::plugin_url() . '/assets/wizards/dashboard/site-design-icon.svg',
-				'status'      => 'disabled',
+				'status'      => true,
 			],
 			[
 				'slug'        => 'reader-revenue',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is the first of a few PRs that stubs out the remaining disabled Wizards with very basic functionality. This one enables the Site Design card, which links directly to the Customizer.

Blocked by https://github.com/Automattic/newspack-plugin/pull/249.

### How to test the changes in this Pull Request:

1. Check out the branch, run `npm run build:webpack`
2. Navigate to Dashboard, click Site Design.
3. Verify you are taken to the Customizer.
4. Click the X above the Customizer left panel, and verify you  are returned to Newspack.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->