### PR TITLE
Notifications For Missing Required Plugins, Theme

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -17,6 +17,21 @@ defined( 'ABSPATH' ) || exit;
 class Plugin_Manager {
 
 	/**
+	 * Array of Newspack required plugins.
+	 *
+	 * @var array
+	 */
+	public static $required_plugins = [
+		'jetpack',
+		'amp',
+		'pwa',
+		'gutenberg',
+		'wordpress-seo',
+		'google-site-kit',
+		'newspack-blocks',
+	];
+
+	/**
 	 * Get info about all the managed plugins and their status.
 	 *
 	 * @todo Define what the structure of this looks like better and load it up from a config or something.
@@ -236,6 +251,21 @@ class Plugin_Manager {
 		return $unmanaged_plugins;
 	}
 
+	/**
+	 * Get info about all the required plugins that aren't installed and active.
+	 *
+	 * @return array of plugin info.
+	 */
+	public static function get_missing_plugins() {
+		$plugins_info    = self::get_installed_plugins_info();
+		$missing_plugins = array();
+		foreach ( self::$required_plugins as $slug ) {
+			if ( ! isset( $plugins_info[ $slug ] ) || ! is_plugin_active( $plugins_info[ $slug ]['Path'] ) ) {
+				$missing_plugins[ $slug ] = $plugins_info[ $slug ];
+			}
+		}
+		return $missing_plugins;
+	}
 
 	/**
 	 * Determine whether plugin installation is allowed in the current environment.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This plugin adds to the unsupported plugin notification. If required plugins are not installed and activated, these will be listed in the notification, in this syntax:
"The following plugins are required by Newspack but are not active: "

If the Newspack Theme is not active this will be described too, in this syntax:
"The Newspack Theme is not currently active."

 If required plugins are missing the notification will use error UI (red) otherwise warning (orange). 

The current list of supported plugins is found [here](https://github.com/Automattic/newspack-plugin/blob/add/missing-plugin-notifications/includes/class-plugin-manager.php#L43-L196) and required plugins [here](https://github.com/Automattic/newspack-plugin/blob/add/missing-plugin-notifications/includes/class-plugin-manager.php#L24-L32). 

Closes https://github.com/Automattic/newspack-plugin/issues/260

### How to test the changes in this Pull Request:

1. Disable one or more required plugins (e.g. AMP). Enable one or more unsupported plugins. Switch to a theme other than Newspack Theme.
2. Observe all three messages. Observe error-level UI (red). Verify that the text is correct, and includes all plugins that should be.
3. Try other combinations (theme disabled/no unsupported plugins, missing plugins/unsupported plugins, etc) and verify the results for all. 
4. Disable all unsupported plugins, enable all required plugins,  enable Newspack Theme. Verify there is no notification shown. 

Note that the notification will only be shown on Newspack Plugin dashboard pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->