### PR TITLE
feat: popup wizard ui for draft popups

### DIFF
--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -42,9 +42,10 @@ class PopupActionCard extends Component {
 			previewPopup,
 			setCategoriesForPopup,
 			setSitewideDefaultPopup,
+			publishPopup,
 			updatePopup,
 		} = this.props;
-		const { id, categories, title, sitewide_default: sitewideDefault } = popup;
+		const { id, categories, title, sitewide_default: sitewideDefault, status } = popup;
 		return (
 			<ActionCard
 				className={ className }
@@ -81,6 +82,7 @@ class PopupActionCard extends Component {
 								setSitewideDefaultPopup={ setSitewideDefaultPopup }
 								updatePopup={ updatePopup }
 								previewPopup={ previewPopup }
+								publishPopup={ 'publish' !== status ? publishPopup : null }
 							/>
 						) }
 					</Fragment>

--- a/assets/wizards/popups/components/popup-popover/index.js
+++ b/assets/wizards/popups/components/popup-popover/index.js
@@ -18,6 +18,7 @@ import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
 import PreviewIcon from '@material-ui/icons/Visibility';
 import FrequencyIcon from '@material-ui/icons/Today';
+import PublishIcon from '@material-ui/icons/Publish';
 import TestIcon from '@material-ui/icons/BugReport';
 import SitewideDefaultIcon from '@material-ui/icons/Public';
 
@@ -52,6 +53,7 @@ class PopupPopover extends Component {
 			previewPopup,
 			setSitewideDefaultPopup,
 			onFocusOutside,
+			publishPopup,
 			updatePopup,
 		} = this.props;
 		const { id, sitewide_default: sitewideDefault, edit_link: editLink, options } = popup;
