### PR TITLE
Add min-width to popover and fix alignment

### DIFF
--- a/assets/components/src/popover/style.scss
+++ b/assets/components/src/popover/style.scss
@@ -10,9 +10,11 @@
 		border: 1px solid $light-gray-500;
 		border-radius: 4px;
 		box-shadow: 0 4px 8px rgba( black, 0.08 );
+		min-width: 238px;
 
 		.newspack-button {
 			color: $dark-gray-300;
+			display: flex;
 			font-weight: normal;
 			padding: 8px;
 
@@ -49,6 +51,11 @@
 			.components-menu-items__item-icon {
 				fill: $dark-gray-900;
 			}
+
+			.components-menu-item__item {
+				display: flex;
+				width: 100%;
+			}
 		}
 
 		.newspack-select-control {
@@ -75,6 +82,10 @@
 
 		.newspack-toggle-control {
 			margin: 0;
+
+			.components-base-control__field {
+				margin: 3px 0;
+			}
 
 			.components-form-toggle {
 				border-top: 0;

--- a/assets/wizards/popups/components/popup-popover/style.scss
+++ b/assets/wizards/popups/components/popup-popover/style.scss
@@ -1,3 +1,5 @@
+@import '~@wordpress/base-styles/colors';
+
 .newspack-popup-action-card-popover-control {
 	width: 100%;
 	display: flex;
@@ -8,8 +10,11 @@
 }
 
 .newspack-popup-info {
-	padding: 4px 13px;
-	background: #f7f7f7;
+	background: $light-gray-100;
+	color: $dark-gray-900;
+	font-size: 12px;
+	line-height: 16px;
+	padding: 4px 8px;
 	text-align: left;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

See title.

Closes #762

### How to test the changes in this Pull Request:

1. Enable Gutenberg 9.6.2
2. Go to Campaigns, click on the "More" button
3. Popover should be narrow
4. Switch to this branch
5. Click on the "More" button
6. Popover should be fine.
7. Disable Gutenberg
8. Test the popover again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->