### PR TITLE
Allow Composer path to be overridden

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -54,6 +54,9 @@ final class Newspack {
 	private function define_constants() {
 		define( 'NEWSPACK_VERSION', '0.0.1' );
 		define( 'NEWSPACK_ABSPATH', dirname( NEWSPACK_PLUGIN_FILE ) . '/' );
+		if ( ! defined( 'NEWSPACK_COMPOSER_ABSPATH' ) ) {
+			define( 'NEWSPACK_COMPOSER_ABSPATH', dirname( NEWSPACK_PLUGIN_FILE ) . '/' );
+		}
 		define( 'NEWSPACK_ACTIVATION_TRANSIENT', '_newspack_activation_redirect' );
 	}
 

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -55,7 +55,7 @@ final class Newspack {
 		define( 'NEWSPACK_VERSION', '0.0.1' );
 		define( 'NEWSPACK_ABSPATH', dirname( NEWSPACK_PLUGIN_FILE ) . '/' );
 		if ( ! defined( 'NEWSPACK_COMPOSER_ABSPATH' ) ) {
-			define( 'NEWSPACK_COMPOSER_ABSPATH', dirname( NEWSPACK_PLUGIN_FILE ) . '/' );
+			define( 'NEWSPACK_COMPOSER_ABSPATH', dirname( NEWSPACK_PLUGIN_FILE ) . '/vendor/' );
 		}
 		define( 'NEWSPACK_ACTIVATION_TRANSIENT', '_newspack_activation_redirect' );
 	}

--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -7,7 +7,7 @@
 
 namespace Newspack;
 
-require_once NEWSPACK_ABSPATH . 'vendor/autoload.php';
+require_once NEWSPACK_COMPOSER_ABSPATH . 'vendor/autoload.php';
 
 use \WP_Error, \WP_Query, Newspack\Theme_Manager;
 

--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -7,7 +7,7 @@
 
 namespace Newspack;
 
-require_once NEWSPACK_COMPOSER_ABSPATH . 'vendor/autoload.php';
+require_once NEWSPACK_COMPOSER_ABSPATH . 'autoload.php';
 
 use \WP_Error, \WP_Query, Newspack\Theme_Manager;
 


### PR DESCRIPTION
If the Newspack plugin is managed as a composer dependency, the Composer path might not align with the main plugin path. This pull requests maintains current behavior while adding a way to specify which directory is used for the Composer autoload file.