### PR TITLE
Improve debug mode

### DIFF
--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { Button, Handoff, TabbedNavigation } from '../';
@@ -38,6 +43,11 @@ export default function withWizardScreen( WrappedComponent ) {
 		const shouldRenderSecondaryButton = secondaryButtonText && secondaryButtonAction;
 		return (
 			<>
+				{ newspack_aux_data.is_debug_mode && (
+					<div className="newspack-wizard__debug-mode-notice">
+						{ __( 'Newspack is in debug mode.', 'newspack' ) }
+					</div>
+				) }
 				<div className="newspack-wizard__header">
 					<div className="newspack-wizard__header__inner">
 						{ headerText && <h1>{ headerText }</h1> }

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -119,6 +119,11 @@
 			}
 		}
 	}
+
+	&__debug-mode-notice {
+		padding: 5px 20px;
+		background: #ffa500;
+	}
 }
 
 // Buttons Card

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -185,5 +185,12 @@ final class Newspack {
 		wp_safe_redirect( admin_url( 'admin.php?page=newspack-setup-wizard' ) );
 		exit;
 	}
+
+	/**
+	 * Is the site in Newspack debug mode?
+	 */
+	public static function is_debug_mode() {
+		return ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) || get_option( 'newspack_debug', false );
+	}
 }
 Newspack::instance();

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -474,6 +474,9 @@ class Plugin_Manager {
 			if ( isset( $managed_plugin['WPCore'] ) ) {
 				$status = 'active';
 			}
+			if ( Newspack::is_debug_mode() ) {
+				$status = 'active';
+			}
 			$managed_plugins[ $plugin_slug ]['Status']      = $status;
 			$managed_plugins[ $plugin_slug ]['Slug']        = $plugin_slug;
 			$managed_plugins[ $plugin_slug ]['HandoffLink'] = isset( $managed_plugins[ $plugin_slug ]['EditPath'] ) ? admin_url( $managed_plugins[ $plugin_slug ]['EditPath'] ) : null;

--- a/includes/configuration_managers/class-configuration-managers.php
+++ b/includes/configuration_managers/class-configuration-managers.php
@@ -104,6 +104,9 @@ class Configuration_Managers {
 	 * @var bool
 	 */
 	public static function is_configured( $slug ) {
+		if ( Newspack::is_debug_mode() ) {
+			return true;
+		}
 		$configuration_manager = self::configuration_manager_class_for_plugin_slug( $slug );
 		if ( is_wp_error( $configuration_manager ) ) {
 			return false;

--- a/includes/configuration_managers/class-jetpack-configuration-manager.php
+++ b/includes/configuration_managers/class-jetpack-configuration-manager.php
@@ -38,9 +38,6 @@ class Jetpack_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Plugin ready state.
 	 */
 	public function is_configured() {
-		if ( ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) || get_option( 'newspack_debug', false ) ) {
-			return true;
-		}
 		if ( $this->is_active() && class_exists( 'Jetpack' ) && \Jetpack::is_active() ) {
 			return true;
 		}

--- a/includes/configuration_managers/class-site-kit-configuration-manager.php
+++ b/includes/configuration_managers/class-site-kit-configuration-manager.php
@@ -136,10 +136,6 @@ class Site_Kit_Configuration_Manager extends Configuration_Manager {
 	public function is_configured() {
 		global $wpdb;
 
-		if ( ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) || get_option( 'newspack_debug', false ) ) {
-			return true;
-		}
-
 		$user     = get_current_user_id();
 		$meta_key = $wpdb->get_blog_prefix() . 'googlesitekit_access_token';
 		$token    = get_user_meta( $user, $meta_key, true );

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -116,7 +116,8 @@ abstract class Wizard {
 		];
 
 		$aux_data = [
-			'is_e2e' => Starter_Content::is_e2e(),
+			'is_e2e'        => Starter_Content::is_e2e(),
+			'is_debug_mode' => Newspack::is_debug_mode(),
 		];
 
 		wp_localize_script( 'newspack_data', 'newspack_urls', $urls );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

- every plugin will be considered active and configured in debug mode
- added a notice in WP Admin when debug mode is active

### How to test the changes in this Pull Request:

1. Go to Settings->Newspack and ensure "debug mode" is disabled
2. Deactivate "Publish to Apple News" plugin
3. Visit the Syndication wizard, observe required plugins screen will prevent you from any configuration
4. Go to Settings->Newspack and enable "debug mode"
5. Visit the Syndication wizard, observe that you can see the configuration links ("Configure")
6. Observe an orange notice above the wizard header, informing about the active debug mode

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->