### PR TITLE
Reset Button, Menu Visibility

### DIFF
--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -7,7 +7,8 @@
 // Reset Padding of the Admin Page
 
 .toplevel_page_newspack,
-body[class*="newspack_page_newspack-"] {
+body[class*="newspack_page_newspack-"],
+body[class*="admin_page_newspack-"] {
 	#wpcontent {
 		padding-left: 0;
 	}

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -123,7 +123,9 @@ final class Newspack {
 	 */
 	public function remove_notifications() {
 		$screen = get_current_screen();
-		if ( ! $screen || 'newspack' !== $screen->parent_base ) {
+
+		$is_newspack_screen = ( 'newspack' === $screen->parent_base ) || ( 'admin_page_newspack-' === substr( $screen->base, 0, 20 ) );
+		if ( ! $screen || ! $is_newspack_screen ) {
 			return;
 		}
 		remove_all_actions( current_action() );

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -106,13 +106,15 @@ final class Newspack {
 	 * Reset Newspack by removing all newspack prefixed options. Triggered by the query param reset_newspack_settings=1
 	 */
 	public function remove_all_newspack_options() {
-		if ( filter_input( INPUT_GET, 'reset_newspack_settings', FILTER_SANITIZE_STRING ) === '1' ) {
+		if ( filter_input( INPUT_POST, 'newspack_reset', FILTER_SANITIZE_STRING ) === 'on' ) {
 			$all_options = wp_load_alloptions();
 			foreach ( $all_options as $key => $value ) {
 				if ( strpos( $key, 'newspack' ) === 0 || strpos( $key, '_newspack' ) === 0 ) {
 					delete_option( $key );
 				}
 			}
+			wp_safe_redirect( admin_url( 'admin.php?page=newspack-setup-wizard' ) );
+			exit;
 		}
 	}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -71,15 +71,22 @@ class Settings {
 		);
 		add_settings_field(
 			'newspack_debug',
-			'Debug Mode',
+			__( 'Debug Mode', 'newspack' ),
 			[ __CLASS__, 'newspack_debug_callback' ],
+			'newspack-settings-admin',
+			'setting_section_id'
+		);
+		add_settings_field(
+			'newspack_reset',
+			__( 'Reset Newspack', 'newspack' ),
+			[ __CLASS__, 'newspack_reset_callback' ],
 			'newspack-settings-admin',
 			'setting_section_id'
 		);
 	}
 
 	/**
-	 * Get the settings option array and print one of its values
+	 * Render Debug checkbox.
 	 */
 	public static function newspack_debug_callback() {
 		$newspack_debug = get_option( 'newspack_debug', false );
@@ -87,6 +94,15 @@ class Settings {
 		printf(
 			'<input type="checkbox" id="newspack_debug" name="newspack_debug" %s />',
 			esc_attr( $newspack_value )
+		);
+	}
+
+	/**
+	 * Render Reset button.
+	 */
+	public static function newspack_reset_callback() {
+		printf(
+			'<input type="checkbox" id="newspack_reset" name="newspack_reset" />'
 		);
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -49,6 +49,22 @@ class Settings {
 				settings_fields( 'newspack_options_group' );
 				do_settings_sections( 'newspack-settings-admin' );
 				submit_button();
+				printf(
+					wp_kses(
+						/* translators: %2$s: Set Up Wizard, %4$s: Components Demo */
+						__( '<p><a href="%1$s">%2$s</a> | <a href="%3$s">%4$s</a></p>', 'newspack' ),
+						array(
+							'p' => array(),
+							'a' => array(
+								'href' => array(),
+							),
+						)
+					),
+					esc_url( admin_url( 'admin.php?page=newspack-setup-wizard' ) ),
+					esc_attr( __( 'Setup Wizard', 'newspack' ) ),
+					esc_url( admin_url( 'admin.php?page=newspack-components-demo' ) ),
+					esc_attr( __( 'Components Demo', 'newspack' ) )
+				);
 			?>
 			</form>
 		</div>
@@ -64,7 +80,7 @@ class Settings {
 			'newspack_debug'
 		);
 		add_settings_section(
-			'setting_section_id',
+			'newspack_settings',
 			'Newspack Custom Settings',
 			null,
 			'newspack-settings-admin'
@@ -74,14 +90,14 @@ class Settings {
 			__( 'Debug Mode', 'newspack' ),
 			[ __CLASS__, 'newspack_debug_callback' ],
 			'newspack-settings-admin',
-			'setting_section_id'
+			'newspack_settings'
 		);
 		add_settings_field(
 			'newspack_reset',
 			__( 'Reset Newspack', 'newspack' ),
 			[ __CLASS__, 'newspack_reset_callback' ],
 			'newspack-settings-admin',
-			'setting_section_id'
+			'newspack_settings'
 		);
 	}
 

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -38,14 +38,11 @@ class Components_Demo extends Wizard {
 	protected $menu_priority = 100;
 
 	/**
-	 * Constructor.
+	 * Whether the wizard should be displayed in the Newspack submenu.
+	 *
+	 * @var bool.
 	 */
-	public function __construct() {
-		parent::__construct();
-
-		// Only show a link to the Components Demo if WP_DEBUG is enabled.
-		$this->hidden = ! defined( 'WP_DEBUG' ) || ! WP_DEBUG;
-	}
+	protected $hidden = true;
 
 	/**
 	 * Get the name for this wizard.

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -41,6 +41,7 @@ class Setup_Wizard extends Wizard {
 			add_action( 'admin_menu', [ $this, 'hide_non_setup_menu_items' ], 1000 );
 
 		}
+		$this->hidden = get_option( NEWSPACK_SETUP_COMPLETE, false );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Adds a "Reset" checkbox in Newspack->Settings, which will clear all Newspack options and redirect to the Setup Wizard.
- Adds links in Newspack->Settings to Setup Wizard and Components Demo.
- Removes Components Demo from the Admin Menu.
- Removes Setup from the Admin Menu if it has been completed.

Closes https://github.com/Automattic/newspack-plugin/issues/310

### How to test the changes in this Pull Request:

1. Navigate to Settings->Newspack.
2. Click "Reset Newspack," then Save Changes.
3. Observe you are redirected to the Setup Wizard and all Newspack options are cleared. This can be verified by checking the database (`SELECT * FROM wp_options WHERE option_name LIKE 'newspack%'`) or by noting that the Newspack Admin menu only contains Setup.
4. Complete the Setup Wizard.
5. Observe Setup is no longer in the Admin menu after it has been completed.
6. Observe Components Demo is no longer in the Admin menu.
7. Navigate to Settings->Newspack. Click the links to Setup Wizard and Components Demo, and verify they go where they are supposed to.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->