### PR TITLE
Web Preview: align items to the center when waiting

### DIFF
--- a/assets/components/src/web-preview/style.scss
+++ b/assets/components/src/web-preview/style.scss
@@ -68,6 +68,7 @@ body.newspack-web-preview__open {
 }
 
 .newspack-web-preview__is-waiting {
+	align-items: center;
 	display: flex;
 	left: 50%;
 	margin: -12px 0 0 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make sure the "Loading..." text is vertically aligned with the spinner when the Web Preview component is loading the iframe.

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/75433915-a3de6580-5948-11ea-99b2-7dc17e06ad82.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/75433925-a80a8300-5948-11ea-9ba5-f17cf4acad82.png)

### How to test the changes in this Pull Request:

1. Check the Site Design Wizard
2. Click on "View demo"
3. Notice the spinner is not vertically aligned with the "Loading..." text
4. Switch to this branch
5. Refresh page and click on "View demo" again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->