### PR TITLE
Fix Handoff React State Update When Unmounted

### DIFF
--- a/assets/components/src/handoff/index.js
+++ b/assets/components/src/handoff/index.js
@@ -31,15 +31,22 @@ class Handoff extends Component {
 	}
 
 	componentDidMount = () => {
+		this._isMounted = true;
 		const { plugin } = this.props;
 		this.retrievePluginInfo( plugin );
+	};
+
+	componentWillUnmount = () => {
+		this._isMounted = false;
 	};
 
 	retrievePluginInfo = plugin => {
 		const { onReady } = this.props;
 		apiFetch( { path: '/newspack/v1/plugins/' + plugin } ).then( pluginInfo => {
-			onReady( pluginInfo );
-			this.setState( { pluginInfo } );
+			if ( this._isMounted ) {
+				onReady( pluginInfo );
+				this.setState( { pluginInfo } );
+			}
 		} );
 	};
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `Handoff` component makes an API request to retrieve data about the plugin it is handing off to. If the component is removed before the request returns, the following warning is seen in the console:

```
backend.js:1 Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    in Handoff (created by _class)
```

It's just a warning, but worth fixing. This PR uses the approach described here to resolve: https://www.robinwieruch.de/react-warning-cant-call-setstate-on-an-unmounted-component

### How to test the changes in this Pull Request:

1. On `master` branch, connect Jetpack (if not already connected), then go to the Setup Wizard and click through to the Jetpack configuration screen. 
2. You will _probably_ see the warning in the console, although it's not completely reliable. You may need to try a few times to repro. 
3. Switch to `fix/handoff-noop` and run `npm run build:webpack`. 
4. It should be impossible to reproduce the warning. 
5. Verify other `Handoff` and make sure everything seems normal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->