### PR TITLE
Update is-loading animation

### DIFF
--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -2,6 +2,7 @@
  * With Wizard
  */
 
+@import '~@wordpress/base-styles/colors';
 @import '../../../shared/scss/colors';
 
 // Reset Padding of the Admin Page
@@ -123,51 +124,95 @@ body[class*='admin_page_newspack-'] {
 // Loading
 
 .newspack-wizard__is-loading {
-	.newspack-wizard {
-		cursor: wait;
-		position: relative;
+	background: white;
+	bottom: 0;
+	cursor: wait;
+	left: 0;
+	position: absolute;
+	right: 0;
+	top: 0;
+
+	> * {
+		display: none !important;
+	}
+
+	&::before,
+	&::after {
+		content: '';
+		display: block;
+	}
+
+	&::before {
+		background: $primary-500;
+		height: 160px;
+		width: 100%;
+	}
+
+	&::after {
+		animation: newspack-wizard__is-loading-animation 1.5s ease-in-out infinite;
+		background: $dark-gray-900;
+		box-shadow: inset -40vw 0 0 0 white, 0 32px 0 0 $dark-gray-300, 0 64px 0 0 $dark-gray-300,
+			40vw 96px 0 0 white, 0 96px 0 0 $dark-gray-300;
+		height: 24px;
+		margin: 68px auto 0;
+		max-width: 1040px;
+		width: calc( 100% - ( 32px * 2 ) );
+
+		@media screen and ( min-width: 744px ) {
+			width: calc( 100% - ( 64px * 2 ) );
+		}
+	}
+
+	// Welcome Screen
+	.newspack_page_newspack-setup-wizard__welcome & {
+		background: $primary-500;
 
 		&::before,
 		&::after {
-			background: white;
-			content: '';
-			display: block;
-			left: 0;
+			left: 50%;
 			position: absolute;
-			right: 0;
-			top: 0;
-			z-index: 102;
-		}
-
-		&::after {
-			border-radius: 4px;
-			bottom: 0;
-			opacity: 0.8;
+			transform: translate( -50% );
 		}
 
 		&::before {
-			animation: newspack-wizard__is-loading-animation 2s ease-in-out infinite;
-			background: $primary-500;
-			height: 4px;
-			right: 100%;
-			z-index: 103;
+			border-radius: 4px;
+			background: white;
+			height: 192px;
+			max-width: 584px;
+			top: 120px;
+			width: calc( 100% - ( 32px * 2 ) );
+
+			@media screen and ( min-width: 744px ) {
+				width: calc( 100% - ( 64px * 2 ) );
+			}
+		}
+
+		&::after {
+			box-shadow: inset -130px 0 0 0 white, 0 32px 0 0 $dark-gray-300, 0 64px 0 0 $dark-gray-300,
+				0 96px 0 0 $dark-gray-300;
+			margin: 0;
+			max-width: 520px;
+			top: 156px;
+			width: calc( 100% - ( 64px * 2 ) );
+
+			@media screen and ( min-width: 600px ) {
+				box-shadow: inset -260px 0 0 0 white, 0 32px 0 0 $dark-gray-300, 0 64px 0 0 $dark-gray-300,
+					0 96px 0 0 $dark-gray-300;
+			}
 		}
 	}
 }
 
 @keyframes newspack-wizard__is-loading-animation {
 	from {
-		left: 0;
-		right: 100%;
+		opacity: 100%;
 	}
 
 	50% {
-		left: 0;
-		right: 0;
+		opacity: 10%;
 	}
 
 	to {
-		left: 100%;
-		right: 0;
+		opacity: 100%;
 	}
 }

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -151,22 +151,22 @@ body[class*='admin_page_newspack-'] {
 	&::after {
 		animation: newspack-wizard__is-loading-animation 1.5s ease-in-out infinite;
 		background: $dark-gray-900;
-		box-shadow: inset -40vw 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300,
-			40vw 128px 0 0 white, 0 128px 0 0 $dark-gray-300;
+		box-shadow: inset -40vw 0 0 0 white, 0 64px 0 0 $dark-gray-300, 40vw 96px 0 0 white,
+			0 96px 0 0 $dark-gray-300;
 		height: 24px;
 		margin: 68px auto 0;
 		max-width: 1040px;
 		width: calc( 100% - ( 32px * 2 ) );
 
 		@media screen and ( min-width: 744px ) {
-			box-shadow: inset -400px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300,
-				200px 128px 0 0 white, 0 128px 0 0 $dark-gray-300;
+			box-shadow: inset -400px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 200px 96px 0 0 white,
+				0 96px 0 0 $dark-gray-300;
 			width: calc( 100% - ( 64px * 2 ) );
 		}
 
 		@media screen and ( min-width: 1224px ) {
-			box-shadow: inset -600px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300,
-				520px 128px 0 0 white, 0 128px 0 0 $dark-gray-300;
+			box-shadow: inset -600px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 520px 96px 0 0 white,
+				0 96px 0 0 $dark-gray-300;
 			width: calc( 100% - ( 64px * 2 ) );
 		}
 	}
@@ -185,7 +185,7 @@ body[class*='admin_page_newspack-'] {
 		&::before {
 			border-radius: 4px;
 			background: white;
-			height: 224px;
+			height: 192px;
 			max-width: 584px;
 			top: 120px;
 			width: calc( 100% - ( 32px * 2 ) );
@@ -196,16 +196,14 @@ body[class*='admin_page_newspack-'] {
 		}
 
 		&::after {
-			box-shadow: inset -130px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300,
-				0 128px 0 0 $dark-gray-300;
+			box-shadow: inset -130px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300;
 			margin: 0;
 			max-width: 520px;
 			top: 156px;
 			width: calc( 100% - ( 64px * 2 ) );
 
 			@media screen and ( min-width: 600px ) {
-				box-shadow: inset -260px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300,
-					0 128px 0 0 $dark-gray-300;
+				box-shadow: inset -260px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300;
 			}
 		}
 	}

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -151,14 +151,22 @@ body[class*='admin_page_newspack-'] {
 	&::after {
 		animation: newspack-wizard__is-loading-animation 1.5s ease-in-out infinite;
 		background: $dark-gray-900;
-		box-shadow: inset -40vw 0 0 0 white, 0 32px 0 0 $dark-gray-300, 0 64px 0 0 $dark-gray-300,
-			40vw 96px 0 0 white, 0 96px 0 0 $dark-gray-300;
+		box-shadow: inset -40vw 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300,
+			40vw 128px 0 0 white, 0 128px 0 0 $dark-gray-300;
 		height: 24px;
 		margin: 68px auto 0;
 		max-width: 1040px;
 		width: calc( 100% - ( 32px * 2 ) );
 
 		@media screen and ( min-width: 744px ) {
+			box-shadow: inset -400px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300,
+				200px 128px 0 0 white, 0 128px 0 0 $dark-gray-300;
+			width: calc( 100% - ( 64px * 2 ) );
+		}
+
+		@media screen and ( min-width: 1224px ) {
+			box-shadow: inset -600px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300,
+				520px 128px 0 0 white, 0 128px 0 0 $dark-gray-300;
 			width: calc( 100% - ( 64px * 2 ) );
 		}
 	}
@@ -177,7 +185,7 @@ body[class*='admin_page_newspack-'] {
 		&::before {
 			border-radius: 4px;
 			background: white;
-			height: 192px;
+			height: 224px;
 			max-width: 584px;
 			top: 120px;
 			width: calc( 100% - ( 32px * 2 ) );
@@ -188,16 +196,16 @@ body[class*='admin_page_newspack-'] {
 		}
 
 		&::after {
-			box-shadow: inset -130px 0 0 0 white, 0 32px 0 0 $dark-gray-300, 0 64px 0 0 $dark-gray-300,
-				0 96px 0 0 $dark-gray-300;
+			box-shadow: inset -130px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300,
+				0 128px 0 0 $dark-gray-300;
 			margin: 0;
 			max-width: 520px;
 			top: 156px;
 			width: calc( 100% - ( 64px * 2 ) );
 
 			@media screen and ( min-width: 600px ) {
-				box-shadow: inset -260px 0 0 0 white, 0 32px 0 0 $dark-gray-300, 0 64px 0 0 $dark-gray-300,
-					0 96px 0 0 $dark-gray-300;
+				box-shadow: inset -260px 0 0 0 white, 0 64px 0 0 $dark-gray-300, 0 96px 0 0 $dark-gray-300,
+					0 128px 0 0 $dark-gray-300;
 			}
 		}
 	}

--- a/assets/wizards/updates/index.js
+++ b/assets/wizards/updates/index.js
@@ -24,11 +24,9 @@ class UpdatesWizard extends Component {
 	 * Render
 	 */
 	render() {
-		const { pluginRequirements } = this.props;
 		return (
 			<HashRouter hashType="slash">
 				<Switch>
-					{ pluginRequirements }
 					<Route
 						path="/"
 						exact


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the loading state animation. Moving away from the thin Material loading bar and instead using something fairly similar to Gutenberg with a "skeleton" loading.

![new-anim](https://user-images.githubusercontent.com/177929/102514325-3db40200-4084-11eb-8a5f-133ec242ddd7.gif)

_Note: there's an issue with the Updates Wizard where the plugin requirement overwrites the loading... not sure what's going on cc @jeffersonrabb_

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Navigate through the different Wizards (including the Setup)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->