### PR TITLE
Update info button icon to use Gutenberg

### DIFF
--- a/assets/components/src/info-button/index.js
+++ b/assets/components/src/info-button/index.js
@@ -7,11 +7,7 @@
  */
 import { Component } from '@wordpress/element';
 import { Tooltip } from '@wordpress/components';
-
-/**
- * Material UI dependencies.
- */
-import InfoIcon from '@material-ui/icons/Info';
+import { Icon, info } from '@wordpress/icons';
 
 /**
  * External dependencies.
@@ -32,7 +28,7 @@ class InfoButton extends Component {
 		return (
 			<Tooltip { ...otherProps }>
 				<div className={ classnames( 'newspack-info-button', className ) }>
-					<InfoIcon />
+					<Icon icon={ info } />
 				</div>
 			</Tooltip>
 		);

--- a/assets/components/src/info-button/style.scss
+++ b/assets/components/src/info-button/style.scss
@@ -13,6 +13,6 @@
 
 	svg {
 		display: block;
-		fill: $dark-gray-900;
+		fill: currentColor;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update the `InfoButton` icon to use Gutenberg instead of Material

### How to test the changes in this Pull Request:

1. Check the components demo, there's a checkbox with the `InfoButton`
2. Switch to this branch
3. Do you see a new icon?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->