### PR TITLE
fix: allow newspack to install site kit

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -448,9 +448,6 @@ class Plugin_Manager {
 			if ( isset( $managed_plugin['WPCore'] ) ) {
 				$status = 'active';
 			}
-			if ( 'google-site-kit' === $plugin_slug ) {
-				$status = 'active';
-			}
 			$managed_plugins[ $plugin_slug ]['Status']      = $status;
 			$managed_plugins[ $plugin_slug ]['Slug']        = $plugin_slug;
 			$managed_plugins[ $plugin_slug ]['HandoffLink'] = isset( $managed_plugins[ $plugin_slug ]['EditPath'] ) ? admin_url( $managed_plugins[ $plugin_slug ]['EditPath'] ) : null;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a regression that caused Newspack to always think Site Kit was installed, which broke the Setup flow.

### How to test the changes in this Pull Request:

1. Spin up a new Jurassic Ninja instance.
2. Run `npm run build && npm run release:archive` on this branch to generate a build.
3. Install the build on the JN instance.
4. Step through the Setup Wizard, including Jetpack and Site Kit connection.
5. Verify the flow works correctly.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->