### PR TITLE
Allow adding external custom dimensions

### DIFF
--- a/assets/wizards/analytics/views/custom-dimensions/index.js
+++ b/assets/wizards/analytics/views/custom-dimensions/index.js
@@ -24,14 +24,6 @@ const SCOPES_OPTIONS = [
 	{ value: 'PRODUCT', label: __( 'Product', 'newspack' ) },
 ];
 
-const CUSTOM_DIMENSIONS_OPTIONS = [
-	{ value: '', label: __( 'none', 'newspack' ) },
-	{ value: 'category', label: __( 'Category', 'newspack' ) },
-	{ value: 'author', label: __( 'Author', 'newspack' ) },
-	{ value: 'word_count', label: __( 'Word count', 'newspack' ) },
-	{ value: 'publish_date', label: __( 'Publish date', 'newspack' ) },
-];
-
 /**
  * Analytics Custom Dimensions screen.
  */
@@ -111,7 +103,7 @@ class CustomDimensions extends Component {
 										</td>
 										<td>
 											<SelectControl
-												options={ CUSTOM_DIMENSIONS_OPTIONS }
+												options={ newspack_analytics_wizard_data.customDimensionsOptions }
 												value={ dimension.role || '' }
 												onChange={ this.handleCustomDimensionSetting( dimension.id ) }
 												className="newspack__analytics-configuration__select"

--- a/assets/wizards/popups/views/analytics/Chart.js
+++ b/assets/wizards/popups/views/analytics/Chart.js
@@ -17,7 +17,7 @@ const Chart = ( { data } ) => (
 	<div className="newspack-campaigns-wizard-analytics__chart">
 		<ResponsiveContainer width={ '100%' } height={ 300 }>
 			<AreaChart data={ data } margin={ { top: 5, right: 20, bottom: 5, left: -15 } }>
-				<Area type="monotoneX" dataKey="value" stroke="#36f" fill="#3366ff1c" />
+				<Area stackId="1" type="monotoneX" dataKey="value" stroke="#36f" fill="#3366ff1c" />
 				<CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
 				<XAxis
 					dataKey="date"

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -51,18 +51,31 @@ class Analytics {
 	 * More about custom dimensions: https://support.google.com/analytics/answer/2709828.
 	 */
 	public static function handle_custom_dimensions_reporting() {
-		$custom_dimensions = Analytics_Wizard::list_configured_custom_dimensions();
+		$custom_dimensions_values = self::get_custom_dimensions_values( get_the_ID() );
+		foreach ( $custom_dimensions_values as $key => $value ) {
+			self::add_custom_dimension_to_ga_config( $key, $value );
+		}
+	}
+
+	/**
+	 * Get values for custom dimensions to be sent to GA.
+	 *
+	 * @param string $post_id Post ID.
+	 */
+	public static function get_custom_dimensions_values( $post_id ) {
+		$custom_dimensions        = Analytics_Wizard::list_configured_custom_dimensions();
+		$custom_dimensions_values = [];
 		foreach ( $custom_dimensions as $dimension ) {
 			$dimension_role = $dimension['role'];
 			// Remove `ga:` prefix.
 			$dimension_id = substr( $dimension['gaID'], 3 );
 
-			$post = get_post();
+			$post = get_post( $post_id );
 			if ( $post ) {
 				if ( 'category' === $dimension_role ) {
-					$categories = get_the_category();
+					$categories = get_the_category( $post_id );
 					if ( ! empty( $categories ) ) {
-						$categories_slugs = implode(
+						$categories_slugs                          = implode(
 							',',
 							array_map(
 								function( $cat ) {
@@ -71,33 +84,25 @@ class Analytics {
 								$categories
 							)
 						);
-						self::add_custom_dimension_to_ga_config( $dimension_id, $categories_slugs );
+						$custom_dimensions_values[ $dimension_id ] = $categories_slugs;
 					}
 				}
 
 				if ( 'author' === $dimension_role ) {
-					$author_id = $post->post_author;
-					self::add_custom_dimension_to_ga_config(
-						$dimension_id,
-						get_the_author_meta( 'display_name', $author_id )
-					);
+					$author_id                                 = $post->post_author;
+					$custom_dimensions_values[ $dimension_id ] = get_the_author_meta( 'display_name', $author_id );
 				}
 
 				if ( 'word_count' === $dimension_role ) {
-					self::add_custom_dimension_to_ga_config(
-						$dimension_id,
-						count( explode( ' ', wp_strip_all_tags( $post->post_content ) ) )
-					);
+					$custom_dimensions_values[ $dimension_id ] = count( explode( ' ', wp_strip_all_tags( $post->post_content ) ) );
 				}
 
 				if ( 'publish_date' === $dimension_role ) {
-					self::add_custom_dimension_to_ga_config(
-						$dimension_id,
-						get_the_time( 'Y-m-d H:i', $post->ID )
-					);
+					$custom_dimensions_values[ $dimension_id ] = get_the_time( 'Y-m-d H:i', $post->ID );
 				}
 			}
 		}
+		return $custom_dimensions_values;
 	}
 
 	/**

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -55,7 +55,7 @@ class Analytics {
 		foreach ( $custom_dimensions as $dimension ) {
 			$dimension_role = $dimension['role'];
 			// Remove `ga:` prefix.
-			$dimension_id = substr( $dimension['id'], 3 );
+			$dimension_id = substr( $dimension['gaID'], 3 );
 
 			$post = get_post();
 			if ( $post ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**For testing https://github.com/Automattic/newspack-popups/pull/325**

Allows other plugins to report custom dimensions and add their config to Newspack Analytics Wizard. 

### How to test the changes in this Pull Request:

1. Follow the testing steps in https://github.com/Automattic/newspack-popups/pull/325

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->