### PR TITLE
LaterPay shouldn't be a required plugin for WC integration

### DIFF
--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -261,7 +261,6 @@ render(
 			'woocommerce',
 			'woocommerce-subscriptions',
 			'woocommerce-name-your-price',
-			'laterpay',
 		] )
 	),
 	document.getElementById( 'newspack-reader-revenue-wizard' )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://github.com/Automattic/newspack-plugin/issues/205#issuecomment-570650796

It doesn't make sense to force people to install LaterPay in order to use the WooCommerce-based Reader Revenue features. LaterPay should have its own flow (design TBD; discussed in the above comment).

### How to test the changes in this Pull Request:

1. Go to Reader Revenue wizard. Observe you can access it without installing LaterPay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->