### PR TITLE
feat: remove gutenberg from list of managed plugins

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -25,7 +25,6 @@ class Plugin_Manager {
 		'jetpack',
 		'amp',
 		'pwa',
-		'gutenberg',
 		'wordpress-seo',
 		'google-site-kit',
 		'newspack-blocks',
@@ -136,12 +135,6 @@ class Plugin_Manager {
 					'filename'   => 'class-site-kit-configuration-manager.php',
 					'class_name' => 'Site_Kit_Configuration_Manager',
 				],
-			],
-			'gutenberg'                     => [
-				'Name'        => 'Gutenberg',
-				'Description' => 'Printing since 1440. This is the development plugin for the new block editor in core.',
-				'Author'      => 'Gutenberg Team',
-				'Download'    => 'wporg',
 			],
 			'jetpack'                       => [
 				'Name'        => __( 'Jetpack', 'newspack' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There have been a few recent incidents where bleeding edge features in the Gutenberg plugin caused issues on Newspack sites. This PR removes it from the list of supported plugins, which reduces the risk of a customer creating problems by installing the plugin accidentally.

### How to test the changes in this Pull Request:

1. Verify Gutenberg does not appear under Newspack on the Plugins page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->