### PR TITLE
chore: remove unused localstorage implementation

### DIFF
--- a/assets/wizards/popups/components/segmentation-preview/index.js
+++ b/assets/wizards/popups/components/segmentation-preview/index.js
@@ -60,28 +60,7 @@ const SegmentationPreview = props => {
 			return null;
 		} );
 
-	const beforeLoad = () => {
-		localStorage.setItem( 'newspack_campaigns-preview-segmentId', JSON.stringify( segment ) );
-		localStorage.setItem(
-			'newspack_campaigns-preview-groupTaxIds',
-			JSON.stringify( sanitizeTerms( campaignGroups ) )
-		);
-	};
-
-	const onClose = () => {
-		localStorage.removeItem( 'newspack_campaigns-preview-segmentId' );
-		localStorage.removeItem( 'newspack_campaigns-preview-groupTaxIds' );
-	};
-
-	return (
-		<WebPreview
-			{ ...props }
-			beforeLoad={ beforeLoad }
-			onClose={ onClose }
-			onLoad={ onWebPreviewLoad }
-			url={ decorateURL( url ) }
-		/>
-	);
+	return <WebPreview { ...props } onLoad={ onWebPreviewLoad } url={ decorateURL( url ) } />;
 };
 
 export default SegmentationPreview;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes unused LocalStorage implementation as @adekbadek pointed out in https://github.com/Automattic/newspack-plugin/pull/770#issuecomment-757755549.

### How to test the changes in this Pull Request:

Verify preview functionality works as it did before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->