### PR TITLE
fix: rework segmentation add button to match standard wizard pattern

### DIFF
--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -292,6 +292,11 @@ class PopupsWizard extends Component {
 										<Segmentation
 											{ ...props }
 											{ ...sharedProps }
+											buttonText={
+												props.location.pathname.match( /^\/segmentation\/?$/ ) &&
+												__( 'Add new segment', 'newspack' )
+											}
+											buttonAction="#/segmentation/new"
 											setSegments={ segmentsList => this.setState( { segments: segmentsList } ) }
 										/>
 									) }

--- a/assets/wizards/popups/views/segmentation/SegmentsList.js
+++ b/assets/wizards/popups/views/segmentation/SegmentsList.js
@@ -19,13 +19,7 @@ import DeleteIcon from '@material-ui/icons/Delete';
  */
 import { ActionCard, Popover, Button, Router } from '../../../../components/src';
 
-const { NavLink, useHistory } = Router;
-
-const AddNewSegmentLink = () => (
-	<NavLink to="segmentation/new">
-		<Button isPrimary>{ __( 'Add new', 'newspack' ) }</Button>
-	</NavLink>
-);
+const { useHistory } = Router;
 
 const SegmentActionCard = ( { segment, deleteSegment } ) => {
 	const [ popoverVisibility, setPopoverVisibility ] = useState( false );
@@ -92,9 +86,6 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments } ) => {
 
 	return segments.length ? (
 		<div className="newspack-campaigns-wizard-segments__list-wrapper">
-			<div className="newspack-campaigns-wizard-segments__list-top">
-				<AddNewSegmentLink />
-			</div>
 			<div className="newspack-campaigns-wizard-segments__list">
 				{ segments.map( segment => (
 					<SegmentActionCard
@@ -114,7 +105,6 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments } ) => {
 					'newspack'
 				) }
 			</div>
-			<AddNewSegmentLink />
 		</div>
 	);
 };

--- a/assets/wizards/popups/views/segmentation/style.scss
+++ b/assets/wizards/popups/views/segmentation/style.scss
@@ -5,10 +5,6 @@
 		margin: -16px 0 32px;
 	}
 
-	&__list-top {
-		display: flex;
-		flex-direction: row-reverse;
-	}
 	&__list {
 		margin-top: 20px;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `Add New` button in the `Segmentation` tab of the `Campaigns` wizard is slightly different from other Add buttons in the wizards. The button is positioned above the `ActionCards` as opposed to below which is the standard. This branch reconfigures it to follow convention.

### How to test the changes in this Pull Request:

Verify the `Add new segment` button follows the convention of the `Overlay` and `Inline` tabs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->