### PR TITLE
fix: button box-shadow since Gutenberg 7.7

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -67,6 +67,7 @@
 		&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
 			background: $primary-600;
 			border-color: $primary-700;
+			box-shadow: none;
 			color: white;
 		}
 
@@ -112,6 +113,7 @@
 	&.is-secondary {
 		background: white;
 		border: 1px solid $light-gray-500;
+		box-shadow: none;
 		color: $primary-500;
 
 		&:active,
@@ -122,6 +124,7 @@
 		&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
 			background: $light-gray-100;
 			border-color: $primary-500;
+			box-shadow: none;
 			color: $primary-500;
 		}
 
@@ -176,6 +179,7 @@
 		&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
 			background: $light-gray-400;
 			border-color: $light-gray-900;
+			box-shadow: none;
 			color: $dark-gray-900;
 		}
 

--- a/assets/components/src/color-picker/style.scss
+++ b/assets/components/src/color-picker/style.scss
@@ -58,6 +58,7 @@
 			background: white;
 			border: 1px solid $light-gray-500;
 			border-radius: 3px;
+			box-shadow: none;
 			color: $primary-500;
 			font-size: inherit;
 			font-weight: bold;
@@ -75,6 +76,7 @@
 			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
 				background: $light-gray-100;
 				border-color: $primary-500;
+				box-shadow: none;
 				color: $primary-500;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Since Gutenberg 7.7 we have a box-shadow around the buttons which doesn't fit with Newspack style. This PR simply removes it.

### How to test the changes in this Pull Request:

1. Go to the components demo `wp-admin/admin.php?page=newspack-components-demo`
2. At the bottom, notice the style of the buttons (hover and not)
3. Switch to this branch
4. Refresh components demo

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->