### PR TITLE
SEO Wizard: Stub

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -100,8 +100,7 @@ class ActionCard extends Component {
 									{ actionDisplay }
 								</Button>
 							) }
-
-							{ ! handoff && ( ! onClick && ! href ) && (
+							{ ! handoff && ! onClick && ! href && (
 								<div className="newspack-action-card__container">
 									{ isWaiting && <Spinner /> }
 									{ actionDisplay }

--- a/assets/wizards/seo/index.js
+++ b/assets/wizards/seo/index.js
@@ -1,0 +1,63 @@
+/**
+ * SEO Wizard
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, render, Fragment } from '@wordpress/element';
+import { ExternalLink } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { withWizard } from '../../components/src';
+import { Intro } from './views';
+
+/**
+ * External dependencies
+ */
+import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
+
+/**
+ * SEO wizard.
+ */
+class SEOWizard extends Component {
+
+	/**
+	 * Render
+	 */
+	render() {
+		const { pluginRequirements } = this.props;
+		return (
+			<Fragment>
+				<HashRouter hashType="slash">
+					<Switch>
+						{ pluginRequirements }
+						<Route
+							path="/"
+							exact
+							render={ routeProps => (
+								<Intro
+									noBackground
+									headerText={ __( 'Search Engine Optimization', 'newspack' ) }
+									secondaryButtonText={ __( 'Back to dashboard' ) }
+									secondaryButtonAction={ window && window.newspack_urls.dashboard }
+									secondaryButtonStyle={ { isDefault: true } }
+								/>
+							) }
+						/>
+						<Redirect to="/" />
+					</Switch>
+				</HashRouter>
+			</Fragment>
+		);
+	}
+}
+
+render(
+	createElement( withWizard( SEOWizard, [ 'wordpress-seo', 'jetpack' ] ) ),
+	document.getElementById( 'newspack-seo-wizard' )
+);

--- a/assets/wizards/seo/views/index.js
+++ b/assets/wizards/seo/views/index.js
@@ -1,0 +1,1 @@
+export { default as Intro } from './intro';

--- a/assets/wizards/seo/views/intro/index.js
+++ b/assets/wizards/seo/views/intro/index.js
@@ -1,0 +1,48 @@
+/**
+ * SEO Intro screen.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { ExternalLink } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ActionCard, withWizardScreen } from '../../../../components/src';
+
+/**
+ * SEO Intro screen.
+ */
+class Intro extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		return (
+			<Fragment>
+				<ActionCard
+					title={ __( 'Yoast SEO' ) }
+					description={ __(
+						'The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more.'
+					) }
+					actionText={ __( 'Configure' ) }
+					href={ '#' }
+				/>
+				<ActionCard
+					title={ __( 'Jetpack SEO' ) }
+					description={ __(
+						'Optimize your site\'s SEO with Jetpack'
+					) }
+					actionText={ __( 'Configure' ) }
+					href={ '#' }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+export default withWizardScreen( Intro );

--- a/assets/wizards/seo/views/intro/index.js
+++ b/assets/wizards/seo/views/intro/index.js
@@ -30,7 +30,7 @@ class Intro extends Component {
 						'The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more.'
 					) }
 					actionText={ __( 'Configure' ) }
-					href={ '#' }
+					handoff="wordpress-seo"
 				/>
 				<ActionCard
 					title={ __( 'Jetpack SEO' ) }
@@ -38,7 +38,8 @@ class Intro extends Component {
 						'Optimize your site\'s SEO with Jetpack'
 					) }
 					actionText={ __( 'Configure' ) }
-					href={ '#' }
+					handoff="jetpack"
+					editLink='admin.php?page=jetpack#/traffic'
 				/>
 			</Fragment>
 		);

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -75,6 +75,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-performance-wizard.php';
 		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-reader-revenue-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-syndication-wizard.php';
+		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-seo-wizard.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-wizards.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-checklists.php';

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -37,6 +37,7 @@ class Wizards {
 			'performance'      => new Performance_Wizard(),
 			'mailchimp'        => new Mailchimp_Wizard(),
 			'newsletter-block' => new Newsletter_Block_Wizard(),
+			'seo'              => new SEO_Wizard(),
 		];
 	}
 

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -87,11 +87,10 @@ class Dashboard extends Wizard {
 			],
 			[
 				'slug'        => 'seo',
-				'name'        => esc_html__( 'SEO', 'newspack' ),
-				'url'         => '#',
+				'name'        => Wizards::get_name( 'seo' ),
+				'url'         => Wizards::get_url( 'seo' ),
 				'description' => esc_html__( 'Search engine and social optimization', 'newspack' ),
 				'image'       => Newspack::plugin_url() . '/assets/wizards/dashboard/seo-icon.svg',
-				'status'      => 'disabled',
 			],
 			[
 				'slug'        => 'engagement',

--- a/includes/wizards/class-seo-wizard.php
+++ b/includes/wizards/class-seo-wizard.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Newspack's SEO Wizard
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error, \WP_Query;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Easy interface for setting up general store info.
+ */
+class SEO_Wizard extends Wizard {
+
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-seo-wizard';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return \esc_html__( 'SEO', 'newspack' );
+	}
+
+	/**
+	 * Get the description of this wizard.
+	 *
+	 * @return string The wizard description.
+	 */
+	public function get_description() {
+		return \esc_html__( 'Search engine and social optimization.', 'newspack' );
+	}
+
+	/**
+	 * Get the duration of this wizard.
+	 *
+	 * @return string A description of the expected duration (e.g. '10 minutes').
+	 */
+	public function get_length() {
+		return esc_html__( '10 minutes', 'newspack' );
+	}
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public function register_api_endpoints() {}
+
+	/**
+	 * Enqueue Subscriptions Wizard scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		parent::enqueue_scripts_and_styles();
+
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+			return;
+		}
+
+		\wp_enqueue_script(
+			'newspack-seo-wizard',
+			Newspack::plugin_url() . '/assets/dist/seo.js',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/seo.js' ),
+			true
+		);
+
+		\wp_register_style(
+			'newspack-seo-wizard',
+			Newspack::plugin_url() . '/assets/dist/seo.css',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/seo.css' )
+		);
+		\wp_style_add_data( 'newspack-seo-wizard', 'rtl', 'replace' );
+		\wp_enqueue_style( 'newspack-seo-wizard' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a stub of the SEO Wizard with basic functionality: two Action Cards, one for Yoast and one for Jetpack. 

Blocked by https://github.com/Automattic/newspack-plugin/pull/247

<img width="1638" alt="Screen Shot 2019-08-28 at 12 58 42 AM" src="https://user-images.githubusercontent.com/1477002/63826867-12595100-c92f-11e9-8eae-c0a7e43623f6.png">

### How to test the changes in this Pull Request:

1. Check out the branch, run `npm run build:webpack`
2. Navigate to the Dashboard and click on the SEO card. 
3. Observe two Action Cards like the screenshot.
4. Click `Configure` links for both and verify you are taken to the Yoast and Jetpack dashboards, with the Newspack Handoff Banner at the top.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->