### PR TITLE
Suppress Notifications

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -41,6 +41,9 @@ final class Newspack {
 		$this->define_constants();
 		$this->includes();
 		add_action( 'admin_menu', [ $this, 'remove_all_newspack_options' ], 1 );
+		add_action( 'admin_notices', [ $this, 'remove_notifications' ], -9999 );
+		add_action( 'network_admin_notices', [ $this, 'remove_notifications' ], -9999 );
+		add_action( 'all_admin_notices', [ $this, 'remove_notifications' ], -9999 );
 	}
 
 	/**
@@ -111,6 +114,17 @@ final class Newspack {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Remove notifications.
+	 */
+	public function remove_notifications() {
+		$screen = get_current_screen();
+		if ( ! $screen || 'newspack' !== $screen->parent_base ) {
+			return;
+		}
+		remove_all_actions( current_action() );
 	}
 }
 Newspack::instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes WordPress notifications from Newspack admin screens. The notifications significantly compete with the blue bar at the top, and this is even more noticeable in the redesign work occurring in https://github.com/Automattic/newspack-plugin/pull/322. A typical Newspack user is not likely to spend much of their time in the Newspack plugin (they will mostly be in the editor) so we can assume that important notices will be seen elsewhere. There is precedent  for this in other plugins such as Site Kit. 

This PR introduces one regression in that the Newspack unsupported plugins warning is no longer shown. In a separate PR let's find an alternate way to display this information that fits within the plugin's UI, cc:  @thomasguillot.

Before:
<img width="1646" alt="Screen Shot 2019-12-13 at 1 17 06 PM" src="https://user-images.githubusercontent.com/1477002/70822463-9a167e80-1dab-11ea-8910-3c2e25e4fa34.png">

After:
<img width="1646" alt="Screen Shot 2019-12-13 at 1 16 14 PM" src="https://user-images.githubusercontent.com/1477002/70822475-a13d8c80-1dab-11ea-9825-54dda82c86a0.png">

cc: @pablohoneyhoney 

### How to test the changes in this Pull Request:

1. On `master`, observe that there are notifications visible above the blue bar in Newspack admin pages.
2. Switch to `add/hide-notifications` and observe that they disappear.
3. Click around other parts of `wp-admin` and verify that notifications are still visible on other plugin pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->