### PR TITLE
feat: taxonomy, segment and placement to popover

### DIFF
--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -63,15 +63,6 @@
 			line-height: 16px;
 		}
 
-		.newspack-form-token-field {
-			margin: 8px 0 0;
-
-			label {
-				font-size: 12px;
-				line-height: 16px;
-			}
-		}
-
 		& + & {
 			margin-top: -24px;
 		}
@@ -234,12 +225,6 @@
 
 	&.newspack-description-card {
 		font-style: italic;
-	}
-
-	// Form Token Field
-
-	.newspack-form-token-field {
-		margin: 16px 0 0;
 	}
 
 	// Multiple Cards

--- a/assets/components/src/popover/index.js
+++ b/assets/components/src/popover/index.js
@@ -22,10 +22,18 @@ class Popover extends Component {
 	 * Render
 	 */
 	render() {
-		const { className, ...otherProps } = this.props;
-		const classes = classnames( 'newspack-popover', className );
+		const { className, padding, ...otherProps } = this.props;
+		const classes = classnames(
+			'newspack-popover',
+			padding && 'newspack-popover__padding-' + padding,
+			className
+		);
 		return <BaseComponent className={ classes } { ...otherProps } />;
 	}
 }
+
+Popover.defaultProps = {
+	padding: false,
+};
 
 export default Popover;

--- a/assets/components/src/popover/style.scss
+++ b/assets/components/src/popover/style.scss
@@ -16,7 +16,7 @@
 			color: $dark-gray-300;
 			display: flex;
 			font-weight: normal;
