### PR TITLE
feat: linked titles in campaigns wizard action cards

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -76,7 +76,7 @@ class ActionCard extends Component {
 					) }
 					<div className="newspack-action-card__region newspack-action-card__region-center">
 						<h2>
-							<span className="newspack-action-card__title dope">
+							<span className="newspack-action-card__title">
 								{ titleLink ? <a href={ titleLink }>{ title }</a> : title }
 							</span>
 							{ badge && <span className="newspack-action-card__badge">{ badge }</span> }

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -76,14 +76,9 @@ class ActionCard extends Component {
 					) }
 					<div className="newspack-action-card__region newspack-action-card__region-center">
 						<h2>
-							{ titleLink ? (
-								<a href={ titleLink }>
-									<span className="newspack-action-card__title">{ title }</span>
-								</a>
-							) : (
-								<span className="newspack-action-card__title">{ title }</span>
-							) }
-
+							<span className="newspack-action-card__title dope">
+								{ titleLink ? <a href={ titleLink }>{ title }</a> : title }
+							</span>
 							{ badge && <span className="newspack-action-card__badge">{ badge }</span> }
 						</h2>
 						<p>{ description }</p>

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -48,6 +48,7 @@ class ActionCard extends Component {
 			onClick,
 			onSecondaryActionClick,
 			isWaiting,
+			titleLink,
 			toggleChecked,
 			toggleOnChange,
 		} = this.props;
@@ -75,7 +76,14 @@ class ActionCard extends Component {
 					) }
 					<div className="newspack-action-card__region newspack-action-card__region-center">
 						<h2>
-							<span className="newspack-action-card__title">{ title }</span>
+							{ titleLink ? (
+								<a href={ titleLink }>
+									<span className="newspack-action-card__title">{ title }</span>
+								</a>
+							) : (
+								<span className="newspack-action-card__title">{ title }</span>
+							) }
+
 							{ badge && <span className="newspack-action-card__badge">{ badge }</span> }
 						</h2>
 						<p>{ description }</p>

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -95,6 +95,11 @@
 		.newspack-action-card__title {
 			margin-right: 8px;
 		}
+
+		a {
+			color: inherit;
+			text-decoration: none;
+		}
 	}
 
 	// Regions

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -99,6 +99,12 @@
 		a {
 			color: inherit;
 			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: $primary-500;
+			}
 		}
 	}
 

--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -36,6 +36,7 @@ const PopupActionCard = ( {
 		id,
 		campaign_groups: campaignGroups,
 		categories,
+		edit_link: editLink,
 		title,
 		sitewide_default: sitewideDefault,
 		status,
@@ -45,6 +46,7 @@ const PopupActionCard = ( {
 			isSmall
 			className={ className }
 			title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack' ) }
+			titleLink={ decodeEntities( editLink ) }
 			key={ id }
 			description={ description }
 			actionText={

--- a/assets/wizards/popups/views/segmentation/SegmentsList.js
+++ b/assets/wizards/popups/views/segmentation/SegmentsList.js
@@ -36,6 +36,7 @@ const SegmentActionCard = ( { segment, deleteSegment } ) => {
 		<ActionCard
 			isSmall
 			title={ segment.name }
+			titleLink={ `#/segmentation/${ segment.id }` }
 			description={ `${ __( 'Created on', 'newspack' ) } ${ format(
 				'Y/m/d',
 				segment.created_at


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Link the titles of Campaign Wizard `ActionCard`s to edit pages. 

Closes https://github.com/Automattic/newspack-plugin/issues/791

### How to test the changes in this Pull Request:

1. Navigate to the Campaigns Wizard. 
2. Click the title of any Campaign `ActionCard`, observe you are taken to the Campaign's edit page.
3. Navigate to the Segmentation tab, click the title of any `ActionCard`. Observe you are taken to the segment's edit page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->