### PR TITLE
Engagement Wizard Popups Screen: ActionCard UI

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -30,6 +30,7 @@ class ActionCard extends Component {
 		const {
 			badge,
 			className,
+			children,
 			title,
 			description,
 			handoff,
@@ -116,12 +117,21 @@ class ActionCard extends Component {
 				</div>
 				{ notification && (
 					<div className="newspack-action-card__notification">
-						{ 'error'   === notificationLevel && ( <Notice noticeText={ notification } isError rawHTML={ notificationHTML } /> ) }
-						{ 'info'    === notificationLevel && ( <Notice noticeText={ notification } isPrimary rawHTML={ notificationHTML } /> ) }
-						{ 'success' === notificationLevel && ( <Notice noticeText={ notification } isSuccess rawHTML={ notificationHTML } /> ) }
-						{ 'warning' === notificationLevel && ( <Notice noticeText={ notification } isWarning rawHTML={ notificationHTML } /> ) }
+						{ 'error' === notificationLevel && (
+							<Notice noticeText={ notification } isError rawHTML={ notificationHTML } />
+						) }
+						{ 'info' === notificationLevel && (
+							<Notice noticeText={ notification } isPrimary rawHTML={ notificationHTML } />
+						) }
+						{ 'success' === notificationLevel && (
+							<Notice noticeText={ notification } isSuccess rawHTML={ notificationHTML } />
+						) }
+						{ 'warning' === notificationLevel && (
+							<Notice noticeText={ notification } isWarning rawHTML={ notificationHTML } />
+						) }
 					</div>
 				) }
+				{ children && <div>{ children }</div> }
 			</Card>
 		);
 	}

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -25,6 +25,25 @@
 		border-left: 4px solid $alert-red;
 	}
 
+	// Supported
+
+	&.newspack-card__is-supported {
+		border-left: 4px solid $alert-green;
+	}
+
+	// Primary
+
+	&.newspack-card__is-primary {
+		border-left: 4px solid $blue-dark-900;
+	}
+
+	// Disabled
+
+	&.newspack-card__is-disabled {
+		border-left: 4px solid $light-gray-700;
+		opacity: 0.5;
+	}
+
 	// Typography
 
 	h2,
@@ -194,6 +213,24 @@
 
 		&.newspack-card__is-unsupported {
 			border-left: 4px solid $alert-red;
+		}
+
+		// Supported
+
+		&.newspack-card__is-supported {
+			border-left: 4px solid $alert-green;
+		}
+
+		// Primary
+
+		&.newspack-card__is-primary {
+			border-left: 4px solid $blue-medium-600;
+		}
+
+		// Disabled
+
+		&.newspack-card__is-disabled {
+			border-left: 4px solid $light-gray-700;
 		}
 	}
 }

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -34,14 +34,13 @@
 	// Primary
 
 	&.newspack-card__is-primary {
-		border-left: 4px solid $blue-dark-900;
+		border-left: 4px solid $primary-500;
 	}
 
 	// Disabled
 
 	&.newspack-card__is-disabled {
 		border-left: 4px solid $light-gray-700;
-		opacity: 0.5;
 	}
 
 	// Typography
@@ -197,6 +196,12 @@
 		font-style: italic;
 	}
 
+	// Form Token Field
+
+	.newspack-form-token-field {
+		margin: 16px 0 0;
+	}
+
 	// Multiple Cards
 
 	& + & {
@@ -224,7 +229,7 @@
 		// Primary
 
 		&.newspack-card__is-primary {
-			border-left: 4px solid $blue-medium-600;
+			border-left: 4px solid $primary-500;
 		}
 
 		// Disabled

--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -27,6 +27,14 @@
 		padding: 3px 12px;
 	}
 
+	&.icon-only {
+		align-items: center;
+		height: 36px;
+		justify-content: center;
+		padding: 0;
+		width: 36px;
+	}
+
 	&:disabled,
 	&:disabled:active:enabled,
 	&[aria-disabled=true],
@@ -197,5 +205,9 @@
 		&.is-large {
 			padding: 0;
 		}
+	}
+
+	.components-tooltip {
+		font-weight: normal;
 	}
 }

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -115,6 +115,27 @@ class EngagementWizard extends Component {
 			} );
 	};
 
