### PR TITLE
feat: allow gam scripts in amp pages

### DIFF
--- a/includes/amp-sanitizers/class-amp-sanitizer-gam.php
+++ b/includes/amp-sanitizers/class-amp-sanitizer-gam.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Allow Google Ad Manager scripts in AMP pages
+ *
+ * @see https://github.com/Automattic/amp-wp
+ * @package Newspack
+ */
+
+/**
+ * Sanitizer class to allow Google Ad Manager scripts in AMP pages.
+ */
+class AMP_Sanitizer_GAM extends AMP_Base_Sanitizer {
+	/**
+	 * Sanitize document.
+	 *
+	 * @since 1.3
+	 */
+	public function sanitize() {
+		$xpath = new DOMXPath( $this->dom );
+		$found = false;
+		foreach ( $xpath->query( '//script[ @data-amp-plus-gam ]' ) as $node ) {
+			if ( $node instanceof DOMElement ) {
+				$node->setAttribute( AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, '' );
+				$found = true;
+			}
+		}
+		if ( $found ) {
+			$this->dom->documentElement->setAttribute( AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, '' );
+		}
+	}
+}

--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -29,7 +29,6 @@ class AMP_Enhancements {
 				return $gtag_opt;
 			}
 		);
-		add_filter( 'should_use_amp_plus', [ __CLASS__, 'amp_plus_mode' ] );
 		add_filter( 'amp_content_sanitizers', [ __CLASS__, 'amp_content_sanitizers' ] );
 	}
 
@@ -39,15 +38,12 @@ class AMP_Enhancements {
 	 * @param  string $context The context for which AMP plus should be assessed.
 	 * @return bool Should AMP plus be applied.
 	 */
-	public static function amp_plus_mode( $context = null ) {
-		if ( ! isset( $_GET['ampplus'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return false;
+	public static function should_use_amp_plus( $context = null ) {
+		$should = false;
+		if ( isset( $_GET['ampplus'] ) && defined( 'NEWSPACK_AMP_PLUS_CONFIG' ) && is_array( NEWSPACK_AMP_PLUS_CONFIG ) && in_array( $context, NEWSPACK_AMP_PLUS_CONFIG ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$should = true;
 		}
-		if ( ! defined( 'NEWSPACK_AMP_PLUS_CONFIG' ) ) {
-			return false;
-		}
-		$config = (array) NEWSPACK_AMP_PLUS_CONFIG;
-		return in_array( $context, $config );
+		return apply_filters( 'should_use_amp_plus', $should, $context );
 	}
 
 	/**
@@ -56,7 +52,7 @@ class AMP_Enhancements {
 	 * @param array $sanitizers The array of sanitizers, 'MyClassName' => [] // array of constructor params for class.
 	 */
 	public static function amp_content_sanitizers( $sanitizers ) {
-		if ( self::amp_plus_mode( 'gam' ) ) {
+		if ( self::should_use_amp_plus( 'gam' ) ) {
 			require_once NEWSPACK_ABSPATH . 'includes/amp-sanitizers/class-amp-sanitizer-gam.php';
 			$sanitizers['AMP_Sanitizer_GAM'] = [];
 		}

--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -40,6 +40,9 @@ class AMP_Enhancements {
 	 * @return bool Should AMP plus be applied.
 	 */
 	public static function amp_plus_mode( $context = null ) {
+		if ( ! isset( $_GET['ampplus'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return false;
+		}
 		if ( ! defined( 'NEWSPACK_AMP_PLUS_CONFIG' ) ) {
 			return false;
 		}

--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -40,12 +40,11 @@ class AMP_Enhancements {
 	 * @return bool Should AMP plus be applied.
 	 */
 	public static function amp_plus_mode( $context = null ) {
-		switch ( $context ) {
-			case 'gam':
-				return true;
-			default:
-				return false;
+		if ( ! defined( 'NEWSPACK_AMP_PLUS_CONFIG' ) ) {
+			return false;
 		}
+		$config = (array) NEWSPACK_AMP_PLUS_CONFIG;
+		return in_array( $context, $config );
 	}
 
 	/**

--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -29,6 +29,36 @@ class AMP_Enhancements {
 				return $gtag_opt;
 			}
 		);
+		add_filter( 'should_use_amp_plus', [ __CLASS__, 'amp_plus_mode' ] );
+		add_filter( 'amp_content_sanitizers', [ __CLASS__, 'amp_content_sanitizers' ] );
+	}
+
+	/**
+	 * AMP plus mode.
+	 *
+	 * @param  string $context The context for which AMP plus should be assessed.
+	 * @return bool Should AMP plus be applied.
+	 */
+	public static function amp_plus_mode( $context = null ) {
+		switch ( $context ) {
+			case 'gam':
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * Allow certain scripts to be included in AMP pages.
+	 *
+	 * @param array $sanitizers The array of sanitizers, 'MyClassName' => [] // array of constructor params for class.
+	 */
+	public static function amp_content_sanitizers( $sanitizers ) {
+		if ( self::amp_plus_mode( 'gam' ) ) {
+			require_once NEWSPACK_ABSPATH . 'includes/amp-sanitizers/class-amp-sanitizer-gam.php';
+			$sanitizers['AMP_Sanitizer_GAM'] = [];
+		}
+		return $sanitizers;
 	}
 }
 AMP_Enhancements::init();

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -565,7 +565,7 @@ class Advertising_Wizard extends Wizard {
 			return;
 		}
 
-		$is_amp = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+		$is_amp = ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) && ! AMP_Enhancements::amp_plus_mode( 'gam' );
 		$code   = $is_amp ? $ad_unit['amp_ad_code'] : $ad_unit['ad_code'];
 		if ( empty( $code ) ) {
 			return;
@@ -573,7 +573,7 @@ class Advertising_Wizard extends Wizard {
 
 		?>
 		<div class='newspack_global_ad <?php echo esc_attr( $placement_slug ); ?>'>
-			<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
+			<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</div>
 		<?php
 	}

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -565,7 +565,7 @@ class Advertising_Wizard extends Wizard {
 			return;
 		}
 
-		$is_amp = ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) && ! AMP_Enhancements::amp_plus_mode( 'gam' );
+		$is_amp = ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) && ! AMP_Enhancements::should_use_amp_plus( 'gam' );
 		$code   = $is_amp ? $ad_unit['amp_ad_code'] : $ad_unit['ad_code'];
 		if ( empty( $code ) ) {
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR creates the basic infrastructure for AMP Plus — an approach where AMP Dev Mode is used to add non-AMP features to AMP pages. The resulting page will be invalid AMP and therefore excluded from the AMP cache and Google search results carousel, however nearly all of the performance advantages of AMP are still present (tree-shaking, minification, various JS libraries, etc). 

The first experiment is Google Ad Manager. The integration allows use of non-AMP Ad Manager embeds in an AMP page. 

### How to test the changes in this Pull Request:

1. Switch Newspack Ads to this branch: https://github.com/Automattic/newspack-ads/pull/81
2. Edit `wp-config.php` and add this line:
```
define( 'NEWSPACK_AMP_PLUS_CONFIG', [ 'gam' ] );
```
3. Add some GAM ads to the site. 
4. Put AMP plugin in Standard mode.
5. Visit a page on the site, append `ampplus` query param to the url (e.g. `https://mywpsite.com/?ampplus`).
6. Verify the page has all the characteristics of an AMP page (minified CSS, AMP scripts) but the ads are not instances of `amp-ad`. 
7. Remove the `ampplus` query param, verify the page is now valid AMP and contains `amp-ad` components.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->