@@ -124,6 +126,15 @@ class PopupPopover extends Component {
 				>
 					{ __( 'Edit', 'newspack' ) }
 				</MenuItem>
+				{ publishPopup && (
+					<MenuItem
+						onClick={ () => publishPopup( id ) }
+						icon={ <PublishIcon /> }
+						className="newspack-button"
+					>
+						{ __( 'Publish', 'newspack' ) }
+					</MenuItem>
+				) }
 				<MenuItem
 					onClick={ () => deletePopup( id ) }
 					icon={ <DeleteIcon /> }

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -128,6 +128,21 @@ class PopupsWizard extends Component {
 	};
 
 	/**
+	 * Publish a popup.
+	 *
+	 * @param {number} popupId ID of the Popup to alter.
+	 */
+	publishPopup = popupId => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: `/newspack/v1/wizard/newspack-popups-wizard/${ popupId }/publish`,
+			method: 'POST',
+		} )
+			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )
+			.catch( error => setError( error ) );
+	};
+
+	/**
 	 * Sort Pop-ups into categories.
 	 */
 	sortPopups = popups => {
@@ -144,23 +159,31 @@ class PopupsWizard extends Component {
 	 * Sort Pop-up groups into categories.
 	 */
 	sortPopupGroup = popups => {
-		const test = popups.filter( ( { options } ) => 'test' === options.frequency );
-		const active = popups.filter( ( { categories, options, sitewide_default: sitewideDefault } ) =>
-			'inline' === options.placement
-				? 'test' !== options.frequency && 'never' !== options.frequency
-				: 'test' !== options.frequency && ( sitewideDefault || categories.length )
+		const test = popups.filter(
+			( { options, status } ) => 'publish' === status && 'test' === options.frequency
+		);
+		const draft = popups.filter( ( { status } ) => 'draft' === status );
+		const active = popups.filter(
+			( { categories, options, sitewide_default: sitewideDefault, status } ) =>
+				'inline' === options.placement
+					? 'test' !== options.frequency && 'never' !== options.frequency && 'publish' === status
+					: 'test' !== options.frequency &&
+					  ( sitewideDefault || categories.length ) &&
+					  'publish' === status
 		);
 		const activeWithSitewideDefaultFirst = [
 			...active.filter( ( { sitewide_default: sitewideDefault } ) => sitewideDefault ),
 			...active.filter( ( { sitewide_default: sitewideDefault } ) => ! sitewideDefault ),
 		];
 		const inactive = popups.filter(
-			( { categories, options, sitewide_default: sitewideDefault } ) =>
+			( { categories, options, sitewide_default: sitewideDefault, status } ) =>
 				'inline' === options.placement
-					? 'never' === options.frequency
-					: 'test' !== options.frequency && ( ! sitewideDefault && ! categories.length )
+					? 'never' === options.frequency && 'publish' === status
+					: 'test' !== options.frequency &&
+					  ( ! sitewideDefault && ! categories.length ) &&
+					  'publish' === status
 		);
-		return { test, active: activeWithSitewideDefaultFirst, inactive };
+		return { draft, test, active: activeWithSitewideDefaultFirst, inactive };
 	};
 
 	previewUrlForPopup = ( { options, id } ) => {
@@ -193,6 +216,7 @@ class PopupsWizard extends Component {
 							this.setState( { previewUrl: this.previewUrlForPopup( popup ) }, () =>
 								showPreview()
 							),
+						publishPopup: this.publishPopup,
 					};
 					return (
 						<HashRouter hashType="slash">

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -55,9 +55,10 @@ class PopupGroup extends Component {
 			previewPopup,
 			setCategoriesForPopup,
 			setSitewideDefaultPopup,
+			publishPopup,
 			updatePopup,
 		} = this.props;
-		const { active = [], test = [], inactive = [] } = items;
+		const { active = [], draft = [], test = [], inactive = [] } = items;
 		const sections = [];
 		const filterOptions = [];
 		if ( active.length > 0 ) {
@@ -144,6 +145,34 @@ class PopupGroup extends Component {
 				);
 			}
 			filterOptions.push( { label, value: 'inactive' } );
+		}
+		if ( draft.length > 0 ) {
+			const label = __( 'Draft', 'newspack' );
+			if ( filter === 'all' || filter === 'draft' ) {
+				sections.push(
+					<Fragment key="inactive">
+						<h2 className="newspack-popups-wizard__group-type">
+							{ __( 'Draft', 'newspack' ) }{' '}
+							<span className="newspack-popups-wizard__group-count">{ draft.length }</span>
+						</h2>
+						{ draft.map( popup => (
+							<PopupActionCard
+								className="newspack-card__is-disabled"
+								deletePopup={ deletePopup }
+								description={ this.descriptionForPopup( popup ) }
+								key={ popup.id }
+								popup={ popup }
+								previewPopup={ previewPopup }
+								publishPopup={ publishPopup }
+								setCategoriesForPopup={ () => null }
+								setSitewideDefaultPopup={ setSitewideDefaultPopup }
+								updatePopup={ updatePopup }
+							/>
+						) ) }
+					</Fragment>
+				);
+			}
+			filterOptions.push( { label, value: 'draft' } );
 		}
 		return sections.length > 0 ? (
 			<Fragment>

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -37,11 +37,12 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	/**
 	 * Retrieve all Pop-up CPTs
 	 *
+	 * @param  boolean $include_unpublished Whether to include unpublished posts.
 	 * @return array All Pop-ups
 	 */
-	public function get_popups() {
+	public function get_popups( $include_unpublished = false ) {
 		return $this->is_configured() ?
-			\Newspack_Popups_Model::retrieve_popups() :
+			\Newspack_Popups_Model::retrieve_popups( $include_unpublished ) :
 			$this->unconfigured_error();
 	}
 

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -156,6 +156,23 @@ class Popups_Wizard extends Wizard {
 				],
 			]
 		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/(?P<id>\d+)/publish',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_publish_popup' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'id'      => [
+						'sanitize_callback' => 'absint',
+					],
+					'options' => [
+						'validate_callback' => [ $this, 'api_validate_options' ],
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -208,7 +225,7 @@ class Popups_Wizard extends Wizard {
 					$popup['edit_link'] = get_edit_post_link( $popup['id'] );
 					return $popup;
 				},
-				$newspack_popups_configuration_manager->get_popups()
+				$newspack_popups_configuration_manager->get_popups( true )
 			);
 		}
 		return rest_ensure_response( $response );
@@ -306,6 +323,22 @@ class Popups_Wizard extends Wizard {
 			wp_delete_post( $id );
 		}
 
+		return $this->api_get_settings();
+	}
+
+	/**
+	 * Publish a Pop-up.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response with complete info to render the Engagement Wizard.
+	 */
+	public function api_publish_popup( $request ) {
+		$id = $request['id'];
+
+		$popup = get_post( $id );
+		if ( is_a( $popup, 'WP_Post' ) && 'newspack_popups_cpt' === $popup->post_type ) {
+			wp_publish_post( $id );
+		}
 		return $this->api_get_settings();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a drafts section in the Popups Wizard to view/edit/delete/publish draft popups. Test with https://github.com/Automattic/newspack-popups/pull/119. 

<img width="1377" alt="Screen Shot 2020-05-05 at 6 40 21 PM" src="https://user-images.githubusercontent.com/1477002/81123175-6e359a00-8f00-11ea-9fb1-b5c64130d7cf.png">

### How to test the changes in this Pull Request:

1. Create two new Pop-ups, one inline and one centered. Save but don't publish them.
2. Navigate to Newspack->Pop-ups. Verify you see the Pop-ups in the Drafts section of the respective tabs.
3. Verify setting the Filter to "Draft" shows only these Pop-ups.
4. Click the triple dots on the right for one of the Popups, click Publish.
5. Verify the Popup is published and moves out of the Drafts area.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->