### PR TITLE
Fix admin color scheme conflict with Newspack buttons

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -5,91 +5,16 @@
 @import '../../../shared/scss/colors';
 @import '~@wordpress/base-styles/colors';
 
-.newspack-button {
-	border-radius: 3px;
-	font-size: 14px;
-	font-weight: bold;
-	height: auto;
-	line-height: 24px;
-	padding: 11px 24px;
-	transition: background 125ms ease-in-out, border-color 125ms ease-in-out,
-		box-shadow 125ms ease-in-out, color 125ms ease-in-out;
-
-	&.is-large {
-		font-size: 17px;
-		height: auto;
-		line-height: 24px;
-	}
-
-	&.is-small {
-		font-size: 14px;
-		height: auto;
-		line-height: 24px;
-		padding: 3px 12px;
-	}
-
-	&.icon-only {
-		align-items: center;
-		height: 36px;
-		justify-content: center;
-		padding: 0;
-		width: 36px;
-	}
-
-	&:disabled,
-	&:disabled:active:enabled,
-	&[aria-disabled='true'],
-	&[aria-disabled='true']:active:enabled {
-		cursor: not-allowed;
-		text-shadow: none;
-	}
-
-	&.is-button {
+body[class*='admin-color-'] {
+	.newspack-button {
 		border-radius: 3px;
 		font-size: 14px;
 		font-weight: bold;
 		height: auto;
 		line-height: 24px;
 		padding: 11px 24px;
-	}
-
-	&.is-primary,
-	&.is-pressed {
-		background: $primary-500;
-		border: 1px solid $primary-600;
-		color: white;
-
-		&:active,
-		&:active:enabled,
-		&:focus,
-		&:focus:enabled,
-		&:hover,
-		&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
-			background: $primary-600;
-			border-color: $primary-700;
-			box-shadow: none;
-			color: white;
-		}
-
-		&:focus,
-		&:focus:enabled {
-			box-shadow: 0 0 0 2px $primary-500;
-		}
-
-		&:disabled,
-		&:disabled:active:enabled,
-		&[aria-disabled='true'],
-		&[aria-disabled='true']:active:enabled {
-			background: $primary-400;
-			border-color: $primary-500;
-			color: $primary-200;
-
-			&:hover {
-				background: $primary-400;
-				border-color: $primary-500;
-				color: $primary-200;
-			}
-		}
+		transition: background 125ms ease-in-out, border-color 125ms ease-in-out,
+			box-shadow 125ms ease-in-out, color 125ms ease-in-out;
 
 		&.is-large {
 			font-size: 17px;
@@ -104,158 +29,244 @@
 			padding: 3px 12px;
 		}
 
-		.newspack-is-waiting {
-			fill: white;
+		&.icon-only {
+			align-items: center;
+			height: 36px;
+			justify-content: center;
+			padding: 0;
+			width: 36px;
 		}
-	}
 
-	&.is-default,
-	&.is-secondary {
-		background: white;
-		border: 1px solid $light-gray-500;
-		box-shadow: none;
-		color: $primary-500;
+		&:disabled,
+		&:disabled:active:enabled,
+		&[aria-disabled='true'],
+		&[aria-disabled='true']:active:enabled {
+			cursor: not-allowed;
+			text-shadow: none;
+		}
 
-		&:active,
-		&:active:enabled,
-		&:focus,
-		&:focus:enabled,
 		&:hover,
-		&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
-			background: $light-gray-100;
-			border-color: $primary-500;
-			box-shadow: none;
+		&[aria-expended='true'] {
 			color: $primary-500;
 		}
 
-		&:focus,
-		&:focus:enabled {
-			border-color: $primary-600;
+		&:focus:not( :disabled ) {
 			box-shadow: 0 0 0 2px $primary-500;
 		}
 
-		&:disabled,
-		&:disabled:active:enabled,
-		&[aria-disabled='true'],
-		&[aria-disabled='true']:active:enabled {
-			background: $light-gray-100;
-			border-color: $light-gray-500;
-			color: $light-gray-900;
+		&.is-button {
+			border-radius: 3px;
+			font-size: 14px;
+			font-weight: bold;
+			height: auto;
+			line-height: 24px;
+			padding: 11px 24px;
+		}
 
-			&:hover {
+		&.is-primary,
+		&.is-pressed {
+			background: $primary-500;
+			border: 1px solid $primary-600;
+			color: white;
+
+			&:active,
+			&:active:enabled,
+			&:focus,
+			&:focus:enabled,
+			&:hover,
+			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
+				background: $primary-600;
+				border-color: $primary-700;
+				box-shadow: none;
+				color: white;
+			}
+
+			&:focus,
+			&:focus:enabled {
+				box-shadow: 0 0 0 2px $primary-500;
+			}
+
+			&:disabled,
+			&:disabled:active:enabled,
+			&[aria-disabled='true'],
+			&[aria-disabled='true']:active:enabled {
+				background: $primary-400;
+				border-color: $primary-500;
+				color: $primary-200;
+
+				&:hover {
+					background: $primary-400;
+					border-color: $primary-500;
+					color: $primary-200;
+				}
+			}
+
+			&.is-large {
+				font-size: 17px;
+				height: auto;
+				line-height: 24px;
+			}
+
+			&.is-small {
+				font-size: 14px;
+				height: auto;
+				line-height: 24px;
+				padding: 3px 12px;
+			}
+
+			.newspack-is-waiting {
+				fill: white;
+			}
+		}
+
+		&.is-default,
+		&.is-secondary {
+			background: white;
+			border: 1px solid $light-gray-500;
+			box-shadow: none;
+			color: $primary-500;
+
+			&:active,
+			&:active:enabled,
+			&:focus,
+			&:focus:enabled,
+			&:hover,
+			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
+				background: $light-gray-100;
+				border-color: $primary-500;
+				box-shadow: none;
+				color: $primary-500;
+			}
+
+			&:focus,
+			&:focus:enabled {
+				border-color: $primary-600;
+				box-shadow: 0 0 0 2px $primary-500;
+			}
+
+			&:disabled,
+			&:disabled:active:enabled,
+			&[aria-disabled='true'],
+			&[aria-disabled='true']:active:enabled {
 				background: $light-gray-100;
 				border-color: $light-gray-500;
 				color: $light-gray-900;
+
+				&:hover {
+					background: $light-gray-100;
+					border-color: $light-gray-500;
+					color: $light-gray-900;
+				}
+			}
+
+			&.is-large {
+				font-size: 17px;
+				height: auto;
+				line-height: 24px;
+			}
+
+			&.is-small {
+				font-size: 14px;
+				height: auto;
+				line-height: 24px;
+				padding: 3px 12px;
 			}
 		}
 
-		&.is-large {
-			font-size: 17px;
-			height: auto;
-			line-height: 24px;
-		}
-
-		&.is-small {
-			font-size: 14px;
-			height: auto;
-			line-height: 24px;
-			padding: 3px 12px;
-		}
-	}
-
-	&.is-tertiary {
-		background: $light-gray-300;
-		border: 1px solid $light-gray-500;
-		color: $dark-gray-600;
-		height: auto;
-		line-height: 24px;
-		padding: 11px 24px;
-
-		&:active,
-		&:active:enabled,
-		&:focus,
-		&:focus:enabled,
-		&:hover,
-		&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
-			background: $light-gray-400;
-			border-color: $light-gray-900;
-			box-shadow: none;
-			color: $dark-gray-900;
-		}
-
-		&:focus,
-		&:focus:enabled {
-			border-color: $primary-600;
-			box-shadow: 0 0 0 2px $primary-500;
-		}
-
-		&:disabled,
-		&:disabled:active:enabled,
-		&[aria-disabled='true'],
-		&[aria-disabled='true']:active:enabled {
+		&.is-tertiary {
 			background: $light-gray-300;
-			border-color: $light-gray-500;
-			color: $dark-gray-100;
+			border: 1px solid $light-gray-500;
+			color: $dark-gray-600;
+			height: auto;
+			line-height: 24px;
+			padding: 11px 24px;
 
-			&:hover {
+			&:active,
+			&:active:enabled,
+			&:focus,
+			&:focus:enabled,
+			&:hover,
+			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
+				background: $light-gray-400;
+				border-color: $light-gray-900;
+				box-shadow: none;
+				color: $dark-gray-900;
+			}
+
+			&:focus,
+			&:focus:enabled {
+				border-color: $primary-600;
+				box-shadow: 0 0 0 2px $primary-500;
+			}
+
+			&:disabled,
+			&:disabled:active:enabled,
+			&[aria-disabled='true'],
+			&[aria-disabled='true']:active:enabled {
 				background: $light-gray-300;
 				border-color: $light-gray-500;
 				color: $dark-gray-100;
+
+				&:hover {
+					background: $light-gray-300;
+					border-color: $light-gray-500;
+					color: $dark-gray-100;
+				}
+			}
+
+			&.is-large {
+				font-size: 17px;
+				height: auto;
+				line-height: 24px;
+			}
+
+			&.is-small {
+				font-size: 14px;
+				height: auto;
+				line-height: 24px;
+				padding: 3px 12px;
+			}
+
+			.newspack-is-waiting {
+				fill: $dark-gray-600;
 			}
 		}
 
-		&.is-large {
-			font-size: 17px;
-			height: auto;
-			line-height: 24px;
-		}
-
-		&.is-small {
-			font-size: 14px;
-			height: auto;
-			line-height: 24px;
-			padding: 3px 12px;
-		}
-
-		.newspack-is-waiting {
-			fill: $dark-gray-600;
-		}
-	}
-
-	&.is-link {
-		background: none;
-		border: 0;
-		border-radius: 0;
-		color: $primary-500;
-		font-weight: normal;
-		padding: 0;
-		transition: color 125ms ease-in-out, outline 125ms ease-in-out;
-
-		&:active,
-		&:active:enabled,
-		&:focus,
-		&:focus:enabled,
-		&:hover,
-		&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
-			background: transparent;
-			color: $primary-600;
-			text-decoration: none;
-		}
-
-		&:focus,
-		&:focus:enabled {
-			box-shadow: none;
-			outline: 2px solid $primary-500;
-			outline-offset: 2px;
-		}
-
-		&.is-small,
-		&.is-large {
+		&.is-link {
+			background: none;
+			border: 0;
+			border-radius: 0;
+			color: $primary-500;
+			font-weight: normal;
 			padding: 0;
-		}
-	}
+			transition: color 125ms ease-in-out, outline 125ms ease-in-out;
 
-	.components-tooltip {
-		font-weight: normal;
+			&:active,
+			&:active:enabled,
+			&:focus,
+			&:focus:enabled,
+			&:hover,
+			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
+				background: transparent;
+				color: $primary-600;
+				text-decoration: none;
+			}
+
+			&:focus,
+			&:focus:enabled {
+				box-shadow: none;
+				outline: 2px solid $primary-500;
+				outline-offset: 2px;
+			}
+
+			&.is-small,
+			&.is-large {
+				padding: 0;
+			}
+		}
+
+		.components-tooltip {
+			font-weight: normal;
+		}
 	}
 }

--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -268,5 +268,28 @@ body[class*='admin-color-'] {
 		.components-tooltip {
 			font-weight: normal;
 		}
+
+		// Icon-only
+
+		&.has-icon:not( .has-text ) {
+			align-items: center;
+			height: 40px;
+			justify-content: center;
+			min-width: 40px;
+			padding: 0;
+			width: 40px;
+
+			&.is-small {
+				height: 32px;
+				min-width: 32px;
+				width: 32px;
+			}
+
+			&.is-large {
+				height: 48px;
+				min-width: 48px;
+				width: 48px;
+			}
+		}
 	}
 }

