### PR TITLE
TextControl: Update the component to simplify it and mostly rely on BaseComponent with custom styles

### DIFF
--- a/assets/components/src/text-control/index.js
+++ b/assets/components/src/text-control/index.js
@@ -5,82 +5,28 @@
 /**
  * WordPress dependencies
  */
-import { TextControl as BaseComponent, withFocusOutside } from '@wordpress/components';
+import { TextControl as BaseComponent } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import murielClassnames from '../../../shared/js/muriel-classnames';
 import './style.scss';
 
-const TextControl = withFocusOutside(
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
 
-	class extends Component {
-
-		/**
-		 * Constructor.
-		 */
-		constructor( props ) {
-			super( props  );
-			this.state = {
-				isFocused: false
-			};
-		};
-
-		/**
-		 * A `withFocusOutside`'s default function, handler for the focus outside the component event.
-		 */
-		handleFocusOutside() {
-			this.setState( { isFocused: false } );
-		}
-
-		/**
-		 * Handle component onClick; also executes the props' onChange handler (the parent's original onClick).
-		 */
-		handleOnClick = ( onClick ) => {
-			this.setState( { isFocused: true } );
-			if (typeof onClick === "function") {
-				onClick();
-			}
-		};
-
-		/**
-		 * Get component's className describing its state.
-		 */
-		getClassName = ( disabled, isEmpty, isActive ) => {
-			let className = "with-value";
-			if ( disabled ) {
-				className = "disabled";
-			} else if ( isEmpty ) {
-				className = "empty";
-			} else if ( isActive ) {
-				className = "active";
-			}
-
-			return className;
-		};
-
-		/**
-		 * Render.
-		 */
-		render() {
-			const { isFocused } = this.state;
-			const { className, onClick, ...otherProps } = this.props;
-			const { label, value, disabled } = otherProps;
-			const isEmpty = '' === value;
-			const isActive = isFocused && ! disabled;
-
-			return (
-				<BaseComponent
-					className={ murielClassnames( "muriel-input-text", className, this.getClassName( disabled, isEmpty, isActive ) ) }
-					placeholder={ label }
-					onClick={ () => this.handleOnClick( onClick ) }
-					{ ...otherProps }
-				/>
-			);
-		}
+class TextControl extends Component {
+	/**
+	 * Render.
+	 */
+	render( props ) {
+		const { className, ...otherProps } = this.props;
+		const classes = classNames( 'newspack-text-control', className );
+		return <BaseComponent className={ classes } { ...otherProps } />;
 	}
-);
+}
 
 export default TextControl;

--- a/assets/components/src/text-control/style.scss
+++ b/assets/components/src/text-control/style.scss
@@ -1,90 +1,66 @@
 /**
- * Text/Number Input styles.
+ * Text Control
  */
 
 @import '../../../shared/scss/muriel-component';
+@import '~@wordpress/base-styles/colors';
 
-.muriel-input-text {
-	background: $muriel-white;
-	border: 1px solid $muriel-gray-200;
-	border-radius: 0;
-	box-shadow: none;
-	padding: 12px 12px 4px;
-	position: relative;
+.newspack-text-control {
+	color: $dark-gray-300;
+	font-size: 14px;
+	line-height: 24px;
+	margin: 32px 0;
 
 	label {
-		color: $muriel-gray-500;
-		font-size: 14px;
-		line-height: 21px;
-
-		&.components-base-control__label {
-			margin: 0;
-		}
+		color: $dark-gray-900;
+		font-size: inherit;
+		font-weight: bold;
+		line-height: inherit;
+		margin: 0;
 	}
 
-	input {
-		background: transparent;
-		border: 0;
-		border-radius: 0;
+	input[type="date"],
+	input[type="datetime-local"],
+	input[type="datetime"],
+	input[type="email"],
+	input[type="month"],
+	input[type="number"],
+	input[type="password"],
+	input[type="search"],
+	input[type="tel"],
+	input[type="text"],
+	input[type="time"],
+	input[type="url"],
+	input[type="week"] {
+		background: white;
+		border: 1px solid $light-gray-500;
+		border-radius: 3px;
 		box-shadow: none;
 		color: inherit;
-		font-size: 16px;
-		line-height: 21px;
+		font-size: inherit;
+		line-height: inherit;
 		margin: 0;
-		min-height: 21px;
-		padding: 0;
+		min-height: 48px;
+		padding: 11px 8px;
+		transition: border-color 125ms ease-in-out, box-shadow 125ms ease-in-out;
+		width: 100%;
 
 		&:focus {
-			box-shadow: 0 0 0 12px $muriel-white, 0 0 0 13px $primary_color_darker, 0 0 0 15px $primary_color_lighter;
+			border-color: $primary_color_darker;
+			box-shadow: 0 0 0 2px $primary_color;
+		}
+
+		&:disabled,
+		&.disabled {
+			border-color: $light-gray-200;
+			color: $light-gray-900;
+			cursor: not-allowed;
 		}
 	}
 
-	&.active {
-		label {
-			display: none;
-		}
-		input {
-			color: $muriel-gray-800;
-		}
-	}
-
-	&.with-value {
-		input {
-			color: $muriel-gray-800;
-
-			&:focus {
-				box-shadow: none;
-			}
-		}
-	}
-
-	&.empty {
-		label {
-			display: none;
-		}
-		input {
-			color: $muriel-gray-500;
-		}
-	}
-
-	&.disabled {
-		label {
-			display: none;
-		}
-		input {
-			color: $muriel-gray-200;
-
-			/* Placeholder styling: */
-			&::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
-				color: $muriel-gray-200;
-				opacity: 1; /* Firefox */
-			}
-			&:-ms-input-placeholder { /* Internet Explorer 10-11 */
-				color: $muriel-gray-200;
-			}
-			&::-ms-input-placeholder { /* Microsoft Edge */
-				color: $muriel-gray-200;
-			}
-		}
+	.components-base-control__field,
+	.components-base-control__label {
+		display: block;
+		margin: 0;
 	}
 }

--- a/assets/components/src/text-control/style.scss
+++ b/assets/components/src/text-control/style.scss
@@ -58,6 +58,14 @@
 		}
 	}
 
+	// Multiple Text Controls
+
+	& + & {
+		margin-top: -16px;
+	}
+
+	// Reset
+
 	.components-base-control__field,
 	.components-base-control__label {
 		display: block;

--- a/assets/components/src/text-control/style.scss
+++ b/assets/components/src/text-control/style.scss
@@ -37,13 +37,17 @@
 		border-radius: 3px;
 		box-shadow: none;
 		color: inherit;
-		font-size: inherit;
+		font-size: 16px;
 		line-height: inherit;
 		margin: 0;
 		min-height: 48px;
 		padding: 11px 8px;
 		transition: border-color 125ms ease-in-out, box-shadow 125ms ease-in-out;
 		width: 100%;
+
+		@media screen and ( min-width: 768px ) {
+			font-size: inherit;
+		}
 
 		&:focus {
 			border-color: $primary_color_darker;

--- a/assets/wizards/readerRevenue/components/money-input/style.scss
+++ b/assets/wizards/readerRevenue/components/money-input/style.scss
@@ -1,28 +1,33 @@
+/**
+ * Money Input
+ */
+
+@import '~@wordpress/base-styles/colors';
+
 .newspack-donations-wizard__money-input {
-	position: relative;
+	align-items: flex-end;
+	display: flex;
 
 	.currency {
-		position: absolute;
-		line-height: 24px;
-		top: 27px;
-		left: 1em;
-		font-size: 16px;
-		z-index: 1;
-		color: $muriel-gray-500;
-		cursor: default;
+		background: $light-gray-500;
+		border-radius: 3px 0 0 3px;
+		color: $dark-gray-900;
+		display: block;
+		flex: 0 0 32px;
+		font-weight: bold;
+		height: 48px;
+		line-height: 48px;
+		margin: 32px 0;
+		text-align: center;
 	}
 
-	.components-text-control__input {
-		margin-left: 1em;
-	}
-
-	.muriel-input-text.active {
-		.components-text-control__input {
-			top: 25px;
+	.newspack-text-control {
+		label {
+			margin-left: -32px;
 		}
 
-		label {
-			display: block;
+		input[type="number"] {
+			border-radius: 0 3px 3px 0;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As part of the redesign of the plugin (see #322) I reworked/simplified the `TextControl` to behave in a similar way as Core, with the Newspack styles.

__Before:__

<img width="661" alt="1 before" src="https://user-images.githubusercontent.com/177929/70861778-af65e700-1f2a-11ea-9ad2-d8cc1b65b579.png">

__After:__
<img width="672" alt="2 after" src="https://user-images.githubusercontent.com/177929/70861750-59913f00-1f2a-11ea-8d30-ad92bb019694.png">

I also took the opportunity to rework the Money Input by having the currency next to the input.

__Before:__

<img width="670" alt="3 before" src="https://user-images.githubusercontent.com/177929/70861776-a7a64280-1f2a-11ea-9d23-536750d8391c.png">

__After:__

<img width="674" alt="4 after" src="https://user-images.githubusercontent.com/177929/70861762-847b9300-1f2a-11ea-9d5f-30a72a2204bf.png">

_Note: I'm aware of a margin issue in the location setup. I plan to fix this in #322._

### How to test the changes in this Pull Request:

1. Check the Components Demo, Setup, Reader Revenue. You should see the current text inputs
2. Switch to this branch
3. Recheck the different pages. Do you see the new text inputs?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->