### PR TITLE
feat: support manual-only placement

### DIFF
--- a/assets/wizards/popups/components/popup-action-card/index.js
+++ b/assets/wizards/popups/components/popup-action-card/index.js
@@ -19,14 +19,18 @@ import PrimaryPopupPopover from '../popup-popover/primary';
 import SecondaryPopupPopover from '../popup-popover/secondary';
 import './style.scss';
 
-const placementForPopup = ( { options: { placement } } ) =>
-	( {
+const placementForPopup = ( { options: { frequency, placement } } ) => {
+	if ( 'manual' === frequency ) {
+		return __( 'Manual Placement', 'newspack' );
+	}
+	return {
 		center: __( 'Center Overlay', 'newspack' ),
 		top: __( 'Top Overlay', 'newspack' ),
 		bottom: __( 'Bottom Overlay', 'newspack' ),
 		inline: __( 'Inline', 'newspack' ),
 		above_header: __( 'Above Header', 'newspack' ),
-	}[ placement ] );
+	}[ placement ];
+};
 
 const PopupActionCard = ( {
 	className,

--- a/assets/wizards/popups/components/popup-popover/index.js
+++ b/assets/wizards/popups/components/popup-popover/index.js
@@ -22,6 +22,7 @@ const frequencyMap = {
 	once: __( 'Once', 'newspack' ),
 	daily: __( 'Once a day', 'newspack' ),
 	always: __( 'Every page', 'newspack' ),
+	manual: __( 'Manual Placement', 'newspack' ),
 };
 
 const frequenciesForPopup = popup => {

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -190,22 +190,22 @@ const PopupGroup = ( {
 								{ __( 'Close Popover', 'newspack' ) }
 							</MenuItem>
 							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt">
-								{ __( 'Inline Campaign', 'newspack' ) }
+								{ __( 'Inline', 'newspack' ) }
 							</MenuItem>
 							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-center">
-								{ __( 'Center Overlay Campaign', 'newspack' ) }
+								{ __( 'Center Overlay', 'newspack' ) }
 							</MenuItem>
 							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-top">
-								{ __( 'Top Overlay Campaign', 'newspack' ) }
+								{ __( 'Top Overlay', 'newspack' ) }
 							</MenuItem>
 							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-bottom">
-								{ __( 'Bottom Overlay Campaign', 'newspack' ) }
+								{ __( 'Bottom Overlay', 'newspack' ) }
 							</MenuItem>
 							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=above-header">
-								{ __( 'Above Header Campaign', 'newspack' ) }
+								{ __( 'Above Header', 'newspack' ) }
 							</MenuItem>
 							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=manual">
-								{ __( 'Manual Placement Campaign', 'newspack' ) }
+								{ __( 'Manual Placement', 'newspack' ) }
 							</MenuItem>
 						</Popover>
 					) }

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -204,6 +204,9 @@ const PopupGroup = ( {
 							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=above-header">
 								{ __( 'Above Header Campaign', 'newspack' ) }
 							</MenuItem>
+							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=manual">
+								{ __( 'Manual Placement Campaign', 'newspack' ) }
+							</MenuItem>
 						</Popover>
 					) }
 				</div>

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -502,7 +502,7 @@ class Popups_Wizard extends Wizard {
 		foreach ( $options as $key => $value ) {
 			switch ( $key ) {
 				case 'frequency':
-					if ( ! in_array( $value, [ 'test', 'never', 'once', 'daily', 'always' ] ) ) {
+					if ( ! in_array( $value, [ 'test', 'never', 'once', 'daily', 'always', 'manual' ] ) ) {
 						return false;
 					}
 					break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds Manual Placement UI to the Campaigns Wizard. Test with https://github.com/Automattic/newspack-popups/pull/373

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->