--- a/assets/components/src/color-picker/style.scss
+++ b/assets/components/src/color-picker/style.scss
@@ -30,74 +30,96 @@
 		font-size: 14px;
 		line-height: 24px;
 
-		.is-link {
-			color: $primary-500;
-			font-size: inherit;
-			line-height: inherit;
-			transition: color 125ms ease-in-out, outline 125ms ease-in-out;
-
-			&:active,
-			&:active:enabled,
-			&:focus,
-			&:focus:enabled,
+		.components-button {
 			&:hover,
-			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
-				color: $primary-600;
-				text-decoration: none;
-			}
-
-			&:focus,
-			&:focus:enabled {
-				box-shadow: none;
-				outline: 2px solid $primary-500;
-				outline-offset: 2px;
-			}
-		}
-
-		.is-secondary.is-small {
-			background: white;
-			border: 1px solid $light-gray-500;
-			border-radius: 3px;
-			box-shadow: none;
-			color: $primary-500;
-			font-size: inherit;
-			font-weight: bold;
-			height: auto;
-			line-height: inherit;
-			padding: 3px 12px;
-			transition: background 125ms ease-in-out, border-color 125ms ease-in-out,
-				box-shadow 125ms ease-in-out, color 125ms ease-in-out;
-
-			&:active,
-			&:active:enabled,
-			&:focus,
-			&:focus:enabled,
-			&:hover,
-			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
-				background: $light-gray-100;
-				border-color: $primary-500;
-				box-shadow: none;
+			&[aria-expended='true'] {
 				color: $primary-500;
 			}
 
-			&:focus,
-			&:focus:enabled {
-				border-color: $primary-600;
+			&:focus:not( :disabled ) {
 				box-shadow: 0 0 0 2px $primary-500;
 			}
 
-			&:disabled,
-			&:disabled:active:enabled,
-			&[aria-disabled='true'],
-			&[aria-disabled='true']:active:enabled {
-				background: $light-gray-100;
-				border-color: $light-gray-500;
-				color: $light-gray-900;
+			&.is-secondary.is-small {
+				background: white;
+				border: 1px solid $light-gray-500;
+				border-radius: 3px;
+				box-shadow: none;
+				color: $primary-500;
+				font-size: inherit;
+				font-weight: bold;
+				height: auto;
+				line-height: inherit;
+				padding: 3px 12px;
+				transition: background 125ms ease-in-out, border-color 125ms ease-in-out,
+					box-shadow 125ms ease-in-out, color 125ms ease-in-out;
 
-				&:hover {
+				&:active,
+				&:active:enabled,
+				&:focus,
+				&:focus:enabled,
+				&:hover,
+				&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
+					background: $light-gray-100;
+					border-color: $primary-500;
+					box-shadow: none;
+					color: $primary-500;
+				}
+
+				&:focus,
+				&:focus:enabled {
+					border-color: $primary-600;
+					box-shadow: 0 0 0 2px $primary-500;
+				}
+
+				&:disabled,
+				&:disabled:active:enabled,
+				&[aria-disabled='true'],
+				&[aria-disabled='true']:active:enabled {
 					background: $light-gray-100;
 					border-color: $light-gray-500;
 					color: $light-gray-900;
+
+					&:hover {
+						background: $light-gray-100;
+						border-color: $light-gray-500;
+						color: $light-gray-900;
+					}
+				}
+			}
+
+			&.is-link {
+				color: $primary-500;
+				font-size: inherit;
+				line-height: inherit;
+				transition: color 125ms ease-in-out, outline 125ms ease-in-out;
+
+				&:active,
+				&:active:enabled,
+				&:focus,
+				&:focus:enabled,
+				&:hover,
+				&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
+					color: $primary-600;
+					text-decoration: none;
+				}
+
+				&:focus,
+				&:focus:enabled {
+					box-shadow: none;
+					outline: 2px solid $primary-500;
+					outline-offset: 2px;
+				}
+
+				&[aria-expended='true'] {
+					color: $primary-500;
+				}
+			}
+
+			&.components-color-picker__saturation-pointer {
+				&:focus {
+					box-shadow: 0 0 0 2px white, 0 0 0 4px $primary-500, 0 0 5px 0 $primary-500,
+						inset 0 0 1px 1px rgba( black, 0.3 ), 0 0 1px 2px rgba( black, 0.4 );
 				}
 			}
 		}
@@ -179,6 +201,7 @@
 	}
 
 	.components-color-picker__inputs-toggle {
-		margin-bottom: 9px;
+		height: 36px;
+		margin-bottom: 6px;
 	}
 }

