### PR TITLE
Fix Site Kit connection error handling

### DIFF
--- a/assets/wizards/analytics/views/configuration/index.js
+++ b/assets/wizards/analytics/views/configuration/index.js
@@ -96,7 +96,7 @@ class Configuration extends Component {
 						/>
 					) }
 				{ error ? (
-					<Notice noticeText={ error } isError />
+					<Notice noticeText={ error } isError rawHTML />
 				) : (
 					<Fragment>
 						<table>

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -47,7 +47,7 @@ class Analytics {
 	}
 
 	/**
-	 * Tell Site Kit to report the article's category as custom dimension of index 1.
+	 * Tell Site Kit to report the article's category as custom dimension.
 	 * More about custom dimensions:
 	 * https://support.google.com/analytics/answer/2709828.
 	 */

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -223,6 +223,13 @@ class Analytics_Wizard extends Wizard {
 					return new WP_Error( 'newspack_analytics_sitekit_authentication', __( 'Please authenticate with the Site Kit plugin.', 'newspack' ) );
 				}
 
+				// A user might have authenticated with Site Kit before this version of the plugin,
+				// which updated authorization scopes, was deployed.
+				$unsatisfied_scopes = $authentication->get_oauth_client()->get_unsatisfied_scopes();
+				if ( 0 !== count( $unsatisfied_scopes ) ) {
+					return new WP_Error( 'newspack_analytics_sitekit_unsatisfied_scopes', __( 'Please re-connect Analytics in the Site Kit plugin.', 'newspack' ) );
+				}
+
 				$client = $authentication->get_oauth_client()->get_client();
 
 				return [
@@ -246,10 +253,14 @@ class Analytics_Wizard extends Wizard {
 		if ( is_wp_error( $ga_utils ) ) {
 			return $ga_utils;
 		}
-		$custom_dimensions = $ga_utils['analytics_service']->management_customDimensions->listManagementCustomDimensions(
-			$ga_utils['settings']['accountID'],
-			$ga_utils['settings']['propertyID']
-		);
+		try {
+			$custom_dimensions = $ga_utils['analytics_service']->management_customDimensions->listManagementCustomDimensions(
+				$ga_utils['settings']['accountID'],
+				$ga_utils['settings']['propertyID']
+			);
+		} catch ( \Throwable $e ) {
+			return new WP_Error( 'newspack_analytics', __( 'Error retrieving custom dimensions.', 'newspack' ) );
+		}
 		if ( isset( $custom_dimensions['items'] ) ) {
 			$option_name = self::$category_dimension_option_name;
 			return array_map(

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -227,7 +227,14 @@ class Analytics_Wizard extends Wizard {
 				// which updated authorization scopes, was deployed.
 				$unsatisfied_scopes = $authentication->get_oauth_client()->get_unsatisfied_scopes();
 				if ( 0 !== count( $unsatisfied_scopes ) ) {
-					return new WP_Error( 'newspack_analytics_sitekit_unsatisfied_scopes', __( 'Please re-connect Analytics in the Site Kit plugin.', 'newspack' ) );
+					return new WP_Error(
+						'newspack_analytics_sitekit_unsatisfied_scopes',
+						__( 'Please re-authorize', 'newspack' ) .
+						' <a href="' . get_admin_url() . 'admin.php?page=googlesitekit-dashboard">' .
+						__( 'Site Kit plugin', 'newspack' ) .
+						'</a> ' .
+						__( 'to allow updating Google Analytics settings.', 'newspack' ) 
+					);
 				}
 
 				$client = $authentication->get_oauth_client()->get_client();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This fixes issues introduced in #588, which were not caught and fixed in #600. 

There are two issues fixed by this PR:
1. Insufficient authorisation scopes detection. #588 added an auth scope, but did not add checking if the user has re-authorised after the update
2. User mismatch handling. It's possible that a user is authenticated with Site Kit, but does not have the correct Analytics module permissions. To account for that and any other edge case scenarios, the listing dimensions call to the Analytics Service was wrapped in a try/catch block.

### How to test the changes in this Pull Request:

1. On a fresh site, install version [`1.14.2`](https://github.com/Automattic/newspack-plugin/releases/download/v1.14.2/newspack-plugin.zip) of the plugin
2. Set up Site Kit, with Analytics
3. Install version [`1.15.0`](https://github.com/Automattic/newspack-plugin/releases/download/v1.15.0/newspack-plugin.zip)
4. Visit the Analytics Wizard, try to add a custom dimension 
5. Observe an error being reported in the UI
6. Create a new WP admin user, log in as them and visit the Analytics Wizard
7. Observe an error being reported in the UI
8. Authenticate with Site Kit as a different Google user than initially…
9. Observe a fatal error when trying to access WP Admin
10. Install the version of the plugin from this branch
11. Observe WP Admin loading again (still, for that new user)
12. Observe a generic error being shown in the Analytics Wizard
13. Log out and and log in as the initial user, visit the Analytics Wizard
14. Observe an error being shown about needing to re-connect with Site Kit
15. Visit Site Kit view, observe a notice from Site Kit about insufficient permissions
16. Click "Redo Setup" and go through the auth flow
17. Visit the Analytics Wizard, observe the functioning UI from #588. Add a custom dimension, observe that it succeeds

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
