### PR TITLE
fix(analytics): non-interaction handling

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -479,6 +479,7 @@ class Analytics {
 										{
 											event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
 											event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+											non_interaction: <?php echo esc_attr( ! empty( $event['non_interaction'] ) && true === $event['non_interaction'] ? 'true' : 'false' ); ?>,
 										}
 									);
 								}
@@ -513,7 +514,7 @@ class Analytics {
 						{
 							event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
 							event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
-							non_interaction: true,
+							non_interaction: <?php echo esc_attr( ! empty( $event['non_interaction'] ) && true === $event['non_interaction'] ? 'true' : 'false' ); ?>,
 						}
 					);
 				};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

non-interaction parameter was not handled in non-AMP visibility event reporting implementation.
This PR fixes that.

### How to test the changes in this Pull Request:

1. Ensure newspack-popups is on `fix/bounce` branch ([PR #168](https://github.com/Automattic/newspack-popups/pull/168)) and this repo is on `master`
2. Load a page with a campaign in non-AMP mode, scroll so that the campaign is visible
3. Observe that the `Seen` event is reported without `ni` parameter (which means non-interaction)
4. Switch to this branch, repeat step 2
5. Observe that the `Seen` event is reported with the `ni` parameter of value `1` 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
