### PR TITLE
Use newspack-popups' preview post link getter

### DIFF
--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -218,15 +218,10 @@ class Popups_Wizard extends Wizard {
 			true
 		);
 
-		$recent_posts = wp_get_recent_posts(
-			[
-				'numberposts' => 1,
-				'post_status' => 'publish',
-			],
-			OBJECT
-		);
-
-		$preview_post = count( $recent_posts ) > 0 ? get_the_permalink( $recent_posts[0] ) : '';
+		$preview_post = '';
+		if ( method_exists( 'Newspack_Popups', 'preview_post_permalink' ) ) {
+			$preview_post = \Newspack_Popups::preview_post_permalink();
+		}
 
 		\wp_localize_script(
 			'newspack-popups-wizard',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Makes the Campaigns Wizard use the preview post URL determined by `newspack-popups` plugin

### How to test the changes in this Pull Request:

1. Switch to `add/preview-post-expose` branch of `newspack-popups` ([PR pending](https://github.com/Automattic/newspack-popups/pull/291))
2. Observe the previews triggered in campaigns wizard are using the latest not-password-protected, not-campaigns-disabled post

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->