### PR TITLE
fix: duplicate key

### DIFF
--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -150,7 +150,7 @@ class PopupGroup extends Component {
 			const label = __( 'Draft', 'newspack' );
 			if ( filter === 'all' || filter === 'draft' ) {
 				sections.push(
-					<Fragment key="inactive">
+					<Fragment key="draft">
 						<h2 className="newspack-popups-wizard__group-type">
 							{ __( 'Draft', 'newspack' ) }{' '}
 							<span className="newspack-popups-wizard__group-count">{ draft.length }</span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A duplicate React key in the drafts section of the Campaigns Wizard led to duplicate `ActionCard`s under some circumstances. 

Closes https://github.com/Automattic/newspack-plugin/issues/536

### How to test the changes in this Pull Request:

1. On `master` create at least one inactive overlay campaign and one inactive inline campaign.
2. Create at least one draft (unpublished) overlay campaign and one draft inline campaign.
3. In the Newspack Campaigns Wizard, toggle between the Overlay and Inline tabs several times. Observe that the Inactive ones multiply each time, creating unexpected duplication.
4. Switch to this branch, reload the Campaigns Wizard, repeat the toggling.
5. Observe the Overlay and Inline screens remain the same no matter how many times you toggle between the two.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->