--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -54,6 +54,15 @@
 				right: -56px;
 			}
 
+			&:hover,
+			&[aria-expended='true'] {
+				color: $primary-500;
+			}
+
+			&:focus:not( :disabled ) {
+				box-shadow: 0 0 0 2px $primary-500;
+			}
+
 			svg {
 				width: 24px;
 				height: 24px;

--- a/assets/components/src/toggle-control/style.scss
+++ b/assets/components/src/toggle-control/style.scss
@@ -24,6 +24,7 @@
 			&.is-checked {
 				.components-form-toggle__track {
 					background: $primary-500;
+					border-color: transparent;
 				}
 			}
 		}

--- a/assets/components/src/wizard-pagination/index.js
+++ b/assets/components/src/wizard-pagination/index.js
@@ -42,7 +42,8 @@ class WizardPagination extends Component {
 						{ __( 'Step' ) } { currentIndex } { __( 'of' ) } { routes.length - 1 }{' '}
 					</div>
 					<Button
-						isLink
+						isPrimary
+						isSmall
 						className="newspack-wizard-pagination__navigation"
 						onClick={ () => history.goBack() }
 					>

--- a/assets/components/src/wizard-pagination/style.scss
+++ b/assets/components/src/wizard-pagination/style.scss
@@ -26,25 +26,12 @@
 	}
 
 	.newspack-wizard-pagination__pagination,
