### PR TITLE
Fix PHP Warnings

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -249,11 +249,12 @@ class Plugin_Manager {
 	 * @return array of plugin info.
 	 */
 	public static function get_missing_plugins() {
+		$managed_plugins = self::get_managed_plugins();
 		$plugins_info    = self::get_installed_plugins_info();
 		$missing_plugins = array();
 		foreach ( self::$required_plugins as $slug ) {
 			if ( ! isset( $plugins_info[ $slug ] ) || ! is_plugin_active( $plugins_info[ $slug ]['Path'] ) ) {
-				$missing_plugins[ $slug ] = $plugins_info[ $slug ];
+				$missing_plugins[ $slug ] = $managed_plugins[ $slug ];
 			}
 		}
 		return $missing_plugins;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes bug causing PHP warnings if required plugins are uninstalled.

Closes https://github.com/Automattic/newspack-plugin/issues/265

### How to test the changes in this Pull Request:

1. Deactivate and uninstall AMP (or Jetpack/Sitekit/Gutenberg/PWA)
2. Navigate to Newspack Dashboard.
3. Observe that there are no PHP warnings.
4. Observe the Missing required plugins notification.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->