### PR TITLE
Button: Fix style missing since Gutenberg 7.2.0

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -6,9 +6,13 @@
 @import '~@wordpress/base-styles/colors';
 
 .newspack-button {
+	border-radius: 3px;
 	font-size: 14px;
 	font-weight: bold;
+	height: auto;
 	line-height: 24px;
+	padding: 11px 24px;
+	transition: background 125ms ease-in-out, border-color 125ms ease-in-out, box-shadow 125ms ease-in-out, color 125ms ease-in-out;
 
 	&.is-large {
 		font-size: 17px;
@@ -23,56 +27,12 @@
 		padding: 3px 12px;
 	}
 
-	&.is-button {
-		background: white;
-		border: 1px solid $light-gray-500;
-		border-radius: 3px;
-		color: $primary-500;
-		height: auto;
-		line-height: 24px;
-		padding: 11px 24px;
-		transition: background 125ms ease-in-out, border-color 125ms ease-in-out, box-shadow 125ms ease-in-out, color 125ms ease-in-out;
-
-		&:active,
-		&:active:enabled,
-		&:focus,
-		&:focus:enabled,
-		&:hover {
-			background: $light-gray-100;
-			border-color: $primary-500;
-			color: $primary-500;
-		}
-
-		&:focus,
-		&:focus:enabled {
-			border-color: $primary-600;
-			box-shadow: 0 0 0 2px $primary-500;
-		}
-
-		&:disabled,
-		&:disabled:active:enabled,
-		&[aria-disabled=true],
-		&[aria-disabled=true]:active:enabled {
-			background: $light-gray-100;
-			border-color: $light-gray-500;
-			color: $light-gray-900;
-			cursor: not-allowed;
-			text-shadow: none;
-
-			&:hover {
-				background: $light-gray-100;
-				border-color: $light-gray-500;
-				color: $light-gray-900;
-			}
-		}
-
-		&.is-small {
-			padding: 3px 12px;
-		}
-
-		&.is-large {
-			padding: 15px 32px;
-		}
+	&:disabled,
+	&:disabled:active:enabled,
+	&[aria-disabled=true],
+	&[aria-disabled=true]:active:enabled {
+		cursor: not-allowed;
+		text-shadow: none;
 	}
 
 	&.is-primary {
@@ -84,7 +44,8 @@
 		&:active:enabled,
 		&:focus,
 		&:focus:enabled,
-		&:hover {
+		&:hover,
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 			background: $primary-600;
 			border-color: $primary-700;
 			color: white;
@@ -110,24 +71,53 @@
 			}
 		}
 
-		&.is-small {
-			padding: 3px 12px;
-		}
-
 		.newspack-is-waiting {
 			fill: white;
+		}
+	}
+
+	&.is-secondary {
+		background: white;
+		border: 1px solid $light-gray-500;
+		color: $primary-500;
+
+		&:active,
+		&:active:enabled,
+		&:focus,
+		&:focus:enabled,
+		&:hover,
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
+			background: $light-gray-100;
+			border-color: $primary-500;
+			color: $primary-500;
+		}
+
+		&:focus,
+		&:focus:enabled {
+			border-color: $primary-600;
+			box-shadow: 0 0 0 2px $primary-500;
+		}
+
+		&:disabled,
+		&:disabled:active:enabled,
+		&[aria-disabled=true],
+		&[aria-disabled=true]:active:enabled {
+			background: $light-gray-100;
+			border-color: $light-gray-500;
+			color: $light-gray-900;
+
+			&:hover {
+				background: $light-gray-100;
+				border-color: $light-gray-500;
+				color: $light-gray-900;
+			}
 		}
 	}
 
 	&.is-tertiary {
 		background: $light-gray-300;
 		border: 1px solid $light-gray-500;
-		border-radius: 3px;
 		color: $dark-gray-600;
-		height: auto;
-		line-height: 24px;
-		padding: 11px 24px;
-		transition: background 125ms ease-in-out, border-color 125ms ease-in-out, box-shadow 125ms ease-in-out, color 125ms ease-in-out;
 
 		&:active,
 		&:active:enabled,
@@ -161,27 +151,26 @@
 			}
 		}
 
-		&.is-small {
-			padding: 3px 12px;
-		}
-
 		.newspack-is-waiting {
 			fill: $dark-gray-600;
 		}
 	}
 
 	&.is-link {
+		background: none;
 		border: 0;
 		border-radius: 0;
 		color: $primary-500;
 		font-weight: normal;
+		padding: 0;
 		transition: color 125ms ease-in-out, outline 125ms ease-in-out;
 
 		&:active,
 		&:active:enabled,
 		&:focus,
 		&:focus:enabled,
-		&:hover {
+		&:hover,
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 			background: transparent;
 			color: $primary-600;
 			text-decoration: none;

--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -44,7 +44,8 @@
 			display: block;
 		}
 
-		.components-icon-button {
+		.components-button.has-icon {
+			height: auto;
 			left: auto;
 			padding: 12px;
 			position: absolute;

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -30,7 +30,7 @@
 		display: none;
 	}
 
-	.is-button,
+	.newspack-button,
 	p {
 		margin: 8px;
 	}

--- a/assets/components/src/wizard-pagination/style.scss
+++ b/assets/components/src/wizard-pagination/style.scss
@@ -26,15 +26,18 @@
 	}
 
 	.newspack-wizard-pagination__pagination,
-	.newspack-button {
+	.newspack-button.is-link {
 		color: inherit;
 		padding: 16px;
 	}
 
-	.newspack-button {
+	.newspack-button.is-link {
 		&:active,
+		&:active:enabled,
 		&:focus,
-		&:hover {
+		&:focus:enabled,
+		&:hover,
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 			color: $primary-200;
 		}
 


### PR DESCRIPTION
#314 # All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since Gutenberg 7.2.0, our Buttons are now "broken":

* Gutenberg removed the use of `is-button`
* Gutenberg added `is-secondary`
* Gutenberg added extra hover check (`&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover)
* Gutenberg removed `components-icon-button` in Modal

This PR fixes it.

Question: What shall we do regarding backward compatibility?

### How to test the changes in this Pull Request:

1. Make sure you have the latest version of Gutenberg (7.2.0)
2. Check the plugin and notice the buttons, they should look smaller and hover shouldn't display the correct color.
3. Disable Gutenberg and check again... it should look fine.
4. Switch to this branch and re-enable Gutenberg
5. Check the plugin again. It should look like step 3, aka fine.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->