### PR TITLE
fix: previewing for inline popups in wizard

### DIFF
--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -11,9 +11,10 @@ import { Component, render, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Material UI dependencies.
+ * External dependencies.
  */
 import HeaderIcon from '@material-ui/icons/NewReleases';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies.
@@ -171,7 +172,7 @@ class PopupsWizard extends Component {
 				  window.newspack_popups_wizard_data &&
 				  window.newspack_popups_wizard_data.preview_post
 				: '/';
-		return `${ previewURL }?newspack_popups_preview_id=${ id }`;
+		return `${ previewURL }?${ stringify( { ...options, newspack_popups_preview_id: id } ) }`;
 	};
 
 	render() {

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -167,7 +167,9 @@ class PopupsWizard extends Component {
 		const { placement, trigger_type: triggerType } = options;
 		const previewURL =
 			'inline' === placement || 'scroll' === triggerType
-				? window && window.newspack_popups_wizard_data && window.newspack_popups_wizard_data.preview_post
+				? window &&
+				  window.newspack_popups_wizard_data &&
+				  window.newspack_popups_wizard_data.preview_post
 				: '/';
 		return `${ previewURL }?newspack_popups_preview_id=${ id }`;
 	};

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -167,7 +167,7 @@ class PopupsWizard extends Component {
 		const { placement, trigger_type: triggerType } = options;
 		const previewURL =
 			'inline' === placement || 'scroll' === triggerType
-				? window && window.newspack_popups_data && window.newspack_popups_data.preview_post
+				? window && window.newspack_popups_wizard_data && window.newspack_popups_wizard_data.preview_post
 				: '/';
 		return `${ previewURL }?newspack_popups_preview_id=${ id }`;
 	};

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -176,6 +176,24 @@ class Popups_Wizard extends Wizard {
 			true
 		);
 
+		$recent_posts = wp_get_recent_posts(
+			[
+				'numberposts' => 1,
+				'post_status' => 'publish',
+			],
+			OBJECT
+		);
+
+		$preview_post = count( $recent_posts ) > 0 ? get_the_permalink( $recent_posts[0] ) : '';
+
+		\wp_localize_script(
+			'newspack-popups-wizard',
+			'newspack_popups_wizard_data',
+			[
+				'preview_post' => $preview_post,
+			]
+		);
+
 		\wp_register_style(
 			'newspack-popups-wizard',
 			Newspack::plugin_url() . '/dist/popups.css',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently previewing Inline Pop-ups in the Pop-up wizard doesn't work. This is because the post to preview over is set by the Pop-ups plugin, and is available only in the editor. This branch makes the same data available to the Pop-ups Wizard. 

### How to test the changes in this Pull Request:

1. On `master`, navigate to the Inline tab of the Pop-ups Wizard.
2. Click the three dots by any Pop-up and choose Preview.
3. Verify the page comes up Not Found.
4. Switch to this branch and repeat 1-2.
5. Verify the pop-up previews over the most recent post.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->