### PR TITLE
Plugin Toggle Component

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -14,6 +14,7 @@ export { default as Modal } from './modal';
 export { default as NewspackLogo } from './newspack-logo';
 export { default as Notice } from './notice';
 export { default as PluginInstaller } from './plugin-installer';
+export { default as PluginToggle } from './plugin-toggle';
 export { default as ProgressBar } from './progress-bar';
 export { default as SecondaryNavigation } from './secondary-navigation';
 export { default as SelectControl } from './select-control';

--- a/assets/components/src/plugin-installer/style.scss
+++ b/assets/components/src/plugin-installer/style.scss
@@ -38,6 +38,10 @@
 		&.newspack-plugin-installer__status-error {
 			border-left-color: $alert-red;
 		}
+
+		&.newspack-plugin-installer__status-installing {
+			opacity: 0.5;
+		}
 	}
 }
 

--- a/assets/components/src/plugin-toggle/README.md
+++ b/assets/components/src/plugin-toggle/README.md
@@ -1,0 +1,55 @@
+# PluginToggle
+
+PluginToggle presents ActionCards for one or more plugins.
+
+Each ActionCard displays the name and description of the plugin. Clicking the ToggleControl installs/activates or uninstalls the plugin. If a plugin is installed, there will be a Handoff link on the right. Optionally the href and label of this link can be overridden.
+
+The component accepts a shouldRefreshAfterUpdate param. If true, the page will be reloaded after any plugin is installed or uninstalled. Updating ensures that the WordPress dashboard accurately represents current state, e.g. that newly installed plugins appear in menus.
+
+### Usage
+
+ActionCards for WooCommerce and Instant Articles for WP. Both will have Handoff links.
+
+```
+<PluginToggle
+	plugins={ {
+		woocommerce: true,
+		'fb-instant-articles': true,
+	} }
+/>
+```
+
+ActionCards for WooCommerce and Instant Articles for WP with custom text and URL for links.
+
+```
+<PluginToggle
+	plugins={ {
+		woocommerce: {
+			actionText: __( 'Use WooCommerce' ),
+			href: '/wp-admin/admin.php?page=newspack',
+		},
+		'fb-instant-articles': {
+			actionText: __( 'Configure Instant Articles' ),
+			href: '/wp-admin/admin.php?page=newspack',
+		},
+	} }
+/>
+```
+
+Same as above, configured to refresh page after plugin state changes.
+
+```
+<PluginToggle
+	shouldRefreshAfterUpdate={ true }
+	plugins={ {
+		woocommerce: {
+			actionText: __( 'Use WooCommerce' ),
+			href: '/wp-admin/admin.php?page=newspack',
+		},
+		'fb-instant-articles': {
+			actionText: __( 'Configure Instant Articles' ),
+			href: '/wp-admin/admin.php?page=newspack',
+		},
+	} }
+/>
+```

--- a/assets/components/src/plugin-toggle/README.md
+++ b/assets/components/src/plugin-toggle/README.md
@@ -4,7 +4,7 @@ PluginToggle presents ActionCards for one or more plugins.
 
 Each ActionCard displays the name and description of the plugin. Clicking the ToggleControl installs/activates or uninstalls the plugin. If a plugin is installed, there will be a Handoff link on the right. Optionally the href and label of this link can be overridden.
 
-The component accepts a shouldRefreshAfterUpdate param. If true, the page will be reloaded after any plugin is installed or uninstalled. Updating ensures that the WordPress dashboard accurately represents current state, e.g. that newly installed plugins appear in menus.
+Each plugin accepts a shouldRefreshAfterUpdate param. If true, the page will be reloaded after the plugin is installed or uninstalled. Updating ensures that the WordPress dashboard accurately represents current state, e.g. that newly installed plugins appear in menus.
 
 ### Usage
 
@@ -36,15 +36,13 @@ ActionCards for WooCommerce and Instant Articles for WP with custom text and URL
 />
 ```
 
-Same as above, configured to refresh page after plugin state changes.
+ActionCards for WooCommerce and Instant Articles for WP. Page will refresh after WooCommerce installation or deinstallation.
 
 ```
 <PluginToggle
