### PR TITLE
Update Checkbox Control and Info Button components with Material Icons

### DIFF
--- a/assets/components/src/checkbox-control/index.js
+++ b/assets/components/src/checkbox-control/index.js
@@ -1,5 +1,5 @@
 /**
- * Muriel-styled Checkbox.
+ * Checkbox Control
  */
 
 /**
@@ -11,10 +11,13 @@ import { CheckboxControl as BaseComponent } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import murielClassnames from '../../../shared/js/muriel-classnames';
 import { InfoButton } from '../';
-
 import './style.scss';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
 
 class CheckboxControl extends Component {
 
@@ -23,7 +26,7 @@ class CheckboxControl extends Component {
 	 */
 	render() {
 		const { className, tooltip, ...otherProps } = this.props;
-		const classes = murielClassnames( 'muriel-checkbox', className );
+		const classes = classnames( 'newspack-checkbox-control', className );
 		return (
 			<div className={ classes }>
 				<BaseComponent { ...otherProps } />

--- a/assets/components/src/checkbox-control/style.scss
+++ b/assets/components/src/checkbox-control/style.scss
@@ -3,67 +3,83 @@
  */
 
 @import '../../../shared/scss/muriel-component';
+@import '~@wordpress/base-styles/colors';
 
-.muriel-checkbox {
-	display: block;
-	position: relative;
+.newspack-checkbox-control {
+	color: $dark-gray-300;
+	display: flex;
+	font-size: 14px;
+	justify-content: space-between;
+	line-height: 24px;
+	margin: 32px 0;
+
+	label {
+		color: $dark-gray-900;
+		font-size: inherit;
+		font-weight: bold;
+		line-height: inherit;
+		margin: 0;
+	}
 
 	input[type="checkbox"] {
-		border: 2px solid $muriel-gray-500;
+		background: white url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath xmlns='http://www.w3.org/2000/svg' d='M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z' fill='%23a2aab2'/%3E%3C/svg%3E");
+		border: 0;
 		border-radius: 3px;
-		height: 22px;
-		margin: 0;
-		width: 22px;
+		box-shadow: none;
+		height: 24px;
+		transition: box-shadow 125ms ease-in-out;
+		width: 24px;
 
-		&:checked {
-			background-color: $primary_color;
-			border-color: $primary_color;
-
-			&:before {
-				font-size: 30px;
-				margin-left: -7px;
-				margin-top: -4px;
-				color: $muriel-white;
-			}
+		&:checked,
+		&.checked {
+			background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath xmlns='http://www.w3.org/2000/svg' d='M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z' fill='%233366ff'/%3E%3C/svg%3E");
 		}
 
 		&:focus {
-			border-color: $primary_color;
-			box-shadow: none;
-			outline: none;
+			box-shadow: 0 0 0 2px $primary_color;
 		}
 	}
 
-	svg.dashicon.components-checkbox-control__checked {
-		height: 22px;
-		left: 0;
-		top: 0;
-		width: 22px;
-	}
+	.components-checkbox-control__input-container {
+		display: block;
+		height: 24px;
+		margin: 0;
+		margin-right: 4px;
+		width: 24px;
 
-	label.components-checkbox-control__label {
-		display: inline-block;
-		font-size: 16px;
-		line-height: 21px;
-		margin-left: 24px;
+		svg {
+			display: none;
+		}
 	}
 
 	.components-base-control__help {
-		color: $muriel-gray-600;
-		font-size: 14px;
-		font-style: normal;
-		line-height: 21px;
-		margin-left: 46px;
-		margin-top: 0;
+		color: inherit;
+		font-size: inherit;
+		line-height: inherit;
+		margin: 0;
+		margin-left: 28px;
+	}
+
+	// Multiple Checkbox Controls
+
+	& + & {
+		margin-top: -16px;
+	}
+
+	// Reset
+
+	.components-base-control {
+		font-size: inherit;
+		line-height: inherit;
 	}
 
 	.components-base-control__field {
-		margin-bottom: 0;
+			display: flex;
+			margin: 0;
 	}
 
-	.components-checkbox-control__input-container {
-		height: 22px;
+	.components-base-control__label {
+		display: block;
 		margin: 0;
-		width: 22px;
 	}
 }

--- a/assets/components/src/info-button/index.js
+++ b/assets/components/src/info-button/index.js
@@ -1,12 +1,12 @@
 /**
- * Muriel-styled Info Button with Tooltip.
+ * Info Button
  */
 
 /**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Tooltip } from '@wordpress/components';
+import { Tooltip, SVG, Path } from '@wordpress/components';
 
 /**
  * External dependencies
@@ -25,7 +25,16 @@ class InfoButton extends Component {
 	 */
 	render() {
 		const { className, ...otherProps } = this.props;
-		return <Tooltip { ...otherProps }><div className={ classnames( 'muriel-info-button', className ) } /></Tooltip>
+		const infoIcon = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+			</SVG>
+		);
+		return (
+			<Tooltip { ...otherProps }>
+				<div className={ classnames( 'newspack-info-button', className ) }>{ infoIcon }</div>
+			</Tooltip>
+		);
 	}
 }
 

--- a/assets/components/src/info-button/info_24px.svg
+++ b/assets/components/src/info-button/info_24px.svg
@@ -1,8 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="20" height="20">
-		<path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM11 17V11H13V17H11ZM11 7V9H13V7H11Z" fill="white"/>
-	</mask>
-	<g mask="url(#mask0)">
-		<rect width="24" height="24" fill="#636D75"/>
-	</g>
-</svg>

--- a/assets/components/src/info-button/style.scss
+++ b/assets/components/src/info-button/style.scss
@@ -1,14 +1,18 @@
 /**
- * Info Button styles
+ * Info Button
  */
 
-@import '../../../shared/scss/muriel-component';
+@import '~@wordpress/base-styles/colors';
 
-.muriel-info-button {
-	background-image: url( 'info_24px.svg' );
-	position: absolute;
-	width: 24px;
+.newspack-info-button {
+	flex: 0 0 24px;
 	height: 24px;
-	right: 16px;
-	top: 0;
+	margin: 0;
+	margin-left: 4px;
+	width: 24px;
+
+	svg {
+		display: block;
+		fill: $dark-gray-900;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

For both components, I'm removing the use of Muriel/Dashicon in favour of Material Icons. Plus a few visual fixes:
* Info Button:
  * Use flexbox instead of absolute positioning
* Checkbox Control:
  * Update font-size and line-height
  * Update margins of elements within the checkbox container

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/70902244-421e8880-1ff4-11ea-934f-4d093ea837d1.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/70902258-48146980-1ff4-11ea-8181-44c13c2a09bf.png)

### How to test the changes in this Pull Request:

1. Best way to see the changes are via the Components Demo. Check the Checkboxes card.
2. Switch to this branch.
3. Notice the new style.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->