### PR TITLE
Update the new segmentation wizard style to use Grid and Card

### DIFF
--- a/assets/components/src/form-token-field/style.scss
+++ b/assets/components/src/form-token-field/style.scss
@@ -10,6 +10,7 @@
 	font-size: 14px;
 	line-height: 24px;
 	margin: 32px 0;
+	width: 100%;
 
 	label {
 		color: $dark-gray-900;

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { useMemo, useEffect, useState } from '@wordpress/element';
+import { useMemo, useEffect, useState, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { find, debounce } from 'lodash';
@@ -11,24 +11,25 @@ import { find, debounce } from 'lodash';
  */
 import {
 	Button,
+	Card,
 	CategoryAutocomplete,
-	TextControl,
 	CheckboxControl,
+	Grid,
+	InfoButton,
 	Router,
+	TextControl,
 } from '../../../../components/src';
 
-const { NavLink, useHistory } = Router;
+const { useHistory } = Router;
 
 const SegmentSettingSection = ( { title, description, children } ) => (
-	<div className="newspack-campaigns-wizard-segments__section">
-		<h3>{ title }</h3>
-		{ description && (
-			<div className="newspack-campaigns-wizard-segments__section__description">
-				{ description }
-			</div>
-		) }
+	<Card noBorder className="newspack-campaigns-wizard-segments__section">
+		<div className="newspack-campaigns-wizard-segments__section__title">
+			<h2>{ title }</h2>
+			{ description && <InfoButton text={ description } /> }
+		</div>
 		<div className="newspack-campaigns-wizard-segments__section__content">{ children }</div>
-	</div>
+	</Card>
 );
 
 const DEFAULT_CONFIG = {
@@ -103,13 +104,17 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 	};
 
 	return (
-		<div>
-			<TextControl
-				placeholder={ __( 'Untitled Segment', 'newspack' ) }
-				value={ name }
-				onChange={ setName }
-			/>
-			<div className="newspack-campaigns-wizard-segments__sections-wrapper">
+		<Fragment>
+			<Card noBorder className="newspack-campaigns-wizard-segments__title">
+				<TextControl
+					placeholder={ __( 'Untitled Segment', 'newspack' ) }
+					value={ name }
+					onChange={ setName }
+					label={ __( 'Title', 'newspack' ) }
+					hideLabelFromVision={ true }
+				/>
+			</Card>
+			<Grid columns={ 3 }>
 				<SegmentSettingSection
 					title={ __( 'Articles read', 'newspack' ) }
 					description={ __( 'Number of articles read in the last 30 day period.', 'newspack' ) }
@@ -226,7 +231,7 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 						label={ __( 'Favorite Categories', 'newspack ' ) }
 					/>
 				</SegmentSettingSection>
-			</div>
+			</Grid>
 
 			{ reach.total > 0 && (
 				<div style={ { opacity: isFetchingReach ? 0.5 : 1 } }>
@@ -240,16 +245,14 @@ const SegmentsList = ( { segmentId, wizardApiFetch } ) => {
 			) }
 
 			<div className="newspack-buttons-card">
-				<div>
-					<NavLink to="/segmentation">
-						<Button>{ __( 'Cancel', 'newspack' ) }</Button>
-					</NavLink>
-					<Button disabled={ ! isSegmentValid } isPrimary onClick={ saveSegment }>
-						{ __( 'Save', 'newspack' ) }
-					</Button>
-				</div>
+				<Button disabled={ ! isSegmentValid } isPrimary onClick={ saveSegment }>
+					{ __( 'Save', 'newspack' ) }
+				</Button>
+				<Button isSecondary href="#/segmentation">
+					{ __( 'Cancel', 'newspack' ) }
+				</Button>
 			</div>
-		</div>
+		</Fragment>
 	);
 };
 

--- a/assets/wizards/popups/views/segmentation/style.scss
+++ b/assets/wizards/popups/views/segmentation/style.scss
@@ -1,10 +1,6 @@
 @import '~@wordpress/base-styles/colors';
 
 .newspack-campaigns-wizard-segments {
-	&__subheader {
-		margin: -16px 0 32px;
-	}
-
 	&__list-top {
 		display: flex;
 		flex-direction: row-reverse;
@@ -12,49 +8,38 @@
 	&__list {
 		margin-top: 20px;
 	}
-
-	&__sections-wrapper {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-start;
-		margin-left: -10px;
-		margin-right: -10px;
+	&__title {
+		margin: 32px 0 64px;
 	}
 	&__section {
-		flex: 1;
-		padding: 10px;
-		margin-bottom: 30px;
-		min-width: 100%;
-		@media screen and ( min-width: 600px ) {
-			min-width: 250px;
-			max-width: 250px;
+		h2 {
+			margin: 0;
 		}
-		h3 {
-			margin-top: 0;
-			margin-bottom: 15px;
-		}
-		&__description {
-			opacity: 0.6;
-			margin-top: -15px;
-			margin-bottom: 15px;
-			font-size: 0.9em;
+		&__title {
+			display: flex;
+			margin: 0 0 16px;
 		}
 		&__content {
 			> div {
-				margin-top: 10px;
+				margin-top: 16px;
 				display: flex;
 				align-items: center;
 				justify-content: space-between;
 				flex-wrap: wrap;
 				> * {
 					margin: 0;
-					&:not( :last-child ) {
-						margin-right: 10px;
-					}
 				}
 			}
-			.components-form-token-field__help {
-				display: none;
+			> *:last-child {
+				margin-bottom: 0 !important;
+			}
+			.newspack-form-token-field .components-form-token-field {
+				&__label {
+					display: none;
+				}
+				&__help {
+					display: block;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of some custom CSS, the layout now relies on Grid. I also added Card and use InfoButton for the descriptions to even the section titles.

After:

![1 after](https://user-images.githubusercontent.com/177929/103669869-c8479d00-4f70-11eb-95b2-eae0d2d98399.png)

Before:

![2 before](https://user-images.githubusercontent.com/177929/103669885-ced61480-4f70-11eb-9bdd-e05c93b21c30.png)

### How to test the changes in this Pull Request:

1. Add new segment
2. Switch to this branch
3. Add new segment

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->