### PR TITLE
Engagement Wizard: Pop-Ups

### DIFF
--- a/assets/components/src/category-autocomplete/index.js
+++ b/assets/components/src/category-autocomplete/index.js
@@ -1,15 +1,23 @@
 /**
- * External dependencies
+ * Category Autocomplete
  */
-import { debounce } from 'lodash';
 
 /**
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
-import { FormTokenField } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies.
+ */
+import { FormTokenField } from '../';
+
+/**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
 
 /**
  * Category autocomplete field component.

--- a/assets/components/src/category-autocomplete/index.js
+++ b/assets/components/src/category-autocomplete/index.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
+ * WordPress dependencies.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { Component } from '@wordpress/element';
+import { FormTokenField } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Category autocomplete field component.
+ */
+class CategoryAutocomplete extends Component {
+	state = {
+		suggestions: {},
+	};
+
+	/**
+	 * Class constructor.
+	 */
+	constructor( props ) {
+		super( props );
+		this.debouncedUpdateSuggestions = debounce( this.updateSuggestions, 100 );
+	}
+
+	/**
+	 * Clean up debounced suggestions method.
+	 */
+	componentWillUnmount() {
+		this.debouncedUpdateSuggestions.cancel();
+	}
+
+	/**
+	 * Refresh the autocomplete UI based on text that was typed.
+	 *
+	 * @param string search The typed text to search for.
+	 */
+	updateSuggestions( search ) {
+		apiFetch( {
+			path: addQueryArgs( '/wp/v2/categories', {
+				search,
+				per_page: 20,
+				_fields: 'id,name',
+				orderby: 'count',
+				order: 'desc',
+			} ),
+		} ).then( categories => {
+			this.setState( {
+				suggestions: categories.reduce(
+					( accumulator, category ) => ( { ...accumulator, [ category.name ]: category } ),
+					{}
+				),
+			} );
+		} );
+	}
+
+	/**
+	 * Prepare categories data for the API endpoint, call the change handler.
+	 *
+	 * @param array tokens An array of category tokens.
+	 */
+	handleOnChange = tokens => {
+		const { onChange } = this.props;
+		const { suggestions } = this.state;
+		// Categories that are already will be objects, while new additions will be strings (the name).
+		// allValues nomalizes the array so that they are all objects.
+		const allValues = tokens.map( token =>
+			typeof token === 'string' ? suggestions[ token ] : token
+		);
+		onChange( allValues );
+	};
+
+	/**
+	 * Render the component.
+	 */
+	render() {
+		const { value, label } = this.props;
+		const { suggestions } = this.state;
+		return (
+			<FormTokenField
+				onInputChange={ input => this.debouncedUpdateSuggestions( input ) }
+				value={ value.map( item => ( { id: item.term_id, value: item.name } ) ) }
+				suggestions={ Object.keys( suggestions ) }
+				onChange={ this.handleOnChange }
+				label={ label }
+			/>
+		);
+	}
+}
+export default CategoryAutocomplete;

--- a/assets/components/src/form-token-field/index.js
+++ b/assets/components/src/form-token-field/index.js
@@ -1,0 +1,36 @@
+/**
+ * Form Token Field
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { FormTokenField as BaseComponent } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import './style.scss';
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+class FormTokenField extends Component {
+	/**
+	 * Render.
+	 */
+	render( props ) {
+		const { className, ...otherProps } = this.props;
+		const classes = classnames( 'newspack-form-token-field__input-container', className );
+		return (
+			<div className="newspack-form-token-field">
+				<BaseComponent className={ classes } { ...otherProps } />
+			</div>
+		);
+	}
+}
+
+export default FormTokenField;

