### PR TITLE
Introduce AMP Enhancements class and fix DocumentCloud AMP compatibility

### DIFF
--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Enhancements and improvements to third-party plugins for AMP compatibility.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Tweaks third-party plugins for better AMP compatibility.
+ * When possible it's preferred to contribute AMP fixes downstream to the actual plugin.
+ */
+class AMP_Enhancements {
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_filter( 'do_shortcode_tag', [ __CLASS__, 'documentcloud_iframe_full_height' ], 10, 2 );
+	}
+
+	/**
+	 * Add an attribute to the iframe instructing AMP that the iframe should be rendered with the "fill" style instead
+	 * of the "fixed-height" style.
+	 *
+	 * @see https://github.com/ampproject/amp-wp/issues/3142
+	 * @param string $output HTML output of the shortcode.
+	 * @param string $tag The shortcode currently being processed.
+	 * @return string Modified shortcode output.
+	 */
+	public static function documentcloud_iframe_full_height( $output, $tag ) {
+		if ( 'documentcloud' !== $tag ) {
+			return $output;
+		}
+
+		return str_replace( '<iframe', '<iframe layout="fill"', $output );
+	}
+}
+AMP_Enhancements::init();

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -83,6 +83,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-handoff-banner.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-donations.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-pwa.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-amp-enhancements.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/configuration_managers/class-configuration-managers.php';
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-issues/issues/18

This PR introduces an `AMP_Enhancements` class so we can make small tweaks to third party plugins for better AMP-compatibility. The DocumentCloud plugin repo hasn't seen any action or releases in years, so AMP compatibility is not likely to be fixed at the source. 

A class for third-party plugin AMP-compatibility tweaks seems like an easier solution to maintain than having separate plugins for AMP-compatibility (e.g. DocumentCloud-AMP, Broadstreet-AMP, MailChimp-AMP, etc.). If you disagree, let me know; I'm open to all ideas.

### How to test the changes in this Pull Request:

1. [Follow steps to reproduce from this issue](https://github.com/ampproject/amp-wp/issues/3142) and verify everything looks good in AMP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->