### PR TITLE
Update/plugin installer icons

### DIFF
--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -7,9 +7,8 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
-import { Spinner } from '@wordpress/components';
+import { Spinner, SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -141,6 +140,16 @@ class PluginInstaller extends Component {
 			const plugin = pluginInfo[ slug ];
 			return plugin.Status !== 'active' && plugin.installationStatus === PLUGIN_STATE_NONE;
 		} );
+		const inactiveIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
+			</SVG>
+		);
+		const activeIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+			</SVG>
+		);
 		if ( asProgressBar ) {
 			const completed = slugs.reduce(
 				( completed, slug ) =>
@@ -166,9 +175,21 @@ class PluginInstaller extends Component {
 						const isButton = ! isWaiting && Status !== 'active';
 						let actionText;
 						if ( installationStatus === PLUGIN_STATE_INSTALLING ) {
-							actionText = __( 'Setting up...' );
+							actionText = __( 'Installing' );
+						} else if ( Status === 'inactive' ) {
+							actionText = (
+								<span className="newspack_plugin-installer__content is-inactive">
+									{ __( 'Not installed' ) }
+									{ inactiveIcon }
+								</span>
+							);
 						} else if ( Status === 'active' ) {
-							actionText = <Dashicon icon="yes" className="newspack_plugin-installer__icon" />;
+							actionText = (
+								<span className="newspack_plugin-installer__content is-active">
+									{ __( 'Installed' ) }
+									{ activeIcon }
+								</span>
+							);
 						}
 						const onClick = isButton ? () => this.installPlugin( slug ) : null;
 						return (

--- a/assets/components/src/plugin-installer/style.scss
+++ b/assets/components/src/plugin-installer/style.scss
@@ -1,7 +1,8 @@
-@import '../../../shared/scss/muriel-component';
+@import "~@wordpress/base-styles/colors";
 
 .newspack-plugin-installer__checkbox-row {
 	position: relative;
+
 	.components-spinner,
 	.newspack-plugin-installer__status {
 		position: absolute;
@@ -9,17 +10,27 @@
 		right: 0;
 	}
 }
-.newspack_plugin-installer__icon {
-	background-color: $primary_color;
-	border: 1px solid $primary_color;
-	border-radius: 16px;
-	width: 16px;
-	height: 16px;
-	color: $muriel-white;
-	margin-right: 12px;
+
+.newspack_plugin-installer__content {
+	display: flex;
+	align-items: center;
+
+	svg {
+		display: block;
+		fill: $light-gray-900;
+		margin-left: 4px;
+	}
+
+	&.is-active {
+		svg {
+			fill: $alert-green;
+		}
+	}
 }
+
 .newspack-plugin-installer_waiting {
 	text-align: center;
+
 	.components-spinner {
 		float: none;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1807,6 +1807,12 @@
       "integrity": "sha512-EuEX/wyR+26Z2GTcaK9kMbBBmN1oIgGj5Q2zjp4O5lWFCKNJS0pHEstRI9nlzTjsr+RCUOYKg6Sge9b0DETr7w==",
       "dev": true
     },
+    "@wordpress/base-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.0.0.tgz",
+      "integrity": "sha512-Cfq3jlDqOSeclqT8aFgY9SdnJlKu0gZFyGtXVfHc2xCYJtkK9Xw4zW2u4RTtGuaKKm4RhgFhls+NaSVFguOIrQ==",
+      "dev": true
+    },
     "@wordpress/blob": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@automattic/calypso-build": "^2.0.0",
     "@babel/core": "^7.4.0",
     "@wordpress/blocks": "^6.2.0",
+    "@wordpress/base-styles": "^1.0.0",
     "@wordpress/browserslist-config": "^2.2.2",
     "@wordpress/components": "^7.3.1",
     "@wordpress/element": "^2.3.0",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In the Plugin Installer, I have replaced the use of Dashicon with Material Icon + Text.

I have also added support for `@wordpress/base-styles`. This allows us to use WordPress SASS variables throughout the plugin. In this case I'm using the green (for active) and grey (for inactive).

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/69436550-7b3b4400-0d39-11ea-887d-5f2973098b4c.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/69436560-81312500-0d39-11ea-9f8c-94e11cf4c112.png)

See #224  .

### How to test the changes in this Pull Request:

1. Go to a wizard page with a list of plugins (e.g. newspack-syndication-wizard) -- If all are active, then deactivate one. You should see a blue "checked" icon next to the plugins that are active.
2. Switch to this branch
3. Refresh the page. Do you see the new icons with a Installed/Not installed text next to it?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->