### PR TITLE
fix: salesforce opportunities should be set to closed/won instead of new

### DIFF
--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -306,7 +306,7 @@ class Salesforce {
 	 * Create a new contact record in Salesforce.
 	 *
 	 * @param array $data Data to use in creating the new contact. Keys must be valid Salesforce field names.
-	 * @return array Response from Salesforce API.
+	 * @return array|WP_Error Response from Salesforce API.
 	 */
 	public static function create_contact( $data ) {
 		$salesforce_settings = self::get_salesforce_settings();
@@ -339,6 +339,13 @@ class Salesforce {
 			);
 		}
 
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error(
+				'newspack_salesforce_contact_failure',
+				$response->get_error_message()
+			);
+		}
+
 		return json_decode( $response['body'] );
 	}
 
@@ -346,7 +353,7 @@ class Salesforce {
 	 * Create a new opportunity record in Salesforce.
 	 *
 	 * @param array $data Data to use in creating the new opportunity. Keys must be valid Salesforce field names.
-	 * @return array Response from Salesforce API.
+	 * @return array|WP_Error Response from Salesforce API.
 	 */
 	public static function create_opportunity( $data ) {
 		$salesforce_settings = self::get_salesforce_settings();
@@ -379,6 +386,13 @@ class Salesforce {
 			);
 		}
 
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error(
+				'newspack_salesforce_opportunity_failure',
+				$response->get_error_message()
+			);
+		}
+
 		return json_decode( $response['body'] );
 	}
 
@@ -388,7 +402,7 @@ class Salesforce {
 	 *
 	 * @param string $opportunity_id Unique ID for the opportunity to link.
 	 * @param string $contact_id Unique ID for the contact to link.
-	 * @return array Response from Salesforce API.
+	 * @return array|WP_Error Response from Salesforce API.
 	 */
 	public static function create_opportunity_contact_role( $opportunity_id, $contact_id ) {
 		$salesforce_settings = self::get_salesforce_settings();
@@ -424,6 +438,13 @@ class Salesforce {
 					],
 					'body'    => wp_json_encode( $data ),
 				]
+			);
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error(
+				'newspack_salesforce_opportunity_contact_role_failure',
+				$response->get_error_message()
 			);
 		}
 

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -401,12 +401,11 @@ class Salesforce {
 	}
 
 	/**
-	 * Does the Salesforce account an NPSP instance?
-	 * Checks for the existence of the NPSP field we want to sync to.
+	 * Does the given sObject type have the given field name?
 	 *
 	 * @param string $field_name   Name of the field.
 	 * @param string $sobject_name Name of the Salesforce sObject to check for the field.
-	 * @return boolean Whether or not the NPSP field exists.
+	 * @return boolean Whether or not the field exists.
 	 */
 	public static function has_field( $field_name = null, $sobject_name = null ) {
 		$has_field = false;

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -208,7 +208,7 @@ class Salesforce {
 					'CloseDate'   => $transaction_date,
 					'Description' => 'WooCommerce Order Number: ' . $data['id'],
 					'Name'        => $transaction['name'],
-					'StageName'   => 'New',
+					'StageName'   => 'Closed Won',
 					'LeadSource'  => 'Post categories: ' . $referer_categories . ', tags: ' . $referer_tags,
 				];
 			}
@@ -397,6 +397,7 @@ class Salesforce {
 			'ContactId'     => $contact_id,
 			'IsPrimary'     => true,
 			'OpportunityId' => $opportunity_id,
+			'Role'          => 'Hard Credit',
 		];
 
 		// Create opportunity contact role record via Salesforce API, using cached access_token.

