### PR TITLE
Fix input and select by resetting value added by WordPress 5.3

### DIFF
--- a/assets/components/src/select-control/style.scss
+++ b/assets/components/src/select-control/style.scss
@@ -38,12 +38,16 @@
 	}
 
 	select {
+		background: transparent;
 		border: 0;
+		border-radius: 0;
 		box-shadow: none;
 		font-size: 16px;
 		height: 21px;
 		line-height: 21px;
 		margin: 0;
+		max-width: 100%;
+		min-height: 21px;
 		padding: 0;
 
 		/* Hide the default down-arrow: */
@@ -52,6 +56,10 @@
 		appearance: none;
 		&::-ms-expand {
 			display: none; /* For IE10 */
+		}
+
+		&:hover {
+			color: $primary_color;
 		}
 
 		&:focus {

--- a/assets/components/src/text-control/style.scss
+++ b/assets/components/src/text-control/style.scss
@@ -23,11 +23,15 @@
 	}
 
 	input {
+		background: transparent;
 		border: 0;
+		border-radius: 0;
 		box-shadow: none;
+		color: inherit;
 		font-size: 16px;
 		line-height: 21px;
 		margin: 0;
+		min-height: 21px;
 		padding: 0;
 
 		&:focus {

--- a/assets/wizards/setup/views/about/style.scss
+++ b/assets/wizards/setup/views/about/style.scss
@@ -5,5 +5,9 @@
 		&:last-child {
 			margin-right: 0;
 		}
+
+		.muriel-component {
+			margin: 0;
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With WordPress 5.3 and the introduction of some extra CSS for the forms, our inputs looked broken.

I'm overwriting this with default settings.

__Before:__

![Screenshot 2019-11-18 at 16 16 07](https://user-images.githubusercontent.com/177929/69069918-394f8c80-0a1f-11ea-8691-802eeea15500.png)

__After:__

![newspack test_wp-admin_admin php_page=newspack-setup-wizard(1280 x 720)](https://user-images.githubusercontent.com/177929/69069935-3fde0400-0a1f-11ea-8566-bfa4630a059a.png)

### How to test the changes in this Pull Request:

1. Load a Newspack site without WP 5.3, check setup, step 2 or 3 -- Inputs should look fine.
2. Now do the same but on a site with WP 5.3, it should look broken now (like my screenshot above)
3. Switch to this branch
4. Check setup, step 2 or 3 -- Does it still look broken? It shouldn't 😊

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->