### PR TITLE
Support: validate token before starting chat

### DIFF
--- a/assets/wizards/support/views/chat/index.js
+++ b/assets/wizards/support/views/chat/index.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { withWizardScreen, Notice, Button } from '../../../../components/src';
+import { withWizardScreen, Notice, Button, Waiting } from '../../../../components/src';
 import './style.scss';
 
 /**
@@ -23,6 +23,7 @@ import './style.scss';
  */
 class Chat extends Component {
 	state = {
+		isInFlight: false,
 		hasToAuthenticate: false,
 	};
 
@@ -49,8 +50,9 @@ class Chat extends Component {
 	componentDidMount() {
 		const { WPCOM_ACCESS_TOKEN } = newspack_support_data;
 		if ( WPCOM_ACCESS_TOKEN ) {
+			this.setState( { isInFlight: true } );
 			apiFetch( {
-				path: `/newspack/v1/wizard/newspack-support-wizard/valdiate-access-token`,
+				path: `/newspack/v1/wizard/newspack-support-wizard/validate-access-token`,
 			} )
 				.then( () => {
 					this.renderChat();
@@ -76,8 +78,10 @@ class Chat extends Component {
 							);
 						}
 					} );
+					this.setState( { isInFlight: false } );
 				} )
 				.catch( () => {
+					this.setState( { isInFlight: false } );
 					this.setState( { hasToAuthenticate: true } );
 				} );
 		} else {
@@ -94,6 +98,12 @@ class Chat extends Component {
 	render() {
 		return (
 			<Fragment>
+				{ this.state.isInFlight && (
+					<div className="newspack_support_loading">
+						<Waiting isLeft />
+						{ __( 'Loading...', 'newspack' ) }
+					</div>
+				) }
 				{ this.state.hasToAuthenticate ? (
 					<Fragment>
 						<Notice

--- a/assets/wizards/support/views/chat/index.js
+++ b/assets/wizards/support/views/chat/index.js
@@ -8,6 +8,7 @@ import Happychat from 'happychat-client';
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { Fragment, Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -48,29 +49,37 @@ class Chat extends Component {
 	componentDidMount() {
 		const { WPCOM_ACCESS_TOKEN } = newspack_support_data;
 		if ( WPCOM_ACCESS_TOKEN ) {
-			this.renderChat();
+			apiFetch( {
+				path: `/newspack/v1/wizard/newspack-support-wizard/valdiate-access-token`,
+			} )
+				.then( () => {
+					this.renderChat();
 
-			let didSendInitialInfo;
-			Happychat.on( 'availability', availability => {
-				if ( ! didSendInitialInfo && availability ) {
-					didSendInitialInfo = true;
-					Happychat.sendUserInfo( {
-						site: {
-							ID: '0',
-							URL: `${ window.location.protocol }//${ window.location.hostname }`,
-						},
-						// just to bust the default 'gettingStarted'
-						howCanWeHelp: 'newspack',
+					let didSendInitialInfo;
+					Happychat.on( 'availability', availability => {
+						if ( ! didSendInitialInfo && availability ) {
+							didSendInitialInfo = true;
+							Happychat.sendUserInfo( {
+								site: {
+									ID: '0',
+									URL: `${ window.location.protocol }//${ window.location.hostname }`,
+								},
+								// just to bust the default 'gettingStarted'
+								howCanWeHelp: 'newspack',
+							} );
+
+							Happychat.sendEvent(
+								__(
+									'[ Newspack customer (fieldguide.automattic.com/supporting-newspack-customers) ]',
+									'newspack'
+								)
+							);
+						}
 					} );
-
-					Happychat.sendEvent(
-						__(
-							'[ Newspack customer (fieldguide.automattic.com/supporting-newspack-customers) ]',
-							'newspack'
-						)
-					);
-				}
-			} );
+				} )
+				.catch( () => {
+					this.setState( { hasToAuthenticate: true } );
+				} );
 		} else {
 			this.setState( { hasToAuthenticate: true } );
 		}

--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -67,6 +67,32 @@ class Support_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
+
+		// Validate WPCOM access token.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/newspack-support-wizard/valdiate-access-token',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_wpcom_validate_access_token' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+	}
+
+	/**
+	 * Validate WPCOM credentials.
+	 */
+	public function api_wpcom_validate_access_token() {
+		$access_token = get_user_meta( get_current_user_id(), self::NEWSPACK_WPCOM_ACCESS_TOKEN, true );
+		$client_id    = self::wpcom_client_id();
+		$response     = wp_safe_remote_get(
+			"https://public-api.wordpress.com/oauth2/token-info?client_id=$client_id&token=$access_token"
+		);
+		if ( 200 !== $response['response']['code'] ) {
+			return new WP_Error( 'invalid_wpcom_token', __( 'Invalid WPCOM token.', 'newspack' ) );
+		}
+		return $response;
 	}
 
 	/**

--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -86,7 +86,7 @@ class Support_Wizard extends Wizard {
 	public function api_wpcom_validate_access_token() {
 		$access_token = get_user_meta( get_current_user_id(), self::NEWSPACK_WPCOM_ACCESS_TOKEN, true );
 		$client_id    = self::wpcom_client_id();
-		$response = wp_safe_remote_get(
+		$response     = wp_safe_remote_get(
 			'https://public-api.wordpress.com/oauth2/token-info?' . http_build_query(
 				array(
 					'client_id' => $client_id,

--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -86,7 +86,6 @@ class Support_Wizard extends Wizard {
 	public function api_wpcom_validate_access_token() {
 		$access_token = get_user_meta( get_current_user_id(), self::NEWSPACK_WPCOM_ACCESS_TOKEN, true );
 		$client_id    = self::wpcom_client_id();
-		error_log( $client_id );
 		$response = wp_safe_remote_get(
 			'https://public-api.wordpress.com/oauth2/token-info?' . http_build_query(
 				array(

--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -86,8 +86,14 @@ class Support_Wizard extends Wizard {
 	public function api_wpcom_validate_access_token() {
 		$access_token = get_user_meta( get_current_user_id(), self::NEWSPACK_WPCOM_ACCESS_TOKEN, true );
 		$client_id    = self::wpcom_client_id();
-		$response     = wp_safe_remote_get(
-			"https://public-api.wordpress.com/oauth2/token-info?client_id=$client_id&token=$access_token"
+		error_log( $client_id );
+		$response = wp_safe_remote_get(
+			'https://public-api.wordpress.com/oauth2/token-info?' . http_build_query(
+				array(
+					'client_id' => $client_id,
+					'token'     => $access_token,
+				)
+			)
 		);
 		if ( 200 !== $response['response']['code'] ) {
 			return new WP_Error( 'invalid_wpcom_token', __( 'Invalid WPCOM token.', 'newspack' ) );

--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -71,7 +71,7 @@ class Support_Wizard extends Wizard {
 		// Validate WPCOM access token.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/newspack-support-wizard/valdiate-access-token',
+			'/wizard/newspack-support-wizard/validate-access-token',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_wpcom_validate_access_token' ],


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Validate WPCOM token before starting Happychat. The token might become invalid due to expiration or because the user disconnected the app.

### How to test the changes in this Pull Request:

1. On branch master:
2. Visit support wizard (`/wp-admin/admin.php?page=newspack-support-wizard#/chat`) and authenticate, unless already authenticated. If you see a "InvalidTokenError" skip the next two steps. 
3. If authenticated successfully, head over to [your WPCOM security settings](https://wordpress.com/me/security/connected-applications) and disconnect the support app. 
4. Now after reloading the Newspack Support wizard, you should see the "InvalidTokenError"
4. Switch to this branch (and rebuild JS)
5. Reload the Newspack Support wizard window, instead of the error there should be a prompt to authenticate with WPCOM – do that 
5. The authentication flow should work just like a first time authentication, ending with the functioning Happychat window

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->