### PR TITLE
Add custom events adding UI

### DIFF
--- a/assets/components/src/consts.js
+++ b/assets/components/src/consts.js
@@ -1,0 +1,2 @@
+export const NEWSPACK_SITE_URL = 'https://newspack.pub';
+export const NEWSPACK_SUPPORT_URL = `${ NEWSPACK_SITE_URL }/support`;

--- a/assets/components/src/text-control/index.js
+++ b/assets/components/src/text-control/index.js
@@ -39,8 +39,8 @@ class TextControl extends Component {
 		const { className, required, ...otherProps } = this.props;
 		const classes = classNames( 'newspack-text-control', className );
 		return required ? (
-			<div ref={ this.wrapperRef } className={ classes }>
-				<BaseComponent required={ required } { ...otherProps } />
+			<div ref={ this.wrapperRef }>
+				<BaseComponent className={ classes } required={ required } { ...otherProps } />
 			</div>
 		) : (
 			<BaseComponent required={ required } className={ classes } { ...otherProps } />

--- a/assets/components/src/text-control/index.js
+++ b/assets/components/src/text-control/index.js
@@ -6,7 +6,8 @@
  * WordPress dependencies
  */
 import { TextControl as BaseComponent } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -19,13 +20,31 @@ import './style.scss';
 import classNames from 'classnames';
 
 class TextControl extends Component {
+	constructor( props ) {
+		super( props );
+		this.wrapperRef = createRef();
+	}
+	componentDidMount() {
+		if ( this.wrapperRef.current ) {
+			const labelEl = this.wrapperRef.current.querySelector( 'label' );
+			if ( labelEl ) {
+				labelEl.setAttribute( 'data-required-text', __( '(required)', 'newspack' ) );
+			}
+		}
+	}
 	/**
 	 * Render.
 	 */
 	render() {
-		const { className, ...otherProps } = this.props;
+		const { className, required, ...otherProps } = this.props;
 		const classes = classNames( 'newspack-text-control', className );
-		return <BaseComponent className={ classes } { ...otherProps } />;
+		return required ? (
+			<div ref={ this.wrapperRef } className={ classes }>
+				<BaseComponent required={ required } { ...otherProps } />
+			</div>
+		) : (
+			<BaseComponent required={ required } className={ classes } { ...otherProps } />
+		);
 	}
 }
 

--- a/assets/components/src/text-control/style.scss
+++ b/assets/components/src/text-control/style.scss
@@ -11,7 +11,6 @@
 	line-height: 24px;
 	margin: 32px 0;
 
-
 	label {
 		color: $dark-gray-900;
 		font-size: inherit;
@@ -24,7 +23,7 @@
 				content: attr( data-required-text );
 				padding-left: 5px;
 				font-weight: normal;
-				opacity: 0.5;
+				color: $dark-gray-300;
 			}
 		}
 	}

--- a/assets/components/src/text-control/style.scss
+++ b/assets/components/src/text-control/style.scss
@@ -11,12 +11,22 @@
 	line-height: 24px;
 	margin: 32px 0;
 
+
 	label {
 		color: $dark-gray-900;
 		font-size: inherit;
 		font-weight: bold;
 		line-height: inherit;
 		margin: 0;
+
+		&[data-required-text] {
+			&::after {
+				content: attr( data-required-text );
+				padding-left: 5px;
+				font-weight: normal;
+				opacity: 0.5;
+			}
+		}
 	}
 
 	input[type='date'],

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -25,11 +25,10 @@ import {
 } from '../';
 import Router from '../proxied-imports/router';
 import { buttonProps } from '../../../shared/js/';
+import { NEWSPACK_SITE_URL } from '../consts';
 import './style.scss';
 
 const { Redirect, Route } = Router;
