### PR TITLE
refactor: rename pop-ups->campaigns

### DIFF
--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -206,7 +206,10 @@ class PopupsWizard extends Component {
 											items={ overlay }
 											buttonText={ __( 'Add new Overlay Campaign', 'newspack' ) }
 											buttonAction="/wp-admin/post-new.php?post_type=newspack_popups_cpt"
-											emptyMessage={ __( 'No Overlay Campaigns have been created yet.', 'newspack' ) }
+											emptyMessage={ __(
+												'No Overlay Campaigns have been created yet.',
+												'newspack'
+											) }
 										/>
 									) }
 								/>
@@ -218,7 +221,10 @@ class PopupsWizard extends Component {
 											items={ inline }
 											buttonText={ __( 'Add new Inline Campaign', 'newspack' ) }
 											buttonAction="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=inline"
-											emptyMessage={ __( 'No Inline Campaigns have been created yet.', 'newspack' ) }
+											emptyMessage={ __(
+												'No Inline Campaigns have been created yet.',
+												'newspack'
+											) }
 										/>
 									) }
 								/>

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -24,8 +24,8 @@ import { PopupGroup } from './views';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
-const headerText = __( 'Pop-ups', 'newspack' );
-const subHeaderText = __( 'Reach your readers with configurable calls-to-action.', 'newspack' );
+const headerText = __( 'Campaigns', 'newspack' );
+const subHeaderText = __( 'Reach your readers with configurable campaigns.', 'newspack' );
 
 const tabbedNavigation = [
 	{
@@ -204,9 +204,9 @@ class PopupsWizard extends Component {
 										<PopupGroup
 											{ ...sharedProps }
 											items={ overlay }
-											buttonText={ __( 'Add new Overlay Pop-up', 'newspack' ) }
+											buttonText={ __( 'Add new Overlay Campaign', 'newspack' ) }
 											buttonAction="/wp-admin/post-new.php?post_type=newspack_popups_cpt"
-											emptyMessage={ __( 'No Overlay Pop-ups have been created yet.', 'newspack' ) }
+											emptyMessage={ __( 'No Overlay Campaigns have been created yet.', 'newspack' ) }
 										/>
 									) }
 								/>
@@ -216,9 +216,9 @@ class PopupsWizard extends Component {
 										<PopupGroup
 											{ ...sharedProps }
 											items={ inline }
-											buttonText={ __( 'Add new Inline Pop-up', 'newspack' ) }
+											buttonText={ __( 'Add new Inline Campaign', 'newspack' ) }
 											buttonAction="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=inline"
-											emptyMessage={ __( 'No Inline Pop-ups have been created yet.', 'newspack' ) }
+											emptyMessage={ __( 'No Inline Campaigns have been created yet.', 'newspack' ) }
 										/>
 									) }
 								/>

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -222,8 +222,8 @@ class Plugin_Manager {
 				'Download'    => 'https://github.com/Automattic/newspack-media-partners/releases/latest/download/newspack-media-partners.zip',
 			],
 			'newspack-popups'               => [
-				'Name'        => 'Newspack Popups',
-				'Description' => 'AMP-compatible popup notifications.',
+				'Name'        => 'Newspack Campaigns',
+				'Description' => 'AMP-compatible overlay and inline Campaigns.',
 				'Author'      => 'Automattic',
 				'PluginURI'   => 'https://newspack.blog',
 				'AuthorURI'   => 'https://automattic.com',

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -46,7 +46,7 @@ class Popups_Wizard extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return \esc_html__( 'Pop-ups', 'newspack' );
+		return \esc_html__( 'Campaigns', 'newspack' );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class Popups_Wizard extends Wizard {
 	 * @return string The wizard description.
 	 */
 	public function get_description() {
-		return \esc_html__( 'Reach your readers with configurable calls-to-action.', 'newspack' );
+		return \esc_html__( 'Reach your readers with configurable campaigns.', 'newspack' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We're renaming "Pop-ups" -> "Campaigns" (discussion in `pamTN9-15s-p2`). This PR changes the name everywhere it's visible in the UI. No class/function/variable names are changed yet. These will be handled in separate PRs, to mitigate risk and ease testing.

Test along with https://github.com/Automattic/newspack-popups/pull/118.

### How to test the changes in this Pull Request:

1. Click "Campaigns" in the admin menu, create a new Campaign. 
2. Verify the name change has been made everywhere.
3. Go to Newspack dashboard, verify name change.
4. Go to Newspack Campaign wizard, verify name change everywhere.
5. Go to Plugins screen, verify name change. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->