### PR TITLE
fix empty space in three-column wizard grid

### DIFF
--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -14,7 +14,13 @@
 		justify-content: space-between;
 		margin-top: -16px;
 
-		.newspack-dashboard-card {
+		&::after {
+			content: '';
+			display: block;
+		}
+
+		.newspack-dashboard-card,
+		&::after {
 			width: 100%;
 
 			@media screen and ( min-width: 600px ) {


### PR DESCRIPTION
Adds a pseudo-element to the wizard when in grid view to avoid an empty space in the middle due to the use of `justify-content: space-between`

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This fixes a pet peeve of mine that's completely visual.

### How to test the changes in this Pull Request:

After installing and building this branch, go to the Newspack dashboard and enable the "grid" view mode.

Before this branch:

<img width="1198" alt="Screen Shot 2020-07-31 at 11 34 08 AM" src="https://user-images.githubusercontent.com/2230142/89061679-5fedf300-d322-11ea-9d8e-f0284e824065.png">

After this branch:

<img width="1206" alt="Screen Shot 2020-07-31 at 11 34 02 AM" src="https://user-images.githubusercontent.com/2230142/89061698-65e3d400-d322-11ea-8eff-da2ce08f66dc.png">

Because we're using a pseudoelement with no height, it shouldn't affect the rendering if the last column has one or three cards, or when displayed as a single column in smaller viewports.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->