### PR TITLE
Add permission callbacks (required in WP 5.5.)

### DIFF
--- a/includes/class-webhooks.php
+++ b/includes/class-webhooks.php
@@ -39,8 +39,9 @@ class Webhooks {
 			NEWSPACK_API_NAMESPACE,
 			'/salesforce/sync',
 			[
-				'methods'  => \WP_REST_Server::EDITABLE,
-				'callback' => [ $this, 'api_sync_salesforce' ],
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_sync_salesforce' ],
+				'permission_callback' => '__return_true',
 			]
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds `permission_callback` to `register_rest_route` calls, as it's a required argument in WP 5.5

### How to test the changes in this Pull Request:

1. Verify that the Salesforce sync works as before – by making a donation and checking of donor data made it so SF

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
