### PR TITLE
Add Organic Profile Block to managed plugins

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -299,6 +299,14 @@ class Plugin_Manager {
 					'class_name' => 'LaterPay_Configuration_Manager',
 				],
 			],
+			'organic-profile-block'         => [
+				'Name'        => 'Organic Profile Block',
+				'Description' => "The Profile Block is created for the Gutenberg content editor. It displays a profile section with an image, name, subtitle, bio and personal social media links. It's perfect for author biographies, personal profiles, or staff pages.",
+				'Author'      => 'Organic Themes',
+				'PluginURI'   => 'https://organicthemes.com/',
+				'AuthorURI'   => 'https://organicthemes.com/',
+				'Download'    => 'wporg',
+			],
 		];
 
 		$default_info = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds [Organic Profile Block](https://wordpress.org/plugins/organic-profile-block/) to the managed plugins list. This is by far the best author profile block plugin I've found for a number of reasons:
- It's stand-alone: No bloat or extra unnecessary blocks we need to deal with.
- It's clean: It doesn't add a bunch of promo materials and upsells to the admin.
- It's flexible: Since it doesn't require existing WP users, it can be used for all sorts of purposes: biographic info in articles, staff list, advisor list, etc.

### How to test the changes in this Pull Request:

1. Install and activate Organic Profile Block through the Newspack Plugins screen area.
2. On a post or page, add one or more Profile blocks.
3. You should see something like this on the frontend:
<img width="830" alt="Screen Shot 2020-01-08 at 11 22 40 AM" src="https://user-images.githubusercontent.com/7317227/72009322-81628280-320a-11ea-812e-3bd01ff77860.png">

### Next step?

We may want to add a couple lines of CSS to the Newspack theme to further improve the style and make it more consistent with the rest of the site. For example, I've added a couple lines of styling to the Hechinger staging site and I think this is a big improvement:

<img width="1154" alt="Screen Shot 2020-01-08 at 11 32 45 AM" src="https://user-images.githubusercontent.com/7317227/72009447-c8507800-320a-11ea-9dc8-c78126e10e14.png">

At minimum, we probably want to remove the drop shadow IMHO.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->