### PR TITLE
fix: increase timeout of Salesforce API requests to 30s

### DIFF
--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -240,6 +240,7 @@ class Salesforce {
 				'headers' => [
 					'Authorization' => 'Bearer ' . $salesforce_settings['access_token'],
 				],
+				'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			]
 		);
 
@@ -252,6 +253,7 @@ class Salesforce {
 					'headers' => [
 						'Authorization' => 'Bearer ' . $access_token,
 					],
+					'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 				]
 			);
 		}
@@ -280,6 +282,7 @@ class Salesforce {
 					'Content-Type'  => 'application/json',
 				],
 				'body'    => wp_json_encode( $data ),
+				'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			]
 		);
 
@@ -295,6 +298,7 @@ class Salesforce {
 						'Content-Type'  => 'application/json',
 					],
 					'body'    => wp_json_encode( $data ),
+					'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 				]
 			);
 		}
@@ -321,6 +325,7 @@ class Salesforce {
 					'Content-Type'  => 'application/json',
 				],
 				'body'    => wp_json_encode( $data ),
+				'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			]
 		);
 
@@ -335,6 +340,7 @@ class Salesforce {
 						'Content-Type'  => 'application/json',
 					],
 					'body'    => wp_json_encode( $data ),
+					'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 				]
 			);
 		}
@@ -373,6 +379,7 @@ class Salesforce {
 			[
 				'headers' => [
 					'Authorization' => 'Bearer ' . $salesforce_settings['access_token'],
+					'timeout'       => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 				],
 			]
 		);
@@ -385,6 +392,7 @@ class Salesforce {
 				[
 					'headers' => [
 						'Authorization' => 'Bearer ' . $access_token,
+						'timeout'       => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 					],
 				]
 			);
@@ -452,6 +460,7 @@ class Salesforce {
 					'Content-Type'  => 'application/json',
 				],
 				'body'    => wp_json_encode( $data ),
+				'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			]
 		);
 
@@ -466,6 +475,7 @@ class Salesforce {
 						'Content-Type'  => 'application/json',
 					],
 					'body'    => wp_json_encode( $data ),
+					'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 				]
 			);
 		}
@@ -507,6 +517,7 @@ class Salesforce {
 					'Content-Type'  => 'application/json',
 				],
 				'body'    => wp_json_encode( $data ),
+				'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			]
 		);
 
@@ -521,6 +532,7 @@ class Salesforce {
 						'Content-Type'  => 'application/json',
 					],
 					'body'    => wp_json_encode( $data ),
+					'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 				]
 			);
 		}
@@ -564,7 +576,10 @@ class Salesforce {
 					'grant_type'    => 'refresh_token',
 					'format'        => 'json',
 				]
-			)
+			),
+			[
+				'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
 		);
 
 		$response_body = json_decode( $salesforce_response['body'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Increases the timeout limit of Salesforce API requests to 30 seconds, from the default of 5.

This should help avoid intermittent timeout errors due to slow request roundtrips with Salesforce that result in unsynced or partially synced data.

Also shouldn't noticeably affect front-end or admin performance because the requests are triggered by webhooks.

### How to test the changes in this Pull Request:

1. Test the Salesforce donation sync functionality and watch the webhooks logs in **WooCommerce > Status > Logs**. 
2. There shouldn't be any timeout errors on sync attempt.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->