### PR TITLE
Add Newspack Image Credits to managed plugins

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -245,6 +245,14 @@ class Plugin_Manager {
 				'PluginURI'   => 'http://wordpress.org/extend/plugins/co-authors-plus/',
 				'Download'    => 'wporg',
 			],
+			'newspack-image-credits'        => [
+				'Name'        => 'Newspack Image Credits',
+				'Description' => 'Add photo credit info to images.',
+				'Author'      => 'Automattic, INN Labs, Project Argo',
+				'PluginURI'   => 'https://newspack.blog',
+				'AuthorURI'   => 'https://automattic.com',
+				'Download'    => 'https://github.com/Automattic/newspack-image-credits/releases/latest/download/newspack-image-credits.zip',
+			],
 		];
 
 		$default_info = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This plugin has been ready for a little while, and there is solid demand for it. Adding it to our list of plugins makes our preferred image credit plugin known and makes it easy to install and activate the plugin.

### How to test the changes in this Pull Request:

1. Go to Plugins screen. Install and activate the plugin from the "Newspack Image Credits" entry in the Newspack plugins section.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->