### PR TITLE
WebPreview: layering fix; renderButton prop

### DIFF
--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component, Fragment, createPortal } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -30,11 +30,33 @@ class WebPreview extends Component {
 	state = {
 		device: 'desktop',
 		loaded: false,
-		previewVisibility: false,
+		isPreviewVisible: false,
+		modalDOMElement: null,
 	};
 
+	/**
+	 * Create a div and append it to the body, so that the modal is on the top layer
+	 */
+	componentDidMount() {
+		const modalDOMElement = document.createElement( 'div' );
+		document.body.appendChild( modalDOMElement );
+		this.setState( { modalDOMElement } );
+	}
+
+	/**
+	 * Cleanup
+	 */
+	componentWillUnmount() {
+		if ( this.state.modalDOMElement ) {
+			document.body.removeChild( this.state.modalDOMElement );
+		}
+	}
+
+	/**
+	 * Add or remove applicable body classes
+	 */
 	componentDidUpdate() {
-		if ( this.state.previewVisibility === true ) {
+		if ( this.state.isPreviewVisible === true ) {
 			document.body.classList.add( 'newspack-web-preview__open' );
 		} else {
 			document.body.classList.remove( 'newspack-web-preview__open' );
@@ -42,83 +64,118 @@ class WebPreview extends Component {
 	}
 
 	/**
-	 * Render.
+	 * Create JSX for the modal
 	 */
-	render() {
-		const { label, url, isPrimary, isSecondary, isTertiary, isLink, isLarge, isSmall } = this.props;
-		const { device, loaded, previewVisibility } = this.state;
+	getWebPreviewModal = () => {
+		const { url } = this.props;
+		const { device, loaded, modalDOMElement, isPreviewVisible } = this.state;
+
+		if ( ! modalDOMElement || ! isPreviewVisible ) {
+			return null;
+		}
+
 		const classes = classnames(
 			'newspack-web-preview__container',
 			device,
 			loaded && 'newspack-web-preview__is-loaded'
 		);
-		return (
-			<Fragment>
-				<Button
-					isPrimary={ isPrimary }
-					isSecondary={ isSecondary }
-					isTertiary={ isTertiary }
-					isLink={ isLink }
-					isLarge={ isLarge }
-					isSmall={ isSmall }
-					onClick={ () => this.setState( { previewVisibility: true } ) }
-				>
-					{ label }
-				</Button>
-				{ !! previewVisibility && (
-					<div className={ classes }>
-						<div className="newspack-web-preview__interior">
-							<div className="newspack-web-preview__toolbar">
-								<div className="newspack-web-preview__toolbar-left">
-									<Button
-										onClick={ () => this.setState( { device: 'desktop' } ) }
-										isPrimary={ 'desktop' === device }
-										isSecondary={ 'desktop' !== device }
-										className="is-desktop"
-									>
-										<DesktopWindowsIcon />
-										<span className="screen-reader-text">{ __( 'Preview desktop size' ) }</span>
-									</Button>
-									<Button
-										onClick={ () => this.setState( { device: 'tablet' } ) }
-										isPrimary={ 'tablet' === device }
-										isSecondary={ 'tablet' !== device }
-										className="is-tablet"
-									>
-										<TabletAndroidIcon />
-										<span className="screen-reader-text">{ __( 'Preview tablet size' ) }</span>
-									</Button>
-									<Button
-										onClick={ () => this.setState( { device: 'phone' } ) }
-										isPrimary={ 'phone' === device }
-										isSecondary={ 'phone' !== device }
-										className="is-phone"
-									>
-										<PhoneAndroidIcon />
-										<span className="screen-reader-text">{ __( 'Preview phone size' ) }</span>
-									</Button>
-								</div>
-								<div className="newspack-web-preview__toolbar-right">
-									<Button
-										onClick={ () => this.setState( { previewVisibility: false, loaded: false } ) }
-									>
-										<CloseIcon />
-										<span className="screen-reader-text">{ __( 'Close preview' ) }</span>
-									</Button>
-								</div>
-							</div>
-							<div className="newspack-web-preview__content">
-								{ ! loaded &&
-									<div className="newspack-web-preview__is-waiting">
-										<Waiting isLeft />
-										{ __( 'Loading...' ) }
-									</div>
-								}
-								<iframe src={ url } onLoad={ () => this.setState( { loaded: true } ) } />
-							</div>
+
+		return createPortal(
+			<div className={ classes }>
+				<div className="newspack-web-preview__interior">
+					<div className="newspack-web-preview__toolbar">
+						<div className="newspack-web-preview__toolbar-left">
+							<Button
+								onClick={ () => this.setState( { device: 'desktop' } ) }
+								isPrimary={ 'desktop' === device }
+								isSecondary={ 'desktop' !== device }
+								className="is-desktop"
+							>
+								<DesktopWindowsIcon />
+								<span className="screen-reader-text">{ __( 'Preview desktop size' ) }</span>
+							</Button>
+							<Button
+								onClick={ () => this.setState( { device: 'tablet' } ) }
+								isPrimary={ 'tablet' === device }
+								isSecondary={ 'tablet' !== device }
+								className="is-tablet"
+							>
+								<TabletAndroidIcon />
+								<span className="screen-reader-text">{ __( 'Preview tablet size' ) }</span>
+							</Button>
+							<Button
+								onClick={ () => this.setState( { device: 'phone' } ) }
+								isPrimary={ 'phone' === device }
+								isSecondary={ 'phone' !== device }
+								className="is-phone"
+							>
+								<PhoneAndroidIcon />
+								<span className="screen-reader-text">{ __( 'Preview phone size' ) }</span>
+							</Button>
+						</div>
+						<div className="newspack-web-preview__toolbar-right">
+							<Button onClick={ () => this.setState( { isPreviewVisible: false, loaded: false } ) }>
+								<CloseIcon />
+								<span className="screen-reader-text">{ __( 'Close preview' ) }</span>
+							</Button>
 						</div>
 					</div>
+					<div className="newspack-web-preview__content">
+						{ ! loaded && (
+							<div className="newspack-web-preview__is-waiting">
+								<Waiting isLeft />
+								{ __( 'Loading...' ) }
+							</div>
+						) }
+						<iframe src={ url } onLoad={ () => this.setState( { loaded: true } ) } />
+					</div>
+				</div>
+			</div>,
+			modalDOMElement
+		);
+	};
+
+	showPreview = () => {
+		this.setState( { isPreviewVisible: true } );
+	};
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const {
+			label,
+			isPrimary,
+			isSecondary,
+			isTertiary,
+			isLink,
+			isLarge,
+			isSmall,
+			/**
+			 * Inversion of control - let the caller render
+			 * the button that will trigger the modal
+			 */
+			renderButton,
+		} = this.props;
+
+		return (
+			<Fragment>
+				{ renderButton ? (
+					renderButton( { showPreview: this.showPreview } )
+				) : (
+					<Button
+						isPrimary={ isPrimary }
+						isSecondary={ isSecondary }
+						isTertiary={ isTertiary }
+						isLink={ isLink }
+						isLarge={ isLarge }
+						isSmall={ isSmall }
+						onClick={ this.showPreview }
+					>
+						{ label }
+					</Button>
 				) }
+				{ this.getWebPreviewModal() }
 			</Fragment>
 		);
 	}

--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -23,6 +23,8 @@ import './style.scss';
  */
 import classnames from 'classnames';
 
+const PORTAL_PARENT_ID = 'newspack-components-web-preview-wrapper';
+
 /**
  * Web Preview. A component to preview a website in an iframe, with device sizing options.
  */
@@ -31,24 +33,27 @@ class WebPreview extends Component {
 		device: 'desktop',
 		loaded: false,
 		isPreviewVisible: false,
-		modalDOMElement: null,
 	};
 
 	/**
-	 * Create a div and append it to the body, so that the modal is on the top layer
+	 * If a div with id PORTAL_PARENT_ID exists, assign it to class field.
+	 * If not, create it and append to the body.
 	 */
 	componentDidMount() {
-		const modalDOMElement = document.createElement( 'div' );
-		document.body.appendChild( modalDOMElement );
-		this.setState( { modalDOMElement } );
+		const existingDOMElement = document.getElementById( PORTAL_PARENT_ID );
+		this.modalDOMElement = existingDOMElement || document.createElement( 'div' );
+		if ( ! existingDOMElement ) {
+			this.modalDOMElement.id = PORTAL_PARENT_ID;
+			document.body.appendChild( this.modalDOMElement );
+		}
 	}
 
 	/**
 	 * Cleanup
 	 */
 	componentWillUnmount() {
-		if ( this.state.modalDOMElement ) {
-			document.body.removeChild( this.state.modalDOMElement );
+		if ( this.modalDOMElement ) {
+			document.body.removeChild( this.modalDOMElement );
 		}
 	}
 
@@ -68,9 +73,9 @@ class WebPreview extends Component {
 	 */
 	getWebPreviewModal = () => {
 		const { url } = this.props;
-		const { device, loaded, modalDOMElement, isPreviewVisible } = this.state;
+		const { device, loaded, isPreviewVisible } = this.state;
 
-		if ( ! modalDOMElement || ! isPreviewVisible ) {
+		if ( ! this.modalDOMElement || ! isPreviewVisible ) {
 			return null;
 		}
 
@@ -131,7 +136,7 @@ class WebPreview extends Component {
 					</div>
 				</div>
 			</div>,
-			modalDOMElement
+			this.modalDOMElement
 		);
 	};
 

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -107,6 +107,14 @@ class ComponentsDemo extends Component {
 								label={ __( 'Preview Newspack Blog', 'newspack' ) }
 								isPrimary
 							/>
+							<WebPreview
+								url="//newspack.blog"
+								renderButton={ ( { showPreview } ) => (
+									<a href="#" onClick={ showPreview }>
+										{ __( 'Preview Newspack Blog', 'newspack' ) }
+									</a>
+								) }
+							/>
 						</Card>
 					</Card>
 					<Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Renders the modal in a div appended to the body, this way there is more control over layering and the modal will always be on top of the admin UI. As it was before has worked fine in components preview, but when used in editor sidebar (https://github.com/Automattic/newspack-popups/pull/36) the modal was below the admin UI.
2. A new prop is introduced: `renderButton`. This lets the caller of this component render it's own button. This was used in https://github.com/Automattic/newspack-popups/pull/36 to disable the button until the post is saved. In general it enables total control over the `WebPreview`'s trigger styling (e.g. it might be a link, not a button).

### How to test the changes in this Pull Request:

1. Open components preview 
2. Click the "Preview Newspack Blog" button 
3. Observe that a model opens, and is placed towards the bottom of body element in DOM
4. Close the modal 
5. Click the "Preview Newspack Blog" link. The result should be the same as after clicking the button

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->