### PR TITLE
Notice: Add new component to the list available

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -10,6 +10,7 @@ export { default as ImageUpload } from './image-upload';
 export { default as Grid } from './grid';
 export { default as Modal } from './modal';
 export { default as NewspackLogo } from './newspack-logo';
+export { default as Notice } from './notice';
 export { default as PluginInstaller } from './plugin-installer';
 export { default as ProgressBar } from './progress-bar';
 export { default as SecondaryNavigation } from './secondary-navigation';

--- a/assets/components/src/notice/index.js
+++ b/assets/components/src/notice/index.js
@@ -1,0 +1,66 @@
+/**
+ * Notice
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { SVG, Path } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+class Notice extends Component {
+	/**
+	 * Render
+	 */
+	render() {
+		const { className, isError, isSuccess, isPrimary, noticeText } = this.props;
+		const classes = classNames(
+			'newspack-notice',
+			className,
+			isError && 'newspack-notice__is-error',
+			isSuccess && 'newspack-notice__is-success',
+			isPrimary && 'newspack-notice__is-primary'
+		);
+		const errorIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
+			</SVG>
+		);
+		const infoIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+			</SVG>
+		);
+		const successIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+			</SVG>
+		);
+		let noticeIcon;
+		if ( isError ) {
+  		noticeIcon = errorIcon;
+		} else if ( isSuccess ) {
+			noticeIcon = successIcon;
+		} else {
+		  noticeIcon = infoIcon;
+		}
+		return (
+			<div className={ classes }>
+				{ noticeIcon }
+				{ noticeText }
+			</div>
+		);
+	}
+}
+
+export default Notice;

--- a/assets/components/src/notice/style.scss
+++ b/assets/components/src/notice/style.scss
@@ -1,0 +1,43 @@
+/**
+ * Notice
+ */
+
+@import '~@wordpress/base-styles/colors';
+@import '../../../shared/scss/muriel-component';
+
+.newspack-notice {
+	align-items: flex-start;
+	background: white;
+	border-radius: 4px;
+	color: $dark-gray-300;
+	display: flex;
+	font-size: 14px;
+	justify-content: flex-start;
+	line-height: 24px;
+	margin: 32px 0;
+
+	svg {
+		display: block;
+		fill: $dark-gray-900;
+		flex: 0 0 24px;
+		margin-right: 4px;
+	}
+
+	&.newspack-notice__is-success {
+		svg {
+			fill: $alert-green;
+		}
+	}
+
+	&.newspack-notice__is-error {
+		svg {
+			fill: $alert-red;
+		}
+	}
+
+	&.newspack-notice__is-primary {
+		svg {
+			fill: $primary_color;
+		}
+	}
+}

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -21,6 +21,7 @@ import {
 	FormattedHeader,
 	Handoff,
 	NewspackLogo,
+	Notice,
 	TextControl,
 	PluginInstaller,
 	ProgressBar,
@@ -131,7 +132,7 @@ class ComponentsDemo extends Component {
 						</Handoff>
 					</Card>
 					<Card>
-						<FormattedHeader headerText={ __( 'Notice/Modal' ) } />
+						<FormattedHeader headerText={ __( 'Modal' ) } />
 						<Button
 							className="is-centered"
 							isTertiary
@@ -157,6 +158,34 @@ class ComponentsDemo extends Component {
 								</Button>
 							</Modal>
 						) }
+					</Card>
+					<Card>
+						<FormattedHeader headerText={ __( 'Notice' ) } />
+						<Notice
+							noticeText={ __( 'This is a Primary info notice.' ) }
+							isPrimary
+						/>
+						<Notice
+							noticeText={ __( 'This is an info notice.' ) }
+						/>
+						<Notice
+							noticeText={ __( 'This is a Primary error notice.' ) }
+							isError
+							isPrimary
+						/>
+						<Notice
+							noticeText={ __( 'This is an error notice.' ) }
+							isError
+						/>
+						<Notice
+							noticeText={ __( 'This is a Primary success notice.' ) }
+							isSuccess
+							isPrimary
+						/>
+						<Notice
+							noticeText={ __( 'This is a success notice.' ) }
+							isSuccess
+						/>
 					</Card>
 					<Card>
 						<FormattedHeader headerText={ __( 'Plugin installer: Progress Bar' ) } />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a new component: Notice. It can be used like so:

`<Notice noticeText={ __( 'This is an error notice.' ) } isError />`

* Supports: isError, isSuccess and isPrimary
* Content is displayed via `noticeText`

It will display a Material Icon (Success, Error, Info -- default ) next to it. Color of the SVG will depend of the "is" status (isError -- red, isSuccess -- green, isPrimary -- primary color)

![Screenshot 2019-12-11 at 16 44 07](https://user-images.githubusercontent.com/177929/70641767-08d1cb80-1c36-11ea-83a8-471e11dac397.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Check the Components demo. Do you see the Notices?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->