### PR TITLE
MC4WP support

### DIFF
--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -14,109 +14,10 @@ defined( 'ABSPATH' ) || exit;
  * When possible it's preferred to contribute AMP fixes downstream to the actual plugin.
  */
 class AMP_Enhancements {
-
 	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-
-		// Add AMP-compatibility to MC4WP: Mailchimp for WordPress plugin.
-		add_filter( 'mc4wp_form_content', [ __CLASS__, 'mc4wp_add_amp_templates' ], 10, 2 );
-		add_filter( 'mc4wp_form_element_attributes', [ __CLASS__, 'mc4wp_add_amp_request' ] );
-		add_action( 'rest_api_init', [ __CLASS__, 'mc4wp_add_form_endpoint' ] );
-	}
-
-	/**
-	 * Add AMP templates for submit/success/error to MC4WP forms.
-	 *
-	 * @param string     $content The form content.
-	 * @param MC4WP_Form $form The form object.
-	 * @return string    Modified $content.
-	 */
-	public static function mc4wp_add_amp_templates( $content, $form ) {
-		if ( ! function_exists( 'is_amp_endpoint' ) || ! is_amp_endpoint() ) {
-			return $content;
-		}
-
-		ob_start();
-		?>
-		<div submitting>
-			<template type="amp-mustache">
-				<?php echo esc_html__( 'Submitting...', 'newspack' ); ?>
-			</template>
-		</div>
-		<div submit-success>
-			<template type="amp-mustache">
-				<?php echo esc_html( $form->get_message( 'subscribed' ) ); ?>
-			</template>
-		</div>
-		<div submit-error>
-			<template type="amp-mustache">
-				{{message}}
-			</template>
-		</div>
-		<?php
-		$content .= ob_get_clean();
-
-		return $content;
-	}
-
-	/**
-	 * Add 'action-xhr' to MC4WP forms.
-	 *
-	 * @param array $attributes Key-Value pairs of attributes output on form.
-	 * @return array Modified $attributes.
-	 */
-	public static function mc4wp_add_amp_request( $attributes ) {
-		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
-			$attributes['action-xhr'] = get_rest_url( null, 'mc4wp/v1/form' );
-		}
-
-		return $attributes;
-	}
-
-	/**
-	 * Register and process an endpoint for handling the mc4wp form.
-	 * A listener checks every request for the form submit, so we just need to fetch the listener and get its status.
-	 */
-	public static function mc4wp_add_form_endpoint() {
-		register_rest_route( 
-			'mc4wp/v1', 
-			'/form', 
-			[
-				'methods'  => 'POST',
-				'callback' => function( $request ) {
-					if ( ! function_exists( 'mc4wp_get_submitted_form' ) ) {
-						return new \WP_Error(
-							'forbidden',
-							esc_html__( 'You cannot use this resource.' ),
-							[
-								'status' => 403,
-							]
-						);
-					};
-
-					$form = mc4wp_get_submitted_form();
-					if ( ! $form ) {
-						return new \WP_Error(
-							'not_found',
-							esc_html__( 'Resource does not exist.' ),
-							[
-								'status' => 404,
-							]
-						);
-					}
-
-					if ( $form->has_errors() ) {
-						$message_key = $form->errors[0];
-						$message     = $form->get_message( $message_key );
-						return new \WP_Error( $message_key, $message );
-					}
-
-					return new \WP_REST_Response( true, 200 );
-				},
-			] 
-		);
 	}
 }
 AMP_Enhancements::init();

