### PR TITLE
Chore: bump version in components

### DIFF
--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-components",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Newspack design system components",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
[`newspack-components`](https://www.npmjs.com/package/newspack-components) are still released the old-school way, so this needs to be updated. 