### PR TITLE
feat: redirect pop-ups page to newspack wizard

### DIFF
--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -38,6 +38,7 @@ class Popups_Wizard extends Wizard {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+		add_action( 'current_screen', [ $this, 'redirect_popups_screen' ] );
 	}
 
 	/**
@@ -353,5 +354,17 @@ class Popups_Wizard extends Wizard {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Redirect Pop-ups list page to Newspack Plugin UI.
+	 */
+	public static function redirect_popups_screen() {
+		$screen = get_current_screen();
+		if ( $screen && 'edit-newspack_popups_cpt' === $screen->id && 'active' === Plugin_Manager::get_managed_plugins()['newspack-popups']['Status'] ) {
+			$popups_url = admin_url( 'admin.php?page=newspack-popups-wizard' );
+			wp_safe_redirect( esc_url( $popups_url ) );
+			exit;
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Redirect Pop-ups list page (`/wp-admin/edit.php?post_type=newspack_popups_cpt`) to Newspack Pop-ups Wizard. 

### How to test the changes in this Pull Request:

1. Enable Newspack Pop-ups. 
2. Navigate to Pop-ups in the admin menu. Verify redirect to Newspack Plugin Wizard screen.
3. Disable Pop-ups plugin, then navigate again to `/wp-admin/edit.php?post_type=newspack_popups_cpt`. Verify the page is not found and no redirection occurs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->