--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -14,10 +14,109 @@ defined( 'ABSPATH' ) || exit;
  * When possible it's preferred to contribute AMP fixes downstream to the actual plugin.
  */
 class AMP_Enhancements {
+
 	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
+
+		// Add AMP-compatibility to MC4WP: Mailchimp for WordPress plugin.
+		add_filter( 'mc4wp_form_content', [ __CLASS__, 'mc4wp_add_amp_templates' ], 10, 2 );
+		add_filter( 'mc4wp_form_element_attributes', [ __CLASS__, 'mc4wp_add_amp_request' ] );
+		add_action( 'rest_api_init', [ __CLASS__, 'mc4wp_add_form_endpoint' ] );
+	}
+
+	/**
+	 * Add AMP templates for submit/success/error to MC4WP forms.
+	 *
+	 * @param string     $content The form content.
+	 * @param MC4WP_Form $form The form object.
+	 * @return string    Modified $content.
+	 */
+	public static function mc4wp_add_amp_templates( $content, $form ) {
+		if ( ! function_exists( 'is_amp_endpoint' ) || ! is_amp_endpoint() ) {
+			return $content;
+		}
+
+		ob_start();
+		?>
+		<div submitting>
+			<template type="amp-mustache">
+				<?php echo esc_html__( 'Submitting...', 'newspack' ); ?>
+			</template>
+		</div>
+		<div submit-success>
+			<template type="amp-mustache">
+				<?php echo esc_html( $form->get_message( 'subscribed' ) ); ?>
+			</template>
+		</div>
+		<div submit-error>
+			<template type="amp-mustache">
+				{{message}}
+			</template>
+		</div>
+		<?php
+		$content .= ob_get_clean();
+
+		return $content;
+	}
+
+	/**
+	 * Add 'action-xhr' to MC4WP forms.
+	 *
+	 * @param array $attributes Key-Value pairs of attributes output on form.
+	 * @return array Modified $attributes.
+	 */
+	public static function mc4wp_add_amp_request( $attributes ) {
+		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+			$attributes['action-xhr'] = get_rest_url( null, 'mc4wp/v1/form' );
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Register and process an endpoint for handling the mc4wp form.
+	 * A listener checks every request for the form submit, so we just need to fetch the listener and get its status.
+	 */
+	public static function mc4wp_add_form_endpoint() {
+		register_rest_route( 
+			'mc4wp/v1', 
+			'/form', 
+			[
+				'methods'  => 'POST',
+				'callback' => function( $request ) {
+					if ( ! function_exists( 'mc4wp_get_submitted_form' ) ) {
+						return new \WP_Error(
+							'forbidden',
+							esc_html__( 'You cannot use this resource.' ),
+							[
+								'status' => 403,
+							]
+						);
+					};
+
+					$form = mc4wp_get_submitted_form();
+					if ( ! $form ) {
+						return new \WP_Error(
+							'not_found',
+							esc_html__( 'Resource does not exist.' ),
+							[
+								'status' => 404,
+							]
+						);
+					}
+
+					if ( $form->has_errors() ) {
+						$message_key = $form->errors[0];
+						$message     = $form->get_message( $message_key );
+						return new \WP_Error( $message_key, $message );
+					}
+
+					return new \WP_REST_Response( true, 200 );
+				},
+			] 
+		);
 	}
 }
 AMP_Enhancements::init();

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -323,6 +323,14 @@ class Plugin_Manager {
 				'AuthorURI'   => 'http://github.com/benhuson/password-protected/',
 				'Download'    => 'wporg',
 			],
+			'mailchimp-for-wp'              => [
+				'Name'        => 'MC4WP: Mailchimp for WordPress',
+				'Description' => 'Mailchimp for WordPress by ibericode. Adds various highly effective sign-up methods to your site.',
+				'Author'      => 'ibericode',
+				'PluginURI'   => 'https://mc4wp.com',
+				'AuthorURI'   => 'https://ibericode.com',
+				'Download'    => 'wporg',
+			],
 		];
 
 		$default_info = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-issues/issues/111.

MC4WP is used by multiple publishers, and it offers a lot of flexibility that we don't have with the Jetpack MailChimp block, like support for multiple newsletters. This PR adds AMP-compatibility to the plugin following @westonruter's [notes](https://wordpress.org/support/topic/form-error-on-2-pages/) I discovered in my research.

I'll offer this as a PR to the MC4WP repo also, because it would be better to have this enhancement upstream, but this PR is here for general review and in case they don't want it.

### How to test the changes in this Pull Request:

1. Install MC4WP via Newspack Plugins. Add your API key in the settings.
2. Create a form and add it to a page with the mc4wp shortcode.
<img width="888" alt="Screen Shot 2020-01-22 at 11 34 30 AM" src="https://user-images.githubusercontent.com/7317227/72927557-551b2b80-3d0b-11ea-948c-0af6c0ffe71a.png">
3. In AMP and non-AMP mode try out the form. You should get the same look and behavior in each.
<img width="780" alt="Screen Shot 2020-01-22 at 11 35 15 AM" src="https://user-images.githubusercontent.com/7317227/72927550-52203b00-3d0b-11ea-9f55-383730019567.png">

**Note:** The form will be unstyled. This is the standard behavior. We can add styling in the main theme after this is merged here or at mc4wp repo.

Upstream status: [Offered this to the MC4WP repo](https://github.com/ibericode/mailchimp-for-wordpress/issues/457#issuecomment-577356819)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->