### PR TITLE
Add Newspack Supporters to managed plugins

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -299,6 +299,14 @@ class Plugin_Manager {
 					'class_name' => 'LaterPay_Configuration_Manager',
 				],
 			],
+			'newspack-supporters'           => [
+				'Name'        => 'Newspack Supporters',
+				'Description' => 'Manage and display your site\'s supporters.',
+				'Author'      => 'Automattic',
+				'PluginURI'   => 'https://newspack.blog',
+				'AuthorURI'   => 'https://automattic.com',
+				'Download'    => 'https://github.com/Automattic/newspack-supporters/releases/latest/download/newspack-supporters.zip',
+			],
 		];
 
 		$default_info = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds Newspack Supporters to the list of managed plugins. This plugin should be widely useful for a variety of sites, especially nonprofits.

### How to test the changes in this Pull Request:

1. Install and activate Newspack Supporters through the Plugins screen.
2. If you want to test the plugin, [instructions are at the repo](https://github.com/Automattic/newspack-supporters).
3. Live demo is available at https://hechingerreport-newspack-2.mystagingwebsite.com/supporters/

Screenshot:
<img width="1138" alt="Screen Shot 2020-01-08 at 11 18 52 AM" src="https://user-images.githubusercontent.com/7317227/72008442-afdf5e00-3208-11ea-90b9-4a2a8234578b.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->