### PR TITLE
feat: add a sticky ad slot to the Advertising wizard

### DIFF
--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -34,6 +34,7 @@ class AdvertisingWizard extends Component {
 					global_above_footer: {},
 					archives: {},
 					search_results: {},
+					sticky: {},
 				},
 				services: {
 					google_ad_manager: {},
@@ -83,6 +84,7 @@ class AdvertisingWizard extends Component {
 		return wizardApiFetch( {
 			path: '/newspack/v1/wizard/advertising/service/' + service,
 			method: enabled ? 'POST' : 'DELETE',
+			quiet: true,
 		} )
 			.then( advertisingData => {
 				return new Promise( resolve => {
@@ -110,6 +112,7 @@ class AdvertisingWizard extends Component {
 		return wizardApiFetch( {
 			path: '/newspack/v1/wizard/advertising/placement/' + placement,
 			method: enabled ? 'POST' : 'DELETE',
+			quiet: true,
 		} )
 			.then( advertisingData => {
 				return new Promise( resolve => {
@@ -149,6 +152,7 @@ class AdvertisingWizard extends Component {
 			wizardApiFetch( {
 				path: '/newspack/v1/wizard/advertising/service/' + service + '/network_code',
 				method: 'post',
+				quiet: true,
 				data: {
 					network_code,
 				},
@@ -183,6 +187,7 @@ class AdvertisingWizard extends Component {
 					ad_unit: data.adUnit,
 					service: data.service,
 				},
+				quiet: true,
 			} )
 				.then( advertisingData => {
 					this.setState(
@@ -230,6 +235,7 @@ class AdvertisingWizard extends Component {
 				path: '/newspack/v1/wizard/advertising/ad_unit/' + ( id || 0 ),
 				method: 'post',
 				data,
+				quiet: true,
 			} )
 				.then( advertisingData => {
 					this.setState(
@@ -260,6 +266,7 @@ class AdvertisingWizard extends Component {
 			wizardApiFetch( {
 				path: '/newspack/v1/wizard/advertising/ad_unit/' + id,
 				method: 'delete',
+				quiet: true,
 			} )
 				.then( advertisingData => {
 					this.setState(

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -59,7 +59,9 @@ class Placements extends Component {
 			global_above_footer,
 			archives,
 			search_results,
+			sticky,
 		} = placements;
+
 		return (
 			<Fragment>
 				<h2>{ __( 'Pre-defined ad placements' ) }</h2>
@@ -131,6 +133,19 @@ class Placements extends Component {
 						services={ services }
 						value={ search_results }
 						onChange={ value => onChange( 'search_results', value ) }
+					/>
+				</ToggleGroup>
+				<ToggleGroup
+					title={ __( 'Sticky' ) }
+					description={ __( 'Choose a sticky ad unit to display at the bottom of the viewport' ) }
+					checked={ sticky && sticky.enabled }
+					onChange={ value => togglePlacement( 'sticky', value ) }
+				>
+					<AdPicker
+						adUnits={ adUnits }
+						services={ services }
+						value={ sticky }
+						onChange={ value => onChange( 'sticky', value ) }
 					/>
 				</ToggleGroup>
 			</Fragment>

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -597,7 +597,7 @@ class Advertising_Wizard extends Wizard {
 				<?php endif; ?>
 				<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
-		<?php
+			<?php
 		endif;
 	}
 

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -57,7 +57,7 @@ class Advertising_Wizard extends Wizard {
 	 *
 	 * @var array
 	 */
-	protected $placements = array( 'global_above_header', 'global_below_header', 'global_above_footer', 'archives', 'search_results' );
+	protected $placements = array( 'global_above_header', 'global_below_header', 'global_above_footer', 'archives', 'search_results', 'sticky' );
 
 	/**
 	 * Constructor.
@@ -68,6 +68,7 @@ class Advertising_Wizard extends Wizard {
 		add_action( 'before_header', [ $this, 'inject_above_header_ad' ] );
 		add_action( 'after_header', [ $this, 'inject_below_header_ad' ] );
 		add_action( 'before_footer', [ $this, 'inject_above_footer_ad' ] );
+		add_action( 'before_footer', [ $this, 'inject_sticky_ad' ] );
 		add_filter( 'newspack_ads_should_show_ads', [ $this, 'maybe_disable_gam_ads' ] );
 	}
 
@@ -517,6 +518,20 @@ class Advertising_Wizard extends Wizard {
 	}
 
 	/**
+	 * Inject a global sticky ad above the header.
+	 */
+	public function inject_sticky_ad() {
+		$placement = $this->get_placement_data( 'sticky' );
+		if ( ! $placement['enabled'] ) {
+			return;
+		}
+
+		if ( 'google_ad_manager' === $placement['service'] && ! empty( $placement['ad_unit'] ) ) {
+			$this->inject_ad_manager_global_ad( 'sticky' );
+		}
+	}
+
+	/**
 	 * Inject a global ad below the header.
 	 */
 	public function inject_below_header_ad() {
@@ -571,11 +586,19 @@ class Advertising_Wizard extends Wizard {
 			return;
 		}
 
-		?>
-		<div class='newspack_global_ad <?php echo esc_attr( $placement_slug ); ?>'>
-			<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		</div>
+		if ( 'sticky' === $placement_slug && $is_amp ) : ?>
+			<amp-sticky-ad class='newspack_amp_sticky_ad <?php echo esc_attr( $placement_slug ); ?>' layout="nodisplay">
+				<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			</amp-sticky-ad>
+		<?php else : ?>
+			<div class='newspack_global_ad <?php echo esc_attr( $placement_slug ); ?>'>
+				<?php if ( 'sticky' === $placement_slug ) : ?>
+					<button class='newspack_sticky_ad__close'></button>
+				<?php endif; ?>
+				<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			</div>
 		<?php
+		endif;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a new pre-defined sticky ad slot to the Advertising wizard. Test alongside https://github.com/Automattic/newspack-theme/pull/1208.

Closes https://github.com/Automattic/newspack-theme/issues/1199.

### How to test the changes in this Pull Request:

1. Check out this branch and run `npm run build`.
2. Go to **Newspack > Advertising** and make sure you have the relevant plugins and service providers configured to display ads.
3. Go to **Global Settings** and confirm there's a new slot for Sticky Ad:

<img width="730" alt="Screen Shot 2021-01-13 at 3 20 51 PM" src="https://user-images.githubusercontent.com/2230142/104517457-43353700-55b3-11eb-8bc5-bf70eb32ad66.png">

4. Enable the Sticky Ad slot and choose a provider and ad unit for the slot.
5. View the front-end of the site in both AMP and non-AMP mode. The unit should render in a fixed container at the bottom of the viewport. Note that the ad slot will render based on its ad unit, so it will only appear if the unit is filled.
6. Test the "close" button functionality in both AMP and non-AMP mode. Clicking the X button should hide the ad for the current page view only.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->