### PR TITLE
Waiting: Add new component to the list available

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -18,6 +18,7 @@ export { default as TabbedNavigation } from './tabbed-navigation';
 export { default as Task } from './task';
 export { default as TextControl } from './text-control';
 export { default as ToggleGroup } from './toggle-group';
+export { default as Waiting } from './waiting';
 export { default as withWizard } from './with-wizard';
 export { default as withWizardScreen } from './with-wizard-screen';
 export { default as WizardPagination } from './wizard-pagination';

--- a/assets/components/src/waiting/index.js
+++ b/assets/components/src/waiting/index.js
@@ -1,0 +1,41 @@
+/**
+ * Waiting
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { SVG, Path } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+class Waiting extends Component {
+	/**
+	 * Render
+	 */
+	render() {
+    const { className, isRight, isLeft } = this.props;
+    const classes = classNames(
+      'newspack-is-waiting',
+      className,
+      isRight && 'newspack-is-waiting__is-right',
+      isLeft && 'newspack-is-waiting__is-left'
+    );
+    return (
+      <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" className={ classes }>
+        <Path d="M12 6v3l4-4-4-4v3c-4.42 0-8 3.58-8 8 0 1.57.46 3.03 1.24 4.26L6.7 14.8c-.45-.83-.7-1.79-.7-2.8 0-3.31 2.69-6 6-6zm6.76 1.74L17.3 9.2c.44.84.7 1.79.7 2.8 0 3.31-2.69 6-6 6v-3l-4 4 4 4v-3c4.42 0 8-3.58 8-8 0-1.57-.46-3.03-1.24-4.26z" />
+      </SVG>
+    );
+  }
+}
+
+export default Waiting;

--- a/assets/components/src/waiting/style.scss
+++ b/assets/components/src/waiting/style.scss
@@ -1,0 +1,29 @@
+/**
+ * Waiting
+ */
+
+@import '~@wordpress/base-styles/colors';
+
+.newspack-is-waiting {
+  animation: newspack-is-waiting__animation 1s infinite linear;
+	display: block;
+	fill: $light-gray-900;
+	flex: 0 0 24px;
+
+  &.newspack-is-waiting__is-left {
+    margin-right: 4px;
+  }
+
+  &.newspack-is-waiting__is-right {
+    margin-left: 4px;
+  }
+}
+
+@keyframes newspack-is-waiting__animation {
+	from {
+		transform: rotate( 0deg );
+	}
+	to {
+		transform: rotate( 360deg );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Similar to #324, I'd like to introduce a new component.

The goal is to replace `<Spinner />` from Core with an animated Material Icon that will match with the rest of the icons used throughout the plugin.

This component can be used like so:

`<Waiting isRight>`

* Supports: isRight, isLeft -- depending on which side there's text next to it.

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/70819524-60a33a80-1dce-11ea-9bc2-a9fdac4d21f7.gif)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/70819545-69940c00-1dce-11ea-8421-22ed941291e9.gif)

### How to test the changes in this Pull Request:

1. Switch to this branch.
2. You can replace `<Spinner />` in Action Card if you want to see it in action and check the Components Demo (note: it won't be perfectly aligned, but that's something I will fix, either in a separate PR or in #322)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->