### PR TITLE
Feat/campaign badges

### DIFF
--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -18,6 +18,15 @@ import { ActionCard, Button, CategoryAutocomplete } from '../../../../components
 import PopupPopover from '../popup-popover';
 import './style.scss';
 
+const placementForPopup = ( { options: { placement } } ) =>
+	( {
+		center: 'Center Overlay',
+		top: 'Top Overlay',
+		bottom: 'Bottom Overlay',
+		inline: 'Inline',
+		above_header: 'Above Header',
+	}[ placement ] );
+
 const PopupActionCard = ( {
 	className,
 	description,
@@ -43,6 +52,7 @@ const PopupActionCard = ( {
 	return (
 		<ActionCard
 			isSmall
+			badge={ placementForPopup( popup ) }
 			className={ className }
 			title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack' ) }
 			key={ id }

--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -20,11 +20,11 @@ import './style.scss';
 
 const placementForPopup = ( { options: { placement } } ) =>
 	( {
-		center: 'Center Overlay',
-		top: 'Top Overlay',
-		bottom: 'Bottom Overlay',
-		inline: 'Inline',
-		above_header: 'Above Header',
+		center: __( 'Center Overlay', 'newspack' ),
+		top: __( 'Top Overlay', 'newspack' ),
+		bottom: __( 'Bottom Overlay', 'newspack' ),
+		inline: __( 'Inline', 'newspack' ),
+		above_header: __( 'Above Header', 'newspack' ),
 	}[ placement ] );
 
 const PopupActionCard = ( {

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -30,17 +30,6 @@ const descriptionForPopup = (
 ) => {
 	const segment = find( segments, [ 'id', options.selected_segment_id ] );
 	const descriptionMessages = [];
-	switch ( options.placement ) {
-		case 'above_header':
-			descriptionMessages.push( __( 'Above header', 'newspack' ) );
-			break;
-		case 'inline':
-			descriptionMessages.push( __( 'Inline', 'newspack' ) );
-			break;
-		default:
-			descriptionMessages.push( __( 'Overlay', 'newspack' ) );
-			break;
-	}
 	if ( segment ) {
 		descriptionMessages.push( `${ __( 'Segment:', 'newspack' ) } ${ segment.name }` );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves campaign placements out of the `ActionCard` description and puts them in badges.

Closes https://github.com/Automattic/newspack-plugin/issues/787

<img width="1236" alt="Screen Shot 2021-01-07 at 12 29 56 PM" src="https://user-images.githubusercontent.com/1477002/103924547-2cd73900-50e4-11eb-8c24-1bb2b1af79aa.png">

### How to test the changes in this Pull Request:

1. Create a campaign for every placement: overlay center, overlay top, overlay bottom, inline, above header.
2. Navigate to Campaigns wizard. Observe the placements are displayed in badges.
3. Observe the placement text is no longer in the descriptions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->