### PR TITLE
Analytics events management

### DIFF
--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -20,16 +20,86 @@ import HeaderIcon from '@material-ui/icons/TrendingUp';
  */
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { Intro } from './views';
+import { Intro, Events } from './views';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
 class AnalyticsWizard extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			eventsEnabled: false,
+			eventCategories: [],
+		};
+	}
+
+	/**
+	 * Get saved info once ready.
+	 */
+	onWizardReady = () => {
+		this.getSettings();
+	};
+
+	/**
+	 * Get settings for the current wizard.
+	 */
+	getSettings() {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: '/newspack/v1/wizard/newspack-analytics-wizard',
+		} )
+			.then( data => this.setState( data ) )
+			.catch( error => setError( error ) );
+	}
+
+	/**
+	 * Update data model
+	 */
+	update = ( data ) => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: '/newspack/v1/wizard/newspack-analytics-wizard/',
+			method: 'POST',
+			data: data,
+		} )
+			.then( _data => {
+				return new Promise( resolve => {
+					this.setState(
+						{
+							..._data,
+						},
+						() => {
+							setError();
+							resolve( this.state );
+						}
+					);
+				} );
+			} )
+			.catch( error => {
+				setError( error );
+			} );
+	};
+
 	/**
 	 * Render
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
+		const { eventsEnabled, eventCategories } = this.state;
+
+		const tabbed_navigation = [
+			{
+				label: __( 'Analytics' ),
+				path: '/',
+				exact: true,
+			},
+			{
+				label: __( 'Events' ),
+				path: '/events',
+				exact: true,
+			},
+		];
+
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -43,9 +113,28 @@ class AnalyticsWizard extends Component {
 									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Analytics', 'newspack' ) }
 									subHeaderText={ __( 'Track traffic and activity' ) }
+									tabbedNavigation={ tabbed_navigation }
 								/>
 							) }
 						/>
+						<Route
+							path="/events"
+							exact
+							render={ () => {
+								return (
+									<Events
+										headerIcon={ <HeaderIcon /> }
+										headerText={ __( 'Analytics', 'newspack' ) }
+										subHeaderText={ __( 'Track traffic and activity' ) }
+										tabbedNavigation={ tabbed_navigation }
+										eventsEnabled={ eventsEnabled }
+										eventCategories={ eventCategories }
+										onChange={ this.update }
+									/>
+								);
+							} }
+						/>
+
 						<Redirect to="/" />
 					</Switch>
 				</HashRouter>

--- a/assets/wizards/analytics/views/events/index.js
+++ b/assets/wizards/analytics/views/events/index.js
@@ -1,0 +1,70 @@
+/**
+ * Syndication Intro View
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	CheckboxControl,
+	TextControl,
+	ToggleControl,
+	withWizardScreen,
+} from '../../../../components/src';
+
+/**
+ * Syndication Intro screen.
+ */
+class Events extends Component {
+	onEventChange( eventCategory, active ) {
+		const { eventsEnabled, eventCategories, onChange } = this.props;
+
+		for ( let i = 0; i < eventCategories.length; ++i ) {
+			if ( eventCategories[i].name === eventCategory ) {
+				eventCategories[i].active = active;
+			}
+		}
+
+		onChange( { eventCategories, eventsEnabled } );
+	}
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const { eventsEnabled, eventCategories, onChange } = this.props;
+
+		return (
+			<div className="newspack-analytics-events-setup-screen">
+				<ToggleControl
+					label={ __( 'Enable automated Google Analytics event tracking' ) }
+					checked={ eventsEnabled }
+					onChange={ _eventsEnabled => onChange( { events, eventsEnabled: _eventsEnabled } ) }
+				/>
+				{ eventsEnabled && (
+					<Fragment>
+						<h2 className="newspack-analytics-events-setup-screen__settings-heading">
+							{ __( 'Types of events to collect' ) }
+						</h2>
+						{ eventCategories.map( eventCategory => (
+							<CheckboxControl
+								label={ eventCategory.name }
+								checked={ eventCategory.active }
+								onChange={ _enabled => this.onEventChange( eventCategory.name, _enabled ) }
+								key={ eventCategory.name }
+							/>
+						) ) }
+					</Fragment>
+				) }
+			</div>
+		);
+	}
+}
+
+export default withWizardScreen( Events );

--- a/assets/wizards/analytics/views/index.js
+++ b/assets/wizards/analytics/views/index.js
@@ -1,1 +1,2 @@
 export { default as Intro } from './intro';