-			padding: 8px;
+			padding: 6px 8px;
 
 			&:hover {
 				.components-menu-items__item-icon {
@@ -33,7 +33,7 @@
 			&.is-link {
 				border-radius: 3px;
 				color: $dark-gray-300;
-				padding: 8px;
+				padding: 6px 8px;
 				text-decoration: none;
 
 				&:active,
@@ -60,14 +60,18 @@
 			}
 		}
 
+		.screen-reader-text {
+			display: flex;
+		}
+
 		.newspack-select-control {
 			margin: 0;
 			width: 100%;
 
 			.components-select-control {
 				select.components-select-control__input {
-					height: 40px;
-					min-height: 40px;
+					height: 36px;
+					min-height: 36px;
 
 					&:focus ~ div.components-input-control__backdrop {
 						border-color: $primary-500;
@@ -78,6 +82,24 @@
 				div.components-input-control__backdrop {
 					padding: 0;
 				}
+			}
+		}
+
+		.newspack-form-token-field {
+			margin: 0;
+			text-align: left;
+
+			.newspack-form-token-field__input-container {
+				min-height: 36px;
+				padding: 3px 5px;
+			}
+
+			.components-form-token-field__suggestions-list {
+				margin: 5px -3px -11px;
+			}
+
+			.components-form-token-field__label {
+				display: block;
 			}
 		}
 
@@ -98,19 +120,23 @@
 		border-color: $light-gray-500;
 	}
 
-	&:not( .has-select-border ) {
-		.components-select-control {
-			div.components-input-control__backdrop {
-				border-color: white;
-			}
-		}
-	}
-
 	&.is-from-bottom {
 		margin-bottom: 8px;
 	}
 
 	&.is-from-top {
 		margin-top: 8px;
+	}
+
+	&__padding-8 {
+		.components-popover__content {
+			padding: 8px;
+		}
+	}
+
+	&__padding-16 {
+		.components-popover__content {
+			padding: 16px;
+		}
 	}
 }

--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { useState, Fragment } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Tooltip } from '@wordpress/components';
-import { Icon, menu, moreVertical } from '@wordpress/icons';
+import { Icon, cog, moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -61,7 +61,7 @@ const PopupActionCard = ( {
 							className="icon-only"
 							onClick={ () => setCategoriesVisibility( ! categoriesVisibility ) }
 						>
-							<Icon icon={ menu } />
+							<Icon icon={ cog } />
 						</Button>
 					</Tooltip>
 					<Tooltip text={ __( 'More options', 'newspack' ) }>

--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -15,7 +15,8 @@ import { Icon, menu, moreVertical } from '@wordpress/icons';
  * Internal dependencies.
  */
 import { ActionCard, Button, CategoryAutocomplete } from '../../../../components/src';
-import PopupPopover from '../popup-popover';
+import PrimaryPopupPopover from '../popup-popover/primary';
+import SecondaryPopupPopover from '../popup-popover/secondary';
 import './style.scss';
 
 const PopupActionCard = ( {
@@ -72,39 +73,29 @@ const PopupActionCard = ( {
 						</Button>
 					</Tooltip>
 					{ popoverVisibility && (
-						<PopupPopover
+						<PrimaryPopupPopover
 							deletePopup={ deletePopup }
 							onFocusOutside={ () => setPopoverVisibility( false ) }
 							popup={ popup }
-							segments={ segments }
 							setSitewideDefaultPopup={ setSitewideDefaultPopup }
 							updatePopup={ updatePopup }
 							previewPopup={ previewPopup }
 							publishPopup={ 'publish' !== status ? publishPopup : null }
 						/>
 					) }
-				</Fragment>
-			}
-		>
-			{ categoriesVisibility && (
-				<Fragment>
-					<CategoryAutocomplete
-						value={ campaignGroups || [] }
-						onChange={ tokens => setTermsForPopup( id, tokens, 'newspack_popups_taxonomy' ) }
-						label={ __( 'Campaign groups', 'newspack' ) }
-						taxonomy="newspack_popups_taxonomy"
-					/>
-					{ ! sitewideDefault && (
-						<CategoryAutocomplete
-							value={ categories || [] }
-							onChange={ tokens => setTermsForPopup( id, tokens, 'category' ) }
-							label={ __( 'Category filtering', 'newspack ' ) }
-							disabled={ sitewideDefault }
+					{ categoriesVisibility && (
+						<SecondaryPopupPopover
+							deletePopup={ deletePopup }
+							onFocusOutside={ () => setCategoriesVisibility( false ) }
+							popup={ popup }
+							segments={ segments }
+							setTermsForPopup={ setTermsForPopup }
+							updatePopup={ updatePopup }
 						/>
 					) }
 				</Fragment>
-			) }
-		</ActionCard>
+			}
+		></ActionCard>
 	);
 };
 export default PopupActionCard;

--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -33,12 +33,7 @@ const PopupActionCard = ( {
 } ) => {
 	const [ categoriesVisibility, setCategoriesVisibility ] = useState( false );
 	const [ popoverVisibility, setPopoverVisibility ] = useState( false );
-	const {
-		id,
-		title,
-		sitewide_default: sitewideDefault,
-		status,
-	} = popup;
+	const { id, title, sitewide_default: sitewideDefault, status } = popup;
 	return (
 		<ActionCard
 			isSmall

--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -14,7 +14,7 @@ import { Icon, cog, moreVertical } from '@wordpress/icons';
 /**
  * Internal dependencies.
  */
-import { ActionCard, Button, CategoryAutocomplete } from '../../../../components/src';
+import { ActionCard, Button } from '../../../../components/src';
 import PrimaryPopupPopover from '../popup-popover/primary';
 import SecondaryPopupPopover from '../popup-popover/secondary';
 import './style.scss';
@@ -35,8 +35,6 @@ const PopupActionCard = ( {
 	const [ popoverVisibility, setPopoverVisibility ] = useState( false );
 	const {
 		id,
-		campaign_groups: campaignGroups,
-		categories,
 		title,
 		sitewide_default: sitewideDefault,
 		status,

--- a/assets/wizards/popups/components/popup-action-card/style.scss
+++ b/assets/wizards/popups/components/popup-action-card/style.scss
@@ -17,8 +17,4 @@
 			border-top: 1px solid $light-gray-500;
 		}
 	}
-
-	&:not( .newspack-card__is-primary ) .newspack-popover {
-		margin-left: 18px;
-	}
 }

--- a/assets/wizards/popups/components/popup-popover/primary.js
+++ b/assets/wizards/popups/components/popup-popover/primary.js
@@ -13,7 +13,7 @@ import { ESCAPE } from '@wordpress/keycodes';
 /**
  * Internal dependencies.
  */
-import { Popover, SelectControl, ToggleControl } from '../../../../components/src';
+import { Popover, ToggleControl } from '../../../../components/src';
 import { isOverlay } from '../../utils';
 import './style.scss';
 
@@ -22,12 +22,6 @@ const frequencyMap = {
 	once: __( 'Once', 'newspack' ),
 	daily: __( 'Once a day', 'newspack' ),
 	always: __( 'Every page', 'newspack' ),
-};
-
-const frequenciesForPopup = popup => {
-	return Object.keys( frequencyMap )
-		.filter( key => ! ( 'always' === key && isOverlay( popup ) ) )
-		.map( key => ( { label: frequencyMap[ key ], value: key } ) );
 };
 
 const PrimaryPopupPopover = ( {
@@ -40,7 +34,7 @@ const PrimaryPopupPopover = ( {
 	updatePopup,
 } ) => {
 	const { id, sitewide_default: sitewideDefault, edit_link: editLink, options, status } = popup;
-	const { frequency, selected_segment_id: selectedSegmentId } = options;
+	const { frequency } = options;
 	const isDraft = 'draft' === status;
 	const isTestMode = 'test' === frequency;
 	return (

--- a/assets/wizards/popups/components/popup-popover/primary.js
+++ b/assets/wizards/popups/components/popup-popover/primary.js
@@ -17,13 +17,6 @@ import { Popover, ToggleControl } from '../../../../components/src';
 import { isOverlay } from '../../utils';
 import './style.scss';
 
-const frequencyMap = {
-	never: __( 'Never', 'newspack' ),
-	once: __( 'Once', 'newspack' ),
-	daily: __( 'Once a day', 'newspack' ),
-	always: __( 'Every page', 'newspack' ),
-};
-
 const PrimaryPopupPopover = ( {
 	deletePopup,
 	popup,

--- a/assets/wizards/popups/components/popup-popover/primary.js
+++ b/assets/wizards/popups/components/popup-popover/primary.js
@@ -48,7 +48,11 @@ const PrimaryPopupPopover = ( {
 			position="bottom left"
 			onFocusOutside={ onFocusOutside }
 			onKeyDown={ event => ESCAPE === event.keyCode && onFocusOutside() }
+			className="newspack-popover__campaigns__primary-popover"
 		>
+			<MenuItem onClick={ () => onFocusOutside() } className="screen-reader-text">
+				{ __( 'Close Popover', 'newspack' ) }
+			</MenuItem>
 			{ isOverlay( { options } ) && ! isTestMode && ! isDraft && (
 				<MenuItem
 					onClick={ () => {
@@ -57,7 +61,7 @@ const PrimaryPopupPopover = ( {
 					} }
 					className="newspack-button"
 				>
-					<div className="newspack-popup-action-card-popover-control">
+					<div className="newspack-popover__campaigns__toggle-control">
 						{ __( 'Sitewide default', 'newspack' ) }
 						<ToggleControl checked={ sitewideDefault } onChange={ () => null } />
 					</div>
@@ -70,7 +74,7 @@ const PrimaryPopupPopover = ( {
 				} }
 				className="newspack-button"
 			>
-				<div className="newspack-popup-action-card-popover-control">
+				<div className="newspack-popover__campaigns__toggle-control">
 					{ __( 'Test mode', 'newspack' ) }
 					<ToggleControl checked={ isTestMode } onChange={ () => null } />
 				</div>
@@ -95,7 +99,7 @@ const PrimaryPopupPopover = ( {
 			<MenuItem onClick={ () => deletePopup( id ) } className="newspack-button">
 				{ __( 'Delete', 'newspack' ) }
 			</MenuItem>
-			<div className="newspack-popup-info">
+			<div className="newspack-popover__campaigns__info">
 				{ __( 'ID:', 'newspack' ) } { popup.id }
 			</div>
 		</Popover>

--- a/assets/wizards/popups/components/popup-popover/primary.js
+++ b/assets/wizards/popups/components/popup-popover/primary.js
@@ -30,14 +30,13 @@ const frequenciesForPopup = popup => {
 		.map( key => ( { label: frequencyMap[ key ], value: key } ) );
 };
 
-const PopupPopover = ( {
+const PrimaryPopupPopover = ( {
 	deletePopup,
 	popup,
 	previewPopup,
 	setSitewideDefaultPopup,
 	onFocusOutside,
 	publishPopup,
-	segments,
 	updatePopup,
 } ) => {
 	const { id, sitewide_default: sitewideDefault, edit_link: editLink, options, status } = popup;
@@ -76,33 +75,6 @@ const PopupPopover = ( {
 					<ToggleControl checked={ isTestMode } onChange={ () => null } />
 				</div>
 			</MenuItem>
-			{ 'test' !== frequency && (
-				<MenuItem className="newspack-button newspack-popup-action-card-select-button">
-					<SelectControl
-						onChange={ value => {
-							updatePopup( id, { frequency: value } );
-							onFocusOutside();
-						} }
-						className="newspack-popup-action-card-select"
-						options={ frequenciesForPopup( popup ) }
-						value={ frequency }
-					/>
-				</MenuItem>
-			) }
-			<MenuItem className="newspack-button newspack-popup-action-card-select-button">
-				<SelectControl
-					onChange={ value => {
-						updatePopup( id, { selected_segment_id: value } );
-						onFocusOutside();
-					} }
-					className="newspack-popup-action-card-select"
-					options={ [
-						{ label: __( 'Default (no segment)', 'newspck' ), value: '' },
-						...segments.map( ( { name, id: segmentId } ) => ( { label: name, value: segmentId } ) ),
-					] }
-					value={ selectedSegmentId }
-				/>
-			</MenuItem>
 			<MenuItem
 				onClick={ () => {
 					onFocusOutside();
@@ -129,4 +101,4 @@ const PopupPopover = ( {
 		</Popover>
 	);
 };
-export default PopupPopover;
+export default PrimaryPopupPopover;

--- a/assets/wizards/popups/components/popup-popover/secondary.js
+++ b/assets/wizards/popups/components/popup-popover/secondary.js
@@ -12,11 +12,7 @@ import { ESCAPE } from '@wordpress/keycodes';
 /**
  * Internal dependencies.
  */
-import {
-	CategoryAutocomplete,
-	Popover,
-	SelectControl,
-} from '../../../../components/src';
+import { CategoryAutocomplete, Popover, SelectControl } from '../../../../components/src';
 import { isOverlay } from '../../utils';
 import './style.scss';
 
@@ -46,7 +42,6 @@ const SecondaryPopupPopover = ( {
 		id,
 		sitewide_default: sitewideDefault,
 		options,
-		status,
 	} = popup;
 	const { frequency, selected_segment_id: selectedSegmentId } = options;
 	return (

--- a/assets/wizards/popups/components/popup-popover/secondary.js
+++ b/assets/wizards/popups/components/popup-popover/secondary.js
@@ -59,51 +59,48 @@ const SecondaryPopupPopover = ( {
 			position="bottom left"
 			onFocusOutside={ onFocusOutside }
 			onKeyDown={ event => ESCAPE === event.keyCode && onFocusOutside() }
+			padding={ 8 }
+			className="newspack-popover__campaigns__secondary-popover"
 		>
+			<MenuItem onClick={ () => onFocusOutside() } className="screen-reader-text">
+				{ __( 'Close Popover', 'newspack' ) }
+			</MenuItem>
 			{ 'test' !== frequency && (
-				<MenuItem className="newspack-button newspack-popup-action-card-select-button">
-					<SelectControl
-						onChange={ value => {
-							updatePopup( id, { frequency: value } );
-							onFocusOutside();
-						} }
-						className="newspack-popup-action-card-select"
-						options={ frequenciesForPopup( popup ) }
-						value={ frequency }
-					/>
-				</MenuItem>
-			) }
-			<MenuItem className="newspack-button newspack-popup-action-card-select-button">
 				<SelectControl
 					onChange={ value => {
-						updatePopup( id, { selected_segment_id: value } );
+						updatePopup( id, { frequency: value } );
 						onFocusOutside();
 					} }
-					className="newspack-popup-action-card-select"
-					options={ [
-						{ label: __( 'Default (no segment)', 'newspck' ), value: '' },
-						...segments.map( ( { name, id: segmentId } ) => ( { label: name, value: segmentId } ) ),
-					] }
-					value={ selectedSegmentId }
+					options={ frequenciesForPopup( popup ) }
+					value={ frequency }
+					label={ __( 'Frequency', 'newspack' ) }
 				/>
-			</MenuItem>
-			<MenuItem className="newspack-button newspack-popup-action-card-select-button">
-				<CategoryAutocomplete
-					value={ campaignGroups || [] }
-					onChange={ tokens => setTermsForPopup( id, tokens, 'newspack_popups_taxonomy' ) }
-					label={ __( 'Campaign groups', 'newspack' ) }
-					taxonomy="newspack_popups_taxonomy"
-				/>
-			</MenuItem>
+			) }
+			<SelectControl
+				onChange={ value => {
+					updatePopup( id, { selected_segment_id: value } );
+					onFocusOutside();
+				} }
+				options={ [
+					{ label: __( 'Default (no segment)', 'newspack' ), value: '' },
+					...segments.map( ( { name, id: segmentId } ) => ( { label: name, value: segmentId } ) ),
+				] }
+				value={ selectedSegmentId }
+				label={ __( 'Segmentation', 'newspack' ) }
+			/>
+			<CategoryAutocomplete
+				value={ campaignGroups || [] }
+				onChange={ tokens => setTermsForPopup( id, tokens, 'newspack_popups_taxonomy' ) }
+				label={ __( 'Campaign groups', 'newspack' ) }
+				taxonomy="newspack_popups_taxonomy"
+			/>
 			{ ! sitewideDefault && (
-				<MenuItem className="newspack-button newspack-popup-action-card-select-button">
-					<CategoryAutocomplete
-						value={ categories || [] }
-						onChange={ tokens => setTermsForPopup( id, tokens, 'category' ) }
-						label={ __( 'Category filtering', 'newspack ' ) }
-						disabled={ sitewideDefault }
-					/>
-				</MenuItem>
+				<CategoryAutocomplete
+					value={ categories || [] }
+					onChange={ tokens => setTermsForPopup( id, tokens, 'category' ) }
+					label={ __( 'Category filtering', 'newspack ' ) }
+					disabled={ sitewideDefault }
+				/>
 			) }
 		</Popover>
 	);

--- a/assets/wizards/popups/components/popup-popover/secondary.js
+++ b/assets/wizards/popups/components/popup-popover/secondary.js
@@ -1,0 +1,111 @@
+/**
+ * Secondary Popup Action Card
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import { MenuItem } from '@wordpress/components';
+import { ESCAPE } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies.
+ */
+import {
+	CategoryAutocomplete,
+	Popover,
+	SelectControl,
+	ToggleControl,
+} from '../../../../components/src';
+import { isOverlay } from '../../utils';
+import './style.scss';
+
+const frequencyMap = {
+	never: __( 'Never', 'newspack' ),
+	once: __( 'Once', 'newspack' ),
+	daily: __( 'Once a day', 'newspack' ),
+	always: __( 'Every page', 'newspack' ),
+};
+
+const frequenciesForPopup = popup => {
+	return Object.keys( frequencyMap )
+		.filter( key => ! ( 'always' === key && isOverlay( popup ) ) )
+		.map( key => ( { label: frequencyMap[ key ], value: key } ) );
+};
+
+const SecondaryPopupPopover = ( {
+	popup,
+	onFocusOutside,
+	segments,
+	setTermsForPopup,
+	updatePopup,
+} ) => {
+	const {
+		campaign_groups: campaignGroups,
+		categories,
+		id,
+		sitewide_default: sitewideDefault,
+		edit_link: editLink,
+		options,
+		status,
+	} = popup;
+	const { frequency, selected_segment_id: selectedSegmentId } = options;
+	const isDraft = 'draft' === status;
+	const isTestMode = 'test' === frequency;
+	return (
+		<Popover
+			position="bottom left"
+			onFocusOutside={ onFocusOutside }
+			onKeyDown={ event => ESCAPE === event.keyCode && onFocusOutside() }
+		>
+			{ 'test' !== frequency && (
+				<MenuItem className="newspack-button newspack-popup-action-card-select-button">
+					<SelectControl
+						onChange={ value => {
+							updatePopup( id, { frequency: value } );
+							onFocusOutside();
+						} }
+						className="newspack-popup-action-card-select"
+						options={ frequenciesForPopup( popup ) }
+						value={ frequency }
+					/>
+				</MenuItem>
+			) }
+			<MenuItem className="newspack-button newspack-popup-action-card-select-button">
+				<SelectControl
+					onChange={ value => {
+						updatePopup( id, { selected_segment_id: value } );
+						onFocusOutside();
+					} }
+					className="newspack-popup-action-card-select"
+					options={ [
+						{ label: __( 'Default (no segment)', 'newspck' ), value: '' },
+						...segments.map( ( { name, id: segmentId } ) => ( { label: name, value: segmentId } ) ),
+					] }
+					value={ selectedSegmentId }
+				/>
+			</MenuItem>
+			<MenuItem className="newspack-button newspack-popup-action-card-select-button">
+				<CategoryAutocomplete
+					value={ campaignGroups || [] }
+					onChange={ tokens => setTermsForPopup( id, tokens, 'newspack_popups_taxonomy' ) }
+					label={ __( 'Campaign groups', 'newspack' ) }
+					taxonomy="newspack_popups_taxonomy"
+				/>
+			</MenuItem>
+			{ ! sitewideDefault && (
+				<MenuItem className="newspack-button newspack-popup-action-card-select-button">
+					<CategoryAutocomplete
+						value={ categories || [] }
+						onChange={ tokens => setTermsForPopup( id, tokens, 'category' ) }
+						label={ __( 'Category filtering', 'newspack ' ) }
+						disabled={ sitewideDefault }
+					/>
+				</MenuItem>
+			) }
+		</Popover>
+	);
+};
+export default SecondaryPopupPopover;

--- a/assets/wizards/popups/components/popup-popover/secondary.js
+++ b/assets/wizards/popups/components/popup-popover/secondary.js
@@ -6,7 +6,6 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { decodeEntities } from '@wordpress/html-entities';
 import { MenuItem } from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';
 
@@ -17,7 +16,6 @@ import {
 	CategoryAutocomplete,
 	Popover,
 	SelectControl,
-	ToggleControl,
 } from '../../../../components/src';
 import { isOverlay } from '../../utils';
 import './style.scss';
@@ -47,13 +45,10 @@ const SecondaryPopupPopover = ( {
 		categories,
 		id,
 		sitewide_default: sitewideDefault,
-		edit_link: editLink,
 		options,
 		status,
 	} = popup;
 	const { frequency, selected_segment_id: selectedSegmentId } = options;
-	const isDraft = 'draft' === status;
-	const isTestMode = 'test' === frequency;
 	return (
 		<Popover
 			position="bottom left"

--- a/assets/wizards/popups/components/popup-popover/style.scss
+++ b/assets/wizards/popups/components/popup-popover/style.scss
@@ -1,24 +1,42 @@
 @import '~@wordpress/base-styles/colors';
 
-.newspack-popup-action-card-popover-control {
-	width: 100%;
-	display: flex;
-	justify-content: space-between;
-}
-.newspack-popup-action-card-select {
-	width: 100%;
-}
+.newspack-popover__campaigns {
+	&__toggle-control {
+		width: 100%;
+		display: flex;
+		justify-content: space-between;
+	}
 
-.newspack-popup-info {
-	background: $light-gray-100;
-	color: $dark-gray-900;
-	font-size: 12px;
-	line-height: 16px;
-	padding: 4px 8px;
-	text-align: left;
-}
+	&__primary-popover {
+		margin-left: 11px;
+	}
 
-.newspack-popup-action-card-select-button {
-	display: block;
-	padding: 0 !important;
+	&__secondary-popover {
+		margin-left: -25px;
+
+		.components-popover__content {
+			min-width: 286px;
+
+			> div > * {
+				margin: 0 0 8px;
+
+				&.newspack-select-control {
+					margin-bottom: 8px;
+				}
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+	}
+
+	&__info {
+		background: $light-gray-100;
+		color: $dark-gray-900;
+		font-size: 12px;
+		line-height: 16px;
+		padding: 4px 8px;
+		text-align: left;
+	}
 }

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -147,7 +147,6 @@ const PopupGroup = ( {
 									</Button>
 									{ previewPopoverIsVisible && (
 										<Popover
-											className="has-select-border"
 											position="bottom right"
 											onFocusOutside={ () => setPreviewPopoverIsVisible( false ) }
 											onKeyDown={ event =>

--- a/assets/wizards/popups/views/segmentation/SegmentsList.js
+++ b/assets/wizards/popups/views/segmentation/SegmentsList.js
@@ -11,10 +11,9 @@ import { ESCAPE } from '@wordpress/keycodes';
  * Material UI dependencies.
  */
 import EditIcon from '@material-ui/icons/Edit';
-import MoreVertIcon from '@material-ui/icons/MoreVert';
 import DeleteIcon from '@material-ui/icons/Delete';
 
-import { Icon, cog, moreVertical } from '@wordpress/icons';
+import { Icon, moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -25,7 +24,9 @@ const { NavLink, useHistory } = Router;
 
 const AddNewSegmentLink = () => (
 	<NavLink to="segmentation/new">
-		<Button isPrimary isSmall>{ __( 'Add new', 'newspack' ) }</Button>
+		<Button isPrimary isSmall>
+			{ __( 'Add new', 'newspack' ) }
+		</Button>
 	</NavLink>
 );
 

--- a/assets/wizards/popups/views/segmentation/SegmentsList.js
+++ b/assets/wizards/popups/views/segmentation/SegmentsList.js
@@ -14,6 +14,8 @@ import EditIcon from '@material-ui/icons/Edit';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import DeleteIcon from '@material-ui/icons/Delete';
 
+import { Icon, cog, moreVertical } from '@wordpress/icons';
+
 /**
  * Internal dependencies.
  */
@@ -23,7 +25,7 @@ const { NavLink, useHistory } = Router;
 
 const AddNewSegmentLink = () => (
 	<NavLink to="segmentation/new">
-		<Button isPrimary>{ __( 'Add new', 'newspack' ) }</Button>
+		<Button isPrimary isSmall>{ __( 'Add new', 'newspack' ) }</Button>
 	</NavLink>
 );
 
@@ -48,7 +50,7 @@ const SegmentActionCard = ( { segment, deleteSegment } ) => {
 							className="icon-only"
 							onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
 						>
-							<MoreVertIcon />
+							<Icon icon={ moreVertical } />
 						</Button>
 					</Tooltip>
 					{ popoverVisibility && (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR moves the Category filtering and Group selection to a Popover instead of a "toggle down".
It also moves the Frequency and Segmentation to that same Popover.
So we have 2 distinct Popovers now: "Settings" and "More".

### How to test the changes in this Pull Request:

1. Navigate to campaigns
2. Notice the Cog and the Dotted icon
3. Test both Popovers

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->