### PR TITLE
Notice: Add background colour depending on status

### DIFF
--- a/assets/components/src/notice/style.scss
+++ b/assets/components/src/notice/style.scss
@@ -25,7 +25,7 @@
 	}
 
 	&.newspack-notice__is-success {
-		background: rgba( $alert-green, 0.07 );
+		background: lighten( $alert-green, 47% );
 
 		> svg {
 			fill: $alert-green;
@@ -33,7 +33,7 @@
 	}
 
 	&.newspack-notice__is-error {
-		background: rgba( $alert-red, 0.04 );
+		background: lighten( $alert-red, 40.5% );
 
 		> svg {
 			fill: $alert-red;
@@ -41,7 +41,7 @@
 	}
 
 	&.newspack-notice__is-warning {
-		background: rgba( $alert-yellow, 0.09 );
+		background: lighten( $alert-yellow, 36% );
 
 		> svg {
 			fill: $alert-yellow;

--- a/assets/components/src/notice/style.scss
+++ b/assets/components/src/notice/style.scss
@@ -7,14 +7,15 @@
 
 .newspack-notice {
 	align-items: flex-start;
-	background: white;
-	border-radius: 4px;
+	background: $light-gray-100;
+	border-radius: 3px;
 	color: $dark-gray-300;
 	display: flex;
 	font-size: 14px;
 	justify-content: flex-start;
 	line-height: 24px;
 	margin: 32px 0;
+	padding: 8px;
 
 	> svg {
 		display: block;
@@ -24,24 +25,32 @@
 	}
 
 	&.newspack-notice__is-success {
+		background: rgba( $alert-green, 0.07 );
+
 		> svg {
 			fill: $alert-green;
 		}
 	}
 
 	&.newspack-notice__is-error {
+		background: rgba( $alert-red, 0.04 );
+
 		> svg {
 			fill: $alert-red;
 		}
 	}
 
 	&.newspack-notice__is-warning {
+		background: rgba( $alert-yellow, 0.09 );
+
 		> svg {
 			fill: $alert-yellow;
 		}
 	}
 
 	&.newspack-notice__is-primary {
+		background: $primary-000;
+
 		> svg {
 			fill: $primary-500;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding a background colour to the `Notice` component depending on its status helps with differentiation over regular text.

![after](https://user-images.githubusercontent.com/177929/71725826-28bb7000-2e2d-11ea-8d26-836c3786e19a.png)

### How to test the changes in this Pull Request:

1. Go to Components Demo (or any setup pages with a Notice)
2. Switch to this branch
3. Check that you see the Notice like in thee screenshot above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->