### PR TITLE
Fix layout issues in Campaigns Wizard

### DIFF
--- a/assets/components/src/action-card-sections/index.js
+++ b/assets/components/src/action-card-sections/index.js
@@ -18,7 +18,7 @@ const ActionCardSections = ( { sections, emptyMessage, renderCard } ) => {
 
 	const renderedSections = useMemo( () => {
 		const validFilters = [ ALL_FILTER ];
-		const validSections = sections.reduce( ( validSectionsAcc, section, i ) => {
+		const validSections = sections.reduce( ( validSectionsAcc, section ) => {
 			if ( section.items.length > 0 ) {
 				const Heading = () => (
 					<h2 className="newspack-action-card-sections__group-type">
@@ -31,7 +31,7 @@ const ActionCardSections = ( { sections, emptyMessage, renderCard } ) => {
 				if ( filter === ALL_FILTER.value || filter === section.key ) {
 					validSectionsAcc.push(
 						<Fragment key={ section.key }>
-							{ allFilters.length > 0 && i === 0 ? (
+							{ allFilters.length > 0 && validSectionsAcc.length === 0 ? (
 								<div className="newspack-action-card-sections__group-wrapper">
 									<Heading />
 									<SelectControl

--- a/assets/components/src/select-control/style.scss
+++ b/assets/components/src/select-control/style.scss
@@ -10,14 +10,15 @@
 	font-size: 14px;
 	line-height: 24px;
 	margin: 32px 0;
-	width: 100%;
+	flex-direction: row !important;
+	align-items: center !important;
 
 	label {
 		color: $dark-gray-900;
 		font-size: inherit;
 		font-weight: bold;
 		line-height: inherit;
-		margin: 0;
+		padding-bottom: 0 !important;
 	}
 
 	select {

--- a/assets/wizards/popups/components/popup-popover/index.js
+++ b/assets/wizards/popups/components/popup-popover/index.js
@@ -19,6 +19,8 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import PreviewIcon from '@material-ui/icons/Visibility';
 import FrequencyIcon from '@material-ui/icons/Today';
 import PublishIcon from '@material-ui/icons/Publish';
+import TestIcon from '@material-ui/icons/BugReport';
+import SitewideDefaultIcon from '@material-ui/icons/Public';
 
 /**
  * Internal dependencies.
@@ -57,20 +59,7 @@ class PopupPopover extends Component {
 		const { frequency, placement } = options;
 		const isDraft = 'draft' === status;
 		const isTestMode = 'test' === frequency;
-		const SitewideDefaultIcon = () => (
-			<ToggleControl
-				className="newspack-popup-action-card-popover-control"
-				checked={ sitewideDefault }
-				onChange={ () => null }
-			/>
-		);
-		const TestModeIcon = () => (
-			<ToggleControl
-				className="newspack-popup-action-card-popover-control"
-				checked={ isTestMode }
-				onChange={ () => null }
-			/>
-		);
+
 		return (
 			<Popover
 				position="bottom left"
@@ -86,7 +75,10 @@ class PopupPopover extends Component {
 						icon={ <SitewideDefaultIcon /> }
 						className="newspack-button"
 					>
-						{ __( 'Sitewide default', 'newspack' ) }
+						<div className="newspack-popup-action-card-popover-control">
+							{ __( 'Sitewide default', 'newspack' ) }
+							<ToggleControl checked={ sitewideDefault } onChange={ () => null } />
+						</div>
 					</MenuItem>
 				) }
 				<MenuItem
@@ -94,10 +86,13 @@ class PopupPopover extends Component {
 						updatePopup( id, { frequency: isTestMode ? 'daily' : 'test' } );
 						onFocusOutside();
 					} }
-					icon={ <TestModeIcon /> }
+					icon={ <TestIcon /> }
 					className="newspack-button"
 				>
-					{ __( 'Test mode', 'newspack' ) }
+					<div className="newspack-popup-action-card-popover-control">
+						{ __( 'Test mode', 'newspack' ) }
+						<ToggleControl checked={ isTestMode } onChange={ () => null } />
+					</div>
 				</MenuItem>
 				{ 'test' !== frequency && (
 					<MenuItem icon={ <FrequencyIcon /> } className="newspack-button">

--- a/assets/wizards/popups/components/popup-popover/index.js
+++ b/assets/wizards/popups/components/popup-popover/index.js
@@ -101,6 +101,7 @@ class PopupPopover extends Component {
 								updatePopup( id, { frequency: value } );
 								onFocusOutside();
 							} }
+							className="newspack-popup-action-card-select"
 							options={ frequenciesForPopup( popup ) }
 							value={ frequency }
 						/>

--- a/assets/wizards/popups/components/popup-popover/index.js
+++ b/assets/wizards/popups/components/popup-popover/index.js
@@ -19,8 +19,6 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import PreviewIcon from '@material-ui/icons/Visibility';
 import FrequencyIcon from '@material-ui/icons/Today';
 import PublishIcon from '@material-ui/icons/Publish';
-import TestIcon from '@material-ui/icons/BugReport';
-import SitewideDefaultIcon from '@material-ui/icons/Public';
 
 /**
  * Internal dependencies.
@@ -41,7 +39,6 @@ const frequenciesForPopup = ( { options } ) => {
 		.filter( key => ! ( 'always' === key && 'inline' !== placement ) )
 		.map( key => ( { label: frequencyMap[ key ], value: key } ) );
 };
-
 class PopupPopover extends Component {
 	/**
 	 * Render.
@@ -60,6 +57,20 @@ class PopupPopover extends Component {
 		const { frequency, placement } = options;
 		const isDraft = 'draft' === status;
 		const isTestMode = 'test' === frequency;
+		const SitewideDefaultIcon = () => (
+			<ToggleControl
+				className="newspack-popup-action-card-popover-control"
+				checked={ sitewideDefault }
+				onChange={ () => null }
+			/>
+		);
+		const TestModeIcon = () => (
+			<ToggleControl
+				className="newspack-popup-action-card-popover-control"
+				checked={ isTestMode }
+				onChange={ () => null }
+			/>
+		);
 		return (
 			<Popover
 				position="bottom left"
@@ -76,11 +87,6 @@ class PopupPopover extends Component {
 						className="newspack-button"
 					>
 						{ __( 'Sitewide default', 'newspack' ) }
-						<ToggleControl
-							className="newspack-popup-action-card-popover-control"
-							checked={ sitewideDefault }
-							onChange={ () => null }
-						/>
 					</MenuItem>
 				) }
 				<MenuItem
@@ -88,15 +94,10 @@ class PopupPopover extends Component {
 						updatePopup( id, { frequency: isTestMode ? 'daily' : 'test' } );
 						onFocusOutside();
 					} }
-					icon={ <TestIcon /> }
+					icon={ <TestModeIcon /> }
 					className="newspack-button"
 				>
 					{ __( 'Test mode', 'newspack' ) }
-					<ToggleControl
-						className="newspack-popup-action-card-popover-control"
-						checked={ isTestMode }
-						onChange={ () => null }
-					/>
 				</MenuItem>
 				{ 'test' !== frequency && (
 					<MenuItem icon={ <FrequencyIcon /> } className="newspack-button">

--- a/assets/wizards/popups/components/popup-popover/style.scss
+++ b/assets/wizards/popups/components/popup-popover/style.scss
@@ -1,4 +1,6 @@
 .newspack-popup-action-card-popover-control {
-	position: absolute;
-	right: 0;
+	margin-left: auto !important;
+	margin-right: 0 !important;
+	display: inline-block;
+	flex: 0 0 auto;
 }

--- a/assets/wizards/popups/components/popup-popover/style.scss
+++ b/assets/wizards/popups/components/popup-popover/style.scss
@@ -1,6 +1,4 @@
 .newspack-popup-action-card-popover-control {
-	margin-left: auto !important;
-	margin-right: 0 !important;
 	display: inline-block;
 	flex: 0 0 auto;
 }

--- a/assets/wizards/popups/components/popup-popover/style.scss
+++ b/assets/wizards/popups/components/popup-popover/style.scss
@@ -3,3 +3,6 @@
 	display: flex;
 	justify-content: space-between;
 }
+.newspack-popup-action-card-select {
+	width: 100%;
+}

--- a/assets/wizards/popups/components/popup-popover/style.scss
+++ b/assets/wizards/popups/components/popup-popover/style.scss
@@ -1,4 +1,5 @@
 .newspack-popup-action-card-popover-control {
-	display: inline-block;
-	flex: 0 0 auto;
+	width: 100%;
+	display: flex;
+	justify-content: space-between;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two layout issues.

### How to test the changes in this Pull Request:

1. On `master`, visit the Campaigns Wizard
2. Observe that if there are no active campaigns, the filter selection will not be rendered
3. Observe that in the popover menu for an overlay campaign, the test mode toggle is rendered on top of sitewide default toggle:

![image](https://user-images.githubusercontent.com/7383192/97875775-2fe82e80-1d1b-11eb-92c0-3b201752b6b4.png)

4. Switch to this branch, observe both issues fixed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->