### PR TITLE
Prevent vendor contents exclusion in zip

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -36,9 +36,8 @@ yarn.lock
 # directories
 node_modules
 .git
-src
 .github
 .circleci
-tests
-bin
-assets
+/tests
+/bin
+/assets

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "lint:scss": "stylelint '**/*.scss' --syntax scss",
     "format:scss": "prettier --write '**/*.scss'",
     "lint:scss:staged": "stylelint --syntax scss",
-    "release:archive": "mkdir -p assets/release && rsync -r . ./assets/release/newspack-plugin --exclude-from='./.distignore' && cd assets/release && zip -r newspack-plugin.zip newspack-plugin",
+    "release:archive": "rm -rf assets/release && mkdir -p assets/release && rsync -r . ./assets/release/newspack-plugin --exclude-from='./.distignore' && cd assets/release && zip -r newspack-plugin.zip newspack-plugin",
     "release": "npm run build && npm run semantic-release"
   },
   "dependencies": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Another release-related issue (caused by #610): due to how rsync parses the ignore file, the `src` directories in `vendor` were excluded in the zip too. We just a vendor package for starter content generation, so this was hard to catch. This PR fixes that.

### How to test the changes in this Pull Request:

1. Create a release
2. Test on a fresh site – go through the setup wizard, observe starter content being created

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
