### PR TITLE
SalesForce integration

### DIFF
--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -37,7 +37,7 @@ class ReaderRevenueWizard extends Component {
 				locationData: {},
 				stripeData: {},
 				donationData: {},
-				salesforceData: {}
+				salesforceData: {},
 			},
 		};
 	}
@@ -109,7 +109,7 @@ class ReaderRevenueWizard extends Component {
 		countryStateFields: data.country_state_fields,
 		currencyFields: data.currency_fields,
 		donationPage: data.donation_page,
-		salesforceData: data.salesforce_settings
+		salesforceData: data.salesforce_settings,
 	} );
 
 	/**
@@ -135,7 +135,7 @@ class ReaderRevenueWizard extends Component {
 			stripeData,
 			donationData,
 			donationPage,
-			salesforceData
+			salesforceData,
 		} = data;
 
 		const tabbedNavigation = [
@@ -260,9 +260,10 @@ class ReaderRevenueWizard extends Component {
 												client_secret: '',
 												access_token: '',
 												refresh_token: '',
-												instance_url: ''
+												instance_url: '',
 											};
-											this.setState( { data: {  ...data, salesforceData: defaultSettings } } );
+
+											this.setState( { data: { ...data, salesforceData: defaultSettings } } );
 											return this.update( 'salesforce', defaultSettings );
 										}
 
@@ -270,10 +271,19 @@ class ReaderRevenueWizard extends Component {
 
 										if ( client_id && client_secret ) {
 											this.update( 'salesforce', salesforceData );
-											window.location.assign( `https://login.salesforce.com/services/oauth2/authorize?response_type=code&client_id=${ encodeURIComponent( client_id ) }&client_secret=${ encodeURIComponent( client_secret ) }&redirect_uri=${ encodeURIComponent( window.location.href ) }` );
+											window.location.assign(
+												`https://login.salesforce.com/services/oauth2/authorize?response_type=code&client_id=${ encodeURIComponent(
+													client_id
+												) }&client_secret=${ encodeURIComponent(
+													client_secret
+												) }&redirect_uri=${ encodeURIComponent( window.location.href ) }`
+											);
 										}
 									} }
-									buttonDisabled={ ! salesforceIsConnected && ( ! salesforceData.client_id || ! salesforceData.client_secret ) }
+									buttonDisabled={
+										! salesforceIsConnected &&
+										( ! salesforceData.client_id || ! salesforceData.client_secret )
+									}
 									onChange={ _salesforceData =>
 										this.setState( { data: { ...data, salesforceData: _salesforceData } } )
 									}

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -22,7 +22,7 @@ import GroupAddIcon from '@material-ui/icons/GroupAdd';
  */
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { Donation, LocationSetup, StripeSetup, RevenueMain, SalesForce } from './views';
+import { Donation, LocationSetup, StripeSetup, RevenueMain, Salesforce } from './views';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
@@ -242,24 +242,25 @@ class ReaderRevenueWizard extends Component {
 						<Route
 							path="/salesforce"
 							render={ routeProps => (
-								<SalesForce
+								<Salesforce
 									routeProps={ routeProps }
 									data={ salesforceData }
 									headerIcon={ <GroupAddIcon /> }
-									headerText={ __( 'Configure SalesForce' ) }
+									headerText={ __( 'Configure Salesforce' ) }
 									isConnected={ salesforceIsConnected }
 									redirectURI={ window.location.href }
 									subHeaderText={ __(
-										'Connect your site with a SalesForce account to capture leads.'
+										'Connect your site with a Salesforce account to capture leads.'
 									) }
-									buttonText={ salesforceIsConnected ? __( 'Clear Connection' ) : __( 'Connect' ) }
+									buttonText={ salesforceIsConnected ? __( 'Reset' ) : __( 'Connect' ) }
 									buttonAction={ () => {
 										if ( salesforceIsConnected ) {
 											const defaultSettings = {
 												client_id: '',
 												client_secret: '',
 												access_token: '',
-												refresh_token: ''
+												refresh_token: '',
+												instance_url: ''
 											};
 											this.setState( { data: {  ...data, salesforceData: defaultSettings } } );
 											return this.update( 'salesforce', defaultSettings );

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -248,7 +248,6 @@ class ReaderRevenueWizard extends Component {
 									headerIcon={ <GroupAddIcon /> }
 									headerText={ __( 'Configure Salesforce' ) }
 									isConnected={ salesforceIsConnected }
-									redirectURI={ window.location.href }
 									subHeaderText={ __(
 										'Connect your site with a Salesforce account to capture leads.'
 									) }

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -52,6 +52,7 @@ class ReaderRevenueWizard extends Component {
 		const { setError, wizardApiFetch } = this.props;
 		return wizardApiFetch( { path: '/newspack/v1/wizard/newspack-reader-revenue-wizard' } )
 			.then( data => {
+				console.log( this.parseData( data ) );
 				return new Promise( resolve => {
 					this.setState(
 						{
@@ -161,6 +162,7 @@ class ReaderRevenueWizard extends Component {
 								<RevenueMain
 									headerIcon={ <HeaderIcon /> }
 									headerText={ __( 'Reader revenue' ) }
+									noBackground
 									subHeaderText={ __( 'Generate revenue from your customers.' ) }
 									tabbedNavigation={ isConfigured && tabbedNavigation }
 									buttonText={ ! isConfigured && __( 'Get Started' ) }

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -305,12 +305,15 @@ class ReaderRevenueWizard extends Component {
 									routeProps={ routeProps }
 									data={ salesforceData }
 									headerIcon={ <GroupAddIcon /> }
-									headerText={ __( 'Configure Salesforce' ) }
+									headerText={ __( 'Configure Salesforce', 'newspack' ) }
 									isConnected={ salesforceIsConnected }
 									subHeaderText={ __(
-										'Connect your site with a Salesforce account to capture leads.'
+										'Connect your site with a Salesforce account to capture leads.',
+										'newspack'
 									) }
-									buttonText={ salesforceIsConnected ? __( 'Reset' ) : __( 'Connect' ) }
+									buttonText={
+										salesforceIsConnected ? __( 'Reset', 'newspack' ) : __( 'Connect', 'newspack' )
+									}
 									buttonAction={ this.handleSalesforce }
 									buttonDisabled={
 										! salesforceIsConnected &&

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -126,7 +126,7 @@ class ReaderRevenueWizard extends Component {
 	 * Render
 	 */
 	render() {
-		const { pluginRequirements } = this.props;
+		const { pluginRequirements, wizardApiFetch } = this.props;
 		const { data } = this.state;
 		const {
 			countryStateFields,
@@ -243,10 +243,12 @@ class ReaderRevenueWizard extends Component {
 							path="/salesforce"
 							render={ routeProps => (
 								<SalesForce
+									routeProps={ routeProps }
 									data={ salesforceData }
 									headerIcon={ <GroupAddIcon /> }
 									headerText={ __( 'Configure SalesForce' ) }
 									isConnected={ salesforceIsConnected }
+									redirectURI={ window.location.href }
 									subHeaderText={ __(
 										'Connect your site with a SalesForce account to capture leads.'
 									) }
@@ -276,6 +278,7 @@ class ReaderRevenueWizard extends Component {
 									}
 									secondaryButtonText={ __( 'Back to Monetization Services', 'newspack' ) }
 									secondaryButtonAction="#"
+									wizardApiFetch={ wizardApiFetch }
 								/>
 							) }
 						/>

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -9,6 +9,7 @@ import '../../shared/js/public-path';
  */
 import { Component, render, Fragment, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Material UI dependencies.
@@ -149,13 +150,12 @@ class ReaderRevenueWizard extends Component {
 		const { client_id, client_secret } = salesforceData;
 
 		if ( client_id && client_secret ) {
-			const loginUrl = `https://login.salesforce.com/services/oauth2/authorize?response_type=code&client_id=${ encodeURIComponent(
-				client_id
-			) }&client_secret=${ encodeURIComponent( client_secret ) }&redirect_uri=${ encodeURIComponent(
-				window.location.href
-			) }`;
-
-			console.log( loginUrl );
+			const loginUrl = addQueryArgs( 'https://login.salesforce.com/services/oauth2/authorize', {
+				response_type: 'code',
+				client_id: encodeURIComponent( client_id ),
+				client_secret: encodeURIComponent( client_secret ),
+				redirect_uri: encodeURI( window.location.href ),
+			} );
 
 			// Save credentials to options table.
 			await this.update( 'salesforce', salesforceData );

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -131,11 +131,6 @@ class ReaderRevenueWizard extends Component {
 		const { salesforceData } = data;
 		const salesforceIsConnected = !! salesforceData.refresh_token;
 
-		// Clear any previous error messages.
-		this.setState( {
-			data: { ...data, salesforceData: { ...salesforceData, error: null } },
-		} );
-
 		// If Salesforce is already connected, button should reset settings.
 		if ( salesforceIsConnected ) {
 			const defaultSettings = {
@@ -160,8 +155,10 @@ class ReaderRevenueWizard extends Component {
 				window.location.href
 			) }`;
 
+			console.log( loginUrl );
+
 			// Save credentials to options table.
-			this.update( 'salesforce', salesforceData );
+			await this.update( 'salesforce', salesforceData );
 
 			// Validate credentials before redirecting.
 			const valid = await wizardApiFetch( {

--- a/assets/wizards/readerRevenue/views/index.js
+++ b/assets/wizards/readerRevenue/views/index.js
@@ -2,3 +2,4 @@ export { default as Donation } from './donation';
 export { default as LocationSetup } from './location-setup';
 export { default as StripeSetup } from './stripe-setup';
 export { default as RevenueMain } from './revenue-main';
+export { default as SalesForce } from './salesforce';

--- a/assets/wizards/readerRevenue/views/index.js
+++ b/assets/wizards/readerRevenue/views/index.js
@@ -2,4 +2,4 @@ export { default as Donation } from './donation';
 export { default as LocationSetup } from './location-setup';
 export { default as StripeSetup } from './stripe-setup';
 export { default as RevenueMain } from './revenue-main';
-export { default as SalesForce } from './salesforce';
+export { default as Salesforce } from './salesforce';

--- a/assets/wizards/readerRevenue/views/revenue-main/index.js
+++ b/assets/wizards/readerRevenue/views/revenue-main/index.js
@@ -32,11 +32,12 @@ class RevenueMain extends Component {
 					href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations"
 				/>
 				<ActionCard
-					title={ __( 'Salesforce' ) }
+					title={ __( 'Salesforce', 'newspack' ) }
 					description={ __(
-						'Integrate Salesforce to capture leads when readers donate to your organization.'
+						'Integrate Salesforce to capture leads when readers donate to your organization.',
+						'newspack'
 					) }
-					actionText={ __( 'Configure' ) }
+					actionText={ __( 'Configure', 'newspack' ) }
 					href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/salesforce"
 				/>
 				<PluginToggle

--- a/assets/wizards/readerRevenue/views/revenue-main/index.js
+++ b/assets/wizards/readerRevenue/views/revenue-main/index.js
@@ -32,9 +32,9 @@ class RevenueMain extends Component {
 					href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations"
 				/>
 				<ActionCard
-					title={ __( 'SalesForce' ) }
+					title={ __( 'Salesforce' ) }
 					description={ __(
-						'Integrate SalesForce to capture leads when readers donate to your organization.'
+						'Integrate Salesforce to capture leads when readers donate to your organization.'
 					) }
 					actionText={ __( 'Configure' ) }
 					href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/salesforce"

--- a/assets/wizards/readerRevenue/views/revenue-main/index.js
+++ b/assets/wizards/readerRevenue/views/revenue-main/index.js
@@ -11,14 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	ActionCard,
-	Button,
-	Card,
-	PluginToggle,
-	TextControl,
-	withWizardScreen
-} from '../../../../components/src';
+import { ActionCard, PluginToggle, withWizardScreen } from '../../../../components/src';
 
 /**
  * Revenue Main Screen Component
@@ -30,43 +23,27 @@ class RevenueMain extends Component {
 	render() {
 		return (
 			<Fragment>
-				<Card key="revenue-main">
-					<ActionCard
-						title={ __( 'Donations' ) }
-						description={ __(
-							'Set up a donations page and accept one-time or recurring payments from your readers.'
-						) }
-						actionText={ __( 'Configure' ) }
-						href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations"
-					/>
-					<PluginToggle
-						plugins={ {
-							laterpay: true,
-						} }
-					/>
-				</Card>
-				<Card key="salesforce">
-					<p>{ __( 'Integrate the Donation feature with SalesForce. To connect with SalesForce, enter your Consumer Key and Secret below, then click the "Connect" button to authorize access to your SalesForce Org.' ) }</p>
-
-					<p>{ __(' To find your Consumer Key and Secret, log into your SalesForce Org and and go to Settings > Apps > App Manager, then find or create the Connected App for this site. The Consumer Key and Secret are displayed under the "API (Enable OAuth Settings)" section.' ) }</p>
-
-					<TextControl
-						label={ __( 'Enter your SalesForce Consumer Key' ) }
-						value={ '' }
-					/>
-					<TextControl
-						label={ __( 'Enter your SalesForce Consumer Secret' ) }
-						value={ '' }
-					/>
-					<div className="newspack-buttons-card">
-						<Button
-							isPrimary
-							onClick={ e => console.log( e ) }
-						>
-							{ __( 'Connect' ) }
-						</Button>
-					</div>
-				</Card>
+				<ActionCard
+					title={ __( 'Donations' ) }
+					description={ __(
+						'Set up a donations page and accept one-time or recurring payments from your readers.'
+					) }
+					actionText={ __( 'Configure' ) }
+					href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations"
+				/>
+				<ActionCard
+					title={ __( 'SalesForce' ) }
+					description={ __(
+						'Integrate SalesForce to capture leads when readers donate to your organization.'
+					) }
+					actionText={ __( 'Configure' ) }
+					href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/salesforce"
+				/>
+				<PluginToggle
+					plugins={ {
+						laterpay: true,
+					} }
+				/>
 			</Fragment>
 		);
 	}

--- a/assets/wizards/readerRevenue/views/revenue-main/index.js
+++ b/assets/wizards/readerRevenue/views/revenue-main/index.js
@@ -11,7 +11,14 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ActionCard, PluginToggle, withWizardScreen } from '../../../../components/src';
+import {
+	ActionCard,
+	Button,
+	Card,
+	PluginToggle,
+	TextControl,
+	withWizardScreen
+} from '../../../../components/src';
 
 /**
  * Revenue Main Screen Component
@@ -23,19 +30,43 @@ class RevenueMain extends Component {
 	render() {
 		return (
 			<Fragment>
-				<ActionCard
-					title={ __( 'Donations' ) }
-					description={ __(
-						'Set up a donations page and accept one-time or recurring payments from your readers.'
-					) }
-					actionText={ __( 'Configure' ) }
-					href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations"
-				/>
-				<PluginToggle
-					plugins={ {
-						laterpay: true,
-					} }
-				/>
+				<Card key="revenue-main">
+					<ActionCard
+						title={ __( 'Donations' ) }
+						description={ __(
+							'Set up a donations page and accept one-time or recurring payments from your readers.'
+						) }
+						actionText={ __( 'Configure' ) }
+						href="/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/donations"
+					/>
+					<PluginToggle
+						plugins={ {
+							laterpay: true,
+						} }
+					/>
+				</Card>
+				<Card key="salesforce">
+					<p>{ __( 'Integrate the Donation feature with SalesForce. To connect with SalesForce, enter your Consumer Key and Secret below, then click the "Connect" button to authorize access to your SalesForce Org.' ) }</p>
+
+					<p>{ __(' To find your Consumer Key and Secret, log into your SalesForce Org and and go to Settings > Apps > App Manager, then find or create the Connected App for this site. The Consumer Key and Secret are displayed under the "API (Enable OAuth Settings)" section.' ) }</p>
+
+					<TextControl
+						label={ __( 'Enter your SalesForce Consumer Key' ) }
+						value={ '' }
+					/>
+					<TextControl
+						label={ __( 'Enter your SalesForce Consumer Secret' ) }
+						value={ '' }
+					/>
+					<div className="newspack-buttons-card">
+						<Button
+							isPrimary
+							onClick={ e => console.log( e ) }
+						>
+							{ __( 'Connect' ) }
+						</Button>
+					</div>
+				</Card>
 			</Fragment>
 		);
 	}

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -135,6 +135,7 @@ class Salesforce extends Component {
 					) }
 
 					<TextControl
+						disabled={ isConnected }
 						label={
 							( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) + __( ' Salesforce Consumer Key' )
 						}
@@ -147,6 +148,7 @@ class Salesforce extends Component {
 						} }
 					/>
 					<TextControl
+						disabled={ isConnected }
 						label={ __(
 							( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) + ' Salesforce Consumer Secret'
 						) }

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -24,6 +24,13 @@ import { Notice, TextControl, withWizardScreen } from '../../../../components/sr
  * Salesforce Settings Screen Component
  */
 class Salesforce extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			error: null,
+		};
+	}
+
 	/**
 	 * On component mount.
 	 */
@@ -80,10 +87,11 @@ class Salesforce extends Component {
 					refresh_token,
 				} );
 			}
-
-			throw new Error( 'Could not retrieve access tokens. Please try connecting again.' );
 		} catch ( e ) {
 			console.error( e );
+			this.setState( {
+				error: 'Could not establish a connection to Salesforce. Please try connecting again.',
+			} );
 		}
 	}
 
@@ -92,12 +100,14 @@ class Salesforce extends Component {
 	 */
 	render() {
 		const { data, isConnected, onChange } = this.props;
-		const { client_id, client_secret } = data;
+		const { client_id, client_secret, error } = data;
 
 		return (
 			<div className="newspack-salesforce-wizard">
 				<Fragment>
 					<h2>{ __( 'Connected App settings' ) }</h2>
+
+					{ this.state.error && <Notice noticeText={ this.state.error } isWarning /> }
 
 					{ isConnected ? (
 						<Notice noticeText={ __( 'Your site is connected to Salesforce.' ) } isSuccess />
@@ -132,6 +142,15 @@ class Salesforce extends Component {
 								'To reconnect your site in case of issues, or to connect to a different Salesforce account, click “Reset" below. You will need to re-enter your Consumer Key and Secret before you can re-connect to Salesforce.'
 							) }
 						</p>
+					) }
+
+					{ error && (
+						<Notice
+							noticeText={ __(
+								'We couldn’t connect to Salesforce. Please verify that you entered the correct Consumer Key and Secret and try again.'
+							) }
+							isWarning
+						/>
 					) }
 
 					<TextControl

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -75,20 +75,6 @@ class Salesforce extends Component {
 		this.setState( { fetching: false } );
 	}
 
-	async testWebhookHandler() {
-		const response = await apiFetch( {
-			path: '/newspack/v1/salesforce/sync',
-			method: 'POST',
-			data: {
-				Email: 'newlead@hotmail.com',
-				FirstName: 'Hatchet',
-				LastName: 'Sullivan'
-			}
-		} );
-
-		console.log( response );
-	}
-
 	/**
 	 * Render.
 	 */
@@ -99,10 +85,6 @@ class Salesforce extends Component {
 			client_id,
 			client_secret
 		} = data;
-
-		console.log( data );
-
-		this.testWebhookHandler();
 
 		const query = parse( window.location.search );
 		const authorizationCode = query.code;

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -25,15 +25,26 @@ import { Notice, TextControl, Waiting, withWizardScreen } from '../../../../comp
  */
 class Salesforce extends Component {
 	/**
-	 * Constructor.
+	 * On component mount.
 	 */
-	constructor( props ) {
-		super( props );
+	componentDidMount() {
+		const query = parse( window.location.search );
+		const authorizationCode = query.code;
 
-		this.state = {
-			error: null,
-			fetching: false,
-		};
+		if ( authorizationCode ) {
+			// Remove `code` param from URL without adding history.
+			window.history.replaceState(
+				{},
+				'',
+				window.location.origin +
+					window.location.pathname +
+					'?page=' +
+					query[ '?page' ] +
+					window.location.hash
+			);
+
+			this.getTokens( authorizationCode );
+		}
 	}
 
 	/**
@@ -80,40 +91,12 @@ class Salesforce extends Component {
 	 */
 	render() {
 		const { data, isConnected, onChange } = this.props;
-		const { error, fetching } = this.state;
 		const { client_id, client_secret } = data;
-
-		const query = parse( window.location.search );
-		const authorizationCode = query.code;
-
-		if ( authorizationCode ) {
-			// Remove param from URL so we don't get stuck in a re-render loop.
-			window.history.replaceState(
-				{},
-				'',
-				window.location.origin +
-					window.location.pathname +
-					'?page=' +
-					query[ '?page' ] +
-					window.location.hash
-			);
-
-			this.getTokens( authorizationCode );
-		}
 
 		return (
 			<div className="newspack-salesforce-wizard">
 				<Fragment>
 					<h2>{ __( 'Connected App settings' ) }</h2>
-
-					{ fetching && (
-						<div className="newspack_salesforce_loading">
-							<Waiting isLeft />
-							{ __( 'Connecting...', 'newspack' ) }
-						</div>
-					) }
-
-					{ error && <Notice noticeText={ error } isWarning /> }
 
 					{ isConnected ? (
 						<Notice noticeText={ __( 'Your site is connected to Salesforce.' ) } isSuccess />

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -219,10 +219,10 @@ class Salesforce extends Component {
 					/>
 					<TextControl
 						disabled={ isConnected }
-						label={ __(
+						label={
 							( isConnected ? __( 'Your', 'newspack' ) : __( 'Enter your', 'newspack' ) ) +
-								__( ' Salesforce Consumer Secret', 'newspack' )
-						) }
+							__( ' Salesforce Consumer Secret', 'newspack' )
+						}
 						value={ client_secret }
 						onChange={ value => {
 							if ( isConnected ) {

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -108,7 +108,7 @@ class Salesforce extends Component {
 			console.error( e );
 			this.setState( {
 				error: __(
-					'We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again.'
+					'We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again.', 'newspack'
 				),
 			} );
 		}
@@ -122,7 +122,7 @@ class Salesforce extends Component {
 	async checkToken() {
 		const { wizardApiFetch } = this.props;
 		const error = __(
-			'We couldn’t validate the connection with Salesforce. Please verify the status of the Connected App in Salesforce.'
+			'We couldn’t validate the connection with Salesforce. Please verify the status of the Connected App in Salesforce.', 'newspack'
 		);
 
 		try {
@@ -150,28 +150,28 @@ class Salesforce extends Component {
 		return (
 			<div className="newspack-salesforce-wizard">
 				<Fragment>
-					<h2>{ __( 'Connected App settings' ) }</h2>
+					<h2>{ __( 'Connected App settings', 'newspack' ) }</h2>
 
 					{ this.state.error && <Notice noticeText={ this.state.error } isWarning /> }
 
 					{ isConnected && ! this.state.error && (
-						<Notice noticeText={ __( 'Your site is connected to Salesforce.' ) } isSuccess />
+						<Notice noticeText={ __( 'Your site is connected to Salesforce.', 'newspack ) } isSuccess />
 					) }
 
 					{ ! isConnected && ! this.state.error && (
 						<Fragment>
 							<p>
 								{ __(
-									'To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to paste the the full URL for this page into the “Callback URL” field in the Connected App’s settings. '
+									'To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to paste the the full URL for this page into the “Callback URL” field in the Connected App’s settings. ', 'newspack'
 								) }
 								<ExternalLink href="https://help.salesforce.com/articleView?id=connected_app_create.htm">
-									{ __( 'Learn how to create a Connected App' ) }
+									{ __( 'Learn how to create a Connected App', 'newspack' ) }
 								</ExternalLink>
 							</p>
 
 							<p>
 								{ __(
-									'Enter your Consumer Key and Secret below, then click “Connect” to authorize access to your Salesforce account.'
+									'Enter your Consumer Key and Secret below, then click “Connect” to authorize access to your Salesforce account.', 'newspack'
 								) }
 							</p>
 						</Fragment>
@@ -180,7 +180,7 @@ class Salesforce extends Component {
 					{ isConnected && (
 						<p>
 							{ __(
-								'To reconnect your site in case of issues, or to connect to a different Salesforce account, click “Reset" below. You will need to re-enter your Consumer Key and Secret before you can re-connect to Salesforce.'
+								'To reconnect your site in case of issues, or to connect to a different Salesforce account, click “Reset" below. You will need to re-enter your Consumer Key and Secret before you can re-connect to Salesforce.', 'newspack'
 							) }
 						</p>
 					) }
@@ -188,7 +188,7 @@ class Salesforce extends Component {
 					{ error && (
 						<Notice
 							noticeText={ __(
-								'We couldn’t connect to Salesforce. Please verify that you entered the correct Consumer Key and Secret and try again. If you just created your Connected App or edited the Callback URL settings, it may take up to an hour before we can establish a connection.'
+								'We couldn’t connect to Salesforce. Please verify that you entered the correct Consumer Key and Secret and try again. If you just created your Connected App or edited the Callback URL settings, it may take up to an hour before we can establish a connection.', 'newspack'
 							) }
 							isWarning
 						/>
@@ -197,7 +197,7 @@ class Salesforce extends Component {
 					<TextControl
 						disabled={ isConnected }
 						label={
-							( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) + __( ' Salesforce Consumer Key' )
+							( isConnected ? __( 'Your', 'newspack' ) : __( 'Enter your', 'newspack' ) ) + __( ' Salesforce Consumer Key', 'newspack' )
 						}
 						value={ client_id }
 						onChange={ value => {
@@ -210,7 +210,7 @@ class Salesforce extends Component {
 					<TextControl
 						disabled={ isConnected }
 						label={ __(
-							( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) + ' Salesforce Consumer Secret'
+							( isConnected ? __( 'Your', 'newspack' ) : __( 'Enter your', 'newspack' ) ) + __( ' Salesforce Consumer Secret', 'newspack' )
 						) }
 						value={ client_secret }
 						onChange={ value => {

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -18,7 +18,7 @@ import { Component, Fragment } from '@wordpress/element';
  * Internal dependencies.
  */
 import './style.scss';
-import { Notice, TextControl, Waiting, withWizardScreen } from '../../../../components/src';
+import { Notice, TextControl, withWizardScreen } from '../../../../components/src';
 
 /**
  * Salesforce Settings Screen Component
@@ -79,11 +79,8 @@ class Salesforce extends Component {
 				throw new Error( 'Could not retrieve access tokens. Please try connecting again.' );
 			}
 		} catch ( e ) {
-			this.setState( { error: e } );
+			console.error( e );
 		}
-
-		// End fetching state.
-		this.setState( { fetching: false } );
 	}
 
 	/**

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -1,5 +1,5 @@
 /**
- * SalesForce Settings Screen
+ * Salesforce Settings Screen
  */
 
 /**
@@ -10,6 +10,7 @@ import { parse } from 'qs';
 /**
  * WordPress dependencies.
  */
+import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
@@ -21,9 +22,9 @@ import './style.scss';
 import { Notice, TextControl, Waiting, withWizardScreen } from '../../../../components/src';
 
 /**
- * SalesForce Settings Screen Component
+ * Salesforce Settings Screen Component
  */
-class SalesForce extends Component {
+class Salesforce extends Component {
 	/**
 	 * Constructor.
 	 */
@@ -37,10 +38,10 @@ class SalesForce extends Component {
 	}
 
 	/**
-	 * Use auth code to request access and refresh tokens for SalesForce API.
+	 * Use auth code to request access and refresh tokens for Salesforce API.
 	 * Saves tokens to options table.
 	 * https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=5
-	 * @param {string} authorizationCode Auth code fetched from SalesForce.
+	 * @param {string} authorizationCode Auth code fetched from Salesforce.
 	 * @return {void}
 	 */
 	async getTokens( authorizationCode ) {
@@ -74,6 +75,20 @@ class SalesForce extends Component {
 		this.setState( { fetching: false } );
 	}
 
+	async testWebhookHandler() {
+		const response = await apiFetch( {
+			path: '/newspack/v1/salesforce/sync',
+			method: 'POST',
+			data: {
+				Email: 'newlead@hotmail.com',
+				FirstName: 'Hatchet',
+				LastName: 'Sullivan'
+			}
+		} );
+
+		console.log( response );
+	}
+
 	/**
 	 * Render.
 	 */
@@ -84,6 +99,10 @@ class SalesForce extends Component {
 			client_id,
 			client_secret
 		} = data;
+
+		console.log( data );
+
+		this.testWebhookHandler();
 
 		const query = parse( window.location.search );
 		const authorizationCode = query.code;
@@ -115,24 +134,28 @@ class SalesForce extends Component {
 
 					{
 						isConnected ?
-						<Notice noticeText={ __( 'Your site is connected to SalesForce.' ) } isSuccess />
+						<Notice noticeText={ __( 'Your site is connected to Salesforce.' ) } isSuccess />
 						:
 						<Fragment>
 							<p>
-								{ __( 'To connect with SalesForce, create or choose a Connected App for this site in your SalesForce dashboard. ' ) }
+								{ __( 'To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to add the the URL for this page as a Redirect URI in the Connected App’s settings. ' ) }
 								<ExternalLink href="https://help.salesforce.com/articleView?id=connected_app_create.htm">
 									{ __( 'Learn how to create a Connected App' ) }
 								</ExternalLink>
 							</p>
 
-							<p>{ __( 'Once you’ve created or located a Connected App for this site, you’ll find the Consumer Key and Secret under the “API (Enable OAuth Settings)” section in SalesForce.' ) }</p>
+							<p>{ __( 'Once you’ve created or located a Connected App for this site, you’ll find the Consumer Key and Secret under the “API (Enable OAuth Settings)” section in Salesforce.' ) }</p>
 
-							<p>{ __( 'Enter your Consumer Key and Secret below, then click “Connect” to authorize access to your SalesForce account.' ) }</p>
+							<p>{ __( 'Enter your Consumer Key and Secret below, then click “Connect” to authorize access to your Salesforce account.' ) }</p>
 						</Fragment>
 					}
 
+					{ isConnected && (
+						<p>{ __( 'To reconnect your site in case of issues, or to connect to a different Salesforce account, click “Reset" below. You will need to re-enter your Consumer Key and Secret before you can re-connect to Salesforce.' ) }</p>
+					) }
+
 					<TextControl
-						label={ ( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) + __( ' SalesForce Consumer Key' ) }
+						label={ ( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) + __( ' Salesforce Consumer Key' ) }
 						value={ client_id }
 						disabled={ isConnected }
 						onChange={ value => {
@@ -140,7 +163,7 @@ class SalesForce extends Component {
 						} }
 					/>
 					<TextControl
-						label={ __( ( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) +' SalesForce Consumer Secret' ) }
+						label={ __( ( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) +' Salesforce Consumer Secret' ) }
 						value={ client_secret }
 						disabled={ isConnected }
 						onChange={ value =>
@@ -153,9 +176,9 @@ class SalesForce extends Component {
 	}
 }
 
-SalesForce.defaultProps = {
+Salesforce.defaultProps = {
 	data: {},
 	onChange: () => null,
 };
 
-export default withWizardScreen( SalesForce );
+export default withWizardScreen( Salesforce );

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -108,7 +108,8 @@ class Salesforce extends Component {
 			console.error( e );
 			this.setState( {
 				error: __(
-					'We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again.', 'newspack'
+					'We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again.',
+					'newspack'
 				),
 			} );
 		}
@@ -122,7 +123,8 @@ class Salesforce extends Component {
 	async checkToken() {
 		const { wizardApiFetch } = this.props;
 		const error = __(
-			'We couldn’t validate the connection with Salesforce. Please verify the status of the Connected App in Salesforce.', 'newspack'
+			'We couldn’t validate the connection with Salesforce. Please verify the status of the Connected App in Salesforce.',
+			'newspack'
 		);
 
 		try {
@@ -155,14 +157,18 @@ class Salesforce extends Component {
 					{ this.state.error && <Notice noticeText={ this.state.error } isWarning /> }
 
 					{ isConnected && ! this.state.error && (
-						<Notice noticeText={ __( 'Your site is connected to Salesforce.', 'newspack ) } isSuccess />
+						<Notice
+							noticeText={ __( 'Your site is connected to Salesforce.', 'newspack' ) }
+							isSuccess
+						/>
 					) }
 
 					{ ! isConnected && ! this.state.error && (
 						<Fragment>
 							<p>
 								{ __(
-									'To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to paste the the full URL for this page into the “Callback URL” field in the Connected App’s settings. ', 'newspack'
+									'To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to paste the the full URL for this page into the “Callback URL” field in the Connected App’s settings. ',
+									'newspack'
 								) }
 								<ExternalLink href="https://help.salesforce.com/articleView?id=connected_app_create.htm">
 									{ __( 'Learn how to create a Connected App', 'newspack' ) }
@@ -171,7 +177,8 @@ class Salesforce extends Component {
 
 							<p>
 								{ __(
-									'Enter your Consumer Key and Secret below, then click “Connect” to authorize access to your Salesforce account.', 'newspack'
+									'Enter your Consumer Key and Secret below, then click “Connect” to authorize access to your Salesforce account.',
+									'newspack'
 								) }
 							</p>
 						</Fragment>
@@ -180,7 +187,8 @@ class Salesforce extends Component {
 					{ isConnected && (
 						<p>
 							{ __(
-								'To reconnect your site in case of issues, or to connect to a different Salesforce account, click “Reset" below. You will need to re-enter your Consumer Key and Secret before you can re-connect to Salesforce.', 'newspack'
+								'To reconnect your site in case of issues, or to connect to a different Salesforce account, click “Reset" below. You will need to re-enter your Consumer Key and Secret before you can re-connect to Salesforce.',
+								'newspack'
 							) }
 						</p>
 					) }
@@ -188,7 +196,8 @@ class Salesforce extends Component {
 					{ error && (
 						<Notice
 							noticeText={ __(
-								'We couldn’t connect to Salesforce. Please verify that you entered the correct Consumer Key and Secret and try again. If you just created your Connected App or edited the Callback URL settings, it may take up to an hour before we can establish a connection.', 'newspack'
+								'We couldn’t connect to Salesforce. Please verify that you entered the correct Consumer Key and Secret and try again. If you just created your Connected App or edited the Callback URL settings, it may take up to an hour before we can establish a connection.',
+								'newspack'
 							) }
 							isWarning
 						/>
@@ -197,7 +206,8 @@ class Salesforce extends Component {
 					<TextControl
 						disabled={ isConnected }
 						label={
-							( isConnected ? __( 'Your', 'newspack' ) : __( 'Enter your', 'newspack' ) ) + __( ' Salesforce Consumer Key', 'newspack' )
+							( isConnected ? __( 'Your', 'newspack' ) : __( 'Enter your', 'newspack' ) ) +
+							__( ' Salesforce Consumer Key', 'newspack' )
 						}
 						value={ client_id }
 						onChange={ value => {
@@ -210,7 +220,8 @@ class Salesforce extends Component {
 					<TextControl
 						disabled={ isConnected }
 						label={ __(
-							( isConnected ? __( 'Your', 'newspack' ) : __( 'Enter your', 'newspack' ) ) + __( ' Salesforce Consumer Secret', 'newspack' )
+							( isConnected ? __( 'Your', 'newspack' ) : __( 'Enter your', 'newspack' ) ) +
+								__( ' Salesforce Consumer Secret', 'newspack' )
 						) }
 						value={ client_secret }
 						onChange={ value => {

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -10,7 +10,6 @@ import { parse } from 'qs';
 /**
  * WordPress dependencies.
  */
-import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
@@ -33,7 +32,7 @@ class Salesforce extends Component {
 
 		this.state = {
 			error: null,
-			fetching: false
+			fetching: false,
 		};
 	}
 
@@ -41,11 +40,12 @@ class Salesforce extends Component {
 	 * Use auth code to request access and refresh tokens for Salesforce API.
 	 * Saves tokens to options table.
 	 * https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=5
+	 *
 	 * @param {string} authorizationCode Auth code fetched from Salesforce.
 	 * @return {void}
 	 */
 	async getTokens( authorizationCode ) {
-		const { data, onChange, redirectURI, wizardApiFetch } = this.props;
+		const { onChange, redirectURI, wizardApiFetch } = this.props;
 
 		// Init fetching state.
 		this.setState( { fetching: true } );
@@ -57,8 +57,8 @@ class Salesforce extends Component {
 				method: 'POST',
 				data: {
 					code: authorizationCode,
-					redirect_uri: redirectURI
-				}
+					redirect_uri: redirectURI,
+				},
 			} );
 
 			// Update values in parent state.
@@ -67,7 +67,7 @@ class Salesforce extends Component {
 			} else {
 				throw new Error( 'Could not retrieve access tokens. Please try connecting again.' );
 			}
-		} catch( e ) {
+		} catch ( e ) {
 			this.setState( { error: e } );
 		}
 
@@ -81,17 +81,22 @@ class Salesforce extends Component {
 	render() {
 		const { data, isConnected, onChange } = this.props;
 		const { error, fetching } = this.state;
-		const {
-			client_id,
-			client_secret
-		} = data;
+		const { client_id, client_secret } = data;
 
 		const query = parse( window.location.search );
 		const authorizationCode = query.code;
 
 		if ( authorizationCode ) {
 			// Remove param from URL so we don't get stuck in a re-render loop.
-			window.history.replaceState( {}, '', window.location.origin + window.location.pathname + '?page=' + query['?page'] + window.location.hash );
+			window.history.replaceState(
+				{},
+				'',
+				window.location.origin +
+					window.location.pathname +
+					'?page=' +
+					query[ '?page' ] +
+					window.location.hash
+			);
 
 			this.getTokens( authorizationCode );
 		}
@@ -101,43 +106,54 @@ class Salesforce extends Component {
 				<Fragment>
 					<h2>{ __( 'Connected App settings' ) }</h2>
 
-					{
-						fetching && (
-							<div className="newspack_salesforce_loading">
-								<Waiting isLeft />
-								{ __( 'Connecting...', 'newspack' ) }
-							</div>
-						)
-					}
+					{ fetching && (
+						<div className="newspack_salesforce_loading">
+							<Waiting isLeft />
+							{ __( 'Connecting...', 'newspack' ) }
+						</div>
+					) }
 
-					{
-						error && <Notice noticeText={ __( error ) } isWarning />
-					}
+					{ error && <Notice noticeText={ error } isWarning /> }
 
-					{
-						isConnected ?
+					{ isConnected ? (
 						<Notice noticeText={ __( 'Your site is connected to Salesforce.' ) } isSuccess />
-						:
+					) : (
 						<Fragment>
 							<p>
-								{ __( 'To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to add the the URL for this page as a Redirect URI in the Connected App’s settings. ' ) }
+								{ __(
+									'To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to add the the URL for this page as a Redirect URI in the Connected App’s settings. '
+								) }
 								<ExternalLink href="https://help.salesforce.com/articleView?id=connected_app_create.htm">
 									{ __( 'Learn how to create a Connected App' ) }
 								</ExternalLink>
 							</p>
 
-							<p>{ __( 'Once you’ve created or located a Connected App for this site, you’ll find the Consumer Key and Secret under the “API (Enable OAuth Settings)” section in Salesforce.' ) }</p>
+							<p>
+								{ __(
+									'Once you’ve created or located a Connected App for this site, you’ll find the Consumer Key and Secret under the “API (Enable OAuth Settings)” section in Salesforce.'
+								) }
+							</p>
 
-							<p>{ __( 'Enter your Consumer Key and Secret below, then click “Connect” to authorize access to your Salesforce account.' ) }</p>
+							<p>
+								{ __(
+									'Enter your Consumer Key and Secret below, then click “Connect” to authorize access to your Salesforce account.'
+								) }
+							</p>
 						</Fragment>
-					}
+					) }
 
 					{ isConnected && (
-						<p>{ __( 'To reconnect your site in case of issues, or to connect to a different Salesforce account, click “Reset" below. You will need to re-enter your Consumer Key and Secret before you can re-connect to Salesforce.' ) }</p>
+						<p>
+							{ __(
+								'To reconnect your site in case of issues, or to connect to a different Salesforce account, click “Reset" below. You will need to re-enter your Consumer Key and Secret before you can re-connect to Salesforce.'
+							) }
+						</p>
 					) }
 
 					<TextControl
-						label={ ( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) + __( ' Salesforce Consumer Key' ) }
+						label={
+							( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) + __( ' Salesforce Consumer Key' )
+						}
 						value={ client_id }
 						disabled={ isConnected }
 						onChange={ value => {
@@ -145,12 +161,12 @@ class Salesforce extends Component {
 						} }
 					/>
 					<TextControl
-						label={ __( ( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) +' Salesforce Consumer Secret' ) }
+						label={ __(
+							( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) + ' Salesforce Consumer Secret'
+						) }
 						value={ client_secret }
 						disabled={ isConnected }
-						onChange={ value =>
-							onChange( { ...data, client_secret: value } )
-						}
+						onChange={ value => onChange( { ...data, client_secret: value } ) }
 					/>
 				</Fragment>
 			</div>

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -120,7 +120,7 @@ class Salesforce extends Component {
 	 * or the Connected App is deleted there.
 	 */
 	async checkToken() {
-		const { data, wizardApiFetch } = this.props;
+		const { wizardApiFetch } = this.props;
 		const error = __(
 			'We couldn’t validate the connection with Salesforce. Please verify the status of the Connected App in Salesforce.'
 		);

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -142,7 +142,7 @@ class Salesforce extends Component {
 					{ error && (
 						<Notice
 							noticeText={ __(
-								'We couldn’t connect to Salesforce. Please verify that you entered the correct Consumer Key and Secret and try again. If you just created your Connected App or edited the Callback URL settings, it may take at least 10 minutes before we can establish a connection.'
+								'We couldn’t connect to Salesforce. Please verify that you entered the correct Consumer Key and Secret and try again. If you just created your Connected App or edited the Callback URL settings, it may take up to an hour before we can establish a connection.'
 							) }
 							isWarning
 						/>

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -90,7 +90,8 @@ class Salesforce extends Component {
 		} catch ( e ) {
 			console.error( e );
 			this.setState( {
-				error: 'Could not establish a connection to Salesforce. Please try connecting again.',
+				error:
+					'We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again.',
 			} );
 		}
 	}
@@ -115,17 +116,11 @@ class Salesforce extends Component {
 						<Fragment>
 							<p>
 								{ __(
-									'To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to add the the URL for this page as a Redirect URI in the Connected App’s settings. '
+									'To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to paste the the full URL for this page into the “Callback URL” field in the Connected App’s settings. '
 								) }
 								<ExternalLink href="https://help.salesforce.com/articleView?id=connected_app_create.htm">
 									{ __( 'Learn how to create a Connected App' ) }
 								</ExternalLink>
-							</p>
-
-							<p>
-								{ __(
-									'Once you’ve created or located a Connected App for this site, you’ll find the Consumer Key and Secret under the “API (Enable OAuth Settings)” section in Salesforce.'
-								) }
 							</p>
 
 							<p>
@@ -147,7 +142,7 @@ class Salesforce extends Component {
 					{ error && (
 						<Notice
 							noticeText={ __(
-								'We couldn’t connect to Salesforce. Please verify that you entered the correct Consumer Key and Secret and try again.'
+								'We couldn’t connect to Salesforce. Please verify that you entered the correct Consumer Key and Secret and try again. If you just created your Connected App or edited the Callback URL settings, it may take at least 10 minutes before we can establish a connection.'
 							) }
 							isWarning
 						/>

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -1,0 +1,89 @@
+/**
+ * SalesForce Settings Screen
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import { Notice, TextControl, withWizardScreen } from '../../../../components/src';
+
+/**
+ * SalesForce Settings Screen Component
+ */
+class SalesForce extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { data, isConnected, onChange } = this.props;
+		const {
+			client_id,
+			client_secret,
+			access_token,
+			refresh_token
+		} = data;
+
+		return (
+			<div className="newspack-salesforce-wizard">
+				<Fragment>
+					<h2>{ __( 'Connected App settings' ) }</h2>
+
+					{
+						! isConnected && ( client_id || client_secret ) && (
+							<Notice noticeText={ __( 'Your site is not connected to SalesForce. Verify your Consumer Key and Secret, then click “Connect” to complete setup.' ) } isWarning />
+						)
+					}
+
+					{
+						isConnected ?
+						<Notice noticeText={ __( 'Your site is connected to SalesForce.' ) } isSuccess />
+						:
+						<Fragment>
+							<p>
+								{ __( 'To connect with SalesForce, create or choose a Connected App for this site in your SalesForce dashboard. ' ) }
+								<ExternalLink href="https://help.salesforce.com/articleView?id=connected_app_create.htm">
+									{ __( 'Learn how to create a Connected App' ) }
+								</ExternalLink>
+							</p>
+
+							<p>{ __( 'Once you’ve created or located a Connected App for this site, you’ll find the Consumer Key and Secret under the “API (Enable OAuth Settings)” section in SalesForce.' ) }</p>
+
+							<p>{ __( 'Enter your Consumer Key and Secret below, then click “Connect” to authorize access to your SalesForce account.' ) }</p>
+						</Fragment>
+					}
+
+					<TextControl
+						label={ ( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) + __( ' SalesForce Consumer Key' ) }
+						value={ client_id }
+						disabled={ isConnected }
+						onChange={ value => {
+							onChange( { ...data, client_id: value } );
+						} }
+					/>
+					<TextControl
+						label={ __( ( isConnected ? __( 'Your' ) : __( 'Enter your' ) ) +' SalesForce Consumer Secret' ) }
+						value={ client_secret }
+						disabled={ isConnected }
+						onChange={ value =>
+							onChange( { ...data, client_secret: value } )
+						}
+					/>
+				</Fragment>
+			</div>
+		);
+	}
+}
+
+SalesForce.defaultProps = {
+	data: {},
+	onChange: () => null,
+};
+
+export default withWizardScreen( SalesForce );

--- a/assets/wizards/readerRevenue/views/salesforce/style.scss
+++ b/assets/wizards/readerRevenue/views/salesforce/style.scss
@@ -1,0 +1,5 @@
+.newspack_salesforce_loading {
+	align-items: center;
+	display: flex;
+	margin: 32px 0;
+}

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -92,6 +92,7 @@ final class Newspack {
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-handoff-banner.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-donations.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-salesforce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-pwa.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-starter-content.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-amp-enhancements.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -96,6 +96,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-pwa.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-starter-content.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-amp-enhancements.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-webhooks.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-settings.php';
 

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -99,7 +99,7 @@ class Salesforce {
 		}
 
 		// If we're resetting, let's delete the existing webhook, if it exists.
-		if ( ! empty( $webhook_id ) && '' === $args['refresh_token'] ) {
+		if ( ! empty( $webhook_id ) && isset( $args['refresh_token'] ) && '' === $args['refresh_token'] ) {
 			self::delete_webhook( $webhook_id );
 		}
 

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -188,6 +188,7 @@ class Salesforce {
 
 		return $fields_to_update;
 	}
+
 	/**
 	 * Look up existing Lead records by email address.
 	 *

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -62,10 +62,21 @@ class SalesForce {
 		$defaults = self::DEFAULT_SETTINGS;
 		$args     = wp_parse_args( $args, $defaults );
 
-		update_option( self::SALESFORCE_CLIENT_ID, $args['client_id'] );
-		update_option( self::SALESFORCE_CLIENT_SECRET, $args['client_secret'] );
-		update_option( self::SALESFORCE_ACCESS_TOKEN, $args['access_token'] );
-		update_option( self::SALESFORCE_REFRESH_TOKEN, $args['refresh_token'] );
+		if ( array_key_exists( 'client_id', $args ) ) {
+			update_option( self::SALESFORCE_CLIENT_ID, $args['client_id'] );
+		}
+
+		if ( array_key_exists( 'client_secret', $args ) ) {
+			update_option( self::SALESFORCE_CLIENT_SECRET, $args['client_secret'] );
+		}
+
+		if ( array_key_exists( 'access_token', $args ) ) {
+			update_option( self::SALESFORCE_ACCESS_TOKEN, $args['access_token'] );
+		}
+
+		if ( array_key_exists( 'refresh_token', $args ) ) {
+			update_option( self::SALESFORCE_REFRESH_TOKEN, $args['refresh_token'] );
+		}
 
 		return self::get_salesforce_settings();
 	}

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -117,7 +117,7 @@ class Salesforce {
 		$webhook->set_topic( 'order.created' ); // Trigger on checkout.
 		$webhook->set_delivery_url( NEWSPACK_API_URL . '/salesforce/sync' );
 		$webhook->set_status( 'active' );
-		$webhook->set_secret( 'newspack' );
+		$webhook->set_user_id( get_current_user_id() );
 		$webhook->save();
 		$webhook_id = $webhook->get_id();
 

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Newspack SalesForce features management.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles SalesForce functionality.
+ */
+class SalesForce {
+	const SALESFORCE_CLIENT_ID     = 'newspack_salesforce_client_id';
+	const SALESFORCE_CLIENT_SECRET = 'newspack_salesforce_client_secret';
+	const SALESFORCE_ACCESS_TOKEN  = 'newspack_salesforce_access_token';
+	const SALESFORCE_REFRESH_TOKEN = 'newspack_salesforce_refresh_token';
+	const DEFAULT_SETTINGS         = [
+		'client_id'     => '',
+		'client_secret' => '',
+		'access_token'  => '',
+		'refresh_token' => '',
+	];
+
+	/**
+	 * Get the SalesForce settings.
+	 *
+	 * @return Array of SalesForce settings.
+	 */
+	public static function get_salesforce_settings() {
+		$settings = self::DEFAULT_SETTINGS;
+
+		$client_id = get_option( self::SALESFORCE_CLIENT_ID, 0 );
+		if ( ! empty( $client_id ) ) {
+			$settings['client_id'] = $client_id;
+		}
+		$client_secret = get_option( self::SALESFORCE_CLIENT_SECRET, 0 );
+		if ( ! empty( $client_secret ) ) {
+			$settings['client_secret'] = $client_secret;
+		}
+		$access_token = get_option( self::SALESFORCE_ACCESS_TOKEN, 0 );
+		if ( ! empty( $access_token ) ) {
+			$settings['access_token'] = $access_token;
+		}
+		$refresh_token = get_option( self::SALESFORCE_REFRESH_TOKEN, 0 );
+		if ( ! empty( $refresh_token ) ) {
+			$settings['refresh_token'] = $refresh_token;
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Set the SalesForce settings.
+	 *
+	 * @param array $args Array of settings info.
+	 * @return array Updated settings.
+	 */
+	public static function set_salesforce_settings( $args ) {
+		$defaults = self::DEFAULT_SETTINGS;
+		$args     = wp_parse_args( $args, $defaults );
+
+		update_option( self::SALESFORCE_CLIENT_ID, $args['client_id'] );
+		update_option( self::SALESFORCE_CLIENT_SECRET, $args['client_secret'] );
+		update_option( self::SALESFORCE_ACCESS_TOKEN, $args['access_token'] );
+		update_option( self::SALESFORCE_REFRESH_TOKEN, $args['refresh_token'] );
+
+		return self::get_salesforce_settings();
+	}
+}

--- a/includes/class-webhooks.php
+++ b/includes/class-webhooks.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Newspack webhooks management.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Define, deliver, and handle webhooks.
+ */
+class Webhooks {
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->salesforce_settings = Salesforce::get_salesforce_settings();
+
+		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+		add_action( 'woocommerce_loaded', [ $this, 'create_woo_webhooks' ] );
+	}
+
+	/**
+	 * Webhooks for WooCommerce.
+	 */
+	public function create_woo_webhooks() {
+		if ( ! empty( $this->salesforce_settings['refresh_token'] ) && ! empty( $this->salesforce_settings['instance_url'] ) ) {
+			$webhook = new \WC_Webhook();
+			$webhook->set_topic( 'order.created' ); // Trigger on checkout.
+			$webhook->set_delivery_url( NEWSPACK_API_NAMESPACE . '/salesforce/sync' );
+			$webhook->set_status( 'active' );
+			$webhook->save();
+		}
+	}
+
+	/**
+	 * Register the endpoints needed to handle webhooks.
+	 */
+	public function register_api_endpoints() {
+
+		// Handle WooCommerce webhook to sync with Salesforce.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/salesforce/sync',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_sync_salesforce' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'email' => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Webhook callback handler for syncing data to Salesforce.
+	 *
+	 * @param WP_REST_Request $request Request containing webhook.
+	 * @throws \Exception Error message.
+	 * @return WP_REST_Response with the response from Salesforce.
+	 */
+	public function api_sync_salesforce( $request ) {
+		$args             = $request->get_params();
+		$fields_to_update = Salesforce::parse_update_data( $args );
+
+		if ( empty( $args['Email'] ) ) {
+			throw new \Exception( 'Please provide a valid email address to query with.' );
+		}
+
+		$leads = Salesforce::get_leads_by_email( $args['Email'] );
+
+		if ( $leads->totalSize > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			// Update existing lead.
+			$response = Salesforce::update_lead( $leads->records[0]->Id, $fields_to_update );
+		} else {
+			// Create new lead.
+			$response = Salesforce::create_lead( $fields_to_update );
+		}
+
+		return \rest_ensure_response( $response );
+	}
+
+	/**
+	 * Check capabilities for using API.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return bool|WP_Error
+	 */
+	public function api_permissions_check( $request ) {
+		if ( ! current_user_can( $this->capability ) ) {
+			return new \WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				[
+					'status' => 403,
+				]
+			);
+		}
+		return true;
+	}
+}
+
+new Webhooks();

--- a/includes/class-webhooks.php
+++ b/includes/class-webhooks.php
@@ -27,20 +27,6 @@ class Webhooks {
 		$this->salesforce_settings = Salesforce::get_salesforce_settings();
 
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
-		add_action( 'woocommerce_loaded', [ $this, 'create_woo_webhooks' ] );
-	}
-
-	/**
-	 * Webhooks for WooCommerce.
-	 */
-	public function create_woo_webhooks() {
-		if ( ! empty( $this->salesforce_settings['refresh_token'] ) && ! empty( $this->salesforce_settings['instance_url'] ) ) {
-			$webhook = new \WC_Webhook();
-			$webhook->set_topic( 'order.created' ); // Trigger on checkout.
-			$webhook->set_delivery_url( NEWSPACK_API_NAMESPACE . '/salesforce/sync' );
-			$webhook->set_status( 'active' );
-			$webhook->save();
-		}
 	}
 
 	/**

--- a/includes/class-webhooks.php
+++ b/includes/class-webhooks.php
@@ -60,14 +60,17 @@ class Webhooks {
 			return \rest_ensure_response( 'No valid email address.' );
 		}
 
-		$leads = Salesforce::get_leads_by_email( $fields_to_update['Email'] );
+		$contacts = Salesforce::get_contacts_by_email( $fields_to_update['Email'] );
 
-		if ( $leads->totalSize > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			// Update existing lead.
-			$response = Salesforce::update_lead( $leads->records[0]->Id, $fields_to_update );
+		if ( $contacts->totalSize > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			// Update existing contact.
+			if ( ! empty( $contacts->records[0]->Description && ! empty( $fields_to_update['Description'] ) ) ) {
+				$fields_to_update['Description'] .= "\n" . $contacts->records[0]->Description; // Update line items.
+			}
+			$response = Salesforce::update_contact( $contacts->records[0]->Id, $fields_to_update );
 		} else {
-			// Create new lead.
-			$response = Salesforce::create_lead( $fields_to_update );
+			// Create new contact.
+			$response = Salesforce::create_contact( $fields_to_update );
 		}
 
 		return \rest_ensure_response( $response );

--- a/includes/util.php
+++ b/includes/util.php
@@ -10,6 +10,7 @@ namespace Newspack;
 defined( 'ABSPATH' ) || exit;
 
 define( 'NEWSPACK_API_NAMESPACE', 'newspack/v1' );
+define( 'NEWSPACK_API_URL', get_site_url() . '/wp-json/' . NEWSPACK_API_NAMESPACE );
 
 /**
  * Clean variables using sanitize_text_field. Arrays are cleaned recursively.

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -181,6 +181,31 @@ class Reader_Revenue_Wizard extends Wizard {
 			]
 		);
 
+		// Save SalesForce settings.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/salesforce/',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_salesforce_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'client_id'     => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'client_secret' => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'access_token'  => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'refresh_token' => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/newspack-donations-wizard/donation/',
@@ -314,6 +339,20 @@ class Reader_Revenue_Wizard extends Wizard {
 	}
 
 	/**
+	 * API endpoint for setting SalesForce settings.
+	 *
+	 * @param WP_REST_Request $request Request containing settings.
+	 * @return WP_REST_Response with the latest settings.
+	 */
+	public function api_update_salesforce_settings( $request ) {
+		$salesforce_response = SalesForce::set_salesforce_settings( $request->get_params() );
+		if ( is_wp_error( $salesforce_response ) ) {
+			return rest_ensure_response( $salesforce_response );
+		}
+		return \rest_ensure_response( $this->fetch_all_data() );
+	}
+
+	/**
 	 * Fetch all data needed to render the Wizard
 	 *
 	 * @return Array
@@ -327,6 +366,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			'stripe_data'          => $wc_configuration_manager->stripe_data(),
 			'donation_data'        => Donations::get_donation_settings(),
 			'donation_page'        => Donations::get_donation_page_info(),
+			'salesforce_settings'  => SalesForce::get_salesforce_settings(),
 		];
 	}
 

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -181,7 +181,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			]
 		);
 
-		// Save SalesForce settings.
+		// Save Salesforce settings.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/salesforce/',
@@ -206,7 +206,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			]
 		);
 
-		// Get access and refresh tokens from SalesForce.
+		// Get access and refresh tokens from Salesforce.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/salesforce/tokens',
@@ -361,13 +361,13 @@ class Reader_Revenue_Wizard extends Wizard {
 	}
 
 	/**
-	 * API endpoint for setting SalesForce settings.
+	 * API endpoint for setting Salesforce settings.
 	 *
 	 * @param WP_REST_Request $request Request containing settings.
 	 * @return WP_REST_Response with the latest settings.
 	 */
 	public function api_update_salesforce_settings( $request ) {
-		$salesforce_response = SalesForce::set_salesforce_settings( $request->get_params() );
+		$salesforce_response = Salesforce::set_salesforce_settings( $request->get_params() );
 		if ( is_wp_error( $salesforce_response ) ) {
 			return rest_ensure_response( $salesforce_response );
 		}
@@ -375,7 +375,7 @@ class Reader_Revenue_Wizard extends Wizard {
 	}
 
 	/**
-	 * API endpoint for getting SalesForce API tokens.
+	 * API endpoint for getting Salesforce API tokens.
 	 *
 	 * @param WP_REST_Request $request Request containing settings.
 	 * @throws \Exception Error message.
@@ -383,14 +383,14 @@ class Reader_Revenue_Wizard extends Wizard {
 	 */
 	public function api_get_salesforce_tokens( $request ) {
 		$args                = $request->get_params();
-		$salesforce_settings = SalesForce::get_salesforce_settings();
+		$salesforce_settings = Salesforce::get_salesforce_settings();
 
 		// Must have a valid API key and secret.
 		if ( empty( $salesforce_settings['client_id'] ) || empty( $salesforce_settings['client_secret'] ) ) {
 			throw new \Exception( 'Invalid Consumer Key or Secret.' );
 		}
 
-		// Hit SalesForce OAuth endpoint to request API tokens.
+		// Hit Salesforce OAuth endpoint to request API tokens.
 		$salesforce_response = wp_safe_remote_post(
 			'https://login.salesforce.com/services/oauth2/token?' . http_build_query(
 				array(
@@ -410,7 +410,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			$update_args = wp_parse_args( $response_body, $salesforce_settings );
 
 			// Save tokens.
-			$update_response = SalesForce::set_salesforce_settings( $update_args );
+			$update_response = Salesforce::set_salesforce_settings( $update_args );
 			if ( is_wp_error( $update_response ) ) {
 				return \rest_ensure_response( $update_response );
 			}
@@ -433,7 +433,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			'stripe_data'          => $wc_configuration_manager->stripe_data(),
 			'donation_data'        => Donations::get_donation_settings(),
 			'donation_page'        => Donations::get_donation_page_info(),
-			'salesforce_settings'  => SalesForce::get_salesforce_settings(),
+			'salesforce_settings'  => Salesforce::get_salesforce_settings(),
 		];
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a Salesforce config view to the Reader Revenue wizard which allows admin users to connect a Salesforce org via the SF [OAuth 2.0 web server flow](https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=5).

When the Newspack site is successfully connected to a Salesforce org, a WooCommerce webhook is generated which will trigger a data sync every time a donation order is created. This webhook is deleted if the Salesforce config is reset.

When an order is created, the webhook fires a request which includes order and billing details. This data is then synced to the connected Salesforce org via the Salesforce REST API. Lead records are looked up by email address and if there's an existing Lead record in SF, donor details are added to that record. If there isn't an existing Lead record, one is created. More details on the SalesForce API here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm

<img width="701" alt="Screen Shot 2020-06-05 at 3 35 18 PM" src="https://user-images.githubusercontent.com/2230142/83924586-35c4ee00-a742-11ea-8f2b-6e3886a075c9.png">

At this stage, this is a proof-of-concept implementation, so I'd like to request feedback on the overall approach as well as the UI and where in the wizard it lives, etc. before I consider it ready for a full review/merge. We may want to split this out into an entirely new wizard (Customer Retention?), but for now, the existing Reader Revenue wizard seemed like the best home for this.

I have not tested this in browsers other than Chrome so far, nor written automated tests for this functionality. So far I've only tested it in a fully setup Newspack site, not as part of a new site setup.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Pull and build this branch to a local Newspack site environment. Run `npm install && npm run dev` to rebuild JS.
2. Visit the Reader Revenue wizard to find the Configure SalesForce page.
3. Sign up for a new SalesForce Developer Org: https://developer.salesforce.com/signup
4. Once your org has been created, follow these instructions to create a new Connected App: https://help.salesforce.com/articleView?id=connected_app_create.htm
  - In short, go to Setup > Apps > App Manager > New Connected App and fill out the form, making sure to enable OAuth settings with the following capabilities: api, refresh_token, offline_access, web
  - Make sure to paste the URL for your Configure SalesForce page into the "Redirect URI" field. This whitelists the URL for use in the OAuth flow, otherwise SalesForce will block access to the login/allow screens in the next few steps.
5. Note the Consumer Key and Consumer Secret strings that are generated in the created Connected App page.
6. In the Configure SalesForce page, enter your Connected App's Consumer Key and Secret into the text fields. The "Connect" button should become available after both fields contain values.
7. After clicking "Connect," you should be redirected to a SalesForce login page (if not already logged in with the same browser), or to an "Allow Access?" page. Click Allow to grant access.
8. You will be redirected back to the wizard page on the Newspack site with an authorization code appended to the URL. The app should automatically fetch API access and refresh tokens using the auth code, then clear the `code` param from the URL.
9. In theory, the site can now use the `access_token` to make requests to the SalesForce org via REST API, or use the `refresh_token` to fetch new `access_token` values.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->