### PR TITLE
Standardize REST API namespace usage

### DIFF
--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -25,7 +25,7 @@ class Plugins_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = '/newspack/v1';
+	protected $namespace = NEWSPACK_API_NAMESPACE;
 
 	/**
 	 * Endpoint resource.

--- a/includes/api/class-wizards-controller.php
+++ b/includes/api/class-wizards-controller.php
@@ -23,7 +23,7 @@ class Wizards_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = '/newspack/v1';
+	protected $namespace = NEWSPACK_API_NAMESPACE;
 
 	/**
 	 * Endpoint resource.

--- a/includes/class-profile.php
+++ b/includes/class-profile.php
@@ -83,7 +83,7 @@ class Profile {
 	public function register_api_endpoints() {
 		// Get profile data.
 		register_rest_route(
-			'newspack/v1/',
+			NEWSPACK_API_NAMESPACE,
 			'/profile/',
 			[
 				'methods'             => WP_REST_Server::READABLE,
@@ -94,7 +94,7 @@ class Profile {
 
 		// Update profile data.
 		register_rest_route(
-			'newspack/v1/',
+			NEWSPACK_API_NAMESPACE,
 			'/profile/',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,

--- a/includes/util.php
+++ b/includes/util.php
@@ -9,6 +9,8 @@ namespace Newspack;
 
 defined( 'ABSPATH' ) || exit;
 
+define( 'NEWSPACK_API_NAMESPACE', 'newspack/v1' );
+
 /**
  * Clean variables using sanitize_text_field. Arrays are cleaned recursively.
  * Non-scalar values are ignored.

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -104,8 +104,8 @@ class Advertising_Wizard extends Wizard {
 
 		// Get all Newspack advertising data.
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/advertising/',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_advertising' ],
@@ -115,8 +115,8 @@ class Advertising_Wizard extends Wizard {
 
 		// Update header code.
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/advertising/service/(?P<service>[\a-z]+)/network_code',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/service/(?P<service>[\a-z]+)/network_code',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_network_code' ],
@@ -134,8 +134,8 @@ class Advertising_Wizard extends Wizard {
 
 		// Enable one service.
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/advertising/service/(?P<service>[\a-z]+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/service/(?P<service>[\a-z]+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_enable_service' ],
@@ -150,8 +150,8 @@ class Advertising_Wizard extends Wizard {
 
 		// Disable one service.
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/advertising/service/(?P<service>[\a-z]+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/service/(?P<service>[\a-z]+)',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'api_disable_service' ],
@@ -166,8 +166,8 @@ class Advertising_Wizard extends Wizard {
 
 		// Update placement.
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/advertising/placement/(?P<placement>[\a-z]+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/placement/(?P<placement>[\a-z]+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_placement' ],
@@ -182,8 +182,8 @@ class Advertising_Wizard extends Wizard {
 
 		// Disable placement.
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/advertising/placement/(?P<placement>[\a-z]+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/placement/(?P<placement>[\a-z]+)',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'api_disable_placement' ],
@@ -198,8 +198,8 @@ class Advertising_Wizard extends Wizard {
 
 		// Save a ad unit.
 		\register_rest_route(
-			'newspack/v1/wizard/',
-			'/advertising/ad_unit/(?P<id>\d+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/ad_unit/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_adunit' ],
@@ -227,8 +227,8 @@ class Advertising_Wizard extends Wizard {
 
 		// Delete a ad unit.
 		\register_rest_route(
-			'newspack/v1/wizard/',
-			'/advertising/ad_unit/(?P<id>\d+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/ad_unit/(?P<id>\d+)',
 			[
 				'methods'             => 'DELETE',
 				'callback'            => [ $this, 'api_delete_adunit' ],

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -72,8 +72,8 @@ class Engagement_Wizard extends Wizard {
 	 */
 	public function register_api_endpoints() {
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'engagement',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/engagement',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_engagement_settings' ],
@@ -81,8 +81,8 @@ class Engagement_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'popup/(?P<id>\d+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/popup/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'api_delete_popup' ],
@@ -95,8 +95,8 @@ class Engagement_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'sitewide-popup/(?P<id>\d+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/sitewide-popup/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_set_sitewide_popup' ],
@@ -109,8 +109,8 @@ class Engagement_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'sitewide-popup/(?P<id>\d+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/sitewide-popup/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'api_unset_sitewide_popup' ],
@@ -123,8 +123,8 @@ class Engagement_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'popup-categories/(?P<id>\d+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/popup-categories/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_set_popup_categories' ],

