### PR TITLE
Support: send initial info on chat start

### DIFF
--- a/assets/wizards/support/views/chat/index.js
+++ b/assets/wizards/support/views/chat/index.js
@@ -53,6 +53,7 @@ class Chat extends Component {
 			let didSendInitialInfo;
 			Happychat.on( 'availability', availability => {
 				if ( ! didSendInitialInfo && availability ) {
+					didSendInitialInfo = true;
 					Happychat.sendUserInfo( {
 						site: {
 							ID: '0',
@@ -63,7 +64,6 @@ class Chat extends Component {
 					} );
 
 					Happychat.sendEvent( __( '[ Newspack customer ]', 'newspack' ) );
-					didSendInitialInfo = true;
 				}
 			} );
 		} else {

--- a/assets/wizards/support/views/chat/index.js
+++ b/assets/wizards/support/views/chat/index.js
@@ -27,9 +27,8 @@ class Chat extends Component {
 
 	closeHappychat = null;
 
-	componentDidMount() {
+	renderChat = () => {
 		const { WPCOM_ACCESS_TOKEN } = newspack_support_data;
-
 		if ( WPCOM_ACCESS_TOKEN ) {
 			this.closeHappychat = Happychat.open( {
 				nodeId: 'newspack-happychat',
@@ -42,6 +41,30 @@ class Chat extends Component {
 				entryOptions: {
 					defaultValues: {},
 				},
+			} );
+		}
+	};
+
+	componentDidMount() {
+		const { WPCOM_ACCESS_TOKEN } = newspack_support_data;
+		if ( WPCOM_ACCESS_TOKEN ) {
+			this.renderChat();
+
+			let didSendInitialInfo;
+			Happychat.on( 'availability', availability => {
+				if ( ! didSendInitialInfo && availability ) {
+					Happychat.sendUserInfo( {
+						site: {
+							ID: '0',
+							URL: `${ window.location.protocol }//${ window.location.hostname }`,
+						},
+						// just to bust the default 'gettingStarted'
+						howCanWeHelp: 'newspack',
+					} );
+
+					Happychat.sendEvent( __( '[ Newspack customer ]', 'newspack' ) );
+					didSendInitialInfo = true;
+				}
 			} );
 		} else {
 			this.setState( { hasToAuthenticate: true } );

--- a/assets/wizards/support/views/chat/index.js
+++ b/assets/wizards/support/views/chat/index.js
@@ -63,7 +63,12 @@ class Chat extends Component {
 						howCanWeHelp: 'newspack',
 					} );
 
-					Happychat.sendEvent( __( '[ Newspack customer ]', 'newspack' ) );
+					Happychat.sendEvent(
+						__(
+							'[ Newspack customer (fieldguide.automattic.com/supporting-newspack-customers) ]',
+							'newspack'
+						)
+					);
 				}
 			} );
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In order for HEs to know that they're dealing with a Newspack customer, an "event" will be sent at the beginning of the chat. Events are used for messages like "user is navigating to billing page", but here we'll use this feature to "mark" a Newspack customer. 

<img width="894" alt="Screenshot 2020-03-05 at 14 43 52" src="https://user-images.githubusercontent.com/7383192/75987318-06f36d80-5ef0-11ea-90bb-99d64109c24c.png">

Also, the "user info" is added here for convenience. It has a link to the site, as well as some browser information. 

### How to test the changes in this Pull Request:

1. Follow the testing outline from #466 
2. See that at the beginning of the chat, user info and a `[ Newspack customer  ]` message are prepended.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->