### PR TITLE
Add Constant Contact to plugins list

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -186,6 +186,14 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=instant-articles-wizard',
 			],
+			'constant-contact-forms'        => [
+				'Name'        => 'Constant Contact Forms',
+				'Description' => 'Be a better marketer. All it takes is Constant Contact email marketing.',
+				'Author'      => 'Constant Contact',
+				'AuthorURI'   => 'https://www.constantcontact.com/index?pn=miwordpress',
+				'PluginURI'   => 'https://www.constantcontact.com',
+				'Download'    => 'wporg',
+			],
 		];
 
 		$default_info = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds Constant Contact to the list of managed plugins, as an alternative to MailChimp.

### How to test the changes in this Pull Request:

1. Verify Newspack installs and activates the plugin correctly from the admin Plugins screen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->