### PR TITLE
Syndication Wizard: Stub

### DIFF
--- a/assets/wizards/syndication/index.js
+++ b/assets/wizards/syndication/index.js
@@ -55,6 +55,6 @@ class SyndicationWizard extends Component {
 }
 
 render(
-	createElement( withWizard( SyndicationWizard, [] ) ),
+	createElement( withWizard( SyndicationWizard, [ 'fb-instant-articles', 'publish-to-apple-news' ] ) ),
 	document.getElementById( 'newspack-syndication-wizard' )
 );

--- a/assets/wizards/syndication/index.js
+++ b/assets/wizards/syndication/index.js
@@ -1,0 +1,60 @@
+/**
+ * Syndication Wizard.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, render, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { withWizard } from '../../components/src';
+import { Intro } from './views';
+
+/**
+ * External dependencies
+ */
+import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
+
+/**
+ * Syndication wizard.
+ */
+class SyndicationWizard extends Component {
+	/**
+	 * Render
+	 */
+	render() {
+		const { pluginRequirements } = this.props;
+		return (
+			<Fragment>
+				<HashRouter hashType="slash">
+					<Switch>
+						{ pluginRequirements }
+						<Route
+							path="/"
+							exact
+							render={ routeProps => (
+								<Intro
+									noBackground
+									headerText={ __( 'Syndication', 'newspack' ) }
+									secondaryButtonText={ __( 'Back to dashboard' ) }
+									secondaryButtonAction={ window && window.newspack_urls.dashboard }
+									secondaryButtonStyle={ { isDefault: true } }
+								/>
+							) }
+						/>
+						<Redirect to="/" />
+					</Switch>
+				</HashRouter>
+			</Fragment>
+		);
+	}
+}
+
+render(
+	createElement( withWizard( SyndicationWizard, [] ) ),
+	document.getElementById( 'newspack-syndication-wizard' )
+);

--- a/assets/wizards/syndication/views/index.js
+++ b/assets/wizards/syndication/views/index.js
@@ -1,0 +1,1 @@
+export { default as Intro } from './intro';

--- a/assets/wizards/syndication/views/intro/index.js
+++ b/assets/wizards/syndication/views/intro/index.js
@@ -29,6 +29,7 @@ class Intro extends Component {
 						'Description TK'
 					) }
 					actionText={ __( 'Configure' ) }
+					handoff="publish-to-apple-news"
 				/>
 				<ActionCard
 					title={ __( 'Facebook Instant Articles' ) }
@@ -36,6 +37,7 @@ class Intro extends Component {
 						'Description TK'
 					) }
 					actionText={ __( 'Configure' ) }
+					handoff="fb-instant-articles"
 				/>
 			</Fragment>
 		);

--- a/assets/wizards/syndication/views/intro/index.js
+++ b/assets/wizards/syndication/views/intro/index.js
@@ -1,0 +1,45 @@
+/**
+ * Syndication Intro View
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ActionCard, withWizardScreen } from '../../../../components/src';
+
+/**
+ * Syndication Intro screen.
+ */
+class Intro extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		return (
+			<Fragment>
+				<ActionCard
+					title={ __( 'Apple News' ) }
+					description={ __(
+						'Description TK'
+					) }
+					actionText={ __( 'Configure' ) }
+				/>
+				<ActionCard
+					title={ __( 'Facebook Instant Articles' ) }
+					description={ __(
+						'Description TK'
+					) }
+					actionText={ __( 'Configure' ) }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+export default withWizardScreen( Intro );

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -74,6 +74,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-advertising-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-performance-wizard.php';
 		include_once NEWSPACK_ABSPATH . '/includes/wizards/class-reader-revenue-wizard.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-syndication-wizard.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-wizards.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-checklists.php';

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -168,6 +168,7 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://www.alleyinteractive.com',
 				'PluginURI'   => 'http://github.com/alleyinteractive/apple-news',
 				'Download'    => 'wporg',
+				'EditPath'    => 'admin.php?page=apple_news_index',
 			],
 			'fb-instant-articles'           => [
 				'Name'        => 'Instant Articles for WP',
@@ -176,6 +177,7 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://vip.wordpress.com/plugins/instant-articles/',
 				'PluginURI'   => 'https://vip.wordpress.com/plugins/instant-articles/',
 				'Download'    => 'wporg',
+				'EditPath'    => 'admin.php?page=instant-articles-wizard',
 			],
 		];
 

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -161,6 +161,22 @@ class Plugin_Manager {
 				'Description' => 'The Newspack theme.',
 				'Author'      => 'Newspack',
 			],
