### PR TITLE
Don't list uninstalled Newspack-approved plugins when using WP CLI

### DIFF
--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -33,6 +33,11 @@ class Admin_Plugins_Screen {
 	 * @return array Modified $plugins.
 	 */
 	public function inject_managed_plugins( $plugins ) {
+		// Don't add managed plugins to the plugins list when using WP CLI.
+		if ( ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+			return $plugins;
+		}
+
 		$managed_plugins   = Plugin_Manager::get_managed_plugins();
 		$installed_plugins = Plugin_Manager::get_installed_plugins();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR improves the output of the WP CLI `plugins` commands by not including uninstalled Newspack-approved plugins. Those plugins don't really make sense to show in the CLI, and it's impossible to distinguish those listings from regular, installed, inactive plugins.

### How to test the changes in this Pull Request:

1. Before applying this patch, run `wp plugins list`. Observe uninstalled, [Newspack-approved plugins](https://github.com/Automattic/newspack-plugin/blob/master/includes/class-plugin-manager.php#L41-L417) are listed at the bottom:

<img width="850" alt="Screen Shot 2020-08-03 at 3 13 23 PM" src="https://user-images.githubusercontent.com/7317227/89232895-515f4000-d59d-11ea-9fe4-21c0399e5199.png">

2. Apply this patch. Run `wp plugins list`. Observe uninstalled, Newspack-approved plugins are not listed:

<img width="688" alt="Screen Shot 2020-08-03 at 3 24 11 PM" src="https://user-images.githubusercontent.com/7317227/89232948-68059700-d59d-11ea-97e9-69d086835d39.png">

3. Go to the Plugins page. Verify uninstalled, Newspack-approved plugins are still listed under the Newspack plugin:

<img width="1447" alt="Screen Shot 2020-08-03 at 3 22 33 PM" src="https://user-images.githubusercontent.com/7317227/89232848-3a205280-d59d-11ea-8c28-5e07605771e4.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->