### PR TITLE
Fix: campaigns-wizard: prevent edge case errors

### DIFF
--- a/assets/wizards/popups/components/popup-popover/index.js
+++ b/assets/wizards/popups/components/popup-popover/index.js
@@ -56,15 +56,17 @@ class PopupPopover extends Component {
 			publishPopup,
 			updatePopup,
 		} = this.props;
-		const { id, sitewide_default: sitewideDefault, edit_link: editLink, options } = popup;
+		const { id, sitewide_default: sitewideDefault, edit_link: editLink, options, status } = popup;
 		const { frequency, placement } = options;
+		const isDraft = 'draft' === status;
+		const isTestMode = 'test' === frequency;
 		return (
 			<Popover
 				position="bottom left"
 				onFocusOutside={ onFocusOutside }
 				onKeyDown={ event => ESCAPE === event.keyCode && onFocusOutside() }
 			>
-				{ 'inline' !== placement && (
+				{ 'inline' !== placement && ! isTestMode && ! isDraft && (
 					<MenuItem
 						onClick={ () => {
 							setSitewideDefaultPopup( id, ! sitewideDefault );
@@ -83,7 +85,7 @@ class PopupPopover extends Component {
 				) }
 				<MenuItem
 					onClick={ () => {
-						updatePopup( id, { frequency: 'test' === frequency ? 'daily' : 'test' } );
+						updatePopup( id, { frequency: isTestMode ? 'daily' : 'test' } );
 						onFocusOutside();
 					} }
 					icon={ <TestIcon /> }
@@ -92,7 +94,7 @@ class PopupPopover extends Component {
 					{ __( 'Test mode', 'newspack' ) }
 					<ToggleControl
 						className="newspack-popup-action-card-popover-control"
-						checked={ 'test' === frequency }
+						checked={ isTestMode }
 						onChange={ () => null }
 					/>
 				</MenuItem>

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -75,11 +75,7 @@ class PopupGroup extends Component {
 						key={ popup.id }
 						popup={ popup }
 						previewPopup={ previewPopup }
-						setCategoriesForPopup={
-							section.key === 'active' || section.key === 'test'
-								? setCategoriesForPopup
-								: () => null
-						}
+						setCategoriesForPopup={ setCategoriesForPopup }
 						setSitewideDefaultPopup={ setSitewideDefaultPopup }
 						updatePopup={ updatePopup }
 						publishPopup={ section.key === 'draft' ? publishPopup : undefined }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes small edge case errors

### How to test the changes in this Pull Request:

1. Create two campaigns, a one a draft and one in test mode 
2. In Campaigns Wizard, observe that neither has the "Sitewide default" toggle in the options popover
3. Assign a category to the draft campaign, observe there is no error and the category is assigned
4. Repeat 3. with the test mode campaign

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
