### PR TITLE
Fix Site Kit module deactivation

### DIFF
--- a/includes/configuration_managers/class-site-kit-configuration-manager.php
+++ b/includes/configuration_managers/class-site-kit-configuration-manager.php
@@ -116,7 +116,7 @@ class Site_Kit_Configuration_Manager extends Configuration_Manager {
 	 * @param string $module The module slug. See `get_module_info` for valid slugs.
 	 */
 	public function deactivate_module( $module ) {
-		$sitekit_active_modules = get_option( 'googlesitekit-active-modules', [] );
+		$sitekit_active_modules = get_option( $this->active_modules_option, [] );
 		$updated_modules        = [];
 
 		foreach ( $sitekit_active_modules as $active_module ) {
@@ -125,7 +125,7 @@ class Site_Kit_Configuration_Manager extends Configuration_Manager {
 			}
 		}
 
-		update_option( 'googlesitekit-active-modules', $updated_modules );
+		update_option( $this->active_modules_option, $updated_modules );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #468. This PR updates the module deactivation to use the updated option key first introduced in #395. There was a mismatch between the option names, because it looks like Site Kit is using underscores now for the option name instead of dashes.

### How to test the changes in this Pull Request:

1. Activate AdSense via Ads wizard.
2. Deactivate AdSense via Ads wizard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->