### PR TITLE
Add Co-Authors Plus as a supported plugin

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -233,6 +233,14 @@ class Plugin_Manager {
 				'WPCore'   => true,
 				'EditPath' => 'options-discussion.php',
 			],
+			'co-authors-plus'               => [
+				'Name'        => 'Co-Authors Plus',
+				'Description' => 'Allows multiple authors and guest authors to be assigned to a post.',
+				'Author'      => 'Mohammad Jangda, Daniel Bachhuber, Automattic, Weston Ruter',
+				'AuthorURI'   => 'http://wordpress.org/extend/plugins/co-authors-plus/',
+				'PluginURI'   => 'http://wordpress.org/extend/plugins/co-authors-plus/',
+				'Download'    => 'wporg',
+			],
 		];
 
 		$default_info = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In https://github.com/Automattic/newspack-theme/pull/559, Laurel added support for Co-Authors Plus to the theme. This PR adds Co-Authors plus to the list of supported plugins, so that our endorsement of this plugin as our preferred solution is documented.

### How to test the changes in this Pull Request:

1. Go to Plugins screen.
2. Install and activate Co-Authors Plus through the Newspack supported plugins section of the Plugins screen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->