### PR TITLE
Integrate ad suppression with global ad settings

### DIFF
--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -123,7 +123,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Returns true if ads should be shown.
 	 */
 	public function should_show_ads() {
-		return $this->is_configured() ? newspack_should_show_ads() : false;
+		return $this->is_configured() && function_exists( 'newspack_ads_should_show_ads' ) ? newspack_ads_should_show_ads() : false;
 	}
 
 	/**

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -118,6 +118,15 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Check whether the current screen should show ads.
+	 *
+	 * @return bool Returns true if ads should be shown.
+	 */
+	public function should_show_ads() {
+		return $this->is_configured() ? newspack_should_show_ads() : false;
+	}
+
+	/**
 	 * Error to return if the plugin is not installed and activated.
 	 *
 	 * @return WP_Error

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -555,7 +555,11 @@ class Advertising_Wizard extends Wizard {
 		}
 
 		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
-		$ad_unit               = $configuration_manager->get_ad_unit( $placement['ad_unit'], $placement_slug );
+		if ( ! $configuration_manager->should_show_ads() ) {
+			return;
+		}
+
+		$ad_unit = $configuration_manager->get_ad_unit( $placement['ad_unit'], $placement_slug );
 		if ( is_wp_error( $ad_unit ) ) {
 			return;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**This PR should be tested with https://github.com/Automattic/newspack-ads/pull/26.**

This half of the feature has the handling for the global ad slots with ad suppression.

### How to test the changes in this Pull Request:

1. Testing instructions at https://github.com/Automattic/newspack-ads/pull/26

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->