### PR TITLE
Append categories, tags data to WC order; sync w/ SF

### DIFF
--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -133,7 +133,9 @@ class Salesforce {
 	public static function delete_webhook( $webhook_id ) {
 		update_option( self::SALESFORCE_WEBHOOK_ID, '' );
 		$webhook = wc_get_webhook( $webhook_id );
-		$webhook->delete( true );
+		if ( null !== $webhook ) {
+			$webhook->delete( true );
+		}
 	}
 
 	/**
@@ -187,8 +189,16 @@ class Salesforce {
 		if ( ! empty( $billing['country'] ) ) {
 			$contact['MailingCountry'] = $billing['country'];
 		}
-		if ( 0 === $data['meta_data'][0]['mailchimp_woocommerce_is_subscribed'] ) {
-			$contact['HasOptedOutOfEmail'] = true;
+
+		$referer_tags       = 'none';
+		$referer_categories = 'none';
+		foreach ( $data['meta_data'] as $meta_field ) {
+			if ( 'referer_tags' === $meta_field['key'] ) {
+				$referer_tags = $meta_field['value'];
+			}
+			if ( 'referer_categories' === $meta_field['key'] ) {
+				$referer_categories = $meta_field['value'];
+			}
 		}
 
 		if ( is_array( $transactions ) ) {
@@ -199,6 +209,7 @@ class Salesforce {
 					'Description' => 'WooCommerce Order Number: ' . $data['id'],
 					'Name'        => $transaction['name'],
 					'StageName'   => 'New',
+					'LeadSource'  => 'Post categories: ' . $referer_categories . ', tags: ' . $referer_tags,
 				];
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #636

Also fixes two tiny issues: 
1. Checking of webhook exists before removing it
2. Removal of setting `HasOptedOutOfEmail` on a SF Contact. It looks like it would never be set, because an object in `$data['meta_data']` array would never have `mailchimp_woocommerce_is_subscribed` key – it would be the value of such object's `value` key. Moreover, if this field is not configured in SF, [a contact will not be created](https://www.petefreitag.com/item/730.cfm). Open for discussion, though. cc @dkoo 

### How to test the changes in this Pull Request:

1. Using a Donate block on a page which has at least one tag and a category, make a donation (e.g. set up a Campaign w/ Donate block)
2. Observe the tags and categories are added to the WC order ("Custom Fields" section of Order details)
3. Observe the Opportunity in SF (on a single Contact view, Opportunities are listed on the right side) – it should have categories an tags listed as "Lead Source"
4. Try also with donating from a page with no categories and tags, observe the information is not appended to a WC order, and that the "Lead Source" in SF lists categories and tags as "none"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
