### PR TITLE
Campaigns Wizard: add segment options for subscriptions, donations

### DIFF
--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -42,6 +42,10 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 					setName( foundSegment.name );
 					setMinPosts( foundSegment.configuration.min_posts );
 					setMaxPosts( foundSegment.configuration.max_posts );
+					setIsSubscribed( foundSegment.configuration.is_subscribed );
+					setIsDonor( foundSegment.configuration.is_donor );
+					setIsNotSubscribed( foundSegment.configuration.is_not_subscribed );
+					setIsNotDonor( foundSegment.configuration.is_not_donor );
 				}
 			} );
 		}

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -23,6 +23,10 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 	const [ name, setName ] = useState( '' );
 	const [ min_posts, setMinPosts ] = useState( 0 );
 	const [ max_posts, setMaxPosts ] = useState( 0 );
+	const [ is_subscribed, setIsSubscribed ] = useState( false );
+	const [ is_donor, setIsDonor ] = useState( false );
+	const [ is_not_subscribed, setIsNotSubscribed ] = useState( false );
+	const [ is_not_donor, setIsNotDonor ] = useState( false );
 	const history = useHistory();
 
 	const isSegmentValid = name.length > 0;
@@ -55,6 +59,10 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 				configuration: {
 					min_posts,
 					max_posts,
+					is_subscribed,
+					is_donor,
+					is_not_subscribed,
+					is_not_donor,
 				},
 			},
 		} ).then( () => history.push( '/segmentation' ) );
@@ -95,6 +103,30 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 							onChange={ setMaxPosts }
 						/>
 					</div>
+				</SegmentSettingSection>
+				<SegmentSettingSection title={ __( 'Newsletter', 'newspack' ) }>
+					<CheckboxControl
+						checked={ is_subscribed }
+						onChange={ setIsSubscribed }
+						label={ __( 'Is subscribed to newsletter', 'newspack' ) }
+					/>
+					<CheckboxControl
+						checked={ is_not_subscribed }
+						onChange={ setIsNotSubscribed }
+						label={ __( 'Is not subscribed to newsletter', 'newspack' ) }
+					/>
+				</SegmentSettingSection>
+				<SegmentSettingSection title={ __( 'Donation', 'newspack' ) }>
+					<CheckboxControl
+						checked={ is_donor }
+						onChange={ setIsDonor }
+						label={ __( 'Has donated', 'newspack' ) }
+					/>
+					<CheckboxControl
+						checked={ is_not_donor }
+						onChange={ setIsNotDonor }
+						label={ __( "Hasn't donated", 'newspack' ) }
+					/>
 				</SegmentSettingSection>
 			</div>
 			<div className="newspack-buttons-card">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

UI for newsletter- and donor-based segmentation (https://github.com/Automattic/newspack-popups/pull/294).

### How to test the changes in this Pull Request:

1. Create a new segment in Campaigns Wizard, Segmentation tab
2. Observe two new sections – "Newsletter", "Donation"
3. Create segments using these options and test if campaigns are acting accordingly

_Note: you might need to bypass HTTPS check on a local instance, to make WC webhook succeed:_

```
add_filter(
	'http_request_args',
	function ( $r ) {
		$r['sslverify'] = false;
		return $r;
	}
);
```

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->