### PR TITLE
Remove DocumentCloud AMP compatibility tweak because it's fixed in AMP

### DIFF
--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -18,24 +18,6 @@ class AMP_Enhancements {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_filter( 'do_shortcode_tag', [ __CLASS__, 'documentcloud_iframe_full_height' ], 10, 2 );
-	}
-
-	/**
-	 * Add an attribute to the iframe instructing AMP that the iframe should be rendered with the "fill" style instead
-	 * of the "fixed-height" style.
-	 *
-	 * @see https://github.com/ampproject/amp-wp/issues/3142
-	 * @param string $output HTML output of the shortcode.
-	 * @param string $tag The shortcode currently being processed.
-	 * @return string Modified shortcode output.
-	 */
-	public static function documentcloud_iframe_full_height( $output, $tag ) {
-		if ( 'documentcloud' !== $tag ) {
-			return $output;
-		}
-
-		return str_replace( '<iframe', '<iframe layout="fill"', $output );
 	}
 }
 AMP_Enhancements::init();


### PR DESCRIPTION
See https://github.com/ampproject/amp-wp/pull/3209

I've kept the AMP_Enhancements class because of https://github.com/Automattic/newspack-plugin/pull/267, and we'll likely still need it for other situations.