### PR TITLE
Move the wizard pagination to the top (like it used to be)

### DIFF
--- a/assets/components/src/wizard-pagination/index.js
+++ b/assets/components/src/wizard-pagination/index.js
@@ -1,5 +1,5 @@
 /**
- * Wizard pagination
+ * Wizard Pagination
  */
 
 /**
@@ -7,17 +7,18 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
+import { SVG, Path } from '@wordpress/components';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import { withRouter } from 'react-router-dom';
 
 /**
- * Internal dependencies
+ * Internal dependencies.
  */
+import { Button } from '../';
 import './style.scss';
-import { Button, Card, FormattedHeader, Handoff, Grid, SecondaryNavigation, TabbedNavigation } from '../';
 
 class WizardPagination extends Component {
 	/**
@@ -26,6 +27,11 @@ class WizardPagination extends Component {
 	render() {
 		const { history, location, routes } = this.props;
 		const currentIndex = parseInt( routes.indexOf( location.pathname ) );
+		const iconArrowBack = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+			</SVG>
+		);
 		if ( ! routes || ! history || ! location ) {
 			return;
 		}
@@ -39,6 +45,7 @@ class WizardPagination extends Component {
 						{ __( 'Step' ) } { currentIndex } { __( 'of' ) } { routes.length - 1 }{' '}
 					</div>
 					<Button isLink className="newspack-wizard-pagination__navigation" onClick={ () => history.goBack() }>
+						{ iconArrowBack }
 						{ __( 'Back' ) }
 					</Button>
 				</div>

--- a/assets/components/src/wizard-pagination/style.scss
+++ b/assets/components/src/wizard-pagination/style.scss
@@ -1,4 +1,54 @@
+/**
+ * Wizard Pagination
+ */
+
+@import '../../../shared/scss/colors';
+
 .newspack-wizard-pagination {
-	margin: 0 auto;
-	text-align: center;
+	align-items: center;
+	background: $primary-500;
+	color: white;
+	display: flex;
+	flex-direction: row-reverse;
+	font-size: 14px;
+	justify-content: space-between;
+	line-height: 24px;
+	margin: -80px 0 64px;
+	padding: 0 16px 16px;
+
+	@media screen and ( min-width: 520px ) {
+		left: 0;
+		margin: 0;
+		padding-bottom: 0;
+		position: absolute;
+		right: 0;
+		top: 36px;
+	}
+
+	.newspack-wizard-pagination__pagination,
+	.newspack-button {
+		color: inherit;
+		padding: 16px;
+	}
+
+	.newspack-button {
+		&:active,
+		&:focus,
+		&:hover {
+			color: $primary-200;
+		}
+
+		svg {
+			fill: currentColor;
+			margin-right: 4px;
+		}
+	}
+}
+
+// Increase z-index on the Logo if we have the pagination
+
+.newspack-logo-wrapper {
+	svg {
+		z-index: 1;
+	}
 }

--- a/assets/components/src/wizard-pagination/style.scss
+++ b/assets/components/src/wizard-pagination/style.scss
@@ -14,12 +14,12 @@
 	justify-content: space-between;
 	line-height: 24px;
 	margin: -80px 0 64px;
-	padding: 0 16px 16px;
+	padding: 0 0 16px;
 
-	@media screen and ( min-width: 520px ) {
+	@media screen and ( min-width: 600px ) {
 		left: 0;
 		margin: 0;
-		padding-bottom: 0;
+		padding: 0 16px;
 		position: absolute;
 		right: 0;
 		top: 36px;

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -1,9 +1,9 @@
 /**
- * Setup Wizard. Introduces Newspack, installs required plugins, and requests some general information about the newsroom.
+ * Setup
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment, render } from '@wordpress/element';
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { Spinner, SVG, Path } from '@wordpress/components';
 
 /**
- * Internal dependencies
+ * Internal dependencies.
  */
 import {
 	About,
@@ -25,7 +25,7 @@ import { Card, withWizard, WizardPagination } from '../../components/src';
 import './style.scss';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { pickBy, includes, forEach } from 'lodash';
@@ -259,6 +259,7 @@ class SetupWizard extends Component {
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
+					<WizardPagination routes={ routes } />
 					<Route
 						path="/"
 						exact
@@ -411,7 +412,6 @@ class SetupWizard extends Component {
 							) : null;
 						} }
 					/>
-					<WizardPagination routes={ routes } />
 				</HashRouter>
 			</Fragment>
 		);

--- a/assets/wizards/setup/style.scss
+++ b/assets/wizards/setup/style.scss
@@ -1,17 +1,7 @@
-.newspack-setup-wizard_progress_bar_explainer {
-	text-align: center;
-}
-.newspack-setup-wizard_newsroom-screen .components-button {
+/**
+ * Setup
+ */
+
+#newspack-setup-wizard {
 	position: relative;
-	.components-spinner {
-		position: absolute;
-		right: 0;
-	}
-}
-#newspack-setup-wizard .muriel-wizardScreen__completeButton {
-	position: relative;
-	.components-spinner {
-		position: absolute;
-		right: 0;
-	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Move the `WizardPagination` back to the top but with better handling of small screens and add Material Icon to the back button.

__Before (small screen):__

![1 before-small](https://user-images.githubusercontent.com/177929/71163101-51941080-2244-11ea-8879-d9b8ca26c327.png)

__Before (large screen):__

![1 before-large](https://user-images.githubusercontent.com/177929/71163089-4d67f300-2244-11ea-9595-df21ea0ab25f.png)

__After (small screen):__

![2 after-small](https://user-images.githubusercontent.com/177929/71163639-6cb35000-2245-11ea-9f9d-71bd54f831ab.png)

__After (large screen):__

![2 after-large](https://user-images.githubusercontent.com/177929/71163070-450fb800-2244-11ea-8ee3-7aa21cf14382.png)

### How to test the changes in this Pull Request:

1. Switch to this branch.
2. Run the Setup Wizard.
3. Does the Pagination sits at the top? Any issues?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->