### PR TITLE
feat: quiet support for yoast premium and yoast news

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -431,6 +431,14 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=wpseo_dashboard',
 			],
+			'wordpress-seo-premium'         => [
+				'Name'  => 'Yoast SEO Premium',
+				'Quiet' => true,
+			],
+			'wpseo-news'                    => [
+				'Name'  => 'Yoast SEO: News',
+				'Quiet' => true,
+			],
 			'wordpress-settings-discussion' => [
 				'Name'     => 'Wordpress Commenting',
 				'WPCore'   => true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds "quiet" support for Yoast Premium and Yoast News.

### How to test the changes in this Pull Request:

1. Verify Yoast Premium and Yoast News do not appear on the plugins list.
2. Install and activate both plugins.
3. Verify both plugins now appear on the plugins list under Newspack, with the em-dash before the name like all other managed plugins.
4. Verify the plugins do not appear in the Newspack Health Check.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->