+			'publish-to-apple-news'         => [
+				'Name'        => 'Publish to Apple News',
+				'Description' => 'Export and sync posts to Apple format.',
+				'Author'      => 'Alley Interactive',
+				'AuthorURI'   => 'https://www.alleyinteractive.com',
+				'PluginURI'   => 'http://github.com/alleyinteractive/apple-news',
+				'Download'    => 'wporg',
+			],
+			'fb-instant-articles'           => [
+				'Name'        => 'Instant Articles for WP',
+				'Description' => 'Add support for Instant Articles for Facebook to your WordPress site.',
+				'Author'      => 'Automattic, Dekode, Facebook',
+				'AuthorURI'   => 'https://vip.wordpress.com/plugins/instant-articles/',
+				'PluginURI'   => 'https://vip.wordpress.com/plugins/instant-articles/',
+				'Download'    => 'wporg',
+			],
 		];
 
 		$default_info = [

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -31,6 +31,7 @@ class Wizards {
 			'dashboard'        => new Dashboard(),
 			'reader-revenue'   => new Reader_Revenue_Wizard(),
 			'advertising'      => new Advertising_Wizard(),
+			'syndication'      => new Syndication_Wizard(),
 			'google-analytics' => new Google_Analytics_Wizard(),
 			'components-demo'  => new Components_Demo(),
 			'performance'      => new Performance_Wizard(),

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -111,11 +111,11 @@ class Dashboard extends Wizard {
 			],
 			[
 				'slug'        => 'syndication',
-				'name'        => esc_html__( 'Syndication', 'newspack' ),
-				'url'         => '#',
+				'name'        => Wizards::get_name( 'syndication' ),
+				'url'         => Wizards::get_url( 'syndication' ),
 				'description' => esc_html__( 'Apple News, Facebook Instant Articles', 'newspack' ),
 				'image'       => Newspack::plugin_url() . '/assets/wizards/dashboard/syndication-icon.svg',
-				'status'      => 'disabled',
+				'status'      => Checklists::get_status( 'syndication' ),
 			],
 		];
 

--- a/includes/wizards/class-syndication-wizard.php
+++ b/includes/wizards/class-syndication-wizard.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Newspack's Syndication Wizard
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error, \WP_Query;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Syndication
+ */
+class Syndication_Wizard extends Wizard {
+
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-syndication-wizard';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return \esc_html__( 'Syndication', 'newspack' );
+	}
+
+	/**
+	 * Get the description of this wizard.
+	 *
+	 * @return string The wizard description.
+	 */
+	public function get_description() {
+		return \esc_html__( 'Distribute your content.', 'newspack' );
+	}
+
+	/**
+	 * Get the duration of this wizard.
+	 *
+	 * @return string A description of the expected duration (e.g. '10 minutes').
+	 */
+	public function get_length() {
+		return esc_html__( '10 minutes', 'newspack' );
+	}
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public function register_api_endpoints() {}
+
+	/**
+	 * Enqueue Subscriptions Wizard scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		parent::enqueue_scripts_and_styles();
+
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+			return;
+		}
+
+		\wp_enqueue_script(
+			'newspack-syndication-wizard',
+			Newspack::plugin_url() . '/assets/dist/syndication.js',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/syndication.js' ),
+			true
+		);
+
+		\wp_register_style(
+			'newspack-syndication-wizard',
+			Newspack::plugin_url() . '/assets/dist/syndication.css',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/syndication.css' )
+		);
+		\wp_style_add_data( 'newspack-syndication-wizard', 'rtl', 'replace' );
+		\wp_enqueue_style( 'newspack-syndication-wizard' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a stub of the Syndication Wizard. It adds the [Facebook Instance Articles](https://wpvip.com/plugins/facebook-instant-articles/) and [Publish To Apple News](https://wordpress.org/plugins/publish-to-apple-news/) plugins, which are both dependencies of the Wizard. The UI consist of two Action Cards each with a Handoff to one of the two plugins. 

Blocked by https://github.com/Automattic/newspack-plugin/pull/247

<img width="1638" alt="Screen Shot 2019-08-28 at 1 04 03 AM" src="https://user-images.githubusercontent.com/1477002/63827069-c064fb00-c92f-11e9-9954-cba054bcd7e8.png">

### How to test the changes in this Pull Request:

1. Check out the branch, run `npm run build:webpack`
2. Navigate to the Newspack Dashboard, and click the Syndication card.
3. Observe the Search Engine Optimization wizard, as shown in the screenshot.
4. Click Configure for each Action Card, and verify you are taken to the appropriate plugin with a Newspack Handoff banner at the top of the screen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->