### PR TITLE
Remove un-cacheable ajax call in AMP mode from WP GDPR Cookie Notice

### DIFF
--- a/includes/amp-enhancements/class-newspack-cookie-notice-amp-markup.php
+++ b/includes/amp-enhancements/class-newspack-cookie-notice-amp-markup.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Overrides Cookie_Notice_AMP_Markup to remove ajax call.
+ *
+ * @package Newspack
+ */
+
+use Felix_Arntz\WP_GDPR_Cookie_Notice\Cookie_Notice\Cookie_Notice_AMP_Markup;
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Modifies the <amp-consent> config for better performance on high-traffic sites.
+ */
+class Newspack_Cookie_Notice_AMP_Markup extends Cookie_Notice_AMP_Markup {
+
+	/**
+	 * Modifies the <amp-consent> config to eliminate the ajax call sent on every request.
+	 * The notice will then always show to people that haven't accepted it yet.
+	 *
+	 * @return array Data to pass to the `<amp-consent>` element.
+	 */
+	protected function get_consent_data() {
+		return [
+			'consentInstanceId' => self::AMP_INSTANCE,
+			'consentRequired'   => true,
+			'promptUI'          => 'wp-gdpr-cookie-notice',
+
+		];
+	}
+}

--- a/includes/amp-enhancements/class-newspack-cookie-notice-amp-markup.php
+++ b/includes/amp-enhancements/class-newspack-cookie-notice-amp-markup.php
@@ -5,9 +5,9 @@
  * @package Newspack
  */
 
-use Felix_Arntz\WP_GDPR_Cookie_Notice\Cookie_Notice\Cookie_Notice_AMP_Markup;
-
 namespace Newspack;
+
+use Felix_Arntz\WP_GDPR_Cookie_Notice\Cookie_Notice\Cookie_Notice_AMP_Markup;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/amp-enhancements/class-wp-gdpr-cookie-notice-performance.php
+++ b/includes/amp-enhancements/class-wp-gdpr-cookie-notice-performance.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * AMP improvements for WP GDPR Cookie Notice.
+ *
+ * @package Newspack
+ */
+
+use Felix_Arntz\WP_GDPR_Cookie_Notice\Shortcodes\WordPress_Shortcode_Parser;
+use Felix_Arntz\WP_GDPR_Cookie_Notice\Settings\Plugin_Option_Reader;
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Improves the server performance of sites using WP GDPR Cookie Notice by eliminating an un-cacheable
+ * ajax call that would get fired on every pageload.
+ */
+class WP_GDPR_Cookie_Notice_Performance {
+
+	/**
+	 * Init.
+	 */
+	public static function init() {
+		add_action( 'wp_footer', [ __CLASS__, 'modify_render_callback' ], 99 );
+		add_action( 'login_footer', [ __CLASS__, 'modify_render_callback' ], 99 );
+	}
+
+	/**
+	 * Replace the cookie notice render callbacks with our own more performant version.
+	 * This is inherently a pretty ugly method because there isn't a nice filter we can use for this modification.
+	 */
+	public static function modify_render_callback() {
+		global $wp_filter;
+
+		if (
+			! function_exists( 'wp_gdpr_cookie_notice' ) 
+			|| is_customize_preview() 
+			|| ! function_exists( 'is_amp_endpoint' ) 
+			|| ! is_amp_endpoint() 
+		) {
+			return;
+		}
+
+		$current_action = current_action();
+		if ( 'wp_footer' !== $current_action && 'login_footer' !== $current_action ) {
+			return;
+		}
+
+		// The original render callbacks are hooked at priority 100.
+		if ( empty( $wp_filter[ $current_action ]->callbacks['100'] ) ) {
+			return;
+		}
+
+		// Replace the render function with our own custom one.
+		foreach ( $wp_filter[ $current_action ]->callbacks['100'] as $index => $callback ) {
+			if (
+				isset( $callback['function'] ) 
+				&& is_array( $callback['function'] ) 
+				&& is_object( $callback['function'][0] )
+				&& 'Felix_Arntz\WP_GDPR_Cookie_Notice\Cookie_Notice\Cookie_Notice' === get_class( $callback['function'][0] )
+			) {
+				$wp_filter[ $current_action ]->callbacks['100'][ $index ]['function'] = [ __CLASS__, 'custom_render' ];
+			}
+		}
+	}
+
+	/**
+	 * Replace the cookie notice rendering with a modified version.
+	 */
+	public static function custom_render() {
+		include_once 'class-newspack-cookie-notice-amp-markup.php';
+
+		$plugin_controller = wp_gdpr_cookie_notice();
+		$service           = $plugin_controller->get_service( 'cookie_notice' );
+
+		$markup = new Newspack_Cookie_Notice_AMP_Markup( 
+			$service->get_form(),
+			$plugin_controller->get_service( 'shortcodes' ),
+			$plugin_controller->get_service( 'options' )
+		);
+		$markup->render();
+	}
+}
+WP_GDPR_Cookie_Notice_Performance::init();
+

