### PR TITLE
Fix the Notice RawHTML object conflict

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -37,6 +37,7 @@ class ActionCard extends Component {
 			href,
 			notification,
 			notificationLevel,
+			notificationHTML,
 			actionText,
 			secondaryActionText,
 			image,
@@ -115,10 +116,10 @@ class ActionCard extends Component {
 				</div>
 				{ notification && (
 					<div className="newspack-action-card__notification">
-						{ 'error'   === notificationLevel && ( <Notice noticeText={ notification } isError rawHTML /> ) }
-						{ 'info'    === notificationLevel && ( <Notice noticeText={ notification } isPrimary /> ) }
-						{ 'success' === notificationLevel && ( <Notice noticeText={ notification } isSuccess /> ) }
-						{ 'warning' === notificationLevel && ( <Notice noticeText={ notification } isWarning /> ) }
+						{ 'error'   === notificationLevel && ( <Notice noticeText={ notification } isError rawHTML={ notificationHTML } /> ) }
+						{ 'info'    === notificationLevel && ( <Notice noticeText={ notification } isPrimary rawHTML={ notificationHTML } /> ) }
+						{ 'success' === notificationLevel && ( <Notice noticeText={ notification } isSuccess rawHTML={ notificationHTML } /> ) }
+						{ 'warning' === notificationLevel && ( <Notice noticeText={ notification } isWarning rawHTML={ notificationHTML } /> ) }
 					</div>
 				) }
 			</Card>

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -115,7 +115,7 @@ class ActionCard extends Component {
 				</div>
 				{ notification && (
 					<div className="newspack-action-card__notification">
-						{ 'error'   === notificationLevel && ( <Notice noticeText={ notification } isError /> ) }
+						{ 'error'   === notificationLevel && ( <Notice noticeText={ notification } isError rawHTML /> ) }
 						{ 'info'    === notificationLevel && ( <Notice noticeText={ notification } isPrimary /> ) }
 						{ 'success' === notificationLevel && ( <Notice noticeText={ notification } isSuccess /> ) }
 						{ 'warning' === notificationLevel && ( <Notice noticeText={ notification } isWarning /> ) }

--- a/assets/components/src/notice/index.js
+++ b/assets/components/src/notice/index.js
@@ -53,7 +53,7 @@ class Notice extends Component {
 			<div className={ classes }>
 				{ noticeIcon }
 				<div className="newspack-notice__content">
-					{ !! rawHTML ? <RawHTML>{ noticeText }</RawHTML> : noticeText }
+					{ rawHTML ? <RawHTML>{ noticeText }</RawHTML> : noticeText }
 				</div>
 			</div>
 		);

--- a/assets/components/src/notice/index.js
+++ b/assets/components/src/notice/index.js
@@ -23,15 +23,15 @@ import './style.scss';
 /**
  * External dependencies.
  */
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 class Notice extends Component {
 	/**
 	 * Render
 	 */
 	render() {
-		const { className, isError, isSuccess, isWarning, isPrimary, noticeText } = this.props;
-		const classes = classNames(
+		const { className, isError, isSuccess, isWarning, isPrimary, noticeText, rawHTML } = this.props;
+		const classes = classnames(
 			'newspack-notice',
 			className,
 			isError && 'newspack-notice__is-error',
@@ -52,7 +52,9 @@ class Notice extends Component {
 		return (
 			<div className={ classes }>
 				{ noticeIcon }
-				<RawHTML className="newspack-notice__content">{ noticeText }</RawHTML>
+				<div className="newspack-notice__content">
+					{ !! rawHTML ? <RawHTML>{ noticeText }</RawHTML> : noticeText }
+				</div>
 			</div>
 		);
 	}

--- a/assets/components/src/notice/style.scss
+++ b/assets/components/src/notice/style.scss
@@ -57,7 +57,7 @@
 	}
 
 	.newspack-notice__content {
-		> * {
+		> div > * {
 			margin: 0;
 		}
 	}

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -244,6 +244,7 @@ class PluginInstaller extends Component {
 								onClick={ onClick }
 								notification={ notification }
 								notificationLevel="error"
+								notificationHTML
 								className={ classes }
 							/>
 						);

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -87,9 +87,7 @@ export default function withWizard( WrappedComponent, requiredPlugins, options )
 		getErrorNotice = error => {
 			const { message } = error;
 			return (
-				<div className="notice notice-error notice-alt update-message">
-					<p>{ message }</p>
-				</div>
+				<Notice noticeText={ message } isError rawHTML />
 			);
 		};
 
@@ -106,7 +104,7 @@ export default function withWizard( WrappedComponent, requiredPlugins, options )
 					title={ __( 'Unrecoverable error' ) }
 					onRequestClose={ () => ( window.location = newspack_urls[ 'dashboard' ] ) }
 				>
-					<Notice noticeText={ message } isError />
+					<Notice noticeText={ message } isError rawHTML />
 					<div className="newspack-buttons-card">
 						<Button isPrimary href={ newspack_urls[ 'dashboard' ] }>
 							{ __( 'Return to dashboard' ) }

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -626,7 +626,7 @@ class Plugin_Manager {
 			$error_message = __( 'Newspack cannot install this plugin. You will need to get it from the plugin\'s site and install it manually.', 'newspack' );
 			if ( ! empty( $managed_plugins[ $plugin_slug ]['PluginURI'] ) ) {
 				/* translators: %s: plugin URL */
-				$error_message = sprintf( __( 'Newspack cannot install this plugin. You will need to get it from <a href="%s" target="_blank">the plugin\'s site</a> and install it manually.', 'newspack' ), esc_url( $managed_plugins[ $plugin_slug ]['PluginURI'] ) );
+				$error_message = sprintf( __( 'Newspack cannot install this plugin. You will need to get it from <a href="%s">the plugin\'s site</a> and install it manually.', 'newspack' ), esc_url( $managed_plugins[ $plugin_slug ]['PluginURI'] ) );
 			}
 
 			return new WP_Error(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Makes `RawHTML` as an option.
Can be set by adding `rawHTML` to a Notice.

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/72270126-92e9c700-361c-11ea-9602-eb37df7de09a.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/72270137-98471180-361c-11ea-9176-64df8ee517d3.png)

### How to test the changes in this Pull Request:

1. If a notice uses something like `ExternalLink` as part of its content. It will look broken (see screenshot above).
2. Switch to this branch. And check all the notices.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->