### PR TITLE
Update components publish script

### DIFF
--- a/assets/components/copy-styles.js
+++ b/assets/components/copy-styles.js
@@ -35,7 +35,7 @@ rcopy( inputDir, outputDirCommon, copyOptions )
 	.catch( err => {
 		console.error( err );
 	} );
-rcopy( path.join( dir, '..', 'shared' ), path.join( dir, 'dist', 'shared' ) )
+rcopy( path.join( dir, '..', 'shared' ), path.join( dir, 'shared' ) )
 	.then( results => {
 		console.log( 'Copied shared lib' );
 	} )

--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-components",
-  "version": "0.1.5",
+  "version": "1.0.3",
   "description": "Newspack design system components",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",
@@ -24,10 +24,14 @@
   },
   "dependencies": {
     "@wordpress/components": "^7.3.1",
-    "@wordpress/element": "^2.3.0"
+    "@wordpress/element": "^2.3.0",
+    "@material-ui/core": "^4.8.2",
+    "@material-ui/icons": "^4.5.1",
+    "@wordpress/base-styles": "^1.0.0",
+    "react-router-dom": "^5.0.1"
   },
   "devDependencies": {
-    "@automattic/calypso-build": "^2.0.0",
+    "@automattic/calypso-build": "^5.1.0",
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "recursive-copy": "2.0.10"
@@ -39,6 +43,6 @@
   },
   "scripts": {
     "prepublishOnly": "transpile && node copy-styles.js",
-    "postpublish": "rm -r dist"
+    "postpublish": "rm -r dist && rm -r shared"
   }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

It's been abut 8 months since the last published release of newspack-components. This PR updates the release script to make publishing work properly with the changes that have taken place since then.

### How to test the changes in this Pull Request:

~1. In this repo, `cd assets/src/components; npm install;`.~
1. In this repo, `cd assets/components; npm install;`. [Edited to fix path]
2. `npm publish --dry-run` to see what would be published.
3. In a separate repo where you want to use the components, [get the latest version of the npm package](https://www.npmjs.com/package/newspack-components).
4. Try something like this to verify the components can be used in third-party applications:
```
import { TextControl, Button, Card } from 'newspack-components';
import { Component, render } from '@wordpress/element';

class PackageTest extends Component {
	render() {
		return (
			<Card>
				<TextControl
					label={'Text Input' }
					value=''
					onChange={ () => {} }
				/>
				<Button isPrimary >
					Button
				</Button>
			</Card>
		);
	}
}

// #wpbody is the ID of the WP admin screen if you're testing on a WP admin screen.
render( <PackageTest />, document.getElementById( 'wpbody' ) );
```
You should see something like this:

<img width="1136" alt="Screen Shot 2020-01-14 at 4 51 56 PM" src="https://user-images.githubusercontent.com/7317227/72395693-28ee2200-36ef-11ea-8acc-e77e34610f77.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->