### PR TITLE
Analytics: add NTG tracking events for newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![newspack-plugin](https://circleci.com/gh/Automattic/newspack-plugin/tree/master.svg?style=shield)](https://circleci.com/gh/Automattic/newspack-plugin)
 
-Welcome to the Newspack plugin repository on GitHub. Here you can browse the source, look at open issues and keep track of development. We also recommend everyone [follow the Newspack blog](https://newspack.blog/) to stay up to date about everything happening in the project.
+Welcome to the Newspack plugin repository on GitHub. Here you can browse the source, look at open issues and keep track of development. We also recommend everyone [follow the Newspack blog](https://newspack.pub/) to stay up to date about everything happening in the project.
 
 The Newspack plugin provides tools and guidance for setting up and managing the important features and plugins a modern newsroom needs.
 
@@ -38,6 +38,12 @@ define('NEWSPACK_WPCOM_CLIENT_ID', '12345');
 // payments
 define( 'NEWSPACK_STRIPE_PLAN', 'plan_...' );
 ```
+
+## News Consumer Insights integration
+
+[News Consumer Insights](https://newsinitiative.withgoogle.com/training/datatools) is a Google Analytics based solution for measuring performance of site audience using benchmarks and getting actionable recommendations to improve business gaps.
+
+This plugin reports NCI events to a Google Analytics account, if one is connected via the Site Kit plugin. We're working on supporting [all applicable NCI events](https://newsinitiative.withgoogle.com/training/states/ntg/assets/ntg-playbook.pdf#page=245). The implementation is in `includes/class-analytics.php` file.
 
 ## Support or Questions
 

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -352,7 +352,7 @@ class Analytics {
 		?>
 		<script>
 			( function() {
-				window.viewedElements = window.viewedElements || [];
+				window.newspackViewedElements = window.newspackViewedElements || [];
 				window.newspackCheckVisibility = window.newspackCheckVisibility || function( el ) {
 					var rect = el.getBoundingClientRect();
 
@@ -369,9 +369,8 @@ class Analytics {
 
 				var reportEvent = function() {
 					for ( var i = 0; i < elements.length; ++i ) {
-						if ( window.newspackCheckVisibility( elements[i] ) && -1 === window.viewedElements.indexOf( elements[i] ) ) {
-							console.log( 'viewed', elements );
-							window.viewedElements.push( elements[i] );
+						if ( window.newspackCheckVisibility( elements[i] ) && -1 === window.newspackViewedElements.indexOf( elements[i] ) ) {
+							window.newspackViewedElements.push( elements[i] );
 
 							gtag(
 								'event',

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -113,7 +113,7 @@ class Analytics {
 				'id'             => 'newsletterSignup',
 				'amp_on'         => 'amp-form-submit-success',
 				'on'             => 'submit',
-				'element'        => '#mailchimp_form',
+				'element'        => '#mailchimp_form, .wp-block-jetpack-mailchimp form',
 				'event_name'     => 'newsletter signup',
 				'event_label'    => 'success',
 				'event_category' => 'NTG newsletter',

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -101,11 +101,22 @@ class Analytics {
 				'on'             => 'scroll',
 				'event_name'     => '100%',
 				'event_value'    => 100,
-				'event_label'    => get_the_title(),
+				'event_label'    => 'success',
 				'event_category' => 'NTG article milestone',
 				'scrollSpec'     => [
 					'verticalBoundaries' => [ 100 ],
 				],
+			],
+
+			// Newsletters.
+			[
+				'id'             => 'newsletterSignup',
+				'amp_on'         => 'amp-form-submit-success',
+				'on'             => 'submit',
+				'element'        => '#mailchimp_form',
+				'event_name'     => 'newsletter signup',
+				'event_label'    => 'success',
+				'event_category' => 'NTG newsletter',
 			],
 		];
 
@@ -191,6 +202,9 @@ class Analytics {
 				case 'scroll':
 					self::output_js_scroll_event( $event );
 					break;
+				case 'submit':
+					self::output_js_submit_event( $event );
+					break;
 				default:
 					break;
 			}
@@ -267,6 +281,35 @@ class Analytics {
 				// Fire initially - page might be loaded with scroll offset.
 				reportEvent()
 				window.addEventListener( 'scroll', reportEvent );
+			} )();
+		</script>
+		<?php
+	}
+
+	/**
+	 * Output JS for a form submit-based event listener.
+	 *
+	 * @param array $event Event info. See 'get_events'.
+	 */
+	protected static function output_js_submit_event( $event ) {
+		?>
+		<script>
+			( function() {
+				var elementSelector = '<?php echo esc_attr( $event['element'] ); ?>';
+				var elements        = Array.prototype.slice.call( document.querySelectorAll( elementSelector ) );
+
+				for ( var i = 0; i < elements.length; ++i ) {
+					elements[i].addEventListener( 'submit', function() {
+						gtag(
+							'event',
+							'<?php echo esc_attr( $event['event_name'] ); ?>',
+							{
+								event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
+								event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+							}
+						);
+					} );
+				}
 			} )();
 		</script>
 		<?php

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -127,9 +127,6 @@ class Analytics {
 				'event_name'     => 'newsletter modal impression 1', // 1: overlay/lightbox
 				'event_label'    => get_the_title(),
 				'event_category' => 'NTG newsletter',
-				'visibilitySpec' => [
-					'totalTimeMin' => 500,
-				],
 			],
 			[
 				'id'             => 'newsletterImpression',
@@ -139,9 +136,6 @@ class Analytics {
 				'event_name'     => 'newsletter modal impression 2', // 2: inline prompt
 				'event_label'    => get_the_title(),
 				'event_category' => 'NTG newsletter',
-				'visibilitySpec' => [
-					'totalTimeMin' => 500,
-				],
 			],
 		];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add additional NTG events as described in the [NTG Playbook](https://newsinitiative.withgoogle.com/training/states/ntg/assets/ntg-playbook.pdf), in order to achieve full NCI support. This will close Issue #559.

Note that this functionality depends on https://github.com/Automattic/newspack-popups/pull/156 in the newspack-popups plugin.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Create an inline or overlay campaign containing a Mailchimp newsletter form block. Ensure that it's Active and viewable in a non-logged-in state (e.g. Active and On Every Page).
2. Open a post or page in a new incognito window.
3. Open the Network tab in dev tools. Filter by "ntg" to see only new requests containing "ntg".
4. Scroll down to the campaign (or wait until the overlay campaign appears). The event should fire only once and only when any part of the element first becomes visible within the viewport. Observe an NTG event request in the Network tab that looks something like this (important part is the `NTG%20newsletter&ea=newsletter%20modal%20impression%201` string: https://www.google-analytics.com/collect?v=1&_v=j83&aip=1&a=2091212415&t=event&_s=5&dl=http%3A%2F%2Fnewspack-dkoo.ngrok.io%2Fnon-consequat-commodo-eros-justo-vulputate-potenti%2F&ul=en-us&de=UTF-8&dt=Non%20consequat%20commodo%20eros%20justo%20vulputate%20potenti%20-%20Newspack&sd=30-bit&sr=1792x1120&vp=1303x1018&je=0&ec=NTG%20newsletter&ea=newsletter%20modal%20impression%201&el=Non%20consequat%20commodo%20eros%20justo%20vulputate%20potenti&_u=CCCACUABB~&jid=&gjid=&cid=305040532.1592848697&tid=UA-169138974-1&_gid=1339759271.1592848697&gtm=2ou6a0&z=2058936163
5. Enter a fake email address and submit the form. Observe an NTG event request in the Network tab that looks something like this (important part is the `NTG%20newsletter&ea=newsletter%20signup` string): https://www.google-analytics.com/r/collect?v=1&_v=j83&aip=1&a=2091212415&t=event&_s=6&dl=http%3A%2F%2Fnewspack-dkoo.ngrok.io%2Fnon-consequat-commodo-eros-justo-vulputate-potenti%2F&ul=en-us&de=UTF-8&dt=Non%20consequat%20commodo%20eros%20justo%20vulputate%20potenti%20-%20Newspack&sd=30-bit&sr=1792x1120&vp=1303x1018&je=0&ec=NTG%20newsletter&ea=newsletter%20signup&el=success&_u=CCCACUABB~&jid=1215251838&gjid=1120199689&cid=305040532.1592848697&tid=UA-169138974-1&_gid=1339759271.1592848697&_r=1&gtm=2ou6a0&z=1924980601
6. If you've connected your local Newspack environment to Site Kit and a Google Analytics account, after several hours you should see these events being reported in the analytics dashboard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->