### PR TITLE
Analytics: report category to GA

### DIFF
--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -20,32 +20,42 @@ import HeaderIcon from '@material-ui/icons/TrendingUp';
  */
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { Intro } from './views';
+import { Plugins, Configuration } from './views';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
+
+const TABS = [
+	{
+		label: __( 'Configuration', 'newspack' ),
+		path: '/',
+		exact: true,
+	},
+	{
+		label: __( 'Plugins', 'newspack' ),
+		path: '/plugins',
+	},
+];
 
 class AnalyticsWizard extends Component {
 	/**
 	 * Render
 	 */
 	render() {
-		const { pluginRequirements } = this.props;
+		const { pluginRequirements, wizardApiFetch } = this.props;
+		const sharedProps = {
+			headerIcon: <HeaderIcon />,
+			headerText: __( 'Analytics', 'newspack' ),
+			subHeaderText: __( 'Track traffic and activity', 'newspack' ),
+			tabbedNavigation: TABS,
+			wizardApiFetch,
+		};
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
 					<Switch>
 						{ pluginRequirements }
-						<Route
-							path="/"
-							exact
-							render={ () => (
-								<Intro
-									headerIcon={ <HeaderIcon /> }
-									headerText={ __( 'Analytics', 'newspack' ) }
-									subHeaderText={ __( 'Track traffic and activity' ) }
-								/>
-							) }
-						/>
+						<Route path="/plugins" exact render={ () => <Plugins { ...sharedProps } /> } />
+						<Route path="/" exact render={ () => <Configuration { ...sharedProps } /> } />
 						<Redirect to="/" />
 					</Switch>
 				</HashRouter>

--- a/assets/wizards/analytics/views/configuration/index.js
+++ b/assets/wizards/analytics/views/configuration/index.js
@@ -131,7 +131,9 @@ class Configuration extends Component {
 							</tbody>
 						</table>
 
-						<p className="is-dark"><strong>{ __( 'Create a new custom dimension:', 'newspack' ) }</strong></p>
+						<p className="is-dark">
+							<strong>{ __( 'Create a new custom dimension:', 'newspack' ) }</strong>
+						</p>
 						<div>
 							<div className="newspack__analytics-configuration__form">
 								<TextControl

--- a/assets/wizards/analytics/views/configuration/index.js
+++ b/assets/wizards/analytics/views/configuration/index.js
@@ -1,0 +1,164 @@
+/* global newspack_analytics_wizard_data */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	Button,
+	Notice,
+	TextControl,
+	SelectControl,
+	CheckboxControl,
+	withWizardScreen,
+} from '../../../../components/src';
+import './style.scss';
+
+const SCOPES_OPTIONS = [
+	{ value: 'HIT', label: __( 'Hit', 'newspack' ) },
+	{ value: 'SESSION', label: __( 'Session', 'newspack' ) },
+	{ value: 'USER', label: __( 'User', 'newspack' ) },
+	{ value: 'PRODUCT', label: __( 'Product', 'newspack' ) },
+];
+
+/**
+ * Analytics Configuration screen.
+ */
+class Configuration extends Component {
+	state = {
+		error: newspack_analytics_wizard_data.customDimensions.error,
+		customDimensions: newspack_analytics_wizard_data.customDimensions,
+		newDimensionName: '',
+		newDimensionScope: SCOPES_OPTIONS[ 0 ].value,
+	};
+
+	handleAPIError = ( { message: error } ) => {
+		this.setState( { error } );
+	};
+
+	handleCustomDimensionCreation = () => {
+		const { wizardApiFetch } = this.props;
+		const { customDimensions, newDimensionName, newDimensionScope } = this.state;
+		wizardApiFetch( {
+			path: '/newspack/v1/wizard/analytics/custom-dimensions',
+			method: 'POST',
+			data: { name: newDimensionName, scope: newDimensionScope },
+		} )
+			.then( newCustomDimension => {
+				this.setState( { customDimensions: [ ...customDimensions, newCustomDimension ] } );
+			} )
+			.catch( this.handleAPIError );
+	};
+
+	handleCategoryDimensionSetting = dimensionId => {
+		const { wizardApiFetch } = this.props;
+		const { customDimensions } = this.state;
+		wizardApiFetch( {
+			path: `/newspack/v1/wizard/analytics/category-dimension/${ dimensionId }`,
+			method: 'POST',
+		} )
+			.then( ( { id } ) => {
+				this.setState( {
+					customDimensions: customDimensions.map( dimension => ( {
+						...dimension,
+						is_category_dimension: dimension.id === id,
+					} ) ),
+				} );
+			} )
+			.catch( this.handleAPIError );
+	};
+
+	render() {
+		const { error, customDimensions, newDimensionName, newDimensionScope } = this.state;
+		const hasCustomDimensions = ! error && customDimensions.length !== 0;
+		return (
+			<div className="newspack__analytics-configuration">
+				<h1>{ __( 'Custom dimensions', 'newspack' ) }</h1>
+				<p>
+					{ __(
+						"Custom dimensions are used to collect and analyze data that Google Analytics doesn't automatically track.",
+						'newspack'
+					) }
+				</p>
+				{ hasCustomDimensions &&
+					customDimensions.filter( dimension => dimension.is_category_dimension ).length === 0 && (
+						<Notice
+							noticeText={ __(
+								'Please set a category dimension. Otherwise, the categories will not be reported to GA.',
+								'newspack'
+							) }
+							isWarning
+						/>
+					) }
+				{ error ? (
+					<Notice noticeText={ error } isError />
+				) : (
+					<Fragment>
+						<table>
+							<thead>
+								<tr>
+									{ [
+										__( 'Name', 'newspack' ),
+										__( 'ID', 'newspack' ),
+										__( 'Category dimension', 'newspack' ),
+									].map( ( colName, i ) => (
+										<th key={ i }>{ colName }</th>
+									) ) }
+								</tr>
+							</thead>
+							<tbody>
+								{ customDimensions.map( dimension => (
+									<tr key={ dimension.id }>
+										<td>
+											<strong>{ dimension.name }</strong>
+										</td>
+										<td>
+											<code>{ dimension.id }</code>
+										</td>
+										<td>
+											<CheckboxControl
+												onChange={ () => this.handleCategoryDimensionSetting( dimension.id ) }
+												checked={ dimension.is_category_dimension }
+											/>
+										</td>
+									</tr>
+								) ) }
+							</tbody>
+						</table>
+
+						<h2>{ __( 'Create a new custom dimension:', 'newspack' ) }</h2>
+						<div>
+							<div className="newspack__analytics-configuration__form">
+								<TextControl
+									value={ newDimensionName }
+									onChange={ val => this.setState( { newDimensionName: val } ) }
+									label={ __( 'Name', 'newspack' ) }
+								/>
+								<SelectControl
+									value={ newDimensionScope }
+									onChange={ val => this.setState( { newDimensionScope: val } ) }
+									label={ __( 'Scope', 'newspack' ) }
+									options={ SCOPES_OPTIONS }
+								/>
+								<Button
+									onClick={ this.handleCustomDimensionCreation }
+									disabled={ newDimensionName.length === 0 }
+									isPrimary
+								>
+									{ __( 'Create', 'newspack' ) }
+								</Button>
+							</div>
+						</div>
+					</Fragment>
+				) }
+			</div>
+		);
+	}
+}
+
+export default withWizardScreen( Configuration );

--- a/assets/wizards/analytics/views/configuration/index.js
+++ b/assets/wizards/analytics/views/configuration/index.js
@@ -77,8 +77,8 @@ class Configuration extends Component {
 		const { error, customDimensions, newDimensionName, newDimensionScope } = this.state;
 		const hasCustomDimensions = ! error && customDimensions.length !== 0;
 		return (
-			<div className="newspack__analytics-configuration">
-				<h1>{ __( 'Custom dimensions', 'newspack' ) }</h1>
+			<div className="newspack__analytics-configuration newspack-card newspack-card__no-background">
+				<h2>{ __( 'Custom dimensions', 'newspack' ) }</h2>
 				<p>
 					{ __(
 						"Custom dimensions are used to collect and analyze data that Google Analytics doesn't automatically track.",
@@ -131,7 +131,7 @@ class Configuration extends Component {
 							</tbody>
 						</table>
 
-						<h2>{ __( 'Create a new custom dimension:', 'newspack' ) }</h2>
+						<p className="is-dark"><strong>{ __( 'Create a new custom dimension:', 'newspack' ) }</strong></p>
 						<div>
 							<div className="newspack__analytics-configuration__form">
 								<TextControl

--- a/assets/wizards/analytics/views/configuration/style.scss
+++ b/assets/wizards/analytics/views/configuration/style.scss
@@ -30,5 +30,8 @@
 				margin-right: 20px !important;
 			}
 		}
+		button {
+			flex-basis: 33%;
+		}
 	}
 }

--- a/assets/wizards/analytics/views/configuration/style.scss
+++ b/assets/wizards/analytics/views/configuration/style.scss
@@ -12,7 +12,8 @@
 	}
 	tbody {
 		td {
-			padding-top: 4px;
+			padding: 4px 0;
+			border-top: 1px solid $light-gray-500;
 		}
 		.newspack-checkbox-control {
 			margin: 0;

--- a/assets/wizards/analytics/views/configuration/style.scss
+++ b/assets/wizards/analytics/views/configuration/style.scss
@@ -1,0 +1,34 @@
+@import '~@wordpress/base-styles/colors';
+
+.newspack__analytics-configuration {
+	th {
+		text-align: left;
+		border-bottom: 1px solid $light-gray-500;
+	}
+	table {
+		width: 100%;
+		margin-bottom: 4em;
+		border-spacing: 0;
+	}
+	tbody {
+		td {
+			padding-top: 4px;
+		}
+		.newspack-checkbox-control {
+			margin: 0;
+		}
+	}
+	&__form {
+		display: flex;
+		align-items: flex-end;
+		.newspack-text-control {
+			width: 100%;
+		}
+		> * {
+			margin: 0 !important;
+			&:not( :last-child ) {
+				margin-right: 20px !important;
+			}
+		}
+	}
+}

--- a/assets/wizards/analytics/views/configuration/style.scss
+++ b/assets/wizards/analytics/views/configuration/style.scss
@@ -22,6 +22,9 @@
 	&__form {
 		display: flex;
 		align-items: flex-end;
+		@media screen and ( max-width: 600px ) {
+			flex-wrap: wrap;
+		}
 		.newspack-text-control {
 			width: 100%;
 		}
@@ -32,7 +35,10 @@
 			}
 		}
 		button {
-			flex-basis: 33%;
+			overflow: visible;
+			@media screen and ( max-width: 600px ) {
+				margin-top: 10px !important;
+			}
 		}
 	}
 }

--- a/assets/wizards/analytics/views/index.js
+++ b/assets/wizards/analytics/views/index.js
@@ -1,1 +1,2 @@
-export { default as Intro } from './intro';
+export { default as Plugins } from './plugins';
+export { default as Configuration } from './configuration';

--- a/assets/wizards/analytics/views/plugins/index.js
+++ b/assets/wizards/analytics/views/plugins/index.js
@@ -1,5 +1,5 @@
 /**
- * Syndication Intro View
+ * Analytics Plugins View
  */
 
 /**
@@ -14,9 +14,9 @@ import { __ } from '@wordpress/i18n';
 import { ActionCard, withWizardScreen } from '../../../../components/src';
 
 /**
- * Syndication Intro screen.
+ * Analytics Plugins screen.
  */
-class Intro extends Component {
+class Plugins extends Component {
 	/**
 	 * Render.
 	 */
@@ -35,4 +35,4 @@ class Intro extends Component {
 	}
 }
 
-export default withWizardScreen( Intro );
+export default withWizardScreen( Plugins );

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -54,21 +54,29 @@ class Analytics {
 	public static function handle_category_reporting() {
 		$categories = get_the_category();
 		if ( ! empty( $categories ) ) {
-			$category_slug = $categories[0]->slug;
+			$categories_slugs = implode(
+				',',
+				array_map(
+					function( $cat ) {
+						return $cat->slug;
+					},
+					$categories
+				)
+			);
 			// Non-AMP.
 			add_filter(
 				'googlesitekit_gtag_opt',
-				function ( $gtag_opt ) use ( $category_slug ) {
-					$gtag_opt['dimension1'] = $category_slug;
+				function ( $gtag_opt ) use ( $categories_slugs ) {
+					$gtag_opt['dimension1'] = $categories_slugs;
 					return $gtag_opt;
 				}
 			);
 			// AMP.
 			add_filter(
 				'googlesitekit_amp_gtag_opt',
-				function ( $gtag_amp_opt ) use ( $category_slug ) {
+				function ( $gtag_amp_opt ) use ( $categories_slugs ) {
 					$tracking_id = $gtag_amp_opt['vars']['gtag_id'];
-					$gtag_amp_opt['vars']['config'][ $tracking_id ]['dimension1'] = $category_slug;
+					$gtag_amp_opt['vars']['config'][ $tracking_id ]['dimension1'] = $categories_slugs;
 					return $gtag_amp_opt;
 				}
 			);

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -52,6 +52,13 @@ class Analytics {
 	 * https://support.google.com/analytics/answer/2709828.
 	 */
 	public static function handle_category_reporting() {
+		$category_dimension_id = get_option( Analytics_Wizard::$category_dimension_option_name );
+		if ( ! $category_dimension_id ) {
+			return;
+		}
+		// Remove `ga:` prefix.
+		$category_dimension_id = substr( $category_dimension_id, 3 );
+
 		$categories = get_the_category();
 		if ( ! empty( $categories ) ) {
 			$categories_slugs = implode(
@@ -66,17 +73,17 @@ class Analytics {
 			// Non-AMP.
 			add_filter(
 				'googlesitekit_gtag_opt',
-				function ( $gtag_opt ) use ( $categories_slugs ) {
-					$gtag_opt['dimension1'] = $categories_slugs;
+				function ( $gtag_opt ) use ( $categories_slugs, $category_dimension_id ) {
+					$gtag_opt[ $category_dimension_id ] = $categories_slugs;
 					return $gtag_opt;
 				}
 			);
 			// AMP.
 			add_filter(
 				'googlesitekit_amp_gtag_opt',
-				function ( $gtag_amp_opt ) use ( $categories_slugs ) {
+				function ( $gtag_amp_opt ) use ( $categories_slugs, $category_dimension_id ) {
 					$tracking_id = $gtag_amp_opt['vars']['gtag_id'];
-					$gtag_amp_opt['vars']['config'][ $tracking_id ]['dimension1'] = $categories_slugs;
+					$gtag_amp_opt['vars']['config'][ $tracking_id ][ $category_dimension_id ] = $categories_slugs;
 					return $gtag_amp_opt;
 				}
 			);

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -448,6 +448,9 @@ class Plugin_Manager {
 			if ( isset( $managed_plugin['WPCore'] ) ) {
 				$status = 'active';
 			}
+			if ( 'google-site-kit' === $plugin_slug ) {
+				$status = 'active';
+			}
 			$managed_plugins[ $plugin_slug ]['Status']      = $status;
 			$managed_plugins[ $plugin_slug ]['Slug']        = $plugin_slug;
 			$managed_plugins[ $plugin_slug ]['HandoffLink'] = isset( $managed_plugins[ $plugin_slug ]['EditPath'] ) ? admin_url( $managed_plugins[ $plugin_slug ]['EditPath'] ) : null;

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -106,7 +106,7 @@ class Analytics_Wizard extends Wizard {
 			if ( ! is_wp_error( $custom_dimensions ) && count( $custom_dimensions ) === 0 ) {
 				$new_custom_dimension = self::create_custom_dimension(
 					[
-						'name'  => '[Newspack] Article Category 2',
+						'name'  => '[Newspack] Article Category',
 						'scope' => 'HIT',
 					]
 				);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Report post categories as a custom GA dimension. 

### How to test the changes in this Pull Request:

1. Make sure Site Kit is configured and Analytics service connected. There should be **no** custom dimensions set up (if there are, create a new Analytics Account in GA and switch to it in Site Kit settings)
1. Visit the Analytics wizard in Newspack plugin, observe a new tab: "Configuration". It should list a single custom dimension (it was created behind the scenes) `[Newspack] Article Category`, and this dimension should be set as the category dimension:
![image](https://user-images.githubusercontent.com/7383192/87972836-e3f4df00-cac7-11ea-8122-484bbb740b6b.png)
2. Visit an article which has a category
2. Observe that all events reported have a `cd1` parameter with value of categories slugs (comma-separated)
2. Visit that article in non-AMP version as well, observe 3. again
3. After a while visit the GA web UI. Go to Behaviour->Site Content->All Pages, set date to today, add secondary dimension of "[Newspack] Article Category"
4. Observe the article category reported in a column
4. In the Analytics wizard, create a new dimension and set it as the category dimension.
4. Repeat step 3-5, with the difference that now the categories should be reported as `cd2` (custom dimension 2)
4. In the Analytics wizard, unset the category dimension, observe a warning notice being displayed above the dimensions table
4. Observe the custom dimension is not reported to GA

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
