### PR TITLE
pluralize plugin in revenue wizard if needed

### DIFF
--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -209,7 +209,9 @@ export default function withWizard( WrappedComponent, requiredPlugins, options )
 								{ complete !== null && (
 									<FormattedHeader
 										headerIcon={ <HeaderIcon /> }
-										headerText={ __( 'Required plugin' ) }
+										headerText={ __( 
+											( requiredPlugins.length > 1 ) ? 'Required plugins' : 'Required plugin' 
+										) }
 										subHeaderText={ __( 'This feature requires the following plugin.' ) }
 									/>
 								) }

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -209,9 +209,11 @@ export default function withWizard( WrappedComponent, requiredPlugins, options )
 								{ complete !== null && (
 									<FormattedHeader
 										headerIcon={ <HeaderIcon /> }
-										headerText={ __( 
-											( requiredPlugins.length > 1 ) ? 'Required plugins' : 'Required plugin' 
-										) }
+										headerText={
+											requiredPlugins.length > 1
+												? __( 'Required plugins' )
+												: __( 'Required plugin' )
+										}
 										subHeaderText={ __( 'This feature requires the following plugin.' ) }
 									/>
 								) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This checks `requiredPlugins.length` and outputs "Required plugins" if it's greater than 1.

Closes #453 .

### How to test the changes in this Pull Request:

1. Enter the Reader Revenue wizard setup
2. I multiple plugins are need it should say "Required plugins" else it will say "Required plugin"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->