### PR TITLE
Salesforce: handle missing webhook

### DIFF
--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -64,7 +64,7 @@ class Salesforce extends Component {
 
 		// If we're already connected, check status of refresh token.
 		if ( ! prevProps.isConnected && isConnected ) {
-			return this.checkToken();
+			return this.checkConnectionStatus();
 		}
 	}
 
@@ -104,7 +104,6 @@ class Salesforce extends Component {
 				} );
 			}
 		} catch ( e ) {
-			console.error( e );
 			this.setState( {
 				error: __(
 					'We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again.',
@@ -119,25 +118,14 @@ class Salesforce extends Component {
 	 * The refresh token is valid until it's manually revoked in the Salesforce dashboard,
 	 * or the Connected App is deleted there.
 	 */
-	async checkToken() {
+	async checkConnectionStatus() {
 		const { wizardApiFetch } = this.props;
-		const error = __(
-			'We couldn’t validate the connection with Salesforce. Please verify the status of the Connected App in Salesforce.',
-			'newspack'
-		);
-
-		try {
-			const response = await wizardApiFetch( {
-				path: '/newspack/v1/wizard/salesforce/introspect',
-				method: 'POST',
-			} );
-
-			if ( true !== response.active ) {
-				this.setState( { error } );
-			}
-		} catch ( e ) {
-			console.error( e );
-			this.setState( { error } );
+		const response = await wizardApiFetch( {
+			path: '/newspack/v1/wizard/salesforce/connection-status',
+			method: 'POST',
+		} );
+		if ( response.error ) {
+			this.setState( { error: response.error } );
 		}
 	}
 
@@ -146,7 +134,7 @@ class Salesforce extends Component {
 	 */
 	render() {
 		const { data, isConnected, onChange } = this.props;
-		const { client_id, client_secret, error } = data;
+		const { client_id = '', client_secret = '', error } = data;
 
 		return (
 			<Grid>

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -265,10 +265,10 @@ class Reader_Revenue_Wizard extends Wizard {
 		// Check validity of refresh token with Salesforce.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/salesforce/introspect',
+			'/wizard/salesforce/connection-status',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_check_salesforce_token' ],
+				'callback'            => [ $this, 'api_check_salesforce_connection_status' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
@@ -516,8 +516,22 @@ class Reader_Revenue_Wizard extends Wizard {
 	 * @throws \Exception Error message.
 	 * @return WP_REST_Response with the active status.
 	 */
-	public function api_check_salesforce_token() {
+	public function api_check_salesforce_connection_status() {
 		$salesforce_settings = Salesforce::get_salesforce_settings();
+
+		// Check if the webhook is configured.
+		$webhook_id = get_option( Salesforce::SALESFORCE_WEBHOOK_ID, 0 );
+		$webhook    = wc_get_webhook( $webhook_id );
+		if ( null == $webhook ) {
+			return \rest_ensure_response(
+				[
+					'error' => __(
+						'Webhook is not configured.',
+						'newspack'
+					),
+				]
+			);
+		}
 
 		// Must have a valid API key and secret.
 		if (
@@ -525,7 +539,14 @@ class Reader_Revenue_Wizard extends Wizard {
 			empty( $salesforce_settings['client_secret'] ) ||
 			empty( $salesforce_settings['refresh_token'] )
 		) {
-			throw new \Exception( 'Invalid Consumer Key, Secret, or Refresh Token.' );
+			return \rest_ensure_response(
+				[
+					'error' => __(
+						'Invalid Consumer Key, Secret, or Refresh Token.',
+						'newspack'
+					),
+				]
+			);
 		}
 
 		// Hit Salesforce OAuth endpoint to introspect refresh token.
@@ -540,6 +561,17 @@ class Reader_Revenue_Wizard extends Wizard {
 		);
 
 		$response_body = json_decode( $salesforce_response['body'] );
+
+		if ( true !== $response_body->active ) {
+			return \rest_ensure_response(
+				[
+					'error' => __(
+						'We couldn’t validate the connection with Salesforce. Please verify the status of the Connected App in Salesforce.',
+						'newspack'
+					),
+				]
+			);
+		}
 
 		return \rest_ensure_response( $response_body );
 	}

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -526,7 +526,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			return \rest_ensure_response(
 				[
 					'error' => __(
-						'Webhook is not configured.',
+						'Webhook is not configured. Please try resetting your Salesforce connection and reconnecting.',
 						'newspack'
 					),
 				]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a warning when Salesforce integration webhook is not configured.

### How to test the changes in this Pull Request:

1. Ensure your SF connection is properly set up in Reader Revenue wizard
2. Break the webhook by deleting it (`wp-admin/admin.php?page=wc-settings&tab=advanced&section=webhooks`)
3. On `master`, verify there's no error in Reader Revenue wizard
4. Switch to this branch, observe an error notice about the missing webhook
5. Reset the SF connection, verify there's no error displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
