### PR TITLE
feat: segmentation webview

### DIFF
--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -61,7 +61,7 @@ class WebPreview extends Component {
 	 * Create JSX for the modal
 	 */
 	getWebPreviewModal = () => {
-		const { url } = this.props;
+		const { beforeLoad = () => {}, onClose = () => {}, url } = this.props;
 		const { device, loaded, isPreviewVisible } = this.state;
 
 		if ( ! this.modalDOMElement || ! isPreviewVisible ) {
@@ -73,7 +73,7 @@ class WebPreview extends Component {
 			device,
 			loaded && 'newspack-web-preview__is-loaded'
 		);
-
+		beforeLoad();
 		return createPortal(
 			<div className={ classes }>
 				<div className="newspack-web-preview__interior">
@@ -108,7 +108,12 @@ class WebPreview extends Component {
 							</Button>
 						</div>
 						<div className="newspack-web-preview__toolbar-right">
-							<Button onClick={ () => this.setState( { isPreviewVisible: false, loaded: false } ) }>
+							<Button
+								onClick={ () => {
+									onClose();
+									this.setState( { isPreviewVisible: false, loaded: false } );
+								} }
+							>
 								<Icon icon={ close } />
 								<span className="screen-reader-text">{ __( 'Close preview' ) }</span>
 							</Button>

--- a/assets/wizards/popups/components/segmentation-preview/index.js
+++ b/assets/wizards/popups/components/segmentation-preview/index.js
@@ -1,0 +1,73 @@
+/**
+ * Segmentation Preview component.
+ * Extension of WebPreview with support for "view-as-segment" functionality.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies.
+ */
+import { WebPreview } from '../../../../components/src';
+
+const SegmentationPreview = props => {
+	const postPreviewLink = window?.newspack_popups_wizard_data?.preview_post;
+	const frontendUrl = window?.newspack_popups_wizard_data?.frontend_url || '/';
+
+	const {
+		campaignGroups = [],
+		onLoad = () => {},
+		segment = '',
+		url = postPreviewLink || frontendUrl,
+	} = props;
+
+	const decorateURL = urlToDecorate => {
+		const params = {
+			view_as: [
+				`groups:${ campaignGroups.join( ',' ) }`,
+				...( segment.length ? [ `segment:${ segment }` ] : [] ),
+			].join( ';' ),
+		};
+		return addQueryArgs( urlToDecorate, params );
+	};
+
+	const onWebPreviewLoad = iframeEl => {
+		if ( iframeEl ) {
+			[ ...iframeEl.contentWindow.document.querySelectorAll( 'a' ) ].forEach( anchor => {
+				const href = anchor.getAttribute( 'href' );
+				if ( href.indexOf( frontendUrl ) === 0 ) {
+					anchor.setAttribute( 'href', decorateURL( href ) );
+				}
+			} );
+			onLoad( iframeEl );
+		}
+	};
+
+	const beforeLoad = () => {
+		localStorage.setItem( 'newspack_campaigns-preview-segmentId', JSON.stringify( segment ) );
+		localStorage.setItem(
+			'newspack_campaigns-preview-groupTaxIds',
+			JSON.stringify( campaignGroups )
+		);
+	};
+
+	const onClose = () => {
+		localStorage.removeItem( 'newspack_campaigns-preview-segmentId' );
+		localStorage.removeItem( 'newspack_campaigns-preview-groupTaxIds' );
+	};
+
+	return (
+		<WebPreview
+			{ ...props }
+			beforeLoad={ beforeLoad }
+			onClose={ onClose }
+			onLoad={ onWebPreviewLoad }
+			url={ decorateURL( url ) }
+		/>
+	);
+};
+
+export default SegmentationPreview;

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -1,22 +1,2 @@
-/**
- * WordPress dependencies.
- */
-import { useState } from '@wordpress/element';
-
 export const isOverlay = popup =>
 	[ 'top', 'bottom', 'center' ].indexOf( popup.options.placement ) >= 0;
-
-export const useStateWithPersistence = ( keyName, fallback ) => {
-	let defaultValue;
-	try {
-		defaultValue = JSON.parse( localStorage.getItem( `newspack_${ keyName }` ) );
-	} catch ( e ) {}
-	const [ value, setValue ] = useState( defaultValue || fallback );
-	return [
-		value,
-		newValue => {
-			setValue( newValue );
-			localStorage.setItem( `newspack_${ keyName }`, JSON.stringify( newValue ) );
-		},
-	];
-};

--- a/assets/wizards/popups/views/preview/index.js
+++ b/assets/wizards/popups/views/preview/index.js
@@ -1,52 +1,27 @@
 /**
  * WordPress dependencies
  */
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies.
  */
 import {
 	withWizardScreen,
-	WebPreview,
 	Button,
 	SelectControl,
 	CategoryAutocomplete,
 } from '../../../../components/src';
-import { useStateWithPersistence } from '../../utils';
+import SegmentationPreview from '../../components/segmentation-preview';
 import './style.scss';
 
 /**
  * Popups "View As" Preview screen.
  */
 const Preview = ( { segments } ) => {
-	const [ segmentId, setSegmentId ] = useStateWithPersistence( 'campaigns-preview-segmentId', '' );
-	const [ groupTaxIds, setGroupTaxSlug ] = useStateWithPersistence(
-		'campaigns-preview-groupTaxIds',
-		[]
-	);
-
-	const postPreviewLink = window?.newspack_popups_wizard_data?.preview_post;
-	const frontendUrl = window?.newspack_popups_wizard_data?.frontend_url || '/';
-
-	const params = {
-		view_as: [
-			`groups:${ groupTaxIds.join( ',' ) }`,
-			...( segmentId.length ? [ `segment:${ segmentId }` ] : [] ),
-		].join( ';' ),
-	};
-
-	const onWebPreviewLoad = iframeEl => {
-		if ( iframeEl ) {
-			[ ...iframeEl.contentWindow.document.querySelectorAll( 'a' ) ].forEach( anchor => {
-				const href = anchor.getAttribute( 'href' );
-				if ( href.indexOf( frontendUrl ) === 0 ) {
-					anchor.setAttribute( 'href', addQueryArgs( href, params ) );
-				}
-			} );
-		}
-	};
+	const [ segmentId, setSegmentId ] = useState( '' );
+	const [ groupTaxIds, setGroupTaxIds ] = useState( [] );
 
 	return (
 		<div className="newspack-campaigns-wizard-preview">
@@ -68,14 +43,14 @@ const Preview = ( { segments } ) => {
 			<CategoryAutocomplete
 				value={ groupTaxIds }
 				onChange={ selected => {
-					setGroupTaxSlug( selected.map( item => item.id ) );
+					setGroupTaxIds( selected.map( item => item.id ) );
 				} }
 				taxonomy="newspack_popups_taxonomy"
 				label={ __( 'Groups', 'newspack' ) }
 			/>
-			<WebPreview
-				onLoad={ onWebPreviewLoad }
-				url={ addQueryArgs( postPreviewLink || frontendUrl, params ) }
+			<SegmentationPreview
+				campaignGroups={ groupTaxIds }
+				segment={ segmentId }
 				renderButton={ ( { showPreview } ) => (
 					<Button isPrimary onClick={ showPreview }>
 						{ __( 'Preview', 'newspack' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This branch introduces `SegmentationPreview`, a new component in the Campaigns Wizard. The component combines logic from the `Preview` view and the `useStateWithPersistence` utility function, which will make it easier and more semantically clear to add the "view-as-segment" feature in multiple places. This also has the slight advantage of setting `localStorage` variables just before previewing, and unsetting them after the preview has been closed. 

### How to test the changes in this Pull Request:

This is a refactor, there should be no visible changes.

1. Verify the Preview feature in Campaigns Wizard works exactly as it did before. Test with no segment, segment set, segment + single campaign group, segment + multiple campaign groups.
2. Verify the `WebPreview` works normally in other contexts, e.g. the Site Design wizard.
3. Bonus: check localStorage before/during/after previewing as a segment. `newspack_campaigns-preview-segmentId` and `newspack_campaigns-preview-groupTaxIds` should be present only while the window is opening. Note that if the page is exited without closing the preview window the keys won't be purged, but this isn't much of a concern.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->