### PR TITLE
Add Material UI package to the dependencies and update all SVG to use icons from `@material-ui/icons`

### DIFF
--- a/assets/components/src/checklist/index.js
+++ b/assets/components/src/checklist/index.js
@@ -7,7 +7,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Children, cloneElement } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
+
+/**
+ * Material UI dependencies.
+ */
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 /**
  * Internal dependencies.
@@ -34,18 +39,8 @@ class Checklist extends Component {
 	render() {
 		const { className, children, progressBarText, ...otherProps } = this.props;
 		const { hideCompleted } = this.state;
-		const iconExpandLess = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/>
-			</SVG>
-		);
-		const iconExpandMore = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
-			</SVG>
-		);
 		const completedLabel = hideCompleted ? __( 'Show completed' ) : __( 'Hide completed' );
-		const completedIcon = hideCompleted ? iconExpandMore : iconExpandLess;
+		const completedIcon = hideCompleted ? <ExpandMoreIcon /> : <ExpandLessIcon />;
 		const classes = classnames(
 			'newspack-checklist',
 			className,

--- a/assets/components/src/info-button/index.js
+++ b/assets/components/src/info-button/index.js
@@ -3,18 +3,23 @@
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component } from '@wordpress/element';
-import { Tooltip, SVG, Path } from '@wordpress/components';
+import { Tooltip } from '@wordpress/components';
 
 /**
- * External dependencies
+ * Material UI dependencies.
+ */
+import InfoIcon from '@material-ui/icons/Info';
+
+/**
+ * External dependencies.
  */
 import classnames from 'classnames';
 
 /**
- * Internal dependencies
+ * Internal dependencies.
  */
 import './style.scss';
 
@@ -25,14 +30,11 @@ class InfoButton extends Component {
 	 */
 	render() {
 		const { className, ...otherProps } = this.props;
-		const infoIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
-			</SVG>
-		);
 		return (
 			<Tooltip { ...otherProps }>
-				<div className={ classnames( 'newspack-info-button', className ) }>{ infoIcon }</div>
+				<div className={ classnames( 'newspack-info-button', className ) }>
+					<InfoIcon />
+				</div>
 			</Tooltip>
 		);
 	}

--- a/assets/components/src/notice/index.js
+++ b/assets/components/src/notice/index.js
@@ -3,18 +3,25 @@
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import ErrorIcon from '@material-ui/icons/Error';
+import InfoIcon from '@material-ui/icons/Info';
+import WarningIcon from '@material-ui/icons/Warning';
+
+/**
+ * Internal dependencies.
  */
 import './style.scss';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import classNames from 'classnames';
 
@@ -32,35 +39,15 @@ class Notice extends Component {
 			isWarning && 'newspack-notice__is-warning',
 			isPrimary && 'newspack-notice__is-primary'
 		);
