### PR TITLE
Campaigns Wizard: display segment reach

### DIFF
--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -1,9 +1,10 @@
 /**
  * WordPress dependencies.
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useMemo, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { find } from 'lodash';
+import apiFetch from '@wordpress/api-fetch';
+import { find, debounce } from 'lodash';
 
 /**
  * Internal dependencies.
@@ -39,6 +40,8 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 	const updateSegmentConfig = key => value =>
 		setSegmentConfig( { ...segmentConfig, [ key ]: value } );
 	const [ name, setName ] = useState( '' );
+	const [ isFetchingReach, setIsFetchingReach ] = useState( { total: 0, in_segment: 0 } );
+	const [ reach, setReach ] = useState( { total: 0, in_segment: 0 } );
 	const history = useHistory();
 
 	const isSegmentValid = name.length > 0;
@@ -57,6 +60,24 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 			} );
 		}
 	}, [ isNew ] );
+
+	const updateReact = useMemo( () => {
+		return debounce( config => {
+			setIsFetchingReach( true );
+			apiFetch( {
+				path: `/newspack/v1/wizard/newspack-popups-wizard/segmentation-reach?config=${ JSON.stringify(
+					config
+				) }`,
+			} ).then( res => {
+				setReach( res );
+				setIsFetchingReach( false );
+			} );
+		}, 500 );
+	}, [] );
+
+	useEffect( () => {
+		updateReact( segmentConfig );
+	}, [ JSON.stringify( segmentConfig ) ] );
 
 	const saveSegment = () => {
 		const path = isNew
@@ -136,6 +157,18 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 					/>
 				</SegmentSettingSection>
 			</div>
+
+			{ reach.total > 0 && (
+				<div style={ { opacity: isFetchingReach ? 0.5 : 1 } }>
+					{ __( 'This segment would reach', 'newspack' ) }{' '}
+					<b>
+						{ Math.round( ( reach.in_segment * 100 ) / reach.total ) }
+						{ '%' }
+					</b>{' '}
+					{ __( 'of recorded visitors. ', 'newspack' ) }
+				</div>
+			) }
+
 			<div className="newspack-buttons-card">
 				<div>
 					<NavLink to="/segmentation">

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -24,14 +24,21 @@ const SegmentSettingSection = ( { title, description, children } ) => (
 	</div>
 );
 
+const DEFAULT_CONFIG = {
+	min_posts: 0,
+	max_posts: 0,
+	is_subscribed: false,
+	is_donor: false,
+	is_not_subscribed: false,
+	is_not_donor: false,
+	favorite_categories: [],
+};
+
 const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
+	const [ segmentConfig, setSegmentConfig ] = useState( DEFAULT_CONFIG );
+	const updateSegmentConfig = key => value =>
+		setSegmentConfig( { ...segmentConfig, [ key ]: value } );
 	const [ name, setName ] = useState( '' );
-	const [ min_posts, setMinPosts ] = useState( 0 );
-	const [ max_posts, setMaxPosts ] = useState( 0 );
-	const [ is_subscribed, setIsSubscribed ] = useState( false );
-	const [ is_donor, setIsDonor ] = useState( false );
-	const [ is_not_subscribed, setIsNotSubscribed ] = useState( false );
-	const [ is_not_donor, setIsNotDonor ] = useState( false );
 	const history = useHistory();
 
 	const isSegmentValid = name.length > 0;
@@ -44,13 +51,8 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 			} ).then( segments => {
 				const foundSegment = find( segments, ( { id } ) => id === segmentId );
 				if ( foundSegment ) {
+					setSegmentConfig( { ...DEFAULT_CONFIG, ...foundSegment.configuration } );
 					setName( foundSegment.name );
-					setMinPosts( foundSegment.configuration.min_posts );
-					setMaxPosts( foundSegment.configuration.max_posts );
-					setIsSubscribed( foundSegment.configuration.is_subscribed );
-					setIsDonor( foundSegment.configuration.is_donor );
-					setIsNotSubscribed( foundSegment.configuration.is_not_subscribed );
-					setIsNotDonor( foundSegment.configuration.is_not_donor );
 				}
 			} );
 		}
@@ -65,14 +67,7 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 			method: 'POST',
 			data: {
 				name,
-				configuration: {
-					min_posts,
-					max_posts,
-					is_subscribed,
-					is_donor,
-					is_not_subscribed,
-					is_not_donor,
-				},
+				configuration: segmentConfig,
 			},
 		} ).then( () => history.push( '/segmentation' ) );
 	};
@@ -88,40 +83,40 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 				<SegmentSettingSection title={ __( 'Number of articles read', 'newspack' ) }>
 					<div>
 						<CheckboxControl
-							checked={ min_posts > 0 }
-							onChange={ value => setMinPosts( value ? 1 : 0 ) }
+							checked={ segmentConfig.min_posts > 0 }
+							onChange={ value => updateSegmentConfig( 'min_posts' )( value ? 1 : 0 ) }
 							label={ __( 'Min.', 'newspack' ) }
 						/>
 						<TextControl
 							placeholder={ __( 'Min. posts', 'newspack' ) }
 							type="number"
-							value={ min_posts }
-							onChange={ setMinPosts }
+							value={ segmentConfig.min_posts }
+							onChange={ updateSegmentConfig( 'min_posts' ) }
 						/>
 					</div>
 					<div>
 						<CheckboxControl
-							checked={ max_posts > 0 }
-							onChange={ value => setMaxPosts( value ? 1 : 0 ) }
+							checked={ segmentConfig.max_posts > 0 }
+							onChange={ value => updateSegmentConfig( 'max_posts' )( value ? 1 : 0 ) }
 							label={ __( 'Max.', 'newspack' ) }
 						/>
 						<TextControl
 							placeholder={ __( 'Max. posts', 'newspack' ) }
 							type="number"
-							value={ max_posts }
-							onChange={ setMaxPosts }
+							value={ segmentConfig.max_posts }
+							onChange={ updateSegmentConfig( 'max_posts' ) }
 						/>
 					</div>
 				</SegmentSettingSection>
 				<SegmentSettingSection title={ __( 'Newsletter', 'newspack' ) }>
 					<CheckboxControl
-						checked={ is_subscribed }
-						onChange={ setIsSubscribed }
+						checked={ segmentConfig.is_subscribed }
+						onChange={ updateSegmentConfig( 'is_subscribed' ) }
 						label={ __( 'Is subscribed to newsletter', 'newspack' ) }
 					/>
 					<CheckboxControl
-						checked={ is_not_subscribed }
-						onChange={ setIsNotSubscribed }
+						checked={ segmentConfig.is_not_subscribed }
+						onChange={ updateSegmentConfig( 'is_not_subscribed' ) }
 						label={ __( 'Is not subscribed to newsletter', 'newspack' ) }
 					/>
 				</SegmentSettingSection>
@@ -130,13 +125,13 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 					description={ __( '(if using WooCommerce checkout)', 'newspack' ) }
 				>
 					<CheckboxControl
-						checked={ is_donor }
-						onChange={ setIsDonor }
+						checked={ segmentConfig.is_donor }
+						onChange={ updateSegmentConfig( 'is_donor' ) }
 						label={ __( 'Has donated', 'newspack' ) }
 					/>
 					<CheckboxControl
-						checked={ is_not_donor }
-						onChange={ setIsNotDonor }
+						checked={ segmentConfig.is_not_donor }
+						onChange={ updateSegmentConfig( 'is_not_donor' ) }
 						label={ __( "Hasn't donated", 'newspack' ) }
 					/>
 				</SegmentSettingSection>

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -135,6 +135,17 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Get segment's potential reacj.
+	 *
+	 * @param object $config Segment configuration.
+	 */
+	public function get_segment_reach( $config ) {
+		return $this->is_configured() ?
+			\Newspack_Popups_Segmentation::get_segment_reach( $config ) :
+			$this->unconfigured_error();
+	}
+
+	/**
 	 * Configure Newspack Popups for Newspack use.
 	 *
 	 * @return bool || WP_Error Return true if successful, or WP_Error if not.

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -215,6 +215,21 @@ class Popups_Wizard extends Wizard {
 			]
 		);
 
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/segmentation-reach',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_segment_reach' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'config'         => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+
 		// Register newspack/v1/popups-analytics/report endpoint.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
@@ -538,6 +553,18 @@ class Popups_Wizard extends Wizard {
 	public function api_delete_segment( $request ) {
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
 		$response                              = $newspack_popups_configuration_manager->delete_segment( $request['id'] );
+		return $response;
+	}
+
+	/**
+	 * Get a specific segment's potential reach.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function api_get_segment_reach( $request ) {
+		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
+		$response                              = $newspack_popups_configuration_manager->get_segment_reach( json_decode( $request['config'] ) );
 		return $response;
 	}
 }

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -223,7 +223,7 @@ class Popups_Wizard extends Wizard {
 				'callback'            => [ $this, 'api_get_segment_reach' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'config'         => [
+					'config' => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Display segment reach – what percentage of recorded audience the segment covers.

Do not merge before https://github.com/Automattic/newspack-popups/pull/324 is merged.

### How to test the changes in this Pull Request:

1. Switch Campaign plugin to `add/segment-size` branch (https://github.com/Automattic/newspack-popups/pull/324)
1. Visit the Campaigns Wizard's Segmentation tab and edit or create a segment
2. Observe the segment reach is displayed above the buttons section
3. Make some changes to the segment, observe the reach is updated dynamically, and that the update does not block the UI

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->