### PR TITLE
Enable alpha builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,11 @@
   },
   "release": {
     "branches": [
-      "release"
+      "release",
+      {
+        "name": "alpha",
+        "prerelease": "alpha"
+      }
     ],
     "prepare": [
       "@semantic-release/changelog",


### PR DESCRIPTION
`semantic-release` config update which will enable [prereleases](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#pre-release-branches). 