### PR TITLE
Add category reporting back, with unauthenticated user handling

### DIFF
--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -20,32 +20,42 @@ import HeaderIcon from '@material-ui/icons/TrendingUp';
  */
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { Intro } from './views';
+import { Plugins, Configuration } from './views';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
+
+const TABS = [
+	{
+		label: __( 'Configuration', 'newspack' ),
+		path: '/',
+		exact: true,
+	},
+	{
+		label: __( 'Plugins', 'newspack' ),
+		path: '/plugins',
+	},
+];
 
 class AnalyticsWizard extends Component {
 	/**
 	 * Render
 	 */
 	render() {
-		const { pluginRequirements } = this.props;
+		const { pluginRequirements, wizardApiFetch } = this.props;
+		const sharedProps = {
+			headerIcon: <HeaderIcon />,
+			headerText: __( 'Analytics', 'newspack' ),
+			subHeaderText: __( 'Track traffic and activity', 'newspack' ),
+			tabbedNavigation: TABS,
+			wizardApiFetch,
+		};
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
 					<Switch>
 						{ pluginRequirements }
-						<Route
-							path="/"
-							exact
-							render={ () => (
-								<Intro
-									headerIcon={ <HeaderIcon /> }
-									headerText={ __( 'Analytics', 'newspack' ) }
-									subHeaderText={ __( 'Track traffic and activity' ) }
-								/>
-							) }
-						/>
+						<Route path="/plugins" exact render={ () => <Plugins { ...sharedProps } /> } />
+						<Route path="/" exact render={ () => <Configuration { ...sharedProps } /> } />
 						<Redirect to="/" />
 					</Switch>
 				</HashRouter>

--- a/assets/wizards/analytics/views/configuration/index.js
+++ b/assets/wizards/analytics/views/configuration/index.js
@@ -1,0 +1,166 @@
+/* global newspack_analytics_wizard_data */
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	Button,
+	Notice,
+	TextControl,
+	SelectControl,
+	CheckboxControl,
+	withWizardScreen,
+} from '../../../../components/src';
+import './style.scss';
+
+const SCOPES_OPTIONS = [
+	{ value: 'HIT', label: __( 'Hit', 'newspack' ) },
+	{ value: 'SESSION', label: __( 'Session', 'newspack' ) },
+	{ value: 'USER', label: __( 'User', 'newspack' ) },
+	{ value: 'PRODUCT', label: __( 'Product', 'newspack' ) },
+];
+
+/**
+ * Analytics Configuration screen.
+ */
+class Configuration extends Component {
+	state = {
+		error: newspack_analytics_wizard_data.customDimensions.error,
+		customDimensions: newspack_analytics_wizard_data.customDimensions,
+		newDimensionName: '',
+		newDimensionScope: SCOPES_OPTIONS[ 0 ].value,
+	};
+
+	handleAPIError = ( { message: error } ) => {
+		this.setState( { error } );
+	};
+
+	handleCustomDimensionCreation = () => {
+		const { wizardApiFetch } = this.props;
+		const { customDimensions, newDimensionName, newDimensionScope } = this.state;
+		wizardApiFetch( {
+			path: '/newspack/v1/wizard/analytics/custom-dimensions',
+			method: 'POST',
+			data: { name: newDimensionName, scope: newDimensionScope },
+		} )
+			.then( newCustomDimension => {
+				this.setState( { customDimensions: [ ...customDimensions, newCustomDimension ] } );
+			} )
+			.catch( this.handleAPIError );
+	};
+
+	handleCategoryDimensionSetting = dimensionId => {
+		const { wizardApiFetch } = this.props;
+		const { customDimensions } = this.state;
+		wizardApiFetch( {
+			path: `/newspack/v1/wizard/analytics/category-dimension/${ dimensionId }`,
+			method: 'POST',
+		} )
+			.then( ( { id } ) => {
+				this.setState( {
+					customDimensions: customDimensions.map( dimension => ( {
+						...dimension,
+						is_category_dimension: dimension.id === id,
+					} ) ),
+				} );
+			} )
+			.catch( this.handleAPIError );
+	};
+
+	render() {
+		const { error, customDimensions, newDimensionName, newDimensionScope } = this.state;
+		const hasCustomDimensions = ! error && customDimensions.length !== 0;
+		return (
+			<div className="newspack__analytics-configuration newspack-card newspack-card__no-background">
+				<h2>{ __( 'Custom dimensions', 'newspack' ) }</h2>
+				<p>
+					{ __(
+						"Custom dimensions are used to collect and analyze data that Google Analytics doesn't automatically track.",
+						'newspack'
+					) }
+				</p>
+				{ hasCustomDimensions &&
+					customDimensions.filter( dimension => dimension.is_category_dimension ).length === 0 && (
+						<Notice
+							noticeText={ __(
+								'Please set a category dimension. Otherwise, the categories will not be reported to GA.',
+								'newspack'
+							) }
+							isWarning
+						/>
+					) }
+				{ error ? (
+					<Notice noticeText={ error } isError />
+				) : (
+					<Fragment>
+						<table>
+							<thead>
+								<tr>
+									{ [
+										__( 'Name', 'newspack' ),
+										__( 'ID', 'newspack' ),
+										__( 'Category dimension', 'newspack' ),
+									].map( ( colName, i ) => (
+										<th key={ i }>{ colName }</th>
+									) ) }
+								</tr>
+							</thead>
+							<tbody>
+								{ customDimensions.map( dimension => (
+									<tr key={ dimension.id }>
+										<td>
+											<strong>{ dimension.name }</strong>
+										</td>
+										<td>
+											<code>{ dimension.id }</code>
+										</td>
+										<td>
+											<CheckboxControl
+												onChange={ () => this.handleCategoryDimensionSetting( dimension.id ) }
+												checked={ dimension.is_category_dimension }
+											/>
+										</td>
+									</tr>
+								) ) }
+							</tbody>
+						</table>
+
+						<p className="is-dark">
+							<strong>{ __( 'Create a new custom dimension:', 'newspack' ) }</strong>
+						</p>
+						<div>
+							<div className="newspack__analytics-configuration__form">
+								<TextControl
+									value={ newDimensionName }
+									onChange={ val => this.setState( { newDimensionName: val } ) }
+									label={ __( 'Name', 'newspack' ) }
+								/>
+								<SelectControl
+									value={ newDimensionScope }
+									onChange={ val => this.setState( { newDimensionScope: val } ) }
+									label={ __( 'Scope', 'newspack' ) }
+									options={ SCOPES_OPTIONS }
+								/>
+								<Button
+									onClick={ this.handleCustomDimensionCreation }
+									disabled={ newDimensionName.length === 0 }
+									isPrimary
+								>
+									{ __( 'Create', 'newspack' ) }
+								</Button>
+							</div>
+						</div>
+					</Fragment>
+				) }
+			</div>
+		);
+	}
+}
+
+export default withWizardScreen( Configuration );

--- a/assets/wizards/analytics/views/configuration/index.js
+++ b/assets/wizards/analytics/views/configuration/index.js
@@ -31,7 +31,7 @@ const SCOPES_OPTIONS = [
  */
 class Configuration extends Component {
 	state = {
-		error: newspack_analytics_wizard_data.customDimensions.error,
+		error: newspack_analytics_wizard_data.analyticsConnectionError,
 		customDimensions: newspack_analytics_wizard_data.customDimensions,
 		newDimensionName: '',
 		newDimensionScope: SCOPES_OPTIONS[ 0 ].value,

--- a/assets/wizards/analytics/views/configuration/style.scss
+++ b/assets/wizards/analytics/views/configuration/style.scss
@@ -1,0 +1,44 @@
+@import '~@wordpress/base-styles/colors';
+
+.newspack__analytics-configuration {
+	th {
+		text-align: left;
+		border-bottom: 1px solid $light-gray-500;
+	}
+	table {
+		width: 100%;
+		margin-bottom: 4em;
+		border-spacing: 0;
+	}
+	tbody {
+		td {
+			padding: 4px 0;
+			border-top: 1px solid $light-gray-500;
+		}
+		.newspack-checkbox-control {
+			margin: 0;
+		}
+	}
+	&__form {
+		display: flex;
+		align-items: flex-end;
+		@media screen and ( max-width: 600px ) {
+			flex-wrap: wrap;
+		}
+		.newspack-text-control {
+			width: 100%;
+		}
+		> * {
+			margin: 0 !important;
+			&:not( :last-child ) {
+				margin-right: 20px !important;
+			}
+		}
+		button {
+			overflow: visible;
+			@media screen and ( max-width: 600px ) {
+				margin-top: 10px !important;
+			}
+		}
+	}
+}

--- a/assets/wizards/analytics/views/index.js
+++ b/assets/wizards/analytics/views/index.js
@@ -1,1 +1,2 @@
-export { default as Intro } from './intro';
+export { default as Plugins } from './plugins';
+export { default as Configuration } from './configuration';

--- a/assets/wizards/analytics/views/plugins/index.js
+++ b/assets/wizards/analytics/views/plugins/index.js
@@ -1,5 +1,5 @@
 /**
- * Syndication Intro View
+ * Analytics Plugins View
  */
 
 /**
@@ -14,9 +14,9 @@ import { __ } from '@wordpress/i18n';
 import { ActionCard, withWizardScreen } from '../../../../components/src';
 
 /**
- * Syndication Intro screen.
+ * Analytics Plugins screen.
  */
-class Intro extends Component {
+class Plugins extends Component {
 	/**
 	 * Render.
 	 */
@@ -35,4 +35,4 @@ class Intro extends Component {
 	}
 }
 
-export default withWizardScreen( Intro );
+export default withWizardScreen( Plugins );

--- a/assets/wizards/analytics/views/plugins/index.js
+++ b/assets/wizards/analytics/views/plugins/index.js
@@ -1,3 +1,5 @@
+/* global newspack_analytics_wizard_data */
+
 /**
  * Analytics Plugins View
  */
@@ -28,7 +30,11 @@ class Plugins extends Component {
 					description={ __( 'Configure and view site analytics' ) }
 					actionText={ __( 'View' ) }
 					handoff="google-site-kit"
-					editLink="admin.php?page=googlesitekit-module-analytics"
+					editLink={
+						newspack_analytics_wizard_data.analyticsConnectionError
+							? undefined
+							: 'admin.php?page=googlesitekit-module-analytics'
+					}
 				/>
 			</Fragment>
 		);

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -33,6 +33,7 @@ class Analytics {
 	 */
 	public function __construct() {
 		add_filter( 'googlesitekit_amp_gtag_opt', [ __CLASS__, 'inject_amp_events' ] );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'handle_category_reporting' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'inject_non_amp_events' ] );
 		add_filter( 'render_block', [ __CLASS__, 'prepare_blocks_for_events' ], 10, 2 );
 		add_action( 'newspack_campaigns_before_campaign_render', [ __CLASS__, 'set_campaign_render_context' ], 10, 1 );
@@ -43,6 +44,50 @@ class Analytics {
 		add_action( 'woocommerce_login_form_end', [ __CLASS__, 'prepare_login_events' ] );
 		add_action( 'woocommerce_register_form_end', [ __CLASS__, 'prepare_registration_events' ] );
 		add_action( 'woocommerce_after_checkout_registration_form', [ __CLASS__, 'prepare_checkout_registration_events' ] );
+	}
+
+	/**
+	 * Tell Site Kit to report the article's category as custom dimension of index 1.
+	 * More about custom dimensions:
+	 * https://support.google.com/analytics/answer/2709828.
+	 */
+	public static function handle_category_reporting() {
+		$category_dimension_id = get_option( Analytics_Wizard::$category_dimension_option_name );
+		if ( ! $category_dimension_id ) {
+			return;
+		}
+		// Remove `ga:` prefix.
+		$category_dimension_id = substr( $category_dimension_id, 3 );
+
+		$categories = get_the_category();
+		if ( ! empty( $categories ) ) {
+			$categories_slugs = implode(
+				',',
+				array_map(
+					function( $cat ) {
+						return $cat->slug;
+					},
+					$categories
+				)
+			);
+			// Non-AMP.
+			add_filter(
+				'googlesitekit_gtag_opt',
+				function ( $gtag_opt ) use ( $categories_slugs, $category_dimension_id ) {
+					$gtag_opt[ $category_dimension_id ] = $categories_slugs;
+					return $gtag_opt;
+				}
+			);
+			// AMP.
+			add_filter(
+				'googlesitekit_amp_gtag_opt',
+				function ( $gtag_amp_opt ) use ( $categories_slugs, $category_dimension_id ) {
+					$tracking_id = $gtag_amp_opt['vars']['gtag_id'];
+					$gtag_amp_opt['vars']['config'][ $tracking_id ][ $category_dimension_id ] = $categories_slugs;
+					return $gtag_amp_opt;
+				}
+			);
+		}
 	}
 
 	/**

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -218,7 +218,13 @@ class Analytics_Wizard extends Wizard {
 				$ga_options     = new Options( $context );
 				$user_options   = new User_Options( $context );
 				$authentication = new Authentication( $context, $ga_options, $user_options );
-				$client         = $authentication->get_oauth_client()->get_client();
+
+				if ( false === $authentication->is_authenticated() ) {
+					return new WP_Error( 'newspack_analytics_sitekit_disconnected', __( 'Please authenticate with Site Kit plugin.', 'newspack' ) );
+				}
+
+				$client = $authentication->get_oauth_client()->get_client();
+
 				return [
 					'analytics_service' => new Google_Service_Analytics( $client ),
 					'settings'          => $site_kit_analytics->get_settings()->get(),

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -239,7 +239,7 @@ class Analytics_Wizard extends Wizard {
 	/**
 	 * List Custom Dimensions.
 	 *
-	 * @return return type
+	 * @return Array|WP_Error Array of custom dimensions on success, or WP_Error object on failure.
 	 */
 	public static function list_custom_dimensions() {
 		$ga_utils = self::get_ga_utils();
@@ -266,10 +266,10 @@ class Analytics_Wizard extends Wizard {
 	}
 
 	/**
-	 * List Custom Dimensions.
+	 * Create a Custom Dimension.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 * @return Object|WP_Error Object on success, or WP_Error object on failure.
 	 */
 	public static function create_custom_dimension( $request ) {
 		$ga_utils = self::get_ga_utils();
@@ -297,7 +297,7 @@ class Analytics_Wizard extends Wizard {
 	 * Set custom dimension as the category-reporting dimension.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 * @return Object|WP_Error Object on success, or WP_Error object on failure.
 	 */
 	public static function set_category_dimension( $request ) {
 		$dimension_id          = $request['id'];

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -31,7 +31,7 @@ class Analytics_Wizard extends Wizard {
 	 *
 	 * @var string
 	 */
-	public static $category_dimension_option_name = 'newspack_analtytics_category_custom_dimension_id';
+	public static $category_dimension_option_name = 'newspack_analytics_category_custom_dimension_id';
 
 	/**
 	 * The slug of this wizard.
@@ -220,7 +220,7 @@ class Analytics_Wizard extends Wizard {
 				$authentication = new Authentication( $context, $ga_options, $user_options );
 
 				if ( false === $authentication->is_authenticated() ) {
-					return new WP_Error( 'newspack_analytics_sitekit_authentication', __( 'Please authenticate with Site Kit plugin.', 'newspack' ) );
+					return new WP_Error( 'newspack_analytics_sitekit_authentication', __( 'Please authenticate with the Site Kit plugin.', 'newspack' ) );
 				}
 
 				$client = $authentication->get_oauth_client()->get_client();
@@ -230,10 +230,10 @@ class Analytics_Wizard extends Wizard {
 					'settings'          => $site_kit_analytics->get_settings()->get(),
 				];
 			} else {
-				return new WP_Error( 'newspack_analytics_sitekit_disconnected', __( 'Please connect Analytics in Site Kit plugin.', 'newspack' ) );
+				return new WP_Error( 'newspack_analytics_sitekit_disconnected', __( 'Please connect Analytics in the Site Kit plugin.', 'newspack' ) );
 			}
 		}
-		return new WP_Error( 'newspack_analytics_sitekit_undefined', __( 'Install Site Kit plugin.', 'newspack' ) );
+		return new WP_Error( 'newspack_analytics_sitekit_undefined', __( 'Please install the Site Kit plugin.', 'newspack' ) );
 	}
 
 	/**

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -7,6 +7,14 @@
 
 namespace Newspack;
 
+use Google\Site_Kit\Modules\Analytics as SiteKitAnalytics;
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Core\Authentication\Authentication;
+use Google\Site_Kit_Dependencies\Google_Service_Analytics;
+use Google\Site_Kit_Dependencies\Google_Service_Analytics_CustomDimension;
+
 use \WP_Error, \WP_Query;
 
 defined( 'ABSPATH' ) || exit;
@@ -17,6 +25,13 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
  * Easy interface for setting up general store info.
  */
 class Analytics_Wizard extends Wizard {
+
+	/**
+	 * Name of the option storing the article category custom dimension id.
+	 *
+	 * @var string
+	 */
+	public static $category_dimension_option_name = 'newspack_analtytics_category_custom_dimension_id';
 
 	/**
 	 * The slug of this wizard.
@@ -38,6 +53,16 @@ class Analytics_Wizard extends Wizard {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+		add_action( 'admin_init', [ $this, 'insert_custom_dimensions' ] );
+
+		// Ensure Site Kit asks for sufficient scopes to add custom dimensions.
+		add_filter(
+			'googlesitekit_auth_scopes',
+			function( array $scopes ) {
+				return array_merge( $scopes, [ 'https://www.googleapis.com/auth/analytics.edit' ] );
+			},
+			1
+		);
 	}
 
 	/**
@@ -68,9 +93,74 @@ class Analytics_Wizard extends Wizard {
 	}
 
 	/**
+	 * Create the custom dimension to report category, if:
+	 * - the GA property has no custom dimensions set,
+	 * - the category dimension option has not been set.
+	 */
+	public function insert_custom_dimensions() {
+		if (
+			get_option( 'has_set_up_category_dimension' ) != 'completed' &&
+			! get_option( self::$category_dimension_option_name )
+		) {
+			$custom_dimensions = self::list_custom_dimensions();
+			if ( ! is_wp_error( $custom_dimensions ) && count( $custom_dimensions ) === 0 ) {
+				$new_custom_dimension = self::create_custom_dimension(
+					[
+						'name'  => '[Newspack] Article Category',
+						'scope' => 'HIT',
+					]
+				);
+				if ( ! is_wp_error( $new_custom_dimension ) ) {
+					$new_custom_dimension = self::set_category_dimension(
+						[
+							'id' => $new_custom_dimension['id'],
+						]
+					);
+					update_option( 'has_set_up_category_dimension_09', 'completed' );
+				}
+			}
+		}
+	}
+
+	/**
 	 * Register the endpoints needed for the wizard screens.
 	 */
-	public function register_api_endpoints() {}
+	public function register_api_endpoints() {
+		// Create a custom dimension.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/analytics/custom-dimensions',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'create_custom_dimension' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'name'  => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'scope' => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+
+		// Set the category custom dimension.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/analytics/category-dimension/(?P<id>[\w:]+)',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'set_category_dimension' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'id' => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+	}
 
 	/**
 	 * Enqueue Subscriptions Wizard scripts and styles.
@@ -89,5 +179,130 @@ class Analytics_Wizard extends Wizard {
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/analytics.js' ),
 			true
 		);
+		$custom_dimensions = self::list_custom_dimensions();
+		if ( is_wp_error( $custom_dimensions ) ) {
+			$custom_dimensions = [
+				'error' => $custom_dimensions->get_error_message(),
+			];
+		}
+		\wp_localize_script(
+			'newspack-analytics-wizard',
+			'newspack_analytics_wizard_data',
+			[
+				'customDimensions' => $custom_dimensions,
+			]
+		);
+
+		\wp_register_style(
+			'newspack-analytics-wizard',
+			Newspack::plugin_url() . '/dist/analytics.css',
+			$this->get_style_dependencies(),
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/analytics.css' )
+		);
+		\wp_style_add_data( 'newspack-analytics-wizard', 'rtl', 'replace' );
+		\wp_enqueue_style( 'newspack-analytics-wizard' );
+
+	}
+
+	/**
+	 * Get GA utils.
+	 *
+	 * @return object authenticated Google_Service_Analytics service and Site Kit settings
+	 */
+	public static function get_ga_utils() {
+		if ( defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
+			$context            = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+			$site_kit_analytics = new SiteKitAnalytics( $context );
+
+			if ( $site_kit_analytics->is_connected() ) {
+				$ga_options     = new Options( $context );
+				$user_options   = new User_Options( $context );
+				$authentication = new Authentication( $context, $ga_options, $user_options );
+				$client         = $authentication->get_oauth_client()->get_client();
+				return [
+					'analytics_service' => new Google_Service_Analytics( $client ),
+					'settings'          => $site_kit_analytics->get_settings()->get(),
+				];
+			} else {
+				return new WP_Error( 'newspack_analytics_sitekit_disconnected', __( 'Please connect Analytics in Site Kit plugin.', 'newspack' ) );
+			}
+		}
+		return new WP_Error( 'newspack_analytics_sitekit_undefined', __( 'Install Site Kit plugin.', 'newspack' ) );
+	}
+
+	/**
+	 * List Custom Dimensions.
+	 *
+	 * @return return type
+	 */
+	public static function list_custom_dimensions() {
+		$ga_utils = self::get_ga_utils();
+		if ( is_wp_error( $ga_utils ) ) {
+			return $ga_utils;
+		}
+		$custom_dimensions = $ga_utils['analytics_service']->management_customDimensions->listManagementCustomDimensions(
+			$ga_utils['settings']['accountID'],
+			$ga_utils['settings']['propertyID']
+		);
+		if ( isset( $custom_dimensions['items'] ) ) {
+			$option_name = self::$category_dimension_option_name;
+			return array_map(
+				function ( &$dimension ) use ( $option_name ) {
+					if ( get_option( $option_name ) === $dimension['id'] ) {
+						$dimension->is_category_dimension = true;
+					}
+					return $dimension;
+				},
+				$custom_dimensions['items']
+			);
+		}
+		return new WP_Error( 'newspack_analytics', __( 'Error retrieving custom dimensions.', 'newspack' ) );
+	}
+
+	/**
+	 * List Custom Dimensions.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public static function create_custom_dimension( $request ) {
+		$ga_utils = self::get_ga_utils();
+		if ( is_wp_error( $ga_utils ) ) {
+			return $ga_utils;
+		}
+
+		try {
+			$custom_dimension_body = new Google_Service_Analytics_CustomDimension();
+			$custom_dimension_body->setName( $request['name'] );
+			$custom_dimension_body->setScope( $request['scope'] );
+			$custom_dimension_body->setActive( true );
+
+			return $ga_utils['analytics_service']->management_customDimensions->insert(
+				$ga_utils['settings']['accountID'],
+				$ga_utils['settings']['propertyID'],
+				$custom_dimension_body
+			);
+		} catch ( \Throwable $error ) {
+			return new WP_Error( 'newspack_analytics', __( 'Error when creating custom dimension.', 'newspack' ) );
+		}
+	}
+
+	/**
+	 * Set custom dimension as the category-reporting dimension.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public static function set_category_dimension( $request ) {
+		$dimension_id          = $request['id'];
+		$existing_dimension_id = get_option( self::$category_dimension_option_name );
+		if ( $existing_dimension_id === $dimension_id ) {
+			$dimension_id = null;
+		}
+		if ( update_option( self::$category_dimension_option_name, $dimension_id ) ) {
+			return [ 'id' => $dimension_id ];
+		} else {
+			return new WP_Error( 'newspack_analytics', __( 'Error when setting category custom dimension.', 'newspack' ) );
+		}
 	}
 }

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -116,7 +116,7 @@ class Analytics_Wizard extends Wizard {
 							'id' => $new_custom_dimension['id'],
 						]
 					);
-					update_option( 'has_set_up_category_dimension_09', 'completed' );
+					update_option( 'has_set_up_category_dimension', 'completed' );
 				}
 			}
 		}

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -179,17 +179,17 @@ class Analytics_Wizard extends Wizard {
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/analytics.js' ),
 			true
 		);
-		$custom_dimensions = self::list_custom_dimensions();
+		$custom_dimensions          = self::list_custom_dimensions();
+		$analytics_connection_error = null;
 		if ( is_wp_error( $custom_dimensions ) ) {
-			$custom_dimensions = [
-				'error' => $custom_dimensions->get_error_message(),
-			];
+			$analytics_connection_error = $custom_dimensions->get_error_message();
 		}
 		\wp_localize_script(
 			'newspack-analytics-wizard',
 			'newspack_analytics_wizard_data',
 			[
-				'customDimensions' => $custom_dimensions,
+				'customDimensions'         => $custom_dimensions,
+				'analyticsConnectionError' => $analytics_connection_error,
 			]
 		);
 

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -220,7 +220,7 @@ class Analytics_Wizard extends Wizard {
 				$authentication = new Authentication( $context, $ga_options, $user_options );
 
 				if ( false === $authentication->is_authenticated() ) {
-					return new WP_Error( 'newspack_analytics_sitekit_disconnected', __( 'Please authenticate with Site Kit plugin.', 'newspack' ) );
+					return new WP_Error( 'newspack_analytics_sitekit_authentication', __( 'Please authenticate with Site Kit plugin.', 'newspack' ) );
 				}
 
 				$client = $authentication->get_oauth_client()->get_client();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

PR #588 was reverted because of two issues:
1. Some local-testing-related code that was erroenusly included – fixed by #598
2. Lack of handling of authentication error when requesting GA data

This PR reintroduces code from #588, with issue 2 handled

### How to test the changes in this Pull Request:

1. Everything in #588, plus:
2. Log in to WP admin as a user which did not authenticate with Site Kit
3. Visit Analytics wizard, observe an error notice being shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