--- a/assets/components/src/form-token-field/style.scss
+++ b/assets/components/src/form-token-field/style.scss
@@ -1,0 +1,110 @@
+/**
+ * Form Token Field
+ */
+
+@import '../../../shared/scss/colors';
+@import '~@wordpress/base-styles/colors';
+
+.newspack-form-token-field {
+	color: $dark-gray-300;
+	font-size: 14px;
+	line-height: 24px;
+	margin: 32px 0;
+
+	label {
+		color: $dark-gray-900;
+		font-size: inherit;
+		font-weight: bold;
+		line-height: inherit;
+		margin: 0;
+	}
+
+	.newspack-form-token-field__input-container {
+		background: white;
+		border: 1px solid $light-gray-500;
+		border-radius: 3px;
+		box-shadow: none;
+		box-sizing: border-box;
+		color: inherit;
+		font-size: 16px;
+		line-height: inherit;
+		margin: 0;
+		min-height: 48px;
+		padding: 9px 8px;
+		transition: border-color 125ms ease-in-out, box-shadow 125ms ease-in-out;
+		width: 100%;
+
+		@media screen and ( min-width: 768px ) {
+			font-size: inherit;
+		}
+
+		&.is-active {
+			border-color: $primary-500;
+			box-shadow: 0 0 0 2px $primary-500;
+		}
+
+		input[type="text"] {
+			border: 0;
+			line-height: inherit;
+			margin: 2px 0;
+			padding: 0;
+
+			&:focus {
+				box-shadow: none;
+			}
+		}
+
+		.components-form-token-field__token-text {
+			font-size: inherit;
+		}
+
+		.components-form-token-field__remove-token {
+			height: 24px;
+		}
+	}
+
+	.components-form-token-field__suggestions-list {
+		border-top-color: $light-gray-500;
+		margin: 12px -8px -11px;
+		padding: 8px 0 0;
+
+		.components-form-token-field__suggestion {
+			font-size: inherit;
+			margin-bottom: 8px;
+
+			&.is-selected {
+				background: $primary-500;
+			}
+		}
+	}
+
+	// Help Text
+
+	.components-form-token-field__help {
+		margin: 0;
+	}
+
+	// Multiple Form Token Field
+
+	& + & {
+		margin-bottom: 32px;
+		margin-top: -16px;
+	}
+
+	// Multiple Controls
+
+	& + .newspack-select-control,
+	& + .newspack-textarea-control,
+	& + .newspack-text-control {
+		margin-bottom: 32px;
+		margin-top: -16px;
+	}
+
+	// Reset
+
+	.components-base-control__field,
+	.components-base-control__label {
+		display: block;
+		margin: 0;
+	}
+}

--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -4,6 +4,7 @@ export { default as Card } from './card';
 export { default as CategoryAutocomplete } from './category-autocomplete';
 export { default as CheckboxControl } from './checkbox-control';
 export { default as Checklist } from './checklist';
+export { default as FormTokenField } from './form-token-field';
 export { default as FormattedHeader } from './formatted-header';
 export { default as Handoff } from './handoff';
 export { default as InfoButton } from './info-button';

--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -1,6 +1,7 @@
 export { default as ActionCard } from './action-card';
 export { default as Button } from './button';
 export { default as Card } from './card';
