### PR TITLE
Add an icon option to the Formatted Header + Add icons for the setup

### DIFF
--- a/assets/components/src/formatted-header/index.js
+++ b/assets/components/src/formatted-header/index.js
@@ -22,11 +22,16 @@ class FormattedHeader extends Component {
 	 * Render.
 	 */
 	render() {
-		const { className, headerText, subHeaderText } = this.props;
+		const { className, headerIcon, headerText, subHeaderText } = this.props;
 		const classes = murielClassnames( 'muriel-formatted-header', className, !! subHeaderText ? 'has-subheader' : null );
 		return (
 			<header className={ classes }>
-				<h1 className="muriel-formatted-header__title">{ headerText }</h1>
+				<h1 className="muriel-formatted-header__title">
+					{ headerIcon && (
+						<span className="muriel-formatted-header__icon">{ headerIcon }</span>
+					) }
+					{ headerText }
+				</h1>
 				{ subHeaderText && (
 					<h2 className="muriel-formatted-header__subtitle">{ subHeaderText }</h2>
 				) }

--- a/assets/components/src/formatted-header/style.scss
+++ b/assets/components/src/formatted-header/style.scss
@@ -10,11 +10,23 @@
 	grid-column: 1 / -1;
 
 	.muriel-formatted-header__title {
+		align-items: center;
+		display: flex;
 		font-size: 24px;
-		line-height: 32px;
-		letter-spacing: -0.5px;
 		font-weight: normal;
+		justify-content: center;
+		letter-spacing: -0.5px;
+		line-height: 32px;
 		margin: .5em 0;
+	}
+
+	.muriel-formatted-header__icon {
+		margin-right: 8px;
+
+		svg {
+			display: block;
+			fill: $primary_color;
+		}
 	}
 
 	.muriel-formatted-header__subtitle {

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -23,6 +23,7 @@ export default function withWizardScreen( WrappedComponent, config ) {
 				buttonText,
 				buttonAction,
 				buttonDisabled,
+				headerIcon,
 				headerText,
 				subHeaderText,
 				noBackground,
@@ -54,7 +55,7 @@ export default function withWizardScreen( WrappedComponent, config ) {
 						<Grid>
 							<Card noBackground>
 								{ headerText && (
-									<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+									<FormattedHeader headerIcon={ headerIcon } headerText={ headerText } subHeaderText={ subHeaderText } />
 								) }
 							</Card>
 							{ tabbedNavigation && (

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -8,7 +8,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment, render } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Spinner } from '@wordpress/components';
+import { Spinner, SVG, Path } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -235,6 +235,27 @@ class SetupWizard extends Component {
 			'/configure-google-site-kit',
 			'/starter-content',
 		];
+		const newsroomIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M10 16v-1H3.01L3 19c0 1.11.89 2 2 2h14c1.11 0 2-.89 2-2v-4h-7v1h-4zm10-9h-4.01V5l-2-2h-4l-2 2v2H4c-1.1 0-2 .9-2 2v3c0 1.11.89 2 2 2h6v-2h4v2h6c1.1 0 2-.9 2-2V9c0-1.1-.9-2-2-2zm-6 0h-4V5h4v2z" />
+			</SVG>
+		);
+		const aboutIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z" />
+				<Path d="M17.5 10.5c.88 0 1.73.09 2.5.26V9.24c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99zM13 12.49v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26V11.9c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.3-4.5.83zM17.5 14.33c-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26v-1.52c-.79-.16-1.64-.24-2.5-.24z" />
+			</SVG>
+		);
+		const configurePluginsIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M12 15.5A3.5 3.5 0 018.5 12 3.5 3.5 0 0112 8.5a3.5 3.5 0 013.5 3.5 3.5 3.5 0 01-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97 0-.33-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0014 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1 0 .33.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.66z" />
+			</SVG>
+		);
+		const starterContentIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M3 18h12v-2H3v2zM3 6v2h18V6H3zm0 7h18v-2H3v2z" />
+			</SVG>
+		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -264,6 +285,7 @@ class SetupWizard extends Component {
 						path="/about"
 						render={ routeProps => (
 							<About
+								headerIcon={ aboutIcon }
 								headerText={ __( 'About your publication' ) }
 								subHeaderText={ __(
 									'Share a few details so we can start setting up your profile'
@@ -286,6 +308,7 @@ class SetupWizard extends Component {
 						path="/newsroom"
 						render={ routeProps => (
 							<Newsroom
+								headerIcon={ newsroomIcon }
 								headerText={ __( 'Tell us about your Newsroom' ) }
 								subHeaderText={ __(
 									'The description helps set the stage for the step content below'
@@ -312,6 +335,7 @@ class SetupWizard extends Component {
 							return (
 								<ConfigurePlugins
 									noBackground
+									headerIcon={ configurePluginsIcon }
 									headerText={ __( 'Configure Core Plugins' ) }
 									subHeaderText={ __(
 										'You’re almost done. Please configure the following core plugins to start using Newspack.'
@@ -335,6 +359,7 @@ class SetupWizard extends Component {
 							return (
 								<ConfigurePlugins
 									noBackground
+									headerIcon={ configurePluginsIcon }
 									headerText={ __( 'Configure Core Plugins' ) }
 									subHeaderText={ __(
 										'You’re almost done. Please configure the following core plugins to start using Newspack.'
@@ -353,6 +378,7 @@ class SetupWizard extends Component {
 						render={ routeProps => {
 							return (
 								<StarterContent
+									headerIcon={ starterContentIcon }
 									headerText={ __( 'Starter Content' ) }
 									subHeaderText={ __( 'Pre-configure the  site for testing and experimentation' ) }
 									buttonText={ __( 'Install Starter Content' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I added an icon option to the Formatted Header.
I added different icons depending on the Step during the setup.

__Before:__

![newspack test_wp-admin_admin php_page=newspack-setup-wizard(1280 x 720)](https://user-images.githubusercontent.com/177929/68692681-cb621b80-056d-11ea-929c-baa54d10bf15.png)

__After:__

![newspack test_wp-admin_admin php_page=newspack-setup-wizard(1280 x 720)](https://user-images.githubusercontent.com/177929/68692610-b1283d80-056d-11ea-87a8-28f0da05e227.png)

### How to test the changes in this Pull Request:

1. Switch to this branch and run `npm run build:webpack`
2. (Re)start the set up of the plugin
3. Do you see the icon next to the title?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->