### PR TITLE
Fix RadioControl label font size and line height

### DIFF
--- a/assets/components/src/radio-control/style.scss
+++ b/assets/components/src/radio-control/style.scss
@@ -13,8 +13,8 @@
 
 	label {
 		color: inherit;
-		font-size: inherit;
-		line-height: inherit;
+		font-size: 14px;
+		line-height: 24px;
 		margin: 0;
 	}
 
@@ -73,7 +73,7 @@
 		}
 	}
 
-	// Multiple Text Controls
+	// Multiple Radio Controls
 
 	& + & {
 		margin-bottom: 32px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The correct font-size/line-height wasn't being applied.

### How to test the changes in this Pull Request:

1. Check a wizard with radio control (e.g. Site Design > Settings)
2. Switch to this branch
3. Notice the change on the labels

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->