### PR TITLE
fix: override site kit _gl query param behavior

### DIFF
--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -20,6 +20,15 @@ class AMP_Enhancements {
 	public static function init() {
 		// Use local storage instead of an ajax endpoint with WP GDPR Cookie Notice.
 		add_filter( 'wp_gdpr_cookie_notice_amp_use_endpoint', '__return_false' );
+		add_filter(
+			'googlesitekit_amp_gtag_opt',
+			function ( $gtag_opt ) {
+				foreach ( $gtag_opt['vars']['config'] as &$config ) {
+					unset( $config['linker']['domains'] );
+				}
+				return $gtag_opt;
+			}
+		);
 	}
 }
 AMP_Enhancements::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

Addresses the issue described in https://github.com/ampproject/amphtml/issues/30176, where in AMP Standard mode Site Kit adds a query param to all internal links. This branch implements the fix described in https://github.com/ampproject/amphtml/issues/30176#issuecomment-690804114

cc: @westonruter 

### How to test the changes in this Pull Request:

1. On a site in AMP Standard mode, with Google Analytics connected through Site Kit, keep Newspack plugin on `master` branch.
2. Click around the site, observe `?_gl=123456789...` style query param appears momentarily when arriving at a new URL on the site.
3. Apply this branch. Observe the behavior is gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->