### PR TITLE
Bump version for release

### DIFF
--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.0.0-alpha.15
+ * Version: 1.0.0-alpha.17
  * Author: Automattic
  * Author URI: https://newspack.blog/
  * License: GPL2


### PR DESCRIPTION
The version was bumped to `alpha.15`, however we released `alpha.16` last week. This PR updates it to the actual next version. 