--- a/includes/wizards/class-health-check-wizard.php
+++ b/includes/wizards/class-health-check-wizard.php
@@ -73,8 +73,8 @@ class Health_Check_Wizard extends Wizard {
 	 */
 	public function register_api_endpoints() {
 		register_rest_route(
-			'newspack/v1/wizard/',
-			$this->slug,
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug,
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_health_data' ],
@@ -82,8 +82,8 @@ class Health_Check_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'repair/(?P<configuration>[\a-z]+)/',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/repair/(?P<configuration>[\a-z]+)/',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_repair_configuration' ],
@@ -96,8 +96,8 @@ class Health_Check_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'unsupported_plugins',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/unsupported_plugins',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'api_delete_unsupported_plugins' ],

--- a/includes/wizards/class-payment-wizard.php
+++ b/includes/wizards/class-payment-wizard.php
@@ -53,8 +53,8 @@ class Payment_Wizard extends Wizard {
 
 		// Get data about Stripe customer/subscription.
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/newspack-payment-wizard/',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/newspack-payment-wizard/',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_stripe_data' ],
@@ -64,8 +64,8 @@ class Payment_Wizard extends Wizard {
 
 		// Create a Stripe checkout session, return information needed to redirect to it.
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/newspack-payment-wizard/checkout',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/newspack-payment-wizard/checkout',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_stripe_checkout_id' ],

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -70,8 +70,8 @@ class Performance_Wizard extends Wizard {
 	 */
 	public function register_api_endpoints() {
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/performance/',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/performance/',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_settings' ],
@@ -79,8 +79,8 @@ class Performance_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/performance/',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/performance/',
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'api_update_settings' ],

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -74,8 +74,8 @@ class Reader_Revenue_Wizard extends Wizard {
 
 		// Get all data required to render the Wizard.
 		\register_rest_route(
-			'newspack/v1/wizard/',
-			$this->slug,
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug,
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_fetch' ],
@@ -85,8 +85,8 @@ class Reader_Revenue_Wizard extends Wizard {
 
 		// Save location info.
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/location/',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/location/',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_location' ],
@@ -121,8 +121,8 @@ class Reader_Revenue_Wizard extends Wizard {
 
 		// Save Stripe info.
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/stripe/',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/stripe/',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_stripe_settings' ],
@@ -152,8 +152,8 @@ class Reader_Revenue_Wizard extends Wizard {
 
 		// Save a subscription.
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/donations/',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/donations/',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_donation_settings' ],
@@ -182,8 +182,8 @@ class Reader_Revenue_Wizard extends Wizard {
 		);
 
 		register_rest_route(
-			'newspack/v1/wizard/newspack-donations-wizard/',
-			'/donation/',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/newspack-donations-wizard/donation/',
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'api_get_donation_settings' ],

--- a/includes/wizards/class-seo-wizard.php
+++ b/includes/wizards/class-seo-wizard.php
@@ -72,8 +72,8 @@ class SEO_Wizard extends Wizard {
 	 */
 	public function register_api_endpoints() {
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'settings',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . 'settings',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_seo_settings' ],
@@ -81,8 +81,8 @@ class SEO_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'settings',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . 'settings',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_seo_settings' ],

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -82,8 +82,8 @@ class Setup_Wizard extends Wizard {
 	public function register_api_endpoints() {
 		// Update option when setup is complete.
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/complete',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/complete',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_complete' ],
@@ -91,8 +91,8 @@ class Setup_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/theme',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/theme',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_retrieve_theme' ],
@@ -100,8 +100,8 @@ class Setup_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/theme/(?P<theme>[\a-z]+)',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/theme/(?P<theme>[\a-z]+)',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_theme' ],
@@ -109,8 +109,8 @@ class Setup_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/theme-mods',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/theme-mods',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_theme_mods' ],
@@ -123,8 +123,8 @@ class Setup_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/starter-content/categories',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/starter-content/categories',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_starter_content_categories' ],
@@ -132,8 +132,8 @@ class Setup_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/starter-content/post',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/starter-content/post',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_starter_content_post' ],
@@ -141,8 +141,8 @@ class Setup_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/starter-content/theme',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/starter-content/theme',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_starter_content_theme' ],
@@ -150,8 +150,8 @@ class Setup_Wizard extends Wizard {
 			]
 		);
 		register_rest_route(
-			'newspack/v1/wizard/' . $this->slug,
-			'/starter-content/homepage',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/starter-content/homepage',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_starter_content_homepage' ],

--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -48,8 +48,8 @@ class Support_Wizard extends Wizard {
 	public function register_api_endpoints() {
 		// Create a support ticket.
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/newspack-support-wizard/ticket',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/newspack-support-wizard/ticket',
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'api_create_support_ticket' ],
@@ -59,8 +59,8 @@ class Support_Wizard extends Wizard {
 
 		// Handle access token from WPCOM.
 		register_rest_route(
-			'newspack/v1/wizard/',
-			'/newspack-support-wizard/wpcom_access_token',
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/newspack-support-wizard/wpcom_access_token',
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'api_wpcom_access_token' ],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In WP 5.4, [REST API route matching is slightly tweaked to improve performance](https://core.trac.wordpress.org/ticket/48530). With this change, all of the Newspack API routes were giving `{"code":"rest_no_route","message":"No route was found matching the URL and request method","data":{"status":404}}` errors.

Some digging revealed that we have a bunch of namespaces, confusing the matcher:
<img width="431" alt="Screen Shot 2020-03-09 at 11 10 41 AM" src="https://user-images.githubusercontent.com/7317227/76244421-3efff680-61f7-11ea-8128-c798bd9efeb9.png">

This PR standardizes all of the API endpoints into one `newspack/v1` namespace, resolving the issue:
<img width="299" alt="Screen Shot 2020-03-09 at 11 08 52 AM" src="https://user-images.githubusercontent.com/7317227/76244453-5212c680-61f7-11ea-9291-41ef1fba28c4.png">

### How to test the changes in this Pull Request:

1. Install WP 5.4 RC1. Navigate to any wizard that uses the REST API. Observe the 404 error when the API call goes out.
2. Apply this patch. Navigate to wizards. Observe issue is resolved. No other behavior should be changed. Wizards should work as normal.
3. This patch shouldn't cause issues using WP 5.3.x.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->