### PR TITLE
Add NTG event triggers for user account login/registration

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -156,7 +156,7 @@ class Analytics {
 				'amp-on'         => 'amp-form-submit-success',
 				'on'             => 'submit',
 				'element'        => '.woocommerce-form-register',
-				'element_search' => 'woocommerce-form-login',
+				'element_search' => 'woocommerce-form-register',
 				'event_category' => 'NTG account',
 				'event_name'     => 'registration',
 				'event_label'    => 'success',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds NTG event triggers for user account login and registration as described in the [NTG Playbook](https://newsinitiative.withgoogle.com/training/states/ntg/assets/ntg-playbook.pdf).

This attempts to create a generalized approach using the `the_content` hook to conditionally output event triggers only if the relevant elements exist on the page.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #560.

### How to test the changes in this Pull Request:

1. In the WP dashboard, go to **WooCommerce > Settings > Accounts & Privacy** and make sure the " Allow customers to create an account during checkout" and "Allow customers to create an account on the 'My account' page" options are checked.
2. In the dashboard, go to Pages and edit the WooCommerce Donate Page, Account Page and Checkout Page. Make sure to disable AMP for all.
3. Visit the Account page as a non-logged-in user (incognito window). You should see a login and registration form. 
4. Open the Network tab in dev tools and filter by the term "NTG account".
5. Enter a (real) email address into the Register form. Observe a request in the Network tab that looks something like this: https://www.google-analytics.com/collect?v=1&_v=j83&aip=1&a=899661711&t=event&_s=4&dl=http%3A%2F%2Fnewspack-dkoo.ngrok.io%2Fmy-account%2F&ul=en-us&de=UTF-8&dt=My%20account%20-%20Newspack&sd=30-bit&sr=1792x1120&vp=1333x1018&je=0&ec=NTG%20account&ea=registration&el=success&_u=CCCACUABB~&jid=&gjid=&cid=amp-itJHxXEIUDR6Al2vptAoxw&tid=UA-169138974-1&_gid=1217836592.1593201537&gtm=2ou6h1&z=348539037
5. Log out and go back to the Account page. This time log in with the email address you registered with. Observe an event request in Network for the login submit.
6. Log out again and go to the Donate page. Fill out the login form there and observe an event for the login submit.

Note that the WooCommerce Account and Donate pages don't work with AMP enabled, so no need to test the AMP implementations for these particular events.

Note also that the page will redirect immediately after the forms submit, so the NTG requests will only be visible momentarily in Network. To double-check that the event triggers are tracking correctly, you can View Source on the page and verify that events exist in the source. They should look something like this (e.g. for login):

```
( function() {
	var elementSelector = '.woocommerce-form-login';
	var elements        = Array.prototype.slice.call( document.querySelectorAll( elementSelector ) );

	for ( var i = 0; i < elements.length; ++i ) {
		elements[i].addEventListener( 'submit', function() {
			gtag(
				'event',
				'login',
				{
					event_category: 'NTG account',
					event_label: 'success',
				}
			);
		} );
	}
} )();
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->