### PR TITLE
Card: Make sure links are using the primary color

### DIFF
--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -2,6 +2,7 @@
  * Card
  */
 
+@import '../../../shared/scss/colors';
 @import '~@wordpress/base-styles/colors';
 
 .newspack-card {
@@ -81,6 +82,25 @@
 
 		@media screen and ( min-width: 744px ) {
 			margin: 64px -64px;
+		}
+	}
+
+	// Links
+
+	a {
+		color: $primary-500;
+
+		&:active,
+		&:focus,
+		&:hover {
+			color: $primary-600;
+			text-decoration: none;
+		}
+
+		&:focus {
+			box-shadow: none;
+			outline: 2px solid $primary-500;
+			outline-offset: 2px;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Links used inside the Card component should be using the primary color and not Core's default blue.

### How to test the changes in this Pull Request:

1. Go to a page where there's a link. A good example is Engagement > Newsletter ("Set up Mailchimp on WordPress.com"
2. The link should be using WordPress's blue (#0073aa)
3. Switch to this branch.
4. The link should now be using Newspack's primary color (#3366ff)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->