### PR TITLE
Add related posts age setting

### DIFF
--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -21,7 +21,6 @@ export { default as PluginToggle } from './plugin-toggle';
 export { default as Popover } from './popover';
 export { default as ProgressBar } from './progress-bar';
 export { default as RadioControl } from './radio-control';
-export { default as RangeControl } from './range-control';
 export { default as SecondaryNavigation } from './secondary-navigation';
 export { default as SelectControl } from './select-control';
 export { default as StyleCard } from './style-card';

--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -21,6 +21,7 @@ export { default as PluginToggle } from './plugin-toggle';
 export { default as Popover } from './popover';
 export { default as ProgressBar } from './progress-bar';
 export { default as RadioControl } from './radio-control';
+export { default as RangeControl } from './range-control';
 export { default as SecondaryNavigation } from './secondary-navigation';
 export { default as SelectControl } from './select-control';
 export { default as StyleCard } from './style-card';

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -74,14 +74,17 @@ class EngagementWizard extends Component {
 		const { relatedPostsMaxAge } = this.state;
 
 		try {
-			const response = await wizardApiFetch( {
+			await wizardApiFetch( {
 				path: '/newspack/v1/wizard/newspack-engagement-wizard/related-posts-max-age',
 				method: 'POST',
 				data: { relatedPostsMaxAge },
 			} );
 			this.setState( { relatedPostsError: null, relatedPostsUpdated: false } );
 		} catch ( e ) {
-			e.message && this.setState( { relatedPostsError: e.message } );
+			this.setState( {
+				relatedPostsError:
+					e.message || __( 'There was an error saving settings. Please try again.', 'newspack' ),
+			} );
 		}
 	};
 
@@ -117,8 +120,8 @@ class EngagementWizard extends Component {
 				path: '/commenting/',
 			},
 			{
-				label: __( 'Related' ),
-				path: '/related-content',
+				label: __( 'Recirculation' ),
+				path: '/recirculation',
 			},
 			{
 				label: __( 'UGC' ),
@@ -143,7 +146,7 @@ class EngagementWizard extends Component {
 			},
 		];
 		const subheader = __(
-			'Newsletters, social, commenting, related content, user-generated content'
+			'Newsletters, social, commenting, recirculation, user-generated content'
 		);
 		return (
 			<Fragment>
@@ -228,7 +231,7 @@ class EngagementWizard extends Component {
 							) }
 						/>
 						<Route
-							path="/related-content"
+							path="/recirculation"
 							exact
 							render={ () => (
 								<RelatedContent

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -26,6 +26,7 @@ import {
 	CommentingCoral,
 	Newsletters,
 	Social,
+	RelatedContent,
 	UGC,
 } from './views';
 
@@ -39,6 +40,10 @@ class EngagementWizard extends Component {
 			connected: false,
 			connectURL: '',
 			wcConnected: false,
+			relatedPostsEnabled: false,
+			relatedPostsMaxAge: 0,
+			relatedPostsUpdated: false,
+			relatedPostsError: null,
 		};
 	}
 
@@ -62,11 +67,40 @@ class EngagementWizard extends Component {
 	}
 
 	/**
+	 * Update Related Content settings.
+	 */
+	updatedRelatedContentSettings = async () => {
+		const { wizardApiFetch } = this.props;
+		const { relatedPostsMaxAge } = this.state;
+
+		try {
+			const response = await wizardApiFetch( {
+				path: '/newspack/v1/wizard/newspack-engagement-wizard/related-posts-max-age',
+				method: 'POST',
+				data: { relatedPostsMaxAge },
+			} );
+			this.setState( { relatedPostsError: null, relatedPostsUpdated: false } );
+		} catch ( e ) {
+			e.message && this.setState( { relatedPostsError: e.message } );
+		}
+	};
+
+	/**
 	 * Render
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
-		const { apiKey, connected, connectURL, wcConnected } = this.state;
+		const {
+			apiKey,
+			connected,
+			connectURL,
+			wcConnected,
+			relatedPostsEnabled,
+			relatedPostsError,
+			relatedPostsMaxAge,
+			relatedPostsUpdated,
+		} = this.state;
+
 		const tabbed_navigation = [
 			{
 				label: __( 'Newsletters' ),
@@ -81,6 +115,10 @@ class EngagementWizard extends Component {
 			{
 				label: __( 'Commenting' ),
 				path: '/commenting/',
+			},
+			{
+				label: __( 'Related' ),
+				path: '/related-content',
 			},
 			{
 				label: __( 'UGC' ),
@@ -104,7 +142,9 @@ class EngagementWizard extends Component {
 				exact: true,
 			},
 		];
-		const subheader = __( 'Newsletters, social, commenting, UGC' );
+		const subheader = __(
+			'Newsletters, social, commenting, related content, user-generated content'
+		);
 		return (
 			<Fragment>
 				<HashRouter hashType="slash">
@@ -184,6 +224,27 @@ class EngagementWizard extends Component {
 									connected={ connected }
 									connectURL={ connectURL }
 									secondaryNavigation={ commentingSecondaryNavigation }
+								/>
+							) }
+						/>
+						<Route
+							path="/related-content"
+							exact
+							render={ () => (
+								<RelatedContent
+									headerIcon={ <HeaderIcon /> }
+									headerText={ __( 'Engagement', 'newspack' ) }
+									relatedPostsEnabled={ relatedPostsEnabled }
+									relatedPostsError={ relatedPostsError }
+									subHeaderText={ subheader }
+									tabbedNavigation={ tabbed_navigation }
+									buttonAction={ () => this.updatedRelatedContentSettings() }
+									buttonText={ __( 'Save', 'newspack' ) }
+									buttonDisabled={ ! relatedPostsEnabled || ! relatedPostsUpdated }
+									relatedPostsMaxAge={ relatedPostsMaxAge }
+									onChange={ value => {
+										this.setState( { relatedPostsMaxAge: value, relatedPostsUpdated: true } );
+									} }
 								/>
 							) }
 						/>

--- a/assets/wizards/engagement/views/index.js
+++ b/assets/wizards/engagement/views/index.js
@@ -1,6 +1,7 @@
 export { default as Newsletters } from './newsletters';
 export { default as Social } from './social';
 export { default as Commenting } from './commenting';
+export { default as RelatedContent } from './related-content';
 export { default as UGC } from './ugc';
 export { default as CommentingDisqus } from './commenting-disqus';
 export { default as CommentingNative } from './commenting-native';

--- a/assets/wizards/engagement/views/related-content/index.js
+++ b/assets/wizards/engagement/views/related-content/index.js
@@ -28,7 +28,7 @@ class RelatedContent extends Component {
 		return (
 			<div className="newspack-salesforce-wizard">
 				<Fragment>
-					<h2>{ __( 'Related Content Settings', 'newspack' ) }</h2>
+					<h2>{ __( 'Recirculation Settings', 'newspack' ) }</h2>
 
 					{ relatedPostsError && <Notice noticeText={ relatedPostsError } isError /> }
 

--- a/assets/wizards/engagement/views/related-content/index.js
+++ b/assets/wizards/engagement/views/related-content/index.js
@@ -1,0 +1,72 @@
+/**
+ * Related content screen.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { ExternalLink } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ActionCard, Notice, TextControl, withWizardScreen } from '../../../../components/src';
+import './style.scss';
+
+/**
+ * Related Content Screen
+ */
+class RelatedContent extends Component {
+	/**
+	 * Render.
+	 */
+	render() {
+		const { onChange, relatedPostsEnabled, relatedPostsError, relatedPostsMaxAge } = this.props;
+
+		return (
+			<div className="newspack-salesforce-wizard">
+				<Fragment>
+					<h2>{ __( 'Related Content Settings', 'newspack' ) }</h2>
+
+					{ relatedPostsError && <Notice noticeText={ relatedPostsError } isError /> }
+
+					<p>
+						{ __( 'These extra settings apply to Related Posts shown by Jetpack.', 'newspack' ) }{' '}
+						{
+							<ExternalLink href="/wp-admin/admin.php?page=jetpack#/traffic" key="jetpack-link">
+								{ __( 'Configure Related Posts in Jetpack', 'newspack' ) }
+							</ExternalLink>
+						}
+					</p>
+
+					{ relatedPostsEnabled ? (
+						<TextControl
+							className="newspack-related-content__age-input"
+							help={ __(
+								'If set, posts will be shown as related content only if published within the past number of months. If 0, any published post can be shown, regardless of publish date.',
+								'newspack'
+							) }
+							label={ __( 'Maximum age of related content, in months', 'newspack' ) }
+							onChange={ value => onChange( value ) }
+							placeholder={ __( 'Maximum age of related content, in months' ) }
+							type="number"
+							value={ relatedPostsMaxAge || 0 }
+						/>
+					) : (
+						<ActionCard
+							title={ __( 'Jetpack Related Posts' ) }
+							description={ __( 'Enable Related Posts via Jetpack.' ) }
+							actionText={ __( 'Configure' ) }
+							handoff="jetpack"
+							editLink="admin.php?page=jetpack#/traffic"
+						/>
+					) }
+				</Fragment>
+			</div>
+		);
+	}
+}
+
+export default withWizardScreen( RelatedContent );

--- a/assets/wizards/engagement/views/related-content/style.scss
+++ b/assets/wizards/engagement/views/related-content/style.scss
@@ -1,0 +1,8 @@
+.newspack-text-control.newspack-related-content {
+	&__age-input {
+		input[type='number'] {
+			display: inline-block;
+			width: auto;
+		}
+	}
+}

--- a/includes/configuration_managers/class-jetpack-configuration-manager.php
+++ b/includes/configuration_managers/class-jetpack-configuration-manager.php
@@ -130,7 +130,13 @@ class Jetpack_Configuration_Manager extends Configuration_Manager {
 	public function deactivate_wordads() {
 		return class_exists( 'Jetpack' ) && \Jetpack::deactivate_module( 'wordads' );
 	}
+
+	/**
+	 * Is Related Posts module active?
+	 *
+	 * @return bool Returns true if the module is currently active.
+	 */
+	public function is_related_posts_enabled() {
+		return class_exists( 'Jetpack' ) && \Jetpack::is_module_active( 'related-posts' );
+	}
 }
-
-
-

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -33,11 +33,19 @@ class Engagement_Wizard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * The name of the option for Related Posts max age.
+	 *
+	 * @var string
+	 */
+	protected $related_posts_option = 'newspack_related_posts_max_age';
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+		add_filter( 'jetpack_relatedposts_filter_date_range', [ $this, 'restrict_age_of_related_posts' ] );
 	}
 
 	/**
@@ -80,6 +88,16 @@ class Engagement_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/related-posts-max-age',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_related_posts_max_age' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'sanitize_callback'   => 'sanitize_text_field',
+			]
+		);
 	}
 
 	/**
@@ -98,13 +116,64 @@ class Engagement_Wizard extends Wizard {
 			'wcConnected' => false,
 		);
 
-		$jetpack_status = $jetpack_configuration_manager->get_mailchimp_connection_status();
-		if ( ! is_wp_error( $jetpack_status ) ) {
-			$response['connected']   = $jetpack_status['connected'];
-			$response['connectURL']  = $jetpack_status['connectURL'];
-			$response['wcConnected'] = $wc_configuration_manager->is_active();
+		$related_posts_max_age = get_option( $this->related_posts_option, 0 );
+
+		$jetpack_mailchimp_status     = $jetpack_configuration_manager->get_mailchimp_connection_status();
+		$jetpack_related_posts_status = $jetpack_configuration_manager->is_related_posts_enabled();
+		if ( ! is_wp_error( $jetpack_mailchimp_status ) ) {
+			$response['connected']           = $jetpack_mailchimp_status['connected'];
+			$response['connectURL']          = $jetpack_mailchimp_status['connectURL'];
+			$response['wcConnected']         = $wc_configuration_manager->is_active();
+			$response['relatedPostsEnabled'] = $jetpack_related_posts_status;
+			$response['relatedPostsMaxAge']  = $related_posts_max_age;
 		}
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Update the Related Posts Max Age setting.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Updated value, if successful, or WP_Error.
+	 */
+	public function api_update_related_posts_max_age( $request ) {
+		$args = $request->get_params();
+
+		if ( is_numeric( $args['relatedPostsMaxAge'] ) && 0 <= $args['relatedPostsMaxAge'] ) {
+			update_option( $this->related_posts_option, $args['relatedPostsMaxAge'] );
+		} else {
+			return new WP_Error(
+				'newspack_related_posts_invalid_arg',
+				esc_html__( 'Invalid argument: max age must be a number greater than zero.', 'newspack' ),
+				[
+					'status' => 400,
+					'level'  => 'notice',
+				]
+			);
+		}
+
+		return \rest_ensure_response(
+			[
+				'relatedPostsMaxAge' => $args['relatedPostsMaxAge'],
+			]
+		);
+	}
+
+	/**
+	 * Restrict the age of related content shown by Jetpack Related Posts.
+	 *
+	 * @param array $date_range Array of start and end dates.
+	 * @return array Filtered array of start/end dates.
+	 */
+	public function restrict_age_of_related_posts( $date_range ) {
+		$related_posts_max_age = get_option( $this->related_posts_option );
+
+		if ( is_numeric( $related_posts_max_age ) ) {
+			$date_range['from'] = strtotime( '-' . $related_posts_max_age . ' months' );
+			$date_range['to']   = time();
+		}
+
+		return $date_range;
 	}
 
 	/**

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -168,7 +168,7 @@ class Engagement_Wizard extends Wizard {
 	public function restrict_age_of_related_posts( $date_range ) {
 		$related_posts_max_age = get_option( $this->related_posts_option );
 
-		if ( is_numeric( $related_posts_max_age ) ) {
+		if ( is_numeric( $related_posts_max_age ) && 0 < $related_posts_max_age ) {
 			$date_range['from'] = strtotime( '-' . $related_posts_max_age . ' months' );
 			$date_range['to']   = time();
 		}


### PR DESCRIPTION
Adds a new tab for Related Content to the Engagement wizard with a new setting that lets publishers restrict the age of content shown by Jetpack's Related Posts module.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a new option to the Engagement wizard that lets publishers set a maximum age (in months) for posts shown by Jetpack's Related Posts module.

Closes #621.

### How to test the changes in this Pull Request:

1. In Jetpack traffic settings (https://[SITE URL]/wp-admin/admin.php?page=jetpack#/traffic), ensure that the Related Posts module ("Show related content after posts" option) is DISABLED.

2. Visit the Newspack Engagement wizard. Observe a new tab called "Related" fourth from the left. Click the tab.

3. In the wizard screen, observe the action card saying to enable Related Posts in Jetpack:

<img width="688" alt="Screen Shot 2020-08-10 at 5 08 23 PM" src="https://user-images.githubusercontent.com/2230142/89840126-b3372100-db2c-11ea-8fce-989e115d8701.png">

4. In Jetpack traffic settings, ENABLE the Related Posts module.

5. Go back to Newspack Engagement > Related. Now observe that there's an input field to set the maximum age of related posts in months:

<img width="686" alt="Screen Shot 2020-08-10 at 5 08 47 PM" src="https://user-images.githubusercontent.com/2230142/89840174-ccd86880-db2c-11ea-9960-c4beaf0f606c.png">

6. Without updating the field (e.g. leaving it at `0`), view any post and observe the Related Posts section at the bottom of the article. The posts shown can be any age.

7. Update the max age field to something low (try `1`) and hit Save. Refresh the post. Now observe that any post shown by Related Posts has a publish date within the number of months set in the field. 
  - This might be easier to do with a fresh Jurassic Ninja instance without creating starter content: you can create a handful of posts and manually set all of their publish dates to some time in the past, then ensure that the max age setting is more recent than all publish dates. In this case, no articles will be displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->