### PR TITLE
Campaigns segmentation: add a note about donation segmentation working only with WC checkout

### DIFF
--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -12,9 +12,14 @@ import { Button, TextControl, CheckboxControl, Router } from '../../../../compon
 
 const { NavLink, useHistory } = Router;
 
-const SegmentSettingSection = ( { title, children } ) => (
+const SegmentSettingSection = ( { title, description, children } ) => (
 	<div className="newspack-campaigns-wizard-segments__section">
 		<h3>{ title }</h3>
+		{ description && (
+			<div className="newspack-campaigns-wizard-segments__section__description">
+				{ description }
+			</div>
+		) }
 		<div className="newspack-campaigns-wizard-segments__section__content">{ children }</div>
 	</div>
 );
@@ -120,7 +125,10 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 						label={ __( 'Is not subscribed to newsletter', 'newspack' ) }
 					/>
 				</SegmentSettingSection>
-				<SegmentSettingSection title={ __( 'Donation', 'newspack' ) }>
+				<SegmentSettingSection
+					title={ __( 'Donation', 'newspack' ) }
+					description={ __( '(if using WooCommerce checkout)', 'newspack' ) }
+				>
 					<CheckboxControl
 						checked={ is_donor }
 						onChange={ setIsDonor }

--- a/assets/wizards/popups/views/segmentation/style.scss
+++ b/assets/wizards/popups/views/segmentation/style.scss
@@ -28,6 +28,12 @@
 		h3 {
 			margin-top: 0;
 		}
+		&__description {
+			opacity: 0.6;
+			margin-top: -15px;
+			margin-bottom: 15px;
+			font-size: 0.9em;
+		}
 		&__content {
 			div {
 				margin-top: 10px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently the donation segmentation will work only if the site uses WC checkout. This PR adds a text to clarify that in the Campaigns Wizard.

### How to test the changes in this Pull Request:

1. Visit Campaigns Wizard, Segmentation tab
2. Observe a note in the "Donation" section

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
