### PR TITLE
Install latest version of Newspack Ads from Newspack

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -54,7 +54,7 @@ class Plugin_Manager {
 				'Author'      => 'Automattic',
 				'PluginURI'   => 'https://newspack.blog',
 				'AuthorURI'   => 'https://automattic.com',
-				'Download'    => 'https://github.com/Automattic/newspack-ads/releases/download/1.0.0-alpha.1/newspack-ads.zip',
+				'Download'    => 'https://github.com/Automattic/newspack-ads/releases/latest/download/newspack-ads.zip',
 			],
 			'newspack-content-converter'    => [
 				'Name'        => esc_html__( 'Newspack Content Converter', 'newspack' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue Steve and I encountered while testing the Ads integration. On a fresh Jurassic.Ninja site, installing Newspack Ads through the Ads wizard causes a fatal error every time the screen is loaded.

```
2020-01-14T22:15:06+00:00 CRITICAL Uncaught Error: Call to undefined method Newspack_Ads_Model::get_network_code() in public/wp-content/plugins/newspack-plugin-3/includes/configuration_managers/class-newspack-ads-configuration-manager.php:43
```

### How to test the changes in this Pull Request:

1. Install the latest Newspack Plugin release on a fresh Jurassic.Ninja site. Go to the Advertising wizard, install the required Newspack Ads plugin through the wizard, observe you get a fatal error and are kicked back to the dashboard whenever the page is loaded.
2. Delete the Ads plugin, modify the URL of the download to the one from this PR. Go to the Advertising wizard, install the required Newspack Ads plugin, observe everything works fine.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->