### PR TITLE
Expose Health Check data to external PHP code

### DIFF
--- a/includes/wizards/class-health-check-wizard.php
+++ b/includes/wizards/class-health-check-wizard.php
@@ -146,7 +146,7 @@ class Health_Check_Wizard extends Wizard {
 	 *
 	 * @return array Advertising data.
 	 */
-	private function retrieve_data() {
+	public static function retrieve_data() {
 		$amp_manager     = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'amp' );
 		$jetpack_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'jetpack' );
 		$sitekit_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'google-site-kit' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This way the Health Check data can be retrieved via WP CLI: 
```
wp eval "echo json_encode(\Newspack\Health_Check_Wizard::retrieve_data());"
```

I assume we don't consider this data sensitive.

### How to test the changes in this Pull Request:

1. Set AMP mode to Standard.
1. Run `wp eval "echo json_encode(\Newspack\Health_Check_Wizard::retrieve_data());`
2. Observe that a JSON string is printed, with the data used by the Health Check wizard, and `"amp":true` inside, e.g.: 
```
{"unsupported_plugins":[],"configuration_status":{"amp":true,"jetpack":true,"sitekit":true}}
```
4. Navigate to Health Check wizard - it should report that AMP is ok.
5. Change AMP mode to Transitional
6. Run the command from step 2. again - is should now output `"amp":false`
7. Navigate to Health Check wizard - it should report that AMP is misconfigured.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->