### PR TITLE
chore: add Newspack Listings as a whitelisted plugin

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -240,7 +240,7 @@ class Plugin_Manager {
 				'Author'      => 'Automattic',
 				'PluginURI'   => 'https://newspack.blog',
 				'AuthorURI'   => 'https://automattic.com',
-				'Download'    => 'https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip',
+				'Download'    => 'https://github.com/Automattic/newspack-listings/releases/latest/download/newspack-listings.zip',
 			],
 			'newspack-rename-comments'      => [
 				'Name'        => 'Newspack Rename Comments',

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -234,6 +234,14 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://automattic.com',
 				'Download'    => 'https://github.com/Automattic/newspack-sponsors/releases/latest/download/newspack-sponsors.zip',
 			],
+			'newspack-listings'             => [
+				'Name'        => 'Newspack Listings',
+				'Description' => 'Create reusable content in list form using the Gutenberg editor.',
+				'Author'      => 'Automattic',
+				'PluginURI'   => 'https://newspack.blog',
+				'AuthorURI'   => 'https://automattic.com',
+				'Download'    => 'https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip',
+			],
 			'newspack-rename-comments'      => [
 				'Name'        => 'Newspack Rename Comments',
 				'Description' => 'Provides the Newspack theme with the ability to allow users to rename comments.',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds Newspack Listings as a whitelisted plugin for easy manual installation. Happy to take feedback on the description copy.

### How to test the changes in this Pull Request:

1. Check out this branch and run `npm run release:archive`.
2. Install and activate the .zip that's generated in `/assets/release/newspack-plugin.zip` to a new test site.
3. Complete the onboarding steps as usual (can skip the Jetpack and Site Kit setup).
4. Go to **Plugins** and verify that Newspack Listings is listed and can be installed with a button click.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->