### PR TITLE
Add header icons to the different wizard pages

### DIFF
--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, SVG, Path } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
@@ -321,6 +321,11 @@ class AdvertisingWizard extends Component {
 				path: '/google_ad_manager-global-codes',
 			},
 		];
+		const headerIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M12 8H4a2 2 0 00-2 2v4a2 2 0 002 2h1v4a1 1 0 001 1h2a1 1 0 001-1v-4h3l5 4V4l-5 4m9.5 4c0 1.71-.96 3.26-2.5 4V8c1.53.75 2.5 2.3 2.5 4z" />
+			</SVG>
+		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -332,6 +337,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => (
 								<Services
 									noBackground
+									headerIcon={ headerIcon }
 									headerText={ __( 'Advertising', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									services={ services }
@@ -353,6 +359,7 @@ class AdvertisingWizard extends Component {
 							path="/ad-placements"
 							render={ routeProps => (
 								<Placements
+									headerIcon={ headerIcon }
 									headerText={ __( 'Advertising', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									placements={ placements }
@@ -375,6 +382,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => (
 								<AdUnits
 									noBackground
+									headerIcon={ headerIcon }
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
 									adUnits={ adUnits }
 									tabbedNavigation={ gam_tabs }
@@ -393,6 +401,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ routeProps => (
 								<HeaderCode
+									headerIcon={ headerIcon }
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
 									adUnits={ adUnits }
 									code={ advertisingData.services.google_ad_manager.header_code }
@@ -416,6 +425,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => {
 								return (
 									<AdUnit
+										headerIcon={ headerIcon }
 										headerText={ __( 'Add an ad unit' ) }
 										subHeaderText={ __(
 											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.'
@@ -445,6 +455,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => {
 								return (
 									<AdUnit
+										headerIcon={ headerIcon }
 										headerText={ __( 'Edit ad unit' ) }
 										subHeaderText={ __(
 											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.'
@@ -467,6 +478,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => (
 								<Fragment>
 									<AdSense
+										headerIcon={ headerIcon }
 										headerText={ __( 'Google AdSense' ) }
 										subHeaderText={ __(
 											'Connect to your AdSense account using the Site Kit plugin, then enable Auto Ads.'

--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, SVG, Path } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
@@ -31,6 +31,11 @@ class AnalyticsWizard extends Component {
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
+		const headerIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z" />
+			</SVG>
+		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -42,6 +47,7 @@ class AnalyticsWizard extends Component {
 							render={ routeProps => (
 								<Intro
 									noBackground
+									headerIcon={ headerIcon }
 									headerText={ __( 'Analytics', 'newspack' ) }
 									subHeaderText={ __( 'Track traffic and activity') }
 									secondaryButtonText={ __( 'Back to dashboard' ) }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -7,7 +7,7 @@
  */
 import { Component, Fragment, render } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Spinner } from '@wordpress/components';
+import { Spinner, SVG, Path } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -84,11 +84,16 @@ class ComponentsDemo extends Component {
 			actionCardToggleChecked,
 			toggleGroupChecked
 		} = this.state;
-
+		const headerIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zM7.632 7.548v8.904H9.79v-3.737l3.666 3.737h2.913L7.632 7.548zm8.736 4.138h-1.765l.69.703h1.075v-.703zm0-2.069h-3.795l.689.703h3.106v-.703zm0-2.069h-5.825l.689.703h5.136v-.703z" />
+			</SVG>
+		);
 		return (
 			<Fragment>
 				<NewspackLogo width="250" className="newspack-components-demo_logo" />
 				<FormattedHeader
+					headerIcon={ headerIcon }
 					headerText={ __( 'Newspack Components' ) }
 					subHeaderText={ __( 'Temporary demo of Newspack components' ) }
 				/>

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, SVG, Path } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
@@ -111,6 +111,11 @@ class EngagementWizard extends Component {
 				exact: true,
 			},
 		];
+		const headerIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M21 6h-2v9H6v2c0 .55.45 1 1 1h11l4 4V7c0-.55-.45-1-1-1zm-4 6V3c0-.55-.45-1-1-1H3c-.55 0-1 .45-1 1v14l4-4h10c.55 0 1-.45 1-1z" />
+			</SVG>
+		);
 		const subheader = __( 'Newsletters, social, commenting, UGC' );
 		return (
 			<Fragment>
@@ -122,6 +127,7 @@ class EngagementWizard extends Component {
 							render={ routeProps => (
 								<Newsletters
 									noBackground
+									headerIcon={ headerIcon }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -141,6 +147,7 @@ class EngagementWizard extends Component {
 								return (
 									<Social
 										noBackground
+										headerIcon={ headerIcon }
 										headerText={ __( 'Engagement', 'newspack' ) }
 										subHeaderText={ subheader }
 										tabbedNavigation={ tabbed_navigation }
@@ -159,6 +166,7 @@ class EngagementWizard extends Component {
 							render={ routeProps => (
 								<CommentingDisqus
 									noBackground
+									headerIcon={ headerIcon }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -174,6 +182,7 @@ class EngagementWizard extends Component {
 							render={ routeProps => (
 								<CommentingNative
 									noBackground
+									headerIcon={ headerIcon }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -189,6 +198,7 @@ class EngagementWizard extends Component {
 							render={ routeProps => (
 								<CommentingCoral
 									noBackground
+									headerIcon={ headerIcon }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -204,6 +214,7 @@ class EngagementWizard extends Component {
 							render={ routeProps => (
 								<UGC
 									noBackground
+									headerIcon={ headerIcon }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }

--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -62,6 +62,11 @@ class HealthCheckWizard extends Component {
 	render() {
 		const { healthCheckData } = this.state;
 		const { unsupported_plugins: unsupportedPlugins } = healthCheckData;
+		const headerIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M15.9 5c-.17 0-.32.09-.41.23l-.07.15-5.18 11.65c-.16.29-.26.61-.26.96 0 1.11.9 2.01 2.01 2.01.96 0 1.77-.68 1.96-1.59l.01-.03L16.4 5.5c0-.28-.22-.5-.5-.5zM1 9l2 2c2.88-2.88 6.79-4.08 10.53-3.62l1.19-2.68C9.89 3.84 4.74 5.27 1 9zm20 2l2-2c-1.64-1.64-3.55-2.82-5.59-3.57l-.53 2.82c1.5.62 2.9 1.53 4.12 2.75zm-4 4l2-2c-.8-.8-1.7-1.42-2.66-1.89l-.55 2.92c.42.27.83.59 1.21.97zM5 13l2 2c1.13-1.13 2.56-1.79 4.03-2l1.28-2.88c-2.63-.08-5.3.87-7.31 2.88z" />
+			</SVG>
+		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -71,6 +76,7 @@ class HealthCheckWizard extends Component {
 							exact
 							render={ routeProps => (
 								<RemoveUnsupportedPlugins
+									headerIcon={ headerIcon }
 									headerText={ __( 'Health Check', 'newspack' ) }
 									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
 									deactivateAllPlugins={ this.deactivateAllPlugins }

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -6,6 +6,7 @@
  * WordPress dependencies
  */
 import { Component, Fragment, render } from '@wordpress/element';
+import { SVG, Path } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
@@ -74,7 +75,7 @@ class PerformanceWizard extends Component {
 					.catch( error => {
 						setError( error ).then( () => reject() );
 					} );
-			} );		
+			} );
 		} );
 	}
 
@@ -84,6 +85,11 @@ class PerformanceWizard extends Component {
 	render() {
 		const { pluginRequirements } = this.props;
 		const { settings } = this.state;
+		const headerIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M20.38 8.57l-1.23 1.85a8 8 0 0 1-.22 7.58H5.07A8 8 0 0 1 15.58 6.85l1.85-1.23A10 10 0 0 0 3.35 19a2 2 0 0 0 1.72 1h13.85a2 2 0 0 0 1.74-1 10 10 0 0 0-.27-10.44zm-9.79 6.84a2 2 0 0 0 2.83 0l5.66-8.49-8.49 5.66a2 2 0 0 0 0 2.83z" />
+			</SVG>
+		);
 		return (
 			<HashRouter hashType="slash">
 				<Switch>
@@ -94,6 +100,7 @@ class PerformanceWizard extends Component {
 						render={ routeProps => (
 							<Intro
 								noCard
+								headerIcon={ headerIcon }
 								headerText={ __( 'Performance options' ) }
 								subHeaderText={ __(
 									'Optimizing your news site for better performance and increased user engagement.'

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -6,6 +6,7 @@
  * WordPress dependencies
  */
 import { Component, render, Fragment } from '@wordpress/element';
+import { SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -154,6 +155,11 @@ class ReaderRevenueWizard extends Component {
 				path: '/configure-landing-page',
 			},
 		];
+		const headerIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M21 18v1c0 1.1-.9 2-2 2H5c-1.11 0-2-.9-2-2V5c0-1.1.89-2 2-2h14c1.1 0 2 .9 2 2v1h-9c-1.11 0-2 .9-2 2v8c0 1.1.89 2 2 2h9zm-9-2h10V8H12v8zm4-2.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z" />
+			</SVG>
+		);
 		const headerText = __( 'Reader Revenue', 'newspack' );
 		const subHeaderText = __( 'Generate revenue from your customers.' );
 		const isConfigured = !! donationData.created;
@@ -167,6 +173,7 @@ class ReaderRevenueWizard extends Component {
 							exact
 							render={ routeProps => (
 								<RevenueMain
+									headerIcon={ headerIcon }
 									headerText={ headerText }
 									subHeaderText={ subHeaderText }
 									tabbedNavigation={ isConfigured && tabbedNavigation }
@@ -182,6 +189,7 @@ class ReaderRevenueWizard extends Component {
 									data={ locationData }
 									countryStateFields={ countryStateFields }
 									currencyFields={ currencyFields }
+									headerIcon={ headerIcon }
 									headerText={ __( 'Set up donations' ) }
 									subHeaderText={ __( "First, please provide your publication's address." ) }
 									buttonText={ isConfigured ? __( 'Save Settings' ) : __( 'Continue Setup' ) }
@@ -200,6 +208,7 @@ class ReaderRevenueWizard extends Component {
 							render={ routeProps => (
 								<StripeSetup
 									data={ stripeData }
+									headerIcon={ headerIcon }
 									headerText={ __( 'Set up donations' ) }
 									subHeaderText={ __(
 										'Next, we will help you set up a payment gateway in order to process transactions.'
@@ -220,6 +229,7 @@ class ReaderRevenueWizard extends Component {
 							render={ routeProps => (
 								<Donation
 									data={ donationData }
+									headerIcon={ headerIcon }
 									headerText={ __( 'Set up donations' ) }
 									subHeaderText={ __( 'Configure your suggested donation presets.' ) }
 									buttonText={ __( 'Save Settings' ) }
@@ -237,6 +247,7 @@ class ReaderRevenueWizard extends Component {
 							path="/configure-landing-page"
 							render={ routeProps => (
 								<ConfigureLandingPage
+									headerIcon={ headerIcon }
 									headerText={ headerText }
 									subHeaderText={ subHeaderText }
 									tabbedNavigation={ isConfigured && tabbedNavigation }

--- a/assets/wizards/seo/index.js
+++ b/assets/wizards/seo/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, SVG, Path } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
@@ -31,6 +31,11 @@ class SEOWizard extends Component {
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
+		const headerIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+			</SVG>
+		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -42,7 +47,8 @@ class SEOWizard extends Component {
 							render={ routeProps => (
 								<Intro
 									noBackground
-									headerText={ __( 'Engagement', 'newspack' ) }
+									headerIcon={ headerIcon }
+									headerText={ __( 'SEO', 'newspack' ) }
 									secondaryButtonText={ __( 'Back to dashboard' ) }
 									secondaryButtonAction={ window && window.newspack_urls.dashboard }
 									secondaryButtonStyle={ { isDefault: true } }

--- a/assets/wizards/syndication/index.js
+++ b/assets/wizards/syndication/index.js
@@ -6,6 +6,7 @@
  * WordPress dependencies
  */
 import { Component, render, Fragment } from '@wordpress/element';
+import { SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -28,6 +29,11 @@ class SyndicationWizard extends Component {
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
+		const headerIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M22 8l-4-4v3H3v2h15v3l4-4zM2 16l4 4v-3h15v-2H6v-3l-4 4z" />
+			</SVG>
+		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -39,6 +45,7 @@ class SyndicationWizard extends Component {
 							render={ routeProps => (
 								<Intro
 									noBackground
+									headerIcon={ headerIcon }
 									headerText={ __( 'Syndication', 'newspack' ) }
 									secondaryButtonText={ __( 'Back to dashboard' ) }
 									secondaryButtonAction={ window && window.newspack_urls.dashboard }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
I'm adding a header icon (next to the header text) to all the different wizard screens:
* Advertising
* Analytics
* Components Demo
* Engagement
* Health Check
* Performance
* Reader Revenue
* SEO
* Syndication

_Icons are based on Material_

### How to test the changes in this Pull Request:

1. Switch to this branch and run `npm run build:webpack`
2. Go through the different screens in the plugin
3. Do you see an icon next to the title that matches it?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->