### PR TITLE
Update dashboard default view to grid

### DIFF
--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -26,7 +26,7 @@ import './style.scss';
  */
 class Dashboard extends Component {
 	state = {
-		view: 'list',
+		view: 'grid',
 	};
 
 	componentDidMount = () => {
@@ -51,18 +51,6 @@ class Dashboard extends Component {
 				<Grid className={ 'view-' + view } isWide={ view === 'grid' && true }>
 					<Card noBackground className="newspack-dashboard-card__views">
 						<Button
-							icon={ <ViewListIcon /> }
-							label={ __( 'List view' ) }
-							isPrimary={ 'list' === view }
-							isLink={ 'list' !== view }
-							isSmall
-							onClick={ () =>
-								this.setState( { view: 'list' }, () =>
-									localStorage.setItem( 'newspack-plugin-dashboard-view', 'list' )
-								)
-							}
-						></Button>
-						<Button
 							icon={ <ViewModuleIcon /> }
 							label={ __( 'Grid view' ) }
 							isPrimary={ 'grid' === view }
@@ -71,6 +59,18 @@ class Dashboard extends Component {
 							onClick={ () =>
 								this.setState( { view: 'grid' }, () =>
 									localStorage.setItem( 'newspack-plugin-dashboard-view', 'grid' )
+								)
+							}
+						></Button>
+						<Button
+							icon={ <ViewListIcon /> }
+							label={ __( 'List view' ) }
+							isPrimary={ 'list' === view }
+							isLink={ 'list' !== view }
+							isSmall
+							onClick={ () =>
+								this.setState( { view: 'list' }, () =>
+									localStorage.setItem( 'newspack-plugin-dashboard-view', 'list' )
 								)
 							}
 						></Button>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The current default view is set to List but it's getting quite long now and the Grid view allows users to quickly scan the different cards without having to scroll. So this PR sets the Grid view to the default view.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Clear localStorage `localStorage.clear();`
3. Navigate to Newspack > Dashboard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->