### PR TITLE
Update checkbox style to match Gutenberg

### DIFF
--- a/assets/components/src/checkbox-control/style.scss
+++ b/assets/components/src/checkbox-control/style.scss
@@ -20,54 +20,38 @@
 		margin: 0;
 	}
 
-	input[type='checkbox'] {
-		background: white;
-		border: 2px solid $dark-gray-300;
-		border-radius: 2px;
-		box-shadow: none;
-		height: 18px;
-		margin: 3px 0;
-		transition: box-shadow 125ms ease-in-out;
-		width: 18px;
+	.components-checkbox-control__input-container {
+		display: block;
+		margin: 0;
+		margin-right: 8px;
 
-		&:hover {
-			border-color: $dark-gray-500;
-		}
-
-		&:focus {
-			border-color: $dark-gray-300;
-			box-shadow: 0 0 0 2px white, 0 0 0 4px $primary-500;
-			outline: 0;
-		}
-
-		&:checked,
-		&.checked {
-			background-color: $primary-500;
-			background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M7 14L2 9l1.41-1.41L7 11.17l7.59-7.59L16 5z' fill='white'/%3E%3C/svg%3E" );
-			background-position: 50%;
-			background-repeat: no-repeat;
-			border-color: transparent;
+		@media screen and ( min-width: 600px ) {
+			margin-bottom: 2px;
+			margin-top: 2px;
 		}
 	}
 
-	.components-checkbox-control__input-container {
-		display: block;
-		height: 24px;
+	.components-checkbox-control__input[type='checkbox'] {
 		margin: 0;
-		margin-right: 8px;
-		width: 18px;
 
-		svg {
-			display: none;
+		&:checked {
+			background-color: $primary-500;
+			border-color: $primary-500;
+		}
+
+		&:focus {
+			border-color: $primary-500;
+			box-shadow: 0 0 0 2px white, 0 0 0 3.5px $primary-500;
 		}
 	}
 
 	.components-base-control__help {
 		color: inherit;
 		font-size: inherit;
+		font-style: italic;
 		line-height: inherit;
 		margin: 0;
-		margin-left: 26px;
+		margin-left: 28px;
 	}
 
 	// Multiple Checkbox Controls


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes the style of the checkbox from Material to Gutenberg

![1 before](https://user-images.githubusercontent.com/177929/101064252-afbc1f80-358b-11eb-9a1d-4368b0578266.png)
![2 after](https://user-images.githubusercontent.com/177929/101064254-b054b600-358b-11eb-82c0-22931540c87b.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Check the different wizards if the checkboxes are being displayed properly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->