### PR TITLE
Add author, word count, publish date custom dimensions

### DIFF
--- a/assets/wizards/analytics/style.scss
+++ b/assets/wizards/analytics/style.scss
@@ -50,4 +50,7 @@
 			font-family: monospace !important;
 		}
 	}
+	&__select{
+		margin: 0;
+	}
 }

--- a/assets/wizards/analytics/style.scss
+++ b/assets/wizards/analytics/style.scss
@@ -50,7 +50,7 @@
 			font-family: monospace !important;
 		}
 	}
-	&__select{
+	&__select {
 		margin: 0;
 	}
 }

--- a/assets/wizards/analytics/views/custom-dimensions/index.js
+++ b/assets/wizards/analytics/views/custom-dimensions/index.js
@@ -29,6 +29,7 @@ const CUSTOM_DIMENSIONS_OPTIONS = [
 	{ value: 'category', label: __( 'Category', 'newspack' ) },
 	{ value: 'author', label: __( 'Author', 'newspack' ) },
 	{ value: 'word_count', label: __( 'Word count', 'newspack' ) },
+	{ value: 'publish_date', label: __( 'Publish date', 'newspack' ) },
 ];
 
 /**

--- a/assets/wizards/analytics/views/custom-dimensions/index.js
+++ b/assets/wizards/analytics/views/custom-dimensions/index.js
@@ -14,7 +14,6 @@ import {
 	Notice,
 	TextControl,
 	SelectControl,
-	CheckboxControl,
 	withWizardScreen,
 } from '../../../../components/src';
 
@@ -23,6 +22,12 @@ const SCOPES_OPTIONS = [
 	{ value: 'SESSION', label: __( 'Session', 'newspack' ) },
 	{ value: 'USER', label: __( 'User', 'newspack' ) },
 	{ value: 'PRODUCT', label: __( 'Product', 'newspack' ) },
+];
+
+const CUSTOM_DIMENSIONS_OPTIONS = [
+	{ value: '', label: __( 'none', 'newspack' ) },
+	{ value: 'category', label: __( 'Category', 'newspack' ) },
+	{ value: 'author', label: __( 'Author', 'newspack' ) },
 ];
 
 /**
@@ -54,27 +59,21 @@ class CustomDimensions extends Component {
 			.catch( this.handleAPIError );
 	};
 
-	handleCategoryDimensionSetting = dimensionId => {
+	handleCustomDimensionSetting = dimensionId => role => {
 		const { wizardApiFetch } = this.props;
-		const { customDimensions } = this.state;
 		wizardApiFetch( {
-			path: `/newspack/v1/wizard/analytics/category-dimension/${ dimensionId }`,
+			path: `/newspack/v1/wizard/analytics/custom-dimensions/${ dimensionId }`,
 			method: 'POST',
+			data: { role },
 		} )
-			.then( ( { id } ) => {
-				this.setState( {
-					customDimensions: customDimensions.map( dimension => ( {
-						...dimension,
-						is_category_dimension: dimension.id === id,
-					} ) ),
-				} );
+			.then( res => {
+				this.setState( { customDimensions: res } );
 			} )
 			.catch( this.handleAPIError );
 	};
 
 	render() {
 		const { error, customDimensions, newDimensionName, newDimensionScope } = this.state;
-		const hasCustomDimensions = ! error && customDimensions.length !== 0;
 		return (
 			<div className="newspack__analytics-configuration newspack-card newspack-card__no-background">
 				<p>
@@ -83,16 +82,6 @@ class CustomDimensions extends Component {
 						'newspack'
 					) }
 				</p>
-				{ hasCustomDimensions &&
-					customDimensions.filter( dimension => dimension.is_category_dimension ).length === 0 && (
-						<Notice
-							noticeText={ __(
-								'Please set a category dimension. Otherwise, the categories will not be reported to GA.',
-								'newspack'
-							) }
-							isWarning
-						/>
-					) }
 				{ error ? (
 					<Notice noticeText={ error } isError rawHTML />
 				) : (
@@ -103,7 +92,7 @@ class CustomDimensions extends Component {
 									{ [
 										__( 'Name', 'newspack' ),
 										__( 'ID', 'newspack' ),
-										__( 'Category dimension', 'newspack' ),
+										__( 'Role', 'newspack' ),
 									].map( ( colName, i ) => (
 										<th key={ i }>{ colName }</th>
 									) ) }
@@ -119,9 +108,11 @@ class CustomDimensions extends Component {
 											<code>{ dimension.id }</code>
 										</td>
 										<td>
-											<CheckboxControl
-												onChange={ () => this.handleCategoryDimensionSetting( dimension.id ) }
-												checked={ dimension.is_category_dimension }
+											<SelectControl
+												options={ CUSTOM_DIMENSIONS_OPTIONS }
+												value={ dimension.role || '' }
+												onChange={ this.handleCustomDimensionSetting( dimension.id ) }
+												className="newspack__analytics-configuration__select"
 											/>
 										</td>
 									</tr>

--- a/assets/wizards/analytics/views/custom-dimensions/index.js
+++ b/assets/wizards/analytics/views/custom-dimensions/index.js
@@ -28,6 +28,7 @@ const CUSTOM_DIMENSIONS_OPTIONS = [
 	{ value: '', label: __( 'none', 'newspack' ) },
 	{ value: 'category', label: __( 'Category', 'newspack' ) },
 	{ value: 'author', label: __( 'Author', 'newspack' ) },
+	{ value: 'word_count', label: __( 'Word count', 'newspack' ) },
 ];
 
 /**

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -93,7 +93,7 @@ class Analytics {
 				if ( 'publish_date' === $dimension_role ) {
 					self::add_custom_dimension_to_ga_config(
 						$dimension_id,
-						date_format( date_create( $post->post_date ), 'Y-m-d' )
+						get_the_time( 'Y-m-d H:i', $post->ID )
 					);
 				}
 			}

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -33,7 +33,7 @@ class Analytics {
 	 */
 	public function __construct() {
 		add_filter( 'googlesitekit_amp_gtag_opt', [ __CLASS__, 'inject_amp_events' ] );
-		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'handle_category_reporting' ] );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'handle_custom_dimensions_reporting' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'inject_non_amp_events' ] );
 		add_filter( 'render_block', [ __CLASS__, 'prepare_blocks_for_events' ], 10, 2 );
 		add_action( 'newspack_campaigns_before_campaign_render', [ __CLASS__, 'set_campaign_render_context' ], 10, 1 );
