### PR TITLE
fix: campaign wizard filter irregularities

### DIFF
--- a/assets/components/src/action-card-sections/index.js
+++ b/assets/components/src/action-card-sections/index.js
@@ -13,11 +13,22 @@ import './style.scss';
 const ALL_FILTER = { label: __( 'All', 'newspack' ), value: 'all' };
 
 const ActionCardSections = ( { sections, emptyMessage, renderCard } ) => {
-	const [ allFilters, setAllFilters ] = useState( [ ALL_FILTER ] );
-	const [ filter, setFilter ] = useState( allFilters[ 0 ].value );
+	const [ filter, setFilter ] = useState( ALL_FILTER.value );
 
 	const renderedSections = useMemo( () => {
-		const validFilters = [ ALL_FILTER ];
+		const validFilters = sections.reduce(
+			( acc, section ) =>
+				section.items.length > 0 ? [ ...acc, { label: section.label, value: section.key } ] : acc,
+			[ ALL_FILTER ]
+		);
+		if (
+			! validFilters.reduce(
+				( filterFound, item ) => ( filter === item.value ? true : filterFound ),
+				false
+			)
+		) {
+			setFilter( ALL_FILTER.value );
+		}
 		const validSections = sections.reduce( ( validSectionsAcc, section ) => {
 			if ( section.items.length > 0 ) {
 				const Heading = () => (
@@ -31,11 +42,11 @@ const ActionCardSections = ( { sections, emptyMessage, renderCard } ) => {
 				if ( filter === ALL_FILTER.value || filter === section.key ) {
 					validSectionsAcc.push(
 						<Fragment key={ section.key }>
-							{ allFilters.length > 0 && validSectionsAcc.length === 0 ? (
+							{ validFilters.length > 0 && validSectionsAcc.length === 0 ? (
 								<div className="newspack-action-card-sections__group-wrapper">
 									<Heading />
 									<SelectControl
-										options={ allFilters }
+										options={ validFilters }
 										value={ filter }
 										onChange={ setFilter }
 										label={ __( 'Filter:', 'newspack' ) }
@@ -50,14 +61,12 @@ const ActionCardSections = ( { sections, emptyMessage, renderCard } ) => {
 						</Fragment>
 					);
 				}
-				validFilters.push( { label: section.label, value: section.key } );
 			}
 			return validSectionsAcc;
 		}, [] );
-		setAllFilters( validFilters );
 
 		return validSections;
-	}, [ sections, filter, allFilters.length ] );
+	}, [ sections, filter ] );
 
 	return renderedSections.length > 0 ? (
 		<Fragment>{ renderedSections }</Fragment>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Addresses two issues with Campaigns Wizard filters. First, as described in https://github.com/Automattic/newspack-plugin/issues/759, when switching between tabs the filters will display the options for the previous tab. Second, when switching tabs if the last filter setting doesn't exist in the new tab, it will reset to "All."

Closes https://github.com/Automattic/newspack-plugin/issues/759

### How to test the changes in this Pull Request:

1. On `master`, go through the repro flow described in https://github.com/Automattic/newspack-plugin/issues/759. Observe the issue with incorrect filter values.
2. Switch to this branch, observe the issue is corrected.
3. In one tab select a filter that does not exist in the other, then switch back to the other. Observe the filter resets to "All."
4. Create a collection of campaigns of different types and statuses, and verify that the wizard works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->