### PR TITLE
Update Wizards icons to use G2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ project.properties
 .sublimelinterrc
 
 # Grunt
+.cache
 /node_modules/
 none
 

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -9,11 +9,7 @@ import '../../shared/js/public-path';
  */
 import { Component, render, Fragment, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * External dependencies.
- */
-import HeaderIcon from '@material-ui/icons/FeaturedVideo';
+import { Icon, stretchWide } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -331,7 +327,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ () => (
 								<Services
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ stretchWide } /> }
 									headerText={ __( 'Advertising', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									services={ services }
@@ -344,7 +340,7 @@ class AdvertisingWizard extends Component {
 							path="/ad-placements"
 							render={ () => (
 								<Placements
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ stretchWide } /> }
 									headerText={ __( 'Advertising', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									placements={ placements }
@@ -365,7 +361,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ () => (
 								<AdUnits
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ stretchWide } /> }
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									adUnits={ adUnits }
@@ -384,7 +380,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ routeProps => (
 								<HeaderCode
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ stretchWide } /> }
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
 									subHeaderText={ __( 'Monetize your content through advertising.' ) }
 									adUnits={ adUnits }
@@ -408,7 +404,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => {
 								return (
 									<AdUnit
-										headerIcon={ <HeaderIcon /> }
+										headerIcon={ <Icon icon={ stretchWide } /> }
 										headerText={ __( 'Add an ad unit' ) }
 										subHeaderText={ __(
 											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.'
@@ -437,7 +433,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => {
 								return (
 									<AdUnit
-										headerIcon={ <HeaderIcon /> }
+										headerIcon={ <Icon icon={ stretchWide } /> }
 										headerText={ __( 'Edit ad unit' ) }
 										subHeaderText={ __(
 											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.'

--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -9,11 +9,7 @@ import '../../shared/js/public-path';
  */
 import { Component, render, Fragment, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Material UI dependencies.
- */
-import HeaderIcon from '@material-ui/icons/TrendingUp';
+import { Icon, chartLine } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -48,7 +44,7 @@ class AnalyticsWizard extends Component {
 	render() {
 		const { pluginRequirements, wizardApiFetch, isLoading } = this.props;
 		const sharedProps = {
-			headerIcon: <HeaderIcon />,
+			headerIcon: <Icon icon={ chartLine } />,
 			headerText: __( 'Analytics', 'newspack' ),
 			subHeaderText: __( 'Track traffic and activity.', 'newspack' ),
 			tabbedNavigation: TABS,

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -11,11 +11,7 @@ import '../../shared/js/public-path';
  */
 import { Component, Fragment, render } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Material UI dependencies.
- */
-import HeaderIcon from '@material-ui/icons/Dashboard';
+import { Icon, tool } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -106,7 +102,7 @@ class ComponentsDemo extends Component {
 					</a>
 				</div>
 				<FormattedHeader
-					headerIcon={ <HeaderIcon /> }
+					headerIcon={ <Icon icon={ tool } /> }
 					headerText={ __( 'Newspack Components' ) }
 					subHeaderText={ __( 'Demo of all the Newspack components' ) }
 				/>

--- a/assets/wizards/dashboard/views/dashboardCard.js
+++ b/assets/wizards/dashboard/views/dashboardCard.js
@@ -20,7 +20,7 @@ import {
 	reusableBlock,
 	rss,
 	search,
-	tag,
+	stretchWide,
 	typography,
 } from '@wordpress/icons';
 
@@ -44,13 +44,13 @@ class DashboardCard extends Component {
 		const iconMap = {
 			'site-design': <Icon icon={ typography } />,
 			'reader-revenue': <Icon icon={ payment } />,
-			advertising: <Icon icon={ megaphone } />,
+			advertising: <Icon icon={ stretchWide } />,
 			syndication: <Icon icon={ rss } />,
 			analytics: <Icon icon={ chartLine } />,
 			seo: <Icon icon={ search } />,
 			'health-check': <Icon icon={ lifesaver } />,
 			engagement: <Icon icon={ postComments } />,
-			popups: <Icon icon={ tag } />,
+			popups: <Icon icon={ megaphone } />,
 			support: <Icon icon={ help } />,
 			updates: <Icon icon={ reusableBlock } />,
 		};

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -9,11 +9,7 @@ import '../../shared/js/public-path';
  */
 import { Component, render, Fragment, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Material UI dependencies.
- */
-import HeaderIcon from '@material-ui/icons/Forum';
+import { Icon, postComments } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -158,7 +154,7 @@ class EngagementWizard extends Component {
 							render={ () => (
 								<Newsletters
 									noBackground
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ postComments } /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -176,7 +172,7 @@ class EngagementWizard extends Component {
 							render={ () => {
 								return (
 									<Social
-										headerIcon={ <HeaderIcon /> }
+										headerIcon={ <Icon icon={ postComments } /> }
 										headerText={ __( 'Engagement', 'newspack' ) }
 										subHeaderText={ subheader }
 										tabbedNavigation={ tabbed_navigation }
@@ -190,7 +186,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ () => (
 								<CommentingDisqus
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ postComments } /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -205,7 +201,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ () => (
 								<CommentingNative
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ postComments } /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -220,7 +216,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ () => (
 								<CommentingCoral
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ postComments } /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }
@@ -235,7 +231,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ () => (
 								<RelatedContent
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ postComments } /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									relatedPostsEnabled={ relatedPostsEnabled }
 									relatedPostsError={ relatedPostsError }
@@ -256,7 +252,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ () => (
 								<UGC
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ postComments } /> }
 									headerText={ __( 'Engagement', 'newspack' ) }
 									subHeaderText={ subheader }
 									tabbedNavigation={ tabbed_navigation }

--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -9,11 +9,7 @@ import '../../shared/js/public-path';
  */
 import { Component, render, Fragment, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Material UI dependencies.
- */
-import HeaderIcon from '@material-ui/icons/Healing';
+import { Icon, lifesaver } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -98,7 +94,7 @@ class HealthCheckWizard extends Component {
 							exact
 							render={ () => (
 								<Plugins
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ lifesaver } /> }
 									headerText={ __( 'Health Check', 'newspack' ) }
 									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
 									deactivateAllPlugins={ this.deactivateAllPlugins }
@@ -119,7 +115,7 @@ class HealthCheckWizard extends Component {
 							render={ () => (
 								<Configuration
 									hasData={ hasData }
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ lifesaver } /> }
 									headerText={ __( 'Health Check', 'newspack' ) }
 									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
 									tabbedNavigation={ tabs }

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -9,11 +9,11 @@ import '../../shared/js/public-path';
  */
 import { Component, render, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Icon, megaphone } from '@wordpress/icons';
 
 /**
  * External dependencies.
  */
-import HeaderIcon from '@material-ui/icons/NewReleases';
 import { stringify } from 'qs';
 
 /**
@@ -227,7 +227,7 @@ class PopupsWizard extends Component {
 				url={ previewUrl }
 				renderButton={ ( { showPreview } ) => {
 					const sharedProps = {
-						headerIcon: <HeaderIcon />,
+						headerIcon: <Icon icon={ megaphone } />,
 						headerText,
 						subHeaderText,
 						tabbedNavigation,

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -10,13 +10,7 @@ import '../../shared/js/public-path';
 import { Component, render, Fragment, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-
-/**
- * Material UI dependencies.
- */
-import HeaderIcon from '@material-ui/icons/AccountBalanceWallet';
-import LoyaltyIcon from '@material-ui/icons/Loyalty';
-import GroupAddIcon from '@material-ui/icons/GroupAdd';
+import { Icon, payment } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -224,7 +218,7 @@ class ReaderRevenueWizard extends Component {
 							exact
 							render={ () => (
 								<RevenueMain
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ payment } /> }
 									headerText={ __( 'Reader revenue' ) }
 									subHeaderText={ __( 'Generate revenue from your customers.' ) }
 									tabbedNavigation={ isConfigured && tabbedNavigation }
@@ -240,7 +234,7 @@ class ReaderRevenueWizard extends Component {
 									data={ locationData }
 									countryStateFields={ countryStateFields }
 									currencyFields={ currencyFields }
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ payment } /> }
 									headerText={ __( 'Reader revenue' ) }
 									subHeaderText={ __( "Configure your publication's address." ) }
 									buttonText={ isConfigured ? __( 'Save Settings' ) : __( 'Continue Setup' ) }
@@ -261,7 +255,7 @@ class ReaderRevenueWizard extends Component {
 							render={ routeProps => (
 								<StripeSetup
 									data={ stripeData }
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ payment } /> }
 									headerText={ __( 'Reader revenue' ) }
 									subHeaderText={ __( 'Configure your payment gateway to process transactions.' ) }
 									buttonText={ isConfigured ? __( 'Save Settings' ) : __( 'Continue Setup' ) }
@@ -282,7 +276,7 @@ class ReaderRevenueWizard extends Component {
 							render={ () => (
 								<Donation
 									data={ donationData }
-									headerIcon={ <LoyaltyIcon /> }
+									headerIcon={ <Icon icon={ payment } /> }
 									headerText={ __( 'Set up donations' ) }
 									subHeaderText={ __(
 										'Configure your landing page and your suggested donation presets.'
@@ -304,7 +298,7 @@ class ReaderRevenueWizard extends Component {
 								<Salesforce
 									routeProps={ routeProps }
 									data={ salesforceData }
-									headerIcon={ <GroupAddIcon /> }
+									headerIcon={ <Icon icon={ payment } /> }
 									headerText={ __( 'Configure Salesforce', 'newspack' ) }
 									isConnected={ salesforceIsConnected }
 									subHeaderText={ __(

--- a/assets/wizards/seo/index.js
+++ b/assets/wizards/seo/index.js
@@ -9,11 +9,7 @@ import '../../shared/js/public-path';
  */
 import { Component, render, Fragment, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Material UI dependencies.
- */
-import HeaderIcon from '@material-ui/icons/Search';
+import { Icon, search } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -87,7 +83,7 @@ class SEOWizard extends Component {
 	 */
 	render() {
 		const { pluginRequirements } = this.props;
-		const headerIcon = <HeaderIcon />;
+		const headerIcon = <Icon icon={ search } />;
 		const headerText = __( 'SEO', 'newspack' );
 		const subHeaderText = __( 'Search engine and social optimization', 'newspack' );
 		const tabbedNavigation = [

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -10,15 +10,7 @@ import '../../shared/js/public-path';
 import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment, render, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Material UI dependencies.
- */
-import BusinessCenterIcon from '@material-ui/icons/BusinessCenter';
-import MenuBookIcon from '@material-ui/icons/MenuBook';
-import SettingsIcon from '@material-ui/icons/Settings';
-import StyleIcon from '@material-ui/icons/Style';
-import SubjectIcon from '@material-ui/icons/Subject';
+import { Icon, cog, home, mediaAndText, people, plugins, typography } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -309,7 +301,7 @@ class SetupWizard extends Component {
 						path="/about"
 						render={ () => (
 							<About
-								headerIcon={ <MenuBookIcon /> }
+								headerIcon={ <Icon icon={ people } /> }
 								headerText={ __( 'About your publication' ) }
 								subHeaderText={ __(
 									'Share a few details so we can start setting up your profile'
@@ -332,7 +324,7 @@ class SetupWizard extends Component {
 						path="/newsroom"
 						render={ () => (
 							<Newsroom
-								headerIcon={ <BusinessCenterIcon /> }
+								headerIcon={ <Icon icon={ home } /> }
 								headerText={ __( 'Tell us about your Newsroom' ) }
 								subHeaderText={ __(
 									'The description helps set the stage for the step content below'
@@ -358,7 +350,7 @@ class SetupWizard extends Component {
 							const pluginConfigured = pluginInfo[ plugin ] && pluginInfo[ plugin ].Configured;
 							return (
 								<ConfigurePlugins
-									headerIcon={ <SettingsIcon /> }
+									headerIcon={ <Icon icon={ cog } /> }
 									headerText={ __( 'Configure Core Plugins' ) }
 									subHeaderText={ __(
 										'Please configure the following core plugins to start using Newspack.'
@@ -381,7 +373,7 @@ class SetupWizard extends Component {
 							const pluginConfigured = pluginInfo[ plugin ] && pluginInfo[ plugin ].Configured;
 							return (
 								<ConfigurePlugins
-									headerIcon={ <SettingsIcon /> }
+									headerIcon={ <Icon icon={ cog } /> }
 									headerText={ __( 'Configure Core Plugins' ) }
 									subHeaderText={ __(
 										'Please configure the following core plugin to start using Newspack.'
@@ -405,8 +397,8 @@ class SetupWizard extends Component {
 							const { theme } = this.state;
 							return (
 								<ThemeSelection
-									headerIcon={ <StyleIcon /> }
-									headerText={ __( 'Theme' ) }
+									headerIcon={ <Icon icon={ typography } /> }
+									headerText={ __( 'Site Design' ) }
 									subHeaderText={ __( 'Choose a Newspack theme' ) }
 									buttonText={ __( 'Continue' ) }
 									buttonAction="#/starter-content"
@@ -422,7 +414,7 @@ class SetupWizard extends Component {
 						render={ () => {
 							return (
 								<StarterContent
-									headerIcon={ <SubjectIcon /> }
+									headerIcon={ <Icon icon={ mediaAndText } /> }
 									headerText={ __( 'Starter Content' ) }
 									subHeaderText={ __( 'Pre-configure the site for testing and experimentation' ) }
 									buttonText={ __( 'Install Starter Content' ) }
@@ -443,7 +435,7 @@ class SetupWizard extends Component {
 							<InstallationProgress
 								autoInstall={ shouldAutoInstallPlugins( routeProps ) }
 								hidden={ '/installation-progress' !== routeProps.location.pathname }
-								headerIcon={ <SettingsIcon /> }
+								headerIcon={ <Icon icon={ plugins } /> }
 								headerText={ __( 'Installation...' ) }
 								subHeaderText={ __(
 									'Please configure the following core plugin to start using Newspack.'

--- a/assets/wizards/site-design/index.js
+++ b/assets/wizards/site-design/index.js
@@ -5,12 +5,7 @@ import '../../shared/js/public-path';
  */
 import { Component, render, Fragment, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Material UI dependencies.
- */
-import SettingsIcon from '@material-ui/icons/Settings';
-import StyleIcon from '@material-ui/icons/Style';
+import { Icon, typography } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -118,8 +113,8 @@ class SiteDesignWizard extends Component {
 								const { theme } = this.state;
 								return (
 									<ThemeSelection
-										headerIcon={ <StyleIcon /> }
-										headerText={ __( 'Theme', 'newspack' ) }
+										headerIcon={ <Icon icon={ typography } /> }
+										headerText={ __( 'Site Design', 'newspack' ) }
 										subHeaderText={ __( 'Choose a Newspack theme', 'newspack' ) }
 										tabbedNavigation={ tabbedNavigation }
 										buttonText={ __( 'Configure', 'newspack' ) }
@@ -138,8 +133,8 @@ class SiteDesignWizard extends Component {
 								const { themeMods } = this.state;
 								return (
 									<ThemeMods
-										headerIcon={ <SettingsIcon /> }
-										headerText={ __( 'Settings', 'newspack' ) }
+										headerIcon={ <Icon icon={ typography } /> }
+										headerText={ __( 'Site Design', 'newspack' ) }
 										subHeaderText={ __( 'Configure your Newspack theme', 'newspack' ) }
 										tabbedNavigation={ tabbedNavigation }
 										themeMods={ themeMods }

--- a/assets/wizards/support/index.js
+++ b/assets/wizards/support/index.js
@@ -12,11 +12,7 @@ import { parse } from 'qs';
  */
 import { render, createElement, Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Material UI dependencies.
- */
-import HeaderIcon from '@material-ui/icons/ContactSupport';
+import { Icon, help } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -74,7 +70,7 @@ class SupportWizard extends Component {
 		const isPreLaunch = newspack_support_data.IS_PRE_LAUNCH;
 
 		const props = {
-			headerIcon: <HeaderIcon />,
+			headerIcon: <Icon icon={ help } />,
 			headerText: __( 'Support', 'newspack' ),
 			subHeaderText: __( 'Contact customer support', 'newspack' ),
 			tabbedNavigation: [

--- a/assets/wizards/syndication/index.js
+++ b/assets/wizards/syndication/index.js
@@ -9,11 +9,7 @@ import '../../shared/js/public-path';
  */
 import { Component, render, Fragment, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Material UI dependencies.
- */
-import HeaderIcon from '@material-ui/icons/SyncAlt';
+import { Icon, rss } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -40,7 +36,7 @@ class SyndicationWizard extends Component {
 							exact
 							render={ () => (
 								<Intro
-									headerIcon={ <HeaderIcon /> }
+									headerIcon={ <Icon icon={ rss } /> }
 									headerText={ __( 'Syndication', 'newspack' ) }
 									subHeaderText={ 'Distribute your content across multiple websites' }
 								/>

--- a/assets/wizards/updates/index.js
+++ b/assets/wizards/updates/index.js
@@ -9,11 +9,7 @@ import '../../shared/js/public-path';
  */
 import { Component, render, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Material UI dependencies.
- */
-import HeaderIcon from '@material-ui/icons/Update';
+import { Icon, reusableBlock } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -39,9 +35,9 @@ class UpdatesWizard extends Component {
 						exact
 						render={ () => (
 							<DevInfo
-								headerIcon={ <HeaderIcon /> }
-								headerText={ __( "What's new?", 'newspack' ) }
-								subHeaderText={ __( 'Updates to the Newspack plugins and theme.' ) }
+								headerIcon={ <Icon icon={ reusableBlock } /> }
+								headerText={ __( 'Updates', 'newspack' ) }
+								subHeaderText={ __( 'Updates to the Newspack plugins and theme.', 'newspack' ) }
 							/>
 						) }
 					/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is a follow-up of #712. Here I update the different wizards icons to G2

### How to test the changes in this Pull Request:

1. Check the different wizards
2. Switch to this branch
3. Check the wizards once again, you should see the updated icons (and match the Dashboard)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->