### PR TITLE
feat: segment picker in campaign popover

### DIFF
--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -35,6 +35,7 @@ class PopupActionCard extends Component {
 			deletePopup,
 			popup,
 			previewPopup,
+			segments,
 			setCategoriesForPopup,
 			setSitewideDefaultPopup,
 			publishPopup,
@@ -75,6 +76,7 @@ class PopupActionCard extends Component {
 								deletePopup={ deletePopup }
 								onFocusOutside={ () => this.setState( { popoverVisibility: false } ) }
 								popup={ popup }
+								segments={ segments }
 								setSitewideDefaultPopup={ setSitewideDefaultPopup }
 								updatePopup={ updatePopup }
 								previewPopup={ previewPopup }

--- a/assets/wizards/popups/components/popup-popover/index.js
+++ b/assets/wizards/popups/components/popup-popover/index.js
@@ -42,13 +42,13 @@ class PopupPopover extends Component {
 			setSitewideDefaultPopup,
 			onFocusOutside,
 			publishPopup,
+			segments,
 			updatePopup,
 		} = this.props;
 		const { id, sitewide_default: sitewideDefault, edit_link: editLink, options, status } = popup;
-		const { frequency } = options;
+		const { frequency, selected_segment_id: selectedSegmentId } = options;
 		const isDraft = 'draft' === status;
 		const isTestMode = 'test' === frequency;
-
 		return (
 			<Popover
 				position="bottom left"
@@ -94,6 +94,20 @@ class PopupPopover extends Component {
 						/>
 					</MenuItem>
 				) }
+				<MenuItem className="newspack-button newspack-popup-action-card-select-button">
+					<SelectControl
+						onChange={ value => {
+							updatePopup( id, { selected_segment_id: value } );
+							onFocusOutside();
+						} }
+						className="newspack-popup-action-card-select"
+						options={ [
+							{ label: __( 'Default (no segment)', 'newspck' ), value: '' },
+							...segments.map( ( { name, id } ) => ( { label: name, value: id } ) ),
+						] }
+						value={ selectedSegmentId }
+					/>
+				</MenuItem>
 				<MenuItem
 					onClick={ () => {
 						onFocusOutside();

--- a/assets/wizards/popups/components/popup-popover/index.js
+++ b/assets/wizards/popups/components/popup-popover/index.js
@@ -103,7 +103,7 @@ class PopupPopover extends Component {
 						className="newspack-popup-action-card-select"
 						options={ [
 							{ label: __( 'Default (no segment)', 'newspck' ), value: '' },
-							...segments.map( ( { name, id } ) => ( { label: name, value: id } ) ),
+							...segments.map( segment => ( { label: segment.name, value: segment.id } ) ),
 						] }
 						value={ selectedSegmentId }
 					/>

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -92,6 +92,7 @@ class PopupGroup extends Component {
 						key={ popup.id }
 						popup={ popup }
 						previewPopup={ previewPopup }
+						segments={ segments }
 						setCategoriesForPopup={ setCategoriesForPopup }
 						setSitewideDefaultPopup={ setSitewideDefaultPopup }
 						updatePopup={ updatePopup }

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -506,6 +506,18 @@ class Popups_Wizard extends Wizard {
 						return false;
 					}
 					break;
+				case 'selected_segment_id':
+					$cm       = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
+					$segments = array_map(
+						function( $segment ) {
+							return $segment['id'];
+						},
+						$cm->get_segments()
+					);
+					if ( strlen( $value ) > 0 && ! in_array( $value, $segments ) ) {
+						return false;
+					}
+					break;
 				default:
 					return false;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a `SelectControl` to each campaign's popover for choosing the segment.

### How to test the changes in this Pull Request:

1. Create a few segments. 
2. In Campaigns Wizard, click the three dots on the right of each `ActionCard`. Observe UI to pick Segment.
3. Set the Segment, verify the change is made.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->