### PR TITLE
Build: change release zip structure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,9 @@ jobs:
     steps:
       - checkout_with_workspace
       - run:
+          name: Install rsync
+          command: sudo apt install rsync
+      - run:
           name: Install PHP packages
           command: composer install --no-dev --no-scripts
       - run:

--- a/.distignore
+++ b/.distignore
@@ -33,11 +33,12 @@ yarn.lock
 *.tar.gz
 *.zip
 
-node_modules/*
-.git/*
-src/*
-.github/*
-.circleci/*
-tests/*
-bin/*
-assets/*
+# directories
+node_modules
+.git
+src
+.github
+.circleci
+tests
+bin
+assets

--- a/bin/release-archive.js
+++ b/bin/release-archive.js
@@ -1,0 +1,26 @@
+/**
+ * After the version in package.json in updated by semantic-release,
+ * this script will create the release zip, including the new version number in the zip file name.
+ */
+
+const util = require( 'util' );
+const exec = util.promisify( require( 'child_process' ).exec );
+
+const pkg = require( '../package.json' );
+
+exec(
+	`mkdir -p assets/release && rsync -r . ./assets/release/newspack-plugin --exclude-from='./.distignore' && cd assets/release && zip -r newspack-plugin-${ pkg.version }.zip newspack-plugin`
+)
+	.then( ( { stdout, stderr } ) => {
+		if ( stdout ) {
+			console.log( stdout );
+		}
+		if ( stderr ) {
+			console.log( stderr );
+			process.exit( 1 );
+		}
+	} )
+	.catch( err => {
+		console.log( err );
+		process.exit( 1 );
+	} );

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "lint:scss": "stylelint '**/*.scss' --syntax scss",
     "format:scss": "prettier --write '**/*.scss'",
     "lint:scss:staged": "stylelint --syntax scss",
-    "release:archive": "mkdir -p assets/release && zip -r assets/release/newspack-plugin.zip . -x@.distignore",
+    "release:archive": "node ./bin/release-archive.js",
     "release": "npm run build && npm run semantic-release"
   },
   "dependencies": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Change release ZIP file structure, so that it matches the structure used by WPORG plugins

### How to test the changes in this Pull Request:

1. Run `npm run release:archive`
1. Observe the release zip has version from the `package.json` in the file name – `newspack-plugin-0.0.0.zip`
2. Install the plugin on a fresh site, confirm that it works as before

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
