### PR TITLE
Campaigns Wizard: handle session read count segmentation

### DIFF
--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -28,6 +28,8 @@ const SegmentSettingSection = ( { title, description, children } ) => (
 const DEFAULT_CONFIG = {
 	min_posts: 0,
 	max_posts: 0,
+	min_session_posts: 0,
+	max_session_posts: 0,
 	is_subscribed: false,
 	is_donor: false,
 	is_not_subscribed: false,
@@ -102,7 +104,10 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 				onChange={ setName }
 			/>
 			<div className="newspack-campaigns-wizard-segments__sections-wrapper">
-				<SegmentSettingSection title={ __( 'Number of articles read', 'newspack' ) }>
+				<SegmentSettingSection
+					title={ __( 'Articles read', 'newspack' ) }
+					description={ __( 'Number of articles read in the last 30 day period.', 'newspack' ) }
+				>
 					<div>
 						<CheckboxControl
 							checked={ segmentConfig.min_posts > 0 }
@@ -127,6 +132,40 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 							type="number"
 							value={ segmentConfig.max_posts }
 							onChange={ updateSegmentConfig( 'max_posts' ) }
+						/>
+					</div>
+				</SegmentSettingSection>
+				<SegmentSettingSection
+					title={ __( 'Articles read in session', 'newspack' ) }
+					description={ __(
+						'Number of articles read in the current session (45 minutes).',
+						'newspack'
+					) }
+				>
+					<div>
+						<CheckboxControl
+							checked={ segmentConfig.min_session_posts > 0 }
+							onChange={ value => updateSegmentConfig( 'min_session_posts' )( value ? 1 : 0 ) }
+							label={ __( 'Min.', 'newspack' ) }
+						/>
+						<TextControl
+							placeholder={ __( 'Min. posts', 'newspack' ) }
+							type="number"
+							value={ segmentConfig.min_session_posts }
+							onChange={ updateSegmentConfig( 'min_session_posts' ) }
+						/>
+					</div>
+					<div>
+						<CheckboxControl
+							checked={ segmentConfig.max_session_posts > 0 }
+							onChange={ value => updateSegmentConfig( 'max_session_posts' )( value ? 1 : 0 ) }
+							label={ __( 'Max.', 'newspack' ) }
+						/>
+						<TextControl
+							placeholder={ __( 'Max. posts', 'newspack' ) }
+							type="number"
+							value={ segmentConfig.max_session_posts }
+							onChange={ updateSegmentConfig( 'max_session_posts' ) }
 						/>
 					</div>
 				</SegmentSettingSection>

--- a/assets/wizards/popups/views/segmentation/style.scss
+++ b/assets/wizards/popups/views/segmentation/style.scss
@@ -16,19 +16,22 @@
 	&__sections-wrapper {
 		display: flex;
 		flex-wrap: wrap;
+		justify-content: flex-start;
 		margin-left: -10px;
 		margin-right: -10px;
 	}
 	&__section {
 		flex: 1;
 		padding: 10px;
+		margin-bottom: 30px;
 		min-width: 100%;
 		@media screen and ( min-width: 600px ) {
-			min-width: 200px;
-			max-width: 50%;
+			min-width: 250px;
+			max-width: 250px;
 		}
 		h3 {
 			margin-top: 0;
+			margin-bottom: 15px;
 		}
 		&__description {
 			opacity: 0.6;


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

_Note: merge only after https://github.com/Automattic/newspack-popups/pull/352 is merged._

Adds UI for session read count segmentation.

### How to test the changes in this Pull Request:

1. Switch to `add/session-read-count-segment` branch of `newspack-popups` (https://github.com/Automattic/newspack-popups/pull/352)
2. Visit the Campaigns Wizard, segmentation tab, observe a new segmentation criterion – "Articles read in session"
3. Create a segment using that criterion, with a min of 2 and max value of 4 set 
4. Create a campaign and assign it to the new segment
5. Visit site in a fresh incognito session. Observe the campaign is displayed only on the 2nd, 3rd, and 4th (different) post visits

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->