### PR TITLE
Install Site Kit from WPORG

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -145,7 +145,7 @@ class Plugin_Manager {
 				'Author'      => 'Google',
 				'AuthorURI'   => 'https://opensource.google.com',
 				'PluginURI'   => 'https://sitekit.withgoogle.com/',
-				'Download'    => 'https://sitekit.withgoogle.com/service/download/google-site-kit.zip',
+				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=googlesitekit-splash',
 				'Configurer'  => [
 					'filename'   => 'class-site-kit-configuration-manager.php',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The old Site Kit zip URL from Google's site installs Site Kit version `1.0.0-rc.3`. It doesn't look like they've continued updating that URL since Site Kit was released on WPORG. This PR updates the Site Kit location to WPORG so we install the latest version.

### How to test the changes in this Pull Request:

1. Download the file at `https://sitekit.withgoogle.com/service/download/google-site-kit.zip` or install Site Kit through Newspack without this PR. Observe it's version `1.0.0-rc.3`.
2. Apply this patch. Install Site Kit through Newspack. Observe it's version `1.2.0`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->