+export { default as CategoryAutocomplete } from './category-autocomplete';
 export { default as CheckboxControl } from './checkbox-control';
 export { default as Checklist } from './checklist';
 export { default as FormattedHeader } from './formatted-header';

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -59,7 +59,7 @@ class EngagementWizard extends Component {
 	getSettings() {
 		const { setError, wizardApiFetch } = this.props;
 		return wizardApiFetch( {
-			path: '/newspack/v1/wizard/newspack-engagement-wizard/connection-status',
+			path: '/newspack/v1/wizard/newspack-engagement-wizard/engagement',
 		} )
 			.then( info => {
 				this.setState( {

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -63,7 +63,7 @@ class EngagementWizard extends Component {
 		} )
 			.then( info => {
 				this.setState( {
-					...info,
+					...this.sanitizeData( info ),
 				} );
 			} )
 			.catch( error => {
@@ -84,7 +84,7 @@ class EngagementWizard extends Component {
 		} )
 			.then( info => {
 				this.setState( {
-					...info,
+					...this.sanitizeData( info ),
 				} );
 			} )
 			.catch( error => {
@@ -109,12 +109,16 @@ class EngagementWizard extends Component {
 		} )
 			.then( info => {
 				this.setState( {
-					...info,
+					...this.sanitizeData( info ),
 				} );
 			} )
 			.catch( error => {
 				setError( error );
 			} );
+	};
+
+	sanitizeData = data => {
+		return { ...data, popups: data.popups || [] };
 	};
 
 	/**

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -42,6 +42,7 @@ class EngagementWizard extends Component {
 			connected: false,
 			connectURL: '',
 			wcConnected: false,
+			popups: [],
 		};
 	}
 
@@ -71,11 +72,57 @@ class EngagementWizard extends Component {
 	}
 
 	/**
+	 * Designate which popup should be the sitewide default.
+	 *
+	 * @param int popupId ID of the Popup to become sitewide default.
+	 */
+	setSiteWideDefaultPopup = popupId => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: '/newspack/v1/wizard/newspack-engagement-wizard/sitewide-popup/' + popupId,
+			method: 'POST',
+		} )
+			.then( info => {
+				this.setState( {
+					...info,
+				} );
+			} )
+			.catch( error => {
+				setError( error );
+			} );
+	};
+
+	/**
+	 * Set categories for a Popup.
+	 *
+	 * @param int popupId ID of the Popup to alter.
+	 * @param array categories Array of categories to assign to the Popup.
+	 */
+	setCategoriesForPopup = ( popupId, categories ) => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: '/newspack/v1/wizard/newspack-engagement-wizard/popup-categories/' + popupId,
+			method: 'POST',
+			data: {
+				categories,
+			},
+		} )
+			.then( info => {
+				this.setState( {
+					...info,
+				} );
+			} )
+			.catch( error => {
+				setError( error );
+			} );
+	};
+
+	/**
 	 * Render
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
-		const { apiKey, connected, connectURL, wcConnected } = this.state;
+		const { apiKey, connected, connectURL, popups, wcConnected } = this.state;
 		const tabbed_navigation = [
 			{
 				label: __( 'Newsletters' ),
@@ -167,6 +214,9 @@ class EngagementWizard extends Component {
 										headerText={ __( 'Engagement', 'newspack' ) }
 										subHeaderText={ subheader }
 										tabbedNavigation={ tabbed_navigation }
+										popups={ popups }
+										setSiteWideDefaultPopup={ this.setSiteWideDefaultPopup }
+										setCategoriesForPopup={ this.setCategoriesForPopup }
 									/>
 								);
 							} }

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -24,6 +24,7 @@ import {
 	CommentingNative,
 	CommentingCoral,
 	Newsletters,
+	Popups,
 	Social,
 	UGC,
 } from './views';
@@ -87,6 +88,11 @@ class EngagementWizard extends Component {
 				exact: true,
 			},
 			{
+				label: __( 'Pop-ups' ),
+				path: '/popups',
+				exact: true,
+			},
+			{
 				label: __( 'Commenting' ),
 				path: '/commenting/',
 			},
@@ -142,6 +148,21 @@ class EngagementWizard extends Component {
 								const { apiKey } = this.state;
 								return (
 									<Social
+										headerIcon={ <HeaderIcon /> }
+										headerText={ __( 'Engagement', 'newspack' ) }
+										subHeaderText={ subheader }
+										tabbedNavigation={ tabbed_navigation }
+									/>
+								);
+							} }
+						/>
+						<Route
+							path="/popups"
+							exact
+							render={ routeProps => {
+								const { apiKey } = this.state;
+								return (
+									<Popups
 										headerIcon={ <HeaderIcon /> }
 										headerText={ __( 'Engagement', 'newspack' ) }
 										subHeaderText={ subheader }

--- a/assets/wizards/engagement/views/index.js
+++ b/assets/wizards/engagement/views/index.js
@@ -1,6 +1,7 @@
 export { default as Newsletters } from './newsletters';
 export { default as Social } from './social';
 export { default as Commenting } from './commenting';
+export { default as Popups } from './popups';
 export { default as UGC } from './ugc';
 export { default as CommentingDisqus } from './commenting-disqus';
 export { default as CommentingNative } from './commenting-native';

--- a/assets/wizards/engagement/views/popups/index.js
+++ b/assets/wizards/engagement/views/popups/index.js
@@ -17,6 +17,7 @@ import {
 	CategoryAutocomplete,
 	PluginInstaller,
 	SelectControl,
+	TextControl,
 	withWizardScreen,
 } from '../../../../components/src';
 
@@ -61,30 +62,36 @@ class Popups extends Component {
 					value={ popups.find( popup => popup.sitewide_default ) }
 					options={ [
 						{ value: '', label: __( '- Select -' ), disabled: true },
-						...popups
-							// Popups with categories cannot be sitewide default, so they are excluded from this Select.
-							.filter( popup => ! popup.categories || ! popup.categories.length )
-							.map( popup => ( {
-								value: popup.id,
-								label: popup.title,
-							} ) ),
+						...popups.map( popup => ( {
+							value: popup.id,
+							label: popup.title,
+							disabled: popup.categories.length,
+						} ) ),
 					] }
 					onChange={ setSiteWideDefaultPopup }
 				/>
 				<h2>{ __( 'Category Filtering' ) }</h2>
 				{ popups
 					// The sitewide default should not be shown in this area.
-					.filter( popup => ! popup.sitewide_default )
 					.map( popup => {
 						const { categories } = popup;
 						return (
 							<div className="newspack-engagement__popups_row" key={ popup.id }>
-								<CategoryAutocomplete
-									value={ categories || [] }
-									suggestions={ this.fetchSuggestions }
-									onChange={ tokens => setCategoriesForPopup( popup.id, tokens ) }
-									label={ popup.title }
-								/>
+								{ popup.sitewide_default ? (
+									<TextControl
+										disabled
+										label={ popup.title }
+										value={ __( 'Sitewide default', 'newspack' ) }
+									/>
+								) : (
+									<CategoryAutocomplete
+										value={ categories || [] }
+										suggestions={ this.fetchSuggestions }
+										onChange={ tokens => setCategoriesForPopup( popup.id, tokens ) }
+										label={ popup.title }
+										disabled={ popup.sitewide_default }
+									/>
+								) }
 							</div>
 						);
 					} ) }

--- a/assets/wizards/engagement/views/popups/index.js
+++ b/assets/wizards/engagement/views/popups/index.js
@@ -1,0 +1,53 @@
+/**
+ * Popups screen.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Disqus dependencies
+ */
+import { ActionCard, PluginInstaller, withWizardScreen } from '../../../../components/src';
+
+/**
+ * Popups Screen
+ */
+class Popups extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			pluginRequirementsMet: false,
+		};
+	}
+	/**
+	 * Render.
+	 */
+	render() {
+		const { pluginRequirementsMet } = this.state;
+		if ( ! pluginRequirementsMet ) {
+			return (
+				<PluginInstaller
+					plugins={ [ 'newspack-popups' ] }
+					onStatus={ ( { complete } ) => this.setState( { pluginRequirementsMet: complete } ) }
+				/>
+			);
+		}
+		return (
+			<Fragment>
+				<p>{ __( 'Explanatory text TK' ) }</p>
+				<ActionCard
+					title={ __( 'Newspack Pop-ups' ) }
+					description={ __( 'AMP-compatible popup notifications.' ) }
+					actionText={ __( 'Configure' ) }
+					href="edit.php?post_type=newspack_popups_cpt"
+				/>
+			</Fragment>
+		);
+	}
+}
+
+export default withWizardScreen( Popups );

