### PR TITLE
Image Upload: Update component to use Newspack's `Button`

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -16,6 +16,13 @@
 		line-height: 24px;
 	}
 
+	&.is-small {
+		font-size: 14px;
+		height: auto;
+		line-height: 24px;
+		padding: 3px 12px;
+	}
+
 	&.is-button {
 		background: white;
 		border: 1px solid $light-gray-500;
@@ -59,6 +66,10 @@
 			}
 		}
 
+		&.is-small {
+			padding: 3px 12px;
+		}
+
 		&.is-large {
 			padding: 15px 32px;
 		}
@@ -97,6 +108,10 @@
 				border-color: $primary-500;
 				color: $primary-200;
 			}
+		}
+
+		&.is-small {
+			padding: 3px 12px;
 		}
 
 		.newspack-is-waiting {
@@ -146,6 +161,10 @@
 			}
 		}
 
+		&.is-small {
+			padding: 3px 12px;
+		}
+
 		.newspack-is-waiting {
 			fill: $dark-gray-600;
 		}
@@ -175,6 +194,7 @@
 			outline-offset: 2px;
 		}
 
+		&.is-small,
 		&.is-large {
 			padding: 0;
 		}

--- a/assets/components/src/image-upload/index.js
+++ b/assets/components/src/image-upload/index.js
@@ -78,39 +78,34 @@ class ImageUpload extends Component {
 	 * Render.
 	 */
 	render = () => {
-		const { className, image } = this.props;
+		const { className, image, removeText, addText } = this.props;
+		const classes = classnames( 'newspack-image-upload', className );
 		const iconAddImage = (
 			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 				<Path d="M19 7v2.99s-1.99.01-2 0V7h-3s.01-1.99 0-2h3V2h2v3h3v2h-3zm-3 4V8h-3V5H5c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-8h-3zM5 19l3-4 2 3 3-4 4 5H5z"/>
 			</SVG>
 		);
-		const iconRemoveImage = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
-			</SVG>
-		);
 		return (
-			<Fragment>
+			<div className={ classes }>
 				{ !! image && (
-				<div className={ classnames( 'newspack-image-upload', 'newspack-image-upload__has-image', className ) }>
+				<Fragment>
 					<div className="newspack-image-upload__image-preview">
 						<img src={ image.url } />
 					</div>
-					<Button onClick={ this.removeImage } isTertiary>
-						{ iconRemoveImage }
-						{ __( 'Remove image' ) }
+					<Button onClick={ this.removeImage } isTertiary isSmall>
+						{ ! removeText && ( __( 'Remove image' ) ) }
+						{ removeText && removeText }
 					</Button>
-				</div>
+				</Fragment>
 				) }
 				{ ! image && (
-					<div className={ classnames( 'newspack-image-upload', className ) }>
-						<Button onClick={ this.openModal } isTertiary>
-							{ iconAddImage }
-							{ __( 'Add an image' ) }
-						</Button>
-					</div>
+				<Button onClick={ this.openModal } className="newspack-image-upload__add-image" isTertiary isSmall>
+					{ iconAddImage }
+					{ ! addText && ( __( 'Add image' ) ) }
+					{ addText && addText }
+				</Button>
 				) }
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/assets/components/src/image-upload/index.js
+++ b/assets/components/src/image-upload/index.js
@@ -96,7 +96,7 @@ class ImageUpload extends Component {
 					<div className="newspack-image-upload__image-preview">
 						<img src={ image.url } />
 					</div>
-					<Button onClick={ this.removeImage } isDefault>
+					<Button onClick={ this.removeImage } isTertiary>
 						{ iconRemoveImage }
 						{ __( 'Remove image' ) }
 					</Button>
@@ -104,7 +104,7 @@ class ImageUpload extends Component {
 				) }
 				{ ! image && (
 					<div className={ classnames( 'newspack-image-upload', className ) }>
-						<Button onClick={ this.openModal } isDefault>
+						<Button onClick={ this.openModal } isTertiary>
 							{ iconAddImage }
 							{ __( 'Add an image' ) }
 						</Button>

--- a/assets/components/src/image-upload/index.js
+++ b/assets/components/src/image-upload/index.js
@@ -1,24 +1,26 @@
 /**
- * Image uploader component.
+ * Image Upload
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, Fragment } from '@wordpress/element';
-import { Button } from '@wordpress/components';
 import { data } from '@wordpress/data';
+import { SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Internal dependencies.
  */
-import murielClassnames from '../../../shared/js/muriel-classnames';
+import { Button } from '../';
 import './style.scss';
 
 /**
- * Image select/upload button and modal.
+ * External dependencies.
  */
+import classnames from 'classnames';
+
 class ImageUpload extends Component {
 
 	/**
@@ -77,21 +79,33 @@ class ImageUpload extends Component {
 	 */
 	render = () => {
 		const { className, image } = this.props;
+		const iconAddImage = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M19 7v2.99s-1.99.01-2 0V7h-3s.01-1.99 0-2h3V2h2v3h3v2h-3zm-3 4V8h-3V5H5c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-8h-3zM5 19l3-4 2 3 3-4 4 5H5z"/>
+			</SVG>
+		);
+		const iconRemoveImage = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
+			</SVG>
+		);
 		return (
 			<Fragment>
 				{ !! image && (
-				<div className={ murielClassnames( 'muriel-image-upload', 'has-image', className ) }>
-					<div className="image-preview">
+				<div className={ classnames( 'newspack-image-upload', 'newspack-image-upload__has-image', className ) }>
+					<div className="newspack-image-upload__image-preview">
 						<img src={ image.url } />
 					</div>
-					<Button className="remove-image" onClick={ this.removeImage }>
+					<Button onClick={ this.removeImage } isDefault>
+						{ iconRemoveImage }
 						{ __( 'Remove image' ) }
 					</Button>
 				</div>
 				) }
 				{ ! image && (
-					<div className={ murielClassnames( 'muriel-image-upload', 'no-image', className ) }>
-						<Button className="add-image" onClick={ this.openModal }>
+					<div className={ classnames( 'newspack-image-upload', className ) }>
+						<Button onClick={ this.openModal } isDefault>
+							{ iconAddImage }
 							{ __( 'Add an image' ) }
 						</Button>
 					</div>

--- a/assets/components/src/image-upload/index.js
+++ b/assets/components/src/image-upload/index.js
@@ -85,6 +85,11 @@ class ImageUpload extends Component {
 				<Path d="M19 7v2.99s-1.99.01-2 0V7h-3s.01-1.99 0-2h3V2h2v3h3v2h-3zm-3 4V8h-3V5H5c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-8h-3zM5 19l3-4 2 3 3-4 4 5H5z"/>
 			</SVG>
 		);
+		const iconRemoveImage = (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
+			</SVG>
+		);
 		return (
 			<div className={ classes }>
 				{ !! image && (
@@ -93,6 +98,7 @@ class ImageUpload extends Component {
 						<img src={ image.url } />
 					</div>
 					<Button onClick={ this.removeImage } isTertiary isSmall>
+						{ iconRemoveImage }
 						{ ! removeText && ( __( 'Remove image' ) ) }
 						{ removeText && removeText }
 					</Button>

--- a/assets/components/src/image-upload/index.js
+++ b/assets/components/src/image-upload/index.js
@@ -7,8 +7,13 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { data } from '@wordpress/data';
-import { SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Material UI dependencies.
+ */
+import AddPhotoAlternateIcon from '@material-ui/icons/AddPhotoAlternate';
+import DeleteIcon from '@material-ui/icons/Delete';
 
 /**
  * Internal dependencies.
@@ -80,16 +85,6 @@ class ImageUpload extends Component {
 	render = () => {
 		const { className, image, removeText, addText } = this.props;
 		const classes = classnames( 'newspack-image-upload', className );
-		const iconAddImage = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M19 7v2.99s-1.99.01-2 0V7h-3s.01-1.99 0-2h3V2h2v3h3v2h-3zm-3 4V8h-3V5H5c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-8h-3zM5 19l3-4 2 3 3-4 4 5H5z"/>
-			</SVG>
-		);
-		const iconRemoveImage = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
-			</SVG>
-		);
 		return (
 			<div className={ classes }>
 				{ !! image && (
@@ -97,8 +92,8 @@ class ImageUpload extends Component {
 					<div className="newspack-image-upload__image-preview">
 						<img src={ image.url } />
 					</div>
-					<Button onClick={ this.removeImage } isTertiary isSmall>
-						{ iconRemoveImage }
+					<Button onClick={ this.removeImage } className="newspack-image-upload__remove-image" isTertiary isSmall>
+						<DeleteIcon />
 						{ ! removeText && ( __( 'Remove image' ) ) }
 						{ removeText && removeText }
 					</Button>
@@ -106,7 +101,7 @@ class ImageUpload extends Component {
 				) }
 				{ ! image && (
 				<Button onClick={ this.openModal } className="newspack-image-upload__add-image" isTertiary isSmall>
-					{ iconAddImage }
+					<AddPhotoAlternateIcon />
 					{ ! addText && ( __( 'Add image' ) ) }
 					{ addText && addText }
 				</Button>

--- a/assets/components/src/image-upload/style.scss
+++ b/assets/components/src/image-upload/style.scss
@@ -1,42 +1,40 @@
 /**
- * Image uploader styles.
+ * Image Upload
  */
 
-@import '../../../shared/scss/muriel-component';
+.newspack-image-upload {
+	margin: 32px 0;
 
-.muriel-image-upload {
-	button {
-		color: $primary_color;
-		font-size: 16px;
-		line-height: 24px;
-		padding: 0;
-		vertical-align: middle;
-	}
+	@media screen and ( min-width: 744px ) {
+		&.newspack-image-upload__has-image {
+			align-items: flex-end;
+			display: flex;
 
-	.image-preview {
-		font-size: 16px;
-		margin-right: 2em;
-
-		img {
-			max-width: 240px;
-			height: auto;
-		}
-	}
-
-	&.no-image {
-		.add-image {
-			&:before {
-				content: '';
-				background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath fill='%23636d75' d='M18 20H4V6h9V4H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-9h-2v9zm-7.79-3.17l-1.96-2.36L5.5 18h11l-3.54-4.71zM20 4V1h-2v3h-3c.01.01 0 2 0 2h3v2.99c.01.01 2 0 2 0V6h3V4h-3z'/%3E%3C/svg%3E");
-				width: 24px;
-				height: 24px;
-				margin-right: 12px;
+			.newspack-button {
+				margin-left: 8px;
 			}
 		}
 	}
 
-	&.has-image {
-		display: flex;
-		align-items: center;
+	.newspack-image-upload__image-preview {
+		margin-bottom: 8px;
+		max-width: 144px;
+
+		@media screen and ( min-width: 744px ) {
+			margin-bottom: 0;
+		}
+
+		img {
+			display: block;
+			max-width: 100%;
+			height: auto;
+		}
+	}
+
+	.newspack-button {
+		svg {
+			fill: currentcolor;
+			margin-right: 4px;
+		}
 	}
 }

--- a/assets/components/src/image-upload/style.scss
+++ b/assets/components/src/image-upload/style.scss
@@ -7,18 +7,22 @@
 .newspack-image-upload {
 	margin: 32px 0;
 
-	.newspack-image-upload__add-image {
-		align-items: center;
-		border-radius: 0;
-		border-style: dashed;
-		height: 144px;
+	.newspack-button {
 		justify-content: center;
 		min-width: 144px;
 
 		svg {
 			display: block;
 			fill: currentcolor;
+			margin-right: 4px;
 		}
+	}
+
+	.newspack-image-upload__add-image {
+		align-items: center;
+		border-radius: 0;
+		border-style: dashed;
+		height: 144px;
 	}
 
 	.newspack-image-upload__image-preview {

--- a/assets/components/src/image-upload/style.scss
+++ b/assets/components/src/image-upload/style.scss
@@ -2,39 +2,34 @@
  * Image Upload
  */
 
+@import '~@wordpress/base-styles/colors';
+
 .newspack-image-upload {
 	margin: 32px 0;
 
-	@media screen and ( min-width: 744px ) {
-		&.newspack-image-upload__has-image {
-			align-items: flex-end;
-			display: flex;
+	.newspack-image-upload__add-image {
+		align-items: center;
+		border-radius: 0;
+		border-style: dashed;
+		height: 144px;
+		justify-content: center;
+		min-width: 144px;
 
-			.newspack-button {
-				margin-left: 8px;
-			}
+		svg {
+			display: block;
+			fill: currentcolor;
 		}
 	}
 
 	.newspack-image-upload__image-preview {
 		margin-bottom: 8px;
 		max-width: 144px;
-
-		@media screen and ( min-width: 744px ) {
-			margin-bottom: 0;
-		}
+		padding: 0;
 
 		img {
 			display: block;
 			max-width: 100%;
 			height: auto;
-		}
-	}
-
-	.newspack-button {
-		svg {
-			fill: currentcolor;
-			margin-right: 4px;
 		}
 	}
 }

--- a/assets/components/src/image-upload/style.scss
+++ b/assets/components/src/image-upload/style.scss
@@ -2,27 +2,21 @@
  * Image Upload
  */
 
-@import '~@wordpress/base-styles/colors';
-
 .newspack-image-upload {
 	margin: 32px 0;
 
 	.newspack-button {
 		justify-content: center;
-		min-width: 144px;
+
+		&.newspack-image-upload__remove-image {
+			min-width: 144px;
+		}
 
 		svg {
 			display: block;
 			fill: currentcolor;
 			margin-right: 4px;
 		}
-	}
-
-	.newspack-image-upload__add-image {
-		align-items: center;
-		border-radius: 0;
-		border-style: dashed;
-		height: 144px;
 	}
 
 	.newspack-image-upload__image-preview {

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -479,11 +479,20 @@ class ComponentsDemo extends Component {
 					<Card className="newspack-components-demo__buttons">
 						<FormattedHeader headerText="Buttons" />
 						<Card noBackground className="newspack-card__buttons-card">
-							<Button isPrimary>{ __( 'isPrimary' ) }</Button>
-							<Button isDefault>{ __( 'isDefault' ) }</Button>
-							<Button isTertiary>{ __( 'isTertiary' ) }</Button>
-							<Button isLink>{ __( 'isLink' ) }</Button>
-							<Button isLarge>{ __( 'isLarge' ) }</Button>
+							<Button isPrimary>isPrimary</Button>
+							<Button isDefault>isDefault</Button>
+							<Button isTertiary>isTertiary</Button>
+							<Button isLink>isLink</Button>
+							<hr />
+							<h2>isLarge</h2>
+							<Button isPrimary isLarge>isPrimary</Button>
+							<Button isDefault isLarge>isDefault</Button>
+							<Button isTertiary isLarge>isTertiary</Button>
+							<hr />
+							<h2>isSmall</h2>
+							<Button isPrimary isSmall>isPrimary</Button>
+							<Button isDefault isSmall>isDefault</Button>
+							<Button isTertiary isSmall>isTertiary</Button>
 						</Card>
 					</Card>
 				</Grid>

--- a/assets/wizards/performance/views/intro/index.js
+++ b/assets/wizards/performance/views/intro/index.js
@@ -65,6 +65,8 @@ class Intro extends Component {
 				<ImageUpload
 					image={ settings.site_icon }
 					onChange={ image => updateSiteIcon( image ) }
+					addText={ __( 'Add icon' ) }
+					removeText={ __( 'Remove icon' ) }
 				/>
 				<Notice noticeText={ __( 'Site icons should be square and at least 144 × 144 pixels.' ) } isPrimary />
 			</Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Use Material Icon for add/remove image
* Uses `isTertiary` button

### How to test the changes in this Pull Request:

1. Go to Performance > Site Icon
2. The current button is easily missable as it doesn't look like a button.
3. Switch to this branch
4. Do you see a `isTertiary` button with an icon? Does the button work?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->