### PR TITLE
Only display author bio length setting when author bio is set to show

### DIFF
--- a/assets/wizards/site-design/views/theme-mods/index.js
+++ b/assets/wizards/site-design/views/theme-mods/index.js
@@ -73,17 +73,17 @@ class ThemeMods extends Component {
 						checked={ authorEmail }
 						onChange={ value => setThemeMods( { show_author_email: value } ) }
 					/>
+					<TextControl
+						label={ __( 'Length', 'newspack' ) }
+						help={ __(
+							'Truncates the author bio on single posts to this approximate character length, but without breaking a word. The full bio appears on the author archive page.',
+							'newspack'
+						) }
+						type="number"
+						value={ authorBioLength }
+						onChange={ value => setThemeMods( { author_bio_length: value } ) }
+					/>
 				</ToggleGroup>
-				<TextControl
-					label={ __( 'Length', 'newspack' ) }
-					help={ __(
-						'Truncates the author bio on single posts to this approximate character length, but without breaking a word. The full bio appears on the author archive page.',
-						'newspack'
-					) }
-					type="number"
-					value={ authorBioLength }
-					onChange={ value => setThemeMods( { author_bio_length: value } ) }
-				/>
 				<hr />
 				<h2>{ __( 'Featured Image', 'newspack' ) }</h2>
 				<RadioControl

--- a/assets/wizards/site-design/views/theme-mods/style.scss
+++ b/assets/wizards/site-design/views/theme-mods/style.scss
@@ -20,7 +20,8 @@
 	}
 
 	.newspack-toggle-group__description {
-		.newspack-toggle-control {
+		.newspack-toggle-control,
+		.newspack-text-control {
 			margin: 16px 0 0 -44px;
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We don't need to display the Author bio's "Length" setting if the Author bio isn't enabled. This PR moves the "Length" setting inside the ToggleGroup that controls the display of the Author bio.

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/75443088-9b8e2680-5958-11ea-9c93-832d05d958dc.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/75443102-a1840780-5958-11ea-9ebc-f05e8f1c55ce.png)

### How to test the changes in this Pull Request:

1. Navigate to Site Design > Settings
2. Notice the "Length" setting in the Author bio section. It's always displayed whether the Author bio toggle is on or off.
3. Switch to this branch.
4. Refresh the page and check if the "Length" setting is only displayed when the Author bio is enabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->