### PR TITLE
Fix handoff: enqueue shared JS in handoff

### DIFF
--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -93,6 +93,15 @@ class Handoff_Banner {
 		wp_enqueue_style( $handle );
 
 		wp_register_script(
+			'newspack_commons',
+			Newspack::plugin_url() . '/dist/commons.js',
+			[],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/commons.js' ),
+			true
+		);
+		wp_enqueue_script( 'newspack_commons' );
+
+		wp_register_script(
 			$handle,
 			Newspack::plugin_url() . '/dist/handoff-banner.js',
 			[ 'wp-element', 'wp-editor', 'wp-components' ],

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -101,6 +101,15 @@ class Handoff_Banner {
 		);
 		wp_enqueue_script( 'newspack_commons' );
 
+		wp_register_style(
+			'newspack-commons',
+			Newspack::plugin_url() . '/dist/commons.css',
+			[ 'wp-components' ],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/commons.css' )
+		);
+		wp_style_add_data( 'newspack-commons', 'rtl', 'replace' );
+		wp_enqueue_style( 'newspack-commons' );
+
 		wp_register_script(
 			$handle,
 			Newspack::plugin_url() . '/dist/handoff-banner.js',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is the only place where the wizards' JS is used outside of the actual wizards.

Closes #493 

### How to test the changes in this Pull Request:

1. Go to components demo, "Handoff Buttons" section, click "Manage AMP"
2. Observe redirection to AMP settings
3. Observe a handoff banner at the top of the page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->