### PR TITLE
Use `RawHTML` instead of span to return the noticeText

### DIFF
--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -127,6 +127,25 @@
 			margin: 64px -64px;
 		}
 	}
+
+	// Links
+
+	a {
+		color: $primary-500;
+
+		&:active,
+		&:focus,
+		&:hover {
+			color: $primary-600;
+			text-decoration: none;
+		}
+
+		&:focus {
+			box-shadow: none;
+			outline: 2px solid $primary-500;
+			outline-offset: 2px;
+		}
+	}
 }
 
 // Overlay

--- a/assets/components/src/notice/index.js
+++ b/assets/components/src/notice/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies.
  */
-import { Component } from '@wordpress/element';
+import { Component, RawHTML } from '@wordpress/element';
 
 /**
  * Material UI dependencies.
@@ -52,7 +52,7 @@ class Notice extends Component {
 		return (
 			<div className={ classes }>
 				{ noticeIcon }
-				<span className="newspack-notice__content">{ noticeText }</span>
+				<RawHTML className="newspack-notice__content">{ noticeText }</RawHTML>
 			</div>
 		);
 	}

--- a/assets/components/src/notice/style.scss
+++ b/assets/components/src/notice/style.scss
@@ -55,4 +55,10 @@
 			fill: $primary-500;
 		}
 	}
+
+	.newspack-notice__content {
+		> * {
+			margin: 0;
+		}
+	}
 }

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -623,10 +623,10 @@ class Plugin_Manager {
 
 		// Return a useful error if we are unable to get download info for the plugin.
 		if ( empty( $managed_plugins[ $plugin_slug ]['Download'] ) ) {
-			$error_message = __( 'Newspack can not install this plugin. You will need to get it from the plugin\'s site and install it manually.', 'newspack' );
+			$error_message = __( 'Newspack cannot install this plugin. You will need to get it from the plugin\'s site and install it manually.', 'newspack' );
 			if ( ! empty( $managed_plugins[ $plugin_slug ]['PluginURI'] ) ) {
 				/* translators: %s: plugin URL */
-				$error_message = sprintf( __( 'Newspack can not install this plugin. You will need to get it from %s and install it manually.', 'newspack' ), esc_url( $managed_plugins[ $plugin_slug ]['PluginURI'] ) );
+				$error_message = sprintf( __( 'Newspack cannot install this plugin. You will need to get it from <a href="%s" target="_blank">the plugin\'s site</a> and install it manually.', 'newspack' ), esc_url( $managed_plugins[ $plugin_slug ]['PluginURI'] ) );
 			}
 
 			return new WP_Error(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Use `RawHTML` component instead of simple `span` to return the content of a Notice
* Fix links style in the Modal
* Update the error message of the Plugin Manager with a direct link to the plugin

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/72147178-e39bbe80-3395-11ea-9d04-26baa5ccee46.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/72147200-e8607280-3395-11ea-8a48-4fd91c9e1344.png)

### How to test the changes in this Pull Request:

1. Disable WooCommerce Name Your Price. Then go to Reader Revenue.
2. Click on Install. You should see an error with no link, just plain text
```Newspack can not install this plugin. You will need to get it from http://www.woocommerce.com/products/name-your-price/ and install it manually.```
3. Switch to this branch. And refresh the page.
4. Try to install again.
5. You can also test by switch the branch of newspack-ads to `update/gam-interface` and try to load the Advertising Wizard (see screenshots above).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->