### PR TITLE
Fix "Only variables should be passed by reference" warnings

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -661,7 +661,8 @@ class Plugin_Manager {
 		// GitHub appends random strings to the end of its downloads.
 		// If we asked for foo.zip, make sure the downloaded file is called foo.tmp.
 		if ( stripos( $plugin_url, 'github' ) ) {
-			$desired_file_name = str_replace( '.zip', '', end( explode( '/', $plugin_url ) ) );
+			$plugin_url_parts  = explode( '/', $plugin_url );
+			$desired_file_name = str_replace( '.zip', '', end( $plugin_url_parts ) );
 			$new_file_name     = preg_replace( '#(' . $desired_file_name . '.*).tmp#', $desired_file_name . '.tmp', $download );
 			rename( $download, $new_file_name ); // phpcs:ignore
 			$download = $new_file_name;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR re-arranges some variables to prevent passing in a variable by reference. This prevents an issue where installing a Newspack plugin from the Plugins screen throws an error like to following:

```
Notice: Only variables should be passed by reference in /srv/users/user55ac21bf/apps/user55ac21bf/public/wp-content/plugins/newspack-plugin-master/includes/class-plugin-manager.php on line 664
Warning: Cannot modify header information - headers already sent by (output started at /srv/users/user55ac21bf/apps/user55ac21bf/public/wp-content/plugins/newspack-plugin-master/includes/class-plugin-manager.php:664) in /srv/users/user55ac21bf/apps/user55ac21bf/public/wp-includes/pluggable.php on line 1265
Warning: Cannot modify header information - headers already sent by (output started at /srv/users/user55ac21bf/apps/user55ac21bf/public/wp-content/plugins/newspack-plugin-master/includes/class-plugin-manager.php:664) in /srv/users/user55ac21bf/apps/user55ac21bf/public/wp-includes/pluggable.php on line 1268
```

### How to test the changes in this Pull Request:

1. Install a GitHub-hosted plugin (e.g. one of the Newspack plugins) through the Newspack plugins screen. Observe it installs correctly and no error is thrown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->