### PR TITLE
Ignore Yoast weight limit to prevent missing `og:image` tags

### DIFF
--- a/includes/wizards/class-seo-wizard.php
+++ b/includes/wizards/class-seo-wizard.php
@@ -38,6 +38,7 @@ class SEO_Wizard extends Wizard {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+		add_filter( 'wpseo_image_image_weight_limit', [ $this, 'ignore_yoast_weight_limit' ] );
 	}
 
 	/**
@@ -213,5 +214,17 @@ class SEO_Wizard extends Wizard {
 		);
 		\wp_style_add_data( 'newspack-seo-wizard', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-seo-wizard' );
+	}
+
+	/**
+	 * We don't want Yoast to exclude large images from og:image tags for 2 reasons:
+	 * 1. Yoast cannot calculate the image size for images served via Jetpack CDN, so any calculations will be incorrect.
+	 * 2. It increases support burden since Yoast doesn't provide the user any explanation for why the image was excluded.
+	 *
+	 * @param int $limit Max image size in bytes.
+	 * @return int Modified $limit.
+	 */
+	public function ignore_yoast_weight_limit( $limit ) {
+		return PHP_INT_MAX;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue where Yoast would not output `og:image` tags on certain posts. Here is the underlying cause:

1. We're not generating intermediate image thumbs any more (those have been offloaded to the Jetpack image CDN), so only the original full-size image gets uploaded.
2. Therefore, Yoast only finds the full-size image when generating `og:image` tags.
3. Yoast has a max size limit of 2MB for images.
4. Yoast can't know the file size of an image as served from Photon and is unaware of Photon in general, so it checks the original, full-size image size to determine whether the image is under the size limit. The Photon image is resized and compressed, so the size of the original and Photon-served image are wildly different.
5. Yoast thinks the image is too big to use for the `og:image` tag, so it doesn't output the tag.

I think the most straightforward solution here is to ignore the size check. Since Yoast doesn't provide any explanation to the user when it skips generating an `og:image` tag, it will also prevent confusion and reduce the support burden of dealing with questions around this issue.

### How to test the changes in this Pull Request:

1. [Get and upload this 4MB image](https://washingtoncitypaper.com/wp-content/uploads/2020/08/WEB_Bowser.5f3d3ff57bb32.png) as the featured image for a post.
2. Delete the intermediate sizes: `wp media regenerate 6950 --image_size=thumbnail` (Replace `6950` with the attachment ID of the image on your site). If you look in the `uploads` directory, you should see only the full-size image and a 150x150 thumbnail after running that command.
3. Before applying this patch, view the page source. Observe no `og:image` tag:
<img width="870" alt="Screen Shot 2020-09-15 at 11 23 43 AM" src="https://user-images.githubusercontent.com/7317227/93249311-f39a4800-f745-11ea-8c43-31dab0a1ad2f.png">
4. Apply this patch. View the page source. Observe `og:image` tag:
<img width="837" alt="Screen Shot 2020-09-15 at 11 23 21 AM" src="https://user-images.githubusercontent.com/7317227/93249315-f5fca200-f745-11ea-8737-f50bf0f30c2d.png">
5. (optional) Do the above steps with Jetpack Image Accelerator active. Should get the same results.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->