### PR TITLE
Ad Wizard Improvements

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -6,7 +6,6 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Dashicon } from '@wordpress/components';
 import { Button, Card, Handoff, Notice, ToggleControl, Waiting } from '../';
 
 /**
@@ -55,7 +54,6 @@ class ActionCard extends Component {
 			className
 		);
 		const hasSecondaryAction = secondaryActionText && onSecondaryActionClick;
-		const actionDisplay = ( simple && <Dashicon icon="arrow-right-alt2" /> ) || actionText;
 		return (
 			<Card className={ classes } onClick={ simple && onClick }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
@@ -79,11 +77,11 @@ class ActionCard extends Component {
 						</h2>
 						<p>{ description }</p>
 					</div>
-					{ actionDisplay && (
+					{ actionText && (
 						<div className="newspack-action-card__region newspack-action-card__region-right">
 							{ handoff && (
 								<Handoff plugin={ handoff } editLink={ editLink } compact isLink>
-									{ actionDisplay }
+									{ actionText }
 								</Handoff>
 							) }
 							{ ( !! onClick || !! href ) && ! handoff && (
@@ -93,12 +91,12 @@ class ActionCard extends Component {
 									onClick={ onClick }
 									className="newspack-action-card__primary_button"
 								>
-									{ actionDisplay }
+									{ actionText }
 								</Button>
 							) }
 							{ ! handoff && ! onClick && ! href && (
 								<div className="newspack-action-card__container">
-									{ actionDisplay }
+									{ actionText }
 									{ isWaiting && <Waiting isRight /> }
 								</div>
 							) }

--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -6,9 +6,13 @@
 @import '~@wordpress/base-styles/colors';
 
 .newspack-button {
+	border-radius: 3px;
 	font-size: 14px;
 	font-weight: bold;
+	height: auto;
 	line-height: 24px;
+	padding: 11px 24px;
+	transition: background 125ms ease-in-out, border-color 125ms ease-in-out, box-shadow 125ms ease-in-out, color 125ms ease-in-out;
 
 	&.is-large {
 		font-size: 17px;
@@ -23,56 +27,12 @@
 		padding: 3px 12px;
 	}
 
-	&.is-button {
-		background: white;
-		border: 1px solid $light-gray-500;
-		border-radius: 3px;
-		color: $primary-500;
-		height: auto;
-		line-height: 24px;
-		padding: 11px 24px;
-		transition: background 125ms ease-in-out, border-color 125ms ease-in-out, box-shadow 125ms ease-in-out, color 125ms ease-in-out;
-
-		&:active,
-		&:active:enabled,
-		&:focus,
-		&:focus:enabled,
-		&:hover {
-			background: $light-gray-100;
-			border-color: $primary-500;
-			color: $primary-500;
-		}
-
-		&:focus,
-		&:focus:enabled {
-			border-color: $primary-600;
-			box-shadow: 0 0 0 2px $primary-500;
-		}
-
-		&:disabled,
-		&:disabled:active:enabled,
-		&[aria-disabled=true],
-		&[aria-disabled=true]:active:enabled {
-			background: $light-gray-100;
-			border-color: $light-gray-500;
-			color: $light-gray-900;
-			cursor: not-allowed;
-			text-shadow: none;
-
-			&:hover {
-				background: $light-gray-100;
-				border-color: $light-gray-500;
-				color: $light-gray-900;
-			}
-		}
-
-		&.is-small {
-			padding: 3px 12px;
-		}
-
-		&.is-large {
-			padding: 15px 32px;
-		}
+	&:disabled,
+	&:disabled:active:enabled,
+	&[aria-disabled=true],
+	&[aria-disabled=true]:active:enabled {
+		cursor: not-allowed;
+		text-shadow: none;
 	}
 
 	&.is-primary {
@@ -84,7 +44,8 @@
 		&:active:enabled,
 		&:focus,
 		&:focus:enabled,
-		&:hover {
+		&:hover,
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 			background: $primary-600;
 			border-color: $primary-700;
 			color: white;
@@ -110,24 +71,53 @@
 			}
 		}
 
-		&.is-small {
-			padding: 3px 12px;
-		}
-
 		.newspack-is-waiting {
 			fill: white;
+		}
+	}
+
+	&.is-secondary {
+		background: white;
+		border: 1px solid $light-gray-500;
+		color: $primary-500;
+
+		&:active,
+		&:active:enabled,
+		&:focus,
+		&:focus:enabled,
+		&:hover,
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
+			background: $light-gray-100;
+			border-color: $primary-500;
+			color: $primary-500;
+		}
+
+		&:focus,
+		&:focus:enabled {
+			border-color: $primary-600;
+			box-shadow: 0 0 0 2px $primary-500;
+		}
+
+		&:disabled,
+		&:disabled:active:enabled,
+		&[aria-disabled=true],
+		&[aria-disabled=true]:active:enabled {
+			background: $light-gray-100;
+			border-color: $light-gray-500;
+			color: $light-gray-900;
+
+			&:hover {
+				background: $light-gray-100;
+				border-color: $light-gray-500;
+				color: $light-gray-900;
+			}
 		}
 	}
 
 	&.is-tertiary {
 		background: $light-gray-300;
 		border: 1px solid $light-gray-500;
-		border-radius: 3px;
 		color: $dark-gray-600;
-		height: auto;
-		line-height: 24px;
-		padding: 11px 24px;
-		transition: background 125ms ease-in-out, border-color 125ms ease-in-out, box-shadow 125ms ease-in-out, color 125ms ease-in-out;
 
 		&:active,
 		&:active:enabled,
@@ -161,27 +151,26 @@
 			}
 		}
 
-		&.is-small {
-			padding: 3px 12px;
-		}
-
 		.newspack-is-waiting {
 			fill: $dark-gray-600;
 		}
 	}
 
 	&.is-link {
+		background: none;
 		border: 0;
 		border-radius: 0;
 		color: $primary-500;
 		font-weight: normal;
+		padding: 0;
 		transition: color 125ms ease-in-out, outline 125ms ease-in-out;
 
 		&:active,
 		&:active:enabled,
 		&:focus,
 		&:focus:enabled,
-		&:hover {
+		&:hover,
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 			background: transparent;
 			color: $primary-600;
 			text-decoration: none;

--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -44,7 +44,8 @@
 			display: block;
 		}
 
-		.components-icon-button {
+		.components-button.has-icon {
+			height: auto;
 			left: auto;
 			padding: 12px;
 			position: absolute;

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -30,7 +30,7 @@
 		display: none;
 	}
 
-	.is-button,
+	.newspack-button,
 	p {
 		margin: 8px;
 	}

--- a/assets/components/src/wizard-pagination/style.scss
+++ b/assets/components/src/wizard-pagination/style.scss
@@ -26,15 +26,18 @@
 	}
 
 	.newspack-wizard-pagination__pagination,
-	.newspack-button {
+	.newspack-button.is-link {
 		color: inherit;
 		padding: 16px;
 	}
 
-	.newspack-button {
+	.newspack-button.is-link {
 		&:active,
+		&:active:enabled,
 		&:focus,
-		&:hover {
+		&:focus:enabled,
+		&:hover,
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 			color: $primary-200;
 		}
 

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -136,27 +136,27 @@ class AdvertisingWizard extends Component {
 	}
 
 	/**
-	 * Update header code.
+	 * Update GAM Network Code.
 	 */
