### PR TITLE
Google Analytics: Fix plugin handoff

### DIFF
--- a/assets/wizards/analytics/views/intro/index.js
+++ b/assets/wizards/analytics/views/intro/index.js
@@ -27,7 +27,7 @@ class Intro extends Component {
 					title={ __( 'Google Analytics' ) }
 					description={ __( 'Configure and view site analytics' ) }
 					actionText={ __( 'View' ) }
-					handoff="publish-to-apple-news"
+					handoff="google-site-kit"
 					editLink="admin.php?page=googlesitekit-module-analytics"
 				/>
 			</Fragment>


### PR DESCRIPTION
Changes the plugin slug to Google Site Kit, not the Apple News plugin.

The plugin handoff component incorrectly points to the Apple News plugin, rather than the Google Site Kit plugin. This PR fixes that.

![Screenshot from 2019-10-29 18-17-02](https://user-images.githubusercontent.com/136342/67797581-e5820100-fa79-11e9-80b9-90ed57759637.png)