+export { default as Events } from './events';

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * Newspack Analytics features.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages Analytics integrations.
+ */
+class Analytics {
+
+	const EVENTS_ENABLED_OPTION          = 'newspack_analytics_events_enabled';
+	const EVENT_CATEGORY_DISABLED_OPTION = 'newspack_analytics_event_categories_disabled';
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'init', [ __CLASS__, 'register_events' ], 11 );
+		add_filter( 'googlesitekit_amp_gtag_opt', [ __CLASS__, 'inject_amp_events' ] );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'inject_non_amp_events' ] );
+	}
+
+	/**
+	 * Return whether analytics events are enabled.
+	 *
+	 * @return bool
+	 */
+	public static function events_enabled() {
+		return boolval( get_option( self::EVENTS_ENABLED_OPTION, true ) );
+	}
+
+	/**
+	 * Disable analytics events.
+	 */
+	public static function disable_events() {
+		update_option( self::EVENTS_ENABLED_OPTION, 0 );
+	}
+
+	/**
+	 * Enable analytics events.
+	 */
+	public static function enable_events() {
+		update_option( self::EVENTS_ENABLED_OPTION, 1 );
+	}
+
+	/**
+	 * Disable analytics events for an event category.
+	 *
+	 * @param string $event_category The event category.
+	 */
+	public static function disable_event_category( $event_category ) {
+		$saved_disabled = get_option( self::EVENT_CATEGORY_DISABLED_OPTION, [] );
+		if ( in_array( $event_category, $saved_disabled ) ) {
+			return;
+		}
+
+		$saved_disabled[] = $event_category;
+		update_option( self::EVENT_CATEGORY_DISABLED_OPTION, $saved_disabled );
+	}
+
+	/**
+	 * Enable analytics events for an event category.
+	 *
+	 * @param string $event_category The event category.
+	 */
+	public static function enable_event_category( $event_category ) {
+		$saved_disabled = get_option( self::EVENT_CATEGORY_DISABLED_OPTION, [] );
+		if ( in_array( $event_category, $saved_disabled ) ) {
+			$index = array_search( $event_category, $saved_disabled );
+			unset( $saved_disabled[ $index ] );
+			update_option( self::EVENT_CATEGORY_DISABLED_OPTION, $saved_disabled );
+		}
+	}
+
+	/**
+	 * Return whether events for an event category are enabled.
+	 *
+	 * @param string $event_category The event category.
+	 * @return bool Whether events are enabled for the category.
+	 */
+	public static function event_category_enabled( $event_category ) {
+		$saved_disabled = get_option( self::EVENT_CATEGORY_DISABLED_OPTION, [] );
+		return ! in_array( $event_category, $saved_disabled );
+	}
+
+	/**
+	 * Get all known event categories and whether they should record events.
+	 *
+	 * @return array Array of 'name' and 'active' pairs.
+	 */
+	public static function get_event_categories() {
+		$event_categories = [];
+		foreach ( self::get_events() as $event ) {
+			$event_categories[ $event['event_category'] ] = [
+				'name'   => $event['event_category'],
+				'active' => self::event_category_enabled( $event['event_category'] ),
+			];
+		}
+		return $event_categories;
+	}
+
+	/**
+	 * Get data about all events.
+	 *
+	 * An event should contain the following fields:
+	 *    'id'             => string Event ID (e.g. "popupFormDisplayed").
+	 *    'on'             => string Type of action (e.g. "click" or "form-submit-success").
+	 *    'amp_on'         => string Type of action for AMP if different (e.g. "amp-form-submit-success").
+	 *    'element'        => string CSS selector for element (e.g. '#popup1').
+	 *    'amp_element'    => string CSS selector for AMP version of element if different.
+	 *    'event_name'     => string Name for event in GA (e.g. 'Clicked').
+	 *    'event_label'    => string Label for event in GA (e.g. 'Popup 1')
+	 *    'event_category' => string Category for event in GA (e.g. 'Newspack Announcements').
+	 * There can also be other fields specific for certain events (e.g. 'scrollSpec' for 'scroll' event listener).
+	 */
+	public static function get_events() {
+		$events = [
+			[
+				'id'             => 'socialShareClickedFacebook',
+				'on'             => 'click',
+				'element'        => 'a.share-facebook',
+				'amp_element'    => 'amp-social-share[type="facebook"]',
+				'event_name'     => 'social share',
+				'event_label'    => 'facebook',
+				'event_category' => 'NTG social',
+			],
+			[
+				'id'             => 'socialShareClickedTwitter',
+				'on'             => 'click',
+				'element'        => 'a.share-twitter',
+				'amp_element'    => 'amp-social-share[type="twitter"]',
+				'event_name'     => 'social share',
+				'event_label'    => 'twitter',
+				'event_category' => 'NTG social',
+			],
+			[
+				'id'             => 'articleRead25',
+				'on'             => 'scroll',
+				'event_name'     => get_the_title(),
+				'event_label'    => '25%',
+				'event_category' => 'NTG article milestone',
+				'scrollSpec'     => [
+					'verticalBoundaries' => [ 25 ],
+				],
+			],
+			[
+				'id'             => 'articleRead50',
+				'on'             => 'scroll',
+				'event_name'     => get_the_title(),
+				'event_label'    => '50%',
+				'event_category' => 'NTG article milestone',
+				'scrollSpec'     => [
+					'verticalBoundaries' => [ 50 ],
+				],
+			],
+			[
+				'id'             => 'articleRead100',
+				'on'             => 'scroll',
+				'event_name'     => get_the_title(),
+				'event_label'    => '100%',
+				'event_category' => 'NTG article milestone',
+				'scrollSpec'     => [
+					'verticalBoundaries' => [ 100 ],
+				],
+			],
+		];
+
+		/**
+		 * Other integrations can add events to track using this filter.
+		 */
+		return apply_filters( 'newspack_analytics_events', $events );
+	}
+
+	/**
+	 * Inject event listeners on AMP pages.
+	 *
+	 * @param array $config AMP Analytics config from Site Kit.
+	 * @return array Modified $config.
+	 */
+	public static function inject_amp_events( $config ) {
+		$event_categories = self::get_event_categories();
+
+		foreach ( self::get_events() as $event ) {
+			if ( isset( $event_categories[ $event['event_category'] ] ) && ! $event_categories[ $event['event_category'] ]['active'] ) {
+				continue;
+			}
+
+			$event_config = [
+				'request' => 'event',
+				'on'      => isset( $event['amp_on'] ) ? $event['amp_on'] : $event['on'],
+				'vars'    => [
+					'event_name'     => $event['event_name'],
+					'event_label'    => $event['event_label'],
+					'event_category' => $event['event_category'],
+				],
+			];
+
+			if ( isset( $event['amp_element'] ) || isset( $event['element'] ) ) {
+				$event_config['selector'] = isset( $event['amp_element'] ) ? $event['amp_element'] : $event['element'];
+			}
+
+			// Handle other config params e.g. 'scrollSpec'.
+			foreach ( $event as $key => $val ) {
+				if ( ! in_array( $key, [ 'id', 'on', 'amp_on', 'element', 'amp_element', 'event_name', 'event_label', 'event_category' ] ) ) {
+					$event_config[ $key ] = $val;
+				}
+			}
+
+			if ( ! isset( $config['triggers'] ) ) {
+				$config['triggers'] = [];
+			}
+
+			$config['triggers'][ $event['id'] ] = $event_config;
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Inject event listeners on non-AMP pages.
+	 */
+	public static function inject_non_amp_events() {
+		// @todo make sure Site Kit analytics is active here first.
+
+		$event_categories = self::get_event_categories();
+
+		foreach ( self::get_events() as $event ) {
+			if ( isset( $event_categories[ $event['event_category'] ] ) && ! $event_categories[ $event['event_category'] ]['active'] ) {
+				continue;
+			}
+
+			switch ( $event['on'] ) {
+				case 'click':
+					self::output_js_click_event( $event );
+					break;
+				case 'scroll':
+					self::output_js_scroll_event( $event );
+					break;
+				default:
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Output JS for a click-based event listener.
+	 *
+	 * @param array $event Event info. See 'get_events'.
+	 */
+	protected static function output_js_click_event( $event ) {
+		?>
+		<script>
+			( function() {
+				const elementSelector = '<?php echo esc_attr( $event['element'] ); ?>';
+				const elements = document.querySelectorAll( elementSelector );
+
+				for ( const element of elements ) {
+					element.addEventListener( 'click', function() {
+						<?php self::output_js_record_ga_event( $event ); ?>
+					} );
+				}
+			} )();
+		</script>
+		<?php
+	}
+
+	/**
+	 * Output JS for a scroll-based event listener.
+	 *
+	 * @param array $event Event info. See 'get_events'.
+	 */
+	protected static function output_js_scroll_event( $event ) {
+		?>
+		<script>
+			( function() {
+				const scrollPercent = <?php echo (int) $event['scrollSpec']['verticalBoundaries'][0]; ?>;
+
+				// @todo throttle this event listener.
+				window.addEventListener( 'scroll', function(){ console.log( window.scrollY ); 
+					if ( ( ( window.scrollY / document.body.clientHeight ) * 100 ) > scrollPercent ) {
+						<?php self::output_js_record_ga_event( $event ); ?>
+					}
+				} );
+			} )();
+		</script>
+		<?php
+	}
+
+	/**
+	 * Output JS GA function that records an event.
+	 *
+	 * @param array $event Event info. See 'get_events'.
+	 */
+	protected static function output_js_record_ga_event( $event ) {
+		?>
+		ga( 'send', 'event', '<?php echo esc_attr( $event['event_category'] ); ?>', '<?php echo esc_attr( $event['event_name'] ); ?>', '<?php echo esc_attr( $event['event_label'] ); ?>' );
+		<?php
+	}
+}
+new Analytics();

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -68,6 +68,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-analytics.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-dashboard.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a Google Analytics events management framework and wizard. We can refine it further, but this should be a good prototype right now. If the idea/architecture/ux looks good, we can refine it further.

*Disclaimer: Haven't actually tested much with a real site to verify analytics get recorded correctly. I'll do QA before switching this PR out of draft. The architecture has been my main concern so far.*

### How to test the changes in this Pull Request:

1. You should see a new Events tab in the Analytics wizard.

<img width="725" alt="Screen Shot 2020-05-05 at 2 35 54 PM" src="https://user-images.githubusercontent.com/7317227/81118471-c60ed980-8edd-11ea-8801-62d9dcc6f3a2.png">

I'm not a huge fan of those category labels, but that's what the NCS doc said to use for the names. Might be good to put something more readable for the event categories.

2. To simulate Site Kit AMP analytics, go to an AMP post and add the following snippet somewhere:

```

add_action( 'wp_footer', function(){
	$gtag_amp_opt = array(
		'vars'            => array(
			'gtag_id' => '123456',
			'config'  => array(
				'123456' => array(
					'groups' => 'default',
					'linker' => array(
						'domains' => array( 'https://newspack.test' ),
					),
				),
			),
		),
		'optoutElementId' => '__gaOptOutExtension',
	);

	$gtag_amp_opt_filtered = apply_filters( 'googlesitekit_amp_gtag_opt', $gtag_amp_opt );
	?>
	<amp-analytics type="gtag" data-credentials="include">
		<script type="application/json">
			<?php echo wp_json_encode( $gtag_amp_opt_filtered ); ?>
		</script>
	</amp-analytics>
	<?php

});

```

3. In the page source you should see something like:

```
<amp-analytics type="gtag" data-credentials="include">
   <script type="application/json">
   {"vars":{"gtag_id":"123456","config":{"123456":{"groups":"default","linker":{"domains":["https:\/\/newspack.test"]}}}},"optoutElementId":"__gaOptOutExtension","triggers":{"socialShareClickedFacebook":{"request":"event","on":"click","vars":{"event_name":"social share","event_label":"facebook","event_category":"NTG social"},"selector":"amp-social-share[type=\"facebook\"]"},"socialShareClickedTwitter":{"request":"event","on":"click","vars":{"event_name":"social share","event_label":"twitter","event_category":"NTG social"},"selector":"amp-social-share[type=\"twitter\"]"},"articleRead25":{"request":"event","on":"scroll","vars":{"event_name":"Vulputate sed per sapien eros urna venenatis turpis","event_label":"25%","event_category":"NTG article milestone"},"scrollSpec":{"verticalBoundaries":[25]}},"articleRead50":{"request":"event","on":"scroll","vars":{"event_name":"Vulputate sed per sapien eros urna venenatis turpis","event_label":"50%","event_category":"NTG article milestone"},"scrollSpec":{"verticalBoundaries":[50]}},"articleRead100":{"request":"event","on":"scroll","vars":{"event_name":"Vulputate sed per sapien eros urna venenatis turpis","event_label":"100%","event_category":"NTG article milestone"},"scrollSpec":{"verticalBoundaries":[100]}}}}		</script>
   </amp-analytics>
```

4. Remove that AMP-mode-specific code snippet from step 2. Go visit a non-AMP page.

5. In the page source you should see some scripts like like:

```
<script>
( function() {
    const elementSelector = 'a.share-twitter';
    const elements = document.querySelectorAll( elementSelector );
    
   for ( const element of elements ) {
       element.addEventListener( 'click', function() {
           ga( 'send', 'event', 'NTG social', 'social share', 'twitter' );
       } );
   }
} )();
</script>
 
etc.

```

4. If you deactivate an event category in the wizard, the events shouldn't show up in the page source on AMP and on non-AMP posts.

5. Other integration like popups can add events using [this filter](https://github.com/Automattic/newspack-plugin/compare/add/analytics?expand=1#diff-55af0c7c94b4a43e428b9ba731be0f2fR177), and they should show up automatically in the wizard and can be enabled/disabled there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->