### PR TITLE
Fix Action Card right region text align

### DIFF
--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -99,12 +99,17 @@
 		align-items: flex-start;
 		flex-direction: column;
 		margin-top: 24px;
+		text-align: right;
 
 		@media screen and ( min-width: 744px ) {
 			align-items: flex-end;
 			flex-direction: column;
 			margin-left: 24px;
 			margin-top: 0;
+		}
+
+		> * {
+			text-align: inherit;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Sets the text-align of the Action Card right region to right (and make sure child items are inheriting this) as it can look a bit strange with the right whitespace when the text is on multiple lines and is left-aligned.

__Before:__

![1-before](https://user-images.githubusercontent.com/177929/73923484-d99cab00-48c2-11ea-9a60-3083d1ca5d82.png)

__After:__

![2-after](https://user-images.githubusercontent.com/177929/73923500-e1f4e600-48c2-11ea-9e95-cdc12e65a0a1.png)

### How to test the changes in this Pull Request:

1. Go to Newspack Components `wp-admin/admin.php?page=newspack-components-demo` 
2. Check the "Instant Articles for WP" Pluggin Toggle
3. Switch to this branch
4. Refresh the Newspack Components
5. "Configure Instant Articles" should be aligned to the right now

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->