### PR TITLE
refactor: campaign view and components rewritten as stateless components

### DIFF
--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -62,7 +62,7 @@ const PopupActionCard = ( {
 					{ popoverVisibility && (
 						<PopupPopover
 							deletePopup={ deletePopup }
-							onFocusOutside={ () => this.setState( { popoverVisibility: false } ) }
+							onFocusOutside={ () => setPopoverVisibility( false ) }
 							popup={ popup }
 							setSitewideDefaultPopup={ setSitewideDefaultPopup }
 							updatePopup={ updatePopup }

--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { useState, Fragment } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Tooltip } from '@wordpress/components';
 import { Icon, menu, moreVertical } from '@wordpress/icons';
@@ -18,90 +18,70 @@ import { ActionCard, Button, CategoryAutocomplete } from '../../../../components
 import PopupPopover from '../popup-popover';
 import './style.scss';
 
-class PopupActionCard extends Component {
-	state = {
-		categoriesVisibility: false,
-		popoverVisibility: false,
-	};
-
-	/**
-	 * Render.
-	 */
-	render = () => {
-		const { categoriesVisibility, popoverVisibility } = this.state;
-		const {
-			className,
-			description,
-			deletePopup,
-			popup,
-			previewPopup,
-			setCategoriesForPopup,
-			setSitewideDefaultPopup,
-			publishPopup,
-			updatePopup,
-		} = this.props;
-		const { id, categories, title, sitewide_default: sitewideDefault, status } = popup;
-		return (
-			<ActionCard
-				isSmall
-				className={ className }
-				title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack' ) }
-				key={ id }
-				description={ description }
-				actionText={
-					<Fragment>
-						{ ! sitewideDefault && (
-							<Tooltip text={ __( 'Category filtering', 'newspack' ) }>
-								<Button
-									className="icon-only"
-									onClick={ () =>
-										this.setState( { categoriesVisibility: ! categoriesVisibility } )
-									}
-								>
-									<Icon icon={ menu } />
-								</Button>
-							</Tooltip>
-						) }
-						<Tooltip text={ __( 'More options', 'newspack' ) }>
+const PopupActionCard = ( {
+	className,
+	description,
+	deletePopup,
+	popup = {},
+	previewPopup,
+	setCategoriesForPopup,
+	setSitewideDefaultPopup,
+	publishPopup,
+	updatePopup,
+} ) => {
+	const [ categoriesVisibility, setCategoriesVisibility ] = useState( false );
+	const [ popoverVisibility, setPopoverVisibility ] = useState( false );
+	const { id, categories, title, sitewide_default: sitewideDefault, status } = popup;
+	return (
+		<ActionCard
+			isSmall
+			className={ className }
+			title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack' ) }
+			key={ id }
+			description={ description }
+			actionText={
+				<Fragment>
+					{ ! sitewideDefault && (
+						<Tooltip text={ __( 'Category filtering', 'newspack' ) }>
 							<Button
 								className="icon-only"
-								onClick={ () => this.setState( { popoverVisibility: ! popoverVisibility } ) }
+								onClick={ () => setCategoriesVisibility( ! categoriesVisibility ) }
 							>
-								<Icon icon={ moreVertical } />
+								<Icon icon={ menu } />
 							</Button>
 						</Tooltip>
-						{ popoverVisibility && (
-							<PopupPopover
-								deletePopup={ deletePopup }
-								onFocusOutside={ () => this.setState( { popoverVisibility: false } ) }
-								popup={ popup }
-								setSitewideDefaultPopup={ setSitewideDefaultPopup }
-								updatePopup={ updatePopup }
-								previewPopup={ previewPopup }
-								publishPopup={ 'publish' !== status ? publishPopup : null }
-							/>
-						) }
-					</Fragment>
-				}
-			>
-				{ categoriesVisibility && (
-					<CategoryAutocomplete
-						value={ categories || [] }
-						onChange={ tokens => setCategoriesForPopup( id, tokens ) }
-						label={ __( 'Category filtering', 'newspack ' ) }
-						disabled={ sitewideDefault }
-					/>
-				) }
-			</ActionCard>
-		);
-	};
-}
-
-PopupActionCard.defaultProps = {
-	popup: {},
-	deletePopup: () => null,
-	setCategoriesForPopup: () => null,
-	setSitewideDefaultPopup: () => null,
+					) }
+					<Tooltip text={ __( 'More options', 'newspack' ) }>
+						<Button
+							className="icon-only"
+							onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
+						>
+							<Icon icon={ moreVertical } />
+						</Button>
+					</Tooltip>
+					{ popoverVisibility && (
+						<PopupPopover
+							deletePopup={ deletePopup }
+							onFocusOutside={ () => this.setState( { popoverVisibility: false } ) }
+							popup={ popup }
+							setSitewideDefaultPopup={ setSitewideDefaultPopup }
+							updatePopup={ updatePopup }
+							previewPopup={ previewPopup }
+							publishPopup={ 'publish' !== status ? publishPopup : null }
+						/>
+					) }
+				</Fragment>
+			}
+		>
+			{ categoriesVisibility && (
+				<CategoryAutocomplete
+					value={ categories || [] }
+					onChange={ tokens => setCategoriesForPopup( id, tokens ) }
+					label={ __( 'Category filtering', 'newspack ' ) }
+					disabled={ sitewideDefault }
+				/>
+			) }
+		</ActionCard>
+	);
 };
-
 export default PopupActionCard;

--- a/assets/wizards/popups/components/popup-popover/index.js
+++ b/assets/wizards/popups/components/popup-popover/index.js
@@ -30,96 +30,88 @@ const frequenciesForPopup = popup => {
 		.filter( key => ! ( 'always' === key && isOverlay( popup ) ) )
 		.map( key => ( { label: frequencyMap[ key ], value: key } ) );
 };
-class PopupPopover extends Component {
-	/**
-	 * Render.
-	 */
-	render = () => {
-		const {
-			deletePopup,
-			popup,
-			previewPopup,
-			setSitewideDefaultPopup,
-			onFocusOutside,
-			publishPopup,
-			updatePopup,
-		} = this.props;
-		const { id, sitewide_default: sitewideDefault, edit_link: editLink, options, status } = popup;
-		const { frequency } = options;
-		const isDraft = 'draft' === status;
-		const isTestMode = 'test' === frequency;
-
-		return (
-			<Popover
-				position="bottom left"
-				onFocusOutside={ onFocusOutside }
-				onKeyDown={ event => ESCAPE === event.keyCode && onFocusOutside() }
-			>
-				{ isOverlay( { options } ) && ! isTestMode && ! isDraft && (
-					<MenuItem
-						onClick={ () => {
-							setSitewideDefaultPopup( id, ! sitewideDefault );
-							onFocusOutside();
-						} }
-						className="newspack-button"
-					>
-						<div className="newspack-popup-action-card-popover-control">
-							{ __( 'Sitewide default', 'newspack' ) }
-							<ToggleControl checked={ sitewideDefault } onChange={ () => null } />
-						</div>
-					</MenuItem>
-				) }
+const PopupPopover = ( {
+	deletePopup,
+	popup,
+	previewPopup,
+	setSitewideDefaultPopup,
+	onFocusOutside,
+	publishPopup,
+	updatePopup,
+} ) => {
+	const { id, sitewide_default: sitewideDefault, edit_link: editLink, options, status } = popup;
+	const { frequency } = options;
+	const isDraft = 'draft' === status;
+	const isTestMode = 'test' === frequency;
+	return (
+		<Popover
+			position="bottom left"
+			onFocusOutside={ onFocusOutside }
+			onKeyDown={ event => ESCAPE === event.keyCode && onFocusOutside() }
+		>
+			{ isOverlay( { options } ) && ! isTestMode && ! isDraft && (
 				<MenuItem
 					onClick={ () => {
-						updatePopup( id, { frequency: isTestMode ? 'daily' : 'test' } );
+						setSitewideDefaultPopup( id, ! sitewideDefault );
 						onFocusOutside();
 					} }
 					className="newspack-button"
 				>
 					<div className="newspack-popup-action-card-popover-control">
-						{ __( 'Test mode', 'newspack' ) }
-						<ToggleControl checked={ isTestMode } onChange={ () => null } />
+						{ __( 'Sitewide default', 'newspack' ) }
+						<ToggleControl checked={ sitewideDefault } onChange={ () => null } />
 					</div>
 				</MenuItem>
-				{ 'test' !== frequency && (
-					<MenuItem className="newspack-button newspack-popup-action-card-select-button">
-						<SelectControl
-							onChange={ value => {
-								updatePopup( id, { frequency: value } );
-								onFocusOutside();
-							} }
-							className="newspack-popup-action-card-select"
-							options={ frequenciesForPopup( popup ) }
-							value={ frequency }
-						/>
-					</MenuItem>
-				) }
-				<MenuItem
-					onClick={ () => {
-						onFocusOutside();
-						previewPopup( popup );
-					} }
-					className="newspack-button"
-				>
-					{ __( 'Preview', 'newspack' ) }
-				</MenuItem>
-				<MenuItem href={ decodeEntities( editLink ) } className="newspack-button" isLink>
-					{ __( 'Edit', 'newspack' ) }
-				</MenuItem>
-				{ publishPopup && (
-					<MenuItem onClick={ () => publishPopup( id ) } className="newspack-button">
-						{ __( 'Publish', 'newspack' ) }
-					</MenuItem>
-				) }
-				<MenuItem onClick={ () => deletePopup( id ) } className="newspack-button">
-					{ __( 'Delete', 'newspack' ) }
-				</MenuItem>
-				<div className="newspack-popup-info">
-					{ __( 'ID:', 'newspack' ) } { popup.id }
+			) }
+			<MenuItem
+				onClick={ () => {
+					updatePopup( id, { frequency: isTestMode ? 'daily' : 'test' } );
+					onFocusOutside();
+				} }
+				className="newspack-button"
+			>
+				<div className="newspack-popup-action-card-popover-control">
+					{ __( 'Test mode', 'newspack' ) }
+					<ToggleControl checked={ isTestMode } onChange={ () => null } />
 				</div>
-			</Popover>
-		);
-	};
-}
-
+			</MenuItem>
+			{ 'test' !== frequency && (
+				<MenuItem className="newspack-button newspack-popup-action-card-select-button">
+					<SelectControl
+						onChange={ value => {
+							updatePopup( id, { frequency: value } );
+							onFocusOutside();
+						} }
+						className="newspack-popup-action-card-select"
+						options={ frequenciesForPopup( popup ) }
+						value={ frequency }
+					/>
+				</MenuItem>
+			) }
+			<MenuItem
+				onClick={ () => {
+					onFocusOutside();
+					previewPopup( popup );
+				} }
+				className="newspack-button"
+			>
+				{ __( 'Preview', 'newspack' ) }
+			</MenuItem>
+			<MenuItem href={ decodeEntities( editLink ) } className="newspack-button" isLink>
+				{ __( 'Edit', 'newspack' ) }
+			</MenuItem>
+			{ publishPopup && (
+				<MenuItem onClick={ () => publishPopup( id ) } className="newspack-button">
+					{ __( 'Publish', 'newspack' ) }
+				</MenuItem>
+			) }
+			<MenuItem onClick={ () => deletePopup( id ) } className="newspack-button">
+				{ __( 'Delete', 'newspack' ) }
+			</MenuItem>
+			<div className="newspack-popup-info">
+				{ __( 'ID:', 'newspack' ) } { popup.id }
+			</div>
+		</Popover>
+	);
+};
 export default PopupPopover;

--- a/assets/wizards/popups/components/popup-popover/index.js
+++ b/assets/wizards/popups/components/popup-popover/index.js
@@ -6,7 +6,6 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { MenuItem } from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -5,7 +5,6 @@
 /**
  * WordPress dependencies.
  */
-import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -18,6 +17,29 @@ import { find } from 'lodash';
  */
 import { withWizardScreen, ActionCardSections } from '../../../../components/src';
 import PopupActionCard from '../../components/popup-action-card';
+
+const descriptionForPopup = (
+	{ categories, sitewide_default: sitewideDefault, options },
+	segments
+) => {
+	const segment = find( segments, [ 'id', options.selected_segment_id ] );
+	const descriptionMessages = [];
+	if ( segment ) {
+		descriptionMessages.push( `${ __( 'Segment:', 'newspack' ) } ${ segment.name }` );
+	}
+	if ( sitewideDefault ) {
+		descriptionMessages.push( __( 'Sitewide default', 'newspack' ) );
+	}
+	if ( options.placement === 'above_header' ) {
+		descriptionMessages.push( __( 'Above header', 'newspack' ) );
+	}
+	if ( categories.length > 0 ) {
+		descriptionMessages.push(
+			__( 'Categories: ', 'newspack' ) + categories.map( category => category.name ).join( ', ' )
+		);
+	}
+	return descriptionMessages.length ? descriptionMessages.join( ' | ' ) : null;
+};
 
 /**
  * Popup group screen
@@ -33,29 +55,6 @@ const PopupGroup = ( {
 	updatePopup,
 	segments,
 } ) => {
-	const descriptionForPopup = (
-		{ categories, sitewide_default: sitewideDefault, options },
-		segments
-	) => {
-		const segment = find( segments, [ 'id', options.selected_segment_id ] );
-		const descriptionMessages = [];
-		if ( segment ) {
-			descriptionMessages.push( `${ __( 'Segment:', 'newspack' ) } ${ segment.name }` );
-		}
-		if ( sitewideDefault ) {
-			descriptionMessages.push( __( 'Sitewide default', 'newspack' ) );
-		}
-		if ( options.placement === 'above_header' ) {
-			descriptionMessages.push( __( 'Above header', 'newspack' ) );
-		}
-		if ( categories.length > 0 ) {
-			descriptionMessages.push(
-				__( 'Categories: ', 'newspack' ) + categories.map( category => category.name ).join( ', ' )
-			);
-		}
-		return descriptionMessages.length ? descriptionMessages.join( ' | ' ) : null;
-	};
-
 	const getCardClassName = ( { key }, { sitewide_default } ) =>
 		( {
 			active: sitewide_default ? 'newspack-card__is-primary' : 'newspack-card__is-supported',

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -22,14 +22,18 @@ import PopupActionCard from '../../components/popup-action-card';
 /**
  * Popup group screen
  */
-
-class PopupGroup extends Component {
-	/**
-	 * Construct the appropriate description for a single Pop-up based on categories and sitewide default status.
-	 *
-	 * @param {Object} popup object.
-	 */
-	descriptionForPopup = (
+const PopupGroup = ( {
+	deletePopup,
+	emptyMessage,
+	items: { active = [], draft = [], test = [], inactive = [] },
+	previewPopup,
+	setCategoriesForPopup,
+	setSitewideDefaultPopup,
+	publishPopup,
+	updatePopup,
+	segments,
+} ) => {
+	const descriptionForPopup = (
 		{ categories, sitewide_default: sitewideDefault, options },
 		segments
 	) => {
@@ -52,56 +56,38 @@ class PopupGroup extends Component {
 		return descriptionMessages.length ? descriptionMessages.join( ' | ' ) : null;
 	};
 
-	/**
-	 * Render.
-	 */
-	render() {
-		const {
-			deletePopup,
-			emptyMessage,
-			items: { active = [], draft = [], test = [], inactive = [] },
-			previewPopup,
-			setCategoriesForPopup,
-			setSitewideDefaultPopup,
-			publishPopup,
-			updatePopup,
-			segments,
-		} = this.props;
+	const getCardClassName = ( { key }, { sitewide_default } ) =>
+		( {
+			active: sitewide_default ? 'newspack-card__is-primary' : 'newspack-card__is-supported',
+			test: 'newspack-card__is-secondary',
+			inactive: 'newspack-card__is-disabled',
+			draft: 'newspack-card__is-disabled',
+		}[ key ] );
 
-		const getCardClassName = ( { key }, { sitewide_default } ) =>
-			( {
-				active: sitewide_default ? 'newspack-card__is-primary' : 'newspack-card__is-supported',
-				test: 'newspack-card__is-secondary',
-				inactive: 'newspack-card__is-disabled',
-				draft: 'newspack-card__is-disabled',
-			}[ key ] );
-
-		return (
-			<ActionCardSections
-				sections={ [
-					{ key: 'active', label: __( 'Active', 'newspack' ), items: active },
-					{ key: 'draft', label: __( 'Draft', 'newspack' ), items: draft },
-					{ key: 'test', label: __( 'Test', 'newspack' ), items: test },
-					{ key: 'inactive', label: __( 'Inactive', 'newspack' ), items: inactive },
-				] }
-				renderCard={ ( popup, section ) => (
-					<PopupActionCard
-						className={ getCardClassName( section, popup ) }
-						deletePopup={ deletePopup }
-						description={ this.descriptionForPopup( popup, segments ) }
-						key={ popup.id }
-						popup={ popup }
-						previewPopup={ previewPopup }
-						setCategoriesForPopup={ setCategoriesForPopup }
-						setSitewideDefaultPopup={ setSitewideDefaultPopup }
-						updatePopup={ updatePopup }
-						publishPopup={ section.key === 'draft' ? publishPopup : undefined }
-					/>
-				) }
-				emptyMessage={ emptyMessage }
-			/>
-		);
-	}
-}
-
+	return (
+		<ActionCardSections
+			sections={ [
+				{ key: 'active', label: __( 'Active', 'newspack' ), items: active },
+				{ key: 'draft', label: __( 'Draft', 'newspack' ), items: draft },
+				{ key: 'test', label: __( 'Test', 'newspack' ), items: test },
+				{ key: 'inactive', label: __( 'Inactive', 'newspack' ), items: inactive },
+			] }
+			renderCard={ ( popup, section ) => (
+				<PopupActionCard
+					className={ getCardClassName( section, popup ) }
+					deletePopup={ deletePopup }
+					description={ descriptionForPopup( popup, segments ) }
+					key={ popup.id }
+					popup={ popup }
+					previewPopup={ previewPopup }
+					setCategoriesForPopup={ setCategoriesForPopup }
+					setSitewideDefaultPopup={ setSitewideDefaultPopup }
+					updatePopup={ updatePopup }
+					publishPopup={ section.key === 'draft' ? publishPopup : undefined }
+				/>
+			) }
+			emptyMessage={ emptyMessage }
+		/>
+	);
+};
 export default withWizardScreen( PopupGroup );

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -41,6 +41,14 @@ const descriptionForPopup = (
 	return descriptionMessages.length ? descriptionMessages.join( ' | ' ) : null;
 };
 
+const getCardClassName = ( { key }, { sitewide_default } ) =>
+	( {
+		active: sitewide_default ? 'newspack-card__is-primary' : 'newspack-card__is-supported',
+		test: 'newspack-card__is-secondary',
+		inactive: 'newspack-card__is-disabled',
+		draft: 'newspack-card__is-disabled',
+	}[ key ] );
+
 /**
  * Popup group screen
  */
@@ -55,14 +63,6 @@ const PopupGroup = ( {
 	updatePopup,
 	segments,
 } ) => {
-	const getCardClassName = ( { key }, { sitewide_default } ) =>
-		( {
-			active: sitewide_default ? 'newspack-card__is-primary' : 'newspack-card__is-supported',
-			test: 'newspack-card__is-secondary',
-			inactive: 'newspack-card__is-disabled',
-			draft: 'newspack-card__is-disabled',
-		}[ key ] );
-
 	return (
 		<ActionCardSections
 			sections={ [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Converts `PopupGroup`, `PopupPopover`, and `PopupActionCard` to stateless components. This branch is a pure refactor and there should be no functional changes whatsoever.

### How to test the changes in this Pull Request:

Verify the Campaigns Wizard Overlay and Inline tabs function exactly as they did before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->