### PR TITLE
Textarea Control: Add new component to the list, using `BaseComponent`

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -18,6 +18,7 @@ export { default as SelectControl } from './select-control';
 export { default as TabbedNavigation } from './tabbed-navigation';
 export { default as Task } from './task';
 export { default as TextControl } from './text-control';
+export { default as TextareaControl } from './textarea-control';
 export { default as ToggleControl } from './toggle-control';
 export { default as ToggleGroup } from './toggle-group';
 export { default as Waiting } from './waiting';

--- a/assets/components/src/select-control/style.scss
+++ b/assets/components/src/select-control/style.scss
@@ -63,7 +63,8 @@
 
 	// Multiple Controls
 
-	& + .newspack-text-control {
+	& + .newspack-text-control,
+	& + .newspack-textarea-control {
 		margin-bottom: 32px;
 		margin-top: -16px;
 	}

--- a/assets/components/src/text-control/style.scss
+++ b/assets/components/src/text-control/style.scss
@@ -71,7 +71,8 @@
 
 	// Multiple Controls
 
-	& + .newspack-select-control {
+	& + .newspack-select-control,
+	& + .newspack-textarea-control {
 		margin-bottom: 32px;
 		margin-top: -16px;
 	}

--- a/assets/components/src/textarea-control/index.js
+++ b/assets/components/src/textarea-control/index.js
@@ -1,0 +1,32 @@
+/**
+ * Textarea Control
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { TextareaControl as BaseComponent } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+class TextareaControl extends Component {
+	/**
+	 * Render.
+	 */
+	render( props ) {
+		const { className, ...otherProps } = this.props;
+		const classes = classnames( 'newspack-textarea-control', className );
+		return <BaseComponent className={ classes } { ...otherProps } />;
+	}
+}
+
+export default TextareaControl;

--- a/assets/components/src/textarea-control/style.scss
+++ b/assets/components/src/textarea-control/style.scss
@@ -1,0 +1,76 @@
+/**
+ * Textarea Control
+ */
+
+@import '../../../shared/scss/colors';
+@import '~@wordpress/base-styles/colors';
+
+.newspack-textarea-control {
+	color: $dark-gray-300;
+	font-size: 14px;
+	line-height: 24px;
+	margin: 32px 0;
+
+	label {
+		color: $dark-gray-900;
+		font-size: inherit;
+		font-weight: bold;
+		line-height: inherit;
+		margin: 0;
+	}
+
+	textarea {
+		background: white;
+		border: 1px solid $light-gray-500;
+		border-radius: 3px;
+		box-shadow: none;
+		color: inherit;
+		display: block;
+		font-size: 16px;
+		line-height: inherit;
+		margin: 0;
+		min-height: 48px;
+		padding: 11px 8px;
+		transition: border-color 125ms ease-in-out, box-shadow 125ms ease-in-out;
+		width: 100%;
+
+		@media screen and ( min-width: 768px ) {
+			font-size: inherit;
+		}
+
+		&:focus {
+			border-color: $primary-500;
+			box-shadow: 0 0 0 2px $primary-500;
+		}
+
+		&:disabled,
+		&.disabled {
+			background: $light-gray-100;
+			color: $light-gray-900;
+			cursor: not-allowed;
+		}
+	}
+
+	// Multiple Textarea Controls
+
+	& + & {
+		margin-bottom: 32px;
+		margin-top: -16px;
+	}
+
+	// Multiple Controls
+
+	& + .newspack-select-control,
+	& + .newspack-text-control {
+		margin-bottom: 32px;
+		margin-top: -16px;
+	}
+
+	// Reset
+
+	.components-base-control__field,
+	.components-base-control__label {
+		display: block;
+		margin: 0;
+	}
+}

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -6,13 +6,12 @@
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
-import { TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { Card, Button, TextControl, withWizardScreen } from '../../../../components/src';
+import { Button, Card, TextControl, TextareaControl, withWizardScreen } from '../../../../components/src';
 
 /**
  * New/Edit Ad Unit Screen.

--- a/assets/wizards/advertising/views/header-code/index.js
+++ b/assets/wizards/advertising/views/header-code/index.js
@@ -6,13 +6,13 @@
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
-import { ExternalLink, TextareaControl } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { Card, Button, TextControl, withWizardScreen } from '../../../../components/src';
+import { Button, Card, TextareaControl, withWizardScreen } from '../../../../components/src';
 
 /**
  * New/Edit Ad Unit Screen.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a new component of `TextareaControl` to the list. It's using `BaseComponent` and it visually matches `TextControl`.

Updated the margin when multiple form elements (input/select) are following each other.

And updated the Advertising pages to make sure they use our `TextareaControl`

### How to test the changes in this Pull Request:

1. Only place with the `TextareaControl` is in the Advertising Wizard.
2. You should see the default WordPress style.
3. Switch to this branch.
4. Now it should look more like an input.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->