### PR TITLE
Sync WC order transactions to Salesforce opportunities

### DIFF
--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -144,8 +144,8 @@ class Salesforce {
 	 * @return @array|bool Parsed data, or false.
 	 */
 	public static function parse_wc_order_data( $data ) {
-		$order_contact = [];
-		$orders        = [];
+		$contact = [];
+		$orders  = [];
 
 		// We need billing and transaction info from the order before we can do anything.
 		if ( empty( $data['billing'] ) || empty( $data['line_items'] ) ) {
@@ -154,34 +154,34 @@ class Salesforce {
 
 		// Parse billing contact info from WooCommerce.
 		if ( ! empty( $data['billing']['email'] ) ) {
-			$order_contact['Email'] = $data['billing']['email'];
+			$contact['Email'] = $data['billing']['email'];
 		}
 		if ( ! empty( $data['billing']['first_name'] ) ) {
-			$order_contact['FirstName'] = $data['billing']['first_name'];
+			$contact['FirstName'] = $data['billing']['first_name'];
 		}
 		if ( ! empty( $data['billing']['last_name'] ) ) {
-			$order_contact['LastName'] = $data['billing']['last_name'];
+			$contact['LastName'] = $data['billing']['last_name'];
 		}
 		if ( ! empty( $data['billing']['phone'] ) ) {
-			$order_contact['HomePhone'] = $data['billing']['phone'];
+			$contact['HomePhone'] = $data['billing']['phone'];
 		}
 		if ( ! empty( $data['billing']['address_1'] ) ) {
-			$order_contact['MailingStreet'] = $data['billing']['address_1'];
+			$contact['MailingStreet'] = $data['billing']['address_1'];
 		}
 		if ( ! empty( $data['billing']['address_2'] ) ) {
-			$order_contact['MailingStreet'] .= "\n" . $data['billing']['address_2'];
+			$contact['MailingStreet'] .= "\n" . $data['billing']['address_2'];
 		}
 		if ( ! empty( $data['billing']['city'] ) ) {
-			$order_contact['MailingCity'] = $data['billing']['city'];
+			$contact['MailingCity'] = $data['billing']['city'];
 		}
 		if ( ! empty( $data['billing']['state'] ) ) {
-			$order_contact['MailingState'] = $data['billing']['state'];
+			$contact['MailingState'] = $data['billing']['state'];
 		}
 		if ( ! empty( $data['billing']['postcode'] ) ) {
-			$order_contact['MailingPostalCode'] = $data['billing']['postcode'];
+			$contact['MailingPostalCode'] = $data['billing']['postcode'];
 		}
 		if ( 0 === $data['meta_data'][0]['mailchimp_woocommerce_is_subscribed'] ) {
-			$order_contact['HasOptedOutOfEmail'] = true;
+			$contact['HasOptedOutOfEmail'] = true;
 		}
 
 		$transaction_date = $data['date_created_gmt'];
@@ -200,7 +200,7 @@ class Salesforce {
 		}
 
 		return [
-			'contact' => $order_contact,
+			'contact' => $contact,
 			'orders'  => $orders,
 		];
 	}

--- a/includes/class-webhooks.php
+++ b/includes/class-webhooks.php
@@ -49,52 +49,79 @@ class Webhooks {
 	 * Webhook callback handler for syncing data to Salesforce.
 	 *
 	 * @param WP_REST_Request $request Request containing webhook.
-	 * @throws \Exception Error message.
-	 * @return WP_REST_Response with the response from Salesforce.
+	 * @return WP_REST_Response|WP_Error The response from Salesforce, or WP_Error.
 	 */
 	public function api_sync_salesforce( $request ) {
-		$args            = $request->get_params();
-		$order_details   = Salesforce::parse_wc_order_data( $args );
-		$order_contact   = $order_details['contact'];
-		$orders          = $order_details['orders'];
-		$order_responses = [];
+		$args          = $request->get_params();
+		$order_details = Salesforce::parse_wc_order_data( $args );
 
-		if ( empty( $order_contact ) || empty( empty( $orders ) ) ) {
-			return \rest_ensure_response( 'No valid order details.' );
+		if ( empty( $order_details ) ) {
+			return new \WP_Error(
+				'newspack_salesforce_invalid_order',
+				__( 'No valid WooCommerce order data.', 'newspack' )
+			);
 		}
 
-		if ( empty( $order_contact['Email'] ) ) {
-			return \rest_ensure_response( 'No valid email address.' );
+		$contact       = $order_details['contact'];
+		$orders        = $order_details['orders'];
+		$opportunities = [];
+
+		if ( empty( $contact ) || empty( $orders ) ) {
+			return new \WP_Error(
+				'newspack_salesforce_invalid_contact_or_transaction',
+				__( 'No valid transaction or contact data.', 'newspack' )
+			);
 		}
 
-		$contacts   = Salesforce::get_contacts_by_email( $order_contact['Email'] );
-		$contact_id = '';
+		if ( empty( $contact['Email'] ) ) {
+			return new \WP_Error(
+				'newspack_salesforce_invalid_contact_email',
+				__( 'No valid contact email address.', 'newspack' )
+			);
+		}
+
+		$contacts = Salesforce::get_contacts_by_email( $contact['Email'] );
+
+		if ( empty( $contacts ) ) {
+			return new \WP_Error(
+				'newspack_salesforce_invalid_salesforce_lookup',
+				__( 'Could not communicate with Salesforce.', 'newspack' )
+			);
+		}
 
 		if ( $contacts->totalSize > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			// Update existing contact.
-			if ( ! empty( $contacts->records[0]->Description && ! empty( $order_contact['Description'] ) ) ) {
-				$order_contact['Description'] .= "\n" . $contacts->records[0]->Description; // Update line items.
-			}
 			$contact_id       = $contacts->records[0]->Id;
-			$contact_response = Salesforce::update_contact( $contact_id, $order_contact );
+			$contact_response = Salesforce::update_contact( $contact_id, $contact );
 		} else {
 			// Create new contact.
-			$contact_response = Salesforce::create_contact( $order_contact );
-			$contact_id       = $contact_response['id'];
+			$contact_response = Salesforce::create_contact( $contact );
+			$contact_id       = $contact_response->id;
 		}
 
-		if ( is_array( $orders ) ) {
+		if ( empty( $contact_id ) ) {
+			return new \WP_Error(
+				'newspack_salesforce_sync_failure',
+				__( 'Could not create or update Salesforce data.', 'newspack' )
+			);
+		}
 
+		// Sync WooCommerce orders to Salesforce opportunities.
+		if ( is_array( $orders ) ) {
 			foreach ( $orders as $order ) {
-				$order['BillToContactId'] = $contact_id;
-				$order_responses[]        = Salesforce::create_order( $order );
+				$opportunity_response = Salesforce::create_opportunity( $order );
+				$opportunity_id       = $opportunity_response->id;
+
+				if ( ! empty( $opportunity_id ) ) {
+					$opportunities[] = $opportunity_response;
+					Salesforce::create_opportunity_contact_role( $opportunity_id, $contact_id );
+				}
 			}
 		}
 
 		return \rest_ensure_response(
 			[
-				'contact' => $contact_response,
-				'orders'  => $order_responses,
+				'contact'       => $contact_response,
+				'opportunities' => $opportunities,
 			]
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This updates the Salesforce data sync to create [Opportunity](https://help.salesforce.com/articleView?id=opportunities.htm&type=5) records for each line item in a successful WooCommerce order. Opportunities are linked to a Contact via an intermediate [OpportunityContactRole](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_opportunitycontactrole.htm).

### How to test the changes in this Pull Request:

#### Setup steps

1. Follow [these instructions](https://newspack.pub/support/reader-revenue/salesforce/) to connect a Salesforce org to your Newspack site. (If you don't have a Salesforce org, [sign up for one here](https://developer.salesforce.com/signup))
2. Ensure that you have all required WooCommerce plugins and the Subscriptions extension fully set up for testing. Make sure you have Check payments enabled and/or Stripe setup for test transactions.
3. Create a page that has a Donate block. View the page as a non-logged-in user.

#### Testing a one-time donation with a new donor/contact

1. From the donate block, choose a **one-time** donation of any amount.
2. Enter a fake/unique email address and test data for all other required fields. Choose any valid payment method and note the transaction date, total, and ID displayed on the checkout confirmation page.
3. After a few moments, go to your Sales console in your Salesforce org and look up All Contacts (instructions toward the bottom of [this page](https://newspack.pub/support/reader-revenue/salesforce/)).
4. Observe a new contact record and view the **Details** tab. The Contact's info and email address should match what you inputted in the WooCommerce checkout form.
5. Also observe an Opportunities panel in the Contact's details page that contains a reference to an Opportunity that was created for your transaction:

<img width="163" alt="Screen Shot 2020-07-27 at 3 22 47 PM" src="https://user-images.githubusercontent.com/2230142/88593615-0e412200-d01d-11ea-8370-85d2c67a57cc.png">

6. Click on the Opportunity and view the **Details** tab. The details should match the details of your WooCommerce transaction (date = Close Date field, total = Amount field, and ID in the Description field).

#### Testing a one-time donation with an existing donor/contact

1. After testing a sync with the new donor/contact as above, make another one-time donation of any amount from the Donate block.
2. Use the same email address as before, but change several other fields (e.g. name or address).
3. Again, note the date, total, and ID on the confirmation page.
4. After a few moments, refresh the Contact's details page in Salesforce. The Contact's details should match the updated values you just inputted. 
5. In the Opportunities panel, you should see a new opportunity that was created for your second transaction:

<img width="509" alt="Screen Shot 2020-07-27 at 3 28 32 PM" src="https://user-images.githubusercontent.com/2230142/88594096-dab2c780-d01d-11ea-8bda-832dbe4a2d18.png">

6. Click on the new Opportunity and verify that the details match the date, total, and ID from the WooCommerce confirmation page.

#### Testing recurring donations with a new donor/contact

You must have a Stripe account and [Stripe configured for test transactions in WooCommerce](https://docs.woocommerce.com/document/stripe/#section-25) in order to test subscriptions.

1. From the Donate block, make a monthly or annual donation of any amount.
2. Use a new unique/fake email address for this donation. You may have to create a user account in order to complete this transaction.
3. Note the date, total, and ID on the confirmation page.
4. After a few moments, in Salesforce, look for a new contact record in the All Contacts view.
5. In the new contact's details page, note a new Opportunity matching your first subscription payment.
6. Test the recurring payment by manually triggering the next scheduled payment. In WP admin, go to **WooCommerce > Status > Scheduled Actions** and filter by Pending actions. You should see a Pending action with the `woocommerce_scheduled_subscription_payment ` hook scheduled for sometime in the future (e.g. if you made a monthly donation, it should be scheduled for ~1 month from today).
7. Hover over the hook name in the table and click the "Run" link that appears to manually trigger the action.
8. Back in Salesforce, you should see a new Opportunity appear in the existing contact's details page with a date, total, and ID matching the scheduled action you triggered.

#### (Optional) Testing subscription updates/cancellations

No new transactions should be scheduled or synced if a subscribing user cancels their subscription. We only sync on the `order.created` hook, which gets triggered by new payment transactions (both one-time and recurring), not on `subscription.updated`, which is triggered by any update to an existing subscription. To test:

1. Go to <site-url>/my-account and log in as the subscriber you created in the steps to test recurring donations.
2. Cancel your subscription.
3. In the WP admin **WooCommerce > Status > Scheduled Actions** filter by Pending and note that there shouldn't be any pending payment actions listed anymore.
4. Instead, there should be a `woocommerce_scheduled_subscription_end_of_prepaid_term` action scheduled. Run it.
5. Observe that no new transactions or contact info updates are synced to Salesforce.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->