### PR TITLE
Add Newspack Blocks As Required Plugin

### DIFF
--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -23,7 +23,7 @@ import './style.scss';
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { pickBy, includes, forEach } from 'lodash';
 
-const REQUIRED_PLUGINS = [ 'jetpack', 'amp', 'pwa', 'wordpress-seo', 'google-site-kit', 'newspack-theme' ];
+const REQUIRED_PLUGINS = [ 'jetpack', 'amp', 'pwa', 'wordpress-seo', 'google-site-kit', 'newspack-blocks', 'newspack-theme' ];
 
 /**
  * Wizard for setting up ability to take payments.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add Newspack Blocks as a required plugin to be installed by the Setup Wizard.

### How to test the changes in this Pull Request:

1. Switch to this branch, run npm run build:webpack
2. If already installed, deactivate and delete Newspack Blocks
3. Run through the Setup Wizard.
4. Verify that Newspack Blocks plugin is installed and activated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->