### PR TITLE
Child Theme Installer

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -64,6 +64,7 @@ final class Newspack {
 	private function includes() {
 		include_once NEWSPACK_ABSPATH . 'includes/util.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-plugin-manager.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-theme-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -414,7 +414,7 @@ class Plugin_Manager {
 	 */
 	public static function activate( $plugin ) {
 		if ( 'newspack-theme' === $plugin ) {
-			return newspack_install_activate_theme();
+			return Theme_Manager::install_activate_theme();
 		}
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';

--- a/includes/class-theme-manager.php
+++ b/includes/class-theme-manager.php
@@ -47,7 +47,7 @@ class Theme_Manager {
 			);
 		}
 
-		$theme_url = 'https://github.com/Automattic/newspack-theme/releases/latest/download/{$slug}.zip';
+		$theme_url = "https://github.com/Automattic/newspack-theme/releases/latest/download/{$slug}.zip";
 
 		$theme_object = wp_get_theme( $slug );
 		if ( ! $theme_object->exists() ) {

--- a/includes/class-theme-manager.php
+++ b/includes/class-theme-manager.php
@@ -25,9 +25,9 @@ class Theme_Manager {
 		'newspack-theme', // Default.
 		'newspack-scott', // Style Pack 1.
 		'newspack-nelson', // Style Pack 2.
-		// 'newspack-TK', Style Pack 3.
+		'newspack-katharine', // Style Pack 3.
 		'newspack-sacha', // Style Pack 4.
-		// 'newspack-TK', Style Pack 5.
+		'newspack-joseph', // Style Pack 5.
 	];
 
 	/**

--- a/includes/class-theme-manager.php
+++ b/includes/class-theme-manager.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Newspack theme manager
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class for managing installation/activation of Newspack theme and child themes.
+ */
+class Theme_Manager {
+
+	/**
+	 * Array of valid Newspack theme slugs.
+	 *
+	 * @var array
+	 */
+	public static $theme_slugs = [
+		'newspack-theme', // Default.
+		'newspack-scott', // Style Pack 1.
+		'newspack-nelson', // Style Pack 2.
+		// 'newspack-TK', Style Pack 3.
+		'newspack-sacha', // Style Pack 4.
+		// 'newspack-TK', Style Pack 5.
+	];
+
+	/**
+	 * Install and activate the Newspack theme or a child theme.
+	 *
+	 * @param string $slug Slug of the theme to install.
+	 */
+	public static function install_activate_theme( $slug = 'newspack-theme' ) {
+		if ( ! in_array( $slug, self::$theme_slugs ) ) {
+			return new \WP_Error(
+				'newspack_theme_invalid_slug',
+				__( 'Invalid theme slug.', 'newspack' )
+			);
+		}
+
+		$theme_url = 'https://github.com/Automattic/newspack-theme/releases/latest/download/{$slug}.zip';
+
+		$theme_object = wp_get_theme( $slug );
+		if ( ! $theme_object->exists() ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+			include_once ABSPATH . 'wp-admin/includes/theme.php';
+			WP_Filesystem();
+
+			$skin     = new \Automatic_Upgrader_Skin();
+			$upgrader = new \Theme_Upgrader( $skin );
+			$success  = $upgrader->install( $theme_url );
+
+			if ( is_wp_error( $success ) ) {
+				return $success;
+			} elseif ( $success ) {
+				// Make sure `-master` or `-1.0.1` etc. are not in the theme folder name.
+				// We just want the folder name to be the theme slug.
+				$theme_object    = $upgrader->theme_info();
+				$theme_folder    = $theme_object->get_template_directory();
+				$expected_folder = $theme_object->get_theme_root() . '/' . $slug;
+				if ( $theme_folder !== $expected_folder ) {
+					rename( $theme_folder, $expected_folder ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_rename
+				}
+			} else {
+				return new \WP_Error(
+					'newspack_theme_failed_install',
+					__( 'Newspack theme installation failed.', 'newspack' )
+				);
+			}
+		}
+
+		switch_theme( $slug );
+		return true;
+	}
+}

--- a/includes/class-theme-manager.php
+++ b/includes/class-theme-manager.php
@@ -66,7 +66,7 @@ class Theme_Manager {
 				// Make sure `-master` or `-1.0.1` etc. are not in the theme folder name.
 				// We just want the folder name to be the theme slug.
 				$theme_object    = $upgrader->theme_info();
-				$theme_folder    = $theme_object->get_template_directory();
+				$theme_folder    = $theme_object->get_stylesheet_directory();
 				$expected_folder = $theme_object->get_theme_root() . '/' . $slug;
 				if ( $theme_folder !== $expected_folder ) {
 					rename( $theme_folder, $expected_folder ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_rename

--- a/includes/class-theme-manager.php
+++ b/includes/class-theme-manager.php
@@ -36,6 +36,10 @@ class Theme_Manager {
 	 * @param string $slug Slug of the theme to install.
 	 */
 	public static function install_activate_theme( $slug = 'newspack-theme' ) {
+		if ( ! self::can_install_themes() ) {
+			return new WP_Error( 'newspack_theme_failed_install', __( 'Themes cannot be installed.', 'newspack' ) );
+		}
+
 		if ( ! in_array( $slug, self::$theme_slugs ) ) {
 			return new \WP_Error(
 				'newspack_theme_invalid_slug',
@@ -76,6 +80,20 @@ class Theme_Manager {
 		}
 
 		switch_theme( $slug );
+		return true;
+	}
+
+	/**
+	 * Determine whether theme installation is allowed in the current environment.
+	 *
+	 * @return bool
+	 */
+	public static function can_install_themes() {
+		if ( ( defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT ) ||
+			( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) ) {
+			return false;
+		}
+
 		return true;
 	}
 }

--- a/includes/util.php
+++ b/includes/util.php
@@ -35,49 +35,6 @@ function newspack_string_to_bool( $string ) {
 }
 
 /**
- * Activate the Newspack theme (installing it if necessary).
- *
- * @return bool | WP_Error True on success. WP_Error on failure.
- */
-function newspack_install_activate_theme() {
-	$theme_slug = 'newspack-theme';
-	$theme_url  = 'https://github.com/Automattic/newspack-theme/releases/latest/download/newspack-theme.zip';
-
-	$theme_object = wp_get_theme( $theme_slug );
-	if ( ! $theme_object->exists() ) {
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-		include_once ABSPATH . 'wp-admin/includes/theme.php';
-		WP_Filesystem();
-
-		$skin     = new \Automatic_Upgrader_Skin();
-		$upgrader = new \Theme_Upgrader( $skin );
-		$success  = $upgrader->install( $theme_url );
-
-		if ( is_wp_error( $success ) ) {
-			return $success;
-		} else if ( $success ) {
-			// Make sure `-master` or `-1.0.1` etc. are not in the theme folder name.
-			// We just want the folder name to be the theme slug.
-			$theme_object    = $upgrader->theme_info();
-			$theme_folder    = $theme_object->get_template_directory();
-			$expected_folder = $theme_object->get_theme_root() . '/' . $theme_slug;
-			if ( $theme_folder !== $expected_folder ) {
-				rename( $theme_folder, $expected_folder );
-			}
-		} else {
-			return new \WP_Error(
-				'newspack_theme_failed_install',
-				__( 'Newspack theme installation failed.', 'newspack' )
-			);
-		}
-	}
-
-	switch_theme( $theme_slug );
-	return true;
-}
-
-/**
  * Get full list of currency codes. Copied from https://github.com/woocommerce/woocommerce/blob/master/includes/wc-core-functions.php
  *
  * @return array

--- a/tests/unit-tests/theme-manager.php
+++ b/tests/unit-tests/theme-manager.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests theme manager functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Theme_Manager;
+
+/**
+ * Test plugin API endpoints functionality.
+ */
+class Newspack_Test_Theme_Controller extends WP_UnitTestCase {
+	/**
+	 * Compatibility checks and clean up.
+	 */
+	public function setUp() {
+		// These tests can't run on environments where we can't install themes e.g. VIP Go.
+		if ( ! Theme_Manager::can_install_themes() ) {
+			$this->markTestSkipped( 'Plugin installation is not allowed in the environment' );
+		}
+	}
+
+	/**
+	 * Test installing Newspack theme.
+	 */
+	public function test_install_activate_default() {
+		$result = Theme_Manager::install_activate_theme();
+		$this->assertTrue( $result );
+		$this->assertEquals( 'newspack-theme', get_stylesheet() );
+	}
+
+	/**
+	 * Test installing non-existent child theme.
+	 */
+	public function test_install_nonexistent_child_theme() {
+		$previous_stylesheet = get_stylesheet();
+
+		$result = Theme_Manager::install_activate_theme( 'newspack-fake' );
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertEquals( $previous_stylesheet, get_stylesheet() );
+	}
+
+	/**
+	 * Test installing Newspack Sacha child theme.
+	 */
+	public function test_install_activate_sacha() {
+		$result = Theme_Manager::install_activate_theme( 'newspack-sacha' );
+		$this->assertTrue( $result );
+		$this->assertEquals( 'newspack-sacha', get_stylesheet() );
+	}
+
+	// TODO: Tests for five other themes after releases have been made.
+}

--- a/tests/unit-tests/theme-manager.php
+++ b/tests/unit-tests/theme-manager.php
@@ -50,5 +50,39 @@ class Newspack_Test_Theme_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 'newspack-sacha', get_stylesheet() );
 	}
 
-	// TODO: Tests for five other themes after releases have been made.
+	/**
+	 * Test installing Newspack Scott child theme.
+	 */
+	public function test_install_activate_scott() {
+		$result = Theme_Manager::install_activate_theme( 'newspack-scott' );
+		$this->assertTrue( $result );
+		$this->assertEquals( 'newspack-scott', get_stylesheet() );
+	}
+
+	/**
+	 * Test installing Newspack Nelson child theme.
+	 */
+	public function test_install_activate_nelson() {
+		$result = Theme_Manager::install_activate_theme( 'newspack-nelson' );
+		$this->assertTrue( $result );
+		$this->assertEquals( 'newspack-nelson', get_stylesheet() );
+	}
+
+	/**
+	 * Test installing Newspack Katharine child theme.
+	 */
+	public function test_install_activate_katharine() {
+		$result = Theme_Manager::install_activate_theme( 'newspack-katharine' );
+		$this->assertTrue( $result );
+		$this->assertEquals( 'newspack-katharine', get_stylesheet() );
+	}
+
+	/**
+	 * Test installing Newspack Joseph child theme.
+	 */
+	public function test_install_activate_joseph() {
+		$result = Theme_Manager::install_activate_theme( 'newspack-joseph' );
+		$this->assertTrue( $result );
+		$this->assertEquals( 'newspack-joseph', get_stylesheet() );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR moves theme management into a dedicated class (`Theme_Manager`), and adds functionality to install and activate the five Newspack child themes. 

### How to test the changes in this Pull Request:

There is now a test for installing each child theme, so in theory running tests may be all you need. To test theme installation in PHP, add this snippet to `newspack.php`:

```
add_action(
	'init',
	function() {
		\Newspack\Theme_Manager::install_activate_theme( 'newspack-theme' );
	}
);
```

Then, refresh the Themes page (you will actually need to refresh twice because the newly installed theme won't show as installed until the next request). Try this with all child themes and verify each is installed an activated successfully:

`newspack-theme`, `newspack-scott`, `newspack-nelson`, `newspack-katharine`, `newspack-sacha`, `newspack-joseph`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->