### PR TITLE
feat: add AutocompleteTokenfield component

### DIFF
--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -30,6 +30,7 @@
     "@wordpress/element": "^2.3.0",
     "@wordpress/i18n": "^3.11.0",
     "classnames": "^2.2.6",
+    "lodash": "^4.17.20",
     "react-router-dom": "^5.0.1"
   },
   "devDependencies": {

--- a/assets/components/src/autocomplete-tokenfield/index.js
+++ b/assets/components/src/autocomplete-tokenfield/index.js
@@ -1,0 +1,184 @@
+/**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { FormTokenField, Spinner } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * An multi-selecting, api-driven autocomplete input suitable for use in block attributes.
+ */
+class AutocompleteTokenField extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			suggestions: [],
+			validValues: {},
+			loading: this.isFetchingInfoOnLoad(),
+		};
+
+		this.debouncedUpdateSuggestions = debounce( this.updateSuggestions, 500 );
+	}
+
+	/**
+	 * If the component has tokens passed in props, it should fetch info after it mounts.
+	 */
+	isFetchingInfoOnLoad = () => {
+		const { tokens, fetchSavedInfo } = this.props;
+		return Boolean( tokens.length && fetchSavedInfo );
+	};
+
+	/**
+	 * When the component loads, fetch information about the tokens so we can populate
+	 * the tokens with the correct labels.
+	 */
+	componentDidMount() {
+		if ( this.isFetchingInfoOnLoad() ) {
+			const { tokens, fetchSavedInfo } = this.props;
+
+			fetchSavedInfo( tokens ).then( results => {
+				const { validValues } = this.state;
+
+				results.forEach( suggestion => {
+					validValues[ suggestion.value ] = suggestion.label;
+				} );
+
+				this.setState( { validValues, loading: false } );
+			} );
+		}
+	}
+
+	/**
+	 * Clean up any unfinished autocomplete api call requests.
+	 */
+	componentWillUnmount() {
+		delete this.suggestionsRequest;
+		this.debouncedUpdateSuggestions.cancel();
+	}
+
+	/**
+	 * Get a list of labels for input values.
+	 *
+	 * @param {Array} values Array of values (ids, etc.).
+	 * @return {Array} array of valid labels corresponding to the values.
+	 */
+	getLabelsForValues( values ) {
+		const { validValues } = this.state;
+		return values.reduce(
+			( accumulator, value ) =>
+				validValues[ value ] ? [ ...accumulator, validValues[ value ] ] : accumulator,
+			[]
+		);
+	}
+
+	/**
+	 * Get a list of values for input labels.
+	 *
+	 * @param {Array} labels Array of labels from the tokens.
+	 * @return {Array} Array of valid values corresponding to the labels.
+	 */
+	getValuesForLabels( labels ) {
+		const { validValues } = this.state;
+		return labels.map( label =>
+			Object.keys( validValues ).find( key => validValues[ key ] === label )
+		);
+	}
+
+	/**
+	 * Refresh the autocomplete dropdown.
+	 *
+	 * @param {string} input Input to fetch suggestions for
+	 */
+	updateSuggestions( input ) {
+		const { fetchSuggestions } = this.props;
+		if ( ! fetchSuggestions ) {
+			return;
+		}
+
+		this.setState( { loading: true }, () => {
+			const request = fetchSuggestions( input );
+			request
+				.then( suggestions => {
+					// A fetch Promise doesn't have an abort option. It's mimicked by
+					// comparing the request reference in on the instance, which is
+					// reset or deleted on subsequent requests or unmounting.
+					if ( this.suggestionsRequest !== request ) {
+						return;
+					}
+
+					const { validValues } = this.state;
+					const currentSuggestions = [];
+
+					suggestions.forEach( suggestion => {
+						currentSuggestions.push( suggestion.label );
+						validValues[ suggestion.value ] = suggestion.label;
+					} );
+
+					this.setState( { suggestions: currentSuggestions, validValues, loading: false } );
+				} )
+				.catch( () => {
+					if ( this.suggestionsRequest === request ) {
+						this.setState( {
+							loading: false,
+						} );
+					}
+				} );
+
+			this.suggestionsRequest = request;
+		} );
+	}
+
+	/**
+	 * When a token is selected, we need to convert the string label into a recognized value suitable for saving as an attribute.
+	 *
+	 * @param {Array} tokenStrings An array of token label strings.
+	 */
+	handleOnChange( tokenStrings ) {
+		const { onChange } = this.props;
+		onChange( this.getValuesForLabels( tokenStrings ) );
+	}
+
+	/**
+	 * To populate the tokens, we need to convert the values into a human-readable label.
+	 *
+	 * @return {Array} An array of token label strings.
+	 */
+	getTokens() {
+		const { tokens } = this.props;
+		return this.getLabelsForValues( tokens );
+	}
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const { help, label = '', maxLength } = this.props;
+		const { suggestions, loading } = this.state;
+
+		return (
+			<div className="autocomplete-tokenfield">
+				<FormTokenField
+					value={ this.getTokens() }
+					suggestions={ suggestions }
+					onChange={ tokens => this.handleOnChange( tokens ) }
+					onInputChange={ input => this.debouncedUpdateSuggestions( input ) }
+					label={ label }
+					maxLength={ maxLength }
+				/>
+				{ loading && <Spinner /> }
+				{ help && <p className="autocomplete-tokenfield__help">{ help }</p> }
+			</div>
+		);
+	}
+}
+
+export default AutocompleteTokenField;

