### PR TITLE
Fix Reader Revenue select for countries with no states defined

### DIFF
--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -55,7 +55,7 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 		$states        = WC()->countries->get_states();
 		$location_info = [];
 		foreach ( $countries as $country_code => $country ) {
-			if ( isset( $states[ $country_code ] ) ) {
+			if ( ! empty( $states[ $country_code ] ) ) {
 				foreach ( $states[ $country_code ] as $state_code => $state ) {
 					$location_info[] = [
 						'value' => $country_code . ':' . $state_code,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #408 

The logic that turns the list of countries and states into a flat list had 2 situations that were being accounted for: when a country has no list of states and when a country has a list of states. There was a third scenario that wasn't being accounted for: when a country has *an empty* list of states (with info provided by WooCommerce). This PR tweaks the logic so that things work correctly in all 3 scenarios.

### How to test the changes in this Pull Request:

1. Go to Reader Revenue wizard and set an address in Germany:
<img width="631" alt="Screen Shot 2020-01-27 at 11 42 06 AM" src="https://user-images.githubusercontent.com/7317227/73208413-4661b980-40fb-11ea-95ac-866975b76f19.png">

2. Go to WooCommerce settings and verify everything saved correctly:
<img width="693" alt="Screen Shot 2020-01-27 at 11 42 13 AM" src="https://user-images.githubusercontent.com/7317227/73208417-48c41380-40fb-11ea-844f-3b61097a6eed.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->