### PR TITLE
Fix: report milestone events for articles only

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -119,7 +119,7 @@ class Analytics {
 			],
 		];
 
-		if ( is_single() ) {
+		if ( ! is_front_page() && ! is_archive() ) {
 			$events = array_merge(
 				$events,
 				[

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -117,43 +117,51 @@ class Analytics {
 				'event_label'    => 'linkedin',
 				'event_category' => 'NTG social',
 			],
-			[
-				'id'              => 'articleRead25',
-				'on'              => 'scroll',
-				'event_name'      => '25%',
-				'event_value'     => 25,
-				'event_label'     => get_the_title(),
-				'event_category'  => 'NTG article milestone',
-				'non_interaction' => true,
-				'scrollSpec'      => [
-					'verticalBoundaries' => [ 25 ],
-				],
-			],
-			[
-				'id'              => 'articleRead50',
-				'on'              => 'scroll',
-				'event_name'      => '50%',
-				'event_value'     => 50,
-				'event_label'     => get_the_title(),
-				'event_category'  => 'NTG article milestone',
-				'non_interaction' => true,
-				'scrollSpec'      => [
-					'verticalBoundaries' => [ 50 ],
-				],
-			],
-			[
-				'id'              => 'articleRead100',
-				'on'              => 'scroll',
-				'event_name'      => '100%',
-				'event_value'     => 100,
-				'event_label'     => get_the_title(),
-				'event_category'  => 'NTG article milestone',
-				'non_interaction' => true,
-				'scrollSpec'      => [
-					'verticalBoundaries' => [ 100 ],
-				],
-			],
 		];
+
+		if ( is_single() ) {
+			$events = array_merge(
+				$events,
+				[
+					[
+						'id'              => 'articleRead25',
+						'on'              => 'scroll',
+						'event_name'      => '25%',
+						'event_value'     => 25,
+						'event_label'     => get_the_title(),
+						'event_category'  => 'NTG article milestone',
+						'non_interaction' => true,
+						'scrollSpec'      => [
+							'verticalBoundaries' => [ 25 ],
+						],
+					],
+					[
+						'id'              => 'articleRead50',
+						'on'              => 'scroll',
+						'event_name'      => '50%',
+						'event_value'     => 50,
+						'event_label'     => get_the_title(),
+						'event_category'  => 'NTG article milestone',
+						'non_interaction' => true,
+						'scrollSpec'      => [
+							'verticalBoundaries' => [ 50 ],
+						],
+					],
+					[
+						'id'              => 'articleRead100',
+						'on'              => 'scroll',
+						'event_name'      => '100%',
+						'event_value'     => 100,
+						'event_label'     => get_the_title(),
+						'event_category'  => 'NTG article milestone',
+						'non_interaction' => true,
+						'scrollSpec'      => [
+							'verticalBoundaries' => [ 100 ],
+						],
+					],
+				]
+			);
+		}
 
 		/**
 		 * Other integrations can add events to track using this filter.
@@ -254,17 +262,6 @@ class Analytics {
 
 			if ( ! isset( $config['triggers'] ) ) {
 				$config['triggers'] = [];
-			}
-
-			if ( 'click' !== $event_config['on'] ) {
-				/**
-				 * This is how non-interactive events are added to amp-analytics.
-				 *
-				 * @see https://github.com/ampproject/amphtml/issues/5018#issuecomment-247402181
-				 */
-				$event_config['extraUrlParams'] = [
-					'ni' => 1,
-				];
 			}
 
 			// Other integrations can use this filter if they need to modify the AMP-specific event config.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

NTG article milestone events were reported for all pages, incl. homepage. This PR fixes it.
Also, there was an unnecessary bit of code that appended `ni` parameter to event reporting for non-interaction event handling. This is not needed, since non-interaction events are marked by `non_interaction` key in event definition.

### How to test the changes in this Pull Request:

1. On `master`, visit homepage and scroll to bottom.
2. Observe that NTG article milestone events were reported.
3. Switch to this branch, repeat 1. 
3. Observe that the NTG milestone events were not reported. 
3. Visit a single article and scroll to the bottom, observe NTG article milestone events being sent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
