### PR TITLE
Fix: empty section in Campaigns Wizard

### DIFF
--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -165,11 +165,14 @@ class PopupsWizard extends Component {
 	/**
 	 * Sort Pop-ups into categories.
 	 */
-	sortPopups = popups =>
-		mapValues(
+	sortPopups = popups => ( {
+		overlay: [],
+		inline: [],
+		...mapValues(
 			groupBy( popups, popup => ( isOverlay( popup ) ? 'overlay' : 'inline' ) ),
 			this.sortPopupGroup
-		);
+		),
+	} );
 
 	/**
 	 * Sort Pop-up groups into categories.


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug introduced in #691 

### How to test the changes in this Pull Request:

1. On `master`, remove all overlay campaigns
2. Visit the Campaign Wizard, observe admin screen crashing
3. Switch to this branch & rebuild
4. Observe the admin screen displaying a "No Overlay Campaigns have been created yet." message

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->