-		const errorIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
-			</SVG>
-		);
-		const infoIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
-			</SVG>
-		);
-		const successIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
-			</SVG>
-		);
-		const warningIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
-			</SVG>
-		);
 		let noticeIcon;
 		if ( isError ) {
-  		noticeIcon = errorIcon;
+  		noticeIcon = <ErrorIcon />;
 		} else if ( isSuccess ) {
-			noticeIcon = successIcon;
+			noticeIcon = <CheckCircleIcon />;
 		} else if ( isWarning ) {
-			noticeIcon = warningIcon;
+			noticeIcon = <WarningIcon />;
 		} else {
-		  noticeIcon = infoIcon;
+		  noticeIcon = <InfoIcon />;
 		}
 		return (
 			<div className={ classes }>

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -1,5 +1,5 @@
 /**
- * Progress bar for displaying visual feedback about steps-completed.
+ * Plugin Installer
  */
 
 /**
@@ -7,8 +7,13 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Material UI dependencies.
+ */
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
 
 /**
  * Internal dependencies.
@@ -22,9 +27,9 @@ const PLUGIN_STATE_INSTALLING = 2;
 const PLUGIN_STATE_ERROR = 3;
 
 /**
- * External dependencies
+ * External dependencies.
  */
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 /**
  * Plugin installer.
@@ -162,16 +167,6 @@ class PluginInstaller extends Component {
 			const plugin = pluginInfo[ slug ];
 			return plugin.Status !== 'active' && plugin.installationStatus === PLUGIN_STATE_NONE;
 		} );
-		const inactiveIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
-			</SVG>
-		);
-		const activeIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
-			</SVG>
-		);
 		if ( asProgressBar ) {
 			const completed = slugs.reduce(
 				( completed, slug ) =>
@@ -202,26 +197,26 @@ class PluginInstaller extends Component {
 							actionText = (
 								<span className="newspack-plugin-installer__status">
 									{ __( 'Install' ) }
-									{ inactiveIcon }
+									<RadioButtonUncheckedIcon />
 								</span>
 							);
 						} else if ( Status === 'inactive' ) {
 							actionText = (
 								<span className="newspack-plugin-installer__status">
 									{ __( 'Activate' ) }
-									{ inactiveIcon }
+									<RadioButtonUncheckedIcon />
 								</span>
 							);
 						} else if ( Status === 'active' ) {
 							actionText = (
 								<span className="newspack-plugin-installer__status">
 									{ __( 'Installed' ) }
-									{ activeIcon }
+									<CheckCircleIcon />
 								</span>
 							);
 						}
 
-						const classes = classNames(
+						const classes = classnames(
 							'newspack-action-card__plugin-installer',
 							this.classForInstallationStatus( installationStatus ),
 						);

--- a/assets/components/src/task/index.js
+++ b/assets/components/src/task/index.js
@@ -7,7 +7,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
+
+/**
+ * Material UI dependencies.
+ */
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 
 /**
  * Internal dependencies.
@@ -39,14 +43,9 @@ class Task extends Component {
 			active && 'is-active',
 			completed && 'is-completed'
 		);
-		const iconDone = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
-			</SVG>
-		);
 		return (
 			<Card className={ classes }>
-				<div className="newspack-task__task-icon">{ completed && iconDone }</div>
+				<div className="newspack-task__task-icon">{ completed && <CheckCircleIcon /> }</div>
 				<div className="newspack-task__task-description">
 					<p className="is-dark"><strong>{ title }</strong></p>
 					{ ! completed && ( <p>{ description }</p> ) }

--- a/assets/components/src/waiting/index.js
+++ b/assets/components/src/waiting/index.js
@@ -3,18 +3,22 @@
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import LoopIcon from '@material-ui/icons/Loop';
+
+/**
+ * Internal dependencies.
  */
 import './style.scss';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import classNames from 'classnames';
 
@@ -30,11 +34,7 @@ class Waiting extends Component {
       isRight && 'newspack-is-waiting__is-right',
       isLeft && 'newspack-is-waiting__is-left'
     );
-    return (
-      <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" className={ classes }>
-        <Path d="M12 6v3l4-4-4-4v3c-4.42 0-8 3.58-8 8 0 1.57.46 3.03 1.24 4.26L6.7 14.8c-.45-.83-.7-1.79-.7-2.8 0-3.31 2.69-6 6-6zm6.76 1.74L17.3 9.2c.44.84.7 1.79.7 2.8 0 3.31-2.69 6-6 6v-3l-4 4 4 4v-3c4.42 0 8-3.58 8-8 0-1.57-.46-3.03-1.24-4.26z" />
-      </SVG>
-    );
+    return <LoopIcon className={ classes }/>;
   }
 }
 

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -3,12 +3,17 @@
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, createRef, Fragment } from '@wordpress/element';
-import { Spinner, SVG, Path } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Material UI dependencies.
+ */
+import WarningIcon from '@material-ui/icons/Warning';
 
 /**
  * Internal dependencies.
@@ -189,11 +194,6 @@ export default function withWizard( WrappedComponent, requiredPlugins, options )
 		 */
 		pluginRequirements = () => {
 			const { complete } = this.state;
-			const iconRequired = (
-				<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-					<Path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/>
-				</SVG>
-			);
 			/* After all plugins are loaded, redirect to / (this could be configurable) */
 			if ( complete ) {
 				return <Redirect from="/plugin-requirements" to="/" />;
@@ -206,7 +206,7 @@ export default function withWizard( WrappedComponent, requiredPlugins, options )
 							<Card noBackground>
 								{ complete !== null && (
 									<FormattedHeader
-										headerIcon={ iconRequired }
+										headerIcon={ <WarningIcon /> }
 										headerText={ __( 'Required plugin' ) }
 										subHeaderText={ __( 'This feature requires the following plugin.' ) }
 									/>

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -13,7 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Material UI dependencies.
  */
-import WarningIcon from '@material-ui/icons/Warning';
+import HeaderIcon from '@material-ui/icons/Warning';
 
 /**
  * Internal dependencies.
@@ -206,7 +206,7 @@ export default function withWizard( WrappedComponent, requiredPlugins, options )
 							<Card noBackground>
 								{ complete !== null && (
 									<FormattedHeader
-										headerIcon={ <WarningIcon /> }
+										headerIcon={ <HeaderIcon /> }
 										headerText={ __( 'Required plugin' ) }
 										subHeaderText={ __( 'This feature requires the following plugin.' ) }
 									/>

--- a/assets/components/src/wizard-pagination/index.js
+++ b/assets/components/src/wizard-pagination/index.js
@@ -7,7 +7,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
+
+/**
+ * Material UI dependencies.
+ */
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 
 /**
  * External dependencies.
@@ -27,11 +31,6 @@ class WizardPagination extends Component {
 	render() {
 		const { history, location, routes } = this.props;
 		const currentIndex = parseInt( routes.indexOf( location.pathname ) );
-		const iconArrowBack = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
-			</SVG>
-		);
 		if ( ! routes || ! history || ! location ) {
 			return;
 		}
@@ -45,7 +44,7 @@ class WizardPagination extends Component {
 						{ __( 'Step' ) } { currentIndex } { __( 'of' ) } { routes.length - 1 }{' '}
 					</div>
 					<Button isLink className="newspack-wizard-pagination__navigation" onClick={ () => history.goBack() }>
-						{ iconArrowBack }
+						<ArrowBackIcon />
 						{ __( 'Back' ) }
 					</Button>
 				</div>

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -6,18 +6,23 @@
  * WordPress dependencies
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink, SVG, Path } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * WordPress dependencies.
+ */
+import FeaturedVideoIcon from '@material-ui/icons/FeaturedVideo';
+
+/**
+ * Internal dependencies.
  */
 import { Card, Grid, TabbedNavigation, withWizard, Button } from '../../components/src';
 import { AdUnit, AdUnits, AdSense, HeaderCode, Placements, Services } from './views';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
@@ -321,11 +326,6 @@ class AdvertisingWizard extends Component {
 				path: '/google_ad_manager-global-codes',
 			},
 		];
-		const headerIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 8H4a2 2 0 00-2 2v4a2 2 0 002 2h1v4a1 1 0 001 1h2a1 1 0 001-1v-4h3l5 4V4l-5 4m9.5 4c0 1.71-.96 3.26-2.5 4V8c1.53.75 2.5 2.3 2.5 4z" />
-			</SVG>
-		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -336,7 +336,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ routeProps => (
 								<Services
-									headerIcon={ headerIcon }
+									headerIcon={ <FeaturedVideoIcon /> }
 									headerText={ __( 'Advertising', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									services={ services }
@@ -351,7 +351,7 @@ class AdvertisingWizard extends Component {
 							path="/ad-placements"
 							render={ routeProps => (
 								<Placements
-									headerIcon={ headerIcon }
+									headerIcon={ <FeaturedVideoIcon /> }
 									headerText={ __( 'Advertising', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									placements={ placements }
@@ -372,7 +372,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ routeProps => (
 								<AdUnits
-									headerIcon={ headerIcon }
+									headerIcon={ <FeaturedVideoIcon /> }
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									adUnits={ adUnits }
@@ -391,7 +391,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ routeProps => (
 								<HeaderCode
-									headerIcon={ headerIcon }
+									headerIcon={ <FeaturedVideoIcon /> }
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									adUnits={ adUnits }
@@ -415,7 +415,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => {
 								return (
 									<AdUnit
-										headerIcon={ headerIcon }
+										headerIcon={ <FeaturedVideoIcon /> }
 										headerText={ __( 'Add an ad unit' ) }
 										subHeaderText={ __(
 											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.'
@@ -444,7 +444,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => {
 								return (
 									<AdUnit
-										headerIcon={ headerIcon }
+										headerIcon={ <FeaturedVideoIcon /> }
 										headerText={ __( 'Edit ad unit' ) }
 										subHeaderText={ __(
 											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.'
@@ -466,7 +466,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => (
 								<Fragment>
 									<AdSense
-										headerIcon={ headerIcon }
+										headerIcon={ <FeaturedVideoIcon /> }
 										headerText={ __( 'Google AdSense' ) }
 										subHeaderText={ __(
 											'Connect to your AdSense account using the Site Kit plugin, then enable Auto Ads.'

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -1,19 +1,18 @@
 /**
- * Google Ad Manager Wizard.
+ * Advertising
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
  * WordPress dependencies.
  */
-import FeaturedVideoIcon from '@material-ui/icons/FeaturedVideo';
+import HeaderIcon from '@material-ui/icons/FeaturedVideo';
 
 /**
  * Internal dependencies.
@@ -26,11 +25,7 @@ import { AdUnit, AdUnits, AdSense, HeaderCode, Placements, Services } from './vi
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
-/**
- * AdUnits wizard for managing and setting up adUnits.
- */
 class AdvertisingWizard extends Component {
-	/**
 	/**
 	 * Constructor.
 	 */
@@ -336,7 +331,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ routeProps => (
 								<Services
-									headerIcon={ <FeaturedVideoIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Advertising', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									services={ services }
@@ -351,7 +346,7 @@ class AdvertisingWizard extends Component {
 							path="/ad-placements"
 							render={ routeProps => (
 								<Placements
-									headerIcon={ <FeaturedVideoIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Advertising', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									placements={ placements }
@@ -372,7 +367,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ routeProps => (
 								<AdUnits
-									headerIcon={ <FeaturedVideoIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									adUnits={ adUnits }
@@ -391,7 +386,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ routeProps => (
 								<HeaderCode
-									headerIcon={ <FeaturedVideoIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									adUnits={ adUnits }
@@ -415,7 +410,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => {
 								return (
 									<AdUnit
-										headerIcon={ <FeaturedVideoIcon /> }
+										headerIcon={ <HeaderIcon /> }
 										headerText={ __( 'Add an ad unit' ) }
 										subHeaderText={ __(
 											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.'
@@ -444,7 +439,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => {
 								return (
 									<AdUnit
-										headerIcon={ <FeaturedVideoIcon /> }
+										headerIcon={ <HeaderIcon /> }
 										headerText={ __( 'Edit ad unit' ) }
 										subHeaderText={ __(
 											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.'
@@ -466,7 +461,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => (
 								<Fragment>
 									<AdSense
-										headerIcon={ <FeaturedVideoIcon /> }
+										headerIcon={ <HeaderIcon /> }
 										headerText={ __( 'Google AdSense' ) }
 										subHeaderText={ __(
 											'Connect to your AdSense account using the Site Kit plugin, then enable Auto Ads.'

--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -1,19 +1,18 @@
 /**
- * Analytics Wizard
+ * Analytics
  */
 
 /**
  * WordPress dependencies.
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Material UI dependencies.
  */
-import SearchIcon from '@material-ui/icons/Search';
+import HeaderIcon from '@material-ui/icons/TrendingUp';
 
 /**
  * Internal dependencies.
@@ -26,9 +25,6 @@ import { Intro } from './views';
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
-/**
- * Analytics wizard.
- */
 class AnalyticsWizard extends Component {
 
 	/**
@@ -46,7 +42,7 @@ class AnalyticsWizard extends Component {
 							exact
 							render={ routeProps => (
 								<Intro
-									headerIcon={ <SearchIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Analytics', 'newspack' ) }
 									subHeaderText={ __( 'Track traffic and activity') }
 									buttonText={ __( 'Back to dashboard' ) }

--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -3,21 +3,26 @@
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink, SVG, Path } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import SearchIcon from '@material-ui/icons/Search';
+
+/**
+ * Internal dependencies.
  */
 import { withWizard } from '../../components/src';
 import { Intro } from './views';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
@@ -31,11 +36,6 @@ class AnalyticsWizard extends Component {
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
-		const headerIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z" />
-			</SVG>
-		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -46,7 +46,7 @@ class AnalyticsWizard extends Component {
 							exact
 							render={ routeProps => (
 								<Intro
-									headerIcon={ headerIcon }
+									headerIcon={ <SearchIcon /> }
 									headerText={ __( 'Analytics', 'newspack' ) }
 									subHeaderText={ __( 'Track traffic and activity') }
 									buttonText={ __( 'Back to dashboard' ) }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -1,16 +1,20 @@
 /**
- * "Components Demo" Wizard.
+ * Components Demo
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, Fragment, render } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Spinner, SVG, Path } from '@wordpress/components';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import DashbordIcon from '@material-ui/icons/Dashboard';
+
+/**
+ * Internal dependencies.
  */
 import {
 	ActionCard,
@@ -33,9 +37,6 @@ import {
 	ToggleGroup,
 } from '../../components/src';
 
-/**
- * Components demo for example purposes.
- */
 class ComponentsDemo extends Component {
 	/**
 	 * constructor. Demo of how the parent interacts with the components, and controls their values.
@@ -84,11 +85,6 @@ class ComponentsDemo extends Component {
 			actionCardToggleChecked,
 			toggleGroupChecked
 		} = this.state;
-		const headerIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zM7.632 7.548v8.904H9.79v-3.737l3.666 3.737h2.913L7.632 7.548zm8.736 4.138h-1.765l.69.703h1.075v-.703zm0-2.069h-3.795l.689.703h3.106v-.703zm0-2.069h-5.825l.689.703h5.136v-.703z" />
-			</SVG>
-		);
 		return (
 			<Fragment>
 				<div className="newspack-logo-wrapper">
@@ -97,7 +93,7 @@ class ComponentsDemo extends Component {
 					</a>
 				</div>
 				<FormattedHeader
-					headerIcon={ headerIcon }
+					headerIcon={ <DashbordIcon /> }
 					headerText={ __( 'Newspack Components' ) }
 					subHeaderText={ __( 'Demo of all the Newspack components' ) }
 				/>

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Material UI dependencies.
  */
-import DashbordIcon from '@material-ui/icons/Dashboard';
+import HeaderIcon from '@material-ui/icons/Dashboard';
 
 /**
  * Internal dependencies.
@@ -93,7 +93,7 @@ class ComponentsDemo extends Component {
 					</a>
 				</div>
 				<FormattedHeader
-					headerIcon={ <DashbordIcon /> }
+					headerIcon={ <HeaderIcon /> }
 					headerText={ __( 'Newspack Components' ) }
 					subHeaderText={ __( 'Demo of all the Newspack components' ) }
 				/>

--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -35,6 +35,14 @@
 					transform: translateX( 8px );
 				}
 			}
+
+			h2 {
+				color: inherit;
+			}
+
+			svg {
+				fill: currentcolor;
+			}
 		}
 
 		&:focus {
@@ -43,13 +51,13 @@
 
 		> svg {
 			margin: 24px;
-			transition: transform 125ms ease-in-out;
 		}
 	}
 
 	h2,
 	p {
 		margin: 0;
+		transition: color 125ms ease-in-out;
 	}
 
 	svg {
@@ -57,6 +65,7 @@
 		fill: $primary-500;
 		height: 24px;
 		margin: 0;
+		transition: fill 125ms ease-in-out, transform 125ms ease-in-out;
 		width: 24px;
 
 		&.icon-completed {

--- a/assets/wizards/dashboard/views/dashboardCard.js
+++ b/assets/wizards/dashboard/views/dashboardCard.js
@@ -43,31 +43,20 @@ class DashboardCard extends Component {
 	render() {
 		const { name, description, slug, url, status } = this.props;
 		const classes = classNames( 'newspack-dashboard-card', slug, status );
-		let icon;
-		if ( slug === 'site-design' ) {
-  		icon = <WebIcon />;
-		} else if ( slug === 'reader-revenue' ) {
-			icon = <AccountBalanceWalletIcon />;
-		} else if ( slug === 'advertising' ) {
-			icon = <FeaturedVideoIcon />;
-		} else if ( slug === 'syndication' ) {
-			icon = <SyncAltIcon />;
-		} else if ( slug === 'analytics' ) {
-			icon = <TrendingUpIcon />;
-		} else if ( slug === 'performance' ) {
-			icon = <SpeedIcon />;
-		} else if ( slug === 'seo' ) {
-			icon = <SearchIcon />;
-		} else if ( slug === 'health-check' ) {
-			icon = <HealingIcon />;
-		} else if ( slug === 'engagement' ) {
-			icon = <ForumIcon />;		
-		} else {
-		  icon = <WidgetsIcon />;
-		}
+		const iconMap = {
+			'site-design': <WebIcon />,
+			'reader-revenue': <AccountBalanceWalletIcon />,
+			'advertising': <FeaturedVideoIcon />,
+			'syndication': <SyncAltIcon />,
+			'analytics': <TrendingUpIcon />,
+			'performance': <SpeedIcon />,
+			'seo': <SearchIcon />,
+			'health-check': <HealingIcon />,
+			'engagement': <ForumIcon />,
+		};
 		const contents = (
 			<div className="newspack-dashboard-card__contents">
-				{ icon }
+				{ iconMap[ slug ] || <WidgetsIcon /> }
 				<div className="newspack-dashboard-card__header">
 					<h2>{ name }</h2>
 					<p>{ description }</p>

--- a/assets/wizards/dashboard/views/dashboardCard.js
+++ b/assets/wizards/dashboard/views/dashboardCard.js
@@ -33,9 +33,6 @@ import { Card } from '../../../components/src';
  */
 import classNames from 'classnames';
 
-/**
- * One card in the dashboard
- */
 class DashboardCard extends Component {
 	/**
 	 * Render.

--- a/assets/wizards/dashboard/views/dashboardCard.js
+++ b/assets/wizards/dashboard/views/dashboardCard.js
@@ -1,20 +1,35 @@
 /**
- * Subscription Management Screens.
+ * Dashboard Card
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, Fragment } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import AccountBalanceWalletIcon from '@material-ui/icons/AccountBalanceWallet';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import FeaturedVideoIcon from '@material-ui/icons/FeaturedVideo';
+import ForumIcon from '@material-ui/icons/Forum';
+import HealingIcon from '@material-ui/icons/Healing';
+import SearchIcon from '@material-ui/icons/Search';
+import SpeedIcon from '@material-ui/icons/Speed';
+import SyncAltIcon from '@material-ui/icons/SyncAlt';
+import TrendingUpIcon from '@material-ui/icons/TrendingUp';
+import WebIcon from '@material-ui/icons/Web';
+import WidgetsIcon from '@material-ui/icons/Widgets';
+
+/**
+ * Internal dependencies.
  */
 import { Card } from '../../../components/src';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import classNames from 'classnames';
 
@@ -26,21 +41,33 @@ class DashboardCard extends Component {
 	 * Render.
 	 */
 	render() {
-		const { name, description, slug, url, svg, status } = this.props;
+		const { name, description, slug, url, status } = this.props;
 		const classes = classNames( 'newspack-dashboard-card', slug, status );
-		const iconLink = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M10.02 6L8.61 7.41 13.19 12l-4.58 4.59L10.02 18l6-6-6-6z" />
-			</SVG>
-		);
-		const iconDone = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" className="icon-completed">
-				<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
-			</SVG>
-		);
+		let icon;
+		if ( slug === 'site-design' ) {
+  		icon = <WebIcon />;
+		} else if ( slug === 'reader-revenue' ) {
+			icon = <AccountBalanceWalletIcon />;
+		} else if ( slug === 'advertising' ) {
+			icon = <FeaturedVideoIcon />;
+		} else if ( slug === 'syndication' ) {
+			icon = <SyncAltIcon />;
+		} else if ( slug === 'analytics' ) {
+			icon = <TrendingUpIcon />;
+		} else if ( slug === 'performance' ) {
+			icon = <SpeedIcon />;
+		} else if ( slug === 'seo' ) {
+			icon = <SearchIcon />;
+		} else if ( slug === 'health-check' ) {
+			icon = <HealingIcon />;
+		} else if ( slug === 'engagement' ) {
+			icon = <ForumIcon />;		
+		} else {
+		  icon = <WidgetsIcon />;
+		}
 		const contents = (
 			<div className="newspack-dashboard-card__contents">
-				{ !! svg && <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><Path d={ svg } /></SVG> }
+				{ icon }
 				<div className="newspack-dashboard-card__header">
 					<h2>{ name }</h2>
 					<p>{ description }</p>
@@ -59,7 +86,7 @@ class DashboardCard extends Component {
 				<Card className={ classes }>
 					<a href={ url }>
 						{ contents }
-						{ 'completed' === status ? iconDone : iconLink }
+						{ 'completed' === status ? <CheckCircleIcon /> : <ChevronRightIcon /> }
 					</a>
 				</Card>
 			);

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -1,5 +1,5 @@
 /**
- * Engagement Wizard
+ * Engagement
  */
 
 /**
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Material UI dependencies.
  */
-import ForumIcon from '@material-ui/icons/Forum';
+import HeaderIcon from '@material-ui/icons/Forum';
 
 /**
  * Internal dependencies.
@@ -33,9 +33,6 @@ import {
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
-/**
- * Engagement wizard.
- */
 class EngagementWizard extends Component {
 	constructor( props ) {
 		super( props );
@@ -126,7 +123,7 @@ class EngagementWizard extends Component {
 							render={ routeProps => (
 								<Newsletters
 									noBackground
-									headerIcon={ <ForumIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -145,7 +142,7 @@ class EngagementWizard extends Component {
 								const { apiKey } = this.state;
 								return (
 									<Social
-										headerIcon={ <ForumIcon /> }
+										headerIcon={ <HeaderIcon /> }
 										headerText={ __( 'Engagement', 'newspack' ) }
 										subHeaderText={ subheader }
 										tabbedNavigation={ tabbed_navigation }
@@ -163,7 +160,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ routeProps => (
 								<CommentingDisqus
-									headerIcon={ <ForumIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -178,7 +175,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ routeProps => (
 								<CommentingNative
-									headerIcon={ <ForumIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -193,7 +190,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ routeProps => (
 								<CommentingCoral
-									headerIcon={ <ForumIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -208,7 +205,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ routeProps => (
 								<UGC
-									headerIcon={ <ForumIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -3,15 +3,19 @@
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink, SVG, Path } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import ForumIcon from '@material-ui/icons/Forum';
+
+/**
+ * Internal dependencies.
  */
 import { withWizard } from '../../components/src';
 import {
@@ -25,7 +29,7 @@ import {
 } from './views';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
@@ -111,11 +115,6 @@ class EngagementWizard extends Component {
 				exact: true,
 			},
 		];
-		const headerIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M21 6h-2v9H6v2c0 .55.45 1 1 1h11l4 4V7c0-.55-.45-1-1-1zm-4 6V3c0-.55-.45-1-1-1H3c-.55 0-1 .45-1 1v14l4-4h10c.55 0 1-.45 1-1z" />
-			</SVG>
-		);
 		const subheader = __( 'Newsletters, social, commenting, UGC' );
 		return (
 			<Fragment>
@@ -127,7 +126,7 @@ class EngagementWizard extends Component {
 							render={ routeProps => (
 								<Newsletters
 									noBackground
-									headerIcon={ headerIcon }
+									headerIcon={ <ForumIcon /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -146,7 +145,7 @@ class EngagementWizard extends Component {
 								const { apiKey } = this.state;
 								return (
 									<Social
-										headerIcon={ headerIcon }
+										headerIcon={ <ForumIcon /> }
 										headerText={ __( 'Engagement', 'newspack' ) }
 										subHeaderText={ subheader }
 										tabbedNavigation={ tabbed_navigation }
@@ -164,7 +163,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ routeProps => (
 								<CommentingDisqus
-									headerIcon={ headerIcon }
+									headerIcon={ <ForumIcon /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -179,7 +178,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ routeProps => (
 								<CommentingNative
-									headerIcon={ headerIcon }
+									headerIcon={ <ForumIcon /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -194,7 +193,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ routeProps => (
 								<CommentingCoral
-									headerIcon={ headerIcon }
+									headerIcon={ <ForumIcon /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -209,7 +208,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ routeProps => (
 								<UGC
-									headerIcon={ headerIcon }
+									headerIcon={ <ForumIcon /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }

--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -1,28 +1,29 @@
 /**
- * Health Check Wizard
+ * Health Check
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink, SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+ import HealingIcon from '@material-ui/icons/Healing';
+
+/**
+ * Internal dependencies.
  */
 import { withWizard } from '../../components/src';
 import { RemoveUnsupportedPlugins } from './views';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
-/**
- * SEO wizard.
- */
 class HealthCheckWizard extends Component {
 	constructor( props ) {
 		super( props );
@@ -62,11 +63,6 @@ class HealthCheckWizard extends Component {
 	render() {
 		const { healthCheckData } = this.state;
 		const { unsupported_plugins: unsupportedPlugins } = healthCheckData;
-		const headerIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M15.9 5c-.17 0-.32.09-.41.23l-.07.15-5.18 11.65c-.16.29-.26.61-.26.96 0 1.11.9 2.01 2.01 2.01.96 0 1.77-.68 1.96-1.59l.01-.03L16.4 5.5c0-.28-.22-.5-.5-.5zM1 9l2 2c2.88-2.88 6.79-4.08 10.53-3.62l1.19-2.68C9.89 3.84 4.74 5.27 1 9zm20 2l2-2c-1.64-1.64-3.55-2.82-5.59-3.57l-.53 2.82c1.5.62 2.9 1.53 4.12 2.75zm-4 4l2-2c-.8-.8-1.7-1.42-2.66-1.89l-.55 2.92c.42.27.83.59 1.21.97zM5 13l2 2c1.13-1.13 2.56-1.79 4.03-2l1.28-2.88c-2.63-.08-5.3.87-7.31 2.88z" />
-			</SVG>
-		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -76,7 +72,7 @@ class HealthCheckWizard extends Component {
 							exact
 							render={ routeProps => (
 								<RemoveUnsupportedPlugins
-									headerIcon={ headerIcon }
+									headerIcon={ <HealingIcon /> }
 									headerText={ __( 'Health Check', 'newspack' ) }
 									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
 									deactivateAllPlugins={ this.deactivateAllPlugins }

--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Material UI dependencies.
  */
- import HealingIcon from '@material-ui/icons/Healing';
+ import HeaderIcon from '@material-ui/icons/Healing';
 
 /**
  * Internal dependencies.
@@ -72,7 +72,7 @@ class HealthCheckWizard extends Component {
 							exact
 							render={ routeProps => (
 								<RemoveUnsupportedPlugins
-									headerIcon={ <HealingIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Health Check', 'newspack' ) }
 									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
 									deactivateAllPlugins={ this.deactivateAllPlugins }

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Material UI dependencies.
  */
-import SpeedIcon from '@material-ui/icons/Speed';
+import HeaderIcon from '@material-ui/icons/Speed';
 
 /**
  * Internal dependencies.
@@ -95,7 +95,7 @@ class PerformanceWizard extends Component {
 						exact
 						render={ routeProps => (
 							<Intro
-								headerIcon={ <SpeedIcon /> }
+								headerIcon={ <HeaderIcon /> }
 								headerText={ __( 'Performance options' ) }
 								subHeaderText={ __(
 									'Optimizing your news site for better performance and increased user engagement.'

--- a/assets/wizards/performance/index.js
+++ b/assets/wizards/performance/index.js
@@ -1,30 +1,31 @@
 /**
- * Performance Wizard.
+ * Performance
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, Fragment, render } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import SpeedIcon from '@material-ui/icons/Speed';
+
+/**
+ * Internal dependencies.
  */
 import { withWizard } from '../../components/src';
 import { Intro } from './views';
 import './style.scss';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
-/**
- * Wizard for configuring PWA features.
- */
 class PerformanceWizard extends Component {
 	/**
 	 * Constructor.
@@ -85,11 +86,6 @@ class PerformanceWizard extends Component {
 	render() {
 		const { pluginRequirements } = this.props;
 		const { settings } = this.state;
-		const headerIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M20.38 8.57l-1.23 1.85a8 8 0 0 1-.22 7.58H5.07A8 8 0 0 1 15.58 6.85l1.85-1.23A10 10 0 0 0 3.35 19a2 2 0 0 0 1.72 1h13.85a2 2 0 0 0 1.74-1 10 10 0 0 0-.27-10.44zm-9.79 6.84a2 2 0 0 0 2.83 0l5.66-8.49-8.49 5.66a2 2 0 0 0 0 2.83z" />
-			</SVG>
-		);
 		return (
 			<HashRouter hashType="slash">
 				<Switch>
@@ -99,7 +95,7 @@ class PerformanceWizard extends Component {
 						exact
 						render={ routeProps => (
 							<Intro
-								headerIcon={ headerIcon }
+								headerIcon={ <SpeedIcon /> }
 								headerText={ __( 'Performance options' ) }
 								subHeaderText={ __(
 									'Optimizing your news site for better performance and increased user engagement.'

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Material UI dependencies.
  */
-import AccountBalanceWalletIcon from '@material-ui/icons/AccountBalanceWallet';
+import HeaderIcon from '@material-ui/icons/AccountBalanceWallet';
 
 /**
  * Internal dependencies.
@@ -25,7 +25,6 @@ import { ConfigureLandingPage, Donation, LocationSetup, StripeSetup, RevenueMain
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
 class ReaderRevenueWizard extends Component {
-	/**
 	/**
 	 * Constructor.
 	 */
@@ -167,7 +166,7 @@ class ReaderRevenueWizard extends Component {
 							exact
 							render={ routeProps => (
 								<RevenueMain
-									headerIcon={ <AccountBalanceWalletIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Accept donations on your site' ) }
 									subHeaderText={ __( 'Generate revenue from your customers.' ) }
 									tabbedNavigation={ isConfigured && tabbedNavigation }
@@ -183,7 +182,7 @@ class ReaderRevenueWizard extends Component {
 									data={ locationData }
 									countryStateFields={ countryStateFields }
 									currencyFields={ currencyFields }
-									headerIcon={ <AccountBalanceWalletIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Set up address' ) }
 									subHeaderText={ __( "Configure your publication's address." ) }
 									buttonText={ isConfigured ? __( 'Save Settings' ) : __( 'Continue Setup' ) }
@@ -202,7 +201,7 @@ class ReaderRevenueWizard extends Component {
 							render={ routeProps => (
 								<StripeSetup
 									data={ stripeData }
-									headerIcon={ <AccountBalanceWalletIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Set up Stripe' ) }
 									subHeaderText={ __( 'Configure your payment gateway to process transactions.' ) }
 									buttonText={ isConfigured ? __( 'Save Settings' ) : __( 'Continue Setup' ) }
@@ -221,7 +220,7 @@ class ReaderRevenueWizard extends Component {
 							render={ routeProps => (
 								<Donation
 									data={ donationData }
-									headerIcon={ <AccountBalanceWalletIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Set up donations' ) }
 									subHeaderText={ __( 'Configure your suggested donation presets.' ) }
 									buttonText={ __( 'Save Settings' ) }
@@ -239,7 +238,7 @@ class ReaderRevenueWizard extends Component {
 							path="/configure-landing-page"
 							render={ routeProps => (
 								<ConfigureLandingPage
-									headerIcon={ <AccountBalanceWalletIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Set up memberships' ) }
 									subHeaderText={ __( 'Configure your memberships landing page.' ) }
 									tabbedNavigation={ isConfigured && tabbedNavigation }

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -1,28 +1,29 @@
 /**
- * Google Ad Manager Wizard.
+ * Reader Revenue
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import AccountBalanceWalletIcon from '@material-ui/icons/AccountBalanceWallet';
+
+/**
+ * Internal dependencies.
  */
 import { withWizard } from '../../components/src';
 import { ConfigureLandingPage, Donation, LocationSetup, StripeSetup, RevenueMain } from './views';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
-/**
- * AdUnits wizard for managing and setting up adUnits.
- */
 class ReaderRevenueWizard extends Component {
 	/**
 	/**
@@ -155,11 +156,6 @@ class ReaderRevenueWizard extends Component {
 				path: '/configure-landing-page',
 			},
 		];
-		const headerIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M21 18v1c0 1.1-.9 2-2 2H5c-1.11 0-2-.9-2-2V5c0-1.1.89-2 2-2h14c1.1 0 2 .9 2 2v1h-9c-1.11 0-2 .9-2 2v8c0 1.1.89 2 2 2h9zm-9-2h10V8H12v8zm4-2.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z" />
-			</SVG>
-		);
 		const isConfigured = !! donationData.created;
 		return (
 			<Fragment>
@@ -171,7 +167,7 @@ class ReaderRevenueWizard extends Component {
 							exact
 							render={ routeProps => (
 								<RevenueMain
-									headerIcon={ headerIcon }
+									headerIcon={ <AccountBalanceWalletIcon /> }
 									headerText={ __( 'Accept donations on your site' ) }
 									subHeaderText={ __( 'Generate revenue from your customers.' ) }
 									tabbedNavigation={ isConfigured && tabbedNavigation }
@@ -187,7 +183,7 @@ class ReaderRevenueWizard extends Component {
 									data={ locationData }
 									countryStateFields={ countryStateFields }
 									currencyFields={ currencyFields }
-									headerIcon={ headerIcon }
+									headerIcon={ <AccountBalanceWalletIcon /> }
 									headerText={ __( 'Set up address' ) }
 									subHeaderText={ __( "Configure your publication's address." ) }
 									buttonText={ isConfigured ? __( 'Save Settings' ) : __( 'Continue Setup' ) }
@@ -206,7 +202,7 @@ class ReaderRevenueWizard extends Component {
 							render={ routeProps => (
 								<StripeSetup
 									data={ stripeData }
-									headerIcon={ headerIcon }
+									headerIcon={ <AccountBalanceWalletIcon /> }
 									headerText={ __( 'Set up Stripe' ) }
 									subHeaderText={ __( 'Configure your payment gateway to process transactions.' ) }
 									buttonText={ isConfigured ? __( 'Save Settings' ) : __( 'Continue Setup' ) }
@@ -225,7 +221,7 @@ class ReaderRevenueWizard extends Component {
 							render={ routeProps => (
 								<Donation
 									data={ donationData }
-									headerIcon={ headerIcon }
+									headerIcon={ <AccountBalanceWalletIcon /> }
 									headerText={ __( 'Set up donations' ) }
 									subHeaderText={ __( 'Configure your suggested donation presets.' ) }
 									buttonText={ __( 'Save Settings' ) }
@@ -243,7 +239,7 @@ class ReaderRevenueWizard extends Component {
 							path="/configure-landing-page"
 							render={ routeProps => (
 								<ConfigureLandingPage
-									headerIcon={ headerIcon }
+									headerIcon={ <AccountBalanceWalletIcon /> }
 									headerText={ __( 'Set up memberships' ) }
 									subHeaderText={ __( 'Configure your memberships landing page.' ) }
 									tabbedNavigation={ isConfigured && tabbedNavigation }

--- a/assets/wizards/seo/index.js
+++ b/assets/wizards/seo/index.js
@@ -1,41 +1,36 @@
 /**
- * SEO Wizard
+ * SEO
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { ExternalLink, SVG, Path } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import SearchIcon from '@material-ui/icons/Search';
+
+/**
+ * Internal dependencies.
  */
 import { withWizard } from '../../components/src';
 import { Intro } from './views';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
-/**
- * SEO wizard.
- */
 class SEOWizard extends Component {
-
 	/**
 	 * Render
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
-		const headerIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
-			</SVG>
-		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -46,7 +41,7 @@ class SEOWizard extends Component {
 							exact
 							render={ routeProps => (
 								<Intro
-									headerIcon={ headerIcon }
+									headerIcon={ <SearchIcon /> }
 									headerText={ __( 'SEO' ) }
 									subHeaderText={ __( 'Search engine and social optimization' ) }
 									buttonText={ __( 'Back to dashboard' ) }

--- a/assets/wizards/seo/index.js
+++ b/assets/wizards/seo/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Material UI dependencies.
  */
-import SearchIcon from '@material-ui/icons/Search';
+import HeaderIcon from '@material-ui/icons/Search';
 
 /**
  * Internal dependencies.
@@ -41,7 +41,7 @@ class SEOWizard extends Component {
 							exact
 							render={ routeProps => (
 								<Intro
-									headerIcon={ <SearchIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'SEO' ) }
 									subHeaderText={ __( 'Search engine and social optimization' ) }
 									buttonText={ __( 'Back to dashboard' ) }

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -8,7 +8,14 @@
 import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment, render } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Spinner, SVG, Path } from '@wordpress/components';
+
+/**
+ * Material UI dependencies.
+ */
+import BusinessCenterIcon from '@material-ui/icons/BusinessCenter';
+import MenuBookIcon from '@material-ui/icons/MenuBook';
+import SettingsIcon from '@material-ui/icons/Settings';
+import SubjectIcon from '@material-ui/icons/Subject';
 
 /**
  * Internal dependencies.
@@ -235,27 +242,6 @@ class SetupWizard extends Component {
 			'/configure-google-site-kit',
 			'/starter-content',
 		];
-		const newsroomIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M10 16v-1H3.01L3 19c0 1.11.89 2 2 2h14c1.11 0 2-.89 2-2v-4h-7v1h-4zm10-9h-4.01V5l-2-2h-4l-2 2v2H4c-1.1 0-2 .9-2 2v3c0 1.11.89 2 2 2h6v-2h4v2h6c1.1 0 2-.9 2-2V9c0-1.1-.9-2-2-2zm-6 0h-4V5h4v2z" />
-			</SVG>
-		);
-		const aboutIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z" />
-				<Path d="M17.5 10.5c.88 0 1.73.09 2.5.26V9.24c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99zM13 12.49v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26V11.9c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.3-4.5.83zM17.5 14.33c-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26v-1.52c-.79-.16-1.64-.24-2.5-.24z" />
-			</SVG>
-		);
-		const configurePluginsIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M12 15.5A3.5 3.5 0 018.5 12 3.5 3.5 0 0112 8.5a3.5 3.5 0 013.5 3.5 3.5 3.5 0 01-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97 0-.33-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0014 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1 0 .33.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.66z" />
-			</SVG>
-		);
-		const starterContentIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M3 18h12v-2H3v2zM3 6v2h18V6H3zm0 7h18v-2H3v2z" />
-			</SVG>
-		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -280,7 +266,7 @@ class SetupWizard extends Component {
 						path="/about"
 						render={ routeProps => (
 							<About
-								headerIcon={ aboutIcon }
+								headerIcon={ <MenuBookIcon /> }
 								headerText={ __( 'About your publication' ) }
 								subHeaderText={ __(
 									'Share a few details so we can start setting up your profile'
@@ -303,7 +289,7 @@ class SetupWizard extends Component {
 						path="/newsroom"
 						render={ routeProps => (
 							<Newsroom
-								headerIcon={ newsroomIcon }
+								headerIcon={ <BusinessCenterIcon /> }
 								headerText={ __( 'Tell us about your Newsroom' ) }
 								subHeaderText={ __(
 									'The description helps set the stage for the step content below'
@@ -329,7 +315,7 @@ class SetupWizard extends Component {
 							const pluginConfigured = pluginInfo[ plugin ] && pluginInfo[ plugin ].Configured;
 							return (
 								<ConfigurePlugins
-									headerIcon={ configurePluginsIcon }
+									headerIcon={ <SettingsIcon /> }
 									headerText={ __( 'Configure Core Plugins' ) }
 									subHeaderText={ __(
 										'Please configure the following core plugin to start using Newspack.'
@@ -352,7 +338,7 @@ class SetupWizard extends Component {
 							const pluginConfigured = pluginInfo[ plugin ] && pluginInfo[ plugin ].Configured;
 							return (
 								<ConfigurePlugins
-									headerIcon={ configurePluginsIcon }
+									headerIcon={ <SettingsIcon /> }
 									headerText={ __( 'Configure Core Plugins' ) }
 									subHeaderText={ __(
 										'Please configure the following core plugin to start using Newspack.'
@@ -373,7 +359,7 @@ class SetupWizard extends Component {
 						render={ routeProps => {
 							return (
 								<StarterContent
-									headerIcon={ starterContentIcon }
+									headerIcon={ <SubjectIcon /> }
 									headerText={ __( 'Starter Content' ) }
 									subHeaderText={ __( 'Pre-configure the site for testing and experimentation' ) }
 									buttonText={ __( 'Install Starter Content' ) }
@@ -393,9 +379,10 @@ class SetupWizard extends Component {
 							<InstallationProgress
 								autoInstall={ '/' !== routeProps.location.pathname }
 								hidden={ '/installation-progress' !== routeProps.location.pathname }
+								headerIcon={ <SettingsIcon /> }
 								headerText={ __( 'Installation...' ) }
 								subHeaderText={ __(
-									'You’re almost done. Please configure the following core plugins to start using Newspack.'
+									'Please configure the following core plugin to start using Newspack.'
 								) }
 								buttonText={ __( 'Continue' ) }
 								buttonAction={ '#/configure-jetpack' }

--- a/assets/wizards/syndication/index.js
+++ b/assets/wizards/syndication/index.js
@@ -1,39 +1,35 @@
 /**
- * Syndication Wizard.
+ * Syndication
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, render, Fragment } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import SyncAltIcon from '@material-ui/icons/SyncAlt';
+
+/**
+ * Internal dependencies.
  */
 import { withWizard } from '../../components/src';
 import { Intro } from './views';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 
-/**
- * Syndication wizard.
- */
 class SyndicationWizard extends Component {
 	/**
 	 * Render
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
-		const headerIcon = (
-			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-				<Path d="M22 8l-4-4v3H3v2h15v3l4-4zM2 16l4 4v-3h15v-2H6v-3l-4 4z" />
-			</SVG>
-		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -44,7 +40,7 @@ class SyndicationWizard extends Component {
 							exact
 							render={ routeProps => (
 								<Intro
-									headerIcon={ headerIcon }
+									headerIcon={ <SyncAltIcon /> }
 									headerText={ __( 'Syndication', 'newspack' ) }
 									subHeaderText={ 'Apple News, Facebook Instant Articles' }
 									buttonText={ __( 'Back to dashboard' ) }

--- a/assets/wizards/syndication/index.js
+++ b/assets/wizards/syndication/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Material UI dependencies.
  */
-import SyncAltIcon from '@material-ui/icons/SyncAlt';
+import HeaderIcon from '@material-ui/icons/SyncAlt';
 
 /**
  * Internal dependencies.
@@ -40,7 +40,7 @@ class SyndicationWizard extends Component {
 							exact
 							render={ routeProps => (
 								<Intro
-									headerIcon={ <SyncAltIcon /> }
+									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Syndication', 'newspack' ) }
 									subHeaderText={ 'Apple News, Facebook Instant Articles' }
 									buttonText={ __( 'Back to dashboard' ) }

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -48,7 +48,7 @@ class Dashboard extends Wizard {
 	/**
 	 * Get the information required to build the dashboard.
 	 * Each tier of the dashboard is an array.
-	 * Each card within the tier is an array of [slug, name, url, description, svg, status].
+	 * Each card within the tier is an array of [slug, name, url, description, status].
 	 *
 	 * @return array
 	 */
@@ -59,7 +59,6 @@ class Dashboard extends Wizard {
 				'name'        => esc_html__( 'Site Design', 'newspack' ),
 				'url'         => admin_url( 'customize.php' ),
 				'description' => esc_html__( 'Branding, color, typography, layouts', 'newspack' ),
-				'svg'         => 'M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-5 14H4v-4h11v4zm0-5H4V9h11v4zm5 5h-4V9h4v9z',
 				'status'      => 'enabled',
 			],
 			[
@@ -67,54 +66,54 @@ class Dashboard extends Wizard {
 				'name'        => Wizards::get_name( 'reader-revenue' ),
 				'url'         => Wizards::get_url( 'reader-revenue' ),
 				'description' => esc_html__( 'Membership, paywall, subscriptions', 'newspack' ),
-				'svg'         => 'M21 18v1c0 1.1-.9 2-2 2H5c-1.11 0-2-.9-2-2V5c0-1.1.89-2 2-2h14c1.1 0 2 .9 2 2v1h-9c-1.11 0-2 .9-2 2v8c0 1.1.89 2 2 2h9zm-9-2h10V8H12v8zm4-2.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z',
 				'status'      => Checklists::get_status( 'reader-revenue' ),
-			],
-			[
-				'slug'        => 'performance',
-				'name'        => esc_html__( 'Performance', 'newspack' ),
-				'url'         => admin_url( 'admin.php?page=newspack-performance-wizard' ),
-				'description' => esc_html__( 'Page Speed, AMP, Progressive Web App', 'newspack' ),
-				'svg'         => 'M20.38 8.57l-1.23 1.85a8 8 0 0 1-.22 7.58H5.07A8 8 0 0 1 15.58 6.85l1.85-1.23A10 10 0 0 0 3.35 19a2 2 0 0 0 1.72 1h13.85a2 2 0 0 0 1.74-1 10 10 0 0 0-.27-10.44zm-9.79 6.84a2 2 0 0 0 2.83 0l5.66-8.49-8.49 5.66a2 2 0 0 0 0 2.83z',
 			],
 			[
 				'slug'        => 'advertising',
 				'name'        => Wizards::get_name( 'advertising' ),
 				'url'         => Wizards::get_url( 'advertising' ),
 				'description' => esc_html__( 'Content monetization', 'newspack' ),
-				'svg'         => 'M12 8H4a2 2 0 00-2 2v4a2 2 0 002 2h1v4a1 1 0 001 1h2a1 1 0 001-1v-4h3l5 4V4l-5 4m9.5 4c0 1.71-.96 3.26-2.5 4V8c1.53.75 2.5 2.3 2.5 4z',
 				'status'      => Checklists::get_status( 'advertising' ),
-			],
-			[
-				'slug'        => 'seo',
-				'name'        => Wizards::get_name( 'seo' ),
-				'url'         => Wizards::get_url( 'seo' ),
-				'description' => esc_html__( 'Search engine and social optimization', 'newspack' ),
-				'svg'         => 'M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z',
-			],
-			[
-				'slug'        => 'engagement',
-				'name'        => Wizards::get_name( 'engagement' ),
-				'url'         => Wizards::get_url( 'engagement' ),
-				'description' => Wizards::get_description( 'engagement' ),
-				'svg'         => 'M21 6h-2v9H6v2c0 .55.45 1 1 1h11l4 4V7c0-.55-.45-1-1-1zm-4 6V3c0-.55-.45-1-1-1H3c-.55 0-1 .45-1 1v14l4-4h10c.55 0 1-.45 1-1z',
-				'status'      => 'enabled',
-			],
-			[
-				'slug'        => 'analytics',
-				'name'        => Wizards::get_name( 'analytics' ),
-				'url'         => Wizards::get_url( 'analytics' ),
-				'description' => esc_html__( 'Track traffic and activity', 'newspack' ),
-				'svg'         => 'M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z',
-				'status'      => 'enabled',
 			],
 			[
 				'slug'        => 'syndication',
 				'name'        => Wizards::get_name( 'syndication' ),
 				'url'         => Wizards::get_url( 'syndication' ),
 				'description' => esc_html__( 'Apple News, Facebook Instant Articles', 'newspack' ),
-				'svg'         => 'M22 8l-4-4v3H3v2h15v3l4-4zM2 16l4 4v-3h15v-2H6v-3l-4 4z',
 				'status'      => Checklists::get_status( 'syndication' ),
+			],
+			[
+				'slug'        => 'analytics',
+				'name'        => Wizards::get_name( 'analytics' ),
+				'url'         => Wizards::get_url( 'analytics' ),
+				'description' => esc_html__( 'Track traffic and activity', 'newspack' ),
+				'status'      => 'enabled',
+			],
+			[
+				'slug'        => 'performance',
+				'name'        => esc_html__( 'Performance', 'newspack' ),
+				'url'         => admin_url( 'admin.php?page=newspack-performance-wizard' ),
+				'description' => esc_html__( 'Page Speed, AMP, Progressive Web App', 'newspack' ),
+			],
+			[
+				'slug'        => 'seo',
+				'name'        => Wizards::get_name( 'seo' ),
+				'url'         => Wizards::get_url( 'seo' ),
+				'description' => esc_html__( 'Search engine and social optimization', 'newspack' ),
+			],
+			[
+				'slug'        => 'health-check',
+				'name'        => Wizards::get_name( 'health-check' ),
+				'url'         => Wizards::get_url( 'health-check' ),
+				'description' => esc_html__( 'Verify and correct site health issues', 'newspack' ),
+				'status'      => 'enabled',
+			],
+			[
+				'slug'        => 'engagement',
+				'name'        => Wizards::get_name( 'engagement' ),
+				'url'         => Wizards::get_url( 'engagement' ),
+				'description' => Wizards::get_description( 'engagement' ),
+				'status'      => 'enabled',
 			],
 		];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1107,7 +1107,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
       "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -1177,6 +1176,11 @@
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
       }
+    },
+    "@emotion/hash": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.4.tgz",
+      "integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A=="
     },
     "@jest/console": {
       "version": "24.7.1",
@@ -1365,6 +1369,106 @@
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/yargs": "^12.0.9"
+      }
+    },
+    "@material-ui/core": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.8.2.tgz",
+      "integrity": "sha512-4dILME6TVCTyi9enavqbYLU8HueaX5YQxfn2IiCiGwHpqp4pIhJCVUVlBf0ADG6lL2K1tWrsawGs/hePpHxAYw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.8.2",
+        "@material-ui/system": "^4.7.1",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.7.1",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.2",
+        "convert-css-length": "^2.0.1",
+        "hoist-non-react-statics": "^3.2.1",
+        "normalize-scroll-left": "^0.2.0",
+        "popper.js": "^1.14.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0",
+        "react-transition-group": "^4.3.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+          "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
+    "@material-ui/icons": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.5.1.tgz",
+      "integrity": "sha512-YZ/BgJbXX4a0gOuKWb30mBaHaoXRqPanlePam83JQPZ/y4kl+3aW0Wv9tlR70hB5EGAkEJGW5m4ktJwMgxQAeA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.8.2.tgz",
+      "integrity": "sha512-r5U+93pkpwQOmHTmwyn2sqTio6PHd873xvSHiKP6fdybAXXX6CZgVvh3W8saZNbYr/QXsS8OHmFv7sYJLt5Yfg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.7.4",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.7.1",
+        "clsx": "^1.0.2",
+        "csstype": "^2.5.2",
+        "hoist-non-react-statics": "^3.2.1",
+        "jss": "^10.0.0",
+        "jss-plugin-camel-case": "^10.0.0",
+        "jss-plugin-default-unit": "^10.0.0",
+        "jss-plugin-global": "^10.0.0",
+        "jss-plugin-nested": "^10.0.0",
+        "jss-plugin-props-sort": "^10.0.0",
+        "jss-plugin-rule-value-function": "^10.0.0",
+        "jss-plugin-vendor-prefixer": "^10.0.0",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+          "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.7.1.tgz",
+      "integrity": "sha512-zH02p+FOimXLSKOW/OT2laYkl9bB3dD1AvnZqsHYoseUaq0aVrpbl2BGjQi+vJ5lg8w73uYlt9zOWzb3+1UdMQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.7.1",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/types": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
+      "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@material-ui/utils": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.7.1.tgz",
+      "integrity": "sha512-+ux0SlLdlehvzCk2zdQ3KiS3/ylWvuo/JwAGhvb8dFVvwR21K28z0PU9OQW2PGogrMEdvX3miEI5tGxTwwWiwQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1577,11 +1681,33 @@
       "integrity": "sha512-sKDlqv6COJrR7ar0+GqqhrXQDzQlMcqMnF2iEU6m9hLo8kxozoAGUazwPyELHlRVmjsbvlnGXjnzyptSXVmceA==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
+      "integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.2.3.tgz",
+      "integrity": "sha512-Hk8jiuT7iLOHrcjKP/ZVSyCNXK73wJAUz60xm0mVhiRujrdiI++j4duLiL282VGxwAgxetHQFfqA29LgEeSkFA==",
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -3233,6 +3359,11 @@
         "shallow-clone": "^1.0.0"
       }
     },
+    "clsx": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.0.4.tgz",
+      "integrity": "sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3390,6 +3521,11 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
+    },
+    "convert-css-length": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.1.tgz",
+      "integrity": "sha512-iGpbcvhLPRKUbBc0Quxx7w/bV14AC3ItuBEGMahA5WTYqB8lq9jH0kTXFheCBASsYnqeMFZhiTruNxr1N59Axg=="
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -3674,6 +3810,25 @@
       "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
       "dev": true
     },
+    "css-vendor": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.7.tgz",
+      "integrity": "sha512-VS9Rjt79+p7M0WkPqcAza4Yq1ZHrsHrwf7hPL/bjQB+c1lwmAI+1FXxYTYt818D/50fFVflw0XKleiBN5RITkg==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "is-in-browser": "^1.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+          "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
     "css-what": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
@@ -3828,6 +3983,11 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csstype": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4112,6 +4272,25 @@
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.3.tgz",
+      "integrity": "sha512-nZD1OtwfWGRBWlpANxacBEZrEuLa16o1nh7YopFWeoF68Zt8GGEmzHu6Xv4F3XaFIC+YXtTLrzgqKxFgLEe4jw==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "csstype": "^2.6.7"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+          "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "dom-scroll-into-view": {
@@ -6551,6 +6730,11 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "hyphenate-style-name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6928,6 +7112,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-number": {
       "version": "3.0.0",
@@ -7642,8 +7831,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.0",
@@ -7773,6 +7961,83 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jss": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.3.tgz",
+      "integrity": "sha512-AcDvFdOk16If9qvC9KN3oFXsrkHWM9+TaPMpVB9orm3z+nq1Xw3ofHyflRe/mkSucRZnaQtlhZs1hdP3DR9uRw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^2.6.5",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.3.tgz",
+      "integrity": "sha512-rild/oFKFkmRP7AoiX9D6bdDAUfmJv8c7sEBvFoi+JP31dn2W8nw4txMKGnV1LJKlFkYprdZt1X99Uvztl1hug==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "^10.0.3"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.3.tgz",
+      "integrity": "sha512-n+XfVLPF9Qh7IOTdQ8M4oRpjpg6egjr/r0NNytubbCafMgCILJYIVrMTGgOTydH+uvak8onQY3f/F9hasPUx6g==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "^10.0.3"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.3.tgz",
+      "integrity": "sha512-kNotkAciJIXpIGYnmueaIifBne9rdq31O8Xq1nF7KMfKlskNRANTcEX5rVnsGKl2yubTMYfjKBFCeDgcQn6+gA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "^10.0.3"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.3.tgz",
+      "integrity": "sha512-OMucRs9YLvWlZ3Ew+VhdgNVMwSS2zZy/2vy+s/etvopnPUzDHgCnJwdY2Wx/SlhLGERJeKKufyih2seH+ui0iw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "^10.0.3",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.3.tgz",
+      "integrity": "sha512-ufhvdCMnRcDa0tNHoZ12OcVNQQyE10yLMohxo/UIMarLV245rM6n9D19A12epjldRgyiS13SoSyLFCJEobprYg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "^10.0.3"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.3.tgz",
+      "integrity": "sha512-RWwIT2UBAIwf3f6DQtt5gyjxHMRJoeO9TQku+ueR8dBMakqSSe8vFwQNfjXEoe0W+Tez5HZCTkZKNMulv3Z+9A==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "^10.0.3"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.3.tgz",
+      "integrity": "sha512-zVs6e5z4tFRK/fJ5kuTLzXlTFQbLeFTVwk7lTZiYNufmZwKT0kSmnOJDUukcSe7JLGSRztjWhnHB/6voP174gw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.7",
+        "jss": "^10.0.3"
       }
     },
     "kind-of": {
@@ -7943,7 +8208,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -8208,8 +8472,48 @@
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
+        "normalize-url": "1.9.1",
         "schema-utils": "^1.0.0",
         "webpack-sources": "^1.1.0"
+      },
+      "dependencies": {
+        "normalize-url": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+          "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "sort-keys": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+          "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+          "dev": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        }
       }
     },
     "minimalistic-assert": {
@@ -8699,6 +9003,11 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
+    "normalize-scroll-left": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
+      "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
+    },
     "normalize-url": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
@@ -8835,8 +9144,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -9343,6 +9651,11 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
+    },
+    "popper.js": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
+      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -9953,7 +10266,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -10194,8 +10506,7 @@
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
-      "dev": true
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
     "react-moment-proptypes": {
       "version": "1.6.0",
@@ -10282,6 +10593,27 @@
         "prop-types": "^15.6.2",
         "react-is": "^16.8.6",
         "scheduler": "^0.13.6"
+      }
+    },
+    "react-transition-group": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
+      "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+          "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "react-with-direction": {
@@ -10452,8 +10784,7 @@
     "regenerator-runtime": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-      "dev": true
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regenerator-transform": {
       "version": "0.13.4",
@@ -12146,8 +12477,7 @@
     "tiny-warning": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
-      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==",
-      "dev": true
+      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
     },
     "tinycolor2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -79,5 +79,9 @@
     "release:build-all": "composer install --no-dev && run-p \"build\"",
     "release:archive": "mkdir -p assets/release && zip -r assets/release/newspack-plugin.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store",
     "release": "run-p \"release:build-all\" && run-p \"release:archive\""
+  },
+  "dependencies": {
+    "@material-ui/core": "^4.8.2",
+    "@material-ui/icons": "^4.5.1"
   }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since the icons used around the plugin are coming from Material, I thought it would make sense to add `material-ui` as a dependency.

That way we can simply import the icon that we need instead of relying on SVG and Path.

I've removed all the different icons that were being displayed via `import { SVG, Path } from '@wordpress/components';` and replaced them with `import *Icon from '@material-ui/icons/*';`

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Check all the pages
3. Do you see the icons everywhere (Title, checkboxes, notices etc...)?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->