### PR TITLE
Health Check Configuration View

### DIFF
--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -18,7 +18,7 @@ import HeaderIcon from '@material-ui/icons/Healing';
  */
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { Plugins } from './views';
+import { Configuration, Plugins } from './views';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
@@ -55,12 +55,37 @@ class HealthCheckWizard extends Component {
 				setError( error );
 			} );
 	};
+
+	repairConfiguration = configuration => {
+		const { wizardApiFetch, setError } = this.props;
+		wizardApiFetch( {
+			path: '/newspack/v1/wizard/newspack-health-check-wizard/repair/' + configuration,
+		} )
+			.then( healthCheckData => this.setState( { healthCheckData } ) )
+			.catch( error => {
+				setError( error );
+			} );
+	};
 	/**
 	 * Render
 	 */
 	render() {
 		const { healthCheckData } = this.state;
-		const { unsupported_plugins: unsupportedPlugins } = healthCheckData;
+		const {
+			unsupported_plugins: unsupportedPlugins,
+			configuration_status: configurationStatus,
+		} = healthCheckData;
+		const tabs = [
+			{
+				label: __( 'Plugins', 'newspack' ),
+				path: '/',
+				exact: true,
+			},
+			{
+				label: __( 'Configuration' ),
+				path: '/configuration',
+			},
+		];
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -74,6 +99,7 @@ class HealthCheckWizard extends Component {
 									headerText={ __( 'Health Check', 'newspack' ) }
 									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
 									deactivateAllPlugins={ this.deactivateAllPlugins }
+									tabbedNavigation={ tabs }
 									unsupportedPlugins={
 										unsupportedPlugins &&
 										Object.keys( unsupportedPlugins ).map( value => ( {
@@ -81,6 +107,20 @@ class HealthCheckWizard extends Component {
 											Slug: value,
 										} ) )
 									}
+								/>
+							) }
+						/>
+						<Route
+							path="/configuration"
+							exact
+							render={ () => (
+								<Configuration
+									headerIcon={ <HeaderIcon /> }
+									headerText={ __( 'Health Check', 'newspack' ) }
+									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
+									tabbedNavigation={ tabs }
+									configurationStatus={ configurationStatus }
+									repairConfiguration={ this.repairConfiguration }
 								/>
 							) }
 						/>

--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -18,7 +18,7 @@ import HeaderIcon from '@material-ui/icons/Healing';
  */
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { RemoveUnsupportedPlugins } from './views';
+import { Plugins } from './views';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
@@ -69,7 +69,7 @@ class HealthCheckWizard extends Component {
 							path="/"
 							exact
 							render={ () => (
-								<RemoveUnsupportedPlugins
+								<Plugins
 									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Health Check', 'newspack' ) }
 									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }

--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -26,6 +26,7 @@ class HealthCheckWizard extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
+			hasData: false,
 			healthCheckData: {
 				unsupportedPlugins: [],
 			},
@@ -38,7 +39,7 @@ class HealthCheckWizard extends Component {
 	fetchHealthData = () => {
 		const { wizardApiFetch, setError } = this.props;
 		wizardApiFetch( { path: '/newspack/v1/wizard/newspack-health-check-wizard/' } )
-			.then( healthCheckData => this.setState( { healthCheckData } ) )
+			.then( healthCheckData => this.setState( { healthCheckData, hasData: true } ) )
 			.catch( error => {
 				setError( error );
 			} );
@@ -70,7 +71,7 @@ class HealthCheckWizard extends Component {
 	 * Render
 	 */
 	render() {
-		const { healthCheckData } = this.state;
+		const { hasData, healthCheckData } = this.state;
 		const {
 			unsupported_plugins: unsupportedPlugins,
 			configuration_status: configurationStatus,
@@ -115,6 +116,7 @@ class HealthCheckWizard extends Component {
 							exact
 							render={ () => (
 								<Configuration
+									hasData={ hasData }
 									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Health Check', 'newspack' ) }
 									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }

--- a/assets/wizards/health-check/views/configuration/index.js
+++ b/assets/wizards/health-check/views/configuration/index.js
@@ -24,41 +24,43 @@ class Configuration extends Component {
 		const { ampStandardMode, configurationStatus, hasData, repairConfiguration } = this.props;
 		const { amp, jetpack, sitekit } = configurationStatus || {};
 		return (
-			<Fragment>
-				<ActionCard
-					className={ amp ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
-					title={ __( 'AMP', 'newspack' ) }
-					description={
-						amp
-							? __( 'AMP plugin is in standard mode.', 'newspack' )
-							: __( 'AMP plugin is not in standard mode. ', 'newspack' )
-					}
-					actionText={ ! amp && __( 'Repair', 'newspack' ) }
-					onClick={ () => repairConfiguration( 'amp' ) }
-				/>
-				<ActionCard
-					className={ jetpack ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
-					title={ __( 'Jetpack', 'newspack' ) }
-					description={
-						jetpack
-							? __( 'Jetpack is connected.', 'newspack' )
-							: __( 'Jetpack is not connected. ', 'newspack' )
-					}
-					actionText={ ! jetpack && __( 'Connect', 'newspack' ) }
-					handoff="jetpack"
-				/>
-				<ActionCard
-					className={ sitekit ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
-					title={ __( 'Google Site Kit', 'newspack' ) }
-					description={
-						sitekit
-							? __( 'Site Kit is connected.', 'newspack' )
-							: __( 'Site Kit is not connected. ', 'newspack' )
-					}
-					actionText={ ! sitekit && __( 'Connect', 'newspack' ) }
-					handoff="google-site-kit"
-				/>
-			</Fragment>
+			hasData && (
+				<Fragment>
+					<ActionCard
+						className={ amp ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
+						title={ __( 'AMP', 'newspack' ) }
+						description={
+							amp
+								? __( 'AMP plugin is in standard mode.', 'newspack' )
+								: __( 'AMP plugin is not in standard mode. ', 'newspack' )
+						}
+						actionText={ ! amp && __( 'Repair', 'newspack' ) }
+						onClick={ () => repairConfiguration( 'amp' ) }
+					/>
+					<ActionCard
+						className={ jetpack ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
+						title={ __( 'Jetpack', 'newspack' ) }
+						description={
+							jetpack
+								? __( 'Jetpack is connected.', 'newspack' )
+								: __( 'Jetpack is not connected. ', 'newspack' )
+						}
+						actionText={ ! jetpack && __( 'Connect', 'newspack' ) }
+						handoff="jetpack"
+					/>
+					<ActionCard
+						className={ sitekit ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
+						title={ __( 'Google Site Kit', 'newspack' ) }
+						description={
+							sitekit
+								? __( 'Site Kit is connected.', 'newspack' )
+								: __( 'Site Kit is not connected. ', 'newspack' )
+						}
+						actionText={ ! sitekit && __( 'Connect', 'newspack' ) }
+						handoff="google-site-kit"
+					/>
+				</Fragment>
+			)
 		);
 	}
 }

--- a/assets/wizards/health-check/views/configuration/index.js
+++ b/assets/wizards/health-check/views/configuration/index.js
@@ -21,7 +21,7 @@ class Configuration extends Component {
 	 * Render.
 	 */
 	render() {
-		const { ampStandardMode, configurationStatus, hasData, repairConfiguration } = this.props;
+		const { configurationStatus, hasData, repairConfiguration } = this.props;
 		const { amp, jetpack, sitekit } = configurationStatus || {};
 		return (
 			hasData && (

--- a/assets/wizards/health-check/views/configuration/index.js
+++ b/assets/wizards/health-check/views/configuration/index.js
@@ -1,0 +1,42 @@
+/**
+ * Notify about site misconfigurations.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ActionCard, withWizardScreen } from '../../../../components/src';
+
+/**
+ * SEO Intro screen.
+ */
+class Configuration extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { configurationStatus, ampStandardMode, repairConfiguration } = this.props;
+		const { amp } = configurationStatus || {};
+		return (
+			<ActionCard
+				className={ amp ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
+				title={ __( 'AMP', 'newspack' ) }
+				description={
+					amp
+						? __( 'AMP plugin is in standard mode.', 'newspack' )
+						: __( 'AMP plugin is not in standard mode. ', 'newspack' )
+				}
+				actionText={ ! amp && __( 'Repair', 'newspack' ) }
+				onClick={ () => repairConfiguration( 'amp' ) }
+			/>
+		);
+	}
+}
+
+export default withWizardScreen( Configuration );

--- a/assets/wizards/health-check/views/configuration/index.js
+++ b/assets/wizards/health-check/views/configuration/index.js
@@ -21,20 +21,44 @@ class Configuration extends Component {
 	 * Render.
 	 */
 	render() {
-		const { configurationStatus, ampStandardMode, repairConfiguration } = this.props;
-		const { amp } = configurationStatus || {};
+		const { ampStandardMode, configurationStatus, hasData, repairConfiguration } = this.props;
+		const { amp, jetpack, sitekit } = configurationStatus || {};
 		return (
-			<ActionCard
-				className={ amp ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
-				title={ __( 'AMP', 'newspack' ) }
-				description={
-					amp
-						? __( 'AMP plugin is in standard mode.', 'newspack' )
-						: __( 'AMP plugin is not in standard mode. ', 'newspack' )
-				}
-				actionText={ ! amp && __( 'Repair', 'newspack' ) }
-				onClick={ () => repairConfiguration( 'amp' ) }
-			/>
+			<Fragment>
+				<ActionCard
+					className={ amp ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
+					title={ __( 'AMP', 'newspack' ) }
+					description={
+						amp
+							? __( 'AMP plugin is in standard mode.', 'newspack' )
+							: __( 'AMP plugin is not in standard mode. ', 'newspack' )
+					}
+					actionText={ ! amp && __( 'Repair', 'newspack' ) }
+					onClick={ () => repairConfiguration( 'amp' ) }
+				/>
+				<ActionCard
+					className={ jetpack ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
+					title={ __( 'Jetpack', 'newspack' ) }
+					description={
+						jetpack
+							? __( 'Jetpack is connected.', 'newspack' )
+							: __( 'Jetpack is not connected. ', 'newspack' )
+					}
+					actionText={ ! jetpack && __( 'Connect', 'newspack' ) }
+					handoff="jetpack"
+				/>
+				<ActionCard
+					className={ sitekit ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
+					title={ __( 'Google Site Kit', 'newspack' ) }
+					description={
+						sitekit
+							? __( 'Site Kit is connected.', 'newspack' )
+							: __( 'Site Kit is not connected. ', 'newspack' )
+					}
+					actionText={ ! sitekit && __( 'Connect', 'newspack' ) }
+					handoff="google-site-kit"
+				/>
+			</Fragment>
 		);
 	}
 }

--- a/assets/wizards/health-check/views/index.js
+++ b/assets/wizards/health-check/views/index.js
@@ -1,1 +1,2 @@
 export { default as Plugins } from './plugins';
+export { default as Configuration } from './configuration';

--- a/assets/wizards/health-check/views/index.js
+++ b/assets/wizards/health-check/views/index.js
@@ -1,1 +1,1 @@
-export { default as RemoveUnsupportedPlugins } from './remove-unsupported-plugins';
+export { default as Plugins } from './plugins';

--- a/assets/wizards/health-check/views/plugins/index.js
+++ b/assets/wizards/health-check/views/plugins/index.js
@@ -16,7 +16,7 @@ import { ActionCard, Button, Notice, withWizardScreen } from '../../../../compon
 /**
  * SEO Intro screen.
  */
-class RemoveUnsupportedPlugins extends Component {
+class Plugins extends Component {
 	/**
 	 * Render.
 	 */
@@ -52,4 +52,4 @@ class RemoveUnsupportedPlugins extends Component {
 	}
 }
 
-export default withWizardScreen( RemoveUnsupportedPlugins );
+export default withWizardScreen( Plugins );

--- a/includes/configuration_managers/class-amp-configuration-manager.php
+++ b/includes/configuration_managers/class-amp-configuration-manager.php
@@ -24,6 +24,25 @@ class AMP_Configuration_Manager extends Configuration_Manager {
 	public $slug = 'amp';
 
 	/**
+	 * Check if AMP plugin is in Standard mode.
+	 *
+	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
+	 */
+	public function is_standard_mode() {
+		if ( ! $this->is_configured() ) {
+			return new \WP_Error(
+				'newspack_amp_not_configured',
+				esc_html__( 'The AMP plugin is not configured properly.', 'newspack' ),
+				[
+					'status' => 400,
+					'level'  => 'fatal',
+				]
+			);
+		}
+		return \AMP_Theme_Support::STANDARD_MODE_SLUG === \AMP_Options_Manager::get_option( 'theme_support' );
+	}
+
+	/**
 	 * Configure AMP for Newspack use.
 	 *
 	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
@@ -33,10 +52,22 @@ class AMP_Configuration_Manager extends Configuration_Manager {
 		if ( ! $active || is_wp_error( $active ) ) {
 			return $active;
 		}
-		if ( class_exists( 'AMP_Options_Manager' ) ) {
+		if ( class_exists( 'AMP_Options_Manager', 'AMP_Theme_Support' ) ) {
 			\AMP_Options_Manager::update_option( 'theme_support', \AMP_Theme_Support::STANDARD_MODE_SLUG );
 		}
 		$this->set_newspack_has_configured( true );
 		return true;
+	}
+
+	/**
+	 * Is AMP installed and connected?
+	 *
+	 * @return bool Plugin ready state.
+	 */
+	public function is_configured() {
+		if ( $this->is_active() && class_exists( 'AMP_Theme_Support', 'AMP_Options_Manager' ) ) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/includes/wizards/class-health-check-wizard.php
+++ b/includes/wizards/class-health-check-wizard.php
@@ -147,12 +147,16 @@ class Health_Check_Wizard extends Wizard {
 	 * @return array Advertising data.
 	 */
 	private function retrieve_data() {
-		$amp_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'amp' );
+		$amp_manager     = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'amp' );
+		$jetpack_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'jetpack' );
+		$sitekit_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'google-site-kit' );
 
 		return array(
 			'unsupported_plugins'  => Plugin_Manager::get_unmanaged_plugins(),
 			'configuration_status' => [
-				'amp' => $amp_manager->is_standard_mode(),
+				'amp'     => $amp_manager->is_standard_mode(),
+				'jetpack' => $jetpack_manager->is_configured(),
+				'sitekit' => $sitekit_manager->is_configured(),
 			],
 		);
 	}

--- a/includes/wizards/class-health-check-wizard.php
+++ b/includes/wizards/class-health-check-wizard.php
@@ -83,6 +83,20 @@ class Health_Check_Wizard extends Wizard {
 		);
 		register_rest_route(
 			'newspack/v1/wizard/' . $this->slug,
+			'repair/(?P<configuration>[\a-z]+)/',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_repair_configuration' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'configuration' => [
+						'sanitize_callback' => [ $this, 'sanitize_configuration' ],
+					],
+				],
+			]
+		);
+		register_rest_route(
+			'newspack/v1/wizard/' . $this->slug,
 			'unsupported_plugins',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
@@ -90,6 +104,23 @@ class Health_Check_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
+	}
+
+	/**
+	 * Repair service API callback.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response containing ad units info.
+	 */
+	public function api_repair_configuration( $request ) {
+		$configuration = $request['configuration'];
+		switch ( $configuration ) {
+			case 'amp':
+				$amp_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'amp' );
+				$amp_manager->configure();
+				break;
+		}
+		return \rest_ensure_response( $this->retrieve_data() );
 	}
 
 	/**
@@ -116,8 +147,13 @@ class Health_Check_Wizard extends Wizard {
 	 * @return array Advertising data.
 	 */
 	private function retrieve_data() {
+		$amp_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'amp' );
+
 		return array(
-			'unsupported_plugins' => Plugin_Manager::get_unmanaged_plugins(),
+			'unsupported_plugins'  => Plugin_Manager::get_unmanaged_plugins(),
+			'configuration_status' => [
+				'amp' => $amp_manager->is_standard_mode(),
+			],
 		);
 	}
 
@@ -147,5 +183,17 @@ class Health_Check_Wizard extends Wizard {
 		);
 		\wp_style_add_data( 'newspack-health-check-wizard', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-health-check-wizard' );
+	}
+
+	/**
+	 * Sanitize the configuration name.
+	 *
+	 * @param string $configuration The configuration name.
+	 * @return string
+	 */
+	public function sanitize_configuration( $configuration ) {
+		$configuration        = sanitize_title( $configuration );
+		$valid_configurations = [ 'amp' ];
+		return in_array( $configuration, $valid_configurations ) ? $configuration : null;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a second view to the Health Check wizard which shows:

- Is AMP in Standard Mode?
- Is Jetpack connected?
- Is Site Kit connected?

Adds tabs to the wizard to support second view.

<img width="1411" alt="Screen Shot 2020-03-09 at 1 00 26 AM" src="https://user-images.githubusercontent.com/1477002/76184208-6fb54100-61a1-11ea-8fde-3fe6846f4490.png">

Closes https://github.com/Automattic/newspack-plugin/issues/473

### How to test the changes in this Pull Request:

1. Disconnect Jetpack. Go to Jetpack Dashboard (`/wp-admin/admin.php?page=jetpack#/dashboard`), under Site connection click "Manage site connection," click Disconnect.
2. Disconnect Site Kit. Navigate to Site Kit dashboard (`/wp-admin/admin.php?page=googlesitekit-splash`). Click your name in the upper right corner, select Disconnect.
3. Switch AMP to Transitional or Reader mode. Navigate to `/wp-admin/admin.php?page=amp-options`, select Template Mode other than Standard, Save.
4. Navigate to Newspack Health Check Wizard.
5. Verify there are two tabs, for Plugins and Configuration.
6. Switch to Configuration tab. Verify AMP, Jetpack and Site Kit are all in an error state.
7. Click "Repair" in the AMP `ActionCard`. Verify the UI returns to success state, and very in the AMP plugin dashboard that the mode is now Standard.
8. Click "Connect" on Jetpack `ActionCard`. Follow flow to set up Jetpack (note that you will need a live URL to do this). Click Handoff "Back to Newspack" button. Verify the Jetpack `ActionCard` is now in green success state.
9. Click "Connect" on Google Site Kit `ActionCard`. Follow flow to SIGN IN WITH GOOGLE. Click Handoff "Back to Newspack" button. Verify the Google Site Kit `ActionCard` is now in green success state.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->