### PR TITLE
feat: popover to choose type of new campaign

### DIFF
--- a/assets/components/src/popover/style.scss
+++ b/assets/components/src/popover/style.scss
@@ -60,6 +60,15 @@
 			}
 		}
 
+		.components-menu-group__label {
+			color: $dark-gray-900;
+			font-size: 12px;
+			font-weight: bold;
+			line-height: 16px;
+			margin: 0;
+			padding: 10px 8px;
+		}
+
 		.screen-reader-text {
 			display: flex;
 		}

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -9,6 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
+import { MenuItem } from '@wordpress/components';
 
 /**
  * External dependencies.
@@ -61,6 +62,7 @@ const PopupGroup = ( {
 	const [ campaignGroups, setCampaignGroups ] = useState( -1 );
 	const [ segmentId, setSegmentId ] = useState();
 	const [ previewPopoverIsVisible, setPreviewPopoverIsVisible ] = useState();
+	const [ addNewPopoverIsVisible, setAddNewPopoverIsVisible ] = useState();
 
 	useEffect( () => {
 		apiFetch( {
@@ -168,9 +170,47 @@ const PopupGroup = ( {
 						/>
 					) }
 				</div>
-				<Button isPrimary isSmall href="/wp-admin/post-new.php?post_type=newspack_popups_cpt">
+				<Button
+					isPrimary
+					isSmall
+					onClick={ () => setAddNewPopoverIsVisible( ! addNewPopoverIsVisible ) }
+				>
 					{ __( 'Add New', 'newspack' ) }
 				</Button>
+				{ addNewPopoverIsVisible && (
+					<Popover
+						className="has-select-border"
+						position="bottom right"
+						onFocusOutside={ () => setAddNewPopoverIsVisible( false ) }
+						onKeyDown={ event => ESCAPE === event.keyCode && setAddNewPopoverIsVisible( false ) }
+					>
+						<MenuItem>
+							<a href="/wp-admin/post-new.php?post_type=newspack_popups_cpt">
+								{ __( 'Inline Campaign', 'newspack' ) }
+							</a>
+						</MenuItem>
+						<MenuItem>
+							<a href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-center">
+								{ __( 'Center Overlay Campaign', 'newspack' ) }
+							</a>
+						</MenuItem>
+						<MenuItem>
+							<a href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-top">
+								{ __( 'Top Overlay Campaign', 'newspack' ) }
+							</a>
+						</MenuItem>
+						<MenuItem>
+							<a href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-bottom">
+								{ __( 'Bottom Overlay Campaign', 'newspack' ) }
+							</a>
+						</MenuItem>
+						<MenuItem>
+							<a href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=above-header">
+								{ __( 'Above Header Campaign', 'newspack' ) }
+							</a>
+						</MenuItem>
+					</Popover>
+				) }
 			</div>
 			{ campaignsToDisplay.map( campaign => (
 				<PopupActionCard

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -184,6 +184,12 @@ const PopupGroup = ( {
 							onFocusOutside={ () => setAddNewPopoverIsVisible( false ) }
 							onKeyDown={ event => ESCAPE === event.keyCode && setAddNewPopoverIsVisible( false ) }
 						>
+							<MenuItem
+								onClick={ () => setAddNewPopoverIsVisible( false ) }
+								className="screen-reader-text"
+							>
+								{ __( 'Close Popover', 'newspack' ) }
+							</MenuItem>
 							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt">
 								{ __( 'Inline Campaign', 'newspack' ) }
 							</MenuItem>

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -170,47 +170,38 @@ const PopupGroup = ( {
 						/>
 					) }
 				</div>
-				<Button
-					isPrimary
-					isSmall
-					onClick={ () => setAddNewPopoverIsVisible( ! addNewPopoverIsVisible ) }
-				>
-					{ __( 'Add New', 'newspack' ) }
-				</Button>
-				{ addNewPopoverIsVisible && (
-					<Popover
-						className="has-select-border"
-						position="bottom right"
-						onFocusOutside={ () => setAddNewPopoverIsVisible( false ) }
-						onKeyDown={ event => ESCAPE === event.keyCode && setAddNewPopoverIsVisible( false ) }
+				<div className="newspack-campaigns__popup-group__add-new-button">
+					<Button
+						isPrimary
+						isSmall
+						onClick={ () => setAddNewPopoverIsVisible( ! addNewPopoverIsVisible ) }
 					>
-						<MenuItem>
-							<a href="/wp-admin/post-new.php?post_type=newspack_popups_cpt">
+						{ __( 'Add New', 'newspack' ) }
+					</Button>
+					{ addNewPopoverIsVisible && (
+						<Popover
+							position="bottom left"
+							onFocusOutside={ () => setAddNewPopoverIsVisible( false ) }
+							onKeyDown={ event => ESCAPE === event.keyCode && setAddNewPopoverIsVisible( false ) }
+						>
+							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt">
 								{ __( 'Inline Campaign', 'newspack' ) }
-							</a>
-						</MenuItem>
-						<MenuItem>
-							<a href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-center">
+							</MenuItem>
+							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-center">
 								{ __( 'Center Overlay Campaign', 'newspack' ) }
-							</a>
-						</MenuItem>
-						<MenuItem>
-							<a href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-top">
+							</MenuItem>
+							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-top">
 								{ __( 'Top Overlay Campaign', 'newspack' ) }
-							</a>
-						</MenuItem>
-						<MenuItem>
-							<a href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-bottom">
+							</MenuItem>
+							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=overlay-bottom">
 								{ __( 'Bottom Overlay Campaign', 'newspack' ) }
-							</a>
-						</MenuItem>
-						<MenuItem>
-							<a href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=above-header">
+							</MenuItem>
+							<MenuItem href="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=above-header">
 								{ __( 'Above Header Campaign', 'newspack' ) }
-							</a>
-						</MenuItem>
-					</Popover>
-				) }
+							</MenuItem>
+						</Popover>
+					) }
+				</div>
 			</div>
 			{ campaignsToDisplay.map( campaign => (
 				<PopupActionCard

--- a/assets/wizards/popups/views/popup-group/style.scss
+++ b/assets/wizards/popups/views/popup-group/style.scss
@@ -58,4 +58,14 @@
 			}
 		}
 	}
+
+	&__add-new-button {
+		position: relative;
+
+		.newspack-popover {
+			background: $primary-500;
+			border-color: $primary-600;
+			margin-left: 23px;
+		}
+	}
 }

--- a/assets/wizards/popups/views/popup-group/style.scss
+++ b/assets/wizards/popups/views/popup-group/style.scss
@@ -74,7 +74,8 @@
 			.components-popover__content {
 				background: $primary-500;
 				border-color: $primary-600;
-				min-width: 216px;
+				min-width: 206px;
+				text-align: right;
 
 				.components-menu-item__button {
 					background: $primary-500;
@@ -82,17 +83,18 @@
 					box-shadow: none;
 					border-radius: 3px;
 					color: white;
+					display: block;
 					font-size: 14px;
 					height: 40px;
 					line-height: 24px;
 					min-height: 40px;
-					padding: 8px;
+					padding: 8px 16px;
 					transition: background-color 125ms ease-in-out, box-shadow 125ms ease-in-out;
 
 					&:active,
 					&:hover,
 					&:focus {
-						background-color: $primary-600;
+						text-decoration: underline;
 					}
 
 					&:focus {

--- a/assets/wizards/popups/views/popup-group/style.scss
+++ b/assets/wizards/popups/views/popup-group/style.scss
@@ -72,29 +72,31 @@
 			margin-left: 23px;
 
 			.components-popover__content {
+				background: $primary-500;
+				border-color: $primary-600;
 				min-width: 216px;
 
-				a {
-					background: white;
+				.components-menu-item__button {
+					background: $primary-500;
 					border: 0;
 					box-shadow: none;
 					border-radius: 3px;
-					color: $dark-gray-300;
+					color: white;
 					font-size: 14px;
 					height: 40px;
 					line-height: 24px;
 					min-height: 40px;
 					padding: 8px;
-					transition: box-shadow 125ms ease-in-out, color 125ms ease-in-out;
+					transition: background-color 125ms ease-in-out, box-shadow 125ms ease-in-out;
 
 					&:active,
 					&:hover,
 					&:focus {
-						color: $primary-500;
+						background-color: $primary-600;
 					}
 
 					&:focus {
-						box-shadow: inset 0 0 0 2px $primary-500;
+						box-shadow: inset 0 0 0 2px white;
 					}
 				}
 			}

--- a/assets/wizards/popups/views/popup-group/style.scss
+++ b/assets/wizards/popups/views/popup-group/style.scss
@@ -68,12 +68,36 @@
 	}
 
 	&__add-new-button {
-		position: relative;
-
 		.newspack-popover {
-			background: $primary-500;
-			border-color: $primary-600;
 			margin-left: 23px;
+
+			.components-popover__content {
+				min-width: 216px;
+
+				a {
+					background: white;
+					border: 0;
+					box-shadow: none;
+					border-radius: 3px;
+					color: $dark-gray-300;
+					font-size: 14px;
+					height: 40px;
+					line-height: 24px;
+					min-height: 40px;
+					padding: 8px;
+					transition: box-shadow 125ms ease-in-out, color 125ms ease-in-out;
+
+					&:active,
+					&:hover,
+					&:focus {
+						color: $primary-500;
+					}
+
+					&:focus {
+						box-shadow: inset 0 0 0 2px $primary-500;
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Test along with Automattic/newspack-popups#374.

This PR adds a Popover to the "Add New" button that lets users pick which type of Campaign they want to create.

Closes https://github.com/Automattic/newspack-plugin/issues/790

### How to test the changes in this Pull Request:

1. Navigate to Campaigns
2. Click on the "Add New" button
3. Create every type of Campaign possible and check if it passed the correct settings in the editor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->