### PR TITLE
Move the Wizard Pagination to the bottom and add new style

### DIFF
--- a/assets/components/src/wizard-pagination/index.js
+++ b/assets/components/src/wizard-pagination/index.js
@@ -17,6 +17,7 @@ import { withRouter } from 'react-router-dom';
  * Internal dependencies
  */
 import './style.scss';
+import { Button, Card, FormattedHeader, Handoff, Grid, SecondaryNavigation, TabbedNavigation } from '../';
 
 class WizardPagination extends Component {
 	/**
@@ -30,15 +31,16 @@ class WizardPagination extends Component {
 		}
 		return (
 			<Fragment>
-				<a className="newspack-wizard-pagination__navigation" onClick={ () => history.goBack() }>
-					<span className="dashicons dashicons-arrow-left-alt" /> { __( 'Back' ) }
-				</a>
-				{ currentIndex > 0 && (
-					<div className="newspack-wizard-pagination__pagination">
-						{ __( 'Page' ) } { currentIndex } { __( 'of' ) } { routes.length }{' '}
-						<span className="dashicons dashicons-arrow-right-alt" />
-					</div>
-				) }
+				<div className="newspack-wizard-pagination">
+					{ currentIndex > 0 && (
+						<div className="newspack-wizard-pagination__pagination">
+							{ __( 'Step' ) } { currentIndex } { __( 'of' ) } { routes.length }{' '}
+						</div>
+					) }
+					<Button isLink className="newspack-wizard-pagination__navigation" onClick={ () => history.goBack() }>
+						{ __( 'Back' ) }
+					</Button>
+				</div>
 			</Fragment>
 		);
 	}

--- a/assets/components/src/wizard-pagination/style.scss
+++ b/assets/components/src/wizard-pagination/style.scss
@@ -1,14 +1,6 @@
-.newspack-wizard {
-	position: relative;
-}
-.newspack-wizard-pagination__navigation {
-	position: absolute;
-	top: 1em;
-	left: 0;
-	cursor: pointer;
-}
-.newspack-wizard-pagination__pagination {
-	position: absolute;
-	top: 1em;
-	right: 1em;
+.newspack-wizard-pagination {
+	margin: 0 auto;
+	max-width: 1040px;
+	text-align: center;
+	transform: translateX(-10px);
 }

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -238,7 +238,6 @@ class SetupWizard extends Component {
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
-					<WizardPagination routes={ routes } />
 					<Route
 						path="/"
 						exact
@@ -392,6 +391,7 @@ class SetupWizard extends Component {
 							) : null;
 						} }
 					/>
+					<WizardPagination routes={ routes } />
 				</HashRouter>
 			</Fragment>
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

* Rename "Page" to "Step"
* Use a button isLink instead of a link for the Back button
* Have Step and Back on top of each other
* Define a max-width on the wrapper based on the Grid

__Before:__

![newspack test_wp-admin_admin php_page=newspack-setup-wizard(1280 x 720)](https://user-images.githubusercontent.com/177929/68683864-70292c80-055f-11ea-978c-19bd30c04730.png)

__After:__

![newspack test_wp-admin_admin php_page=newspack-setup-wizard(1280 x 720)](https://user-images.githubusercontent.com/177929/68683802-54258b00-055f-11ea-94be-8e04b4d51554.png)

### How to test the changes in this Pull Request:

1. Switch to this branch and run `npm run build:webpack`
2. (Re)start the set up of the plugin
3. Do you see the new Back / Step x of y?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->