### PR TITLE
API Fetch Wizard Dependency

### DIFF
--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -598,7 +598,7 @@ class Advertising_Wizard extends Wizard {
 		\wp_enqueue_script(
 			'newspack-advertising-wizard',
 			Newspack::plugin_url() . '/assets/dist/advertising.js',
-			[ 'wp-components', 'wp-api-fetch' ],
+			$this->get_script_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/advertising.js' ),
 			true
 		);
@@ -606,7 +606,7 @@ class Advertising_Wizard extends Wizard {
 		\wp_register_style(
 			'newspack-advertising-wizard',
 			Newspack::plugin_url() . '/assets/dist/advertising.css',
-			[ 'wp-components' ],
+			$this->get_style_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/advertising.css' )
 		);
 		\wp_style_add_data( 'newspack-advertising-wizard', 'rtl', 'replace' );

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -88,7 +88,7 @@ class Components_Demo extends Wizard {
 		wp_enqueue_script(
 			'newspack-components-demo',
 			Newspack::plugin_url() . '/assets/dist/componentsDemo.js',
-			[ 'wp-components', 'wp-api-fetch' ],
+			$this->get_script_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/componentsDemo.js' ),
 			true
 		);
@@ -96,7 +96,7 @@ class Components_Demo extends Wizard {
 		wp_register_style(
 			'newspack-components-demo',
 			Newspack::plugin_url() . '/assets/dist/componentsDemo.css',
-			[ 'wp-components' ],
+			$this->get_style_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/componentsDemo.css' )
 		);
 		wp_style_add_data( 'newspack-components-demo', 'rtl', 'replace' );

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -186,7 +186,7 @@ class Dashboard extends Wizard {
 		wp_register_script(
 			'newspack-dashboard',
 			Newspack::plugin_url() . '/assets/dist/dashboard.js',
-			[ 'wp-components', 'wp-api-fetch' ],
+			$this->get_script_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/dashboard.js' ),
 			true
 		);
@@ -196,7 +196,7 @@ class Dashboard extends Wizard {
 		wp_register_style(
 			'newspack-dashboard',
 			Newspack::plugin_url() . '/assets/dist/dashboard.css',
-			[ 'wp-components' ],
+			$this->get_style_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/dashboard.css' )
 		);
 		wp_style_add_data( 'newspack-dashboard', 'rtl', 'replace' );

--- a/includes/wizards/class-mailchimp-wizard.php
+++ b/includes/wizards/class-mailchimp-wizard.php
@@ -78,7 +78,7 @@ class Mailchimp_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-mailchimp-wizard',
 			Newspack::plugin_url() . '/assets/dist/mailchimp.js',
-			[ 'wp-components', 'wp-api-fetch' ],
+			$this->get_script_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/mailchimp.js' ),
 			true
 		);
@@ -86,7 +86,7 @@ class Mailchimp_Wizard extends Wizard {
 		wp_register_style(
 			'newspack-mailchimp-wizard',
 			Newspack::plugin_url() . '/assets/dist/mailchimp.css',
-			[ 'wp-components' ],
+			$this->get_style_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/mailchimp.css' )
 		);
 		wp_style_add_data( 'newspack-mailchimp-wizard', 'rtl', 'replace' );

--- a/includes/wizards/class-newsletter-block-wizard.php
+++ b/includes/wizards/class-newsletter-block-wizard.php
@@ -112,7 +112,7 @@ class Newsletter_Block_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-newsletter-block-wizard',
 			Newspack::plugin_url() . '/assets/dist/newsletterBlock.js',
-			[ 'wp-components', 'wp-api-fetch' ],
+			$this->get_script_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/newsletterBlock.js' ),
 			true
 		);
@@ -120,7 +120,7 @@ class Newsletter_Block_Wizard extends Wizard {
 		wp_register_style(
 			'newspack-newsletter-block-wizard',
 			Newspack::plugin_url() . '/assets/dist/newsletterBlock.css',
-			[ 'wp-components' ],
+			$this->get_style_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/newsletterBlock.css' )
 		);
 		wp_style_add_data( 'newspack-newsletter-block-wizard', 'rtl', 'replace' );

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -161,7 +161,7 @@ class Performance_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-performance-wizard',
 			Newspack::plugin_url() . '/assets/dist/performance.js',
-			[ 'wp-components', 'wp-api-fetch' ],
+			$this->get_script_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/performance.js' ),
 			true
 		);
@@ -169,7 +169,7 @@ class Performance_Wizard extends Wizard {
 		wp_register_style(
 			'newspack-performance-wizard',
 			Newspack::plugin_url() . '/assets/dist/performance.css',
-			[ 'wp-components' ],
+			$this->get_style_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/performance.css' )
 		);
 		wp_style_add_data( 'newspack-performance-wizard', 'rtl', 'replace' );

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -376,7 +376,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		\wp_enqueue_script(
 			'newspack-reader-revenue-wizard',
 			Newspack::plugin_url() . '/assets/dist/readerRevenue.js',
-			[ 'wp-components', 'wp-api-fetch' ],
+			$this->get_script_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/readerRevenue.js' ),
 			true
 		);
@@ -384,7 +384,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		\wp_register_style(
 			'newspack-reader-revenue-wizard',
 			Newspack::plugin_url() . '/assets/dist/readerRevenue.css',
-			[ 'wp-components' ],
+			$this->get_style_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/readerRevenue.css' )
 		);
 		\wp_style_add_data( 'newspack-reader-revenue-wizard', 'rtl', 'replace' );

--- a/includes/wizards/class-seo-wizard.php
+++ b/includes/wizards/class-seo-wizard.php
@@ -85,7 +85,7 @@ class SEO_Wizard extends Wizard {
 		\wp_enqueue_script(
 			'newspack-seo-wizard',
 			Newspack::plugin_url() . '/assets/dist/seo.js',
-			[ 'wp-components', 'wp-api-fetch' ],
+			$this->get_script_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/seo.js' ),
 			true
 		);
@@ -93,7 +93,7 @@ class SEO_Wizard extends Wizard {
 		\wp_register_style(
 			'newspack-seo-wizard',
 			Newspack::plugin_url() . '/assets/dist/seo.css',
-			[ 'wp-components' ],
+			$this->get_style_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/seo.css' )
 		);
 		\wp_style_add_data( 'newspack-seo-wizard', 'rtl', 'replace' );

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -105,14 +105,14 @@ class Setup_Wizard extends Wizard {
 		wp_enqueue_script(
 			'newspack-setup-wizard',
 			Newspack::plugin_url() . '/assets/dist/setup.js',
-			[ 'wp-components', 'wp-api-fetch' ],
+			$this->get_script_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/setup.js' ),
 			true
 		);
 		wp_register_style(
 			'newspack-setup-wizard',
 			Newspack::plugin_url() . '/assets/dist/setup.css',
-			[ 'wp-components' ],
+			$this->get_style_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/setup.css' )
 		);
 		wp_style_add_data( 'newspack-setup-wizard', 'rtl', 'replace' );

--- a/includes/wizards/class-syndication-wizard.php
+++ b/includes/wizards/class-syndication-wizard.php
@@ -85,7 +85,7 @@ class Syndication_Wizard extends Wizard {
 		\wp_enqueue_script(
 			'newspack-syndication-wizard',
 			Newspack::plugin_url() . '/assets/dist/syndication.js',
-			[ 'wp-components', 'wp-api-fetch' ],
+			$this->get_script_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/syndication.js' ),
 			true
 		);
@@ -93,7 +93,7 @@ class Syndication_Wizard extends Wizard {
 		\wp_register_style(
 			'newspack-syndication-wizard',
 			Newspack::plugin_url() . '/assets/dist/syndication.css',
-			[ 'wp-components' ],
+			$this->get_style_dependencies(),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/syndication.css' )
 		);
 		\wp_style_add_data( 'newspack-syndication-wizard', 'rtl', 'replace' );

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -179,6 +179,28 @@ abstract class Wizard {
 	}
 
 	/**
+	 * Get an array of Script dependencies
+	 *
+	 * @param array $dependencies Additional depedencies to add to the baseline ones.
+	 * @return array An array of script dependencies.
+	 */
+	public function get_script_dependencies( $dependencies = [] ) {
+		$base_dependencies = [ 'wp-components', 'wp-api-fetch' ];
+		return array_merge( $base_dependencies, $dependencies );
+	}
+
+	/**
+	 * Get an array of Stylesheet dependencies.
+	 *
+	 * @param array $dependencies Additional depedencies to add to the baseline ones.
+	 * @return array An array of script dependencies.
+	 */
+	public function get_style_dependencies( $dependencies = [] ) {
+		$base_dependencies = [ 'wp-components' ];
+		return array_merge( $base_dependencies, $dependencies );
+	}
+
+	/**
 	 * Get this wizard's name.
 	 *
 	 * @return string The wizard name.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the error reported in https://github.com/Automattic/newspack-plugin/issues/269 by adding API Fetch as a dependency to all Wizards.

Closes https://github.com/Automattic/newspack-plugin/issues/269

### How to test the changes in this Pull Request:

Navigate to all Wizards, verify that they load successfully without the console error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->