### PR TITLE
Fix Starter Content Homepage Column Blocks

### DIFF
--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -117,12 +117,12 @@ class Starter_Content {
 		?>
 		<!-- wp:columns {"className":"is-style-borders"} --><div class="wp-block-columns is-style-borders">
 
-			<!-- wp:column {"width":66.66} --><div class="wp-block-column" style="flex-basis:calc(66.66% - 16px)">
+			<!-- wp:column {"width":66.66} --><div class="wp-block-column" style="flex-basis:66.66%">
 
 				<!-- wp:newspack-blocks/homepage-articles {"postsToShow":1,"categories":[<?php echo esc_attr( $categories[1]->term_id ); ?>],"sectionHeader":"<?php echo esc_html( $categories[1]->name ); ?>"} /-->
 
 			</div><!-- /wp:column -->
-			<!-- wp:column {"width":33.33} --><div class="wp-block-column" style="flex-basis:calc(33.33% - 16px)">
+			<!-- wp:column {"width":33.33} --><div class="wp-block-column" style="flex-basis:33.33%">
 
 				<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"imageShape":"square","showAvatar":false,"postsToShow":3,"mediaPosition":"left","categories":[<?php echo esc_attr( $categories[2]->term_id ); ?>],"typeScale":2,"imageScale":1,"sectionHeader":"<?php echo esc_html( $categories[2]->name ); ?>"} /-->
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the homepage markup generated by the Starter Content Wizard so that Columns are not invalidated. 

Closes https://github.com/Automattic/newspack-plugin/issues/393

### How to test the changes in this Pull Request:

1. On a local instance, delete all Posts and Pages.
2. On `master` run through the Setup Wizard, including Starter Content.
3. Navigate to Pages->Homepage, verify the column blocks are invalid.
4. Switch to this branch, repeat steps 1-2.
5. Navigate to Pages->Homepage, verify the column blocks work properly and are not invalidated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->