### PR TITLE
Wrap noticies in a container so they can be styled and match the header

### DIFF
--- a/assets/components/src/newspack-logo/index.js
+++ b/assets/components/src/newspack-logo/index.js
@@ -8,7 +8,29 @@
 import { Component } from '@wordpress/element';
 import { Path, SVG } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 class NewspackLogo extends Component {
+	componentDidMount() {
+		// If there are notices, wrap them in a container.
+		var container = document.createElement( 'div' );
+		container.className = 'newspack-notice-wrapper';
+		var containerAdded = false;
+		var notices = document.querySelectorAll( '#wpbody-content > div[class*="notice"]' );
+		for ( var i = 0; i < notices.length; i++ ) {
+			var notice = notices[i];
+			if ( ! containerAdded ) {
+				notice.parentNode.insertBefore( container, notice );
+				containerAdded = true;
+			}
+			notice.parentNode.removeChild( notice );
+			container.appendChild( notice );
+		}
+	}
+
 	/**
 	 * Render.
 	 */

--- a/assets/components/src/newspack-logo/style.scss
+++ b/assets/components/src/newspack-logo/style.scss
@@ -1,0 +1,11 @@
+/**
+ * Newspack Logo
+ */
+
+@import '../../../shared/scss/muriel-component';
+
+.newspack-notice-wrapper {
+  background: $primary-color;
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I'm not sure if this is the right approach but here's my logic: we constantly load the NewspackLogo component and notices can clash with the blue background we have in the header.

This PR wraps all the notices in `#wpbody-content` into a container so we can have a blue background.

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/70809715-49f2e880-1dba-11ea-9ff9-6f52a4eb2464.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/70809734-50816000-1dba-11ea-80a2-590c134456b2.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Add a bunch of plugins that adds _annoying_ notices in the header of wpadmin
3. Check the pages of the plugin, the notices should have a background, matching the header where the Newspack logo sits.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->