### PR TITLE
Support: token removal UI & auth scope change

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -128,6 +128,9 @@ final class Newspack {
 			update_option( Payment_Wizard::NEWSPACK_STRIPE_CUSTOMER, null );
 			update_option( Payment_Wizard::NEWSPACK_STRIPE_SUBSCRIPTION, null );
 		}
+		if ( Support_Wizard::get_wpcom_access_token() && filter_input( INPUT_POST, 'newspack_remove_wpcom_token', FILTER_SANITIZE_STRING ) === 'on' ) {
+			delete_user_meta( get_current_user_id(), Support_Wizard::NEWSPACK_WPCOM_ACCESS_TOKEN );
+		}
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -108,6 +108,15 @@ class Settings {
 				'newspack_settings'
 			);
 		}
+		if ( Support_Wizard::get_wpcom_access_token() ) {
+			add_settings_field(
+				'newspack_remove_wpcom_token',
+				__( 'Remove WPCOM Token', 'newspack' ),
+				[ __CLASS__, 'newspack_remove_wpcom_token_callback' ],
+				'newspack-settings-admin',
+				'newspack_settings'
+			);
+		}
 	}
 
 	/**
@@ -123,7 +132,7 @@ class Settings {
 	}
 
 	/**
-	 * Render Reset button.
+	 * Render Reset checkbox.
 	 */
 	public static function newspack_reset_callback() {
 		printf(
@@ -132,11 +141,20 @@ class Settings {
 	}
 
 	/**
-	 * Render reset subscription button.
+	 * Render reset subscription checkbox.
 	 */
 	public static function newspack_reset_subscription_callback() {
 		printf(
 			'<input type="checkbox" id="newspack_reset_subscription" name="newspack_reset_subscription" />'
+		);
+	}
+
+	/**
+	 * Render remove WPCOM token checkbox.
+	 */
+	public static function newspack_remove_wpcom_token_callback() {
+		printf(
+			'<input type="checkbox" id="newspack_remove_wpcom_token" name="newspack_remove_wpcom_token" />'
 		);
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -111,7 +111,7 @@ class Settings {
 		if ( Support_Wizard::get_wpcom_access_token() ) {
 			add_settings_field(
 				'newspack_remove_wpcom_token',
-				__( 'Remove WPCOM Token', 'newspack' ),
+				__( 'Reset WordPress.com authentication', 'newspack' ),
 				[ __CLASS__, 'newspack_remove_wpcom_token_callback' ],
 				'newspack-settings-admin',
 				'newspack_settings'

--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -331,7 +331,7 @@ class Support_Wizard extends Wizard {
 			'newspack_support_data',
 			array(
 				'API_URL'            => self::support_api_url(),
-				'WPCOM_AUTH_URL'     => 'https://public-api.wordpress.com/oauth2/authorize?client_id=' . $client_id . '&redirect_uri=' . $redirect_uri . '&response_type=token',
+				'WPCOM_AUTH_URL'     => 'https://public-api.wordpress.com/oauth2/authorize?client_id=' . $client_id . '&redirect_uri=' . $redirect_uri . '&response_type=token&scope=global',
 				'WPCOM_ACCESS_TOKEN' => $access_token,
 			)
 		);

--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -92,10 +92,17 @@ class Support_Wizard extends Wizard {
 	}
 
 	/**
+	 * Retrieve WPCOM access token.
+	 */
+	public static function get_wpcom_access_token() {
+		return get_user_meta( get_current_user_id(), self::NEWSPACK_WPCOM_ACCESS_TOKEN, true );
+	}
+
+	/**
 	 * Validate WPCOM credentials.
 	 */
 	public function api_wpcom_validate_access_token() {
-		$access_token = get_user_meta( get_current_user_id(), self::NEWSPACK_WPCOM_ACCESS_TOKEN, true );
+		$access_token = self::get_wpcom_access_token();
 		$client_id    = self::wpcom_client_id();
 		$response     = wp_safe_remote_get(
 			'https://public-api.wordpress.com/oauth2/token-info?' . http_build_query(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As it says on the tin. The [auth](https://developer.wordpress.com/docs/oauth2/) scope change makes for a simpler UI, without the blog selection.

### How to test the changes in this Pull Request:

1. Authenticate with WPCOM to enable support features
2. Go to Settings->Newspack. Check 'Remove WPCOM Token' and save changes
3. Observe the option is gone, as there's no token now
3. Go back to Support wizard, authenticate again
3. Observe that the WPCOM auth screen does not prompt for blog selection, as it was before
3. Complete auth and observe that the support wizard features are active 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
