### PR TITLE
Update radio style to match Gutenberg

### DIFF
--- a/assets/components/src/radio-control/style.scss
+++ b/assets/components/src/radio-control/style.scss
@@ -42,27 +42,34 @@
 	// Radio
 
 	input[type='radio'] {
-		border: 2px solid $light-gray-900;
-		box-shadow: none;
-		height: 20px;
-		margin: 2px;
-		width: 20px;
-		transition: box-shadow 125ms ease-in-out;
+		height: 24px;
+		margin-right: 8px;
+		width: 24px;
+
+		@media screen and ( min-width: 782px ) {
+			height: 20px;
+			width: 20px;
+		}
+
+		&:checked {
+			background-color: $primary-500;
+			border-color: $primary-500;
+
+			&::before {
+				height: 6px;
+				margin: 5px 0 0 5px;
+				width: 6px;
+
+				@media screen and ( min-width: 782px ) {
+					border: 0;
+					margin: 6px 0 0 6px;
+				}
+			}
+		}
 
 		&:focus {
-			box-shadow: 0 0 0 2px white, 0 0 0 4px $primary-500;
-			outline: 0;
-		}
-
-		&:checked::before {
-			background: $primary-500;
-			height: 10px;
-			margin: 3px;
-			width: 10px;
-		}
-
-		+ label {
-			padding-left: 4px;
+			border-color: $primary-500;
+			box-shadow: 0 0 0 2px white, 0 0 0 3.5px $primary-500;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes the style of the radio from Material to Gutenberg

![1 before](https://user-images.githubusercontent.com/177929/101068803-15f77100-3591-11eb-8f59-e11e242ccad1.png)
![2 before](https://user-images.githubusercontent.com/177929/101068808-16900780-3591-11eb-978e-4203a58b659c.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Check the different wizards if the checkboxes are being displayed properly (the only one I can think of is Site Design...)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->