### PR TITLE
Make GAM toggle work correctly

### DIFF
--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -68,6 +68,7 @@ class Advertising_Wizard extends Wizard {
 		add_action( 'before_header', [ $this, 'inject_above_header_ad' ] );
 		add_action( 'after_header', [ $this, 'inject_below_header_ad' ] );
 		add_action( 'before_footer', [ $this, 'inject_above_footer_ad' ] );
+		add_filter( 'newspack_ads_should_show_ads', [ $this, 'maybe_disable_gam_ads' ] );
 	}
 
 	/**
@@ -575,6 +576,25 @@ class Advertising_Wizard extends Wizard {
 			<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
 		</div>
 		<?php
+	}
+
+	/**
+	 * If the Ad Manager integration is toggled off, don't show ads on the frontend.
+	 *
+	 * @param bool $should_show_ads Whether Newspack Ads should display ads or not.
+	 * @return bool Modified $should_show_ads.
+	 */
+	public function maybe_disable_gam_ads( $should_show_ads ) {
+		if ( is_admin() ) {
+			return $should_show_ads;
+		}
+
+		$services = self::get_services();
+		if ( ! $services['google_ad_manager']['enabled'] ) {
+			return false;
+		}
+
+		return $should_show_ads;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #571 .

This PR makes it so that toggling off Google Ad Manager integration in the Ads wizard will actually disable the integration. Previously, it would do nothing.

### How to test the changes in this Pull Request:

0. Verify you can reproduce #571 before testing this PR.
1. https://github.com/Automattic/newspack-ads/pull/46 is a companion PR that needs to be checked out in addition to this one.
2. Set up a global ad and an ad block.
3. Toggle the GAM integration on in the Newspack Advertising wizard. Observe ads:
<img width="1093" alt="Screen Shot 2020-06-30 at 12 21 02 PM" src="https://user-images.githubusercontent.com/7317227/86168647-5bd57800-bacd-11ea-8043-cdf6d6c5e1d8.png">
4. Toggle the GAM integration off. Observe no ads:
<img width="1172" alt="Screen Shot 2020-06-30 at 12 21 14 PM" src="https://user-images.githubusercontent.com/7317227/86168651-5d9f3b80-bacd-11ea-8dc6-f474169d6c82.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->