### PR TITLE
Analytics: report single category if primary category is set

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -73,7 +73,15 @@ class Analytics {
 			$post = get_post( $post_id );
 			if ( $post ) {
 				if ( 'category' === $dimension_role ) {
-					$categories = get_the_category( $post_id );
+					$categories       = get_the_category( $post_id );
+					$primary_category = get_post_meta( $post_id, '_yoast_wpseo_primary_category', true );
+					if ( $primary_category ) {
+						foreach ( $categories as $category ) {
+							if ( $category->term_id === (int) $primary_category ) {
+								$categories = [ $category ];
+							}
+						}
+					}
 					if ( ! empty( $categories ) ) {
 						$categories_slugs                          = implode(
 							',',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #716.

### How to test the changes in this Pull Request:

1. Create a post, assign multiple categories to it
1. Disable Yoast plugin
1. Ensure there is a custom dimension assigned to report post category in Analytics Wizard
2. View post in an incognito session (not logged in), observe a `pageview` event is sent to GA*, observe all categories are sent as a comma-separated list 
3. Enable Yoast plugin, edit the post and choose a primary category 
4. Again view the post, observe the primary category is the only one reported 

\* in network tab in devtools, filter by "pageview"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
