### PR TITLE
Update Site Kit connection check for latest SK version

### DIFF
--- a/includes/configuration_managers/class-site-kit-configuration-manager.php
+++ b/includes/configuration_managers/class-site-kit-configuration-manager.php
@@ -137,7 +137,20 @@ class Site_Kit_Configuration_Manager extends Configuration_Manager {
 		if ( ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) || get_option( 'newspack_debug', false ) ) {
 			return true;
 		}
-		return $this->is_active() && ! empty( $this->get_modules_info() );
+
+		/**
+		 * Once connected, Site Kit stores encrypted auth tokens in the `googlesitekit_credentials` option.
+		 * Site Kit has not been configured if this option is empty or the default.
+		 * If configured, this option will contain an encrypted string.
+		 *
+		 * @see https://github.com/google/site-kit-wp/blob/2f74fd30d283a8b40dc5756ee7088164fad46ce6/includes/Core/Authentication/Credentials.php
+		 */
+		$creds = get_option( 'googlesitekit_credentials', false );
+		if ( empty( $creds ) || ( is_array( $creds ) && empty( $creds['oauth2_client_id'] ) ) ) {
+			return false;
+		}
+
+		return $this->is_active();
 	}
 
 	/**

--- a/includes/configuration_managers/class-site-kit-configuration-manager.php
+++ b/includes/configuration_managers/class-site-kit-configuration-manager.php
@@ -134,23 +134,17 @@ class Site_Kit_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Whether Site Kit is active and set up.
 	 */
 	public function is_configured() {
+		global $wpdb;
+
 		if ( ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) || get_option( 'newspack_debug', false ) ) {
 			return true;
 		}
 
-		/**
-		 * Once connected, Site Kit stores encrypted auth tokens in the `googlesitekit_credentials` option.
-		 * Site Kit has not been configured if this option is empty or the default.
-		 * If configured, this option will contain an encrypted string.
-		 *
-		 * @see https://github.com/google/site-kit-wp/blob/2f74fd30d283a8b40dc5756ee7088164fad46ce6/includes/Core/Authentication/Credentials.php
-		 */
-		$creds = get_option( 'googlesitekit_credentials', false );
-		if ( empty( $creds ) || ( is_array( $creds ) && empty( $creds['oauth2_client_id'] ) ) ) {
-			return false;
-		}
+		$user     = get_current_user_id();
+		$meta_key = $wpdb->get_blog_prefix() . 'googlesitekit_access_token';
+		$token    = get_user_meta( $user, $meta_key, true );
 
-		return $this->is_active();
+		return $this->is_active() && ! empty( $token );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In the latest version of Site Kit, `apply_filters( 'googlesitekit_modules_data', [] )` will return module info regardless of connection status. This PR updates the connection check to work nicely with this change.

### How to test the changes in this Pull Request:

1. You probably want to spin up a Jurassic Ninja site so the Site Kit connection will work correctly.
2. Go to `/wp-admin/admin.php?page=newspack-setup-wizard#/configure-google-site-kit` and verify it says you're not connected. Click the handoff button and connect Site Kit.
3. When you are finished connecting and return back to the setup screen, it should say you are connected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->