-	shouldRefreshAfterUpdate={ true }
 	plugins={ {
 		woocommerce: {
-			actionText: __( 'Use WooCommerce' ),
-			href: '/wp-admin/admin.php?page=newspack',
+			shouldRefreshAfterUpdate: true,
 		},
 		'fb-instant-articles': {
 			actionText: __( 'Configure Instant Articles' ),

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -68,7 +68,7 @@ class PluginToggle extends Component {
 		const { pluginInfo } = this.state;
 		return this.prepareDataForRender( plugins, pluginInfo ).map( plugin => {
 			const { name, description, href, slug, status, editPath, inFlight } = plugin;
-			const pluginStatus = this.statusForPlugin( plugin );
+			const pluginStatus = this.isPluginInstalledAndActive( plugin );
 			const handoff = ! href && pluginStatus && editPath ? slug : null;
 			return (
 				<ActionCard
@@ -79,7 +79,7 @@ class PluginToggle extends Component {
 					handoff={ handoff }
 					href={ href }
 					toggle
-					toggleChecked={ this.statusForPlugin( plugin ) }
+					toggleChecked={ this.isPluginInstalledAndActive( plugin ) }
 					toggleOnChange={ value => this.managePlugin( slug, value ) }
 				/>
 			);
@@ -147,7 +147,7 @@ class PluginToggle extends Component {
 			);
 		}
 		// No action button at all if the plugin isn't installed and active.
-		if ( ! this.statusForPlugin( plugin ) ) {
+		if ( ! this.isPluginInstalledAndActive( plugin ) ) {
 			return null;
 		}
 		if ( href || editPath ) {
@@ -156,9 +156,9 @@ class PluginToggle extends Component {
 	};
 
 	/**
-	 * Get installation/activation state for a plugin.
+	 * Get installation/activation status for a plugin.
 	 */
-	statusForPlugin = plugin => {
+	isPluginInstalledAndActive = plugin => {
 		const { status } = plugin;
 		return status === 'active';
 	};

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -68,7 +68,6 @@ class PluginToggle extends Component {
 	render() {
 		const { plugins } = this.props;
 		const { pluginInfo } = this.state;
-		console.log( pluginInfo );
 		return this.prepareDataForRender( plugins, pluginInfo ).map( plugin => {
 			const { name, description, href, slug, status, editPath, inFlight } = plugin;
 			const pluginStatus = this.statusForPlugin( plugin );

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -43,7 +43,7 @@ class PluginToggle extends Component {
 	 * Install/activate or remove a plugin.
 	 */
 	managePlugin = ( plugin, value ) => {
-		const { shouldRefreshAfterUpdate } = this.props;
+		const { plugins } = this.props;
 		const { pluginInfo } = this.state;
 		const action = value ? 'configure' : 'uninstall';
 		const params = {
@@ -57,6 +57,7 @@ class PluginToggle extends Component {
 			},
 			() => {
 				apiFetch( params ).then( response => {
+					const { shouldRefreshAfterUpdate } = plugins[ plugin ];
 					this.setState( { pluginInfo: { ...pluginInfo, [ plugin ]: response } }, () => shouldRefreshAfterUpdate && location.reload() );
 				} );
 			}

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -52,7 +52,7 @@ class PluginToggle extends Component {
 
 		this.setState(
 			{
-				pluginInfo: { ...pluginInfo, [ plugin ]: { ...pluginInfo[ plugin ], inFlight: true } },
+				pluginInfo: { ...pluginInfo, [ plugin ]: { ...pluginInfo[ plugin ], inFlight: action } },
 			},
 			() => {
 				apiFetch( params ).then( response => {
@@ -127,7 +127,21 @@ class PluginToggle extends Component {
 	actionTextForPlugin = plugin => {
 		const { actionText, editPath, href, inFlight, name } = plugin;
 		// Show spinner when plugin data is unavailable, or when an API call is in flight.
-		if ( inFlight || ! name ) {
+		if ( 'configure' === inFlight ) {
+			return (
+				<Fragment>
+					{ __( 'Installing...', 'newspack' ) } <Waiting isRight />
+				</Fragment>
+			);
+		}
+		if ( 'uninstall' === inFlight ) {
+			return (
+				<Fragment>
+					{ __( 'Uninstalling...', 'newspack' ) } <Waiting isRight />
+				</Fragment>
+			);
+		}
+		if ( ! name ) {
 			return (
 				<Fragment>
 					{ __( 'Loading...', 'newspack' ) } <Waiting isRight />

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -1,0 +1,152 @@
+/**
+ * Plugin toggle group component.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import { ActionCard, Waiting } from '../';
+import './style.scss';
+
+/**
+ * Plugin toggle group component.
+ */
+class PluginToggle extends Component {
+	state = {
+		pluginInfo: {},
+	};
+
+	componentDidMount = () => {
+		this.retrievePluginInfo();
+	};
+
+	/**
+	 * Retrieve complete data about Newspack plugins.
+	 */
+	retrievePluginInfo = () => {
+		const { plugins } = this.props;
+		return new Promise( ( resolve, reject ) => {
+			apiFetch( { path: '/newspack/v1/plugins/' } ).then( pluginInfo =>
+				this.setState( { pluginInfo } )
+			);
+		} );
+	};
+
+	/**
+	 * Install/activate or remove a plugin.
+	 */
+	managePlugin = ( plugin, value ) => {
+		const { pluginInfo } = this.state;
+		const action = value ? 'configure' : 'uninstall';
+		const params = {
+			path: `/newspack/v1/plugins/${ plugin }/${ action }/`,
+			method: 'post',
+		};
+
+		this.setState(
+			{
+				pluginInfo: { ...pluginInfo, [ plugin ]: { ...pluginInfo[ plugin ], inFlight: true } },
+			},
+			() => {
+				apiFetch( params ).then( response => {
+					this.setState( { pluginInfo: { ...pluginInfo, [ plugin ]: response } } );
+				} );
+			}
+		);
+	};
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const { plugins } = this.props;
+		const { pluginInfo } = this.state;
+		console.log( pluginInfo );
+		return this.prepareDataForRender( plugins, pluginInfo ).map( plugin => {
+			const { name, description, href, slug, status, editpath, inFlight } = plugin;
+			const pluginStatus = this.statusForPlugin( plugin );
+			const handoff = pluginStatus && editpath ? slug : null;
+			return (
+				<ActionCard
+					className={ this.classNameForPlugin( plugin ) }
+					title={ name }
+					description={ description }
+					actionText={ this.actionTextForPlugin( plugin ) }
+					handoff={ handoff }
+					href={ href }
+					toggle
+					toggleChecked={ this.statusForPlugin( plugin ) }
+					toggleOnChange={ value => this.managePlugin( slug, value ) }
+				/>
+			);
+		} );
+	}
+
+	/**
+	 * Prepare plugins data for render. Change all keys to camelCase, merge API-fetched data with prop.
+	 */
+	prepareDataForRender = ( pluginsFromProps, pluginsFromAPI ) =>
+		Object.keys( pluginsFromProps )
+			.map( pluginSlug =>
+				pluginsFromAPI[ pluginSlug ]
+					? Object.keys( pluginsFromAPI[ pluginSlug ] ).reduce(
+							( accumulator, key ) => ( {
+								...accumulator,
+								[ key.charAt( 0 ).toLowerCase() + key.slice( 1 ) ]: pluginsFromAPI[ pluginSlug ][
+									key
+								],
+							} ),
+							{}
+					  )
+					: {}
+			)
+			.map( plugin => Object.assign( plugin, pluginsFromProps[ plugin.slug ] ) );
+
+	/**
+	 * Generate a classname for the ActionCard based on plugin state. Applies 'in-flight' class if an API is underway and 'loading' if the plugin data is not yet available.
+	 */
+	classNameForPlugin = plugin => {
+		const { status, inFlight } = plugin;
+		if ( inFlight ) {
+			return 'in-flight';
+		}
+		if ( ! status ) {
+			return 'loading';
+		}
+	};
+
+	/**
+	 * Generate the ActionCard action text for a plugin.
+	 */
+	actionTextForPlugin = plugin => {
+		const { actionText, editpath, href, inFlight, name } = plugin;
+		// Show spinner when plugin data is unavailable, or when an API call is in flight.
+		if ( inFlight || ! name ) {
+			return <Waiting />;
+		}
+		// No action button at all if the plugin isn't installed and active.
+		if ( ! this.statusForPlugin( plugin ) ) {
+			return null;
+		}
+		if ( href || editpath ) {
+			return actionText ? actionText : __( 'Configure', 'newspack' );
+		}
+	};
+
+	/**
+	 * Get installation/activation state for a plugin.
+	 */
+	statusForPlugin = plugin => {
+		const { status } = plugin;
+		return status === 'active';
+	};
+}
+
+export default PluginToggle;

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -43,6 +43,7 @@ class PluginToggle extends Component {
 	 * Install/activate or remove a plugin.
 	 */
 	managePlugin = ( plugin, value ) => {
+		const { shouldRefreshAfterUpdate } = this.props;
 		const { pluginInfo } = this.state;
 		const action = value ? 'configure' : 'uninstall';
 		const params = {
@@ -56,7 +57,7 @@ class PluginToggle extends Component {
 			},
 			() => {
 				apiFetch( params ).then( response => {
-					this.setState( { pluginInfo: { ...pluginInfo, [ plugin ]: response } } );
+					this.setState( { pluginInfo: { ...pluginInfo, [ plugin ]: response } }, () => shouldRefreshAfterUpdate && location.reload() );
 				} );
 			}
 		);

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -41,7 +41,7 @@ class PluginToggle extends Component {
 	managePlugin = ( plugin, value ) => {
 		const { plugins } = this.props;
 		const { pluginInfo } = this.state;
-		const action = value ? 'configure' : 'uninstall';
+		const action = value ? 'configure' : 'deactivate';
 		const params = {
 			path: `/newspack/v1/plugins/${ plugin }/${ action }/`,
 			method: 'post',
@@ -133,10 +133,10 @@ class PluginToggle extends Component {
 				</Fragment>
 			);
 		}
-		if ( 'uninstall' === inFlight ) {
+		if ( 'deactivate' === inFlight ) {
 			return (
 				<Fragment>
-					{ __( 'Uninstalling...', 'newspack' ) } <Waiting isRight />
+					{ __( 'Deactivating...', 'newspack' ) } <Waiting isRight />
 				</Fragment>
 			);
 		}

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -66,12 +66,13 @@ class PluginToggle extends Component {
 	render() {
 		const { plugins } = this.props;
 		const { pluginInfo } = this.state;
-		return this.prepareDataForRender( plugins, pluginInfo ).map( plugin => {
+		return this.prepareDataForRender( plugins, pluginInfo ).map( ( plugin, index ) => {
 			const { name, description, href, slug, status, editPath, inFlight } = plugin;
 			const pluginStatus = this.isPluginInstalledAndActive( plugin );
 			const handoff = ! href && pluginStatus && editPath ? slug : null;
 			return (
 				<ActionCard
+					key={ index }
 					className={ this.classNameForPlugin( plugin ) }
 					title={ name }
 					description={ description }

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -72,7 +72,7 @@ class PluginToggle extends Component {
 		return this.prepareDataForRender( plugins, pluginInfo ).map( plugin => {
 			const { name, description, href, slug, status, editPath, inFlight } = plugin;
 			const pluginStatus = this.statusForPlugin( plugin );
-			const handoff = pluginStatus && editPath ? slug : null;
+			const handoff = ! href && pluginStatus && editPath ? slug : null;
 			return (
 				<ActionCard
 					className={ this.classNameForPlugin( plugin ) }

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -131,7 +131,7 @@ class PluginToggle extends Component {
 		if ( inFlight || ! name ) {
 			return (
 				<Fragment>
-					{ __( 'Loading', 'newspack' ) } <Waiting isRight />
+					{ __( 'Loading...', 'newspack' ) } <Waiting isRight />
 				</Fragment>
 			);
 		}

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -129,7 +129,11 @@ class PluginToggle extends Component {
 		const { actionText, editpath, href, inFlight, name } = plugin;
 		// Show spinner when plugin data is unavailable, or when an API call is in flight.
 		if ( inFlight || ! name ) {
-			return <Waiting />;
+			return (
+				<Fragment>
+					{ __( 'Loading', 'newspack' ) } <Waiting isRight />
+				</Fragment>
+			);
 		}
 		// No action button at all if the plugin isn't installed and active.
 		if ( ! this.statusForPlugin( plugin ) ) {

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -70,9 +70,9 @@ class PluginToggle extends Component {
 		const { pluginInfo } = this.state;
 		console.log( pluginInfo );
 		return this.prepareDataForRender( plugins, pluginInfo ).map( plugin => {
-			const { name, description, href, slug, status, editpath, inFlight } = plugin;
+			const { name, description, href, slug, status, editPath, inFlight } = plugin;
 			const pluginStatus = this.statusForPlugin( plugin );
-			const handoff = pluginStatus && editpath ? slug : null;
+			const handoff = pluginStatus && editPath ? slug : null;
 			return (
 				<ActionCard
 					className={ this.classNameForPlugin( plugin ) }
@@ -126,7 +126,7 @@ class PluginToggle extends Component {
 	 * Generate the ActionCard action text for a plugin.
 	 */
 	actionTextForPlugin = plugin => {
-		const { actionText, editpath, href, inFlight, name } = plugin;
+		const { actionText, editPath, href, inFlight, name } = plugin;
 		// Show spinner when plugin data is unavailable, or when an API call is in flight.
 		if ( inFlight || ! name ) {
 			return (
@@ -139,7 +139,7 @@ class PluginToggle extends Component {
 		if ( ! this.statusForPlugin( plugin ) ) {
 			return null;
 		}
-		if ( href || editpath ) {
+		if ( href || editPath ) {
 			return actionText ? actionText : __( 'Configure', 'newspack' );
 		}
 	};

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -1,8 +1,4 @@
 /**
- * Plugin toggle group component.
- */
-
-/**
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';

--- a/assets/components/src/plugin-toggle/style.scss
+++ b/assets/components/src/plugin-toggle/style.scss
@@ -7,6 +7,8 @@
 .newspack-action-card {
 	&.in-flight,
 	&.loading {
+		opacity: 0.5;
+
 		.newspack-action-card__region-right {
 			.newspack-button {
 				color: $dark-gray-300;

--- a/assets/components/src/plugin-toggle/style.scss
+++ b/assets/components/src/plugin-toggle/style.scss
@@ -1,0 +1,12 @@
+/**
+ * Plugin Installer
+ */
+
+@import '~@wordpress/base-styles/colors';
+
+.newspack-action-card.in-flight {
+	opacity: 0.5;
+}
+.newspack-action-card.loading {
+	opacity: 0.2;
+}

--- a/assets/components/src/plugin-toggle/style.scss
+++ b/assets/components/src/plugin-toggle/style.scss
@@ -1,12 +1,18 @@
 /**
- * Plugin Installer
+ * Plugin Toggle
  */
 
 @import '~@wordpress/base-styles/colors';
 
-.newspack-action-card.in-flight {
-	opacity: 0.5;
-}
-.newspack-action-card.loading {
-	opacity: 0.2;
+.newspack-action-card {
+	&.in-flight,
+	&.loading {
+		.newspack-action-card__region-right {
+			.newspack-button {
+				color: $dark-gray-300;
+				pointer-events: none;
+				text-decoration: none;
+			}
+		}
+	}
 }

--- a/assets/components/src/waiting/style.scss
+++ b/assets/components/src/waiting/style.scss
@@ -28,9 +28,9 @@
 
 @keyframes newspack-is-waiting__animation {
 	from {
-		transform: rotate( 0deg );
+		transform: rotate( 360deg );
 	}
 	to {
-		transform: rotate( 360deg );
+		transform: rotate( 0deg );
 	}
 }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -28,6 +28,7 @@ import {
 	Notice,
 	TextControl,
 	PluginInstaller,
+	PluginToggle,
 	ProgressBar,
 	Checklist,
 	Task,
@@ -99,6 +100,19 @@ class ComponentsDemo extends Component {
 					subHeaderText={ __( 'Demo of all the Newspack components' ) }
 				/>
 				<Grid>
+					<Card>
+						<FormattedHeader headerText={ __( 'Plugin toggles' ) } />
+						<PluginToggle
+							plugins={ {
+								laterpay: true,
+								'organic-profile-block': {
+									href: 'wp-admin/admin.php?page=newspack',
+									actionText: __( 'Dashboard' ),
+								},
+								'password-protected': true,
+							} }
+						/>
+					</Card>
 					<Card>
 						<FormattedHeader headerText={ __( 'Web Previews' ) } />
 						<Card noBackground className="newspack-card__buttons-card">

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -104,10 +104,12 @@ class ComponentsDemo extends Component {
 						<FormattedHeader headerText={ __( 'Plugin toggles' ) } />
 						<PluginToggle
 							plugins={ {
-								'laterpay': true,
-								'organic-profile-block': true,
-								'password-protected': {
-									actionText: __( 'Settings' ),
+								woocommerce: {
+									shouldRefreshAfterUpdate: true,
+								},
+								'fb-instant-articles': {
+									actionText: __( 'Configure Instant Articles' ),
+									href: '/wp-admin/admin.php?page=newspack',
 								},
 							} }
 						/>

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -107,7 +107,6 @@ class ComponentsDemo extends Component {
 								'laterpay': true,
 								'organic-profile-block': true,
 								'password-protected': {
-									href: '/wp-admin/options-general.php?page=password-protected',
 									actionText: __( 'Settings' ),
 								},
 							} }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -104,12 +104,12 @@ class ComponentsDemo extends Component {
 						<FormattedHeader headerText={ __( 'Plugin toggles' ) } />
 						<PluginToggle
 							plugins={ {
-								laterpay: true,
-								'organic-profile-block': {
-									href: 'wp-admin/admin.php?page=newspack',
-									actionText: __( 'Dashboard' ),
+								'laterpay': true,
+								'organic-profile-block': true,
+								'password-protected': {
+									href: '/wp-admin/options-general.php?page=password-protected',
+									actionText: __( 'Settings' ),
 								},
-								'password-protected': true,
 							} }
 						/>
 					</Card>

--- a/assets/wizards/handoff-banner/style.scss
+++ b/assets/wizards/handoff-banner/style.scss
@@ -55,6 +55,12 @@
 	.site-kit_page_googlesitekit-splash & {
 		margin-bottom: -25px;
 	}
+
+	// LaterPay
+
+	body[class*="laterpay_page_laterpay"] & {
+		margin-left: 0;
+	}
 }
 
 .newspack-handoff-banner {

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -293,7 +293,7 @@ class Plugin_Manager {
 				'PluginURI'   => 'https://wordpress.org/plugins/laterpay/',
 				'AuthorURI'   => 'https://www.laterpay.net/',
 				'Download'    => 'wporg',
-				'Editpath'    => 'admin.php?page=laterpay-pricing-tab',
+				'EditPath'    => 'admin.php?page=laterpay-pricing-tab',
 				'Configurer'  => [
 					'filename'   => 'class-laterpay-configuration-manager.php',
 					'class_name' => 'LaterPay_Configuration_Manager',

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -322,6 +322,7 @@ class Plugin_Manager {
 				'PluginURI'   => 'http://github.com/benhuson/password-protected/',
 				'AuthorURI'   => 'http://github.com/benhuson/password-protected/',
 				'Download'    => 'wporg',
+				'EditPath'    => 'options-general.php?page=password-protected',
 			],
 			'mailchimp-for-wp'              => [
 				'Name'        => 'MC4WP: Mailchimp for WordPress',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a component that allows toggling the installation of multiple plugins. The plugin has a [README](https://github.com/Automattic/newspack-plugin/blob/3a0dc567d90bc69de5b6c26876c851936fb1ccbc/assets/components/src/plugin-toggle/README.md) describing the use in more detail.

<img width="725" alt="Screen Shot 2020-01-29 at 2 52 45 PM" src="https://user-images.githubusercontent.com/1477002/73392329-98dfd900-42a7-11ea-9642-fa807471378e.png">

### How to test the changes in this Pull Request:

1. Checkout and build this branch.
2. On main Plugins page, deactivate WooCommerce and Instant Articles for WP.
3. Navigate to the Components Demo (Settings->Newspack then click on Components Demo link at the bottom).
4. Toggle WooCommerce on. After installation, the page should reload revealing the WC item in the left nav. The text to the right should read "Configure" and should be a Handoff link to WooCommerce.
5. Toggle Instant Articles for WP on. Verify the page does NOT reload. The text to the right should be "Configure Instant Articles," and should link to the Newspack dashboard. 
6. Following instructions in the README, replace the component in the source for Components Demo, and rebuild. 
7. Verify the outcomes described in the README are accurate. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->