@@ -47,47 +47,68 @@ class Analytics {
 	}
 
 	/**
-	 * Tell Site Kit to report the article's category as custom dimension.
-	 * More about custom dimensions:
-	 * https://support.google.com/analytics/answer/2709828.
+	 * Tell Site Kit to report the article's data as custom dimensions.
+	 * More about custom dimensions: https://support.google.com/analytics/answer/2709828.
 	 */
-	public static function handle_category_reporting() {
-		$category_dimension_id = get_option( Analytics_Wizard::$category_dimension_option_name );
-		if ( ! $category_dimension_id ) {
-			return;
-		}
-		// Remove `ga:` prefix.
-		$category_dimension_id = substr( $category_dimension_id, 3 );
+	public static function handle_custom_dimensions_reporting() {
+		$custom_dimensions = Analytics_Wizard::list_configured_custom_dimensions();
+		foreach ( $custom_dimensions as $dimension ) {
+			$dimension_role = $dimension['role'];
+			$dimension_id   = substr( $dimension['id'], 3 ); // Remove `ga:` prefix.
 
-		$categories = get_the_category();
-		if ( ! empty( $categories ) ) {
-			$categories_slugs = implode(
-				',',
-				array_map(
-					function( $cat ) {
-						return $cat->slug;
-					},
-					$categories
-				)
-			);
-			// Non-AMP.
-			add_filter(
-				'googlesitekit_gtag_opt',
-				function ( $gtag_opt ) use ( $categories_slugs, $category_dimension_id ) {
-					$gtag_opt[ $category_dimension_id ] = $categories_slugs;
-					return $gtag_opt;
+			if ( 'category' === $dimension_role ) {
+				$categories = get_the_category();
+				if ( ! empty( $categories ) ) {
+					$categories_slugs = implode(
+						',',
+						array_map(
+							function( $cat ) {
+								return $cat->slug;
+							},
+							$categories
+						)
+					);
+					self::add_custom_dimension_to_ga_config( $dimension_id, $categories_slugs );
 				}
-			);
-			// AMP.
-			add_filter(
-				'googlesitekit_amp_gtag_opt',
-				function ( $gtag_amp_opt ) use ( $categories_slugs, $category_dimension_id ) {
-					$tracking_id = $gtag_amp_opt['vars']['gtag_id'];
-					$gtag_amp_opt['vars']['config'][ $tracking_id ][ $category_dimension_id ] = $categories_slugs;
-					return $gtag_amp_opt;
+			}
+
+			if ( 'author' === $dimension_role ) {
+				$post = get_post();
+				if ( $post ) {
+					$author_id = $post->post_author;
+					self::add_custom_dimension_to_ga_config(
+						$dimension_id,
+						get_the_author_meta( 'first_name', $author_id ) . ' ' . get_the_author_meta( 'last_name', $author_id )
+					);
 				}
-			);
+			}
 		}
+	}
+
+	/**
+	 * Add custom dimension to GA config via Site Kit filters.
+	 *
+	 * @param string $dimension_id Dimension ID.
+	 * @param string $payload Payload.
+	 */
+	public static function add_custom_dimension_to_ga_config( $dimension_id, $payload ) {
+		// Non-AMP.
+		add_filter(
+			'googlesitekit_gtag_opt',
+			function ( $gtag_opt ) use ( $payload, $dimension_id ) {
+				$gtag_opt[ $dimension_id ] = $payload;
+				return $gtag_opt;
+			}
+		);
+		// AMP.
+		add_filter(
+			'googlesitekit_amp_gtag_opt',
+			function ( $gtag_amp_opt ) use ( $payload, $dimension_id ) {
+				$tracking_id = $gtag_amp_opt['vars']['gtag_id'];
+				$gtag_amp_opt['vars']['config'][ $tracking_id ][ $dimension_id ] = $payload;
+				return $gtag_amp_opt;
+			}
+		);
 	}
 
 	/**

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -79,7 +79,7 @@ class Analytics {
 					$author_id = $post->post_author;
 					self::add_custom_dimension_to_ga_config(
 						$dimension_id,
-						get_the_author_meta( 'first_name', $author_id ) . ' ' . get_the_author_meta( 'last_name', $author_id )
+						get_the_author_meta( 'display_name', $author_id )
 					);
 				}
 

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -54,31 +54,39 @@ class Analytics {
 		$custom_dimensions = Analytics_Wizard::list_configured_custom_dimensions();
 		foreach ( $custom_dimensions as $dimension ) {
 			$dimension_role = $dimension['role'];
-			$dimension_id   = substr( $dimension['id'], 3 ); // Remove `ga:` prefix.
+			// Remove `ga:` prefix.
+			$dimension_id = substr( $dimension['id'], 3 );
 
-			if ( 'category' === $dimension_role ) {
-				$categories = get_the_category();
-				if ( ! empty( $categories ) ) {
-					$categories_slugs = implode(
-						',',
-						array_map(
-							function( $cat ) {
-								return $cat->slug;
-							},
-							$categories
-						)
-					);
-					self::add_custom_dimension_to_ga_config( $dimension_id, $categories_slugs );
+			$post = get_post();
+			if ( $post ) {
+				if ( 'category' === $dimension_role ) {
+					$categories = get_the_category();
+					if ( ! empty( $categories ) ) {
+						$categories_slugs = implode(
+							',',
+							array_map(
+								function( $cat ) {
+									return $cat->slug;
+								},
+								$categories
+							)
+						);
+						self::add_custom_dimension_to_ga_config( $dimension_id, $categories_slugs );
+					}
 				}
-			}
 
-			if ( 'author' === $dimension_role ) {
-				$post = get_post();
-				if ( $post ) {
+				if ( 'author' === $dimension_role ) {
 					$author_id = $post->post_author;
 					self::add_custom_dimension_to_ga_config(
 						$dimension_id,
 						get_the_author_meta( 'first_name', $author_id ) . ' ' . get_the_author_meta( 'last_name', $author_id )
+					);
+				}
+
+				if ( 'word_count' === $dimension_role ) {
+					self::add_custom_dimension_to_ga_config(
+						$dimension_id,
+						count( explode( ' ', wp_strip_all_tags( $post->post_content ) ) )
 					);
 				}
 			}

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -89,6 +89,13 @@ class Analytics {
 						count( explode( ' ', wp_strip_all_tags( $post->post_content ) ) )
 					);
 				}
+
+				if ( 'publish_date' === $dimension_role ) {
+					self::add_custom_dimension_to_ga_config(
+						$dimension_id,
+						date_format( date_create( $post->post_date ), 'Y-m-d' )
+					);
+				}
 			}
 		}
 	}

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -29,9 +29,10 @@ class Analytics_Wizard extends Wizard {
 	/**
 	 * Custom dimensions options names.
 	 */ // phpcs:ignore Squiz.Commenting.VariableComment.Missing
-	public static $category_dimension_option_name   = 'newspack_analytics_category_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
-	public static $author_dimension_option_name     = 'newspack_analytics_author_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
-	public static $word_count_dimension_option_name = 'newspack_analytics_word_count_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	public static $category_dimension_option_name     = 'newspack_analytics_category_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	public static $author_dimension_option_name       = 'newspack_analytics_author_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	public static $word_count_dimension_option_name   = 'newspack_analytics_word_count_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	public static $publish_date_dimension_option_name = 'newspack_analytics_publish_date_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 
 	/**
 	 * Name of the option storing site's custom events (serialised).
@@ -310,6 +311,9 @@ class Analytics_Wizard extends Wizard {
 					if ( get_option( self::$word_count_dimension_option_name ) === $dimension['id'] ) { // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.SelfInsideClosure
 						$dimension->role = 'word_count';
 					}
+					if ( get_option( self::$publish_date_dimension_option_name ) === $dimension['id'] ) { // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.SelfInsideClosure
+						$dimension->role = 'publish_date';
+					}
 					return $dimension;
 				},
 				$custom_dimensions['items']
@@ -338,6 +342,10 @@ class Analytics_Wizard extends Wizard {
 					'role' => 'word_count',
 					'id'   => get_option( self::$word_count_dimension_option_name ),
 				],
+				[
+					'role' => 'publish_date',
+					'id'   => get_option( self::$publish_date_dimension_option_name ),
+				],
 			],
 			function( $item ) {
 				return $item['id'];
@@ -351,7 +359,7 @@ class Analytics_Wizard extends Wizard {
 	 * @param String $name Name.
 	 */
 	public static function validate_custom_dimension_name( $name ) {
-		return in_array( $name, [ 'author', 'category', 'word_count', '' ] );
+		return in_array( $name, [ 'author', 'category', 'word_count', 'publish_date', '' ] );
 	}
 
 	/**
@@ -398,6 +406,9 @@ class Analytics_Wizard extends Wizard {
 				break;
 			case 'word_count':
 				self::set_custom_dimension( $request['id'], self::$word_count_dimension_option_name );
+				break;
+			case 'publish_date':
+				self::set_custom_dimension( $request['id'], self::$publish_date_dimension_option_name );
 				break;
 			default:
 				self::set_custom_dimension( $request['id'] );

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -27,11 +27,10 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Analytics_Wizard extends Wizard {
 
 	/**
-	 * Name of the option storing the article category custom dimension id.
-	 *
-	 * @var string
-	 */
-	public static $category_dimension_option_name = 'newspack_analytics_category_custom_dimension_id';
+	 * Custom dimensions options names.
+	 */ // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	public static $category_dimension_option_name = 'newspack_analytics_category_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	public static $author_dimension_option_name   = 'newspack_analytics_author_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 
 	/**
 	 * Name of the option storing site's custom events (serialised).
@@ -60,7 +59,6 @@ class Analytics_Wizard extends Wizard {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
-		add_action( 'admin_init', [ $this, 'insert_custom_dimensions' ] );
 
 		// Ensure Site Kit asks for sufficient scopes to add custom dimensions.
 		add_filter(
@@ -100,36 +98,6 @@ class Analytics_Wizard extends Wizard {
 	}
 
 	/**
-	 * Create the custom dimension to report category, if:
-	 * - the GA property has no custom dimensions set,
-	 * - the category dimension option has not been set.
-	 */
-	public function insert_custom_dimensions() {
-		if (
-			get_option( 'has_set_up_category_dimension' ) != 'completed' &&
-			! get_option( self::$category_dimension_option_name )
-		) {
-			$custom_dimensions = self::list_custom_dimensions();
-			if ( ! is_wp_error( $custom_dimensions ) && count( $custom_dimensions ) === 0 ) {
-				$new_custom_dimension = self::create_custom_dimension(
-					[
-						'name'  => '[Newspack] Article Category',
-						'scope' => 'HIT',
-					]
-				);
-				if ( ! is_wp_error( $new_custom_dimension ) ) {
-					$new_custom_dimension = self::set_category_dimension(
-						[
-							'id' => $new_custom_dimension['id'],
-						]
-					);
-					update_option( 'has_set_up_category_dimension', 'completed' );
-				}
-			}
-		}
-	}
-
-	/**
 	 * Register the endpoints needed for the wizard screens.
 	 */
 	public function register_api_endpoints() {
@@ -152,17 +120,21 @@ class Analytics_Wizard extends Wizard {
 			]
 		);
 
-		// Set the category custom dimension.
+		// Set the custom dimensions.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/analytics/category-dimension/(?P<id>[\w:]+)',
+			'/wizard/analytics/custom-dimensions/(?P<id>[\w:]+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'set_category_dimension' ],
+				'callback'            => [ $this, 'api_set_custom_dimensions' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'id' => [
+					'id'   => [
 						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'role' => [
+						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ __CLASS__, 'validate_custom_dimension_name' ],
 					],
 				],
 			]
@@ -308,7 +280,7 @@ class Analytics_Wizard extends Wizard {
 	}
 
 	/**
-	 * List Custom Dimensions.
+	 * List Custom Dimensions from connected GA account, marking the configured ones with `role` attribute.
 	 *
 	 * @return Array|WP_Error Array of custom dimensions on success, or WP_Error object on failure.
 	 */
@@ -326,11 +298,13 @@ class Analytics_Wizard extends Wizard {
 			return new WP_Error( 'newspack_analytics', __( 'Error retrieving custom dimensions.', 'newspack' ) );
 		}
 		if ( isset( $custom_dimensions['items'] ) ) {
-			$option_name = self::$category_dimension_option_name;
 			return array_map(
-				function ( &$dimension ) use ( $option_name ) {
-					if ( get_option( $option_name ) === $dimension['id'] ) {
-						$dimension->is_category_dimension = true;
+				function ( &$dimension ) {
+					if ( get_option( self::$category_dimension_option_name ) === $dimension['id'] ) { // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.SelfInsideClosure
+						$dimension->role = 'category';
+					}
+					if ( get_option( self::$author_dimension_option_name ) === $dimension['id'] ) { // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.SelfInsideClosure
+						$dimension->role = 'author';
 					}
 					return $dimension;
 				},
@@ -338,6 +312,38 @@ class Analytics_Wizard extends Wizard {
 			);
 		}
 		return new WP_Error( 'newspack_analytics', __( 'Error retrieving custom dimensions.', 'newspack' ) );
+	}
+
+	/**
+	 * List configured Custom Dimensions.
+	 *
+	 * @return Array|WP_Error Array of configured custom dimensions on success, or WP_Error object on failure.
+	 */
+	public static function list_configured_custom_dimensions() {
+		return array_filter(
+			[
+				[
+					'role' => 'author',
+					'id'   => get_option( self::$author_dimension_option_name ),
+				],
+				[
+					'role' => 'category',
+					'id'   => get_option( self::$category_dimension_option_name ),
+				],
+			],
+			function( $item ) {
+				return $item['id'];
+			}
+		);
+	}
+
+	/**
+	 * Validate custom dimension name.
+	 *
+	 * @param String $name Name.
+	 */
+	public static function validate_custom_dimension_name( $name ) {
+		return in_array( $name, [ 'author', 'category', '' ] );
 	}
 
 	/**
@@ -374,17 +380,38 @@ class Analytics_Wizard extends Wizard {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return Object|WP_Error Object on success, or WP_Error object on failure.
 	 */
-	public static function set_category_dimension( $request ) {
-		$dimension_id          = $request['id'];
-		$existing_dimension_id = get_option( self::$category_dimension_option_name );
-		if ( $existing_dimension_id === $dimension_id ) {
-			$dimension_id = null;
+	public static function api_set_custom_dimensions( $request ) {
+		switch ( $request['role'] ) {
+			case 'category':
+				self::set_custom_dimension( $request['id'], self::$category_dimension_option_name );
+				break;
+			case 'author':
+				self::set_custom_dimension( $request['id'], self::$author_dimension_option_name );
+				break;
+			default:
+				self::set_custom_dimension( $request['id'] );
 		}
-		if ( update_option( self::$category_dimension_option_name, $dimension_id ) ) {
-			return [ 'id' => $dimension_id ];
-		} else {
-			return new WP_Error( 'newspack_analytics', __( 'Error when setting category custom dimension.', 'newspack' ) );
+		return self::list_custom_dimensions();
+	}
+
+	/**
+	 * Set custom dimension option.
+	 *
+	 * @param string $dimension_id Dimension id.
+	 * @param string $dimension_option_name Dimension option name.
+	 */
+	public static function set_custom_dimension( $dimension_id, $dimension_option_name = null ) {
+		global $wpdb;
+
+		// Unset the option that was there before.
+		$options_table_name = $wpdb->prefix . 'options';
+		$data               = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare( "SELECT option_name FROM $options_table_name WHERE option_value=%s;", $dimension_id ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+		foreach ( $data as $result ) {
+			delete_option( $result->option_name );
 		}
+		update_option( $dimension_option_name, $dimension_id );
 	}
 
 	/**

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -29,8 +29,9 @@ class Analytics_Wizard extends Wizard {
 	/**
 	 * Custom dimensions options names.
 	 */ // phpcs:ignore Squiz.Commenting.VariableComment.Missing
-	public static $category_dimension_option_name = 'newspack_analytics_category_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
-	public static $author_dimension_option_name   = 'newspack_analytics_author_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	public static $category_dimension_option_name   = 'newspack_analytics_category_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	public static $author_dimension_option_name     = 'newspack_analytics_author_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	public static $word_count_dimension_option_name = 'newspack_analytics_word_count_custom_dimension_id'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 
 	/**
 	 * Name of the option storing site's custom events (serialised).
@@ -306,6 +307,9 @@ class Analytics_Wizard extends Wizard {
 					if ( get_option( self::$author_dimension_option_name ) === $dimension['id'] ) { // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.SelfInsideClosure
 						$dimension->role = 'author';
 					}
+					if ( get_option( self::$word_count_dimension_option_name ) === $dimension['id'] ) { // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.SelfInsideClosure
+						$dimension->role = 'word_count';
+					}
 					return $dimension;
 				},
 				$custom_dimensions['items']
@@ -323,12 +327,16 @@ class Analytics_Wizard extends Wizard {
 		return array_filter(
 			[
 				[
+					'role' => 'category',
+					'id'   => get_option( self::$category_dimension_option_name ),
+				],
+				[
 					'role' => 'author',
 					'id'   => get_option( self::$author_dimension_option_name ),
 				],
 				[
-					'role' => 'category',
-					'id'   => get_option( self::$category_dimension_option_name ),
+					'role' => 'word_count',
+					'id'   => get_option( self::$word_count_dimension_option_name ),
 				],
 			],
 			function( $item ) {
@@ -343,7 +351,7 @@ class Analytics_Wizard extends Wizard {
 	 * @param String $name Name.
 	 */
 	public static function validate_custom_dimension_name( $name ) {
-		return in_array( $name, [ 'author', 'category', '' ] );
+		return in_array( $name, [ 'author', 'category', 'word_count', '' ] );
 	}
 
 	/**
@@ -387,6 +395,9 @@ class Analytics_Wizard extends Wizard {
 				break;
 			case 'author':
 				self::set_custom_dimension( $request['id'], self::$author_dimension_option_name );
+				break;
+			case 'word_count':
+				self::set_custom_dimension( $request['id'], self::$word_count_dimension_option_name );
 				break;
 			default:
 				self::set_custom_dimension( $request['id'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add additional custom dimensions.

### How to test the changes in this Pull Request:

1. On a site with GA configured, visit Analytics wizard, Custom Dimensions tab
2. Observe that a custom dimension in the table has a select with five options – four custom dimensions and a "none" option
3. If there are less than four custom dimensions, add some using the form in "Create a new custom dimension" section
4. Set the custom dimensions to their roles, so that all roles are covered
5. Visit an article as a non-logged in user – observe the custom dimensions are reported with correct values (look for a request to a `/collect` endpoint) as `cdN` parameters, where `N` is the index of the custom dimension
6. In the settings, observe that duplicate roles for custom dimensions are not possible (if dimension A is set to role X, setting dimension B to role X will set the role of custom dimension A to "none") 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