+	/**
+	 * Delete a popup.
+	 *
+	 * @param int popupId ID of the Popup to alter.
+	 */
+	deletePopup = popupId => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: '/newspack/v1/wizard/newspack-engagement-wizard/popup/' + popupId,
+			method: 'DELETE',
+		} )
+			.then( info => {
+				this.setState( {
+					...this.sanitizeData( info ),
+				} );
+			} )
+			.catch( error => {
+				setError( error );
+			} );
+	};
+
 	sanitizeData = data => {
 		return { ...data, popups: data.popups || [] };
 	};
@@ -219,6 +240,7 @@ class EngagementWizard extends Component {
 										popups={ popups }
 										setSiteWideDefaultPopup={ this.setSiteWideDefaultPopup }
 										setCategoriesForPopup={ this.setCategoriesForPopup }
+										deletePopup={ this.deletePopup }
 									/>
 								);
 							} }

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -74,11 +74,11 @@ class EngagementWizard extends Component {
 	 *
 	 * @param int popupId ID of the Popup to become sitewide default.
 	 */
-	setSiteWideDefaultPopup = popupId => {
+	setSiteWideDefaultPopup = ( popupId, state ) => {
 		const { setError, wizardApiFetch } = this.props;
 		return wizardApiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/sitewide-popup/' + popupId,
-			method: 'POST',
+			method: state ? 'POST' : 'DELETE',
 		} )
 			.then( info => {
 				this.setState( {

--- a/assets/wizards/engagement/views/popups/components/popup-action-card/index.js
+++ b/assets/wizards/engagement/views/popups/components/popup-action-card/index.js
@@ -98,14 +98,16 @@ class PopupActionCard extends Component {
 				description={ this.descriptionForPopup( popup ) }
 				actionText={
 					<Fragment>
-						<Tooltip text={ __( 'Category filtering', 'newspack' ) }>
-							<Button
-								className="icon-only"
-								onClick={ () => this.setState( { categoriesVisibility: ! categoriesVisibility } ) }
-							>
-								<FilterListIcon />
-							</Button>
-						</Tooltip>
+						{ ! sitewideDefault && (
+							<Tooltip text={ __( 'Category filtering', 'newspack' ) }>
+								<Button
+									className="icon-only"
+									onClick={ () => this.setState( { categoriesVisibility: ! categoriesVisibility } ) }
+								>
+									<FilterListIcon />
+								</Button>
+							</Tooltip>
+						) }
 						<Tooltip text={ __( 'More options', 'newspack' ) }>
 							<Button
 								className="icon-only"

--- a/assets/wizards/engagement/views/popups/components/popup-action-card/index.js
+++ b/assets/wizards/engagement/views/popups/components/popup-action-card/index.js
@@ -1,0 +1,175 @@
+/**
+ * Popup Action Card
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { Popover, Panel, PanelRow, PanelBody, Tooltip } from '@wordpress/components';
+
+/**
+ * Material UI dependencies.
+ */
+import FilterListIcon from '@material-ui/icons/FilterList';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import EditIcon from '@material-ui/icons/Edit';
+import DeleteIcon from '@material-ui/icons/Delete';
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies.
+ */
+import {
+	ActionCard,
+	Button,
+	CategoryAutocomplete,
+	ToggleControl,
+} from '../../../../../../components/src';
+import './style.scss';
+
+class PopupActionCard extends Component {
+	state = {
+		categoriesVisibility: false,
+		popoverVisibility: false,
+	};
+
+	/**
+	 * Construct the appropriate description for a single Pop-up based on categories and sitewide default status.
+	 *
+	 * @param {Object} Popup object.
+	 */
+	descriptionForPopup = popup => {
+		const { categories, sitewide_default: sitewideDefault } = popup;
+		if ( sitewideDefault ) {
+			return __( 'Sitewide default', 'newspack' );
+		}
+		if ( categories.length > 0 ) {
+			return (
+				__( 'Categories: ', 'newspack' ) + categories.map( category => category.name ).join( ', ' )
+			);
+		}
+		return __( 'Inactive', 'newspack' );
+	};
+
+	/**
+	 * Generate class names for a single popup based on categories, sitewide default status, and if data is available.
+	 *
+	 * @param {Object} Popup object.
+	 */
+	classNameForPopup = popup => {
+		const { sitewide_default: sitewideDefault, categories } = popup;
+		let statusClass;
+		if ( sitewideDefault ) {
+			statusClass = 'newspack-card__is-primary';
+		} else if ( categories.length ) {
+			statusClass = 'newspack-card__is-supported';
+		} else {
+			statusClass = 'newspack-card__is-disabled';
+		}
+		return classnames( 'newspack-engagement__popups-action-card', statusClass );
+	};
+
+	/**
+	 * Render.
+	 */
+	render = () => {
+		const { categoriesVisibility, popoverVisibility } = this.state;
+		const { deletePopup, popup, setCategoriesForPopup, setSiteWideDefaultPopup } = this.props;
+		const {
+			id,
+			categories,
+			title,
+			sitewide_default: sitewideDefault,
+			edit_link: editLink,
+			delete_link: deleteLink,
+		} = popup;
+		return (
+			<ActionCard
+				className={ this.classNameForPopup( popup ) }
+				title={ decodeEntities( title ) }
+				key={ id }
+				description={ this.descriptionForPopup( popup ) }
+				actionText={
+					<Fragment>
+						<Tooltip text={ __( 'Category filtering', 'newspack' ) }>
+							<Button
+								isSmall
+								onClick={ () => this.setState( { categoriesVisibility: ! categoriesVisibility } ) }
+							>
+								<FilterListIcon />
+							</Button>
+						</Tooltip>
+						<Tooltip text={ __( 'More options', 'newspack' ) }>
+							<Button
+								isSmall
+								onClick={ () => this.setState( { popoverVisibility: ! popoverVisibility } ) }
+							>
+								<MoreVertIcon />
+							</Button>
+						</Tooltip>
+						{ popoverVisibility && (
+							<Popover
+								position="bottom right"
+								className="components-autocomplete__popover"
+								onFocusOutside={ event => this.setState( { popoverVisibility: false } ) }
+							>
+								<Panel>
+									<PanelBody>
+										<PanelRow className="newspack-engagement__popups-action-card__panel-row first">
+											<ToggleControl
+												label={ __( 'Sitewide Defaults' ) }
+												checked={ sitewideDefault }
+												onChange={ value =>
+													this.setState( { popoverVisibility: false }, () =>
+														setSiteWideDefaultPopup( id )
+													)
+												}
+											/>
+										</PanelRow>
+										<PanelRow className="newspack-engagement__popups-action-card__panel-row">
+											<Button isSmall href={ decodeEntities( editLink ) }>
+												<EditIcon />
+												{ __( 'Edit', 'newspack' ) }
+											</Button>
+										</PanelRow>
+										<PanelRow className="newspack-engagement__popups-action-card__panel-row">
+											<Button isSmall onClick={ () => deletePopup( id ) }>
+												<DeleteIcon />
+												{ __( 'Delete', 'newspack' ) }
+											</Button>
+										</PanelRow>
+									</PanelBody>
+								</Panel>
+							</Popover>
+						) }
+					</Fragment>
+				}
+			>
+				{ categoriesVisibility && (
+					<CategoryAutocomplete
+						value={ categories || [] }
+						onChange={ tokens => setCategoriesForPopup( id, tokens ) }
+						label={ __( 'Category Filtering', 'newspack ' ) }
+						disabled={ sitewideDefault }
+					/>
+				) }
+			</ActionCard>
+		);
+	};
+}
+
+PopupActionCard.defaultProps = {
+	popup: {},
+	deletePopup: () => null,
+	setCategoriesForPopup: () => null,
+	setSiteWideDefaultPopup: () => null,
+};
+
+export default PopupActionCard;

--- a/assets/wizards/engagement/views/popups/components/popup-action-card/index.js
+++ b/assets/wizards/engagement/views/popups/components/popup-action-card/index.js
@@ -128,7 +128,7 @@ class PopupActionCard extends Component {
 										checked={ sitewideDefault }
 										onChange={ value =>
 											this.setState( { popoverVisibility: false }, () =>
-												setSiteWideDefaultPopup( id )
+												setSiteWideDefaultPopup( id, value )
 											)
 										}
 									/>

--- a/assets/wizards/engagement/views/popups/components/popup-action-card/index.js
+++ b/assets/wizards/engagement/views/popups/components/popup-action-card/index.js
@@ -119,7 +119,7 @@ class PopupActionCard extends Component {
 						{ popoverVisibility && (
 							<Popover
 								position="bottom left"
-								className="components-autocomplete__popover"
+								className="newspack-popover"
 								onFocusOutside={ event => this.setState( { popoverVisibility: false } ) }
 							>
 								<MenuGroup className="newspack-menu-group__sitewide">

--- a/assets/wizards/engagement/views/popups/components/popup-action-card/index.js
+++ b/assets/wizards/engagement/views/popups/components/popup-action-card/index.js
@@ -8,7 +8,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { Popover, Panel, PanelRow, PanelBody, Tooltip } from '@wordpress/components';
+import { Popover, MenuItem, MenuGroup, Tooltip } from '@wordpress/components';
 
 /**
  * Material UI dependencies.
@@ -100,7 +100,7 @@ class PopupActionCard extends Component {
 					<Fragment>
 						<Tooltip text={ __( 'Category filtering', 'newspack' ) }>
 							<Button
-								isSmall
+								className="icon-only"
 								onClick={ () => this.setState( { categoriesVisibility: ! categoriesVisibility } ) }
 							>
 								<FilterListIcon />
@@ -108,7 +108,7 @@ class PopupActionCard extends Component {
 						</Tooltip>
 						<Tooltip text={ __( 'More options', 'newspack' ) }>
 							<Button
-								isSmall
+								className="icon-only"
 								onClick={ () => this.setState( { popoverVisibility: ! popoverVisibility } ) }
 							>
 								<MoreVertIcon />
@@ -116,37 +116,37 @@ class PopupActionCard extends Component {
 						</Tooltip>
 						{ popoverVisibility && (
 							<Popover
-								position="bottom right"
+								position="bottom left"
 								className="components-autocomplete__popover"
 								onFocusOutside={ event => this.setState( { popoverVisibility: false } ) }
 							>
-								<Panel>
-									<PanelBody>
-										<PanelRow className="newspack-engagement__popups-action-card__panel-row first">
-											<ToggleControl
-												label={ __( 'Sitewide Defaults' ) }
-												checked={ sitewideDefault }
-												onChange={ value =>
-													this.setState( { popoverVisibility: false }, () =>
-														setSiteWideDefaultPopup( id )
-													)
-												}
-											/>
-										</PanelRow>
-										<PanelRow className="newspack-engagement__popups-action-card__panel-row">
-											<Button isSmall href={ decodeEntities( editLink ) }>
-												<EditIcon />
-												{ __( 'Edit', 'newspack' ) }
-											</Button>
-										</PanelRow>
-										<PanelRow className="newspack-engagement__popups-action-card__panel-row">
-											<Button isSmall onClick={ () => deletePopup( id ) }>
-												<DeleteIcon />
-												{ __( 'Delete', 'newspack' ) }
-											</Button>
-										</PanelRow>
-									</PanelBody>
-								</Panel>
+								<MenuGroup className="newspack-menu-group__sitewide">
+									<ToggleControl
+										label={ __( 'Sitewide default' ) }
+										checked={ sitewideDefault }
+										onChange={ value =>
+											this.setState( { popoverVisibility: false }, () =>
+												setSiteWideDefaultPopup( id )
+											)
+										}
+									/>
+								</MenuGroup>
+								<MenuGroup>
+									<MenuItem
+										href={ decodeEntities( editLink ) }
+										icon={ <EditIcon /> }
+										className="newspack-button"
+									>
+										{ __( 'Edit', 'newspack' ) }
+									</MenuItem>
+									<MenuItem
+										onClick={ () => deletePopup( id ) }
+										icon={ <DeleteIcon /> }
+										className="newspack-button"
+									>
+										{ __( 'Delete', 'newspack' ) }
+									</MenuItem>
+								</MenuGroup>
 							</Popover>
 						) }
 					</Fragment>
@@ -156,7 +156,7 @@ class PopupActionCard extends Component {
 					<CategoryAutocomplete
 						value={ categories || [] }
 						onChange={ tokens => setCategoriesForPopup( id, tokens ) }
-						label={ __( 'Category Filtering', 'newspack ' ) }
+						label={ __( 'Category filtering', 'newspack ' ) }
 						disabled={ sitewideDefault }
 					/>
 				) }

--- a/assets/wizards/engagement/views/popups/components/popup-action-card/style.scss
+++ b/assets/wizards/engagement/views/popups/components/popup-action-card/style.scss
@@ -11,10 +11,8 @@
 	}
 }
 
-.newspack-action-card__container {
+.newspack-action-card {
 	.newspack-popover {
-		margin-left: 18px;
-
 		.components-menu-group + .components-menu-group {
 			border-top: 1px solid $light-gray-500;
 		}
@@ -29,5 +27,9 @@
 			border-radius: 0;
 			font-weight: normal;
 		}
+	}
+
+	&:not(.newspack-card__is-primary) .newspack-popover {
+		margin-left: 18px;
 	}
 }

--- a/assets/wizards/engagement/views/popups/components/popup-action-card/style.scss
+++ b/assets/wizards/engagement/views/popups/components/popup-action-card/style.scss
@@ -12,7 +12,7 @@
 }
 
 .newspack-action-card__container {
-	.components-popover {
+	.newspack-popover {
 		margin-left: 18px;
 
 		.components-menu-group + .components-menu-group {

--- a/assets/wizards/engagement/views/popups/components/popup-action-card/style.scss
+++ b/assets/wizards/engagement/views/popups/components/popup-action-card/style.scss
@@ -1,0 +1,25 @@
+/**
+ * Popup Action Card styles
+ */
+
+.newspack-engagement__popups-action-card .newspack-action-card__region-right {
+	align-self: start;
+}
+
+.newspack-action-card__popover {
+	padding: 0;
+
+}
+
+.newspack-engagement__popups-action-card__panel-row {
+	display: block;
+	svg {
+		margin-right: 10px;
+	}
+	.newspack-toggle-control .components-base-control__field label {
+		margin-left: 10px;
+	}
+	&.first {
+		margin-bottom: 1px solid gray;
+	}
+}

--- a/assets/wizards/engagement/views/popups/components/popup-action-card/style.scss
+++ b/assets/wizards/engagement/views/popups/components/popup-action-card/style.scss
@@ -2,24 +2,32 @@
  * Popup Action Card styles
  */
 
-.newspack-engagement__popups-action-card .newspack-action-card__region-right {
-	align-self: start;
+@import '~@wordpress/base-styles/colors';
+
+.newspack-menu-group__sitewide {
+	> div {
+		padding-left: 15px;
+		padding-right: 15px;
+	}
 }
 
-.newspack-action-card__popover {
-	padding: 0;
+.newspack-action-card__container {
+	.components-popover {
+		margin-left: 18px;
 
-}
+		.components-menu-group + .components-menu-group {
+			border-top: 1px solid $light-gray-500;
+		}
 
-.newspack-engagement__popups-action-card__panel-row {
-	display: block;
-	svg {
-		margin-right: 10px;
-	}
-	.newspack-toggle-control .components-base-control__field label {
-		margin-left: 10px;
-	}
-	&.first {
-		margin-bottom: 1px solid gray;
+		.newspack-toggle-control {
+			.components-base-control__field .components-form-toggle {
+				margin-right: 8px;
+			}
+		}
+
+		.newspack-button {
+			border-radius: 0;
+			font-weight: normal;
+		}
 	}
 }

--- a/assets/wizards/engagement/views/popups/index.js
+++ b/assets/wizards/engagement/views/popups/index.js
@@ -6,8 +6,7 @@
  * WordPress dependencies.
  */
 import { Component, Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { decodeEntities } from '@wordpress/html-entities';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
@@ -15,12 +14,11 @@ import { decodeEntities } from '@wordpress/html-entities';
 import {
 	ActionCard,
 	Button,
-	CategoryAutocomplete,
+	Notice,
 	PluginInstaller,
-	SelectControl,
-	TextControl,
 	withWizardScreen,
 } from '../../../../components/src';
+import PopupActionCard from './components/popup-action-card';
 import './style.scss';
 
 /**
@@ -31,6 +29,8 @@ class Popups extends Component {
 		super( props );
 		this.state = {
 			pluginRequirementsMet: false,
+			categoriesVisibility: {},
+			popoverVisibility: {},
 		};
 	}
 
@@ -38,8 +38,8 @@ class Popups extends Component {
 	 * Render.
 	 */
 	render() {
-		const { pluginRequirementsMet } = this.state;
-		const { popups, setSiteWideDefaultPopup, setCategoriesForPopup } = this.props;
+		const { pluginRequirementsMet, categoriesVisibility, popoverVisibility } = this.state;
+		const { deletePopup, popups, setSiteWideDefaultPopup, setCategoriesForPopup } = this.props;
 		const hasPopups = popups && popups.length > 0;
 		if ( ! pluginRequirementsMet ) {
 			return (
@@ -49,59 +49,45 @@ class Popups extends Component {
 				/>
 			);
 		}
+		const popupsWithSiteSitewideFirst = [
+			...popups.filter( popup => popup.sitewide_default ),
+			...popups.filter( popup => ! popup.sitewide_default ),
+		];
+
+		const inactivePopupCount = popups.reduce(
+			( accumulator, popup ) =>
+				accumulator + ( ! popup.categories.length && ! popup.sitewide_default ? 1 : 0 ),
+			0
+		);
 
 		return (
 			<Fragment>
-				<ActionCard
-					title={ __( 'Newspack Pop-ups' ) }
-					description={ __( 'AMP-compatible popup notifications.' ) }
-					actionText={ __( 'Manage' ) }
-					href="edit.php?post_type=newspack_popups_cpt"
-				/>
+				{ inactivePopupCount > 0 && (
+					<Notice
+						noticeText={ sprintf(
+							'You have %d inactive %s.',
+							inactivePopupCount,
+							_n( 'popup', 'popups', inactivePopupCount, 'Popups', 'newspack' ),
+							'newspack'
+						) }
+						isWarning
+					/>
+				) }
 				{ hasPopups && (
 					<Fragment>
-						<hr />
-						<h2>{ __( 'Configure active Pop-up' ) }</h2>
-						<SelectControl
-							label={ __( 'Sitewide default' ) }
-							value={ popups.find( popup => popup.sitewide_default ) }
-							options={ [
-								{ value: '', label: __( '- Select -' ), disabled: true },
-								...popups.map( popup => ( {
-									value: popup.id,
-									label: decodeEntities( popup.title ),
-									disabled: popup.categories.length,
-								} ) ),
-							] }
-							onChange={ setSiteWideDefaultPopup }
-						/>
-						<h2>{ __( 'Category Filtering' ) }</h2>
+						<h2>{ __( 'Manage Pop-ups' ) }</h2>
+						{ popupsWithSiteSitewideFirst.map( popup => (
+							<PopupActionCard
+								key={ popup.id }
+								popup={ popup }
+								setCategoriesForPopup={ setCategoriesForPopup }
+								setSiteWideDefaultPopup={ setSiteWideDefaultPopup }
+								deletePopup={ deletePopup }
+							/>
+						) ) }
 					</Fragment>
 				) }
-				{ hasPopups &&
-					popups
-						.map( popup => {
-							const { categories } = popup;
-							return (
-								<div className="newspack-engagement__popups-row" key={ popup.id }>
-									{ popup.sitewide_default ? (
-										<TextControl
-											disabled
-											label={ decodeEntities( popup.title ) }
-											value={ __( 'Sitewide default', 'newspack' ) }
-										/>
-									) : (
-										<CategoryAutocomplete
-											value={ categories || [] }
-											suggestions={ this.fetchSuggestions }
-											onChange={ tokens => setCategoriesForPopup( popup.id, tokens ) }
-											label={ decodeEntities( popup.title ) }
-											disabled={ popup.sitewide_default }
-										/>
-									) }
-								</div>
-							);
-						} ) }
+				{ ! hasPopups && <p>{ __( 'No Pop-ups have been created yet.', 'newspack' ) }</p> }
 				<div className="newspack-buttons-card">
 					<Button href="/wp-admin/post-new.php?post_type=newspack_popups_cpt" isPrimary>
 						{ hasPopups

--- a/assets/wizards/engagement/views/popups/style.scss
+++ b/assets/wizards/engagement/views/popups/style.scss
@@ -3,7 +3,7 @@
  */
 
 .newspack-engagement__popups-row {
-  & + & {
-    margin-top: -16px;
-  }
+	& + & {
+		margin-top: -16px;
+	}
 }

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -57,6 +57,17 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Unset the sitewide Popup.
+	 *
+	 * @param integer $id ID of sitewide popup.
+	 */
+	public function unset_sitewide_popup( $id ) {
+		return $this->is_configured() ?
+			\Newspack_Popups_Model::unset_sitewide_popup( $id ) :
+			$this->unconfigured_error();
+	}
+
+	/**
 	 * Set categories for a Popup.
 	 *
 	 * @param integer $id ID of sitewide popup.

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -110,6 +110,20 @@ class Engagement_Wizard extends Wizard {
 		);
 		register_rest_route(
 			'newspack/v1/wizard/' . $this->slug,
+			'sitewide-popup/(?P<id>\d+)',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'api_unset_sitewide_popup' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'id' => [
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+		register_rest_route(
+			'newspack/v1/wizard/' . $this->slug,
 			'popup-categories/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
@@ -192,6 +206,25 @@ class Engagement_Wizard extends Wizard {
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
 
 		$response = $newspack_popups_configuration_manager->set_sitewide_popup( $sitewide_default );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return $this->api_get_engagement_settings();
+	}
+
+	/**
+	 * Unset the sitewide default Popup
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response with the info.
+	 */
+	public function api_unset_sitewide_popup( $request ) {
+		$sitewide_default = $request['id'];
+
+		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
+
+		$response = $newspack_popups_configuration_manager->unset_sitewide_popup( $sitewide_default );
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is redo of the Pop-up management UI in the Engagement Wizard. 

<img width="1685" alt="Screen Shot 2020-02-04 at 12 29 02 PM" src="https://user-images.githubusercontent.com/1477002/73770187-f82b6680-4749-11ea-8876-86f8d3dbc2cc.png">

At the top is a notice bar which will indicate if there are inactive popups. An inactive popup is one which has no categories assigned and is not the sitewide default.

The Manage Pop-ups area has an `ActionCard` for each popup. The sitewide default (if there is one) will be at the top. Each lists the name and whether it is Sitewide Default, Inactive, or has categories assigned. Colors on the left indicate this status as well (blue = sitewide, green = in use, gray = inactive). The three dots on the right display a menu where the sitewide default state can be set along with Edit and Delete links. The categories icon (upside down triangle) reveals Category Filtering area, where categories can be assigned or removed. The sitewide default does not have category UI. 
 
Closes https://github.com/Automattic/newspack-plugin/issues/405.

### Testing Instructions

This PR is all about UI, so testing really comes down to trying everything, verifying it works, and suggesting improvements. Here are some guidelines for testing, although these needn't be followed too closely.

- If you have any Pop-ups, go delete them all to start with a clean slate.
- Navigate to the Newspack Engagement wizard and click Pop-ups tab. 
- Verify the "No Pop-ups have been created yet" display.
- Click "Add first Pop-up," and create a Pop-up. 
- Navigate back to the Engagement Wizard, verify you see the new Popup, and it is in Inactive state.
- Click the three dots, switch on Sitewide Default. Verify the `ActionCard` color is now blue and the description is Sitewide Default. On Pop-ups list page (/wp-admin/edit.php?post_type=newspack_popups_cpt) verify the Pop-up is now marked "Sitewide Default" and if you edit the post the Sitewide Default checkbox is checked.
- Navigate back to the Pop-ups screen, click Add new Pop-up. Create a new Popup (nothing special) then navigate back to the Wizard.
- By the second one, click the categories button. Verify category UI appears, then add a category. Verify the UI updates and describes the categories. The color should change from gray to green.
- Try switching off Sitewide Default, and switching from one Pop-up to another.
- Try deleting a Pop-up. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->