### PR TITLE
Add grid view option to the Dashboard

### DIFF
--- a/assets/components/src/card/index.js
+++ b/assets/components/src/card/index.js
@@ -22,11 +22,12 @@ class Card extends Component {
 	 * Render
 	 */
 	render() {
-		const { className, noBackground, ...otherProps } = this.props;
+		const { className, noBackground, isButtons, ...otherProps } = this.props;
 		const classes = classNames(
 			'newspack-card',
 			className,
-			noBackground && 'newspack-card__no-background'
+			noBackground && 'newspack-card__no-background',
+			isButtons && 'newspack-card__buttons-card'
 		);
 		return <div className={ classes } { ...otherProps } />;
 	}

--- a/assets/components/src/card/index.js
+++ b/assets/components/src/card/index.js
@@ -22,12 +22,12 @@ class Card extends Component {
 	 * Render
 	 */
 	render() {
-		const { className, noBackground, isButtons, ...otherProps } = this.props;
+		const { className, noBackground, buttonsCard, ...otherProps } = this.props;
 		const classes = classNames(
 			'newspack-card',
 			className,
 			noBackground && 'newspack-card__no-background',
-			isButtons && 'newspack-card__buttons-card'
+			buttonsCard && 'newspack-card__buttons-card'
 		);
 		return <div className={ classes } { ...otherProps } />;
 	}

--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -21,7 +21,7 @@
 
 	// No Background
 
-	&.newspack-card__no-background {
+	&__no-background {
 		background: none;
 		box-shadow: none;
 		padding: 0;
@@ -29,7 +29,7 @@
 
 	// Buttons Card
 
-	&.newspack-card__buttons-card {
+	&__buttons-card {
 		margin: 24px -8px;
 
 		.newspack-button {
@@ -39,7 +39,7 @@
 
 	// Is Clickable
 
-	&.newspack-card__is-clickable {
+	&__is-clickable {
 		cursor: pointer;
 		transition: box-shadow 150ms ease-in-out, transform 150ms ease-in-out;
 

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -127,7 +127,7 @@ class ComponentsDemo extends Component {
 					</Card>
 					<Card>
 						<FormattedHeader headerText={ __( 'Web Previews' ) } />
-						<Card noBackground className="newspack-card__buttons-card">
+						<Card noBackground buttonsCard>
 							<WebPreview
 								url="//newspack.blog"
 								label={ __( 'Preview Newspack Blog', 'newspack' ) }
@@ -223,7 +223,7 @@ class ComponentsDemo extends Component {
 					</Card>
 					<Card>
 						<FormattedHeader headerText={ __( 'Handoff Buttons' ) } />
-						<Card noBackground className="newspack-card__buttons-card">
+						<Card noBackground buttonsCard>
 							<Handoff
 								modalTitle="Manage AMP"
 								modalBody="Click to go to the AMP dashboard. There will be a notification bar at the top with a link to return to Newspack."
@@ -244,7 +244,7 @@ class ComponentsDemo extends Component {
 					</Card>
 					<Card>
 						<FormattedHeader headerText={ __( 'Modal' ) } />
-						<Card noBackground className="newspack-card__buttons-card">
+						<Card noBackground buttonsCard>
 							<Button isPrimary onClick={ () => this.setState( { modalShown: true } ) }>
 								{ __( 'Open modal' ) }
 							</Button>
@@ -259,7 +259,7 @@ class ComponentsDemo extends Component {
 										'Based on industry research, we advise to test the modal component, and continuing this sentence so we can see how the text wraps is one good way of doing that.'
 									) }
 								</p>
-								<Card noBackground className="newspack-card__buttons-card">
+								<Card noBackground buttonsCard>
 									<Button isPrimary onClick={ () => this.setState( { modalShown: false } ) }>
 										{ __( 'Dismiss' ) }
 									</Button>
@@ -283,7 +283,7 @@ class ComponentsDemo extends Component {
 					</Card>
 					<Card>
 						<FormattedHeader headerText={ __( 'Plugin installer: Progress Bar' ) } />
-						<Card noBackground className="newspack-card__buttons-card">
+						<Card noBackground buttonsCard>
 							<Button
 								onClick={ () => this.setState( { showPluginInstallerWithProgressBar: true } ) }
 								className="is-centered"
@@ -586,13 +586,15 @@ class ComponentsDemo extends Component {
 					</Card>
 					<Card className="newspack-components-demo__buttons">
 						<FormattedHeader headerText="Buttons" />
-						<Card noBackground className="newspack-card__buttons-card">
+						<Card noBackground buttonsCard>
 							<Button isPrimary>isPrimary</Button>
 							<Button isDefault>isDefault</Button>
 							<Button isTertiary>isTertiary</Button>
 							<Button isLink>isLink</Button>
-							<hr />
-							<h2>isLarge</h2>
+						</Card>
+						<hr />
+						<h2>isLarge</h2>
+						<Card noBackground buttonsCard>
 							<Button isPrimary isLarge>
 								isPrimary
 							</Button>
@@ -602,8 +604,10 @@ class ComponentsDemo extends Component {
 							<Button isTertiary isLarge>
 								isTertiary
 							</Button>
-							<hr />
-							<h2>isSmall</h2>
+						</Card>
+						<hr />
+						<h2>isSmall</h2>
+						<Card noBackground buttonsCard>
 							<Button isPrimary isSmall>
 								isPrimary
 							</Button>

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -1,35 +1,63 @@
 import '../../shared/js/public-path';
 
-/* global newspack_dashboard */
-
 /**
- * WordPress dependencies
+ * WordPress dependencies.
  */
 import { Component, Fragment, render } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Material UI dependencies.
  */
-import { Grid, NewspackLogo } from '../../components/src';
+import ViewStreamIcon from '@material-ui/icons/ViewStream';
+import ViewModuleIcon from '@material-ui/icons/ViewModule';
+
+/**
+ * Internal dependencies.
+ */
+import { Button, Card, Grid, NewspackLogo } from '../../components/src';
 import DashboardCard from './views/dashboardCard';
 import './style.scss';
 
 /**
- * The Newspack dashboard.
+ * Newspack Dashboard.
  */
 class Dashboard extends Component {
+	state = {
+		view: 'list',
+	};
+
 	/**
 	 * Render.
 	 */
 	render() {
 		const { items } = this.props;
+		const { view } = this.state;
 
 		return (
 			<Fragment>
 				<div className="newspack-logo-wrapper">
 					<NewspackLogo />
 				</div>
-				<Grid>
+				<Grid className={ "view-" + view } isWide={ view === 'grid' && true }>
+					<Card noBackground className="newspack-dashboard-card__views">
+						<Button
+							onClick={ () => this.setState( { view: 'list' } ) }
+							isPrimary={ 'list' === view }
+							isSecondary={ 'list' !== view }
+						>
+							<ViewStreamIcon />
+							<span className="screen-reader-text">{ __( 'List view' ) }</span>
+						</Button>
+						<Button
+							onClick={ () => this.setState( { view: 'grid' } ) }
+							isPrimary={ 'grid' === view }
+							isSecondary={ 'grid' !== view }
+						>
+							<ViewModuleIcon />
+							<span className="screen-reader-text">{ __( 'Grid view' ) }</span>
+						</Button>
+					</Card>
 					{ items.map( card => (
 						<DashboardCard { ...card } key={ card.slug } />
 					) ) }

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -1,3 +1,5 @@
+/* global newspack_dashboard */
+
 import '../../shared/js/public-path';
 
 /**
@@ -79,4 +81,4 @@ class Dashboard extends Component {
 		);
 	}
 }
-render( <Dashboard items={ newspack_dashboard } />, document.getElementById( 'newspack' ) ); // eslint-disable-line
+render( <Dashboard items={ newspack_dashboard } />, document.getElementById( 'newspack' ) );

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -41,19 +41,11 @@ class Dashboard extends Component {
 				</div>
 				<Grid className={ 'view-' + view } isWide={ view === 'grid' && true }>
 					<Card noBackground className="newspack-dashboard-card__views">
-						<Button
-							onClick={ () => this.setState( { view: 'list' } ) }
-							isPrimary={ 'list' === view }
-							isSecondary={ 'list' !== view }
-						>
+						<Button isLink onClick={ () => this.setState( { view: 'list' } ) }>
 							<ViewStreamIcon />
 							<span className="screen-reader-text">{ __( 'List view' ) }</span>
 						</Button>
-						<Button
-							onClick={ () => this.setState( { view: 'grid' } ) }
-							isPrimary={ 'grid' === view }
-							isSecondary={ 'grid' !== view }
-						>
+						<Button isLink onClick={ () => this.setState( { view: 'grid' } ) }>
 							<ViewModuleIcon />
 							<span className="screen-reader-text">{ __( 'Grid view' ) }</span>
 						</Button>

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Material UI dependencies.
  */
-import ViewStreamIcon from '@material-ui/icons/ViewStream';
+import ViewListIcon from '@material-ui/icons/ViewList';
 import ViewModuleIcon from '@material-ui/icons/ViewModule';
 
 /**
@@ -56,7 +56,7 @@ class Dashboard extends Component {
 								)
 							}
 						>
-							<ViewStreamIcon />
+							<ViewListIcon />
 							<span className="screen-reader-text">{ __( 'List view' ) }</span>
 						</Button>
 						<Button

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -27,6 +27,13 @@ class Dashboard extends Component {
 		view: 'list',
 	};
 
+	componentDidMount = () => {
+		const view = localStorage.getItem( 'newspack-plugin-dashboard-view' );
+		if ( 'list' === view || 'grid' === view ) {
+			this.setState( { view } );
+		}
+	};
+
 	/**
 	 * Render.
 	 */
@@ -41,11 +48,25 @@ class Dashboard extends Component {
 				</div>
 				<Grid className={ 'view-' + view } isWide={ view === 'grid' && true }>
 					<Card noBackground className="newspack-dashboard-card__views">
-						<Button isLink onClick={ () => this.setState( { view: 'list' } ) }>
+						<Button
+							isLink
+							onClick={ () =>
+								this.setState( { view: 'list' }, () =>
+									localStorage.setItem( 'newspack-plugin-dashboard-view', 'list' )
+								)
+							}
+						>
 							<ViewStreamIcon />
 							<span className="screen-reader-text">{ __( 'List view' ) }</span>
 						</Button>
-						<Button isLink onClick={ () => this.setState( { view: 'grid' } ) }>
+						<Button
+							isLink
+							onClick={ () =>
+								this.setState( { view: 'grid' }, () =>
+									localStorage.setItem( 'newspack-plugin-dashboard-view', 'grid' )
+								)
+							}
+						>
 							<ViewModuleIcon />
 							<span className="screen-reader-text">{ __( 'Grid view' ) }</span>
 						</Button>

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -39,7 +39,7 @@ class Dashboard extends Component {
 				<div className="newspack-logo-wrapper">
 					<NewspackLogo />
 				</div>
-				<Grid className={ "view-" + view } isWide={ view === 'grid' && true }>
+				<Grid className={ 'view-' + view } isWide={ view === 'grid' && true }>
 					<Card noBackground className="newspack-dashboard-card__views">
 						<Button
 							onClick={ () => this.setState( { view: 'list' } ) }
@@ -66,4 +66,4 @@ class Dashboard extends Component {
 		);
 	}
 }
-render( <Dashboard items={ newspack_dashboard } />, document.getElementById( 'newspack' ) );
+render( <Dashboard items={ newspack_dashboard } />, document.getElementById( 'newspack' ) ); // eslint-disable-line

--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -8,14 +8,20 @@
 .newspack-grid {
 	margin-bottom: 32px;
 
+	&.view-list {
+		.newspack-button:first-of-type {
+			color: $primary-200;
+		}
+	}
+
 	&.view-grid {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
 		margin-top: -16px;
 
-		@media screen and ( min-width: 600px ) {
-			margin-top: 0;
+		.newspack-button:last-of-type {
+			color: $primary-200;
 		}
 
 		.newspack-dashboard-card {
@@ -79,7 +85,7 @@
 		}
 
 		> svg {
-			margin: 24px;
+			margin: 24px 24px 24px 0;
 		}
 	}
 
@@ -123,36 +129,29 @@
 
 	&__views {
 		display: none;
-		flex: 0 0 100%;
-		justify-content: center;
 		margin: 0;
+		padding: 44px 24px;
+		position: absolute;
+		right: 0;
+		top: 0;
 
 		@media screen and ( min-width: 600px ) {
-			display: flex;
+			display: block;
 		}
 
 		.newspack-button {
-			border-radius: 0;
-			height: 48px;
+			height: 40px;
 			justify-content: center;
-			padding: 0;
-			width: 48px;
+			width: 40px;
+			color: white;
 
-			&:first-of-type {
-				border-radius: 3px 0 0 3px;
-			}
-
-			&:last-of-type {
-				border-radius: 0 3px 3px 0;
-			}
-
-			&.is-primary,
-			&:focus {
-				z-index: 1;
-			}
-
-			+ .newspack-button {
-				margin-left: -1px;
+			&:active,
+			&:active:enabled,
+			&:focus,
+			&:focus:enabled,
+			&:hover,
+			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
+				color: $primary-200;
 			}
 		}
 	}

--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -5,8 +5,36 @@
 @import '~@wordpress/base-styles/colors';
 @import '../../shared/scss/colors';
 
+.newspack-grid {
+	margin-bottom: 32px;
+
+	&.view-grid {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		margin-top: -16px;
+
+		@media screen and ( min-width: 600px ) {
+			margin-top: 0;
+		}
+
+		.newspack-dashboard-card {
+			width: 100%;
+
+			@media screen and ( min-width: 600px ) {
+				width: calc( ( 100% - 16px ) / 2 );
+			}
+
+			@media screen and ( min-width: 1224px ) {
+				width: calc( ( 100% - 32px ) / 3 );
+			}
+		}
+	}
+}
+
 .newspack-dashboard-card {
 	box-shadow: 0 4px 8px rgba( black, 0.08 );
+	margin: 16px 0 0;
 	padding: 0;
 
 	&.disabled {
@@ -20,6 +48,7 @@
 		border-radius: inherit;
 		color: inherit;
 		display: flex;
+		height: 100%;
 		justify-content: space-between;
 		text-decoration: none;
 		transition: background-color 125ms ease-in-out, box-shadow 125ms ease-in-out;
@@ -73,7 +102,7 @@
 		}
 	}
 
-	.newspack-dashboard-card__contents {
+	&__contents {
 		align-items: center;
 		display: flex;
 		justify-content: flex-start;
@@ -90,9 +119,41 @@
 		}
 	}
 
-	// Multiple Cards
+	// Views
 
-	& + & {
-		margin-top: -16px;
+	&__views {
+		display: none;
+		flex: 0 0 100%;
+		justify-content: center;
+		margin: 0;
+
+		@media screen and ( min-width: 600px ) {
+			display: flex;
+		}
+
+		.newspack-button {
+			border-radius: 0;
+			height: 48px;
+			justify-content: center;
+			padding: 0;
+			width: 48px;
+
+			&:first-of-type {
+				border-radius: 3px 0 0 3px;
+			}
+
+			&:last-of-type {
+				border-radius: 0 3px 3px 0;
+			}
+
+			&.is-primary,
+			&:focus {
+				z-index: 1;
+			}
+
+			+ .newspack-button {
+				margin-left: -1px;
+			}
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds 2 icons in the header to change the view of the dashboard: List or Grid.

![Kapture 2020-03-30 at 12 42 01](https://user-images.githubusercontent.com/177929/77908908-465d7180-7284-11ea-9d81-09b85bfa38c5.gif)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Go to Newspack > Dashboard. Do you see the 2 icons at the top?
3. Change the view to Grid
4. Go to a different page then come back to the Dashboard. Do you still see the Dashboard as a grid?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->