### PR TITLE
Handle alpha builds on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,9 @@ workflows:
             - build
           filters:
             branches:
-              only: release
+              only:
+                - release
+                - alpha
   php:
     jobs:
       - lint-php


### PR DESCRIPTION
#623 updated the `semantic-release` config, but I forgot to also update CircleCI config, so that `semantic-release` would actually be ran on the `alpha` branch