### PR TITLE
Add a wrapper around the `NewspackLogo`

### DIFF
--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -227,13 +227,15 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 			return (
 				<Fragment>
 					{ this.getError() }
-					<a href={ newspack_urls && newspack_urls.dashboard }>
-						<NewspackLogo
-							width={ fullLogo ? 240 : 50 }
-							compact={ ! fullLogo }
-							className="newspack-logo"
-						/>
-					</a>
+					<div className="newspack-logo-wrapper">
+						<a href={ newspack_urls && newspack_urls.dashboard }>
+							<NewspackLogo
+								width={ fullLogo ? 240 : 50 }
+								compact={ ! fullLogo }
+								className="newspack-logo"
+							/>
+						</a>
+					</div>
 					<div className={ !! loading ? 'muriel-wizardScreen__loading' : '' }>
 						<WrappedComponent
 							pluginRequirements={ requiredPlugins && this.pluginRequirements() }

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -1,8 +1,15 @@
 @import '../../../shared/scss/muriel-component';
 
-.newspack-wizard .newspack-logo {
-	display: block;
-	margin: 2em auto 0 auto;
+.newspack-wizard {
+	.newspack-logo-wrapper {
+		display: flex;
+		justify-content: center;
+		margin: 2em 0 0;
+
+		.newspack-logo {
+			display: block;
+		}
+	}
 }
 
 .muriel-wizardScreen__loading {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I'm adding a div around the Newspack Logo in the Wizard. This allows us to avoid having a full-width link.

### How to test the changes in this Pull Request:

1. Switch to this branch and run `npm run build:webpack`
2. (Re)start the set up of the plugin
3. Inspect the logo. Do you see a `<div class="newspack-logo-wrapper">` around the link?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->