### PR TITLE
Fix retrieved data when country without state is shop location

### DIFF
--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -125,7 +125,7 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 	public function location_data() {
 		$countrystate_raw = wc_get_base_location();
 		return [
-			'countrystate' => '*' === $countrystate_raw['state'] ? $countrystate_raw['country'] : $countrystate_raw['country'] . ':' . $countrystate_raw['state'],
+			'countrystate' => ( empty( $countrystate_raw['state'] ) || '*' === $countrystate_raw['state'] ) ? $countrystate_raw['country'] : $countrystate_raw['country'] . ':' . $countrystate_raw['state'],
 			'address1'     => WC()->countries->get_base_address(),
 			'address2'     => WC()->countries->get_base_address_2(),
 			'city'         => WC()->countries->get_base_city(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #284 

This PR fixes an issue where countries without states were not showing up as the shop location in the Reader Revenue wizard. This is because e.g. for Chile it was returning `CL:` as the country code, when it should just be `CL`.

### How to test the changes in this Pull Request:

1. In the Reader Revenue > Location wizard, select a country without a state (e.g. Chile) as your location and save. Observe it saves nicely. Go to WooCommerce > Settings > General and observe the country is saved nicely there also.
2. In the Reader Revenue > Location wizard, select a country with a state (e.g. US - Oregon) as your location and save. Observe it saves nicely. Go to WooCommerce > Settings > General and observe the country is saved nicely there also.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->