--- a/includes/amp-enhancements/class-wp-gdpr-cookie-notice-performance.php
+++ b/includes/amp-enhancements/class-wp-gdpr-cookie-notice-performance.php
@@ -5,10 +5,10 @@
  * @package Newspack
  */
 
+namespace Newspack;
+
 use Felix_Arntz\WP_GDPR_Cookie_Notice\Shortcodes\WordPress_Shortcode_Parser;
 use Felix_Arntz\WP_GDPR_Cookie_Notice\Settings\Plugin_Option_Reader;
-
-namespace Newspack;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/amp-enhancements/class-wp-gdpr-cookie-notice-performance.php
+++ b/includes/amp-enhancements/class-wp-gdpr-cookie-notice-performance.php
@@ -7,9 +7,6 @@
 
 namespace Newspack;
 
-use Felix_Arntz\WP_GDPR_Cookie_Notice\Shortcodes\WordPress_Shortcode_Parser;
-use Felix_Arntz\WP_GDPR_Cookie_Notice\Settings\Plugin_Option_Reader;
-
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -7,10 +7,6 @@
 
 namespace Newspack;
 
-use Felix_Arntz\WP_GDPR_Cookie_Notice\Shortcodes\WordPress_Shortcode_Parser;
-use Felix_Arntz\WP_GDPR_Cookie_Notice\Settings\Plugin_Option_Reader;
-use Felix_Arntz\WP_GDPR_Cookie_Notice\Cookie_Notice\Cookie_Notice_AMP_Markup;
-
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -7,6 +7,10 @@
 
 namespace Newspack;
 
+use Felix_Arntz\WP_GDPR_Cookie_Notice\Shortcodes\WordPress_Shortcode_Parser;
+use Felix_Arntz\WP_GDPR_Cookie_Notice\Settings\Plugin_Option_Reader;
+use Felix_Arntz\WP_GDPR_Cookie_Notice\Cookie_Notice\Cookie_Notice_AMP_Markup;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -18,6 +22,10 @@ class AMP_Enhancements {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
+		// WP GDPR Cookie Notice plugin enhancements.
+		if ( is_plugin_active( 'wp-gdpr-cookie-notice/wp-gdpr-cookie-notice.php' ) ) {
+			include_once 'amp-enhancements/class-wp-gdpr-cookie-notice-performance.php';
+		}
 	}
 }
 AMP_Enhancements::init();

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -406,6 +406,14 @@ class Plugin_Manager {
 				'WPCore'   => true,
 				'EditPath' => 'options-discussion.php',
 			],
+			'wp-gdpr-cookie-notice'         => [
+				'Name'        => 'WP GDPR Cookie Notice',
+				'Description' => esc_html__( 'Simple performant cookie consent notice that supports AMP, granular cookie control and live preview customization.', 'newspack' ),
+				'Author'      => 'Felix Arntz',
+				'AuthorURI'   => 'https://felix-arntz.me/',
+				'PluginURI'   => 'https://wordpress.org/plugins/wp-gdpr-cookie-notice/',
+				'Download'    => 'wporg',
+			],
 			'wp-user-avatar'                => [
 				'Name'        => 'WP User Avatar',
 				'Description' => 'Use any image from your WordPress Media Library as a custom user avatar. Add your own Default Avatar.',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR improves server-side performance of the WP GDPR Cookie Notice plugin. Previously in AMP mode, it would fire an un-cacheable ajax call on every request to determine whether to show the cookie notice. This change removes that call and makes it so that the cookie notice will be indiscriminately shown for users that haven't accepted it.

I've also added WP GDPR Cookie Notice to the list of managed plugins, since it was missing and it's our approved cookie notice solution.

### How to test the changes in this Pull Request:
0. Install and activate WP GDPR Cookie Notice. If you don't have `https` on your local environment, you'll need to modify [this line](https://github.com/felixarntz/wp-gdpr-cookie-notice/blob/master/src/cookie-notice/class-cookie-notice-amp-markup.php#L64) to `'checkConsentHref' =>  str_replace( 'http:', '', add_query_arg( 'action', self::AMP_CHECK_CONSENT_HREF_ACTION, admin_url( 'admin-ajax.php' ) ) )`, otherwise the notice won't work on your local environment.
1. Before applying the patch, in an incognito window with the network inspector open, view the site in AMP mode. Observe the notice sends an ajax request.
<img width="1563" alt="Screen Shot 2020-08-05 at 12 02 04 PM" src="https://user-images.githubusercontent.com/7317227/89457008-927c5f00-d719-11ea-8c05-c716af89da69.png">
 
2. Apply the patch. In an incognito window with the network inspector open, view the site in AMP mode. Observe no ajax request is sent. Accept the notice (this will send an ajax request to update preferences, but that should be OK). Verify the notice remembers that you've accepted on subsequent page loads.
<img width="1568" alt="Screen Shot 2020-08-05 at 12 02 36 PM" src="https://user-images.githubusercontent.com/7317227/89457182-cf485600-d719-11ea-9f3c-5496de3dfd29.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->