### PR TITLE
Update style of the group's select control in the campaign wizard

### DIFF
--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -129,7 +129,7 @@ const PopupGroup = ( {
 						value={ campaignGroup }
 						onChange={ value => setCampaignGroup( +value ) }
 						label={ __( 'Groups', 'newspack' ) }
-						labelPosition="side"
+						hideLabelFromVision={ true }
 						disabled={ -1 === campaignGroups }
 					/>
 					{ campaignGroup > 0 && (

--- a/assets/wizards/popups/views/popup-group/style.scss
+++ b/assets/wizards/popups/views/popup-group/style.scss
@@ -2,6 +2,7 @@
  * Popup group
  */
 
+@import '~@wordpress/base-styles/colors';
 @import '../../../../shared/scss/colors';
 
 .newspack-campaigns__popup-group {
@@ -10,15 +11,22 @@
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
-		margin: 32px 0 -16px;
+		margin: 32px 0 -24px;
 
 		.newspack-select-control {
 			margin: 0;
 
 			.components-select-control {
 				select.components-select-control__input {
+					color: $dark-gray-900;
+					font-size: 17px;
+					font-weight: bold;
 					height: 36px;
+					line-height: 24px;
 					min-height: 36px;
+				}
+				div.components-input-control__backdrop {
+					border-color: $light-gray-100;
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hides the label and increases the font of the select, so it looks almost like a page title as opposed to a standard select

### How to test the changes in this Pull Request:

1. Navigate to campaigns
2. Notice the new Groups select

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->