### PR TITLE
withWizard tweaks

### DIFF
--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-components",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Newspack design system components",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -36,3 +36,5 @@ export { default as WebPreview } from './web-preview';
 export { default as withWizard } from './with-wizard';
 export { default as withWizardScreen } from './with-wizard-screen';
 export { default as WizardPagination } from './wizard-pagination';
+
+export { default as Router } from './proxied-imports/router';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

To prepare withWizard for usage outside on the Newspack Plugin, some tweaks are needed:

- Export `Router` with `newspack-components`
- Enable `withWizard` usage without `newspack_urls` variable
- `withWizard` – link logo to Newspack site by default when used outside of plugin

### How to test the changes in this Pull Request:

1. Nothing should change in the plugin, so just a smoke test is needed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
