### PR TITLE
Chore: update newspack-components' version

### DIFF
--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-components",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Newspack design system components",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
I've published a new version of `newspack-components` on npm.