### PR TITLE
Update toggle group and toggle control vertical alignment

### DIFF
--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -182,6 +182,7 @@
 
 	.components-toggle-control {
 		margin-bottom: 24px;
+		margin-top: 0;
 
 		@media screen and ( min-width: 744px ) {
 			margin-bottom: 0;

--- a/assets/components/src/checkbox-control/style.scss
+++ b/assets/components/src/checkbox-control/style.scss
@@ -9,7 +9,6 @@
 	color: $dark-gray-300;
 	display: flex;
 	font-size: 14px;
-	justify-content: space-between;
 	line-height: 24px;
 	margin: 32px 0;
 
@@ -57,7 +56,7 @@
 	// Multiple Checkbox Controls
 
 	& + & {
-		margin-top: -16px;
+		margin-top: -24px;
 	}
 
 	// Reset

--- a/assets/components/src/text-control/style.scss
+++ b/assets/components/src/text-control/style.scss
@@ -85,7 +85,7 @@
 
 	& + & {
 		margin-bottom: 32px;
-		margin-top: -16px;
+		margin-top: -24px;
 	}
 
 	// Multiple Controls
@@ -93,7 +93,7 @@
 	+ .newspack-select-control,
 	+ .newspack-textarea-control {
 		margin-bottom: 32px;
-		margin-top: -16px;
+		margin-top: -24px;
 	}
 
 	// Reset

--- a/assets/components/src/textarea-control/style.scss
+++ b/assets/components/src/textarea-control/style.scss
@@ -55,7 +55,7 @@
 
 	& + & {
 		margin-bottom: 32px;
-		margin-top: -16px;
+		margin-top: -24px;
 	}
 
 	// Multiple Controls
@@ -63,7 +63,7 @@
 	+ .newspack-select-control,
 	+ .newspack-text-control {
 		margin-bottom: 32px;
-		margin-top: -16px;
+		margin-top: -24px;
 	}
 
 	// Reset

--- a/assets/components/src/toggle-control/style.scss
+++ b/assets/components/src/toggle-control/style.scss
@@ -6,9 +6,11 @@
 @import '~@wordpress/base-styles/colors';
 
 .newspack-toggle-control {
+	margin: 32px 0;
+
 	.components-base-control__field {
+		align-items: flex-start;
 		margin: 0;
-		height: 24px;
 
 		.components-toggle-control__label {
 			color: $dark-gray-300;
@@ -18,8 +20,7 @@
 		}
 
 		.components-form-toggle {
-			border-top: 3px solid transparent;
-			margin-right: 8px;
+			margin: 3px 8px 3px 0;
 
 			&.is-checked {
 				.components-form-toggle__track {
@@ -49,6 +50,13 @@
 		+ .components-form-toggle__track {
 			box-shadow: 0 0 0 2px white, 0 0 0 4px $primary-500;
 		}
+	}
+
+	// Multiple Textarea Controls
+
+	& + & {
+		margin-bottom: 32px;
+		margin-top: -24px;
 	}
 
 	// Reset

--- a/assets/components/src/toggle-control/style.scss
+++ b/assets/components/src/toggle-control/style.scss
@@ -52,7 +52,7 @@
 		}
 	}
 
-	// Multiple Textarea Controls
+	// Multiple Toggle Controls
 
 	& + & {
 		margin-bottom: 32px;

--- a/assets/components/src/toggle-group/style.scss
+++ b/assets/components/src/toggle-group/style.scss
@@ -7,6 +7,11 @@
 	margin: 32px 0;
 
 	& &__description p {
+		margin-bottom: 0;
+		margin-top: 0;
+	}
+
+	.newspack-toggle-control {
 		margin: 0;
 	}
 
@@ -14,6 +19,6 @@
 
 	& + & {
 		margin-bottom: 32px;
-		margin-top: -16px;
+		margin-top: -24px;
 	}
 }

--- a/assets/wizards/site-design/views/theme-mods/style.scss
+++ b/assets/wizards/site-design/views/theme-mods/style.scss
@@ -2,14 +2,6 @@
  * Theme Selection Screen
  */
 
-.newspack-toggle-control {
-	margin: 32px 0;
-
-	& + & {
-		margin: -16px 0 32px 0;
-	}
-}
-
 .newspack-toggle-group {
 	+ .newspack-text-control {
 		margin-top: -16px;
@@ -22,7 +14,7 @@
 	.newspack-toggle-group__description {
 		.newspack-toggle-control,
 		.newspack-text-control {
-			margin: 16px 0 0 -44px;
+			margin: 8px 0 0 -44px;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Avoid forcing the height of a toggle component to 24px, adds a margin top and bottom. Also, reduces margin between Form components, including toggles.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Check the different wizards

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->