### PR TITLE
fix: mop up a couple of remain instances of "lead" in text

### DIFF
--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -308,7 +308,7 @@ class ReaderRevenueWizard extends Component {
 									headerText={ __( 'Configure Salesforce', 'newspack' ) }
 									isConnected={ salesforceIsConnected }
 									subHeaderText={ __(
-										'Connect your site with a Salesforce account to capture leads.',
+										'Connect your site with a Salesforce account to capture donor contact information.',
 										'newspack'
 									) }
 									buttonText={

--- a/assets/wizards/readerRevenue/views/revenue-main/index.js
+++ b/assets/wizards/readerRevenue/views/revenue-main/index.js
@@ -34,7 +34,7 @@ class RevenueMain extends Component {
 				<ActionCard
 					title={ __( 'Salesforce', 'newspack' ) }
 					description={ __(
-						'Integrate Salesforce to capture leads when readers donate to your organization.',
+						'Integrate Salesforce to capture contact information when readers donate to your organization.',
 						'newspack'
 					) }
 					actionText={ __( 'Configure', 'newspack' ) }


### PR DESCRIPTION
This should be a very quick one—text in the wizard should talk about contacts, not leads.