### PR TITLE
Use less SVG for the Checkbox Control styles

### DIFF
--- a/assets/components/src/checkbox-control/style.scss
+++ b/assets/components/src/checkbox-control/style.scss
@@ -2,7 +2,7 @@
  * Checkbox styles.
  */
 
-@import '../../../shared/scss/muriel-component';
+@import '../../../shared/scss/colors';
 @import '~@wordpress/base-styles/colors';
 
 .newspack-checkbox-control {
@@ -21,21 +21,32 @@
 	}
 
 	input[type="checkbox"] {
-		background: white url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath xmlns='http://www.w3.org/2000/svg' d='M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z' fill='%23a2aab2'/%3E%3C/svg%3E");
-		border: 0;
+		background: white;
+		border: 1px solid $light-gray-500;
 		border-radius: 3px;
 		box-shadow: none;
 		height: 24px;
-		transition: box-shadow 125ms ease-in-out;
+		transition: background 125ms ease-in-out, border-color 125ms ease-in-out, box-shadow 125ms ease-in-out;
 		width: 24px;
 
 		&:checked,
+		&.checked,
+		&:hover {
+			background-color: $primary-500;
+			border-color: $primary-600;
+		}
+
+		&:checked,
 		&.checked {
-			background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath xmlns='http://www.w3.org/2000/svg' d='M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z' fill='%233366ff'/%3E%3C/svg%3E");
+			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath xmlns='http://www.w3.org/2000/svg' d='M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z' fill='white'/%3E%3C/svg%3E");
+			background-position: 50%;
+			background-repeat: no-repeat;
+			transition: 0s;
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 2px $primary_color;
+			border-color: $primary-600;
+			box-shadow: 0 0 0 2px $primary-500;
 		}
 	}
 
@@ -43,7 +54,7 @@
 		display: block;
 		height: 24px;
 		margin: 0;
-		margin-right: 4px;
+		margin-right: 8px;
 		width: 24px;
 
 		svg {
@@ -56,7 +67,7 @@
 		font-size: inherit;
 		line-height: inherit;
 		margin: 0;
-		margin-left: 28px;
+		margin-left: 32px;
 	}
 
 	// Multiple Checkbox Controls

--- a/assets/components/src/checkbox-control/style.scss
+++ b/assets/components/src/checkbox-control/style.scss
@@ -22,31 +22,31 @@
 
 	input[type="checkbox"] {
 		background: white;
-		border: 1px solid $light-gray-500;
-		border-radius: 3px;
+		border: 2px solid $dark-gray-300;
+		border-radius: 2px;
 		box-shadow: none;
-		height: 24px;
-		transition: background 125ms ease-in-out, border-color 125ms ease-in-out, box-shadow 125ms ease-in-out;
-		width: 24px;
+		height: 18px;
+		margin: 3px 0;
+		transition: box-shadow 125ms ease-in-out;
+		width: 18px;
 
-		&:checked,
-		&.checked,
 		&:hover {
-			background-color: $primary-500;
-			border-color: $primary-600;
+			border-color: $dark-gray-500;
+		}
+
+		&:focus {
+			border-color: $dark-gray-300;
+			box-shadow: 0 0 0 2px white, 0 0 0 4px $primary-500;
+			outline: 0;
 		}
 
 		&:checked,
 		&.checked {
-			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath xmlns='http://www.w3.org/2000/svg' d='M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z' fill='white'/%3E%3C/svg%3E");
+			background-color: $primary-500;
+			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M7 14L2 9l1.41-1.41L7 11.17l7.59-7.59L16 5z' fill='white'/%3E%3C/svg%3E");
 			background-position: 50%;
 			background-repeat: no-repeat;
-			transition: 0s;
-		}
-
-		&:focus {
-			border-color: $primary-600;
-			box-shadow: 0 0 0 2px $primary-500;
+			border-color: transparent;
 		}
 	}
 
@@ -55,7 +55,7 @@
 		height: 24px;
 		margin: 0;
 		margin-right: 8px;
-		width: 24px;
+		width: 18px;
 
 		svg {
 			display: none;
@@ -67,7 +67,7 @@
 		font-size: inherit;
 		line-height: inherit;
 		margin: 0;
-		margin-left: 32px;
+		margin-left: 26px;
 	}
 
 	// Multiple Checkbox Controls


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Replicated the Material style of the checkbox but with a border instead so we can add a hover state and it feels similar to `ToggleControl`.

By only having an SVG when the checkbox is checked we also offer a better support for browsers not supporting it (the tick when checked will be missing but at least the checkbox will be blue)

Finally, we remove Muriel colors.

### How to test the changes in this Pull Request:

1. Switch to this branch.
2. Go to a page where we have checkboxes (e.g. Setup - Newsroom)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->