### PR TITLE
WebPreview Component

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -22,6 +22,7 @@ export { default as TextareaControl } from './textarea-control';
 export { default as ToggleControl } from './toggle-control';
 export { default as ToggleGroup } from './toggle-group';
 export { default as Waiting } from './waiting';
+export { default as WebPreview } from './web-preview';
 export { default as withWizard } from './with-wizard';
 export { default as withWizardScreen } from './with-wizard-screen';
 export { default as WizardPagination } from './wizard-pagination';

--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -34,26 +34,24 @@
 		border: none;
 		height: auto;
 		margin: 0;
-		padding: 48px 0 32px;
-
-		@media screen and ( min-width: 744px ) {
-			padding-top: 64px;
-		}
+		padding: 64px 0 32px;
 
 		.components-modal__header-heading-container {
 			display: block;
 		}
 
 		.components-button.has-icon {
-			height: auto;
+			height: 48px;
+			justify-content: center;
 			left: auto;
-			padding: 12px;
+			padding: 0;
 			position: absolute;
-			right: -48px;
-			top: 0;
+			right: -40px;
+			top: 8px;
+			width: 48px;
 
 			@media screen and ( min-width: 744px ) {
-				right: -64px;
+				right: -56px;
 			}
 
 			svg {
@@ -63,12 +61,6 @@
 				& + span {
 					display: none;
 				}
-			}
-
-			&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
-			&:not(:disabled):not([aria-disabled="true"]):not(.is-default):active {
-				border: none;
-				box-shadow: none;
 			}
 		}
 

--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -11,18 +11,19 @@ import { __ } from '@wordpress/i18n';
 /**
  * Material UI dependencies.
  */
-import TabletMac from '@material-ui/icons/TabletMac';
-import PhoneIphone from '@material-ui/icons/PhoneIphone';
-import DesktopMac from '@material-ui/icons/DesktopMac';
+import CloseIcon from '@material-ui/icons/Close';
+import DesktopWindowsIcon from '@material-ui/icons/DesktopWindows';
+import PhoneAndroidIcon from '@material-ui/icons/PhoneAndroid';
+import TabletAndroidIcon from '@material-ui/icons/TabletAndroid';
 
 /**
- * Internal dependencies
+ * Internal dependencies.
  */
 import { Button, Waiting } from '../';
 import './style.scss';
 
 /**
- * External dependencies
+ * External dependencies.
  */
 import classnames from 'classnames';
 
