### PR TITLE
Use "all" in view-as spec

### DIFF
--- a/assets/wizards/popups/components/segmentation-preview/index.js
+++ b/assets/wizards/popups/components/segmentation-preview/index.js
@@ -27,7 +27,7 @@ const SegmentationPreview = props => {
 	} = props;
 
 	const decorateURL = urlToDecorate => {
-		const view_as = [ ...( segment.length ? [ `segment:${ segment }` ] : [] ) ];
+		const view_as = segment.length ? [ `segment:${ segment }` ] : [ 'all' ];
 
 		if ( showUnpublished ) {
 			view_as.push( 'show_unpublished:true' );

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -226,7 +226,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					description={ __( 'Most read categories of reader.', 'newspack' ) }
 				>
 					<CategoryAutocomplete
-						value={ segmentConfig.favorite_categories }
+						value={ segmentConfig.favorite_categories.map( v => parseInt( v ) ) }
 						onChange={ selected => {
 							updateSegmentConfig( 'favorite_categories' )( selected.map( item => item.id ) );
 						} }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Follow instructions in https://github.com/Automattic/newspack-popups/pull/395

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->