--- a/assets/components/src/autocomplete-tokenfield/index.js
+++ b/assets/components/src/autocomplete-tokenfield/index.js
@@ -175,7 +175,7 @@ class AutocompleteTokenField extends Component {
 					maxLength={ maxLength }
 				/>
 				{ loading && <Spinner /> }
-				{ help && <p className="autocomplete-tokenfield__help">{ help }</p> }
+				{ help && <p className="newspack-autocomplete-tokenfield__help">{ help }</p> }
 			</div>
 		);
 	}

--- a/assets/components/src/autocomplete-tokenfield/index.js
+++ b/assets/components/src/autocomplete-tokenfield/index.js
@@ -165,7 +165,7 @@ class AutocompleteTokenField extends Component {
 		const { suggestions, loading } = this.state;
 
 		return (
-			<div className="autocomplete-tokenfield">
+			<div className="newspack-autocomplete-tokenfield">
 				<FormTokenField
 					value={ this.getTokens() }
 					suggestions={ suggestions }

--- a/assets/components/src/autocomplete-tokenfield/style.scss
+++ b/assets/components/src/autocomplete-tokenfield/style.scss
@@ -1,0 +1,32 @@
+.autocomplete-tokenfield {
+	position: relative;
+
+	.components-spinner {
+		position: absolute;
+		right: 1rem;
+		top: 1rem;
+	}
+
+	/* Workaround for hard-coded help text in FormTokenField. */
+	.components-form-token-field {
+		> .components-form-token-field__help {
+			display: none;
+		}
+
+		> .components-form-token-field__token-text {
+			align-items: center;
+			display: flex;
+		}
+	}
+
+	.autocomplete-tokenfield__help {
+		font-size: 1rem;
+		font-style: italic;
+		margin-top: 0;
+	}
+
+	.components-form-token-field__suggestions-list {
+		margin-left: 0;
+		padding-left: 0;
+	}
+}

--- a/assets/components/src/autocomplete-tokenfield/style.scss
+++ b/assets/components/src/autocomplete-tokenfield/style.scss
@@ -1,4 +1,4 @@
-.autocomplete-tokenfield {
+.newspack-autocomplete-tokenfield {
 	position: relative;
 
 	.components-spinner {
@@ -19,7 +19,7 @@
 		}
 	}
 
-	.autocomplete-tokenfield__help {
+	.newspack-autocomplete-tokenfield__help {
 		font-size: 1rem;
 		font-style: italic;
 		margin-top: 0;

--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -1,5 +1,6 @@
 export { default as ActionCard } from './action-card';
 export { default as ActionCardSections } from './action-card-sections';
+export { default as AutocompleteTokenField } from './autocomplete-tokenfield';
 export { default as Button } from './button';
 export { default as ButtonGroup } from './button-group';
 export { default as Card } from './card';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As suggested in https://github.com/Automattic/newspack-listings/pull/1#discussion_r492030845, adds the AutocompleteTokenfield component from the Homepage Posts block to newspack-components. This component provides an autocomplete search input field for use in the block editor.

After this PR is released and the NPM package updated, we should be able to remove the code from the `newspack-listings` and `newspack-blocks` repos and import the component from NPM instead.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

Not sure how to test the NPM package functionality until this PR has been merged and the package updated on NPM, but you can test that the component works by importing it to an existing editor component in this repo and adding it to the render output, something like this:

```
<AutocompleteTokenField
	key="test"
	tokens={ [] }
	onChange={ value => console.log( value ) }
	fetchSuggestions={ value => console.log( value ) }
	fetchSavedInfo={ value => console.log( value ) }
	label={ 'Test autocomplete search field' }
	help={ __(
		'Begin typing post title, click autocomplete result to select.',
		'newspack-plugin'
	) }
/>
```

The field won't do anything or provide suggestions without actual fetch functions being passed to the props, but seeing the field and being able to interact with it should be enough to confirm that it works as an import from `newspack-components`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->