### PR TITLE
Add support for LaterPay

### DIFF
--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -266,6 +266,7 @@ render(
 			'woocommerce',
 			'woocommerce-subscriptions',
 			'woocommerce-name-your-price',
+			'laterpay',
 		] )
 	),
 	document.getElementById( 'newspack-reader-revenue-wizard' )

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -277,6 +277,15 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://automattic.com',
 				'Download'    => 'https://github.com/Automattic/newspack-media-partners/releases/latest/download/newspack-media-partners.zip',
 			],
+			'laterpay'                      => [
+				'Name'        => 'LaterPay',
+				'Description' => 'A frictionless monetization solution to convert your readers into paying customers.',
+				'Author'      => 'LaterPay',
+				'PluginURI'   => 'https://wordpress.org/plugins/laterpay/',
+				'AuthorURI'   => 'https://www.laterpay.net/',
+				'Download'    => 'wporg',
+				'Editpath'    => 'admin.php?page=laterpay-pricing-tab',
+			],
 		];
 
 		$default_info = [

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -285,6 +285,10 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://www.laterpay.net/',
 				'Download'    => 'wporg',
 				'Editpath'    => 'admin.php?page=laterpay-pricing-tab',
+				'Configurer'  => [
+					'filename'   => 'class-laterpay-configuration-manager.php',
+					'class_name' => 'LaterPay_Configuration_Manager',
+				],
 			],
 		];
 

--- a/includes/configuration_managers/class-configuration-managers.php
+++ b/includes/configuration_managers/class-configuration-managers.php
@@ -20,37 +20,41 @@ class Configuration_Managers {
 	 * @var array
 	 */
 	protected static $configuration_managers = [
-		'jetpack'         => [
+		'jetpack'               => [
 			'filename'   => 'class-jetpack-configuration-manager.php',
 			'class_name' => 'Jetpack_Configuration_Manager',
 		],
-		'amp'             => [
+		'amp'                   => [
 			'filename'   => 'class-amp-configuration-manager.php',
 			'class_name' => 'AMP_Configuration_Manager',
 		],
-		'google-site-kit' => [
+		'google-site-kit'       => [
 			'filename'   => 'class-site-kit-configuration-manager.php',
 			'class_name' => 'Site_Kit_Configuration_Manager',
 		],
-		'progressive-wp'  => [
+		'progressive-wp'        => [
 			'filename'   => 'class-progressive-wp-configuration-manager.php',
 			'class_name' => 'Progressive_WP_Configuration_Manager',
 		],
-		'newspack-ads'    => [
+		'newspack-ads'          => [
 			'filename'   => 'class-newspack-ads-configuration-manager.php',
 			'class_name' => 'Newspack_Ads_Configuration_Manager',
 		],
-		'woocommerce'     => [
+		'woocommerce'           => [
 			'filename'   => 'class-woocommerce-configuration-manager.php',
 			'class_name' => 'WooCommerce_Configuration_Manager',
 		],
-		'newspack-theme'  => [
+		'newspack-theme'        => [
 			'filename'   => 'class-newspack-theme-configuration-manager.php',
 			'class_name' => 'Newspack_Theme_Configuration_Manager',
 		],
-		'publish-to-apple-news'  => [
+		'publish-to-apple-news' => [
 			'filename'   => 'class-publish-to-apple-news-configuration-manager.php',
 			'class_name' => 'Publish_To_Apple_News_Configuration_Manager',
+		],
+		'laterpay'              => [
+			'filename'   => 'class-laterpay-configuration-manager.php',
+			'class_name' => 'LaterPay_Configuration_Manager',
 		],
 	];
 

--- a/includes/configuration_managers/class-laterpay-configuration-manager.php
+++ b/includes/configuration_managers/class-laterpay-configuration-manager.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * LaterPay plugin configuration manager.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
+
+/**
+ * Provide an interface for configuring and querying the configuration of LaterPay.
+ */
+class LaterPay_Configuration_Manager extends Configuration_Manager {
+
+	/**
+	 * The slug of the plugin.
+	 *
+	 * @var string
+	 */
+	public $slug = 'laterpay';
+
+	/**
+	 * Configure LaterPay for Newspack use.
+	 *
+	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
+	 */
+	public function configure() {
+		$active = $this->is_active();
+
+		if ( ! $active || is_wp_error( $active ) ) {
+			return $active;
+		}
+
+		if ( class_exists( 'LaterPay_Controller_Admin_Appearance' ) ) {
+
+			$primary_color   = '#01a99d';
+			$secondary_color = '#01766e';
+
+			if ( function_exists( 'newspack_get_primary_color' ) ) {
+				$primary_color   = newspack_get_primary_color();
+				$secondary_color = newspack_get_secondary_color();
+			}
+
+			if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
+				$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
+				$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
+			}
+
+			update_option( 'laterpay_main_color', $primary_color );
+			update_option( 'laterpay_hover_color', $secondary_color );
+
+		}
+		$this->set_newspack_has_configured( true );
+		return true;
+	}
+}


### PR DESCRIPTION

- This PR adds support for LaterPay in Reader Revenue, it updates the plugins appearance color based on current primary and secondary color based on customizer.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-plugin/issues/205 

### How to test the changes in this Pull Request:

- Please check following videos for detailed information on testing.
- Test on Default theme ( Twenty Nineteen ) - [video](https://drive.google.com/open?id=10G7lHTluxVb8V59j3tqz2-9omWiwuvGR)
- Test on NewsPack theme - [video](https://drive.google.com/open?id=1xxT9sT61UCxLGdYa2sIwuHxSz-WCQDpB)
- Make sure AMP Website Mode	is set to **Transitional**,  as the plugin doesn't support AMP yet, so the test would have to be done on non AMP post/page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->