@@ -36,52 +37,75 @@ class WebPreview extends Component {
 	 * Render.
 	 */
 	render() {
-		const { label, url } = this.props;
+		const { label, url, isPrimary, isSecondary, isTertiary, isLink, isLarge, isSmall } = this.props;
 		const { device, loaded, previewVisibility } = this.state;
-		const className = classnames( 'newspack-web-preview__container', device );
+		const classes = classnames(
+			'newspack-web-preview__container',
+			device,
+			loaded && 'newspack-web-preview__is-loaded'
+		);
 		return (
 			<Fragment>
 				<Button
-					isPrimary
+					isPrimary={ isPrimary }
+					isSecondary={ isSecondary }
+					isTertiary={ isTertiary }
+					isLink={ isLink }
+					isLarge={ isLarge }
+					isSmall={ isSmall }
 					onClick={ () => this.setState( { previewVisibility: true } ) }
 				>
 					{ label }
 				</Button>
 				{ !! previewVisibility && (
-					<div className={ className }>
+					<div className={ classes }>
 						<div className="newspack-web-preview__interior">
 							<div className="newspack-web-preview__toolbar">
-								<Button
-									isSmall
-									onClick={ () => this.setState( { device: 'desktop' } ) }
-									isPrimary={ 'desktop' === device }
-								>
-									<DesktopMac />
-								</Button>
-								<Button
-									isSmall
-									onClick={ () => this.setState( { device: 'tablet' } ) }
-									isPrimary={ 'tablet' === device }
-								>
-									<TabletMac />
-								</Button>
-								<Button
-									isSmall
-									onClick={ () => this.setState( { device: 'phone' } ) }
-									isPrimary={ 'phone' === device }
-								>
-									<PhoneIphone />
-								</Button>
-								<div className="newspack-web-preview__toolbar_right">
+								<div className="newspack-web-preview__toolbar-left">
+									<Button
+										onClick={ () => this.setState( { device: 'desktop' } ) }
+										isPrimary={ 'desktop' === device }
+										isSecondary={ 'desktop' !== device }
+										className="is-desktop"
+									>
+										<DesktopWindowsIcon />
+										<span className="screen-reader-text">{ __( 'Preview desktop size' ) }</span>
+									</Button>
+									<Button
+										onClick={ () => this.setState( { device: 'tablet' } ) }
+										isPrimary={ 'tablet' === device }
+										isSecondary={ 'tablet' !== device }
+										className="is-tablet"
+									>
+										<TabletAndroidIcon />
+										<span className="screen-reader-text">{ __( 'Preview tablet size' ) }</span>
+									</Button>
+									<Button
+										onClick={ () => this.setState( { device: 'phone' } ) }
+										isPrimary={ 'phone' === device }
+										isSecondary={ 'phone' !== device }
+										className="is-phone"
+									>
+										<PhoneAndroidIcon />
+										<span className="screen-reader-text">{ __( 'Preview phone size' ) }</span>
+									</Button>
+								</div>
+								<div className="newspack-web-preview__toolbar-right">
 									<Button
 										onClick={ () => this.setState( { previewVisibility: false, loaded: false } ) }
 									>
-										{ __( 'Close', 'newspack' ) }
+										<CloseIcon />
+										<span className="screen-reader-text">{ __( 'Close preview' ) }</span>
 									</Button>
 								</div>
 							</div>
 							<div className="newspack-web-preview__content">
-								{ ! loaded && <Waiting /> }
+								{ ! loaded &&
+									<div className="newspack-web-preview_is-waiting">
+										<Waiting isLeft />
+										{ __( 'Loading...' ) }
+									</div>
+								}
 								<iframe src={ url } onLoad={ () => this.setState( { loaded: true } ) } />
 							</div>
 						</div>

--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -109,7 +109,7 @@ class WebPreview extends Component {
 							</div>
 							<div className="newspack-web-preview__content">
 								{ ! loaded &&
-									<div className="newspack-web-preview_is-waiting">
+									<div className="newspack-web-preview__is-waiting">
 										<Waiting isLeft />
 										{ __( 'Loading...' ) }
 									</div>

--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -127,7 +127,7 @@ class WebPreview extends Component {
 
 WebPreview.defaultProps = {
 	url: '//newspack.blog',
-	label: __( 'Preview Site', 'newspack' ),
+	label: __( 'Preview', 'newspack' ),
 };
 
 export default WebPreview;

--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -1,0 +1,100 @@
+/**
+ * Web Preview
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Material UI dependencies.
+ */
+import TabletMac from '@material-ui/icons/TabletMac';
+import PhoneIphone from '@material-ui/icons/PhoneIphone';
+import DesktopMac from '@material-ui/icons/DesktopMac';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Waiting } from '../';
+import './style.scss';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+class WebPreview extends Component {
+	state = {
+		device: 'desktop',
+		loaded: false,
+		previewVisibility: false,
+	};
+	/**
+	 * Render.
+	 */
+	render() {
+		const { label, url } = this.props;
+		const { device, loaded, previewVisibility } = this.state;
+		const className = classnames( 'newspack-web-preview__container', device );
+		return (
+			<Fragment>
+				<Button
+					isPrimary
+					onClick={ () => this.setState( { previewVisibility: true } ) }
+				>
+					{ label }
+				</Button>
+				{ !! previewVisibility && (
+					<div className={ className }>
+						<div className="newspack-web-preview__interior">
+							<div className="newspack-web-preview__toolbar">
+								<Button
+									isSmall
+									onClick={ () => this.setState( { device: 'desktop' } ) }
+									isPrimary={ 'desktop' === device }
+								>
+									<DesktopMac />
+								</Button>
+								<Button
+									isSmall
+									onClick={ () => this.setState( { device: 'tablet' } ) }
+									isPrimary={ 'tablet' === device }
+								>
+									<TabletMac />
+								</Button>
+								<Button
+									isSmall
+									onClick={ () => this.setState( { device: 'phone' } ) }
+									isPrimary={ 'phone' === device }
+								>
+									<PhoneIphone />
+								</Button>
+								<div className="newspack-web-preview__toolbar_right">
+									<Button
+										onClick={ () => this.setState( { previewVisibility: false, loaded: false } ) }
+									>
+										{ __( 'Close', 'newspack' ) }
+									</Button>
+								</div>
+							</div>
+							<div className="newspack-web-preview__content">
+								{ ! loaded && <Waiting /> }
+								<iframe src={ url } onLoad={ () => this.setState( { loaded: true } ) } />
+							</div>
+						</div>
+					</div>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+WebPreview.defaultProps = {
+	url: '//newspack.blog',
+	label: __( 'Preview Site', 'newspack' ),
+};
+
+export default WebPreview;

--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -33,6 +33,15 @@ class WebPreview extends Component {
 		loaded: false,
 		previewVisibility: false,
 	};
+
+	componentDidUpdate() {
+		if ( this.state.previewVisibility === true ) {
+			document.body.classList.add( 'newspack-web-preview__open' );
+		} else {
+			document.body.classList.remove( 'newspack-web-preview__open' );
+		}
+	}
+
 	/**
 	 * Render.
 	 */

--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -1,8 +1,4 @@
 /**
- * Web Preview
- */
-
-/**
  * WordPress dependencies.
  */
 import { Component, Fragment } from '@wordpress/element';
@@ -27,6 +23,9 @@ import './style.scss';
  */
 import classnames from 'classnames';
 
+/**
+ * Web Preview. A component to preview a website in an iframe, with device sizing options.
+ */
 class WebPreview extends Component {
 	state = {
 		device: 'desktop',

--- a/assets/components/src/web-preview/style.scss
+++ b/assets/components/src/web-preview/style.scss
@@ -5,6 +5,10 @@
 @import '../../../shared/scss/colors';
 @import '~@wordpress/base-styles/colors';
 
+body.newspack-web-preview__open {
+	overflow: hidden;
+}
+
 .newspack-web-preview__container {
 	background: rgba( $primary-500, 0.8 );
 	box-sizing: border-box;
@@ -52,6 +56,7 @@
 	iframe {
 		display: block;
 		height: 100%;
+		height: calc( 100% - 65px );
 		margin: 0 auto;
 		max-width: 100%;
 		opacity: 0;

--- a/assets/components/src/web-preview/style.scss
+++ b/assets/components/src/web-preview/style.scss
@@ -1,0 +1,60 @@
+/**
+ * Web Preview
+ */
+
+@import '../../../shared/scss/colors';
+@import '~@wordpress/base-styles/colors';
+
+.newspack-web-preview__container {
+	background: rgba( 255, 255, 255, 0.7 );
+	height: 100%;
+	left: 0;
+	margin: 0;
+	position: fixed;
+	top: 0;
+	width: 100%;
+	z-index: 99999;
+	&.tablet iframe {
+		max-width: 783px;
+	}
+	&.phone iframe {
+		max-width: 460px;
+	}
+}
+.newspack-web-preview__interior {
+	background: white;
+	border: 1px solid lightgray;
+	height: calc( 100% - 50px );
+	margin: 25px;
+	width: calc( 100% - 50px );
+}
+.newspack-web-preview__content {
+	height: 100%;
+	iframe {
+		display: block;
+		height: 100%;
+		margin: 0 auto;
+		padding: 0;
+		pointer-events: all;
+		transition: max-width 0.2s ease-out;
+		width: 100%;
+	}
+	.newspack-is-waiting {
+		left: 50%;
+		margin: -12px 0 0 -12px;
+		position: absolute;
+		top: 50%;
+	}
+	-webkit-overflow-scrolling: touch;
+	width: 100%;
+}
+.newspack-web-preview__toolbar {
+	border-bottom: 1px solid lightgray;
+	display: flex;
+	padding: 1em;
+}
+.newspack-web-preview__toolbar_right {
+	display: flex;
+	flex: 1;
+	justify-content: flex-end;
+}

--- a/assets/components/src/web-preview/style.scss
+++ b/assets/components/src/web-preview/style.scss
@@ -67,7 +67,7 @@ body.newspack-web-preview__open {
 	}
 }
 
-.newspack-web-preview_is-waiting {
+.newspack-web-preview__is-waiting {
 	display: flex;
 	left: 50%;
 	margin: -12px 0 0 0;

--- a/assets/components/src/web-preview/style.scss
+++ b/assets/components/src/web-preview/style.scss
@@ -6,55 +6,124 @@
 @import '~@wordpress/base-styles/colors';
 
 .newspack-web-preview__container {
-	background: rgba( 255, 255, 255, 0.7 );
+	background: rgba( $primary-500, 0.8 );
+	box-sizing: border-box;
 	height: 100%;
 	left: 0;
 	margin: 0;
+	max-width: 100%;
+	padding: 24px 24px 0;
 	position: fixed;
 	top: 0;
 	width: 100%;
 	z-index: 99999;
+
 	&.tablet iframe {
-		max-width: 783px;
+		max-width: 768px;
 	}
+
 	&.phone iframe {
-		max-width: 460px;
+		max-width: 480px;
+	}
+
+	&.newspack-web-preview__is-loaded iframe {
+		opacity: 1;
 	}
 }
+
 .newspack-web-preview__interior {
 	background: white;
-	border: 1px solid lightgray;
-	height: calc( 100% - 50px );
-	margin: 25px;
-	width: calc( 100% - 50px );
-}
-.newspack-web-preview__content {
+	border-radius: 4px 4px 0 0;
+	box-shadow: 0 8px 16px rgba( black, 0.08 );
 	height: 100%;
+	width: 100%;
+
+	animation: newspack-web-preview__appear-animation 0.1s ease-out;
+	animation-fill-mode: forwards;
+}
+
+.newspack-web-preview__content {
+	background: $light-gray-100;
+	height: 100%;
+	-webkit-overflow-scrolling: touch;
+	overflow-x: hidden;
+	width: 100%;
+
 	iframe {
 		display: block;
 		height: 100%;
 		margin: 0 auto;
+		max-width: 100%;
+		opacity: 0;
+		outline: 1px solid $light-gray-500;
 		padding: 0;
 		pointer-events: all;
-		transition: max-width 0.2s ease-out;
+		transition: max-width 125ms ease-in-out, opacity 250ms ease-in-out;
 		width: 100%;
 	}
-	.newspack-is-waiting {
-		left: 50%;
-		margin: -12px 0 0 -12px;
-		position: absolute;
-		top: 50%;
-	}
-	-webkit-overflow-scrolling: touch;
-	width: 100%;
 }
-.newspack-web-preview__toolbar {
-	border-bottom: 1px solid lightgray;
+
+.newspack-web-preview_is-waiting {
 	display: flex;
-	padding: 1em;
+	left: 50%;
+	margin: -12px 0 0 -12px;
+	position: absolute;
+	top: 50%;
 }
-.newspack-web-preview__toolbar_right {
+
+.newspack-web-preview__toolbar {
+	border-bottom: 1px solid $light-gray-500;
+	display: flex;
+
+	.newspack-button {
+		height: 48px;
+		justify-content: center;
+		margin: 8px;
+		padding: 0;
+		width: 48px;
+	}
+}
+
+.newspack-web-preview__toolbar-left {
+	flex: 0 0 auto;
+
+	.newspack-button {
+		display: none;
+
+		@media screen and ( min-width: 528px ) {
+			&.is-phone,
+			&.is-tablet {
+				display: inline-flex;
+			}
+
+			&.is-phone {
+				margin-left: -4px;
+			}
+		}
+
+		@media screen and ( min-width: 816px ) {
+			&.is-desktop {
+				display: inline-flex;
+			}
+
+			&.is-tablet {
+				margin-left: -4px;
+			}
+		}
+	}
+}
+
+.newspack-web-preview__toolbar-right {
 	display: flex;
 	flex: 1;
 	justify-content: flex-end;
+}
+
+@keyframes newspack-web-preview__appear-animation {
+	from {
+		margin-top: 32px;
+	}
+	to {
+		margin-top: 0;
+	}
 }

--- a/assets/components/src/web-preview/style.scss
+++ b/assets/components/src/web-preview/style.scss
@@ -22,12 +22,12 @@ body.newspack-web-preview__open {
 	width: 100%;
 	z-index: 99999;
 
-	&.tablet iframe {
-		max-width: 768px;
-	}
-
 	&.phone iframe {
 		max-width: 480px;
+	}
+
+	&.tablet iframe {
+		max-width: 768px;
 	}
 
 	&.newspack-web-preview__is-loaded iframe {
@@ -36,14 +36,13 @@ body.newspack-web-preview__open {
 }
 
 .newspack-web-preview__interior {
+	animation: newspack-web-preview__appear-animation 0.1s ease-out;
+	animation-fill-mode: forwards;
 	background: white;
 	border-radius: 4px 4px 0 0;
 	box-shadow: 0 8px 16px rgba( black, 0.08 );
 	height: 100%;
 	width: 100%;
-
-	animation: newspack-web-preview__appear-animation 0.1s ease-out;
-	animation-fill-mode: forwards;
 }
 
 .newspack-web-preview__content {
@@ -71,9 +70,10 @@ body.newspack-web-preview__open {
 .newspack-web-preview_is-waiting {
 	display: flex;
 	left: 50%;
-	margin: -12px 0 0 -12px;
+	margin: -12px 0 0 0;
 	position: absolute;
 	top: 50%;
+	transform: translateX(-50%);
 }
 
 .newspack-web-preview__toolbar {

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -35,6 +35,7 @@ import {
 	Modal,
 	Grid,
 	ToggleGroup,
+	WebPreview,
 } from '../../components/src';
 
 class ComponentsDemo extends Component {
@@ -83,7 +84,7 @@ class ComponentsDemo extends Component {
 			modalShown,
 			showPluginInstallerWithProgressBar,
 			actionCardToggleChecked,
-			toggleGroupChecked
+			toggleGroupChecked,
 		} = this.state;
 		return (
 			<Fragment>
@@ -98,6 +99,10 @@ class ComponentsDemo extends Component {
 					subHeaderText={ __( 'Demo of all the Newspack components' ) }
 				/>
 				<Grid>
+					<Card>
+						<FormattedHeader headerText={ __( 'Web Previews' ) } />
+						<WebPreview url="//newspack.blog" label={ __( 'Preview Newspack Blog', 'newspack' ) } />
+					</Card>
 					<Card>
 						<ToggleGroup
 							title={ __( 'Example Toggle Group' ) }
@@ -132,10 +137,7 @@ class ComponentsDemo extends Component {
 					<Card>
 						<FormattedHeader headerText={ __( 'Modal' ) } />
 						<Card noBackground className="newspack-card__buttons-card">
-							<Button
-								isPrimary
-								onClick={ () => this.setState( { modalShown: true } ) }
-							>
+							<Button isPrimary onClick={ () => this.setState( { modalShown: true } ) }>
 								{ __( 'Open modal' ) }
 							</Button>
 						</Card>
@@ -167,9 +169,9 @@ class ComponentsDemo extends Component {
 						<Notice noticeText={ __( 'This is a Primary error notice.' ) } isError isPrimary />
 						<Notice noticeText={ __( 'This is an error notice.' ) } isError />
 						<Notice noticeText={ __( 'This is a Primary success notice.' ) } isSuccess isPrimary />
-						<Notice	noticeText={ __( 'This is a success notice.' ) } isSuccess />
-						<Notice	noticeText={ __( 'This is a Primary warning notice.' ) } isWarning isPrimary />
-						<Notice	noticeText={ __( 'This is a warning notice.' ) } isWarning />
+						<Notice noticeText={ __( 'This is a success notice.' ) } isSuccess />
+						<Notice noticeText={ __( 'This is a Primary warning notice.' ) } isWarning isPrimary />
+						<Notice noticeText={ __( 'This is a warning notice.' ) } isWarning />
 					</Card>
 					<Card>
 						<FormattedHeader headerText={ __( 'Plugin installer: Progress Bar' ) } />
@@ -303,7 +305,7 @@ class ComponentsDemo extends Component {
 					<ActionCard
 						title="Example Nine"
 						description="Action Card with Toggle Control."
-						actionText={ actionCardToggleChecked && "Set Up" }
+						actionText={ actionCardToggleChecked && 'Set Up' }
 						onClick={ () => {
 							console.log( 'Set Up' );
 						} }
@@ -485,14 +487,26 @@ class ComponentsDemo extends Component {
 							<Button isLink>isLink</Button>
 							<hr />
 							<h2>isLarge</h2>
-							<Button isPrimary isLarge>isPrimary</Button>
-							<Button isDefault isLarge>isDefault</Button>
-							<Button isTertiary isLarge>isTertiary</Button>
+							<Button isPrimary isLarge>
+								isPrimary
+							</Button>
+							<Button isDefault isLarge>
+								isDefault
+							</Button>
+							<Button isTertiary isLarge>
+								isTertiary
+							</Button>
 							<hr />
 							<h2>isSmall</h2>
-							<Button isPrimary isSmall>isPrimary</Button>
-							<Button isDefault isSmall>isDefault</Button>
-							<Button isTertiary isSmall>isTertiary</Button>
+							<Button isPrimary isSmall>
+								isPrimary
+							</Button>
+							<Button isDefault isSmall>
+								isDefault
+							</Button>
+							<Button isTertiary isSmall>
+								isTertiary
+							</Button>
 						</Card>
 					</Card>
 				</Grid>

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -101,7 +101,13 @@ class ComponentsDemo extends Component {
 				<Grid>
 					<Card>
 						<FormattedHeader headerText={ __( 'Web Previews' ) } />
-						<WebPreview url="//newspack.blog" label={ __( 'Preview Newspack Blog', 'newspack' ) } />
+						<Card noBackground className="newspack-card__buttons-card">
+							<WebPreview
+								url="//newspack.blog"
+								label={ __( 'Preview Newspack Blog', 'newspack' ) }
+								isPrimary
+							/>
+						</Card>
 					</Card>
 					<Card>
 						<ToggleGroup


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the `WebPreview` component, which previews a website in an iFrame, with UI to resize to Desktop/Tablet/Phone sizes.

### How to test the changes in this Pull Request:

1. Navigate to Settings->Newspack, and click "Components Demo" in the footer.
2. In the `Web Previews` card, click `Preview Newspack Blog`.  
3. Observe an overlay appears with the Newspack Blog iFramed within. There should be a `Waiting` component visible until the site loads.
4. Try clicking the three device icons and observe changes to the dimensions of the website.
5. Click `Close`, observe the overlay disappears.

<img width="1725" alt="Screen Shot 2020-01-13 at 8 40 57 PM" src="https://user-images.githubusercontent.com/1477002/72306619-bffe9f80-3645-11ea-906b-20620092d966.png">
<img width="1725" alt="Screen Shot 2020-01-13 at 8 40 59 PM" src="https://user-images.githubusercontent.com/1477002/72306620-c4c35380-3645-11ea-89aa-8408681e7025.png">
<img width="1725" alt="Screen Shot 2020-01-13 at 8 41 01 PM" src="https://user-images.githubusercontent.com/1477002/72306625-c856da80-3645-11ea-9064-6e573b2e89e9.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->