### PR TITLE
Fix: php testing on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,7 @@ jobs:
           command: |
             sudo apt-get update && sudo apt-get install subversion
             sudo -E docker-php-ext-install mysqli
-            sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-            sudo apt-get update && sudo apt-get install mysql-client-5.7
+            sudo apt-get update && sudo apt-get install default-mysql-client
       - run:
           name: Run Tests
           command: |


### PR DESCRIPTION
A tweak in CI config. If the `test-php` CI job is passing here, then this fix works.