### PR TITLE
Deterministic Starter Content

### DIFF
--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -347,6 +347,7 @@ class Starter_Content {
 	 * Download and add a featured image to a post.
 	 *
 	 * @param int $post_id The post ID.
+	 * @param int $post_index The index of the post within the set of starter content posts.
 	 *
 	 * @return string Block markup.
 	 */

--- a/includes/raw_assets/markup/body.txt
+++ b/includes/raw_assets/markup/body.txt
@@ -1,0 +1,9 @@
+Etiam iaculis nunc ac metus. Pellentesque dapibus hendrerit tortor. Cras sagittis. Etiam rhoncus. Fusce convallis metus id felis luctus adipiscing.
+
+Praesent egestas neque eu enim. Praesent adipiscing. Praesent ac sem eget est egestas volutpat. Mauris turpis nunc, blandit et, volutpat molestie, porta ut, ligula. Fusce a quam.
+
+Pellentesque dapibus hendrerit tortor. Praesent ac massa at ligula laoreet iaculis. Nulla porta dolor. Pellentesque ut neque. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+
+Pellentesque posuere. Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Etiam ut purus mattis mauris sodales aliquam. Pellentesque dapibus hendrerit tortor. In consectetuer turpis ut velit.
+
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce id purus. Curabitur blandit mollis lacus. Aenean ut eros et nisl sagittis vestibulum. Etiam sit amet orci eget eros faucibus tincidunt. Vivamus aliquet elit ac nisl.

--- a/includes/raw_assets/markup/title.txt
+++ b/includes/raw_assets/markup/title.txt
@@ -1,0 +1,1 @@
+Suspendisse pulvinar augue ac venenatis condimentum sem libero volutpat nibh


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Setup Wizard's Starter Content generation relies on randomness to generate an authentic set of content, with categories, titles, content, images, and layout all chosen randomly. As @adekbadek noted in https://github.com/Automattic/newspack-plugin/pull/459#issuecomment-592942122, this will be problematic for e2e testing. This branch introduces deterministic starter content that should render identically every time. The flag to use this approach is a `wp-config` flag (`WP_NEWSPACK_DETERMINISTIC_STARTER_CONTENT`). As the specifics of our e2e testing implementation become clearer, we may need to change this to an environment variable. 

<img width="1621" alt="Screen Shot 2020-03-12 at 11 42 06 PM" src="https://user-images.githubusercontent.com/1477002/76588925-c6cb5680-64be-11ea-88a9-c5be28211f2d.png">

### How to test the changes in this Pull Request:

1. Delete all posts and categories. 
2. Run the Starter Content Wizard (`/wp-admin/admin.php?page=newspack-setup-wizard#/starter-content`)
3. Screenshot the homepage.
4. Delete all posts/categories again.
5. In `wp-config.php`, add: ```WP_NEWSPACK_DETERMINISTIC_STARTER_CONTENT```
6. Run Starter Content Wizard again and screenshot.
7. Delete everything again, re-run Starter Content.
8. Verify that the second screenshot is exactly the same as the new site—same images, same headlines, same categories, posts have the same templates and title style.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->