--- a/includes/class-webhooks.php
+++ b/includes/class-webhooks.php
@@ -116,7 +116,14 @@ class Webhooks {
 
 		// Sync WooCommerce orders to Salesforce opportunities.
 		if ( is_array( $orders ) ) {
+			$is_npsp = Salesforce::has_field( 'npsp__Primary_Contact__c', 'Opportunity' );
+
 			foreach ( $orders as $order ) {
+				// Add the NPSP "Primary Contact" field if the Salesforce instance supports it.
+				if ( $is_npsp ) {
+					$order['npsp__Primary_Contact__c'] = $contact_id;
+				}
+
 				$opportunity_response = Salesforce::create_opportunity( $order );
 
 				if ( is_wp_error( $opportunity_response ) ) {

--- a/includes/class-webhooks.php
+++ b/includes/class-webhooks.php
@@ -96,6 +96,14 @@ class Webhooks {
 		} else {
 			// Create new contact.
 			$contact_response = Salesforce::create_contact( $contact );
+
+			if ( is_wp_error( $contact_response ) ) {
+				return new \WP_Error(
+					'newspack_salesforce_contact_failure',
+					$contact_response->get_error_message()
+				);
+			}
+
 			$contact_id       = $contact_response->id;
 		}
 
@@ -110,6 +118,14 @@ class Webhooks {
 		if ( is_array( $orders ) ) {
 			foreach ( $orders as $order ) {
 				$opportunity_response = Salesforce::create_opportunity( $order );
+
+				if ( is_wp_error( $opportunity_response ) ) {
+					return new \WP_Error(
+						'newspack_salesforce_opportunity_failure',
+						$response->get_error_message()
+					);
+				}
+
 				$opportunity_id       = $opportunity_response->id;
 
 				if ( ! empty( $opportunity_id ) ) {

--- a/includes/class-webhooks.php
+++ b/includes/class-webhooks.php
@@ -129,7 +129,7 @@ class Webhooks {
 				if ( is_wp_error( $opportunity_response ) ) {
 					return new \WP_Error(
 						'newspack_salesforce_opportunity_failure',
-						$response->get_error_message()
+						$opportunity_response->get_error_message()
 					);
 				}
 

--- a/includes/class-webhooks.php
+++ b/includes/class-webhooks.php
@@ -104,7 +104,7 @@ class Webhooks {
 				);
 			}
 
-			$contact_id       = $contact_response->id;
+			$contact_id = $contact_response->id;
 		}
 
 		if ( empty( $contact_id ) ) {
@@ -133,7 +133,7 @@ class Webhooks {
 					);
 				}
 
-				$opportunity_id       = $opportunity_response->id;
+				$opportunity_id = $opportunity_response->id;
 
 				if ( ! empty( $opportunity_id ) ) {
 					$opportunities[] = $opportunity_response;


### PR DESCRIPTION
Brought to our attention by TRNN, this is a requirement for them to use the roll-up reports they use to track donations.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Makes some changes to the Salesforce sync functionality to make the synced data work better with NPSP roll-up reports, as requested by TRNN.

### How to test the changes in this Pull Request:

1. Ensure that you have a Salesforce developer account connected to your Newspack site ([instructions here](https://newspack.pub/support/reader-revenue/salesforce/)).
2. Make a donation through the Donate block and make sure to fill in all contact info in the checkout form.
3. Log into Salesforce and go to **Sales Console > Opportunities** to find the data synced from WooCommerce. Click on the Opportunity that corresponds to your order, then click the **Details** tab.
4. Confirm that the "Stage" for the opportunity is set to "Closed Won" (visible at the top of the opportunity screen, and in the Details tab).
5. If the Salesforce instance is [NPSP](https://www.salesforce.org/trial/npsp/), confirm that there's a "Primary Contact" field set with the contact info matching what you inputted in WooCommerce.
6. Under **Contact Roles**, confirm that there's a contact listed as Primary with a role of "Hard Credit" (there may be two contact roles for the same contact, the other being "Donor", but this is expected). Click on the contact name, then the Details tab, and confirm that the contact details match what you entered in the WooCommerce checkout form.

Note: TRNN has tested and confirmed that the fix works as desired on their NPSP account.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->