### PR TITLE
Add small action card and plugin installer

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -43,6 +43,7 @@ class ActionCard extends Component {
 			secondaryActionText,
 			image,
 			imageLink,
+			isSmall,
 			simple,
 			onClick,
 			onSecondaryActionClick,
@@ -53,6 +54,7 @@ class ActionCard extends Component {
 		const classes = classnames(
 			'newspack-action-card',
 			simple && 'newspack-card__is-clickable',
+			isSmall && 'is-small',
 			className
 		);
 		return (

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -43,6 +43,35 @@
 		border-left: 4px solid $light-gray-700;
 	}
 
+	// Small
+	&.is-small {
+		padding: 8px 16px;
+
+		h2 {
+			font-size: 14px;
+		}
+
+		p,
+		.newspack-action-card__region-right,
+		.newspack-action-card__primary_button {
+			font-size: 12px;
+			line-height: 18px;
+		}
+
+		.newspack-form-token-field {
+			margin: 8px 0 0;
+
+			label {
+				font-size: 12px;
+				line-height: 18px;
+			}
+		}
+
+		& + & {
+			margin-top: -24px;
+		}
+	}
+
 	// Typography
 
 	h2,

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -55,7 +55,7 @@
 		.newspack-action-card__region-right,
 		.newspack-action-card__primary_button {
 			font-size: 12px;
-			line-height: 18px;
+			line-height: 16px;
 		}
 
 		.newspack-form-token-field {
@@ -63,7 +63,7 @@
 
 			label {
 				font-size: 12px;
-				line-height: 18px;
+				line-height: 16px;
 			}
 		}
 

--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -78,7 +78,7 @@
 
 	small {
 		font-size: 12px;
-		line-height: 18px;
+		line-height: 16px;
 	}
 
 	// Thematic Break

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -243,7 +243,7 @@ class PluginInstaller extends Component {
 								title={ Name }
 								description={ Description }
 								actionText={ actionText }
-								isSmall = { isSmall }
+								isSmall={ isSmall }
 								isWaiting={ isWaiting }
 								onClick={ onClick }
 								notification={ notification }

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -158,7 +158,7 @@ class PluginInstaller extends Component {
 	 * Render.
 	 */
 	render() {
-		const { asProgressBar, autoInstall } = this.props;
+		const { asProgressBar, autoInstall, isSmall } = this.props;
 		const { pluginInfo } = this.state;
 		const slugs = Object.keys( pluginInfo );
 
@@ -243,6 +243,7 @@ class PluginInstaller extends Component {
 								title={ Name }
 								description={ Description }
 								actionText={ actionText }
+								isSmall = { isSmall }
 								isWaiting={ isWaiting }
 								onClick={ onClick }
 								notification={ notification }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -302,13 +302,23 @@ class ComponentsDemo extends Component {
 					<Card>
 						<FormattedHeader headerText={ __( 'Plugin installer' ) } />
 						<PluginInstaller
-							plugins={ [
-								'woocommerce',
-								'amp',
-								'wordpress-seo',
-								'google-site-kit',
-								'woocommerce-subscriptions',
-							] }
+							plugins={ [ 'woocommerce', 'amp', 'wordpress-seo' ] }
+							canUninstall
+							onStatus={ ( { complete, pluginInfo } ) => {
+								console.log(
+									complete
+										? 'All plugins installed successfully'
+										: 'Plugin installation incomplete',
+									pluginInfo
+								);
+							} }
+						/>
+					</Card>
+					<Card>
+						<FormattedHeader headerText={ __( 'Plugin installer (small)' ) } />
+						<PluginInstaller
+							plugins={ [ 'woocommerce', 'amp', 'wordpress-seo' ] }
+							isSmall
 							canUninstall
 							onStatus={ ( { complete, pluginInfo } ) => {
 								console.log(
@@ -323,6 +333,20 @@ class ComponentsDemo extends Component {
 					<Card noBackground>
 						<PluginInstaller
 							plugins={ [ 'woocommerce', 'amp', 'wordpress-seo' ] }
+							onStatus={ ( { complete, pluginInfo } ) => {
+								console.log(
+									complete
+										? 'All plugins installed successfully'
+										: 'Plugin installation incomplete',
+									pluginInfo
+								);
+							} }
+						/>
+					</Card>
+					<Card noBackground>
+						<PluginInstaller
+							plugins={ [ 'woocommerce', 'amp', 'wordpress-seo' ] }
+							isSmall
 							onStatus={ ( { complete, pluginInfo } ) => {
 								console.log(
 									complete
@@ -423,6 +447,15 @@ class ComponentsDemo extends Component {
 						badge="Premium"
 						title="Example Ten"
 						description="An example of an action card with a badge."
+						actionText="Install"
+						onClick={ () => {
+							console.log( 'Install clicked' );
+						} }
+					/>
+					<ActionCard
+						isSmall
+						title="Example Eleven (small)"
+						description="An example of a small action card."
 						actionText="Install"
 						onClick={ () => {
 							console.log( 'Install clicked' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This allows to create a "skinny" version of the Action Card and Plugin Installer, with less padding and smaller font-sizes.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Check the components demo
3. Try to create a new Action Card and/or Plugin Installer and use the `isSmall` prop

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->