### PR TITLE
Fixes To Setup Wizard Plugin Installation

### DIFF
--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -30,6 +30,7 @@ class PluginInstaller extends Component {
 		super( ...arguments );
 		this.state = {
 			pluginInfo: {},
+			installationInitialized: false,
 		};
 	}
 
@@ -42,9 +43,13 @@ class PluginInstaller extends Component {
 	};
 
 	componentDidUpdate = prevProps => {
-		const { plugins } = this.props;
+		const { autoInstall, plugins } = this.props;
+		const { installationInitialized } = this.state;
 		if ( plugins !== prevProps.plugins ) {
 			this.retrievePluginInfo( plugins );
+		}
+		if ( autoInstall && ! installationInitialized ) {
+			this.installAllPlugins();
 		}
 	};
 
@@ -67,6 +72,7 @@ class PluginInstaller extends Component {
 
 	installAllPlugins = () => {
 		const { pluginInfo } = this.state;
+		this.setState( { installationInitialized: true } );
 		const promises = Object.keys( pluginInfo )
 			.filter( slug => 'active' !== pluginInfo[ slug ].Status )
 			.map( slug => () => this.installPlugin( slug ) );
@@ -145,9 +151,9 @@ class PluginInstaller extends Component {
 		}
 		return (
 			<div>
-				{ ( ! pluginInfo || ! Object.keys( pluginInfo ).length )  && (
+				{ ( ! pluginInfo || ! Object.keys( pluginInfo ).length ) && (
 					<div className="newspack-plugin-installer_waiting">
-						<p>{ __( 'Retrieving plugin information...') }</p>
+						<p>{ __( 'Retrieving plugin information...' ) }</p>
 						<Spinner />
 					</div>
 				) }
@@ -178,16 +184,16 @@ class PluginInstaller extends Component {
 							/>
 						);
 					} ) }
-					{ ! autoInstall && pluginInfo && slugs.length > 0 && (
-						<Button
-							disabled={ ! needsInstall }
-							isPrimary
-							className="is-centered"
-							onClick={ this.installAllPlugins }
-						>
-							{ __( 'Install' ) }
-						</Button>
-					) }
+				{ ! autoInstall && pluginInfo && slugs.length > 0 && (
+					<Button
+						disabled={ ! needsInstall }
+						isPrimary
+						className="is-centered"
+						onClick={ this.installAllPlugins }
+					>
+						{ __( 'Install' ) }
+					</Button>
+				) }
 			</div>
 		);
 	}
@@ -195,6 +201,6 @@ class PluginInstaller extends Component {
 
 PluginInstaller.defaultProps = {
 	onStatus: () => {},
-}
+};
 
 export default PluginInstaller;

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -36,17 +36,11 @@ export default function withWizardScreen( WrappedComponent, config ) {
 				secondaryButtonStyle,
 				hidden,
 			} = this.props;
