### PR TITLE
Support Stripe Mode (Live/Test)

### DIFF
--- a/assets/wizards/payment/index.js
+++ b/assets/wizards/payment/index.js
@@ -30,6 +30,7 @@ const { HashRouter, Redirect, Route, Switch } = Router;
 class PaymentWizard extends Component {
 	state = {
 		customer: {},
+		hasData: false,
 	};
 	componentDidMount = () => {
 		this.retrieve();
@@ -37,7 +38,9 @@ class PaymentWizard extends Component {
 	retrieve = () => {
 		const { setError, wizardApiFetch } = this.props;
 		return wizardApiFetch( { path: '/newspack/v1/wizard/newspack-payment-wizard/' } )
-			.then( ( { customer, subscription } ) => this.setState( { customer, subscription } ) )
+			.then( ( { card, customer, subscription } ) =>
+				this.setState( { card, customer, subscription, hasData: true } )
+			)
 			.catch( error => setError( error ) );
 	};
 	checkout = () => {
@@ -57,7 +60,7 @@ class PaymentWizard extends Component {
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
-		const { customer, subscription } = this.state;
+		const { card, customer, hasData, subscription } = this.state;
 		const needsSubscription =
 			! customer || customer.deleted || ( ! subscription || 'canceled' === subscription.status );
 		return (
@@ -70,13 +73,15 @@ class PaymentWizard extends Component {
 							path="/"
 							render={ () => (
 								<PaymentMethod
-									headerIcon={ <HeaderIcon /> }
-									headerText={ __( 'Managed Newspack' ) }
-									subHeaderText={ __( 'Manage payment methods for hosted Newspack.' ) }
-									customer={ customer }
 									buttonText={ needsSubscription ? __( 'Subscribe', 'newspack' ) : null }
 									buttonAction={ this.checkout }
+									card={ card }
+									hasData={ hasData }
+									headerIcon={ <HeaderIcon /> }
+									headerText={ __( 'Managed Newspack' ) }
 									onUpdateSubscription={ this.checkout }
+									subHeaderText={ __( 'Manage payment methods for hosted Newspack.' ) }
+									subscription={ subscription }
 								/>
 							) }
 						/>

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
 	},
 	"require"    : {
 			"composer/installers": "~1.6",
-			"stripe/stripe-php": "^7.25",
-		"joshtronic/php-loremipsum": "^1.0"
+      "joshtronic/php-loremipsum": "^1.0"
 	},
 	"require-dev": {
 		"brainmaestro/composer-git-hooks": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3e8a5f4110177d1a03172055bee447a",
+    "content-hash": "eff7aaa5501b76640e37c3ebf4aecd29",
     "packages": [
         {
             "name": "composer/installers",
@@ -176,63 +176,6 @@
                 "lorem"
             ],
             "time": "2020-01-10T03:49:13+00:00"
-        },
-        {
-            "name": "stripe/stripe-php",
-            "version": "v7.26.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "14163c10e1edb0e7720c9c295a1e7c7a0bf48e75"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/14163c10e1edb0e7720c9c295a1e7c7a0bf48e75",
-                "reference": "14163c10e1edb0e7720c9c295a1e7c7a0bf48e75",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "php": ">=5.6.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.15",
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^5.7",
-                "squizlabs/php_codesniffer": "^3.3",
-                "symfony/process": "~3.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Stripe\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Stripe and contributors",
-                    "homepage": "https://github.com/stripe/stripe-php/contributors"
-                }
-            ],
-            "description": "Stripe PHP Library",
-            "homepage": "https://stripe.com/",
-            "keywords": [
-                "api",
-                "payment processing",
-                "stripe"
-            ],
-            "time": "2020-02-26T19:59:00+00:00"
         }
     ],
     "packages-dev": [
@@ -679,41 +622,41 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.0.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "91c294166c38d8c0858a86fad76d8c14dc1144c8"
+                "reference": "4fa15ae7be74e53f6ec8c83ed403b97e23b665e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/91c294166c38d8c0858a86fad76d8c14dc1144c8",
-                "reference": "91c294166c38d8c0858a86fad76d8c14dc1144c8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4fa15ae7be74e53f6ec8c83ed403b97e23b665e9",
+                "reference": "4fa15ae7be74e53f6ec8c83ed403b97e23b665e9",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5",
+                "php": "^7.1.3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
                 "symfony/service-contracts": "^1.1|^2"
             },
             "conflict": {
-                "symfony/dependency-injection": "<4.4",
-                "symfony/event-dispatcher": "<4.4",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3|>=5",
                 "symfony/lock": "<4.4",
-                "symfony/process": "<4.4"
+                "symfony/process": "<3.3"
             },
             "provide": {
                 "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0",
-                "symfony/var-dumper": "^4.4|^5.0"
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^4.3|^5.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -724,7 +667,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -751,7 +694,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-25T15:56:29+00:00"
+            "time": "2020-02-24T13:10:00+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -872,20 +815,20 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.0.1",
+            "version": "v1.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "144c5e51266b281231e947b51223ba14acf1a749"
+                "reference": "ffc7f5692092df31515df2a5ecf3b7302b3ddacf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/144c5e51266b281231e947b51223ba14acf1a749",
-                "reference": "144c5e51266b281231e947b51223ba14acf1a749",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ffc7f5692092df31515df2a5ecf3b7302b3ddacf",
+                "reference": "ffc7f5692092df31515df2a5ecf3b7302b3ddacf",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5",
+                "php": "^7.1.3",
                 "psr/container": "^1.0"
             },
             "suggest": {
@@ -894,7 +837,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -926,7 +869,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-11-18T17:27:11+00:00"
+            "time": "2019-10-14T12:27:06+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -123,6 +123,10 @@ final class Newspack {
 			wp_safe_redirect( admin_url( 'admin.php?page=newspack-setup-wizard' ) );
 			exit;
 		}
+		if ( Payment_Wizard::configured() && filter_input( INPUT_POST, 'newspack_reset_subscription', FILTER_SANITIZE_STRING ) === 'on' ) {
+			update_option( Payment_Wizard::NEWSPACK_STRIPE_CUSTOMER, null );
+			update_option( Payment_Wizard::NEWSPACK_STRIPE_SUBSCRIPTION, null );
+		}
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -99,6 +99,15 @@ class Settings {
 			'newspack-settings-admin',
 			'newspack_settings'
 		);
+		if ( Payment_Wizard::configured() ) {
+			add_settings_field(
+				'newspack_reset_subscription',
+				__( 'Reset Managed Newspack Subscription', 'newspack' ),
+				[ __CLASS__, 'newspack_reset_subscription_callback' ],
+				'newspack-settings-admin',
+				'newspack_settings'
+			);
+		}
 	}
 
 	/**
@@ -119,6 +128,15 @@ class Settings {
 	public static function newspack_reset_callback() {
 		printf(
 			'<input type="checkbox" id="newspack_reset" name="newspack_reset" />'
+		);
+	}
+
+	/**
+	 * Render reset subscription button.
+	 */
+	public static function newspack_reset_subscription_callback() {
+		printf(
+			'<input type="checkbox" id="newspack_reset_subscription" name="newspack_reset_subscription" />'
 		);
 	}
 }

--- a/includes/wizards/class-payment-wizard.php
+++ b/includes/wizards/class-payment-wizard.php
@@ -86,6 +86,7 @@ class Payment_Wizard extends Wizard {
 		$params = [
 			'customer_id'     => sanitize_text_field( get_option( self::NEWSPACK_STRIPE_CUSTOMER, '' ) ),
 			'subscription_id' => sanitize_text_field( get_option( self::NEWSPACK_STRIPE_SUBSCRIPTION, '' ) ),
+			'mode'            => self::stripe_mode(),
 		];
 		$result = Client::wpcom_json_api_request_as_blog(
 			$path,
@@ -120,6 +121,7 @@ class Payment_Wizard extends Wizard {
 			'base_url'        => get_admin_url( null, 'admin.php' ) . '?page=newspack-payment-wizard',
 			'stripe_plan_id'  => self::stripe_plan(),
 			'user_email'      => $user->user_email,
+			'mode'            => self::stripe_mode(),
 		];
 		$result = Client::wpcom_json_api_request_as_blog(
 			$path,
@@ -156,6 +158,7 @@ class Payment_Wizard extends Wizard {
 		$args   = [ 'method' => 'POST' ];
 		$params = [
 			'session_id' => $session_id,
+			'mode'       => self::stripe_mode(),
 		];
 		$result = Client::wpcom_json_api_request_as_blog(
 			$path,
@@ -245,5 +248,14 @@ class Payment_Wizard extends Wizard {
 	 */
 	public static function configured() {
 		return self::stripe_plan();
+	}
+
+	/**
+	 * Which Stripe mode to use (live|test).
+	 *
+	 * @return string Stripe mode (live|test).
+	 */
+	public static function stripe_mode() {
+		return ( defined( 'NEWSPACK_STRIPE_MODE' ) && 'live' === NEWSPACK_STRIPE_MODE ) ? 'live' : 'test';
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

- Adds support for using Stripe test or live mode, using `NEWSPACK_STRIPE_MODE` constant.
- Displays last four digits of the current card. 
- Improved Wizard loading.
- Remove unused Stripe Composer dependency.

### How to test the changes in this Pull Request:

Full testing instructions in https://code.a8c.com/D39657

Addition (3/2/2020):

To reset subscription/customer data, navigate to Settings->Newspack. Check `Reset Managed Newspack Subscription` and click Save Changes. This will clear out the persisted customer and subscription IDs, allowing a switch from test->live mode without fatals. The checkbox should only be visible if `NEWSPACK_STRIPE_PLAN` and `NEWSPACK_STRIPE_MODE` constants are set in `wp-config.php`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->