-	updateHeaderCode = ( code, service ) => {
+	updateNetworkCode = ( code, service ) => {
 		const { advertisingData } = this.state;
-		advertisingData.services[ service ].header_code = code;
+		advertisingData.services[ service ].network_code = code;
 		this.setState( { advertisingData } );
 	};
 
 	/**
-	 * Save header code.
+	 * Save Network Code.
 	 */
-	saveHeaderCode = service => {
+	saveNetworkCode = service => {
 		const { setError, wizardApiFetch } = this.props;
 		const { advertisingData } = this.state;
-		const header_code = advertisingData.services[ service ].header_code;
+		const network_code = advertisingData.services[ service ].network_code;
 		return new Promise( ( resolve, reject ) => {
 			wizardApiFetch( {
-				path: '/newspack/v1/wizard/advertising/service/' + service + '/header_code',
+				path: '/newspack/v1/wizard/advertising/service/' + service + '/network_code',
 				method: 'post',
 				data: {
-					header_code,
+					network_code,
 				},
 			} )
 				.then( advertisingData => {
@@ -223,12 +223,12 @@ class AdvertisingWizard extends Component {
 		const { setError, wizardApiFetch } = this.props;
 		const { adUnits } = this.state.advertisingData;
 		const adUnit = adUnits[ id ];
-		const { name, ad_code, amp_ad_code, ad_service } = adUnit;
+		const { name, code, sizes, ad_service } = adUnit;
 		const data = {
 			id,
+			code,
 			name,
-			ad_code,
-			amp_ad_code,
+			sizes,
 			ad_service,
 		};
 		return new Promise( ( resolve, reject ) => {
@@ -390,13 +390,13 @@ class AdvertisingWizard extends Component {
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									adUnits={ adUnits }
-									code={ advertisingData.services.google_ad_manager.header_code }
+									code={ advertisingData.services.google_ad_manager.network_code }
 									tabbedNavigation={ gam_tabs }
 									service={ 'google_ad_manager' }
-									onChange={ value => this.updateHeaderCode( value, 'google_ad_manager' ) }
+									onChange={ value => this.updateNetworkCode( value, 'google_ad_manager' ) }
 									buttonText={ __( 'Save' ) }
 									buttonAction={ () =>
-										this.saveHeaderCode( 'google_ad_manager' ).then( response =>
+										this.saveNetworkCode( 'google_ad_manager' ).then( response =>
 											routeProps.history.push( '/google_ad_manager' )
 										)
 									}
@@ -419,8 +419,8 @@ class AdvertisingWizard extends Component {
 											adUnits[ 0 ] || {
 												id: 0,
 												name: '',
-												ad_code: '',
-												amp_ad_code: '',
+												code: '',
+												sizes: [],
 											}
 										}
 										service={ 'google_ad_manager' }

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -420,7 +420,7 @@ class AdvertisingWizard extends Component {
 												id: 0,
 												name: '',
 												code: '',
-												sizes: [],
+												sizes: [ [ 120, 120 ] ],
 											}
 										}
 										service={ 'google_ad_manager' }

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -376,7 +376,7 @@ class AdvertisingWizard extends Component {
 									onDelete={ id => this.deleteAdUnit( id ) }
 									buttonText={ __( 'Add an individual ad unit' ) }
 									buttonAction="#/google_ad_manager/create"
-									secondaryButtonText={ __( 'Back to advertising options' ) }
+									secondaryButtonText={ __( "Back to advertising options" ) }
 									secondaryButtonAction="#/"
 								/>
 							) }
@@ -400,6 +400,8 @@ class AdvertisingWizard extends Component {
 											routeProps.history.push( '/google_ad_manager' )
 										)
 									}
+									secondaryButtonText={ __( "I'm done configuring ads" ) }
+									secondaryButtonAction="#/google_ad_manager"
 								/>
 							) }
 						/>

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -376,7 +376,7 @@ class AdvertisingWizard extends Component {
 									onDelete={ id => this.deleteAdUnit( id ) }
 									buttonText={ __( 'Add an individual ad unit' ) }
 									buttonAction="#/google_ad_manager/create"
-									secondaryButtonText={ __( "Back to advertising options" ) }
+									secondaryButtonText={ __( 'Back to advertising options' ) }
 									secondaryButtonAction="#/"
 								/>
 							) }
@@ -400,8 +400,6 @@ class AdvertisingWizard extends Component {
 											routeProps.history.push( '/google_ad_manager' )
 										)
 									}
-									secondaryButtonText={ __( "I'm done configuring ads" ) }
-									secondaryButtonAction="#/google_ad_manager"
 								/>
 							) }
 						/>

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -75,15 +75,17 @@ class AdUnit extends Component {
 								this.handleOnChange( 'sizes', sizes );
 							} }
 						/>
-						<Button
-							isTertiary
-							onClick={ () => {
-								sizes.splice( index, 1 );
-								this.handleOnChange( 'sizes', sizes );
-							} }
-						>
-							<DeleteIcon />
-						</Button>
+						{ sizes.length > 1 && (
+							<Button
+								isTertiary
+								onClick={ () => {
+									sizes.splice( index, 1 );
+									this.handleOnChange( 'sizes', sizes );
+								} }
+							>
+								<DeleteIcon />
+							</Button>
+						) }
 					</div>
 				) ) }
 				<Button

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -7,11 +7,13 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import DeleteIcon from '@material-ui/icons/Delete';
 
 /**
  * Internal dependencies
  */
