### PR TITLE
feat: pass UTM params to Salesforce opportunities

### DIFF
--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -190,14 +190,18 @@ class Salesforce {
 			$contact['MailingCountry'] = $billing['country'];
 		}
 
-		$referer_tags       = 'none';
-		$referer_categories = 'none';
+		$lead_source = '';
+
 		foreach ( $data['meta_data'] as $meta_field ) {
-			if ( 'referer_tags' === $meta_field['key'] ) {
-				$referer_tags = $meta_field['value'];
-			}
-			if ( 'referer_categories' === $meta_field['key'] ) {
-				$referer_categories = $meta_field['value'];
+			if ( in_array( $meta_field['key'], array_keys( Donations::DONATION_ORDER_META_KEYS ) ) ) {
+				$meta_label = Donations::DONATION_ORDER_META_KEYS[ $meta_field['key'] ]['label'];
+				$meta_value = ! empty( $meta_field['value'] ) ? $meta_field['value'] : 'none';
+
+				if ( ! empty( $lead_source ) ) {
+					$lead_source .= '; ';
+				}
+
+				$lead_source .= $meta_label . ': ' . $meta_value;
 			}
 		}
 
@@ -209,7 +213,7 @@ class Salesforce {
 					'Description' => 'WooCommerce Order Number: ' . $data['id'],
 					'Name'        => $transaction['name'],
 					'StageName'   => 'Closed Won',
-					'LeadSource'  => 'Post categories: ' . $referer_categories . ', tags: ' . $referer_tags,
+					'LeadSource'  => $lead_source,
 				];
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If using the Newspack/WooCommerce checkout flow and Salesforce, allows any UTM params on the referring post URL to be passed through to the WooCommerce checkout page and then to the Salesforce Opportunity. UTM params are parsed and stored in the "Lead Source" field on the Salesforce Opportunity records. UTM params are only added to Lead Source if they exist in the referrer URL.

Also slightly changes handling of the referrer categories and tags: previously, if the referring post or page had no categories or tags, the "Post Categories" and "Tags" would still be added to the Lead Source field with a value of `none`. Now, to match handling of the UTM params, if there are no post categories or tags, these are omitted from the Lead Source field.

Closes #781.

### How to test the changes in this Pull Request:

1. Check out this branch. Make sure your site is set to use Newspack in Reader Revenue > Platform and that you have the required WooCommerce plugins setup and a Salesforce account linked. ([instructions](https://newspack.pub/support/reader-revenue/#getting-started))
2. Add a Donate block to a post with one or more categories and tags.
3. Visit the post on the front-end and append some UTM params to the URL, e.g. `?utm_source=YouTube&utm_medium=card&utm_campaign=Test&utm_term=video` (see https://ga-dev-tools.appspot.com/campaign-url-builder/ for a list of possible UTM params and their usage). Make sure to hit enter so the params actually get parsed on the server side.
4. Select options in the Donate block and click "Donate Now".
5. In the WooCommerce checkout page, confirm that you see all of the UTM params you appended to the prior URL still appended to this checkout page's URL. Also confirm that you see `referer_tags` and `referer_categories` params with values of the tags and categories from the prior post.
6. Fill out the checkout form and complete the donation.
7. After a few minutes, in Salesforce, view your Opportunities and find the Opportunity record that corresponds with your test donation.
8. Click on **Details** and look for the **Lead Source** field. Confirm that you see the info from the referring post's categories, tags, and UTM params here. It should be formatted something like: `Post Categories: news,tech; Post Tags: mobile devices; Campaign Source: YouTube; Campaign Medium: card; Campaign Name: test; Campaign Term: video`
9. Repeat steps 2-8 but with a post or page without any categories and tags and omitting some or all of the UTM params. Confirm that the resulting Opportunity record's Lead Source does not contain references to data that is missing or empty. (e.g., it shouldn't mention "Post Categories" if there are no categories or "Campaign Name" if there's no `utm_campaign` param).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->