### PR TITLE
Update the Formatted Header and make sure every Wizard Pages have `iconHeader` and `subHeaderText`

### DIFF
--- a/assets/components/src/formatted-header/style.scss
+++ b/assets/components/src/formatted-header/style.scss
@@ -6,6 +6,7 @@
 @import '../../../shared/scss/colors';
 
 .newspack-formatted-header {
+	margin: 32px 0;
 	text-align: center;
 
 	// Title
@@ -36,6 +37,8 @@
 
 	.newspack-formatted-header__subtitle {
 		color: $dark-gray-900;
+		font-size: 14px;
+		line-height: 24px;
 		margin: 8px 0 0;
 	}
 }

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { Component, createRef, Fragment } from '@wordpress/element';
-import { Spinner } from '@wordpress/components';
+import { Spinner, SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -189,6 +189,11 @@ export default function withWizard( WrappedComponent, requiredPlugins, options )
 		 */
 		pluginRequirements = () => {
 			const { complete } = this.state;
+			const iconRequired = (
+				<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+					<Path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/>
+				</SVG>
+			);
 			/* After all plugins are loaded, redirect to / (this could be configurable) */
 			if ( complete ) {
 				return <Redirect from="/plugin-requirements" to="/" />;
@@ -201,6 +206,7 @@ export default function withWizard( WrappedComponent, requiredPlugins, options )
 							<Card noBackground>
 								{ complete !== null && (
 									<FormattedHeader
+										headerIcon={ iconRequired }
 										headerText={ __( 'Required plugin' ) }
 										subHeaderText={ __( 'This feature requires the following plugin.' ) }
 									/>

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -99,7 +99,7 @@ class ComponentsDemo extends Component {
 				<FormattedHeader
 					headerIcon={ headerIcon }
 					headerText={ __( 'Newspack Components' ) }
-					subHeaderText={ __( 'Temporary demo of Newspack components' ) }
+					subHeaderText={ __( 'Demo of all the Newspack components' ) }
 				/>
 				<Grid>
 					<Card>

--- a/assets/wizards/seo/index.js
+++ b/assets/wizards/seo/index.js
@@ -47,7 +47,8 @@ class SEOWizard extends Component {
 							render={ routeProps => (
 								<Intro
 									headerIcon={ headerIcon }
-									headerText={ __( 'SEO', 'newspack' ) }
+									headerText={ __( 'SEO' ) }
+									subHeaderText={ __( 'Search engine and social optimization' ) }
 									buttonText={ __( 'Back to dashboard' ) }
 									buttonAction={ window && window.newspack_urls.dashboard }
 								/>

--- a/assets/wizards/syndication/index.js
+++ b/assets/wizards/syndication/index.js
@@ -46,6 +46,7 @@ class SyndicationWizard extends Component {
 								<Intro
 									headerIcon={ headerIcon }
 									headerText={ __( 'Syndication', 'newspack' ) }
+									subHeaderText={ 'Apple News, Facebook Instant Articles' }
 									buttonText={ __( 'Back to dashboard' ) }
 									buttonAction={ window && window.newspack_urls.dashboard }
 								/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

* Formatted Header: Add top/bottom margin to component + fix `subHeaderText` font-size and line-height
* With Wizard: Add an icon to the "Required plugin" `FormattedHeader`
* Components Demo: Update `subHeaderText`
* SEO: Update `headerText` and `subHeaderText`
* Syndication: Update `subHeaderText`

### How to test the changes in this Pull Request:

1. Switch to this branch.
2. Check every of the plugin.
3. Do we have an icon and a subheader for every `FormattedHeader` we use? Does it look broken?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->