-import { Button, Card, TextControl, TextareaControl, withWizardScreen } from '../../../../components/src';
+import { Button, Card, TextControl, withWizardScreen } from '../../../../components/src';
+import './style.scss';
 
 /**
  * New/Edit Ad Unit Screen.
@@ -34,7 +36,8 @@ class AdUnit extends Component {
 	 */
 	render() {
 		const { adUnit, onSave, service } = this.props;
-		const { id, name, ad_code, amp_ad_code } = adUnit;
+		const { id, code, name } = adUnit;
+		const sizes = adUnit.sizes && Array.isArray( adUnit.sizes ) ? adUnit.sizes : [];
 		return (
 			<Fragment>
 				<TextControl
@@ -42,18 +45,46 @@ class AdUnit extends Component {
 					value={ name || '' }
 					onChange={ value => this.handleOnChange( 'name', value ) }
 				/>
-				<TextareaControl
-					label={ __( 'Paste the AMP ad code from Ad Manager here.' ) }
-					value={ amp_ad_code || '' }
-					placeholder={ __( 'AMP Ad code' ) }
-					onChange={ value => this.handleOnChange( 'amp_ad_code', value ) }
+				<TextControl
+					label={ __( 'Ad unit code' ) }
+					value={ code || '' }
+					onChange={ value => this.handleOnChange( 'code', value ) }
 				/>
-				<TextareaControl
-					label={ __( 'Paste the HTML ad code from Ad Manager here.' ) }
-					placeholder={ __( 'HTML Ad code' ) }
-					value={ ad_code || '' }
-					onChange={ value => this.handleOnChange( 'ad_code', value ) }
-				/>
+				{ sizes.map( ( size, index ) => (
+					<div className="newspack_ad_unit__sizes">
+						<TextControl
+							label={ __( 'Width' ) }
+							value={ size[ 0 ] }
+							onChange={ value => {
+								sizes[ index ][ 0 ] = value;
+								this.handleOnChange( 'sizes', sizes );
+							} }
+						/>
+						<TextControl
+							label={ __( 'Height' ) }
+							value={ size[ 1 ] }
+							onChange={ value => {
+								sizes[ index ][ 1 ] = value;
+								this.handleOnChange( 'sizes', sizes );
+							} }
+						/>
+						<Button
+							isSmall
+							onClick={ () => {
+								sizes.splice( index, 1 );
+								this.handleOnChange( 'sizes', sizes );
+							} }
+						>
+							<DeleteIcon />
+						</Button>
+					</div>
+				) ) }
+				<Button
+					isPrimary
+					onClick={ () => this.handleOnChange( 'sizes', [ ...sizes, [ 120, 120 ] ] ) }
+				>
+					{ __( 'Add Size', 'newspack' ) }
+				</Button>
 				<div className="newspack-buttons-card">
 					<Button isPrimary onClick={ () => onSave( id ) }>
 						{ __( 'Save' ) }

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -1,16 +1,21 @@
 /**
- * New/Edit Ad Unit Screen.
+ * New/Edit Ad Unit Screen
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import DeleteIcon from '@material-ui/icons/Delete';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
+ */
+import DeleteIcon from '@material-ui/icons/Delete';
+import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
+
+/**
+ * Internal dependencies.
  */
 import { Button, Card, TextControl, withWizardScreen } from '../../../../components/src';
 import './style.scss';
@@ -69,7 +74,7 @@ class AdUnit extends Component {
 							} }
 						/>
 						<Button
-							isSmall
+							isTertiary
 							onClick={ () => {
 								sizes.splice( index, 1 );
 								this.handleOnChange( 'sizes', sizes );
@@ -80,11 +85,14 @@ class AdUnit extends Component {
 					</div>
 				) ) }
 				<Button
-					isPrimary
+					isTertiary
+					className="newspack-button__add-size"
 					onClick={ () => this.handleOnChange( 'sizes', [ ...sizes, [ 120, 120 ] ] ) }
 				>
+					<LibraryAddIcon />
 					{ __( 'Add Size', 'newspack' ) }
 				</Button>
+				<div className="clear"></div>
 				<div className="newspack-buttons-card">
 					<Button isPrimary onClick={ () => onSave( id ) }>
 						{ __( 'Save' ) }

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -42,7 +42,7 @@ class AdUnit extends Component {
 	render() {
 		const { adUnit, onSave, service } = this.props;
 		const { id, code, name } = adUnit;
-		const sizes = adUnit.sizes && Array.isArray( adUnit.sizes ) ? adUnit.sizes : [];
+		const sizes = adUnit.sizes && Array.isArray( adUnit.sizes ) ? adUnit.sizes : [ [ 120, 120 ] ];
 		return (
 			<Fragment>
 				<TextControl

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -60,6 +60,7 @@ class AdUnit extends Component {
 						<TextControl
 							label={ __( 'Width' ) }
 							value={ size[ 0 ] }
+							type="number"
 							onChange={ value => {
 								sizes[ index ][ 0 ] = value;
 								this.handleOnChange( 'sizes', sizes );
@@ -68,6 +69,7 @@ class AdUnit extends Component {
 						<TextControl
 							label={ __( 'Height' ) }
 							value={ size[ 1 ] }
+							type="number"
 							onChange={ value => {
 								sizes[ index ][ 1 ] = value;
 								this.handleOnChange( 'sizes', sizes );
@@ -92,7 +94,7 @@ class AdUnit extends Component {
 					<LibraryAddIcon />
 					{ __( 'Add Size', 'newspack' ) }
 				</Button>
-				<div className="clear"></div>
+				<div className="clear" />
 				<div className="newspack-buttons-card">
 					<Button isPrimary onClick={ () => onSave( id ) }>
 						{ __( 'Save' ) }

--- a/assets/wizards/advertising/views/ad-unit/style.scss
+++ b/assets/wizards/advertising/views/ad-unit/style.scss
@@ -1,18 +1,66 @@
+/**
+ * Ad Unit
+ */
+
+@import '~@wordpress/base-styles/colors';
+
 .newspack_ad_unit__sizes {
+	border-bottom: 1px solid $light-gray-200;
+
 	@media screen and ( min-width: 744px ) {
+		align-items: flex-end;
 		display: flex;
 		justify-content: space-between;
 		width: 100%;
 	}
 
 	.newspack-text-control {
-		margin: 16px 16px 16px 0;
-		&:last-of-type {
-			margin-right: 0;
-		}
+		margin: 16px 0;
+
 		@media screen and ( min-width: 744px ) {
+			margin-right: 16px;
 			width: 48%;
 			width: calc( 50% - 8px );
+
+			&:last-of-type {
+				margin-right: 0;
+			}
 		}
 	}
+
+	.newspack-button {
+		align-items: center;
+		flex: 0 0 auto;
+		height: 48px;
+		justify-content: center;
+		margin-bottom: 16px;
+		padding: 0;
+		width: 48px;
+
+		@media screen and ( min-width: 744px ) {
+			margin-left: 16px;
+		}
+	}
+
+	.newspack-text-control + & {
+		border-top: 1px solid $light-gray-200;
+	}
+
+	& + .newspack-button {
+		margin-top: 16px;
+	}
+}
+
+.newspack-button__add-size {
+	@media screen and ( min-width: 744px ) {
+		float: right;
+	}
+
+	svg {
+		margin-right: 4px;
+	}
+}
+
+.newspack-buttons-card {
+	margin-top: 48px;
 }

--- a/assets/wizards/advertising/views/ad-unit/style.scss
+++ b/assets/wizards/advertising/views/ad-unit/style.scss
@@ -1,0 +1,18 @@
+.newspack_ad_unit__sizes {
+	@media screen and ( min-width: 744px ) {
+		display: flex;
+		justify-content: space-between;
+		width: 100%;
+	}
+
+	.newspack-text-control {
+		margin: 16px 16px 16px 0;
+		&:last-of-type {
+			margin-right: 0;
+		}
+		@media screen and ( min-width: 744px ) {
+			width: 48%;
+			width: calc( 50% - 8px );
+		}
+	}
+}

--- a/assets/wizards/advertising/views/adsense/index.js
+++ b/assets/wizards/advertising/views/adsense/index.js
@@ -7,7 +7,6 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/assets/wizards/advertising/views/header-code/index.js
+++ b/assets/wizards/advertising/views/header-code/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Button, Card, TextareaControl, withWizardScreen } from '../../../../components/src';
+import { Button, Card, TextControl, withWizardScreen } from '../../../../components/src';
 
 /**
  * New/Edit Ad Unit Screen.
@@ -38,11 +38,9 @@ class HeaderCode extends Component {
 		const { onChange, code, service } = this.props;
 		return (
 			<Fragment>
-				<TextareaControl
-					label={ __(
-						'If the ad service requires to render a global ad code on every page, paste it here.'
-					) }
-					placeholder={ __( 'Header Ad Code' ) }
+				<TextControl
+					label={ __( 'Google Ad Manager Network Code', 'newspack' ) }
+					placeholder={ __( '123456789' ) }
 					value={ code }
 					onChange={ onChange }
 				/>

--- a/assets/wizards/engagement/views/commenting/index.js
+++ b/assets/wizards/engagement/views/commenting/index.js
@@ -12,7 +12,7 @@ import { ExternalLink } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { Card, Button, withWizardScreen } from '../../../../components/src';
+import { Card, Button, Notice, withWizardScreen } from '../../../../components/src';
 
 /**
  * Commenting Screen
@@ -35,12 +35,7 @@ class Commenting extends Component {
 						</p>
 					) }
 					{ !! connected && (
-						<p className="newspack-newsletter-block-wizard__jetpack-success">
-							<Dashicon icon="yes-alt" />
-							{ __(
-								'You can insert newsletter sign up forms in your content using the Mailchimp block.'
-							) }
-						</p>
+						<Notice noticeText={ __( 'You can insert newsletter sign up forms in your content using the Mailchimp block.' ) } isSuccess />
 					) }
 					<p>
 						{ __(

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -7,12 +7,12 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Dashicon, ExternalLink } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { Card, TextControl, PluginInstaller, withWizardScreen } from '../../../../components/src';
+import { Card, Notice, TextControl, PluginInstaller, withWizardScreen } from '../../../../components/src';
 
 /**
  * Initial connection to Mailchimp.
@@ -40,12 +40,7 @@ class Newsletters extends Component {
 					</p>
 				) }
 				{ !! connected && (
-					<p className="newspack-newsletter-block-wizard__jetpack-success">
-						<Dashicon icon="yes-alt" />
-						{ __(
-							'You can insert newsletter sign up forms in your content using the Mailchimp block.'
-						) }
-					</p>
+					<Notice noticeText={ __( 'You can insert newsletter sign up forms in your content using the Mailchimp block.' ) } isSuccess />
 				) }
 				<p className="wpcom-link">
 					<ExternalLink href={ connectURL }>

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -299,6 +299,14 @@ class Plugin_Manager {
 					'class_name' => 'LaterPay_Configuration_Manager',
 				],
 			],
+			'organic-profile-block'         => [
+				'Name'        => 'Organic Profile Block',
+				'Description' => "The Profile Block is created for the Gutenberg content editor. It displays a profile section with an image, name, subtitle, bio and personal social media links. It's perfect for author biographies, personal profiles, or staff pages.",
+				'Author'      => 'Organic Themes',
+				'PluginURI'   => 'https://organicthemes.com/',
+				'AuthorURI'   => 'https://organicthemes.com/',
+				'Download'    => 'wporg',
+			],
 		];
 
 		$default_info = [

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -299,6 +299,14 @@ class Plugin_Manager {
 					'class_name' => 'LaterPay_Configuration_Manager',
 				],
 			],
+			'newspack-supporters'           => [
+				'Name'        => 'Newspack Supporters',
+				'Description' => 'Manage and display your site\'s supporters.',
+				'Author'      => 'Automattic',
+				'PluginURI'   => 'https://newspack.blog',
+				'AuthorURI'   => 'https://automattic.com',
+				'Download'    => 'https://github.com/Automattic/newspack-supporters/releases/latest/download/newspack-supporters.zip',
+			],
 			'organic-profile-block'         => [
 				'Name'        => 'Organic Profile Block',
 				'Description' => "The Profile Block is created for the Gutenberg content editor. It displays a profile section with an image, name, subtitle, bio and personal social media links. It's perfect for author biographies, personal profiles, or staff pages.",

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -33,14 +33,14 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
-	 * Get header code for ad service.
+	 * Get Network Code for ad service.
 	 *
 	 * @param string $service The service to retrieve.
 	 * @return string | WP_Error Array of ad units or WP_Error if Newspack Ads isn't installed and activated.
 	 */
-	public function get_header_code( $service ) {
+	public function get_network_code( $service ) {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::get_header_code( $service ) :
+			\Newspack_Ads_Model::get_network_code( $service ) :
 			$this->unconfigured_error();
 	}
 
@@ -48,12 +48,12 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 * Create/update header code for ad service.
 	 *
 	 * @param string $service The service to retrieve.
-	 * @param string $header_code The code.
+	 * @param string $network_code The code.
 	 * @return bool | WP_Error Array of ad units or WP_Error if Newspack Ads isn't installed and activated.
 	 */
-	public function set_header_code( $service, $header_code ) {
+	public function set_network_code( $service, $network_code ) {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::set_header_code( $service, $header_code ) :
+			\Newspack_Ads_Model::set_network_code( $service, $network_code ) :
 			$this->unconfigured_error();
 	}
 

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -116,17 +116,17 @@ class Advertising_Wizard extends Wizard {
 		// Update header code.
 		register_rest_route(
 			'newspack/v1/wizard/',
-			'/advertising/service/(?P<service>[\a-z]+)/header_code',
+			'/advertising/service/(?P<service>[\a-z]+)/network_code',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_update_header_code' ],
-				'permission_callback' => [ $this, 'api_permissions_check_unfiltered_html' ],
+				'callback'            => [ $this, 'api_update_network_code' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'service'     => [
+					'service'      => [
 						'sanitize_callback' => [ $this, 'sanitize_service' ],
 					],
-					'header_code' => [
-						// 'sanitize_callback' => 'esc_js', @todo If a `script` tag goes here, esc_js is the wrong function to use.
+					'network_code' => [
+						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
 			]
@@ -159,25 +159,6 @@ class Advertising_Wizard extends Wizard {
 				'args'                => [
 					'service' => [
 						'sanitize_callback' => [ $this, 'sanitize_service' ],
-					],
-				],
-			]
-		);
-
-		// Update header code.
-		register_rest_route(
-			'newspack/v1/wizard/',
-			'/advertising/service/(?P<service>[\a-z]+)/header_code',
-			[
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_update_header_code' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'service'     => [
-						'sanitize_callback' => [ $this, 'sanitize_service' ],
-					],
-					'header_code' => [
-						// 'sanitize_callback' => 'esc_js', @todo If a `script` tag goes here, esc_js is the wrong function to use.
 					],
 				],
 			]
@@ -222,22 +203,24 @@ class Advertising_Wizard extends Wizard {
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_adunit' ],
-				'permission_callback' => [ $this, 'api_permissions_check_unfiltered_html' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'id'          => [
+					'id'         => [
 						'sanitize_callback' => 'absint',
 					],
-					'name'        => [
+					'name'       => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'code'       => [
 						'sanitize_callback' => 'sanitize_text_field',
 						'validate_callback' => [ $this, 'api_validate_not_empty' ],
 					],
-					'ad_code'     => [
-						// 'sanitize_callback' => 'esc_js', @todo If a `script` tag goes here, esc_js is the wrong function to use.
+					'sizes'      => [
+						// 'sanitize_callback' => 'sanitize_text_field', TODO: Correct sanitization for this field.
 					],
-					'amp_ad_code' => [
-						// 'sanitize_callback' => 'esc_js', @todo If a `script` tag goes here, esc_js is the wrong function to use.
+					'ad_service' => [
+						'sanitize_callback' => 'sanitize_text_field',
 					],
-					'ad_service'  => [],
 				],
 			]
 		);
@@ -249,7 +232,7 @@ class Advertising_Wizard extends Wizard {
 			[
 				'methods'             => 'DELETE',
 				'callback'            => [ $this, 'api_delete_adunit' ],
-				'permission_callback' => [ $this, 'api_permissions_check_unfiltered_html' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
 					'id' => [
 						'sanitize_callback' => 'absint',
@@ -357,11 +340,11 @@ class Advertising_Wizard extends Wizard {
 
 		$params = $request->get_params();
 		$adunit = [
-			'id'          => 0,
-			'name'        => '',
-			'ad_code'     => '',
-			'amp_ad_code' => '',
-			'ad_service'  => '',
+			'id'         => 0,
+			'code'       => '',
+			'name'       => '',
+			'sizes'      => [],
+			'ad_service' => '',
 		];
 		$args   = \wp_parse_args( $params, $adunit );
 		// Update and existing or add a new ad unit.
@@ -395,12 +378,12 @@ class Advertising_Wizard extends Wizard {
 	 * @param WP_REST_Request $request Request with ID of ad unit to delete.
 	 * @return WP_REST_Response Boolean Delete success.
 	 */
-	public function api_update_header_code( $request ) {
+	public function api_update_network_code( $request ) {
 		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
 
-		$service     = $request['service'];
-		$header_code = $request['header_code'];
-		$configuration_manager->set_header_code( $service, $header_code );
+		$service      = $request['service'];
+		$network_code = $request['network_code'];
+		$configuration_manager->set_network_code( $service, $network_code );
 
 		return \rest_ensure_response( $this->retrieve_data() );
 	}
@@ -449,9 +432,9 @@ class Advertising_Wizard extends Wizard {
 		$services = array();
 		foreach ( $this->services as $service => $data ) {
 			$services[ $service ] = array(
-				'label'       => $data['label'],
-				'enabled'     => get_option( self::NEWSPACK_ADVERTISING_SERVICE_PREFIX . $service, '' ),
-				'header_code' => $configuration_manager->get_header_code( $service ),
+				'label'        => $data['label'],
+				'enabled'      => get_option( self::NEWSPACK_ADVERTISING_SERVICE_PREFIX . $service, '' ),
+				'network_code' => $configuration_manager->get_network_code( $service ),
 			);
 		}
 		/* Check availability of WordAds based on current Jetpack plan */

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -216,7 +216,7 @@ class Advertising_Wizard extends Wizard {
 						'validate_callback' => [ $this, 'api_validate_not_empty' ],
 					],
 					'sizes'      => [
-						// 'sanitize_callback' => 'sanitize_text_field', TODO: Correct sanitization for this field.
+						'sanitize_callback' => [ $this, 'sanitize_sizes' ],
 					],
 					'ad_service' => [
 						'sanitize_callback' => 'sanitize_text_field',
@@ -594,5 +594,24 @@ class Advertising_Wizard extends Wizard {
 		);
 		\wp_style_add_data( 'newspack-advertising-wizard', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-advertising-wizard' );
+	}
+
+	/**
+	 * Sanitize array of ad unit sizes.
+	 *
+	 * @param array $sizes Array of sizes to sanitize.
+	 * @return array Sanitized array.
+	 */
+	public static function sanitize_sizes( $sizes ) {
+		$sizes     = is_array( $sizes ) ? $sizes : [];
+		$sanitized = [];
+		foreach ( $sizes as $size ) {
+			$size    = is_array( $size ) && 2 === count( $size ) ? $size : [ 0, 0 ];
+			$size[0] = absint( $size[0] );
+			$size[1] = absint( $size[1] );
+
+			$sanitized[] = $size;
+		}
+		return $sanitized;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR needs to be tested in tandem with https://github.com/Automattic/newspack-ads/pull/15. The two together bring a number of improvements to the Google Ad Manager integration. 

- Users no longer need to copy and paste raw code from the GAM dashboard, which was an awkward and tedious task.
- There is no longer a requirement that the user have the `unfiltered_html` capabilitiy.
- The risk of breaking a site by pasting slightly incorrect code is now removed.
- These changes pave the way for future iterations where Newspack synchronizes programmatically with a Google Ad Manager account.
- Users can now assign multiple sizes to a single Ad Unit.
- There's now a Widget. Ad Units can be placed in three ways: 1) pre-defined ad placements, 2) Gutenberg block, 3) Widget.

Ideally testing takes place with a Google Ad Manager account, but as an alternative @philipjohn has provided many sample GAM codes in pamTN9-kv-p2. This new work makes no attempt to convert old ad units and header code, so it's probably best to clear old material out and start fresh.

@thomasguillot, the multiple size interface is new UI and could use some finesse.

### How to test the changes in this Pull Request:

1. Navigate to Newspack->Advertising, switch on Google Ad Manager. Click "Configure," then the "Global Code" tab. Here you enter the Network Code, which can be found in the upper left of the GAM dashboard. It is also the first path component of all slots in the sample codes. 
2. Click the "Individual Ad Units" tab, and click "Add." 
3. "Ad Unit Name" is purely a label, it is never used in code. If this is left blank, the value of "Ad Unit Code" will be used for both.
4. "Ad Unit Code" is the machine-readable (slug-like) version of the Ad Unit title that GAM generates. You can get this code in the GAM dashboard by navigating to Inventory->Ad Units, clicking on any unit's title, and locating the "Code" field. In the sample code, this is the second path component in any slot definition.
5. Next click to add a size, which reveals a Width/Height pair. Enter values for both. Try adding multiples sizes, and try deleting some. Verify all of this UI behaves as expected, and that values are saved properly.
6. Try a Pre-defined ad placement. Navigate back to the front page of the Advertising Wizard then click the "Global Settings" tab. Toggle on one of the regions, set Ad Provider to Google Ad Manager, and select one of the Ad Units.
7. Verify the unit appears on published pages in both AMP and non-AMP requests.
8. Try the Gutenberg block. Edit a post, add the "Ad Unit" block. Select an ad unit, and verify that the block resizes to the unit's size (if the unit has multiple sizes, the first one will be used).
9. Publish and view the page, and verify the unit appears in AMP and non-AMP requests.
10. Try the Widget. Navigate to Appearance->Wizards, and add the Newspack Ad Unit Widget to a sidebar. Select an Ad Unit, and verify the unit appears in both AMP and non-AMP requests.
11. Probably wise to test with multiple units, deployed in different ways. Also, try some Ad Units with multiple sizes and some with only one.

### Screenshots

<img width="1541" alt="Screen Shot 2020-01-09 at 11 07 38 PM" src="https://user-images.githubusercontent.com/1477002/72125015-e87c5600-3334-11ea-8a1d-336a499e25ca.png">
<img width="1541" alt="Screen Shot 2020-01-09 at 11 07 59 PM" src="https://user-images.githubusercontent.com/1477002/72125018-eb774680-3334-11ea-80b2-a3ee27181f22.png">
<img width="1541" alt="Screen Shot 2020-01-09 at 11 08 50 PM" src="https://user-images.githubusercontent.com/1477002/72125042-0649bb00-3335-11ea-9651-293fbc92f693.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->