### PR TITLE
fix: remove trailing slash in namespace in rest routes

### DIFF
--- a/includes/class-profile.php
+++ b/includes/class-profile.php
@@ -84,7 +84,7 @@ class Profile {
 		// Get profile data.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/profile/',
+			'/profile',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_profile' ],
@@ -95,7 +95,7 @@ class Profile {
 		// Update profile data.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/profile/',
+			'/profile',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_profile' ],

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -105,7 +105,7 @@ class Advertising_Wizard extends Wizard {
 		// Get all Newspack advertising data.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/',
+			'/wizard/advertising',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_advertising' ],
@@ -572,7 +572,7 @@ class Advertising_Wizard extends Wizard {
 
 		?>
 		<div class='newspack_global_ad <?php echo esc_attr( $placement_slug ); ?>'>
-			<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
+			<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</div>
 		<?php
 	}

--- a/includes/wizards/class-health-check-wizard.php
+++ b/includes/wizards/class-health-check-wizard.php
@@ -83,7 +83,7 @@ class Health_Check_Wizard extends Wizard {
 		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/repair/(?P<configuration>[\a-z]+)/',
+			'/wizard/' . $this->slug . '/repair/(?P<configuration>[\a-z]+)',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_repair_configuration' ],

--- a/includes/wizards/class-payment-wizard.php
+++ b/includes/wizards/class-payment-wizard.php
@@ -54,7 +54,7 @@ class Payment_Wizard extends Wizard {
 		// Get data about Stripe customer/subscription.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/newspack-payment-wizard/',
+			'/wizard/newspack-payment-wizard',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_stripe_data' ],

--- a/includes/wizards/class-performance-wizard.php
+++ b/includes/wizards/class-performance-wizard.php
@@ -71,7 +71,7 @@ class Performance_Wizard extends Wizard {
 	public function register_api_endpoints() {
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/performance/',
+			'/wizard/performance',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_settings' ],
@@ -80,7 +80,7 @@ class Performance_Wizard extends Wizard {
 		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/performance/',
+			'/wizard/performance',
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'api_update_settings' ],

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -86,7 +86,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		// Save location info.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/location/',
+			'/wizard/' . $this->slug . '/location',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_location' ],
@@ -122,7 +122,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		// Save Stripe info.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/stripe/',
+			'/wizard/' . $this->slug . '/stripe',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_stripe_settings' ],
@@ -153,7 +153,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		// Save a subscription.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/donations/',
+			'/wizard/' . $this->slug . '/donations',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_donation_settings' ],
@@ -183,7 +183,7 @@ class Reader_Revenue_Wizard extends Wizard {
 
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/newspack-donations-wizard/donation/',
+			'/wizard/newspack-donations-wizard/donation',
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'api_get_donation_settings' ],


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As of WordPress 5.4.2 Namespaces with trailing slashes throw warnings.

### How to test the changes in this Pull Request:

1. Verify no warnings.
2. Verify endpoints work as before.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->