### PR TITLE
Button: Fix styles when Gutenberg 7.2.0 is not yet installed

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -35,6 +35,15 @@
 		text-shadow: none;
 	}
 
+	&.is-button {
+		border-radius: 3px;
+		font-size: 14px;
+		font-weight: bold;
+		height: auto;
+		line-height: 24px;
+		padding: 11px 24px;
+	}
+
 	&.is-primary {
 		background: $primary-500;
 		border: 1px solid $primary-600;
@@ -76,6 +85,7 @@
 		}
 	}
 
+	&.is-default,
 	&.is-secondary {
 		background: white;
 		border: 1px solid $light-gray-500;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Gutenberg 7.2.0 introduced new classes for the buttons.

Sites not running the latest version of Gutenberg (or simply WP) will see "broken" buttons. This PR adds the old classes used by the buttons.

__Before:__

![Screenshot 2020-01-17 at 14 50 04](https://user-images.githubusercontent.com/177929/72621186-aeb0de00-3938-11ea-9307-52caf375b9e5.png)

__After:__

![Screenshot 2020-01-17 at 14 47 09](https://user-images.githubusercontent.com/177929/72620994-511c9180-3938-11ea-8e10-7ead3b650e75.png)

_Note: there's still an issue with isLarge/isSmall/isTertiary but we don't use these during the setup so it's not too much of an issue._

### How to test the changes in this Pull Request:

1. Disable Gutenberg
2. Check the Setup wizard.
3. Switch to this branch.
4. Refresh the Setup wizard.
5. You can do the same with the Components Demo for example.
6. Re-enable G7.2.0 and check if everything is still looking ok.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->