### PR TITLE
Small visual update to the campaign and segmentation wizards

### DIFF
--- a/assets/wizards/popups/components/popup-popover/secondary.js
+++ b/assets/wizards/popups/components/popup-popover/secondary.js
@@ -76,7 +76,7 @@ const SecondaryPopupPopover = ( {
 					...segments.map( ( { name, id: segmentId } ) => ( { label: name, value: segmentId } ) ),
 				] }
 				value={ selectedSegmentId }
-				label={ __( 'Segmentation', 'newspack' ) }
+				label={ __( 'Segment', 'newspack' ) }
 			/>
 			<CategoryAutocomplete
 				value={ campaignGroups || [] }

--- a/assets/wizards/popups/views/popup-group/style.scss
+++ b/assets/wizards/popups/views/popup-group/style.scss
@@ -67,3 +67,12 @@
 		}
 	}
 }
+
+.newspack-popups-wizard {
+	.newspack-action-card {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		min-height: 40px;
+	}
+}

--- a/assets/wizards/popups/views/segmentation/SegmentsList.js
+++ b/assets/wizards/popups/views/segmentation/SegmentsList.js
@@ -25,7 +25,7 @@ const { NavLink, useHistory } = Router;
 const AddNewSegmentLink = () => (
 	<NavLink to="segmentation/new">
 		<Button isPrimary isSmall>
-			{ __( 'Add new', 'newspack' ) }
+			{ __( 'Add New', 'newspack' ) }
 		</Button>
 	</NavLink>
 );

--- a/assets/wizards/popups/views/segmentation/style.scss
+++ b/assets/wizards/popups/views/segmentation/style.scss
@@ -4,9 +4,7 @@
 	&__list-top {
 		display: flex;
 		flex-direction: row-reverse;
-	}
-	&__list {
-		margin-top: 20px;
+		margin: 32px 0 -24px;
 	}
 	&__title {
 		margin: 32px 0 64px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds visual balance between the Campaigns and Segmentation wizrads

### How to test the changes in this Pull Request:

1. Check both wizards

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->