### PR TITLE
Change mobile preset width of WebPreview

### DIFF
--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -23,11 +23,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@wordpress/components": "^7.3.1",
-    "@wordpress/element": "^2.3.0",
     "@material-ui/core": "^4.8.2",
     "@material-ui/icons": "^4.5.1",
     "@wordpress/base-styles": "^1.0.0",
+    "@wordpress/components": "^7.3.1",
+    "@wordpress/element": "^2.3.0",
+    "@wordpress/i18n": "^3.11.0",
+    "classnames": "^2.2.6",
     "react-router-dom": "^5.0.1"
   },
   "devDependencies": {

--- a/assets/components/src/web-preview/style.scss
+++ b/assets/components/src/web-preview/style.scss
@@ -23,7 +23,7 @@ body.newspack-web-preview__open {
 	z-index: 99999;
 
 	&.phone iframe {
-		max-width: 480px;
+		max-width: 320px;
 	}
 
 	&.tablet iframe {
@@ -53,6 +53,7 @@ body.newspack-web-preview__open {
 	width: 100%;
 
 	iframe {
+		background: #fff;
 		display: block;
 		height: 100%;
 		height: calc( 100% - 65px );

--- a/assets/components/src/web-preview/style.scss
+++ b/assets/components/src/web-preview/style.scss
@@ -16,7 +16,7 @@ body.newspack-web-preview__open {
 	left: 0;
 	margin: 0;
 	max-width: 100%;
-	padding: 24px 24px 0;
+	padding: 24px;
 	position: fixed;
 	top: 0;
 	width: 100%;
@@ -39,7 +39,8 @@ body.newspack-web-preview__open {
 	animation: newspack-web-preview__appear-animation 0.1s ease-out;
 	animation-fill-mode: forwards;
 	background: white;
-	border-radius: 4px 4px 0 0;
+	border-radius: 4px;
+	overflow: hidden;
 	box-shadow: 0 8px 16px rgba( black, 0.08 );
 	height: 100%;
 	width: 100%;
@@ -47,7 +48,7 @@ body.newspack-web-preview__open {
 
 .newspack-web-preview__content {
 	background: $light-gray-100;
-	height: 100%;
+	height: calc( 100% - 64px );
 	-webkit-overflow-scrolling: touch;
 	overflow-x: hidden;
 	width: 100%;
@@ -56,7 +57,6 @@ body.newspack-web-preview__open {
 		background: #fff;
 		display: block;
 		height: 100%;
-		height: calc( 100% - 65px );
 		margin: 0 auto;
 		max-width: 100%;
 		opacity: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Update mobile preset to 320px wide, which is the smallest mobile size conventionally supported and therefore more useful for previewing. 

Also updates the iframe's background to white. Some websites have transparent background and browsers default to white then.

### How to test the changes in this Pull Request:

1. Open Newspack components preview, trigger a WebPreview in "Web Previews" section
2. Change preset to mobile, observe that the iframe is now 320px wide

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->