### PR TITLE
Remove Dashicon component in Action Card and Wizards Screens

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -6,7 +6,6 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Dashicon } from '@wordpress/components';
 import { Button, Card, Handoff, Notice, ToggleControl, Waiting } from '../';
 
 /**
@@ -55,7 +54,6 @@ class ActionCard extends Component {
 			className
 		);
 		const hasSecondaryAction = secondaryActionText && onSecondaryActionClick;
-		const actionDisplay = ( simple && <Dashicon icon="arrow-right-alt2" /> ) || actionText;
 		return (
 			<Card className={ classes } onClick={ simple && onClick }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
@@ -79,11 +77,11 @@ class ActionCard extends Component {
 						</h2>
 						<p>{ description }</p>
 					</div>
-					{ actionDisplay && (
+					{ actionText && (
 						<div className="newspack-action-card__region newspack-action-card__region-right">
 							{ handoff && (
 								<Handoff plugin={ handoff } editLink={ editLink } compact isLink>
-									{ actionDisplay }
+									{ actionText }
 								</Handoff>
 							) }
 							{ ( !! onClick || !! href ) && ! handoff && (
@@ -93,12 +91,12 @@ class ActionCard extends Component {
 									onClick={ onClick }
 									className="newspack-action-card__primary_button"
 								>
-									{ actionDisplay }
+									{ actionText }
 								</Button>
 							) }
 							{ ! handoff && ! onClick && ! href && (
 								<div className="newspack-action-card__container">
-									{ actionDisplay }
+									{ actionText }
 									{ isWaiting && <Waiting isRight /> }
 								</div>
 							) }

--- a/assets/wizards/advertising/views/adsense/index.js
+++ b/assets/wizards/advertising/views/adsense/index.js
@@ -7,7 +7,6 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/assets/wizards/engagement/views/commenting/index.js
+++ b/assets/wizards/engagement/views/commenting/index.js
@@ -12,7 +12,7 @@ import { ExternalLink } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { Card, Button, withWizardScreen } from '../../../../components/src';
+import { Card, Button, Notice, withWizardScreen } from '../../../../components/src';
 
 /**
  * Commenting Screen
@@ -35,12 +35,7 @@ class Commenting extends Component {
 						</p>
 					) }
 					{ !! connected && (
-						<p className="newspack-newsletter-block-wizard__jetpack-success">
-							<Dashicon icon="yes-alt" />
-							{ __(
-								'You can insert newsletter sign up forms in your content using the Mailchimp block.'
-							) }
-						</p>
+						<Notice noticeText={ __( 'You can insert newsletter sign up forms in your content using the Mailchimp block.' ) } isSuccess />
 					) }
 					<p>
 						{ __(

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -7,12 +7,12 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Dashicon, ExternalLink } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { Card, TextControl, PluginInstaller, withWizardScreen } from '../../../../components/src';
+import { Card, Notice, TextControl, PluginInstaller, withWizardScreen } from '../../../../components/src';
 
 /**
  * Initial connection to Mailchimp.
@@ -40,12 +40,7 @@ class Newsletters extends Component {
 					</p>
 				) }
 				{ !! connected && (
-					<p className="newspack-newsletter-block-wizard__jetpack-success">
-						<Dashicon icon="yes-alt" />
-						{ __(
-							'You can insert newsletter sign up forms in your content using the Mailchimp block.'
-						) }
-					</p>
+					<Notice noticeText={ __( 'You can insert newsletter sign up forms in your content using the Mailchimp block.' ) } isSuccess />
 				) }
 				<p className="wpcom-link">
 					<ExternalLink href={ connectURL }>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

For the Engagement screens, replace the Dashicon with `Notice`.
For the Adsense screen, simply remove the import since it's not being used.
And also, remove the Dashicon from the `Action Card` and use `actionText` instead of `actionDisplay`

### How to test the changes in this Pull Request:

1. Switch to this branch.
2. Check the Engagement screen. Do you see the notice when looking at the Newsletter tab (when connected to Mailchimp).
3. Check any action cards.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->