### PR TITLE
Fix the ad picker select layout margins

### DIFF
--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -72,6 +72,10 @@
 		}
 	}
 
+	strong {
+		font-weight: bold;
+	}
+
 	// Thematic Break
 
 	hr {

--- a/assets/components/src/select-control/style.scss
+++ b/assets/components/src/select-control/style.scss
@@ -10,6 +10,7 @@
 	font-size: 14px;
 	line-height: 24px;
 	margin: 32px 0;
+	width: 100%;
 
 	label {
 		color: $dark-gray-900;

--- a/assets/wizards/advertising/views/placements/ad-picker/index.js
+++ b/assets/wizards/advertising/views/placements/ad-picker/index.js
@@ -21,7 +21,7 @@ class AdPicker extends Component {
 	adUnitsForSelect = adUnits => {
 		return [
 			{
-				label: __( '- Select an ad unit -' ),
+				label: '---',
 				value: null,
 			},
 			...Object.values( adUnits ).map( adUnit => {
@@ -36,7 +36,7 @@ class AdPicker extends Component {
 	adServicesForSelect = services => {
 		return [
 			{
-				label: __( '- Select an ad provider -' ),
+				label: '---',
 				value: null,
 			},
 			...Object.keys( services )

--- a/assets/wizards/advertising/views/placements/ad-picker/style.scss
+++ b/assets/wizards/advertising/views/placements/ad-picker/style.scss
@@ -1,8 +1,24 @@
-.newspack-ad-picker {
-	display: flex;
-	& > * {
-		flex: 1;
-		margin-right: 20px;
-		max-width: calc( 50% - 20px );
+/**
+ * Ad Picker
+ */
+
+.newspack-toggle-group__description {
+	flex: 1;
+
+	.newspack-ad-picker {
+		@media screen and ( min-width: 744px ) {
+			display: flex;
+			justify-content: space-between;
+			width: 100%;
+		}
+
+		.newspack-select-control {
+			margin: 16px 0;
+
+			@media screen and ( min-width: 744px ) {
+				width: 48%;
+				width: calc(50% - 8px);
+			}
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Use flexbox to display select-control in 2 columns on larger screens
* Reduce default label content since it's redundant and we already have the label to describe what it is
* Card: Make sure `strong` is always using the bold font-weight
* Select Control: Make sure it's always being displayed at 100% 

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #346.

### How to test the changes in this Pull Request:

1. Switch to this branch.
2. Check the Ad Picker. On small screens and large screens. Does it still look broken?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->