### PR TITLE
Developer Mode: Skip Site Kit and Jetpack Connected Checks

### DIFF
--- a/includes/configuration_managers/class-jetpack-configuration-manager.php
+++ b/includes/configuration_managers/class-jetpack-configuration-manager.php
@@ -38,7 +38,7 @@ class Jetpack_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Plugin ready state.
 	 */
 	public function is_configured() {
-		if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			return true;
 		}
 		if ( $this->is_active() && class_exists( 'Jetpack' ) && \Jetpack::is_active() ) {

--- a/includes/configuration_managers/class-jetpack-configuration-manager.php
+++ b/includes/configuration_managers/class-jetpack-configuration-manager.php
@@ -38,6 +38,9 @@ class Jetpack_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Plugin ready state.
 	 */
 	public function is_configured() {
+		if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
+			return true;
+		}
 		if ( $this->is_active() && class_exists( 'Jetpack' ) && \Jetpack::is_active() ) {
 			return true;
 		}

--- a/includes/configuration_managers/class-site-kit-configuration-manager.php
+++ b/includes/configuration_managers/class-site-kit-configuration-manager.php
@@ -116,7 +116,7 @@ class Site_Kit_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Whether Site Kit is active and set up.
 	 */
 	public function is_configured() {
-		if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			return true;
 		}
 		return $this->is_active() && ! empty( $this->get_modules_info() );

--- a/includes/configuration_managers/class-site-kit-configuration-manager.php
+++ b/includes/configuration_managers/class-site-kit-configuration-manager.php
@@ -116,6 +116,9 @@ class Site_Kit_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Whether Site Kit is active and set up.
 	 */
 	public function is_configured() {
+		if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
+			return true;
+		}
 		return $this->is_active() && ! empty( $this->get_modules_info() );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Setup Wizard requires that both Jetpack and Site Kit be installed and connected. If either does  not meet these conditions, the user cannot proceed past the final two screens of the setup Wizard. This creates a pain point in local development, where the site often does not have a public URL. Without a public URL neither Jetpack nor Site Kit can be connected. 

In this branch, if the `WP_DEBUG` flag is true, the check no longer requires that JP/SK be connected. Installation is still required, but not connection.

### How to test the changes in this Pull Request:

Jurassic Ninja instances have `WP_DEBUG` set to true, so this is an ideal way to test.

1. Check out this branch and create a release `npm run release`
2. Spin up a new Jurassic Ninja instance https://jurassic.ninja/
3. Without activating Jetpack, go to the Plugins page and install the release you just created (which will be `assets/release/newspack-plugin.zip`).
4. Activate Newspack, and run through the Setup Wizard.
5. Observe that the Jetpack and Site Kit screens have a CONTINUE button rather than CONFIGURE, and you are allowed to complete the setup Wizard and see the full dashboard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->