### PR TITLE
Starter content: parallelise post creation; tweaks for handling E2E

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
 	},
 	globals: {
 		newspack_urls: 'readonly',
+		newspack_aux_data: 'readonly',
 	},
 	ignorePatterns: [ 'dist/', 'node_modules/', 'assets/components/node_modules' ],
 	rules: {

--- a/assets/components/src/style-card/index.js
+++ b/assets/components/src/style-card/index.js
@@ -24,14 +24,14 @@ class StyleCard extends Component {
 	 * Render.
 	 */
 	render() {
-		const { className, cardTitle, url, image, isActive, onClick } = this.props;
+		const { className, cardTitle, url, image, isActive, onClick, id } = this.props;
 		const classes = classnames(
 			'newspack-style-card',
 			isActive && 'newspack-style-card__is-active',
 			className
 		);
 		return (
-			<div className={ classes } tabIndex="0">
+			<div className={ classes } tabIndex="0" id={ id }>
 				<div className="newspack-style-card__image">
 					{ image && <img src={ image } alt="style-card" /> }
 					<div className="newspack-style-card__actions">

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -67,6 +67,7 @@ class SetupWizard extends Component {
 			profile: {},
 			currencies: {},
 			countries: {},
+			starterContentInstallStarted: false,
 			starterContentProgress: null,
 			starterContentTotal: null,
 			theme: null,
@@ -196,54 +197,56 @@ class SetupWizard extends Component {
 	};
 
 	incrementStarterContentProgress = () => {
-		const { starterContentProgress } = this.state;
 		this.setState(
-			{ starterContentProgress: starterContentProgress + 1 },
-			() => this.state.starterContentProgress >= 43 && this.finish()
+			( { starterContentProgress } ) => ( { starterContentProgress: starterContentProgress + 1 } ),
+			() =>
+				this.state.starterContentProgress >= this.state.starterContentTotal &&
+				this.finishStarterContentInstall()
 		);
 	};
 
-	installStarterContent = () => {
-		this.setState( { starterContentProgress: 0, starterContentTotal: 43 } );
-		const promises = [
-			() =>
+	installStarterContent = async () => {
+		// there are 12 categories in starter content, this will result in one post in each for e2e
+		const starterPostsCount = newspack_aux_data.is_e2e ? 12 : 40;
+		this.setState( {
+			starterContentInstallStarted: true,
+			starterContentProgress: 0,
+			starterContentTotal: starterPostsCount + 3,
+		} );
+
+		await apiFetch( {
+			path: `/newspack/v1/wizard/newspack-setup-wizard/starter-content/categories`,
+			method: 'post',
+		} ).then( this.incrementStarterContentProgress );
+
+		const postsPromises = [];
+		for ( let x = 0; x < starterPostsCount; x++ ) {
+			postsPromises.push(
 				apiFetch( {
-					path: `/newspack/v1/wizard/newspack-setup-wizard/starter-content/categories`,
-					method: 'post',
-				} ).then( () => this.incrementStarterContentProgress() ),
-		];
-		for ( let x = 0; x < 40; x++ ) {
-			promises.push( () =>
-				apiFetch( {
-					path: `/newspack/v1/wizard/newspack-setup-wizard/starter-content/post`,
+					path: `/newspack/v1/wizard/newspack-setup-wizard/starter-content/post/${ x }`,
 					method: 'post',
 				} )
-					.then( () => this.incrementStarterContentProgress() )
-					.catch( () => this.incrementStarterContentProgress() )
+					.then( this.incrementStarterContentProgress )
+					.catch( this.incrementStarterContentProgress )
 			);
 		}
-		promises.push( () =>
-			apiFetch( {
-				path: `/newspack/v1/wizard/newspack-setup-wizard/starter-content/homepage`,
-				method: 'post',
-			} ).then( () => this.incrementStarterContentProgress() )
-		);
-		promises.push( () =>
-			apiFetch( {
-				path: `/newspack/v1/wizard/newspack-setup-wizard/starter-content/theme`,
-				method: 'post',
-			} ).then( () => this.incrementStarterContentProgress() )
-		);
-		return new Promise( () => {
-			promises.reduce(
-				( promise, action ) =>
-					promise.then( result => action().then( Array.prototype.concat.bind( result ) ) ),
-				Promise.resolve( [] )
-			);
-		} );
+
+		await Promise.all( postsPromises );
+
+		await apiFetch( {
+			path: `/newspack/v1/wizard/newspack-setup-wizard/starter-content/homepage`,
+			method: 'post',
+		} ).then( this.incrementStarterContentProgress );
+
+		await apiFetch( {
+			path: `/newspack/v1/wizard/newspack-setup-wizard/starter-content/theme`,
+			method: 'post',
+		} ).then( this.incrementStarterContentProgress );
+
+		this.finishStarterContentInstall();
 	};
 
-	finish = () => {
+	finishStarterContentInstall = () => {
 		this.updateProfile().then( () =>
 			this.completeSetup().then( () => ( window.location = newspack_urls.dashboard ) )
 		);
@@ -259,6 +262,7 @@ class SetupWizard extends Component {
 			profile,
 			countries,
 			currencies,
+			starterContentInstallStarted,
 			starterContentTotal,
 			starterContentProgress,
 		} = this.state;
@@ -413,12 +417,13 @@ class SetupWizard extends Component {
 									headerText={ __( 'Starter Content' ) }
 									subHeaderText={ __( 'Pre-configure the site for testing and experimentation' ) }
 									buttonText={ __( 'Install Starter Content' ) }
-									buttonAction={ () => this.installStarterContent().then( this.finish ) }
-									buttonDisabled={ starterContentProgress }
+									buttonAction={ this.installStarterContent }
+									buttonDisabled={ starterContentInstallStarted }
 									secondaryButtonText={ starterContentProgress ? null : __( 'Not right now' ) }
-									secondaryButtonAction={ this.finish }
+									secondaryButtonAction={ this.finishStarterContentInstall }
 									starterContentProgress={ starterContentProgress }
 									starterContentTotal={ starterContentTotal }
+									displayProgressBar={ starterContentInstallStarted }
 								/>
 							);
 						} }

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -276,6 +276,15 @@ class SetupWizard extends Component {
 			'/theme-style-selection',
 			'/starter-content',
 		];
+
+		// background auto installation is a nice feature, but in e2e it
+		// cretes an undeterministic environment, since the installation-progress
+		// is not visited (https://github.com/Automattic/newspack-e2e-tests/issues/3)
+		const shouldAutoInstallPlugins = routeProps =>
+			newspack_aux_data.is_e2e
+				? '/installation-progress' === routeProps.location.pathname
+				: '/' !== routeProps.location.pathname;
+
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -432,7 +441,7 @@ class SetupWizard extends Component {
 						path={ [ '/' ] }
 						render={ routeProps => (
 							<InstallationProgress
-								autoInstall={ '/' !== routeProps.location.pathname }
+								autoInstall={ shouldAutoInstallPlugins( routeProps ) }
 								hidden={ '/installation-progress' !== routeProps.location.pathname }
 								headerIcon={ <SettingsIcon /> }
 								headerText={ __( 'Installation...' ) }

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -278,7 +278,7 @@ class SetupWizard extends Component {
 		];
 
 		// background auto installation is a nice feature, but in e2e it
-		// cretes an undeterministic environment, since the installation-progress
+		// creates an undeterministic environment, since the installation-progress
 		// is not visited (https://github.com/Automattic/newspack-e2e-tests/issues/3)
 		const shouldAutoInstallPlugins = routeProps =>
 			newspack_aux_data.is_e2e

--- a/assets/wizards/setup/views/starter-content/index.js
+++ b/assets/wizards/setup/views/starter-content/index.js
@@ -21,7 +21,7 @@ class StarterContent extends Component {
 	 * Render.
 	 */
 	render() {
-		const { starterContentProgress, starterContentTotal } = this.props;
+		const { displayProgressBar, starterContentProgress, starterContentTotal } = this.props;
 		return (
 			<div className="newspack-setup-wizard__welcome">
 				<p>
@@ -29,7 +29,7 @@ class StarterContent extends Component {
 						'Optionally pre-populate the site with categories, 40 placeholder stories, Newspack branding, and some homepage blocks. This feature will pre-configure the site for experimentation and testing and all placeholder content can be deleted and replaced later.'
 					) }
 				</p>
-				{ starterContentProgress > 0 && starterContentTotal > 0 && (
+				{ displayProgressBar && (
 					<ProgressBar
 						completed={ starterContentProgress }
 						total={ starterContentTotal }

--- a/assets/wizards/site-design/views/theme-selection/index.js
+++ b/assets/wizards/site-design/views/theme-selection/index.js
@@ -31,6 +31,7 @@ class ThemeSelection extends Component {
 					url="//newspack.newspackstaging.com"
 					isActive={ theme === 'newspack-theme' }
 					onClick={ () => updateTheme( 'newspack-theme' ) }
+					id={ `card--newspack-theme` }
 				/>
 				<StyleCard
 					cardTitle="Scott"
@@ -38,6 +39,7 @@ class ThemeSelection extends Component {
 					url="//scott.newspackstaging.com"
 					isActive={ theme === 'newspack-scott' }
 					onClick={ () => updateTheme( 'newspack-scott' ) }
+					id={ `card--newspack-scott` }
 				/>
 				<StyleCard
 					cardTitle="Nelson"
@@ -45,6 +47,7 @@ class ThemeSelection extends Component {
 					url="//nelson.newspackstaging.com"
 					isActive={ theme === 'newspack-nelson' }
 					onClick={ () => updateTheme( 'newspack-nelson' ) }
+					id={ `card--newspack-nelson` }
 				/>
 				<StyleCard
 					cardTitle="Katharine"
@@ -52,6 +55,7 @@ class ThemeSelection extends Component {
 					url="//katharine.newspackstaging.com"
 					isActive={ theme === 'newspack-katharine' }
 					onClick={ () => updateTheme( 'newspack-katharine' ) }
+					id={ `card--newspack-katharine` }
 				/>
 				<StyleCard
 					cardTitle="Sacha"
@@ -59,6 +63,7 @@ class ThemeSelection extends Component {
 					url="//sacha.newspackstaging.com"
 					isActive={ theme === 'newspack-sacha' }
 					onClick={ () => updateTheme( 'newspack-sacha' ) }
+					id={ `card--newspack-sacha` }
 				/>
 				<StyleCard
 					cardTitle="Joseph"
@@ -66,6 +71,7 @@ class ThemeSelection extends Component {
 					url="//joseph.newspackstaging.com"
 					isActive={ theme === 'newspack-joseph' }
 					onClick={ () => updateTheme( 'newspack-joseph' ) }
+					id={ `card--newspack-joseph` }
 				/>
 			</StyleCardGroup>
 		);

--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -99,7 +99,10 @@ class Starter_Content {
 			]
 		);
 
-		wp_set_post_categories( $post_id, $categories[0] );
+		$category_ids = get_option( NEWSPACK_STARTER_CONTENT_CATEGORIES );
+		$category_id = self::is_e2e() ? $category_ids[$post_index] : $categories[0];
+
+		wp_set_post_categories( $post_id, $category_id );
 		wp_publish_post( $post_id );
 
 		return $post_id;

--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -15,7 +15,6 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'NEWSPACK_STARTER_CONTENT_CATEGORIES', '_newspack_starter_content_categories' );
 define( 'NEWSPACK_STARTER_CONTENT_POSTS', '_newspack_starter_content_posts' );
-define( 'NEWSPACK_STARTER_CONTENT_POST_INDEX', '_newspack_starter_content_post_index' );
 
 /**
  * Manages settings for PWA.
@@ -32,13 +31,13 @@ class Starter_Content {
 	/**
 	 * Create a single post.
 	 *
+	 * @param number $post_index Post index.
 	 * @return int Post ID
 	 */
-	public static function create_post() {
+	public static function create_post( $post_index ) {
 		if ( ! function_exists( 'wp_insert_post' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/post.php';
 		}
-		$post_index     = get_option( NEWSPACK_STARTER_CONTENT_POST_INDEX, 0 );
 		$page_templates = [ '', 'single-feature.php' ];
 		$paragraphs     = explode( PHP_EOL, self::get_lipsum( 'paras', 5 ) );
 		$title          = self::generate_title();
@@ -60,6 +59,10 @@ class Starter_Content {
 				)
 			),
 		];
+
+		if ( self::is_e2e() ) {
+			$post_data['post_date'] = '2020-03-03 10:00:00';
+		};
 
 		$post_id = wp_insert_post( $post_data );
 
@@ -99,8 +102,6 @@ class Starter_Content {
 		wp_set_post_categories( $post_id, $categories[0] );
 		wp_publish_post( $post_id );
 
-		update_option( NEWSPACK_STARTER_CONTENT_POST_INDEX, $post_index + 1 );
-
 		return $post_id;
 	}
 
@@ -118,7 +119,6 @@ class Starter_Content {
 			self::$starter_categories
 		);
 		update_option( NEWSPACK_STARTER_CONTENT_CATEGORIES, $category_ids );
-		update_option( NEWSPACK_STARTER_CONTENT_POST_INDEX, 0 );
 		return $category_ids;
 	}
 
@@ -359,7 +359,8 @@ class Starter_Content {
 			require_once ABSPATH . 'wp-admin/includes/image.php';
 		}
 
-		$url = self::is_e2e() ? 'https://picsum.photos/id/' . $post_index . '/1200/800' : 'https://picsum.photos/1200/800';
+		// Use same image everywhere for e2e.
+		$url = self::is_e2e() ? 'https://picsum.photos/id/424/1200/800' : 'https://picsum.photos/1200/800';
 
 		$temp_file = download_url( $url );
 
@@ -412,7 +413,7 @@ class Starter_Content {
 	 *
 	 * @return bool E2E testing environment?
 	 */
-	private static function is_e2e() {
+	public static function is_e2e() {
 		return defined( 'WP_NEWSPACK_DETERMINISTIC_STARTER_CONTENT' ) && WP_NEWSPACK_DETERMINISTIC_STARTER_CONTENT;
 	}
 }

--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -100,7 +100,7 @@ class Starter_Content {
 		);
 
 		$category_ids = get_option( NEWSPACK_STARTER_CONTENT_CATEGORIES );
-		$category_id = self::is_e2e() ? $category_ids[$post_index] : $categories[0];
+		$category_id  = self::is_e2e() ? $category_ids[ $post_index ] : $categories[0];
 
 		wp_set_post_categories( $post_id, $category_id );
 		wp_publish_post( $post_id );

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -133,7 +133,7 @@ class Setup_Wizard extends Wizard {
 		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/starter-content/post',
+			'/wizard/' . $this->slug . '/starter-content/post/(?P<id>[\a-z]+)',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_starter_content_post' ],
@@ -183,10 +183,12 @@ class Setup_Wizard extends Wizard {
 	/**
 	 * Install one starter content post
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response containing info.
 	 */
-	public function api_starter_content_post() {
-		$status = Starter_Content::create_post();
+	public function api_starter_content_post( $request ) {
+		$id     = $request['id'];
+		$status = Starter_Content::create_post( $id );
 		return rest_ensure_response( [ 'status' => $status ] );
 	}
 

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -7,6 +7,7 @@
 
 namespace Newspack;
 
+use Newspack\Starter_Content;
 defined( 'ABSPATH' ) || exit;
 
 define( 'NEWSPACK_WIZARD_COMPLETED_OPTION_PREFIX', 'newspack_wizard_completed_' );
@@ -116,7 +117,12 @@ abstract class Wizard {
 			],
 		];
 
+		$aux_data = [
+			'is_e2e' => Starter_Content::is_e2e(),
+		];
+
 		wp_localize_script( 'newspack_data', 'newspack_urls', $urls );
+		wp_localize_script( 'newspack_data', 'newspack_aux_data', $aux_data );
 		wp_enqueue_script( 'newspack_data' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR introduces an optimisation of starter content creation by parallelising requests. 

This PR also introduces a couple of changes to enable E2E testing:
- handling `id` attribute on `StyleCard` and using it on theme selection cards
- using URL query param instead of option to achieve deterministic content for E2E
- using the same image for all E2E posts
- hardcoded post publication date for E2E posts

### How to test the changes in this Pull Request:

1. Visit `/wp-admin/admin.php?page=newspack-setup-wizard#/starter-content` and create some starter content. Is should be faster than than before, but other than that with no changes.
2. Set `WP_NEWSPACK_DETERMINISTIC_STARTER_CONTENT` env var to `1` (e.g. `define( 'WP_NEWSPACK_DETERMINISTIC_STARTER_CONTENT', '1' );` in `wp-config.php`)
3. Run the starter content again. It should create just 12 posts, all with the same image, title, and content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->