### PR TITLE
Wizard: (Re)add loading animation

### DIFF
--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -243,28 +243,30 @@ export default function withWizard( WrappedComponent, requiredPlugins, options )
 							</a>
 						) }
 					</div>
-					<WrappedComponent
-						pluginRequirements={ requiredPlugins && this.pluginRequirements() }
-						clearError={ this.clearError }
-						getError={ this.getError }
-						setError={ this.setError }
-						startLoading={ this.startLoading }
-						doneLoading={ this.doneLoading }
-						wizardApiFetch={ this.wizardApiFetch }
-						ref={ this.wrappedComponentRef }
-						{ ...this.props }
-					/>
-					{ buttonText && buttonAction && (
-						<Grid>
-							<Card noBackground>
-								<div className="newspack-buttons-card">
-									<Button isPrimary { ...buttonProps( buttonAction ) }>
-										{ buttonText }
-									</Button>
-								</div>
-							</Card>
-						</Grid>
-					) }
+					<div className={ !! loading ? 'newspack-wizard__is-loading' : 'newspack-wizard__is-loaded' }>
+						<WrappedComponent
+							pluginRequirements={ requiredPlugins && this.pluginRequirements() }
+							clearError={ this.clearError }
+							getError={ this.getError }
+							setError={ this.setError }
+							startLoading={ this.startLoading }
+							doneLoading={ this.doneLoading }
+							wizardApiFetch={ this.wizardApiFetch }
+							ref={ this.wrappedComponentRef }
+							{ ...this.props }
+						/>
+						{ buttonText && buttonAction && (
+							<Grid>
+								<Card noBackground>
+									<div className="newspack-buttons-card">
+										<Button isPrimary { ...buttonProps( buttonAction ) }>
+											{ buttonText }
+										</Button>
+									</div>
+								</Card>
+							</Grid>
+						) }
+					</div>
 				</Fragment>
 			);
 		}

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -89,3 +89,44 @@ body[class*="admin_page_newspack-"] {
 		transition: color 125ms ease-in-out;
 	}
 }
