### PR TITLE
Add NTG event trigger for user comment submission

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -37,6 +37,7 @@ class Analytics {
 		add_filter( 'render_block', [ __CLASS__, 'prepare_blocks_for_events' ], 10, 2 );
 		add_action( 'newspack_campaigns_before_campaign_render', [ __CLASS__, 'set_campaign_render_context' ], 10, 1 );
 		add_action( 'newspack_campaigns_after_campaign_render', [ __CLASS__, 'reset_render_context' ], 10, 1 );
+		add_action( 'comment_form', [ __CLASS__, 'prepare_comment_events' ] );
 	}
 
 	/**
@@ -216,6 +217,21 @@ class Analytics {
 			],
 		];
 		return $content;
+	}
+
+	/**
+	 * Prepare event triggers on user commenting.
+	 */
+	public static function prepare_comment_events() {
+		self::$block_events[] = [
+			'id'             => 'addComment',
+			'amp_on'         => 'amp-form-submit-success',
+			'on'             => 'submit',
+			'element'        => '#commentform',
+			'event_name'     => 'comment added',
+			'event_category' => 'NTG user',
+			'event_label'    => get_the_title(),
+		];
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is a quick one. The User Interaction NTG category covers a few event triggers, but only this one is currently possible to implement in an AMP site. 

Closes #561.

### How to test the changes in this Pull Request:

1. Ensure that commenting is enabled in WP Settings > Discussion.
2. While not logged in, view a post that allows commenting.
3. Open the Dev Tools > Network tab. Filter requests by the term "NTG user".
4. Fill out the comment form and submit it. After form submission but before the page reloads with the comment displayed, you should see a Google Analytics request being sent that looks like this: https://www.google-analytics.com/collect?v=1&_v=j83&aip=1&a=515809510&t=event&_s=7&dl=http%3A%2F%2Fnewspack-dkoo.ngrok.io%2Fmy-best-post%2F&ul=en-us&de=UTF-8&dt=My%20best%20post%20-%20Newspack&sd=24-bit&sr=2560x1440&vp=2089x1338&je=0&ec=NTG%20user&ea=comment%20added&el=My%20best%20post&_u=CCCACUABB~&jid=&gjid=&cid=amp-zAjwuxoe1HC1QkxXuqBzEQ&tid=UA-169138974-1&_gid=1414644995.1594075247&gtm=2ou6o0&z=959988951
5. Because it might be hard to view the request in real-time due to the form submission triggering a page refresh, you can also check the page source and look for an event trigger with an `event_name` of `comment added`.
6. Repeat the test with AMP both enabled and disabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->