### PR TITLE
Plugin "Quiet" Mode

### DIFF
--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -42,6 +42,10 @@ class Admin_Plugins_Screen {
 				continue;
 			}
 
+			if ( isset( $plugin_info['Quiet'] ) && $plugin_info['Quiet'] ) {
+				continue;
+			}
+
 			$plugins[ $slug ] = $plugin_info;
 		}
 

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -56,6 +56,15 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://automattic.com',
 				'Download'    => 'https://github.com/Automattic/newspack-ads/releases/download/1.0.0-alpha.1/newspack-ads.zip',
 			],
+			'newspack-content-converter'    => [
+				'Name'        => esc_html__( 'Newspack Content Converter', 'newspack' ),
+				'Description' => esc_html__( 'Batch conversion of Classic->Gutenberg post conversion.' ),
+				'Author'      => 'Automattic',
+				'PluginURI'   => 'https://newspack.blog',
+				'AuthorURI'   => 'https://automattic.com',
+				'Download'    => 'https://github.com/Automattic/newspack-content-converter/releases/latest/download/newspack-content-con verter.zip',
+				'Quiet'       => true,
+			],
 			'jetpack'                       => [
 				'Name'        => __( 'Jetpack', 'newspack' ),
 				'Description' => esc_html__( 'Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.', 'newspack' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As Newspack develops feature plugins we're finding there's an awkward zone where the plugin is being installed and used on staging sites, but is not fully ready for a release. If the plugin has not been whitelisted in the plugin manager class there's a strange situation where the Health Check screen will flag a Newspack product as unsupported, which is weird. On the other hand, if the plugin has been whitelisted it will appear on the main plugin screen, which suggests it is fully released.  To work around this situation, this PR adds a `Quiet` param for plugins, which causes the plugin to be whitelisted but not appear on the plugins screen unless it has been installed. The Newspack Content Converter has been added to the whitelist with this setting.

### How to test the changes in this Pull Request:

1. On `master` install the [Newspack Content Converter](https://github.com/Automattic/newspack-content-converter/releases) plugin. 
2. Navigate to `Newspack->Health Check` and verify that it is listed as unsupported.
3. Switch to this branch, and verify it is no longer listed as unsupported.
4. On plugins screen, deactivate and delete Newspack Content Converter.
5. Refresh the page, and verify it is not listed as an uninstalled but supported Newspack Managed plugin.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->