+
+// Loading
+
+.newspack-wizard__is-loading {
+	cursor: wait;
+
+	.newspack-wizard {
+		position: relative;
+
+		&:before,
+		&:after {
+			background: white;
+			content: "";
+			display: block;
+			left: 0;
+			position: absolute;
+			right: 0;
+			top: 0;
+			z-index: 102;
+		}
+
+		&:after {
+			border-radius: 4px;
+			bottom: 0;
+			opacity: 0.8;
+		}
+
+		&:before {
+			animation: newspack-wizard__is-loading-animation 1s ease-in-out 1;
+			background: $primary-500;
+			height: 4px;
+			right: 100%;
+			z-index: 103;
+		}
+	}
+}
+
+@keyframes newspack-wizard__is-loading-animation {
+	from { right: 100%; }
+	to { right: 0; }
+}

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -93,9 +93,8 @@ body[class*="admin_page_newspack-"] {
 // Loading
 
 .newspack-wizard__is-loading {
-	cursor: wait;
-
 	.newspack-wizard {
+		cursor: wait;
 		position: relative;
 
 		&:before,
@@ -117,7 +116,7 @@ body[class*="admin_page_newspack-"] {
 		}
 
 		&:before {
-			animation: newspack-wizard__is-loading-animation 1s ease-in-out 1;
+			animation: newspack-wizard__is-loading-animation 2s ease-in-out infinite;
 			background: $primary-500;
 			height: 4px;
 			right: 100%;
@@ -127,6 +126,18 @@ body[class*="admin_page_newspack-"] {
 }
 
 @keyframes newspack-wizard__is-loading-animation {
-	from { right: 100%; }
-	to { right: 0; }
+	from {
+		left: 0;
+		right: 100%;
+	}
+
+	50% {
+		left: 0;
+		right: 0;
+	}
+
+	to {
+		left: 100%;
+		right: 0;
+	}
 }

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -136,27 +136,27 @@ class AdvertisingWizard extends Component {
 	}
 
 	/**
-	 * Update header code.
+	 * Update GAM Network Code.
 	 */
-	updateHeaderCode = ( code, service ) => {
+	updateNetworkCode = ( code, service ) => {
 		const { advertisingData } = this.state;
-		advertisingData.services[ service ].header_code = code;
+		advertisingData.services[ service ].network_code = code;
 		this.setState( { advertisingData } );
 	};
 
 	/**
-	 * Save header code.
+	 * Save Network Code.
 	 */
-	saveHeaderCode = service => {
+	saveNetworkCode = service => {
 		const { setError, wizardApiFetch } = this.props;
 		const { advertisingData } = this.state;
-		const header_code = advertisingData.services[ service ].header_code;
+		const network_code = advertisingData.services[ service ].network_code;
 		return new Promise( ( resolve, reject ) => {
 			wizardApiFetch( {
-				path: '/newspack/v1/wizard/advertising/service/' + service + '/header_code',
+				path: '/newspack/v1/wizard/advertising/service/' + service + '/network_code',
 				method: 'post',
 				data: {
-					header_code,
+					network_code,
 				},
 			} )
 				.then( advertisingData => {
@@ -223,12 +223,12 @@ class AdvertisingWizard extends Component {
 		const { setError, wizardApiFetch } = this.props;
 		const { adUnits } = this.state.advertisingData;
 		const adUnit = adUnits[ id ];
-		const { name, ad_code, amp_ad_code, ad_service } = adUnit;
+		const { name, code, sizes, ad_service } = adUnit;
 		const data = {
 			id,
+			code,
 			name,
-			ad_code,
-			amp_ad_code,
+			sizes,
 			ad_service,
 		};
 		return new Promise( ( resolve, reject ) => {
@@ -390,13 +390,13 @@ class AdvertisingWizard extends Component {
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									adUnits={ adUnits }
-									code={ advertisingData.services.google_ad_manager.header_code }
+									code={ advertisingData.services.google_ad_manager.network_code }
 									tabbedNavigation={ gam_tabs }
 									service={ 'google_ad_manager' }
-									onChange={ value => this.updateHeaderCode( value, 'google_ad_manager' ) }
+									onChange={ value => this.updateNetworkCode( value, 'google_ad_manager' ) }
 									buttonText={ __( 'Save' ) }
 									buttonAction={ () =>
-										this.saveHeaderCode( 'google_ad_manager' ).then( response =>
+										this.saveNetworkCode( 'google_ad_manager' ).then( response =>
 											routeProps.history.push( '/google_ad_manager' )
 										)
 									}
@@ -419,8 +419,8 @@ class AdvertisingWizard extends Component {
 											adUnits[ 0 ] || {
 												id: 0,
 												name: '',
-												ad_code: '',
-												amp_ad_code: '',
+												code: '',
+												sizes: [ [ 120, 120 ] ],
 											}
 										}
 										service={ 'google_ad_manager' }

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -1,17 +1,24 @@
 /**
- * New/Edit Ad Unit Screen.
+ * New/Edit Ad Unit Screen
  */
 
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
  */
-import { Button, Card, TextControl, TextareaControl, withWizardScreen } from '../../../../components/src';
+import DeleteIcon from '@material-ui/icons/Delete';
+import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
+
+/**
+ * Internal dependencies.
+ */
+import { Button, Card, TextControl, withWizardScreen } from '../../../../components/src';
+import './style.scss';
 
 /**
  * New/Edit Ad Unit Screen.
@@ -34,7 +41,8 @@ class AdUnit extends Component {
 	 */
 	render() {
 		const { adUnit, onSave, service } = this.props;
-		const { id, name, ad_code, amp_ad_code } = adUnit;
+		const { id, code, name } = adUnit;
+		const sizes = adUnit.sizes && Array.isArray( adUnit.sizes ) ? adUnit.sizes : [ [ 120, 120 ] ];
 		return (
 			<Fragment>
 				<TextControl
@@ -42,18 +50,53 @@ class AdUnit extends Component {
 					value={ name || '' }
 					onChange={ value => this.handleOnChange( 'name', value ) }
 				/>
-				<TextareaControl
-					label={ __( 'Paste the AMP ad code from Ad Manager here.' ) }
-					value={ amp_ad_code || '' }
-					placeholder={ __( 'AMP Ad code' ) }
-					onChange={ value => this.handleOnChange( 'amp_ad_code', value ) }
+				<TextControl
+					label={ __( 'Ad unit code' ) }
+					value={ code || '' }
+					onChange={ value => this.handleOnChange( 'code', value ) }
 				/>
-				<TextareaControl
-					label={ __( 'Paste the HTML ad code from Ad Manager here.' ) }
-					placeholder={ __( 'HTML Ad code' ) }
-					value={ ad_code || '' }
-					onChange={ value => this.handleOnChange( 'ad_code', value ) }
-				/>
+				{ sizes.map( ( size, index ) => (
+					<div className="newspack_ad_unit__sizes">
+						<TextControl
+							label={ __( 'Width' ) }
+							value={ size[ 0 ] }
+							type="number"
+							onChange={ value => {
+								sizes[ index ][ 0 ] = value;
+								this.handleOnChange( 'sizes', sizes );
+							} }
+						/>
+						<TextControl
+							label={ __( 'Height' ) }
+							value={ size[ 1 ] }
+							type="number"
+							onChange={ value => {
+								sizes[ index ][ 1 ] = value;
+								this.handleOnChange( 'sizes', sizes );
+							} }
+						/>
+						{ sizes.length > 1 && (
+							<Button
+								isTertiary
+								onClick={ () => {
+									sizes.splice( index, 1 );
+									this.handleOnChange( 'sizes', sizes );
+								} }
+							>
+								<DeleteIcon />
+							</Button>
+						) }
+					</div>
+				) ) }
+				<Button
+					isTertiary
+					className="newspack-button__add-size"
+					onClick={ () => this.handleOnChange( 'sizes', [ ...sizes, [ 120, 120 ] ] ) }
+				>
+					<LibraryAddIcon />
+					{ __( 'Add Size', 'newspack' ) }
+				</Button>
+				<div className="clear" />
 				<div className="newspack-buttons-card">
 					<Button isPrimary onClick={ () => onSave( id ) }>
 						{ __( 'Save' ) }

--- a/assets/wizards/advertising/views/ad-unit/style.scss
+++ b/assets/wizards/advertising/views/ad-unit/style.scss
@@ -1,0 +1,66 @@
+/**
+ * Ad Unit
+ */
+
+@import '~@wordpress/base-styles/colors';
+
+.newspack_ad_unit__sizes {
+	border-bottom: 1px solid $light-gray-200;
+
+	@media screen and ( min-width: 744px ) {
+		align-items: flex-end;
+		display: flex;
+		justify-content: space-between;
+		width: 100%;
+	}
+
+	.newspack-text-control {
+		margin: 16px 0;
+
+		@media screen and ( min-width: 744px ) {
+			margin-right: 16px;
+			width: 48%;
+			width: calc( 50% - 8px );
+
+			&:last-of-type {
+				margin-right: 0;
+			}
+		}
+	}
+
+	.newspack-button {
+		align-items: center;
+		flex: 0 0 auto;
+		height: 48px;
+		justify-content: center;
+		margin-bottom: 16px;
+		padding: 0;
+		width: 48px;
+
+		@media screen and ( min-width: 744px ) {
+			margin-left: 16px;
+		}
+	}
+
+	.newspack-text-control + & {
+		border-top: 1px solid $light-gray-200;
+	}
+
+	& + .newspack-button {
+		margin-top: 16px;
+	}
+}
+
+.newspack-button__add-size {
+	@media screen and ( min-width: 744px ) {
+		float: right;
+	}
+
+	svg {
+		margin-right: 4px;
+	}
+}
+
+.newspack-buttons-card {
+	margin-top: 48px;
+}

--- a/assets/wizards/advertising/views/header-code/index.js
+++ b/assets/wizards/advertising/views/header-code/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Button, Card, TextareaControl, withWizardScreen } from '../../../../components/src';
+import { Button, Card, TextControl, withWizardScreen } from '../../../../components/src';
 
 /**
  * New/Edit Ad Unit Screen.
@@ -38,11 +38,9 @@ class HeaderCode extends Component {
 		const { onChange, code, service } = this.props;
 		return (
 			<Fragment>
-				<TextareaControl
-					label={ __(
-						'If the ad service requires to render a global ad code on every page, paste it here.'
-					) }
-					placeholder={ __( 'Header Ad Code' ) }
+				<TextControl
+					label={ __( 'Google Ad Manager Network Code', 'newspack' ) }
+					placeholder={ __( '123456789' ) }
 					value={ code }
 					onChange={ onChange }
 				/>

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -33,14 +33,14 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
-	 * Get header code for ad service.
+	 * Get Network Code for ad service.
 	 *
 	 * @param string $service The service to retrieve.
 	 * @return string | WP_Error Array of ad units or WP_Error if Newspack Ads isn't installed and activated.
 	 */
-	public function get_header_code( $service ) {
+	public function get_network_code( $service ) {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::get_header_code( $service ) :
+			\Newspack_Ads_Model::get_network_code( $service ) :
 			$this->unconfigured_error();
 	}
 
@@ -48,12 +48,12 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 * Create/update header code for ad service.
 	 *
 	 * @param string $service The service to retrieve.
-	 * @param string $header_code The code.
+	 * @param string $network_code The code.
 	 * @return bool | WP_Error Array of ad units or WP_Error if Newspack Ads isn't installed and activated.
 	 */
-	public function set_header_code( $service, $header_code ) {
+	public function set_network_code( $service, $network_code ) {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::set_header_code( $service, $header_code ) :
+			\Newspack_Ads_Model::set_network_code( $service, $network_code ) :
 			$this->unconfigured_error();
 	}
 

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -116,17 +116,17 @@ class Advertising_Wizard extends Wizard {
 		// Update header code.
 		register_rest_route(
 			'newspack/v1/wizard/',
-			'/advertising/service/(?P<service>[\a-z]+)/header_code',
+			'/advertising/service/(?P<service>[\a-z]+)/network_code',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_update_header_code' ],
-				'permission_callback' => [ $this, 'api_permissions_check_unfiltered_html' ],
+				'callback'            => [ $this, 'api_update_network_code' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'service'     => [
+					'service'      => [
 						'sanitize_callback' => [ $this, 'sanitize_service' ],
 					],
-					'header_code' => [
-						// 'sanitize_callback' => 'esc_js', @todo If a `script` tag goes here, esc_js is the wrong function to use.
+					'network_code' => [
+						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
 			]
@@ -159,25 +159,6 @@ class Advertising_Wizard extends Wizard {
 				'args'                => [
 					'service' => [
 						'sanitize_callback' => [ $this, 'sanitize_service' ],
-					],
-				],
-			]
-		);
-
-		// Update header code.
-		register_rest_route(
-			'newspack/v1/wizard/',
-			'/advertising/service/(?P<service>[\a-z]+)/header_code',
-			[
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_update_header_code' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'service'     => [
-						'sanitize_callback' => [ $this, 'sanitize_service' ],
-					],
-					'header_code' => [
-						// 'sanitize_callback' => 'esc_js', @todo If a `script` tag goes here, esc_js is the wrong function to use.
 					],
 				],
 			]
@@ -222,22 +203,24 @@ class Advertising_Wizard extends Wizard {
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_adunit' ],
-				'permission_callback' => [ $this, 'api_permissions_check_unfiltered_html' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'id'          => [
+					'id'         => [
 						'sanitize_callback' => 'absint',
 					],
-					'name'        => [
+					'name'       => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'code'       => [
 						'sanitize_callback' => 'sanitize_text_field',
 						'validate_callback' => [ $this, 'api_validate_not_empty' ],
 					],
-					'ad_code'     => [
-						// 'sanitize_callback' => 'esc_js', @todo If a `script` tag goes here, esc_js is the wrong function to use.
+					'sizes'      => [
+						'sanitize_callback' => [ $this, 'sanitize_sizes' ],
 					],
-					'amp_ad_code' => [
-						// 'sanitize_callback' => 'esc_js', @todo If a `script` tag goes here, esc_js is the wrong function to use.
+					'ad_service' => [
+						'sanitize_callback' => 'sanitize_text_field',
 					],
-					'ad_service'  => [],
 				],
 			]
 		);
@@ -249,7 +232,7 @@ class Advertising_Wizard extends Wizard {
 			[
 				'methods'             => 'DELETE',
 				'callback'            => [ $this, 'api_delete_adunit' ],
-				'permission_callback' => [ $this, 'api_permissions_check_unfiltered_html' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
 					'id' => [
 						'sanitize_callback' => 'absint',
@@ -357,11 +340,11 @@ class Advertising_Wizard extends Wizard {
 
 		$params = $request->get_params();
 		$adunit = [
-			'id'          => 0,
-			'name'        => '',
-			'ad_code'     => '',
-			'amp_ad_code' => '',
-			'ad_service'  => '',
+			'id'         => 0,
+			'code'       => '',
+			'name'       => '',
+			'sizes'      => [],
+			'ad_service' => '',
 		];
 		$args   = \wp_parse_args( $params, $adunit );
 		// Update and existing or add a new ad unit.
@@ -395,12 +378,12 @@ class Advertising_Wizard extends Wizard {
 	 * @param WP_REST_Request $request Request with ID of ad unit to delete.
 	 * @return WP_REST_Response Boolean Delete success.
 	 */
-	public function api_update_header_code( $request ) {
+	public function api_update_network_code( $request ) {
 		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
 
-		$service     = $request['service'];
-		$header_code = $request['header_code'];
-		$configuration_manager->set_header_code( $service, $header_code );
+		$service      = $request['service'];
+		$network_code = $request['network_code'];
+		$configuration_manager->set_network_code( $service, $network_code );
 
 		return \rest_ensure_response( $this->retrieve_data() );
 	}
@@ -449,9 +432,9 @@ class Advertising_Wizard extends Wizard {
 		$services = array();
 		foreach ( $this->services as $service => $data ) {
 			$services[ $service ] = array(
-				'label'       => $data['label'],
-				'enabled'     => get_option( self::NEWSPACK_ADVERTISING_SERVICE_PREFIX . $service, '' ),
-				'header_code' => $configuration_manager->get_header_code( $service ),
+				'label'        => $data['label'],
+				'enabled'      => get_option( self::NEWSPACK_ADVERTISING_SERVICE_PREFIX . $service, '' ),
+				'network_code' => $configuration_manager->get_network_code( $service ),
 			);
 		}
 		/* Check availability of WordAds based on current Jetpack plan */
@@ -611,5 +594,24 @@ class Advertising_Wizard extends Wizard {
 		);
 		\wp_style_add_data( 'newspack-advertising-wizard', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-advertising-wizard' );
+	}
+
+	/**
+	 * Sanitize array of ad unit sizes.
+	 *
+	 * @param array $sizes Array of sizes to sanitize.
+	 * @return array Sanitized array.
+	 */
+	public static function sanitize_sizes( $sizes ) {
+		$sizes     = is_array( $sizes ) ? $sizes : [];
+		$sanitized = [];
+		foreach ( $sizes as $size ) {
+			$size    = is_array( $size ) && 2 === count( $size ) ? $size : [ 0, 0 ];
+			$size[0] = absint( $size[0] );
+			$size[1] = absint( $size[1] );
+
+			$sanitized[] = $size;
+		}
+		return $sanitized;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In order to get visual feedback when clicking a button, this PR adds back the loading animation.

### How to test the changes in this Pull Request:

Go to the advertising wizard. And toggle the different ads providers

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->