### PR TITLE
Fix Dashicon height/width and position when checkbox is checked

### DIFF
--- a/assets/components/src/checkbox-control/style.scss
+++ b/assets/components/src/checkbox-control/style.scss
@@ -26,6 +26,19 @@
 				color: $muriel-white;
 			}
 		}
+
+		&:focus {
+			border-color: $primary_color;
+			box-shadow: none;
+			outline: none;
+		}
+	}
+
+	svg.dashicon.components-checkbox-control__checked {
+		height: 22px;
+		left: 0;
+		top: 0;
+		width: 22px;
 	}
 
 	label.components-checkbox-control__label {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Set the same height/width for the Dashicon as the actual checkbox
* Reposition the Dashicon so it sits perfectly on top of the checkbox
* Add a focus state to the checkbox to overwrite the default colour

Closes #295

### How to test the changes in this Pull Request:

1. Check out the branch and execute `npm run build:webpack`
2. Go through the Setup Wizard, and stop on screen 3 where there are 4 checkboxes at the bottom.
3. Click on one to check.
4. Observe the appearance of check.
5. Reduce browser to mobile width.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->