-			if ( hidden ) {
-				return (
-					<div className="muriel-wizardScreen__hidden">
-						<WrappedComponent { ...this.props } />
-					</div>
-				);
-			}
 			const classes = murielClassnames(
 				'muriel-wizardScreen',
 				className,
-				noBackground ? 'muriel-wizardScreen__no-background' : ''
+				noBackground ? 'muriel-wizardScreen__no-background' : '',
+				hidden ? 'muriel-wizardScreen__hidden' : '',
 			);
 			const content = (
 				<div className="muriel-wizardScreen__content">
@@ -56,19 +50,21 @@ export default function withWizardScreen( WrappedComponent, config ) {
 			const retrievedButtonProps = buttonProps( buttonAction );
 			return (
 				<Fragment>
-					<Grid>
-						<Card noBackground>
-							{ headerText && (
-								<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
-							) }
-						</Card>
-						{ tabbedNavigation && (
+					{ ! hidden && (
+						<Grid>
 							<Card noBackground>
-								<TabbedNavigation items={ tabbedNavigation } />
-								{ secondaryNavigation && <SecondaryNavigation items={ secondaryNavigation } /> }
+								{ headerText && (
+									<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+								) }
 							</Card>
-						) }
-					</Grid>
+							{ tabbedNavigation && (
+								<Card noBackground>
+									<TabbedNavigation items={ tabbedNavigation } />
+									{ secondaryNavigation && <SecondaryNavigation items={ secondaryNavigation } /> }
+								</Card>
+							) }
+						</Grid>
+					) }
 					{ !! noCard && content }
 					{ ! noCard && (
 						<Grid>
@@ -77,41 +73,43 @@ export default function withWizardScreen( WrappedComponent, config ) {
 							</Card>
 						</Grid>
 					) }
-					<Grid>
-						<Card className="is-centered" noBackground>
-							{ buttonText && buttonAction && !! retrievedButtonProps.plugin && (
-								<Handoff
-									isPrimary
-									className="is-centered muriel-wizardScreen__completeButton"
-									{ ...retrievedButtonProps }
-								>
-									{ buttonText }
-								</Handoff>
-							) }
-							{ notice }
-							{ buttonText && buttonAction && ! retrievedButtonProps.plugin && (
-								<Button
-									isPrimary={ ! buttonDisabled }
-									isDefault={ !! buttonDisabled }
-									className="is-centered muriel-wizardScreen__completeButton"
-									disabled={ buttonDisabled }
-									{ ...retrievedButtonProps }
-								>
-									{ buttonText }
-								</Button>
-							) }
-							{ footer }
-							{ secondaryButtonText && (
-								<Button
-									{ ...secondaryButtonStyle }
-									className="is-centered"
-									{ ...buttonProps( secondaryButtonAction ) }
-								>
-									{ secondaryButtonText }
-								</Button>
-							) }
-						</Card>
-					</Grid>
+					{ ! hidden && (
+						<Grid>
+							<Card className="is-centered" noBackground>
+								{ buttonText && buttonAction && !! retrievedButtonProps.plugin && (
+									<Handoff
+										isPrimary
+										className="is-centered muriel-wizardScreen__completeButton"
+										{ ...retrievedButtonProps }
+									>
+										{ buttonText }
+									</Handoff>
+								) }
+								{ notice }
+								{ buttonText && buttonAction && ! retrievedButtonProps.plugin && (
+									<Button
+										isPrimary={ ! buttonDisabled }
+										isDefault={ !! buttonDisabled }
+										className="is-centered muriel-wizardScreen__completeButton"
+										disabled={ buttonDisabled }
+										{ ...retrievedButtonProps }
+									>
+										{ buttonText }
+									</Button>
+								) }
+								{ footer }
+								{ secondaryButtonText && (
+									<Button
+										{ ...secondaryButtonStyle }
+										className="is-centered"
+										{ ...buttonProps( secondaryButtonAction ) }
+									>
+										{ secondaryButtonText }
+									</Button>
+								) }
+							</Card>
+						</Grid>
+					) }
 				</Fragment>
 			);
 		}

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -279,15 +279,10 @@ class SetupWizard extends Component {
 						} }
 					/>
 					<Route
-						path={ [
-							'/about',
-							'/newsroom',
-							'/configure-jetpack',
-							'/configure-google-site-kit',
-							'/installation-progress',
-						] }
+						path={ [ '/' ] }
 						render={ routeProps => (
 							<InstallationProgress
+								autoInstall={ '/' !== routeProps.location.pathname }
 								hidden={ '/installation-progress' !== routeProps.location.pathname }
 								noBackground
 								headerText={ __( 'Installation...' ) }

--- a/assets/wizards/setup/views/installation-progress/index.js
+++ b/assets/wizards/setup/views/installation-progress/index.js
@@ -20,13 +20,9 @@ class InstallationProgress extends Component {
 	 * Render.
 	 */
 	render() {
-		const { plugins, onStatus } = this.props;
+		const { autoInstall, plugins, onStatus } = this.props;
 		return (
-			<PluginInstaller
-				autoInstall
-				plugins={ plugins }
-				onStatus={ onStatus }
-			/>
+			<PluginInstaller autoInstall={ autoInstall } plugins={ plugins } onStatus={ onStatus } />
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a few issues with the Setup wizard that caused sporadic installation failures. The issues relate to the rendering of the `InstallationProgress` view which contains the `PluginInstaller` component. In the `Welcome` route (`/`) `InstallationProgress` isn't rendered at all. Then, in all subsequent views it's rendered hidden, with one exception: if installation is not yet complete the `Newsroom` view's Continue button leads to a visible version of the `InstallationProgress` screen. Due to problems in the handling of the `hidden` prop, this visible version of `InstallationProgress` caused `PluginInstaller` to re-mount, which led to two competing plugin installation API calls at the same time. In this situation the first API request succeeds, but the second one fails because the plugin directory already exists. This failure is reported in the UI and in some cases leads to duplicate installations.

This PR fixes these problems in a few ways:

- Correct `withWizardScreen`'s handling of the `hidden` prop so that the content is not re-rendered when the prop changes from true to false. 
- Change `InstallationProgress`'s route so it is rendered on all screens of the Setup wizard (usually hidden). 

Related to problems discussed in https://github.com/Automattic/newspack-plugin/pull/249
Possibly resolves https://github.com/Automattic/newspack-plugin/issues/188, although we may want to investigate hardening the APIs so they assess and handle the case where the plugin directory already exists.

### How to test the changes in this Pull Request:

1. On `master` branch, deactivate and delete several plugins. Also activate a theme other than Newspack and delete the Newspack theme.
2. Navigate to the Setup wizard, and click through the buttons on the first three screens as quickly as possible. The goal is to get to the `InstallationProgress` screen before the plugins finish installing.
3. Observe installation progress on the `InstallationProgress` screen. One or more should fail. With `The plugin directory already exists.` error message. This may need to be tried a few times to repro. In some cases, there won't be an error but the blue checkbox will fail  to appear. 
4. Do the same flow, but after clicking the blue button on the first view, click the "back" button in the upper left corner and then click through all blue buttons. Since the plugin installer is not rendered in the `/` route, this should also lead to some duplicate API hijinx.
5. Switch branches to `fix/plugin-installer-double-mount`, run `npm run build:webpack`, and try all of the above flows again. They should succeed consistently. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->