### PR TITLE
Add notice if Disqus is run without compatibility plugin

### DIFF
--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -19,6 +19,8 @@ class AMP_Enhancements {
 	 */
 	public static function init() {
 		add_filter( 'do_shortcode_tag', [ __CLASS__, 'documentcloud_iframe_full_height' ], 10, 2 );
+		add_action( 'admin_notices', [ __CLASS__, 'disqus_amp_notice' ] );
+		add_action( 'admin_notices', [ __CLASS__, 'disqus_amp_activate' ], 9 );
 	}
 
 	/**
@@ -36,6 +38,50 @@ class AMP_Enhancements {
 		}
 
 		return str_replace( '<iframe', '<iframe layout="fill"', $output );
+	}
+
+	/**
+	 * Output a notice if Disqus is being run without the AMP-compatibility plugin.
+	 */
+	public static function disqus_amp_notice() {
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return;
+		}
+
+		$plugins = Plugin_Manager::get_managed_plugins();
+
+		if ( 'active' === $plugins['disqus-comment-system']['Status'] && 'active' !== $plugins['newspack-disqus-amp']['Status'] ) {
+			$cta = 'inactive' === $plugins['newspack-disqus-amp']['Status'] ? __( 'Activate Newspack Disqus AMP compatibility.', 'newspack' ) : __( 'Install and activate Newspack Disqus AMP compatibility.', 'newspack' );
+			?>
+			<div class='notice notice-error'>
+				<p><?php esc_html_e( 'You are using the Disqus comment system without the Newspack Disqus AMP plugin. Your comments form will not display on AMP pages.', 'newspack' ); ?></p>
+				<p><a href='<?php echo esc_url( wp_nonce_url( admin_url(), 'newspack_activate_disqus_amp', 'newspack_activate_disqus_amp' ) ); ?>' class='button burron-primary'><?php echo esc_html( $cta ); ?></a></p>
+			</div>
+			<?php
+		}
+	}
+
+	/**
+	 * Process the link in the notice to install the Disqus AMP-compatibility plugin.
+	 */
+	public static function disqus_amp_activate() {
+		if ( ! filter_input( INPUT_GET, 'newspack_activate_disqus_amp', FILTER_SANITIZE_SPECIAL_CHARS ) || ! wp_verify_nonce( filter_input( INPUT_GET, 'newspack_activate_disqus_amp', FILTER_SANITIZE_SPECIAL_CHARS ), 'newspack_activate_disqus_amp' ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			wp_die( esc_html__( 'You cannot perform this action.', 'newspack' ) );
+		}
+
+		Plugin_Manager::activate( 'newspack-disqus-amp' );
+		$plugins = Plugin_Manager::get_managed_plugins();
+		if ( 'active' === $plugins['newspack-disqus-amp']['Status'] ) {
+			?>
+			<div class='notice notice-success is-dismissible'>
+				<p><?php esc_html_e( 'Newspack Disqus AMP is now active. Your comments form will work correctly on AMP and non-AMP pages.', 'newspack' ); ?></p>
+			</div>
+			<?php
+		}
 	}
 }
 AMP_Enhancements::init();

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -186,6 +186,23 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=instant-articles-wizard',
 			],
+			'disqus-comment-system'         => [
+				'Name'        => 'Disqus for WordPress',
+				'Description' => 'Disqus helps publishers increase engagement and build loyal audiences.',
+				'Author'      => 'Disqus',
+				'AuthorURI'   => 'https://disqus.com/',
+				'PluginURI'   => 'https://wordpress.org/plugins/disqus-comment-system/',
+				'Download'    => 'wporg',
+			],
+			'newspack-disqus-amp'           => [
+				'Name'        => 'Newspack Disqus AMP',
+				'Description' => 'Adds AMP-compatibility to the Disqus plugin.',
+				'Author'      => 'Automattic',
+				'AuthorURI'   => 'https://disqus.com/',
+				'PluginURI'   => 'https://newspack.blog',
+				'AuthorURI'   => 'https://automattic.com',
+				'Download'    => 'https://github.com/Automattic/newspack-disqus-amp/releases/latest/download/newspack-disqus-amp.zip',
+			],
 		];
 
 		$default_info = [
@@ -566,7 +583,8 @@ class Plugin_Manager {
 		// GitHub appends random strings to the end of its downloads.
 		// If we asked for foo.zip, make sure the downloaded file is called foo.tmp.
 		if ( stripos( $plugin_url, 'github' ) ) {
-			$desired_file_name = str_replace( '.zip', '', end( explode( '/', $plugin_url ) ) );
+			$plugin_url_parts  = explode( '/', $plugin_url );
+			$desired_file_name = str_replace( '.zip', '', end( $plugin_url_parts ) );
 			$new_file_name     = preg_replace( '#(' . $desired_file_name . '.*).tmp#', $desired_file_name . '.tmp', $download );
 			rename( $download, $new_file_name ); // phpcs:ignore
 			$download = $new_file_name;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a notice to the admin screen if the user is running Disqus without the AMP-compatibility plugin. The notice has a link that installs and activates the Disqus-AMP-compatibility plugin when clicked:

<img width="939" alt="Screen Shot 2019-09-07 at 7 31 29 AM" src="https://user-images.githubusercontent.com/7317227/64476273-bfa74280-d141-11e9-8efd-abcc676e3a4d.png">
<img width="935" alt="Screen Shot 2019-09-07 at 7 31 43 AM" src="https://user-images.githubusercontent.com/7317227/64476274-bfa74280-d141-11e9-9af9-d64c9812a4d9.png">

If this seems like a good approach, we can do the same treatment for TablePress and the TablePress-AMP plugin.

### How to test the changes in this Pull Request:

1. Install and activate Disqus plugin. Observe notice at the top of screen with warning.
2. Click link in notice to install AMP-compatibility plugin. Observe successful installation.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->