-	.newspack-button.is-link {
-		color: inherit;
-		padding: 16px;
+	.newspack-button {
+		margin: 16px;
 	}
 
-	.newspack-button.is-link {
-		&:active,
-		&:active:enabled,
-		&:focus,
-		&:focus:enabled,
-		&:hover,
-		&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
-			color: $primary-200;
-		}
-
-		svg {
-			fill: currentColor;
-			margin-right: 4px;
-		}
+	.newspack-wizard-pagination__pagination {
+		font-weight: bold;
 	}
 }
 

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -61,8 +61,7 @@ class Dashboard extends Component {
 									localStorage.setItem( 'newspack-plugin-dashboard-view', 'list' )
 								)
 							}
-						>
-						</Button>
+						></Button>
 						<Button
 							icon={ <ViewModuleIcon /> }
 							label={ __( 'Grid view' ) }
@@ -74,8 +73,7 @@ class Dashboard extends Component {
 									localStorage.setItem( 'newspack-plugin-dashboard-view', 'grid' )
 								)
 							}
-						>
-						</Button>
+						></Button>
 					</Card>
 					{ items.map( card => (
 						<DashboardCard { ...card } key={ card.slug } />

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -51,26 +51,30 @@ class Dashboard extends Component {
 				<Grid className={ 'view-' + view } isWide={ view === 'grid' && true }>
 					<Card noBackground className="newspack-dashboard-card__views">
 						<Button
-							isLink
+							icon={ <ViewListIcon /> }
+							label={ __( 'List view' ) }
+							isPrimary={ 'list' === view }
+							isLink={ 'list' !== view }
+							isSmall
 							onClick={ () =>
 								this.setState( { view: 'list' }, () =>
 									localStorage.setItem( 'newspack-plugin-dashboard-view', 'list' )
 								)
 							}
 						>
-							<ViewListIcon />
-							<span className="screen-reader-text">{ __( 'List view' ) }</span>
 						</Button>
 						<Button
-							isLink
+							icon={ <ViewModuleIcon /> }
+							label={ __( 'Grid view' ) }
+							isPrimary={ 'grid' === view }
+							isLink={ 'grid' !== view }
+							isSmall
 							onClick={ () =>
 								this.setState( { view: 'grid' }, () =>
 									localStorage.setItem( 'newspack-plugin-dashboard-view', 'grid' )
 								)
 							}
 						>
-							<ViewModuleIcon />
-							<span className="screen-reader-text">{ __( 'Grid view' ) }</span>
 						</Button>
 					</Card>
 					{ items.map( card => (

--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -8,21 +8,11 @@
 .newspack-grid {
 	margin-bottom: 32px;
 
-	&.view-list {
-		.newspack-button:first-of-type {
-			color: $primary-200;
-		}
-	}
-
 	&.view-grid {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
 		margin-top: -16px;
-
-		.newspack-button:last-of-type {
-			color: $primary-200;
-		}
 
 		.newspack-dashboard-card {
 			width: 100%;
@@ -130,28 +120,32 @@
 	&__views {
 		display: none;
 		margin: 0;
-		padding: 44px 24px;
+		padding: 46px 22px;
 		position: absolute;
 		right: 0;
 		top: 0;
 
 		@media screen and ( min-width: 600px ) {
-			display: block;
+			display: flex;
 		}
+	}
+}
 
-		.newspack-button {
-			height: 40px;
-			justify-content: center;
-			width: 40px;
-			color: white;
+// Views - Buttons
 
-			&:active,
-			&:active:enabled,
-			&:focus,
-			&:focus:enabled,
-			&:hover,
-			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
-				color: $primary-200;
+body[class*='admin-color-'] {
+	.newspack-dashboard-card {
+		&__views {
+			.newspack-button {
+				margin: 2px;
+
+				&.is-primary {
+					pointer-events: none;
+				}
+
+				&.is-link {
+					color: white;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If you use an admin colour scheme, then it will affect the buttons throughout our plugin.

This PR adds extra classes to make sure Newspack colours are always applied to the Newspack components.

![Screenshot 2020-04-01 at 12 27 03](https://user-images.githubusercontent.com/177929/78132530-cf0b1780-7414-11ea-8a61-063054358c53.png)

This PR also updates buttons against our blue background (welcome wizard + dashboard) to use Primary buttons instead of a custom isLink

_Note: issue noticed when publisher shared screen with us -- didn't seem to bother them 😅_

### How to test the changes in this Pull Request:

1. Go to Users > Your Profile.
2. Select an admin colour scheme other than the default one.
3. Go to Newspack Components Demo `wp-admin/admin.php?page=newspack-components-demo`
4. Notice the disaster 😱 (e.g. screenshot above)
5. Switch to this branch.
6. Refresh the demo page.
7. It should be much better! 😎

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->