### PR TITLE
Designate our supported S3 integration

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -245,6 +245,14 @@ class Plugin_Manager {
 				'PluginURI'   => 'http://wordpress.org/extend/plugins/co-authors-plus/',
 				'Download'    => 'wporg',
 			],
+			's3-uploads'                    => [
+				'Name'        => 'S3 Uploads',
+				'Description' => 'Lightweight "drop-in" for storing WordPress uploads on Amazon S3 instead of the local filesystem.',
+				'Author'      => 'Human Made Limited',
+				'PluginURI'   => 'https://github.com/humanmade/S3-Uploads',
+				'AuthorURI'   => 'http://hmn.md',
+				'Download'    => 'https://github.com/humanmade/S3-Uploads/archive/2.2.1.zip',
+			],
 		];
 
 		$default_info = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR marks The Human Made S3 integration as our recommended S3 integration for people that need S3. 

They don't provide a nice zip like we do on their releases, so we need to tag a specific version (which is not ideal). We can re-approach this in the future and see what we can do about it; there should be something we can do with the GitHub API.

### How to test the changes in this Pull Request:

1. Verify S3 plugin shows up in the list of Newspack plugins on the Plugins screen. It can be installed through the plugins list, however once installed the installed plugin won't show up in the Newspack list because of the `-2.2.1` appended to the folder (it will be in the regular plugins area). That's going to require some adjustments to the installer to sort out, so we can handle those in a separate PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->