### PR TITLE
feat: hide the confusing help text in category autocomplete field

### DIFF
--- a/assets/components/src/category-autocomplete/index.js
+++ b/assets/components/src/category-autocomplete/index.js
@@ -13,6 +13,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies.
  */
 import { FormTokenField } from '../';
+import './style.scss';
 
 /**
  * External dependencies
@@ -99,19 +100,22 @@ class CategoryAutocomplete extends Component {
 		const { value, label } = this.props;
 		const { suggestions, allCategories } = this.state;
 		return (
-			<FormTokenField
-				onInputChange={ input => this.debouncedUpdateSuggestions( input ) }
-				value={ value.reduce( ( acc, item ) => {
-					const category = typeof item === 'number' ? find( allCategories, [ 'id', item ] ) : item;
-					if ( category ) {
-						acc.push( { id: category.term_id || category.id, value: category.name } );
-					}
-					return acc;
-				}, [] ) }
-				suggestions={ Object.keys( suggestions ) }
-				onChange={ this.handleOnChange }
-				label={ label }
-			/>
+			<div className="newspack-category-autocomplete">
+				<FormTokenField
+					onInputChange={ input => this.debouncedUpdateSuggestions( input ) }
+					value={ value.reduce( ( acc, item ) => {
+						const category =
+							typeof item === 'number' ? find( allCategories, [ 'id', item ] ) : item;
+						if ( category ) {
+							acc.push( { id: category.term_id || category.id, value: category.name } );
+						}
+						return acc;
+					}, [] ) }
+					suggestions={ Object.keys( suggestions ) }
+					onChange={ this.handleOnChange }
+					label={ label }
+				/>
+			</div>
 		);
 	}
 }

--- a/assets/components/src/category-autocomplete/style.scss
+++ b/assets/components/src/category-autocomplete/style.scss
@@ -1,0 +1,9 @@
+/**
+ * Category Autocomplete
+ */
+
+.newspack-category-autocomplete {
+	.components-form-token-field__help {
+		display: none;
+	}
+}

--- a/assets/components/src/form-token-field/style.scss
+++ b/assets/components/src/form-token-field/style.scss
@@ -81,7 +81,7 @@
 	// Help Text
 
 	.components-form-token-field__help {
-		margin: 0;
+		display: none;
 	}
 
 	// Multiple Form Token Field

--- a/assets/components/src/form-token-field/style.scss
+++ b/assets/components/src/form-token-field/style.scss
@@ -81,7 +81,7 @@
 	// Help Text
 
 	.components-form-token-field__help {
-		display: none;
+		margin: 0;
 	}
 
 	// Multiple Form Token Field


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The helper text underneath the `CategoryAutocomplete` component is confusing and doesn't accurately describe the behavior of the component (`Separate with commas or the enter key.`). This text is [hard-coded into the Gutenberg component](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/form-token-field/index.js#L660-L669), so for now the best way to resolve this is to hide it with CSS.

<img width="1049" alt="Screen Shot 2020-12-30 at 4 19 24 PM" src="https://user-images.githubusercontent.com/1477002/103382500-41507b80-4abd-11eb-850d-580b199a1777.png">

### How to test the changes in this Pull Request:

1. Build from this branch, verify the helper text is gone. This can be done by viewing the category filtering in the Campaigns Wizard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->