--- a/assets/wizards/engagement/views/popups/index.js
+++ b/assets/wizards/engagement/views/popups/index.js
@@ -39,6 +39,7 @@ class Popups extends Component {
 	render() {
 		const { pluginRequirementsMet } = this.state;
 		const { popups, setSiteWideDefaultPopup, setCategoriesForPopup } = this.props;
+		const hasPopups = popups && popups.length > 0;
 		if ( ! pluginRequirementsMet ) {
 			return (
 				<PluginInstaller
@@ -56,49 +57,56 @@ class Popups extends Component {
 					actionText={ __( 'Manage' ) }
 					href="edit.php?post_type=newspack_popups_cpt"
 				/>
-				<hr />
-				<h2>{ __( 'Configure active Pop-up' ) }</h2>
-				<SelectControl
-					label={ __( 'Sitewide default' ) }
-					value={ popups.find( popup => popup.sitewide_default ) }
-					options={ [
-						{ value: '', label: __( '- Select -' ), disabled: true },
-						...popups.map( popup => ( {
-							value: popup.id,
-							label: popup.title,
-							disabled: popup.categories.length,
-						} ) ),
-					] }
-					onChange={ setSiteWideDefaultPopup }
-				/>
-				<h2>{ __( 'Category Filtering' ) }</h2>
-				{ popups
-					// The sitewide default should not be shown in this area.
-					.map( popup => {
-						const { categories } = popup;
-						return (
-							<div className="newspack-engagement__popups-row" key={ popup.id }>
-								{ popup.sitewide_default ? (
-									<TextControl
-										disabled
-										label={ popup.title }
-										value={ __( 'Sitewide default', 'newspack' ) }
-									/>
-								) : (
-									<CategoryAutocomplete
-										value={ categories || [] }
-										suggestions={ this.fetchSuggestions }
-										onChange={ tokens => setCategoriesForPopup( popup.id, tokens ) }
-										label={ popup.title }
-										disabled={ popup.sitewide_default }
-									/>
-								) }
-							</div>
-						);
-					} ) }
+				{ hasPopups && (
+					<Fragment>
+						<hr />
+						<h2>{ __( 'Configure active Pop-up' ) }</h2>
+						<SelectControl
+							label={ __( 'Sitewide default' ) }
+							value={ popups.find( popup => popup.sitewide_default ) }
+							options={ [
+								{ value: '', label: __( '- Select -' ), disabled: true },
+								...popups.map( popup => ( {
+									value: popup.id,
+									label: popup.title,
+									disabled: popup.categories.length,
+								} ) ),
+							] }
+							onChange={ setSiteWideDefaultPopup }
+						/>
+						<h2>{ __( 'Category Filtering' ) }</h2>
+					</Fragment>
+				) }
+				{ hasPopups &&
+					popups
+						// The sitewide default should not be shown in this area.
+						.map( popup => {
+							const { categories } = popup;
+							return (
+								<div className="newspack-engagement__popups-row" key={ popup.id }>
+									{ popup.sitewide_default ? (
+										<TextControl
+											disabled
+											label={ popup.title }
+											value={ __( 'Sitewide default', 'newspack' ) }
+										/>
+									) : (
+										<CategoryAutocomplete
+											value={ categories || [] }
+											suggestions={ this.fetchSuggestions }
+											onChange={ tokens => setCategoriesForPopup( popup.id, tokens ) }
+											label={ popup.title }
+											disabled={ popup.sitewide_default }
+										/>
+									) }
+								</div>
+							);
+						} ) }
 				<div className="newspack-buttons-card">
 					<Button href="/wp-admin/post-new.php?post_type=newspack_popups_cpt" isPrimary>
-						{ __( 'Add new Pop-up' ) }
+						{ hasPopups
+							? __( 'Add new Pop-up', 'newspack' )
+							: __( 'Add first Pop-up', 'newspack' ) }
 					</Button>
 				</div>
 			</Fragment>

--- a/assets/wizards/engagement/views/popups/index.js
+++ b/assets/wizards/engagement/views/popups/index.js
@@ -3,15 +3,15 @@
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Disqus dependencies
+ * Internal dependencies.
  */
-import { ActionCard, PluginInstaller, withWizardScreen } from '../../../../components/src';
+import { ActionCard, Button, PluginInstaller, SelectControl, withWizardScreen } from '../../../../components/src';
 
 /**
  * Popups Screen
@@ -38,13 +38,27 @@ class Popups extends Component {
 		}
 		return (
 			<Fragment>
-				<p>{ __( 'Explanatory text TK' ) }</p>
 				<ActionCard
 					title={ __( 'Newspack Pop-ups' ) }
 					description={ __( 'AMP-compatible popup notifications.' ) }
-					actionText={ __( 'Configure' ) }
+					actionText={ __( 'Manage' ) }
 					href="edit.php?post_type=newspack_popups_cpt"
 				/>
+				<hr />
+				<h2>{ __( 'Configure active Pop-up' ) }</h2>
+				<SelectControl
+					label={ __( 'Sitewide default' ) }
+					value={ '' }
+					options={ [
+						{ value: '', label: __( '- Select -' ), disabled: true }
+					] }
+					value={ '' }
+				/>
+				<div className="newspack-buttons-card">
+					<Button onClick="/post-new.php?post_type=newspack_popups_cpt" isPrimary>
+						{ __( 'Add new Pop-up' ) }
+					</Button>
+				</div>
 			</Fragment>
 		);
 	}

--- a/assets/wizards/engagement/views/popups/index.js
+++ b/assets/wizards/engagement/views/popups/index.js
@@ -7,6 +7,7 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies.
@@ -68,7 +69,7 @@ class Popups extends Component {
 								{ value: '', label: __( '- Select -' ), disabled: true },
 								...popups.map( popup => ( {
 									value: popup.id,
-									label: popup.title,
+									label: decodeEntities( popup.title ),
 									disabled: popup.categories.length,
 								} ) ),
 							] }
@@ -86,7 +87,7 @@ class Popups extends Component {
 									{ popup.sitewide_default ? (
 										<TextControl
 											disabled
-											label={ popup.title }
+											label={ decodeEntities( popup.title ) }
 											value={ __( 'Sitewide default', 'newspack' ) }
 										/>
 									) : (
@@ -94,7 +95,7 @@ class Popups extends Component {
 											value={ categories || [] }
 											suggestions={ this.fetchSuggestions }
 											onChange={ tokens => setCategoriesForPopup( popup.id, tokens ) }
-											label={ popup.title }
+											label={ decodeEntities( popup.title ) }
 											disabled={ popup.sitewide_default }
 										/>
 									) }

--- a/assets/wizards/engagement/views/popups/index.js
+++ b/assets/wizards/engagement/views/popups/index.js
@@ -79,7 +79,6 @@ class Popups extends Component {
 				) }
 				{ hasPopups &&
 					popups
-						// The sitewide default should not be shown in this area.
 						.map( popup => {
 							const { categories } = popup;
 							return (

--- a/assets/wizards/engagement/views/popups/index.js
+++ b/assets/wizards/engagement/views/popups/index.js
@@ -20,6 +20,7 @@ import {
 	TextControl,
 	withWizardScreen,
 } from '../../../../components/src';
+import './style.scss';
 
 /**
  * Popups Screen
@@ -76,7 +77,7 @@ class Popups extends Component {
 					.map( popup => {
 						const { categories } = popup;
 						return (
-							<div className="newspack-engagement__popups_row" key={ popup.id }>
+							<div className="newspack-engagement__popups-row" key={ popup.id }>
 								{ popup.sitewide_default ? (
 									<TextControl
 										disabled

--- a/assets/wizards/engagement/views/popups/style.scss
+++ b/assets/wizards/engagement/views/popups/style.scss
@@ -1,0 +1,9 @@
+/**
+ * Popups
+ */
+
+.newspack-engagement__popups-row {
+  & + & {
+    margin-top: -16px;
+  }
+}

--- a/includes/configuration_managers/class-configuration-managers.php
+++ b/includes/configuration_managers/class-configuration-managers.php
@@ -40,6 +40,10 @@ class Configuration_Managers {
 			'filename'   => 'class-newspack-ads-configuration-manager.php',
 			'class_name' => 'Newspack_Ads_Configuration_Manager',
 		],
+		'newspack-popups'       => [
+			'filename'   => 'class-newspack-popups-configuration-manager.php',
+			'class_name' => 'Newspack_Popups_Configuration_Manager',
+		],
 		'woocommerce'           => [
 			'filename'   => 'class-woocommerce-configuration-manager.php',
 			'class_name' => 'WooCommerce_Configuration_Manager',

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Newspack Pop-ups Configuration Manager
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
+
+/**
+ * Provide an interface for configuring and querying the configuration of Newspack Pop-ups.
+ */
+class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
+
+	/**
+	 * The slug of the plugin.
+	 *
+	 * @var string
+	 */
+	public $slug = 'newspack-popups';
+
+	/**
+	 * Get whether the Newspack Popups plugin is active and set up.
+	 *
+	 * @return bool Whether Newspack Popups is installed and activated.
+	 */
+	public function is_configured() {
+		return class_exists( 'Newspack_Popups_Model' );
+	}
+
+	/**
+	 * Retrieve all Pop-up CPTs
+	 *
+	 * @return array All Pop-ups
+	 */
+	public function get_popups() {
+		return $this->is_configured() ?
+			\Newspack_Popups_Model::retrieve_popups() :
+			$this->unconfigured_error();
+	}
+
+	/**
+	 * Set the sitewide Popup.
+	 *
+	 * @param integer $id ID of sitewide popup.
+	 */
+	public function set_sitewide_popup( $id ) {
+		return $this->is_configured() ?
+			\Newspack_Popups_Model::set_sitewide_popup( $id ) :
+			$this->unconfigured_error();
+	}
+
+	/**
+	 * Set categories for a Popup.
+	 *
+	 * @param integer $id ID of sitewide popup.
+	 * @param array   $categories Array of categories to be set.
+	 */
+	public function set_popup_categories( $id, $categories ) {
+		return $this->is_configured() ?
+			\Newspack_Popups_Model::set_popup_categories( $id, $categories ) :
+			$this->unconfigured_error();
+	}
+
+	/**
+	 * Configure Newspack Popups for Newspack use.
+	 *
+	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
+	 */
+	public function configure() {
+		return true;
+	}
+
+	/**
+	 * Error to return if the plugin is not installed and activated.
+	 *
+	 * @return WP_Error
+	 */
+	private function unconfigured_error() {
+		return new \WP_Error(
+			'newspack_missing_required_plugin',
+			esc_html__( 'The Newspack Popups plugin is not installed and activated. Install and/or activate it to access this feature.', 'newspack' ),
+			[
+				'status' => 400,
+				'level'  => 'fatal',
+			]
+		);
+	}
+}

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -73,10 +73,10 @@ class Engagement_Wizard extends Wizard {
 	public function register_api_endpoints() {
 		register_rest_route(
 			'newspack/v1/wizard/' . $this->slug,
-			'connection-status',
+			'engagement',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'api_get_connection_status_settings' ],
+				'callback'            => [ $this, 'api_get_engagement_settings' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
@@ -119,7 +119,7 @@ class Engagement_Wizard extends Wizard {
 	 * @see jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
 	 * @return WP_REST_Response with the info.
 	 */
-	public function api_get_connection_status_settings() {
+	public function api_get_engagement_settings() {
 		$jetpack_configuration_manager         = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'jetpack' );
 		$wc_configuration_manager              = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
@@ -150,7 +150,7 @@ class Engagement_Wizard extends Wizard {
 			return $response;
 		}
 
-		return $this->api_get_connection_status_settings();
+		return $this->api_get_engagement_settings();
 	}
 
 	/**
@@ -170,7 +170,7 @@ class Engagement_Wizard extends Wizard {
 			return $response;
 		}
 
-		return $this->api_get_connection_status_settings();
+		return $this->api_get_engagement_settings();
 	}
 
 	/**

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -124,8 +124,17 @@ class Engagement_Wizard extends Wizard {
 		$wc_configuration_manager              = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
 
-		$response = $jetpack_configuration_manager->get_mailchimp_connection_status();
-		if ( ! is_wp_error( $response ) ) {
+		$response = array(
+			'connected'   => false,
+			'connectURL'  => null,
+			'wcConnected' => false,
+			'popups'      => array(),
+		);
+
+		$jetpack_status = $jetpack_configuration_manager->get_mailchimp_connection_status();
+		if ( ! is_wp_error( $jetpack_status ) ) {
+			$response['connected']   = $jetpack_status['connected'];
+			$response['connectURL']  = $jetpack_status['connectURL'];
 			$response['wcConnected'] = $wc_configuration_manager->is_active();
 		}
 		if ( $newspack_popups_configuration_manager->is_configured() ) {

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -195,7 +195,7 @@ class Engagement_Wizard extends Wizard {
 		\wp_enqueue_script(
 			'newspack-engagement-wizard',
 			Newspack::plugin_url() . '/assets/dist/engagement.js',
-			$this->get_script_dependencies(),
+			$this->get_script_dependencies( array( 'wp-html-entities' ) ),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/dist/engagement.js' ),
 			true
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

~Adds a basic Pop-ups screen to Engagement Wizard, which requires installation/activation of the Newspack Pop-ups plugin. Must be tested with https://github.com/Automattic/newspack-popups/pull/34.~

This PR ads a Pop-Ups screen to the Engagement Wizard, which does the following:
- Manages installation of the Newspack Popups plugin.
- Allows selection of the Sitewide Default Pop-up, which is the popup that will potentially be shown on all pages, not just category pages. 
- UI to add category filters to Pop-ups.
- Button to create a new Popup.

The PR also introduces a Newspack-styled `FormTokenField` component and a Category Autocomplete component based largely on the Autocomplete Tokenfield component in Newspack Blocks (https://github.com/Automattic/newspack-blocks/blob/master/src/components/autocomplete-tokenfield.js).

A Pop-up is only eligible to be the Sitewide Default if it has no categories assigned. In the Sitewide Default Select, Pop-ups with categories will be visible but  disabled. In the Category Filtering area, the selected Sitewide Default will appear disabled. 

### How to test the changes in this Pull Request:

1. Clone https://github.com/Automattic/newspack-popups into `wp-content/plugins` (or symlink). Branch switch to https://github.com/Automattic/newspack-popups/pull/34.
2. Navigate to Newspack->Engagement->Popups. Observe the required plugin installer UI, and click Activate to activate Newspack Popups. 
3. Click "Add First Pop-up." Observe redirect to new Pop-up editor page.
4. Create three Pop-ups, two with no categories and one with at least one category assigned.
5. Navigate back to Newspack->Engagement->Popups. Observe the newer of the two category-less ones is the selected Sitewide Default. Observe the Pop-up with a category is disabled in this select. 
6. In the Category Filtering area, observe the Sitewide Default is disabled and says "Sitewide Default." 
7. Change the Sitewide Default.  Observe the change to the  Category Filtering UI, and on the Pop-ups list page (`/wp-admin/edit.php?post_type=newspack_popups_cpt`) the selected item has `— Sitewide Default` appended to its name.
8. Back in Newspack->Engagement->Popups, try adding and removing categories from the Pop-ups. Observe that Pop-ups with Categories become disabled in the Sitewide Default Select. Observe the Categories are correctly reflected in the Edit page for the Pop-up. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->