### PR TITLE
Apple News Configuration Manager #311

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -184,6 +184,10 @@ class Plugin_Manager {
 				'PluginURI'   => 'http://github.com/alleyinteractive/apple-news',
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=apple_news_index',
+				'Configurer'  => [
+					'filename'   => 'class-publish-to-apple-news-configuration-manager.php',
+					'class_name' => 'Publish_To_Apple_News_Configuration_Manager',
+				],
 			],
 			'fb-instant-articles'           => [
 				'Name'        => 'Instant Articles for WP',

--- a/includes/configuration_managers/class-configuration-managers.php
+++ b/includes/configuration_managers/class-configuration-managers.php
@@ -48,6 +48,10 @@ class Configuration_Managers {
 			'filename'   => 'class-newspack-theme-configuration-manager.php',
 			'class_name' => 'Newspack_Theme_Configuration_Manager',
 		],
+		'publish-to-apple-news'  => [
+			'filename'   => 'class-publish-to-apple-news-configuration-manager.php',
+			'class_name' => 'Publish_To_Apple_News_Configuration_Manager',
+		],
 	];
 
 	/**

--- a/includes/configuration_managers/class-publish-to-apple-news-configuration-manager.php
+++ b/includes/configuration_managers/class-publish-to-apple-news-configuration-manager.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Publish to Apple News plugin configuration manager.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
+
+/**
+ * Provide an interface for configuring and querying the configuration of Publish to Apple News.
+ */
+class Publish_To_Apple_News_Configuration_Manager extends Configuration_Manager {
+
+	/**
+	 * The slug of the plugin.
+	 *
+	 * @var string
+	 */
+	public $slug = 'publish-to-apple-news';
+
+	/**
+	 * Configure Publish to Apple News for Newspack use.
+	 *
+	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
+	 */
+	public function configure() {
+		$active = $this->is_active();
+		if ( ! $active || is_wp_error( $active ) ) {
+			return $active;
+		}
+		if ( class_exists( 'Admin_Apple_Settings' ) ) {
+			$defaults = new \Apple_Exporter\Settings();
+			$settings = new \Admin_Apple_Settings();
+			$settings->save_settings( $defaults->all() );
+		}
+
+		$this->set_newspack_has_configured( true );
+		return true;
+	}
+}


### PR DESCRIPTION
Added in configuration manager for Apple News to save the default Apple News settings into the database upon install.  This then eliminates the PHP Warning message on post edit screen.

### All Submissions:

* [ X ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ X ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:


Closes #311 .

### How to test the changes in this Pull Request:

1. Using a clean install of Newspack
2. Install Syndication plugins, Apple News
3. Browse to block editor page, a warning no longer appears.

### Other information:

* [ X ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ X ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->