### PR TITLE
Whitelist Plugin: Password Protected

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -315,6 +315,14 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://organicthemes.com/',
 				'Download'    => 'wporg',
 			],
+			'password-protected'            => [
+				'Name'        => 'Password Protected',
+				'Description' => 'A very simple way to quickly password protect your WordPress site with a single password. Please note: This plugin does not restrict access to uploaded files and images and does not work with some caching setups.',
+				'Author'      => 'Ben Huson',
+				'PluginURI'   => 'http://github.com/benhuson/password-protected/',
+				'AuthorURI'   => 'http://github.com/benhuson/password-protected/',
+				'Download'    => 'wporg',
+			],
 		];
 
 		$default_info = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Whitelists the Password Protected plugin, which is typically used on staging sites before launch: https://wordpress.org/plugins/password-protected/

### How to test the changes in this Pull Request:

1. If Password Protected is installed, de-activate and delete it.
2. Check out `add/password-protected-plugin`. 
3. Navigate to Plugins admin page. 
4. Observe "Password Protected" is listed as a Newspack-supported plugin.
5. Install Password Protected.
6. Navigate to Newspack->Health Check and verify it is not listed there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->