### PR TITLE
Update popup action card to use small style

### DIFF
--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -48,6 +48,7 @@ class PopupActionCard extends Component {
 		const { id, categories, title, sitewide_default: sitewideDefault, status } = popup;
 		return (
 			<ActionCard
+				isSmall
 				className={ className }
 				title={ decodeEntities( title ) }
 				key={ id }

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -186,13 +186,7 @@ class PopupGroup extends Component {
 					/>
 				) }
 
-				{ sections.reduce(
-					( acc, item ) => [
-						...acc,
-						item,
-					],
-					[]
-				) }
+				{ sections.reduce( ( acc, item ) => [ ...acc, item ], [] ) }
 			</Fragment>
 		) : (
 			<p>{ emptyMessage }</p>

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -187,10 +187,9 @@ class PopupGroup extends Component {
 				) }
 
 				{ sections.reduce(
-					( acc, item, index ) => [
+					( acc, item ) => [
 						...acc,
 						item,
-						index < sections.length - 1 && <hr key={ index } />,
 					],
 					[]
 				) }

--- a/assets/wizards/popups/views/popup-group/style.scss
+++ b/assets/wizards/popups/views/popup-group/style.scss
@@ -49,11 +49,10 @@
 		&__group-type {
 			align-items: center;
 			display: flex;
-
-			margin-bottom: 16px;
+			margin-bottom: 8px;
 
 			+ .newspack-action-card {
-				margin-top: 16px;
+				margin-top: 8px;
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the `isSmall` prop to the Popup Action Card. I also removed the `<hr />`s to save some space.

![new-popup-wizard](https://user-images.githubusercontent.com/177929/81315266-0444fe00-9082-11ea-8fc8-2182bedf9670.png)

### How to test the changes in this Pull Request:

1. Navigate to Newspack > ~Pop-ups~ Campaigns
2. Switch to this branch
3. Refresh and notice the differences

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->