### PR TITLE
Action Card: Always display secondary button and remove unused CSS

### DIFF
--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -90,16 +90,10 @@
 		}
 	}
 
-	// Spinner
+	// Waiting
 
 	.newspack-action-card__container {
 		display: flex;
-	}
-
-	.components-spinner {
-		margin-top: 0;
-		margin-bottom: 0;
-		min-width: 18px;
 	}
 
 	// Notifications
@@ -149,24 +143,18 @@
 
 	// Buttons
 
-	button.is-link {
-		color: $primary-500;
+	.newspack-button {
+		&.newspack-action-card__secondary_button {
+			&.is-link {
+				color: $alert-red;
 
-		&:hover {
-			color: $primary-600;
+				&:active,
+				&:focus,
+				&:hover {
+					color: darken( $alert-red, 20% );
+				}
+			}
 		}
-	}
-
-	button.newspack-action-card__secondary_button {
-		visibility: hidden;
-
-		&.is-link {
-			color: $alert-red;
-		}
-	}
-
-	&:hover button.newspack-action-card__secondary_button {
-		visibility: visible;
 	}
 
 	// Badge
@@ -185,6 +173,7 @@
 	}
 
 	// Description Card
+
 	&.newspack-description-card {
 		font-style: italic;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the accessibility and makes sure that the secondary button on an action card is always visible.

### How to test the changes in this Pull Request:

1. Go to the Components Demo. Check an action card with a 2ndary button. You should only see the button on hover.
2. Switch to this branch.
3. Refresh the Components Demo. Do you now see the 2ndary button?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->