### PR TITLE
feat: amp plus google optimize implementation

### DIFF
--- a/includes/amp-sanitizers/class-amp-sanitizer-google-optimize.php
+++ b/includes/amp-sanitizers/class-amp-sanitizer-google-optimize.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Allow Google Ad Manager scripts in AMP pages
+ *
+ * @see https://github.com/Automattic/amp-wp
+ * @package Newspack
+ */
+
+/**
+ * Sanitizer class to allow Google Ad Manager scripts in AMP pages.
+ */
+class AMP_Sanitizer_Google_Optimize extends AMP_Base_Sanitizer {
+	/**
+	 * Sanitize document.
+	 *
+	 * @since 1.3
+	 */
+	public function sanitize() {
+		$xpath = new DOMXPath( $this->dom );
+		$found = false;
+		foreach ( $xpath->query( '//script[ contains(@src, "www.googleoptimize.com/optimize.js") ]' ) as $node ) {
+			if ( $node instanceof DOMElement ) {
+				$node->setAttribute( AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, '' );
+				$found = true;
+			}
+		}
+		if ( $found ) {
+			$this->dom->documentElement->setAttribute( AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, '' );
+		}
+	}
+}

--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -7,6 +7,10 @@
 
 namespace Newspack;
 
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Modules\Optimize;
+
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -30,6 +34,25 @@ class AMP_Enhancements {
 			}
 		);
 		add_filter( 'amp_content_sanitizers', [ __CLASS__, 'amp_content_sanitizers' ] );
+		if ( self::should_use_amp_plus( 'googleoptimize' ) ) {
+			add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_amp_plus_googleoptimize_scripts' ] );
+		}
+	}
+
+	/**
+	 * Enqueue Google Optimize script if needed
+	 *
+	 * @return void
+	 */
+	public static function enqueue_amp_plus_googleoptimize_scripts() {
+		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$go      = new Optimize( $context );
+		if ( $go->is_connected() ) {
+			$info   = $go->prepare_info_for_js();
+			$id     = $info['settings']['optimizeID'];
+			$script = sprintf( 'https://www.googleoptimize.com/optimize.js?id=%s', $id );
+			wp_enqueue_script( 'googleoptimize', $script, false, '1', true );
+		}
 	}
 
 	/**
@@ -55,6 +78,10 @@ class AMP_Enhancements {
 		if ( self::should_use_amp_plus( 'gam' ) ) {
 			require_once NEWSPACK_ABSPATH . 'includes/amp-sanitizers/class-amp-sanitizer-gam.php';
 			$sanitizers['AMP_Sanitizer_GAM'] = [];
+		}
+		if ( self::should_use_amp_plus( 'googleoptimize' ) ) {
+			require_once NEWSPACK_ABSPATH . 'includes/amp-sanitizers/class-amp-sanitizer-google-optimize.php';
+			$sanitizers['AMP_Sanitizer_Google_Optimize'] = [];
 		}
 		return $sanitizers;
 	}

--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -45,6 +45,9 @@ class AMP_Enhancements {
 	 * @return void
 	 */
 	public static function enqueue_amp_plus_googleoptimize_scripts() {
+		if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
+			return;
+		}
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$go      = new Optimize( $context );
 		if ( $go->is_connected() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

AMP Plus implementation of Google Optimize. In AMP Plus mode, if an Optimize container is defined in Site Kit the Google Optimize script will be added to the page and the AMP sanitizer will ignore it.

Closes https://github.com/Automattic/newspack-plugin/issues/701

### How to test the changes in this Pull Request:

1. Spin up Jurassic Ninja instance, install Newspack plugin built from this branch, go through Newspack setup wizard including Jetpack, Site Kit steps, and starter content steps.
2. In Site Kit set up Analytics.
3. If you don't have one already, set up a Google Optimize account here: https://optimize.google.com/. In Google Optimize, create a new container and copy the container ID. 
4. In Site Kit set up Optimize, paste in the container ID.
5. In Optimize, create an Experience. Use the homepage of the JN instance, and select A/B Test.
6. Add a Variant. Edit the Variant and change something on the homepage (for example, change the text of the site title or tagline).
7. Link to Analytics.
8. Add an Objective. Use "Pageviews."
9. The installation check will fail if the site is in AMP standard more or if you are logged in as an admin. First switch AMP to Transitional mode, then log out. 
9. Do the Installation Check in Optimize.
10. Start the experiment. 
11. View the homepage in various browsers (with AMP still in Transitional mode). You should see the variant 50% of the time.
12. Log back in to the WordPress site and switch AMP back to Standard mode. 
13. Edit the site's `wp-config.php` file, and add: 
```
define( 'NEWSPACK_AMP_PLUS_CONFIG', [ 'gam', 'googleoptimize' ] );
```
14. View the homepage with `?ampplus` appended to the URL. 
15. Observe the Optimize test is working.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->