### PR TITLE
Release Aug 04 bis bis

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -36,9 +36,8 @@ yarn.lock
 # directories
 node_modules
 .git
-src
 .github
 .circleci
-tests
-bin
-assets
+/tests
+/bin
+/assets

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "lint:scss": "stylelint '**/*.scss' --syntax scss",
     "format:scss": "prettier --write '**/*.scss'",
     "lint:scss:staged": "stylelint --syntax scss",
-    "release:archive": "mkdir -p assets/release && rsync -r . ./assets/release/newspack-plugin --exclude-from='./.distignore' && cd assets/release && zip -r newspack-plugin.zip newspack-plugin",
+    "release:archive": "rm -rf assets/release && mkdir -p assets/release && rsync -r . ./assets/release/newspack-plugin --exclude-from='./.distignore' && cd assets/release && zip -r newspack-plugin.zip newspack-plugin",
     "release": "npm run build && npm run semantic-release"
   },
   "dependencies": {


### PR DESCRIPTION
A new release. #610 broke the startup content generation, because `src` directory inside of `vendor` was not included in the zip. #619 fixed that.