### PR TITLE
Campaigns Wizard: display segment name in campaign card

### DIFF
--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -59,6 +59,7 @@ class PopupsWizard extends Component {
 				inline: [],
 				overlay: [],
 			},
+			segments: [],
 			previewUrl: null,
 		};
 	}
@@ -74,7 +75,9 @@ class PopupsWizard extends Component {
 		return wizardApiFetch( {
 			path: '/newspack/v1/wizard/newspack-popups-wizard/',
 		} )
-			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )
+			.then( ( { popups, segments } ) =>
+				this.setState( { popups: this.sortPopups( popups ), segments } )
+			)
 			.catch( error => setError( error ) );
 	};
 
@@ -217,7 +220,7 @@ class PopupsWizard extends Component {
 			startLoading,
 			doneLoading,
 		} = this.props;
-		const { popups, previewUrl } = this.state;
+		const { popups, segments, previewUrl } = this.state;
 		const { inline, overlay } = popups;
 		return (
 			<WebPreview
@@ -245,6 +248,7 @@ class PopupsWizard extends Component {
 								showPreview()
 							),
 						publishPopup: this.publishPopup,
+						segments,
 					};
 					return (
 						<HashRouter hashType="slash">

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -9,6 +9,11 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies.
+ */
+import { find } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { withWizardScreen, ActionCardSections } from '../../../../components/src';
@@ -24,16 +29,24 @@ class PopupGroup extends Component {
 	 *
 	 * @param {Object} popup object.
 	 */
-	descriptionForPopup = ( { categories, sitewide_default: sitewideDefault } ) => {
+	descriptionForPopup = (
+		{ categories, sitewide_default: sitewideDefault, options },
+		segments
+	) => {
+		const segment = find( segments, [ 'id', options.selected_segment_id ] );
+		const descriptionMessages = [];
+		if ( segment ) {
+			descriptionMessages.push( `${ __( 'Segment:', 'newspack' ) } ${ segment.name }` );
+		}
 		if ( sitewideDefault ) {
-			return __( 'Sitewide default', 'newspack' );
+			descriptionMessages.push( __( 'Sitewide default', 'newspack' ) );
 		}
 		if ( categories.length > 0 ) {
-			return (
+			descriptionMessages.push(
 				__( 'Categories: ', 'newspack' ) + categories.map( category => category.name ).join( ', ' )
 			);
 		}
-		return null;
+		return descriptionMessages.length ? descriptionMessages.join( ' | ' ) : null;
 	};
 
 	/**
@@ -49,6 +62,7 @@ class PopupGroup extends Component {
 			setSitewideDefaultPopup,
 			publishPopup,
 			updatePopup,
+			segments,
 		} = this.props;
 
 		const getCardClassName = ( { key }, { sitewide_default } ) =>
@@ -71,7 +85,7 @@ class PopupGroup extends Component {
 					<PopupActionCard
 						className={ getCardClassName( section, popup ) }
 						deletePopup={ deletePopup }
-						description={ this.descriptionForPopup( popup ) }
+						description={ this.descriptionForPopup( popup, segments ) }
 						key={ popup.id }
 						popup={ popup }
 						previewPopup={ previewPopup }

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -294,17 +294,19 @@ class Popups_Wizard extends Wizard {
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
 
 		$response = [
-			'popups' => [],
+			'popups'   => [],
+			'segments' => [],
 		];
 
 		if ( $newspack_popups_configuration_manager->is_configured() ) {
-			$response['popups'] = array_map(
+			$response['popups']   = array_map(
 				function( $popup ) {
 					$popup['edit_link'] = get_edit_post_link( $popup['id'] );
 					return $popup;
 				},
 				$newspack_popups_configuration_manager->get_popups( true )
 			);
+			$response['segments'] = $newspack_popups_configuration_manager->get_segments( true );
 		}
 		return rest_ensure_response( $response );
 	}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds information about segment in Campaigns Wizard card

### How to test the changes in this Pull Request:

1. Assign a segment to a campaign
2. Observe that it's name is displayed as part of the description of a list item in Campaigns Wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->