-
-const NEWSPACK_SITE_URL = 'https://newspack.pub';
 
 /**
  * Higher-Order Component to provide plugin management and error handling to Newspack Wizards.

--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -27,7 +27,7 @@ const { HashRouter, Redirect, Route, Switch } = Router;
 
 const TABS = [
 	{
-		label: __( 'Custom Events', 'newspack' ),
+		label: __( 'Plugins', 'newspack' ),
 		path: '/',
 		exact: true,
 	},
@@ -36,8 +36,8 @@ const TABS = [
 		path: '/custom-dimensions',
 	},
 	{
-		label: __( 'Plugins', 'newspack' ),
-		path: '/plugins',
+		label: __( 'Custom Events', 'newspack' ),
+		path: '/custom-events',
 	},
 ];
 
@@ -60,13 +60,17 @@ class AnalyticsWizard extends Component {
 				<HashRouter hashType="slash">
 					<Switch>
 						{ pluginRequirements }
-						<Route path="/plugins" exact render={ () => <Plugins { ...sharedProps } /> } />
 						<Route
 							path="/custom-dimensions"
 							exact
 							render={ () => <CustomDimensions { ...sharedProps } /> }
 						/>
-						<Route path="/" exact render={ () => <CustomEvents { ...sharedProps } /> } />
+						<Route
+							path="/custom-events"
+							exact
+							render={ () => <CustomEvents { ...sharedProps } /> }
+						/>
+						<Route path="/" exact render={ () => <Plugins { ...sharedProps } /> } />
 						<Redirect to="/" />
 					</Switch>
 				</HashRouter>

--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -20,13 +20,13 @@ import HeaderIcon from '@material-ui/icons/TrendingUp';
  */
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { Plugins, Configuration } from './views';
+import { Plugins, CustomDimensions } from './views';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
 const TABS = [
 	{
-		label: __( 'Configuration', 'newspack' ),
+		label: __( 'Custom Dimensions', 'newspack' ),
 		path: '/',
 		exact: true,
 	},
@@ -55,7 +55,7 @@ class AnalyticsWizard extends Component {
 					<Switch>
 						{ pluginRequirements }
 						<Route path="/plugins" exact render={ () => <Plugins { ...sharedProps } /> } />
-						<Route path="/" exact render={ () => <Configuration { ...sharedProps } /> } />
+						<Route path="/" exact render={ () => <CustomDimensions { ...sharedProps } /> } />
 						<Redirect to="/" />
 					</Switch>
 				</HashRouter>

--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -20,15 +20,20 @@ import HeaderIcon from '@material-ui/icons/TrendingUp';
  */
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { Plugins, CustomDimensions } from './views';
+import { Plugins, CustomDimensions, CustomEvents } from './views';
+import './style.scss';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
 const TABS = [
 	{
-		label: __( 'Custom Dimensions', 'newspack' ),
+		label: __( 'Custom Events', 'newspack' ),
 		path: '/',
 		exact: true,
+	},
+	{
+		label: __( 'Custom Dimensions', 'newspack' ),
+		path: '/custom-dimensions',
 	},
 	{
 		label: __( 'Plugins', 'newspack' ),
@@ -41,13 +46,14 @@ class AnalyticsWizard extends Component {
 	 * Render
 	 */
 	render() {
-		const { pluginRequirements, wizardApiFetch } = this.props;
+		const { pluginRequirements, wizardApiFetch, isLoading } = this.props;
 		const sharedProps = {
 			headerIcon: <HeaderIcon />,
 			headerText: __( 'Analytics', 'newspack' ),
-			subHeaderText: __( 'Track traffic and activity', 'newspack' ),
+			subHeaderText: __( 'Track traffic and activity.', 'newspack' ),
 			tabbedNavigation: TABS,
 			wizardApiFetch,
+			isLoading,
 		};
 		return (
 			<Fragment>
@@ -55,7 +61,12 @@ class AnalyticsWizard extends Component {
 					<Switch>
 						{ pluginRequirements }
 						<Route path="/plugins" exact render={ () => <Plugins { ...sharedProps } /> } />
-						<Route path="/" exact render={ () => <CustomDimensions { ...sharedProps } /> } />
+						<Route
+							path="/custom-dimensions"
+							exact
+							render={ () => <CustomDimensions { ...sharedProps } /> }
+						/>
+						<Route path="/" exact render={ () => <CustomEvents { ...sharedProps } /> } />
 						<Redirect to="/" />
 					</Switch>
 				</HashRouter>

--- a/assets/wizards/analytics/style.scss
+++ b/assets/wizards/analytics/style.scss
@@ -22,12 +22,6 @@
 			margin: 0;
 		}
 	}
-	&__clickable-row {
-		cursor: pointer;
-		&:hover {
-			background-color: #3366ff0d;
-		}
-	}
 	&__form {
 		display: flex;
 		align-items: flex-end;

--- a/assets/wizards/analytics/style.scss
+++ b/assets/wizards/analytics/style.scss
@@ -22,6 +22,12 @@
 			margin: 0;
 		}
 	}
+	&__clickable-row {
+		cursor: pointer;
+		&:hover {
+			background-color: #3366ff0d;
+		}
+	}
 	&__form {
 		display: flex;
 		align-items: flex-end;
@@ -42,6 +48,11 @@
 			@media screen and ( max-width: 600px ) {
 				margin-top: 10px !important;
 			}
+		}
+	}
+	&__code {
+		input {
+			font-family: monospace !important;
 		}
 	}
 }

--- a/assets/wizards/analytics/style.scss
+++ b/assets/wizards/analytics/style.scss
@@ -5,6 +5,7 @@
 		margin-top: -25px;
 	}
 	th {
+		padding: 6px 0;
 		text-align: left;
 		border-bottom: 1px solid $light-gray-500;
 	}

--- a/assets/wizards/analytics/views/custom-dimensions/index.js
+++ b/assets/wizards/analytics/views/custom-dimensions/index.js
@@ -17,7 +17,6 @@ import {
 	CheckboxControl,
 	withWizardScreen,
 } from '../../../../components/src';
-import './style.scss';
 
 const SCOPES_OPTIONS = [
 	{ value: 'HIT', label: __( 'Hit', 'newspack' ) },

--- a/assets/wizards/analytics/views/custom-dimensions/index.js
+++ b/assets/wizards/analytics/views/custom-dimensions/index.js
@@ -27,9 +27,9 @@ const SCOPES_OPTIONS = [
 ];
 
 /**
- * Analytics Configuration screen.
+ * Analytics Custom Dimensions screen.
  */
-class Configuration extends Component {
+class CustomDimensions extends Component {
 	state = {
 		error: newspack_analytics_wizard_data.analyticsConnectionError,
 		customDimensions: newspack_analytics_wizard_data.customDimensions,
@@ -78,7 +78,6 @@ class Configuration extends Component {
 		const hasCustomDimensions = ! error && customDimensions.length !== 0;
 		return (
 			<div className="newspack__analytics-configuration newspack-card newspack-card__no-background">
-				<h2>{ __( 'Custom dimensions', 'newspack' ) }</h2>
 				<p>
 					{ __(
 						"Custom dimensions are used to collect and analyze data that Google Analytics doesn't automatically track.",
@@ -163,4 +162,4 @@ class Configuration extends Component {
 	}
 }
 
-export default withWizardScreen( Configuration );
+export default withWizardScreen( CustomDimensions );

--- a/assets/wizards/analytics/views/custom-dimensions/style.scss
+++ b/assets/wizards/analytics/views/custom-dimensions/style.scss
@@ -1,6 +1,9 @@
 @import '~@wordpress/base-styles/colors';
 
 .newspack__analytics-configuration {
+	> p:first-child {
+		margin-top: -25px;
+	}
 	th {
 		text-align: left;
 		border-bottom: 1px solid $light-gray-500;

--- a/assets/wizards/analytics/views/custom-events/index.js
+++ b/assets/wizards/analytics/views/custom-events/index.js
@@ -133,7 +133,7 @@ class CustomEvents extends Component {
 					rawHTML
 					isInfo
 					noticeText={ `${ __(
-						'This is an advanced feature, read more about on our',
+						'This is an advanced feature, read more about it on our',
 						'newspack'
 					) } <a href="${ NEWSPACK_SUPPORT_URL }/analytics">${ __(
 						'support page',

--- a/assets/wizards/analytics/views/custom-events/index.js
+++ b/assets/wizards/analytics/views/custom-events/index.js
@@ -135,7 +135,7 @@ class CustomEvents extends Component {
 					noticeText={ `${ __(
 						'This is an advanced feature, read more about it on our',
 						'newspack'
-					) } <a href="${ NEWSPACK_SUPPORT_URL }/analytics">${ __(
+					) } <a target="_blank" href="${ NEWSPACK_SUPPORT_URL }/analytics">${ __(
 						'support page',
 						'newspack'
 					) }</a>.` }

--- a/assets/wizards/analytics/views/custom-events/index.js
+++ b/assets/wizards/analytics/views/custom-events/index.js
@@ -4,6 +4,8 @@
  * External dependencies
  */
 import { find } from 'lodash';
+import DoneIcon from '@material-ui/icons/Done';
+import ClearIcon from '@material-ui/icons/Clear';
 
 /**
  * WordPress dependencies
@@ -23,6 +25,7 @@ import {
 	withWizardScreen,
 	Modal,
 } from '../../../../components/src';
+import { NEWSPACK_SUPPORT_URL } from '../../../../components/src/consts';
 
 /**
  * Not implemented:
@@ -126,6 +129,17 @@ class CustomEvents extends Component {
 						'newspack'
 					) }
 				</p>
+				<Notice
+					rawHTML
+					isInfo
+					noticeText={ `${ __(
+						'This is an advanced feature, read more about on our',
+						'newspack'
+					) } <a href="${ NEWSPACK_SUPPORT_URL }/analytics">${ __(
+						'support page',
+						'newspack'
+					) }</a>.` }
+				/>
 				{ error ? (
 					<Notice noticeText={ error } isError />
 				) : (
@@ -139,6 +153,7 @@ class CustomEvents extends Component {
 										__( 'Category', 'newspack' ),
 										__( 'Label', 'newspack' ),
 										__( 'Trigger', 'newspack' ),
+										__( 'Edit', 'newspack' ),
 									].map( ( colName, i ) => (
 										<th key={ i }>{ colName }</th>
 									) ) }
@@ -146,17 +161,18 @@ class CustomEvents extends Component {
 							</thead>
 							<tbody>
 								{ customEvents.map( event => (
-									<tr
-										className="newspack__analytics-configuration__clickable-row"
-										key={ event.id }
-										onClick={ this.setEditModal( event.id ) }
-									>
-										<td>{ <CheckboxControl checked={ event.is_active } disabled /> }</td>
+									<tr key={ event.id }>
+										<td>{ event.is_active ? <DoneIcon /> : <ClearIcon /> }</td>
 										<td>{ event.event_name }</td>
 										<td>{ event.event_category }</td>
 										<td>{ event.event_label }</td>
 										<td>
 											<code>{ event.on }</code>
+										</td>
+										<td>
+											<Button isSmall isLink onClick={ this.setEditModal( event.id ) }>
+												{ __( 'Edit', 'newspack' ) }
+											</Button>
 										</td>
 									</tr>
 								) ) }
@@ -182,12 +198,14 @@ class CustomEvents extends Component {
 										value={ editedEvent.event_name }
 										onChange={ this.updateEditedEvent( 'event_name' ) }
 										label={ __( 'Action', 'newspack' ) }
+										required
 									/>
 									<TextControl
 										disabled={ isLoading }
 										value={ editedEvent.event_category }
 										onChange={ this.updateEditedEvent( 'event_category' ) }
 										label={ __( 'Category', 'newspack' ) }
+										required
 									/>
 									<TextControl
 										disabled={ isLoading }
@@ -201,6 +219,7 @@ class CustomEvents extends Component {
 										onChange={ this.updateEditedEvent( 'on' ) }
 										label={ __( 'Trigger', 'newspack' ) }
 										options={ TRIGGER_OPTIONS }
+										required
 									/>
 									<TextControl
 										disabled={ isLoading }
@@ -208,6 +227,7 @@ class CustomEvents extends Component {
 										onChange={ this.updateEditedEvent( 'element' ) }
 										label={ __( 'Selector', 'newspack' ) }
 										className="newspack__analytics-configuration__code"
+										required
 									/>
 									<TextControl
 										disabled={ isLoading }
@@ -220,7 +240,7 @@ class CustomEvents extends Component {
 										disabled={ isLoading }
 										checked={ editedEvent.non_interaction }
 										onChange={ this.updateEditedEvent( 'non_interaction' ) }
-										label={ __( 'Non-interaction', 'newspack' ) }
+										label={ __( 'Non-interaction event', 'newspack' ) }
 									/>
 									<CheckboxControl
 										disabled={ isLoading }

--- a/assets/wizards/analytics/views/custom-events/index.js
+++ b/assets/wizards/analytics/views/custom-events/index.js
@@ -1,0 +1,260 @@
+/* global newspack_analytics_wizard_data */
+
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	Button,
+	Notice,
+	TextControl,
+	SelectControl,
+	CheckboxControl,
+	withWizardScreen,
+	Modal,
+} from '../../../../components/src';
+
+/**
+ * Not implemented:
+ * - visibility, ini-load: require the element to be AMP element,
+ * - scroll: requires some more UI for scroll parameters, can be implemented later.
+ */
+const TRIGGER_OPTIONS = [
+	{ value: 'click', label: __( 'Click', 'newspack' ) },
+	{ value: 'submit', label: __( 'Submit', 'newspack' ) },
+];
+
+const NEW_EVENT_TEMPLATE = {
+	event_name: '',
+	event_category: '',
+	event_label: '',
+	on: TRIGGER_OPTIONS[ 0 ].value,
+	element: '',
+	amp_element: '',
+	non_interaction: true,
+	is_active: true,
+};
+
+const validateEvent = event =>
+	Boolean( event.event_name && event.event_category && event.on && event.element );
+
+/**
+ * Analytics Custom Events screen.
+ */
+class CustomEvents extends Component {
+	state = {
+		error: newspack_analytics_wizard_data.analyticsConnectionError,
+		customEvents: newspack_analytics_wizard_data.customEvents,
+		editedEvent: NEW_EVENT_TEMPLATE,
+		editedEventId: null,
+	};
+
+	handleAPIError = ( { message: error } ) => this.setState( { error } );
+
+	updateCustomEvents = updatedEvents => {
+		const { wizardApiFetch } = this.props;
+		wizardApiFetch( {
+			path: '/newspack/v1/wizard/analytics/custom-events',
+			method: 'POST',
+			data: { events: updatedEvents },
+		} )
+			.then( ( { events } ) =>
+				this.setState( {
+					customEvents: events,
+					editedEvent: NEW_EVENT_TEMPLATE,
+					editedEventId: null,
+				} )
+			)
+			.catch( this.handleAPIError );
+	};
+
+	handleCustomEventEdit = () => {
+		const { customEvents, editedEvent, editedEventId } = this.state;
+		if ( editedEventId === 'new' ) {
+			this.updateCustomEvents( [ ...customEvents, editedEvent ] );
+		} else {
+			this.updateCustomEvents(
+				customEvents.map( event => {
+					if ( event.id === editedEventId ) {
+						return editedEvent;
+					}
+					return event;
+				} )
+			);
+		}
+	};
+
+	updateEditedEvent = key => value =>
+		this.setState( ( { editedEvent } ) => ( { editedEvent: { ...editedEvent, [ key ]: value } } ) );
+
+	setEditModal = editedEventId => () => {
+		const editedEvent =
+			editedEventId !== null && find( this.state.customEvents, [ 'id', editedEventId ] );
+		this.setState( {
+			editedEventId,
+			...( editedEvent
+				? {
+						editedEvent,
+				  }
+				: {
+						editedEvent: NEW_EVENT_TEMPLATE,
+				  } ),
+		} );
+	};
+
+	render() {
+		const { error, customEvents, editedEvent, editedEventId } = this.state;
+		const { isLoading } = this.props;
+
+		const isCreatingEvent = editedEventId === 'new';
+
+		return (
+			<div className="newspack__analytics-configuration newspack-card newspack-card__no-background">
+				<p>
+					{ __(
+						'Custom events are used to collect and analyze specific user interactions.',
+						'newspack'
+					) }
+				</p>
+				{ error ? (
+					<Notice noticeText={ error } isError />
+				) : (
+					<Fragment>
+						<table>
+							<thead>
+								<tr>
+									{ [
+										__( 'Active', 'newspack' ),
+										__( 'Action', 'newspack' ),
+										__( 'Category', 'newspack' ),
+										__( 'Label', 'newspack' ),
+										__( 'Trigger', 'newspack' ),
+									].map( ( colName, i ) => (
+										<th key={ i }>{ colName }</th>
+									) ) }
+								</tr>
+							</thead>
+							<tbody>
+								{ customEvents.map( event => (
+									<tr
+										className="newspack__analytics-configuration__clickable-row"
+										key={ event.id }
+										onClick={ this.setEditModal( event.id ) }
+									>
+										<td>{ <CheckboxControl checked={ event.is_active } disabled /> }</td>
+										<td>{ event.event_name }</td>
+										<td>{ event.event_category }</td>
+										<td>{ event.event_label }</td>
+										<td>
+											<code>{ event.on }</code>
+										</td>
+									</tr>
+								) ) }
+							</tbody>
+						</table>
+
+						<Button onClick={ this.setEditModal( 'new' ) } isPrimary>
+							{ __( 'Create a new custom event', 'newspack' ) }
+						</Button>
+
+						{ editedEventId !== null && (
+							<Modal
+								title={
+									isCreatingEvent
+										? __( 'New custom event', 'newspack' )
+										: __( 'Editing custom event', 'newspack' )
+								}
+								onRequestClose={ this.setEditModal( null ) }
+							>
+								<div>
+									<TextControl
+										disabled={ isLoading }
+										value={ editedEvent.event_name }
+										onChange={ this.updateEditedEvent( 'event_name' ) }
+										label={ __( 'Action', 'newspack' ) }
+									/>
+									<TextControl
+										disabled={ isLoading }
+										value={ editedEvent.event_category }
+										onChange={ this.updateEditedEvent( 'event_category' ) }
+										label={ __( 'Category', 'newspack' ) }
+									/>
+									<TextControl
+										disabled={ isLoading }
+										value={ editedEvent.event_label }
+										onChange={ this.updateEditedEvent( 'event_label' ) }
+										label={ __( 'Label', 'newspack' ) }
+									/>
+									<SelectControl
+										disabled={ isLoading }
+										value={ editedEvent.on }
+										onChange={ this.updateEditedEvent( 'on' ) }
+										label={ __( 'Trigger', 'newspack' ) }
+										options={ TRIGGER_OPTIONS }
+									/>
+									<TextControl
+										disabled={ isLoading }
+										value={ editedEvent.element }
+										onChange={ this.updateEditedEvent( 'element' ) }
+										label={ __( 'Selector', 'newspack' ) }
+										className="newspack__analytics-configuration__code"
+									/>
+									<TextControl
+										disabled={ isLoading }
+										value={ editedEvent.amp_element }
+										onChange={ this.updateEditedEvent( 'amp_element' ) }
+										label={ __( 'AMP Selector', 'newspack' ) }
+										className="newspack__analytics-configuration__code"
+									/>
+									<CheckboxControl
+										disabled={ isLoading }
+										checked={ editedEvent.non_interaction }
+										onChange={ this.updateEditedEvent( 'non_interaction' ) }
+										label={ __( 'Non-interaction', 'newspack' ) }
+									/>
+									<CheckboxControl
+										disabled={ isLoading }
+										checked={ editedEvent.is_active }
+										onChange={ this.updateEditedEvent( 'is_active' ) }
+										label={ __( 'Active', 'newspack' ) }
+									/>
+									<Button
+										onClick={ this.handleCustomEventEdit }
+										disabled={ ! validateEvent( editedEvent ) || isLoading }
+										isPrimary
+									>
+										{ isCreatingEvent ? __( 'Create', 'newspack' ) : __( 'Update', 'newspack' ) }
+									</Button>
+									{ ! isCreatingEvent && (
+										<Button
+											disabled={ isLoading }
+											onClick={ () =>
+												this.updateCustomEvents(
+													this.state.customEvents.filter( ( { id } ) => editedEvent.id !== id )
+												)
+											}
+										>
+											{ __( 'Delete', 'newspack' ) }
+										</Button>
+									) }
+								</div>
+							</Modal>
+						) }
+					</Fragment>
+				) }
+			</div>
+		);
+	}
+}
+
+export default withWizardScreen( CustomEvents );

--- a/assets/wizards/analytics/views/index.js
+++ b/assets/wizards/analytics/views/index.js
@@ -1,2 +1,3 @@
 export { default as Plugins } from './plugins';
 export { default as CustomDimensions } from './custom-dimensions';
+export { default as CustomEvents } from './custom-events';

--- a/assets/wizards/analytics/views/index.js
+++ b/assets/wizards/analytics/views/index.js
@@ -1,2 +1,2 @@
 export { default as Plugins } from './plugins';
-export { default as Configuration } from './configuration';
+export { default as CustomDimensions } from './custom-dimensions';

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -444,15 +444,18 @@ class Analytics {
 				var elements        = Array.prototype.slice.call( document.querySelectorAll( elementSelector ) );
 
 				for ( var i = 0; i < elements.length; ++i ) {
-					elements[i].addEventListener( 'click', function() {
-						gtag(
-							'event',
-							'<?php echo esc_attr( $event['event_name'] ); ?>',
-							{
-								event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
-								event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
-							}
-						);
+					elements[i].addEventListener( 'click', function( event ) {
+						<?php // Ensure the clicked element still matches the selector. For example an aria attribue might've changed. ?>
+						if (event.currentTarget.matches(elementSelector)) {
+							gtag(
+								'event',
+								'<?php echo esc_attr( $event['event_name'] ); ?>',
+								{
+									event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
+									event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+								}
+							);
+						};
 					} );
 				}
 			} )();

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -214,6 +214,25 @@ class Analytics {
 			);
 		}
 
+		$custom_events = array_reduce(
+			json_decode( get_option( Analytics_Wizard::$custom_events_option_name, '[]' ) ),
+			function ( $all_custom_events, $event ) {
+				$event = (array) $event;
+				if ( $event['is_active'] ) {
+					if ( 'submit' === $event['on'] ) {
+						$event['amp_on'] = 'amp-form-submit-success';
+					}
+					if ( '' === $event['amp_element'] ) {
+						unset( $event['amp_element'] );
+					}
+					$all_custom_events[] = $event;
+				}
+				return $all_custom_events;
+			},
+			[]
+		);
+		$events        = array_merge( $events, $custom_events );
+
 		/**
 		 * Other integrations can add events to track using this filter.
 		 */
@@ -440,7 +459,7 @@ class Analytics {
 		?>
 		<script>
 			( function() {
-				var elementSelector = '<?php echo esc_attr( $event['element'] ); ?>';
+				var elementSelector = '<?php echo str_replace( '&quot;', '"', esc_attr( $event['element'] ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Allow quotes for CSS selectors validity. ?>';
 				var elements        = Array.prototype.slice.call( document.querySelectorAll( elementSelector ) );
 
 				for ( var i = 0; i < elements.length; ++i ) {

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -34,6 +34,13 @@ class Analytics_Wizard extends Wizard {
 	public static $category_dimension_option_name = 'newspack_analytics_category_custom_dimension_id';
 
 	/**
+	 * Name of the option storing site's custom events (serialised).
+	 *
+	 * @var string
+	 */
+	public static $custom_events_option_name = 'newspack_analytics_custom_events';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -160,6 +167,54 @@ class Analytics_Wizard extends Wizard {
 				],
 			]
 		);
+
+		// Set custom events.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/analytics/custom-events',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'set_custom_events' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'events' => [
+						'type'     => 'array',
+						'required' => true,
+						'items'    => [
+							'type'       => 'object',
+							'properties' => [
+								'event_name'      => [
+									'type' => 'string',
+								],
+								'event_category'  => [
+									'type' => 'string',
+								],
+								'event_label'     => [
+									'type' => 'string',
+								],
+								'on'              => [
+									'type' => 'string',
+									'enum' => [ 'click', 'submit' ],
+								],
+								'element'         => [
+									'type' => 'string',
+								],
+								'amp_element'     => [
+									'type' => 'string',
+								],
+								'non_interaction' => [
+									'type' => 'boolean',
+								],
+								'is_active'       => [
+									'type' => 'boolean',
+								],
+							],
+							'required'   => [ 'event_name', 'event_category', 'on', 'element' ],
+						],
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -184,10 +239,12 @@ class Analytics_Wizard extends Wizard {
 		if ( is_wp_error( $custom_dimensions ) ) {
 			$analytics_connection_error = $custom_dimensions->get_error_message();
 		}
+		$custom_events = get_option( self::$custom_events_option_name, '[]' );
 		\wp_localize_script(
 			'newspack-analytics-wizard',
 			'newspack_analytics_wizard_data',
 			[
+				'customEvents'             => json_decode( $custom_events ),
 				'customDimensions'         => $custom_dimensions,
 				'analyticsConnectionError' => $analytics_connection_error,
 			]
@@ -307,6 +364,30 @@ class Analytics_Wizard extends Wizard {
 		}
 		if ( update_option( self::$category_dimension_option_name, $dimension_id ) ) {
 			return [ 'id' => $dimension_id ];
+		} else {
+			return new WP_Error( 'newspack_analytics', __( 'Error when setting category custom dimension.', 'newspack' ) );
+		}
+	}
+
+	/**
+	 * Update custom events collection.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return Object|WP_Error Object on success, or WP_Error object on failure.
+	 */
+	public static function set_custom_events( $request ) {
+		$custom_events = array_map(
+			function ( $event ) {
+				$event = (array) $event;
+				if ( ! isset( $event['id'] ) ) {
+					$event['id'] = uniqid();
+				}
+				return $event;
+			},
+			$request['events']
+		);
+		if ( update_option( self::$custom_events_option_name, wp_json_encode( $custom_events ) ) ) {
+			return [ 'events' => $custom_events ];
 		} else {
 			return new WP_Error( 'newspack_analytics', __( 'Error when setting category custom dimension.', 'newspack' ) );
 		}

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -290,7 +290,7 @@ class Analytics_Wizard extends Wizard {
 						' <a href="' . get_admin_url() . 'admin.php?page=googlesitekit-dashboard">' .
 						__( 'Site Kit plugin', 'newspack' ) .
 						'</a> ' .
-						__( 'to allow updating Google Analytics settings.', 'newspack' ) 
+						__( 'to allow updating Google Analytics settings.', 'newspack' )
 					);
 				}
 
@@ -407,7 +407,7 @@ class Analytics_Wizard extends Wizard {
 		if ( update_option( self::$custom_events_option_name, wp_json_encode( $custom_events ) ) ) {
 			return [ 'events' => $custom_events ];
 		} else {
-			return new WP_Error( 'newspack_analytics', __( 'Error when setting category custom dimension.', 'newspack' ) );
+			return new WP_Error( 'newspack_analytics', __( 'Error when setting custom events.', 'newspack' ) );
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adding custom events insertion UI. Only `click` and `submit` events are handled: 
- `visibility`, `ini-load` require the element to be AMP element,
- `scroll` requires some more UI for scroll parameters, can be implemented later.

Design considerations:

1. This is an advanced feature, misuse of which can brake sites – we may wanna add some warning there
2. Some fields in the form are not required, not sure if we have an established pattern for that
3. The "Active" field is of a different kind, maybe it should be displayed differently in the form? 

Closes #601

### How to test the changes in this Pull Request:

1. Open the Analytics Wizard, observe a new tab – "Custom Events"
2. Add a custom event, e.g. a click on `#search-toggle`
3. Visit the front end (as non-logged-in user), oberve the event being sent on action (look for requests to `https://www.google-analytics.com/r/collect` in Network tab) 
4. Test on both AMP and non-AMP versions
4. Mark the event as not active, observe it's not sent anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
