### PR TITLE
Analytics: add non-AMP submit, ini-load events handling

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -191,6 +191,9 @@ class Analytics {
 				case 'scroll':
 					self::output_js_scroll_event( $event );
 					break;
+				case 'submit':
+					self::output_js_submit_event( $event );
+					break;
 				default:
 					break;
 			}
@@ -267,6 +270,35 @@ class Analytics {
 				// Fire initially - page might be loaded with scroll offset.
 				reportEvent()
 				window.addEventListener( 'scroll', reportEvent );
+			} )();
+		</script>
+		<?php
+	}
+
+	/**
+	 * Output JS for a form submit-based event listener.
+	 *
+	 * @param array $event Event info. See 'get_events'.
+	 */
+	protected static function output_js_submit_event( $event ) {
+		?>
+		<script>
+			( function() {
+				var elementSelector = '<?php echo esc_attr( $event['element'] ); ?>';
+				var elements        = Array.prototype.slice.call( document.querySelectorAll( elementSelector ) );
+
+				for ( var i = 0; i < elements.length; ++i ) {
+					elements[i].addEventListener( 'submit', function() {
+						gtag(
+							'event',
+							'<?php echo esc_attr( $event['event_name'] ); ?>',
+							{
+								event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
+								event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+							}
+						);
+					} );
+				}
 			} )();
 		</script>
 		<?php

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -332,6 +332,7 @@ class Analytics {
 						{
 							event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
 							event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+							non_interaction: true,
 						}
 					);
 				};

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -182,7 +182,15 @@ class Analytics {
 			return;
 		}
 
-		foreach ( self::get_events() as $event ) {
+		// Discard events with duplicate ids.
+		$all_events   = self::get_events();
+		$unique_array = [];
+		foreach ( $all_events as $element ) {
+			$hash                  = $element['id'];
+			$unique_array[ $hash ] = $element;
+		}
+
+		foreach ( $unique_array as $event ) {
 			ob_start();
 			switch ( $event['on'] ) {
 				case 'click':

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -202,6 +202,9 @@ class Analytics {
 				case 'submit':
 					self::output_js_submit_event( $event );
 					break;
+				case 'ini-load':
+					self::output_js_ini_load_event( $event );
+					break;
 				default:
 					break;
 			}
@@ -306,6 +309,54 @@ class Analytics {
 							}
 						);
 					} );
+				}
+			} )();
+		</script>
+		<?php
+	}
+
+	/**
+	 * Output JS for a load event listener.
+	 *
+	 * @param array $event Event info. See 'get_events'.
+	 */
+	protected static function output_js_ini_load_event( $event ) {
+		$element = isset( $event['element'] ) ? $event['element'] : '';
+		?>
+		<script>
+			( function() {
+				var handleEvent = function() {
+					gtag(
+						'event',
+						'<?php echo esc_attr( $event['event_name'] ); ?>',
+						{
+							event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
+							event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+						}
+					);
+				};
+
+				var elementSelector = '<?php echo esc_attr( $element ); ?>';
+				if (elementSelector) {
+					var elements = Array.prototype.slice.call( document.querySelectorAll( elementSelector ) );
+					for ( var i = 0; i < elements.length; ++i ) {
+
+						var observer = new MutationObserver(function(mutations) {
+							mutations.forEach(function(mutation) {
+								if (
+									mutation.attributeName === 'amp-access-hide' &&
+									mutation.type == "attributes" &&
+									! mutation.target.hasAttribute('amp-access-hide')
+								) {
+									handleEvent()
+								}
+							});
+						});
+
+						observer.observe(elements[i], { attributes: true });
+					}
+				} else {
+					window.addEventListener('load', handleEvent)
 				}
 			} )();
 		</script>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds handling of submit and ini-load analytics events in non-AMP context. Also, adds filtering the events array so that there are only unique events (by id). 

Note: some of this code is taken from #557, thanks @dkoo ;) 

### How to test the changes in this Pull Request:

1. Add an inline campaign, insert the top Subscribe pattern from "Newspack Patterns"
1. Use the `newspack_analytics_events` filter to add reporting of `submit` and `ini-load` events, like so: 

```php
add_filter(
	'newspack_analytics_events',
	function ( $evts ) {
		return array_merge( 
			$evts, 
			[
				[
					'id'             => 'campaignLoaded',
					'on'             => 'ini-load',
					'element'        => '.newspack-inline-popup',
					'event_name'     => 'Load Event Name',
					'event_label'    => 'Load Event Label',
					'event_category' => 'Load Event Category',
				],
				[
					'id'             => 'formSubmitSuccess',
					'amp_on'         => 'amp-form-submit-success',
					'on'             => 'submit',
					'element'        => '#mailchimp_form',
					'event_name'     => 'Submit Event Name',
					'event_label'    => 'Submit Event Label',
					'event_category' => 'Submit Event Category',
				]
			]
		);
	}
);
```

2. View the page with the campaign (as a non-logged-in user!)
2. Observe that the two events are reported* on both AMP and non-AMP versions of a page
3. Duplicate one of the events, observe that same no. of events is still reported
4. Repeat step 1 to create a new campaign or view the page in a new incognito session or on a different browser
5. Dismiss the campaign by clicking "I'm not interested" button. Refresh the page
5. Observe the load event _not_ being reported

\* Devtools' Network tab -> filter all requests by `google-analytics`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
