### PR TITLE
Make sure the installer wizard button text is based on plugin status

### DIFF
--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -167,6 +167,19 @@ class PluginInstaller extends Component {
 			const plugin = pluginInfo[ slug ];
 			return plugin.Status !== 'active' && plugin.installationStatus === PLUGIN_STATE_NONE;
 		} );
+
+		// Store all plugin status info for installer button text value based on current status.
+		let currentPluginStatuses = [];
+		slugs.forEach( slug => {
+			const plugin = pluginInfo[ slug ];
+			currentPluginStatuses.push( plugin.Status );
+		} );
+
+		// Make sure plugin status falls in either one of these, to handle button text.
+		const pluginInstalled = ( currentStatus) => currentStatus === 'active' || currentStatus === 'inactive';
+
+		let buttonText = currentPluginStatuses.every( pluginInstalled ) ? __( 'Activate' ) : __( 'Install' );
+
 		if ( asProgressBar ) {
 			const completed = slugs.reduce(
 				( completed, slug ) =>
@@ -242,7 +255,7 @@ class PluginInstaller extends Component {
 							isPrimary
 							onClick={ this.installAllPlugins }
 						>
-							{ __( 'Install' ) }
+							{  buttonText }
 						</Button>
 					</div>
 				) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #334 .

### How to test the changes in this Pull Request:

From reported issue description.

1. Disable one of the syndication plugins
2. Go to Newspack > Syndication
3. Verify the button text is as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
   ```
    Test Suites: 3 passed, 3 total
    Tests:       11 passed, 11 total
    Snapshots:   0 total
    Time:        14.411s
    Ran all test suites.
    ```

<!-- Mark completed items with an [x] -->