### PR TITLE
Button: Rework the tertiary button

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -81,8 +81,7 @@
 
 		&:focus,
 		&:focus:enabled {
-			border-color: $primary-800;
-			box-shadow: 0 0 0 2px $primary-700;
+			box-shadow: 0 0 0 2px $primary-500;
 		}
 
 		&:disabled,
@@ -106,13 +105,14 @@
 	}
 
 	&.is-tertiary {
-		background: $dark-gray-700;
-		border: 1px solid $dark-gray-800;
+		background: $light-gray-300;
+		border: 1px solid $light-gray-500;
 		border-radius: 3px;
-		color: white;
+		color: $dark-gray-600;
 		height: auto;
 		line-height: 24px;
 		padding: 11px 24px;
+		transition: background 125ms ease-in-out, border-color 125ms ease-in-out, box-shadow 125ms ease-in-out, color 125ms ease-in-out;
 
 		&:active,
 		&:active:enabled,
@@ -120,34 +120,34 @@
 		&:focus:enabled,
 		&:hover,
 		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
-			background: $dark-gray-800;
-			border-color: $dark-gray-900;
-			color: white;
+			background: $light-gray-400;
+			border-color: $light-gray-900;
+			color: $dark-gray-900;
 		}
 
 		&:focus,
 		&:focus:enabled {
-			border-color: black;
-			box-shadow: 0 0 0 2px $dark-gray-900;
+			border-color: $primary-600;
+			box-shadow: 0 0 0 2px $primary-500;
 		}
 
 		&:disabled,
 		&:disabled:active:enabled,
 		&[aria-disabled=true],
 		&[aria-disabled=true]:active:enabled {
-			background: $dark-gray-600;
-			border-color: $dark-gray-700;
-			color: $light-gray-700;
+			background: $light-gray-300;
+			border-color: $light-gray-500;
+			color: $dark-gray-100;
 
 			&:hover {
-				background: $dark-gray-600;
-				border-color: $dark-gray-700;
-				color: $light-gray-700;
+				background: $light-gray-300;
+				border-color: $light-gray-500;
+				color: $dark-gray-100;
 			}
 		}
 
 		.newspack-is-waiting {
-			fill: white;
+			fill: $dark-gray-600;
 		}
 	}
 
@@ -156,7 +156,7 @@
 		border-radius: 0;
 		color: $primary-500;
 		font-weight: normal;
-		transition: color 125ms ease-in-out;
+		transition: color 125ms ease-in-out, outline 125ms ease-in-out;
 
 		&:active,
 		&:active:enabled,
@@ -172,7 +172,7 @@
 		&:focus:enabled {
 			box-shadow: none;
 			outline: 2px solid $primary-500;
-			outline-offset: 4px;
+			outline-offset: 2px;
 		}
 
 		&.is-large {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Remove dark background and use a slightly less dark one.
* Update the border and color accordingly
* Focus box-shadow to use Primary color
* Make sure transitions work

__Before:__

<img width="574" alt="1 before" src="https://user-images.githubusercontent.com/177929/71381336-f018cc80-25ca-11ea-84b2-2c7fbe90661e.png">

__After:__

<img width="578" alt="2 after" src="https://user-images.githubusercontent.com/177929/71381342-f73fda80-25ca-11ea-8d4e-9411aa548e2a.png">

### How to test the changes in this Pull Request:

1. Go to components demo. Check the isTertiary button. It should be very dark, almost black.
2. Switch to this branch.
3. It's now using a lighter grey background.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->