### PR TITLE
Segmentation UI improvements

### DIFF
--- a/assets/components/src/hooks/index.js
+++ b/assets/components/src/hooks/index.js
@@ -1,0 +1,3 @@
+import usePrompt from './usePrompt';
+
+export default { usePrompt };

--- a/assets/components/src/hooks/usePrompt.js
+++ b/assets/components/src/hooks/usePrompt.js
@@ -1,0 +1,56 @@
+// https://gist.github.com/sibelius/60a4e11da1f826b8d60dc3975a1ac805
+
+/**
+ * External dependencies.
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import Router from '../proxied-imports/router';
+
+const { useHistory } = Router;
+
+export default ( when, message ) => {
+	const history = useHistory();
+
+	const self = useRef( null );
+
+	const onWindowOrTabClose = event => {
+		if ( ! when ) {
+			return;
+		}
+
+		if ( typeof event === 'undefined' ) {
+			event = window.event;
+		}
+
+		if ( event ) {
+			event.returnValue = message;
+		}
+
+		return message;
+	};
+
+	useEffect( () => {
+		if ( when ) {
+			self.current = history.block( message );
+		} else {
+			self.current = null;
+		}
+
+		window.addEventListener( 'beforeunload', onWindowOrTabClose );
+
+		return () => {
+			if ( self.current ) {
+				self.current();
+				self.current = null;
+			}
+
+			window.removeEventListener( 'beforeunload', onWindowOrTabClose );
+		};
+	}, [ message, when ] );
+
+	return self.current;
+};

--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -34,3 +34,4 @@ export { default as withWizardScreen } from './with-wizard-screen';
 export { default as WizardPagination } from './wizard-pagination';
 
 export { default as Router } from './proxied-imports/router';
+export { default as hooks } from './hooks';

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -253,7 +253,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 						// eslint-disable-next-line no-nested-ternary
 						value={ segmentConfig.is_donor ? 1 : segmentConfig.is_not_donor ? 2 : 0 }
 						options={ [
-							{ value: 0, label: __( 'Both donors and non-donors', 'newspack' ) },
+							{ value: 0, label: __( 'Donors and non-donors', 'newspack' ) },
 							{ value: 1, label: __( 'Donors', 'newspack' ) },
 							{ value: 2, label: __( 'Non-donors', 'newspack' ) },
 						] }

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -66,6 +66,8 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	const isDirty =
 		segmentInitially !== null &&
 		JSON.stringify( segmentInitially ) !== JSON.stringify( segmentConfig );
+	const isEmpty = JSON.stringify( segmentConfig ) === JSON.stringify( DEFAULT_CONFIG );
+	console.log( segmentConfig, isEmpty );
 
 	const unblock = hooks.usePrompt(
 		isDirty,
@@ -223,9 +225,9 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 						// eslint-disable-next-line no-nested-ternary
 						value={ segmentConfig.is_subscribed ? 1 : segmentConfig.is_not_subscribed ? 2 : 0 }
 						options={ [
-							{ value: 0, label: __( 'N/A', 'newspack' ) },
-							{ value: 1, label: __( 'Is subscribed', 'newspack' ) },
-							{ value: 2, label: __( 'Is not subscribed', 'newspack' ) },
+							{ value: 0, label: __( 'Subscribers and non-subscribers', 'newspack' ) },
+							{ value: 1, label: __( 'Subscribers', 'newspack' ) },
+							{ value: 2, label: __( 'Non-subscribers', 'newspack' ) },
 						] }
 					/>
 				</SegmentSettingSection>
@@ -251,9 +253,9 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 						// eslint-disable-next-line no-nested-ternary
 						value={ segmentConfig.is_donor ? 1 : segmentConfig.is_not_donor ? 2 : 0 }
 						options={ [
-							{ value: 0, label: __( 'N/A', 'newspack' ) },
-							{ value: 1, label: __( 'Has donated', 'newspack' ) },
-							{ value: 2, label: __( "Hasn't donated", 'newspack' ) },
+							{ value: 0, label: __( 'Both donors and non-donors', 'newspack' ) },
+							{ value: 1, label: __( 'Donors', 'newspack' ) },
+							{ value: 2, label: __( 'Non-donors', 'newspack' ) },
 						] }
 					/>
 				</SegmentSettingSection>
@@ -295,7 +297,11 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 			) }
 
 			<div className="newspack-buttons-card">
-				<Button disabled={ ! isSegmentValid || ! isDirty } isPrimary onClick={ saveSegment }>
+				<Button
+					disabled={ ! isSegmentValid || ! isDirty || isEmpty }
+					isPrimary
+					onClick={ saveSegment }
+				>
 					{ __( 'Save', 'newspack' ) }
 				</Button>
 				<Button isSecondary href="#/segmentation">

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -67,7 +67,6 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 		segmentInitially !== null &&
 		JSON.stringify( segmentInitially ) !== JSON.stringify( segmentConfig );
 	const isEmpty = JSON.stringify( segmentConfig ) === JSON.stringify( DEFAULT_CONFIG );
-	console.log( segmentConfig, isEmpty );
 
 	const unblock = hooks.usePrompt(
 		isDirty,

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -14,6 +14,7 @@ import {
 	Card,
 	CategoryAutocomplete,
 	CheckboxControl,
+	SelectControl,
 	Grid,
 	InfoButton,
 	Router,
@@ -47,8 +48,12 @@ const DEFAULT_CONFIG = {
 
 const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	const [ segmentConfig, setSegmentConfig ] = useState( DEFAULT_CONFIG );
-	const updateSegmentConfig = key => value =>
-		setSegmentConfig( { ...segmentConfig, [ key ]: value } );
+	const updateSegmentConfig = keyOrPartialUpdate => {
+		if ( typeof keyOrPartialUpdate === 'string' ) {
+			return value => setSegmentConfig( { ...segmentConfig, [ keyOrPartialUpdate ]: value } );
+		}
+		return setSegmentConfig( { ...segmentConfig, ...keyOrPartialUpdate } );
+	};
 	const [ name, setName ] = useState( '' );
 	const [ isFetchingReach, setIsFetchingReach ] = useState( { total: 0, in_segment: 0 } );
 	const [ reach, setReach ] = useState( { total: 0, in_segment: 0 } );
@@ -183,30 +188,56 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					</div>
 				</SegmentSettingSection>
 				<SegmentSettingSection title={ __( 'Newsletter', 'newspack' ) }>
-					<CheckboxControl
-						checked={ segmentConfig.is_subscribed }
-						onChange={ updateSegmentConfig( 'is_subscribed' ) }
-						label={ __( 'Is subscribed to newsletter', 'newspack' ) }
-					/>
-					<CheckboxControl
-						checked={ segmentConfig.is_not_subscribed }
-						onChange={ updateSegmentConfig( 'is_not_subscribed' ) }
-						label={ __( 'Is not subscribed to newsletter', 'newspack' ) }
+					<SelectControl
+						onChange={ value => {
+							value = parseInt( value );
+							if ( value === 0 ) {
+								updateSegmentConfig( {
+									is_subscribed: false,
+									is_not_subscribed: false,
+								} );
+							} else {
+								updateSegmentConfig( {
+									is_subscribed: value === 1,
+									is_not_subscribed: value === 2,
+								} );
+							}
+						} }
+						// eslint-disable-next-line no-nested-ternary
+						value={ segmentConfig.is_subscribed ? 1 : segmentConfig.is_not_subscribed ? 2 : 0 }
+						options={ [
+							{ value: 0, label: __( 'N/A', 'newspack' ) },
+							{ value: 1, label: __( 'Is subscribed', 'newspack' ) },
+							{ value: 2, label: __( 'Is not subscribed', 'newspack' ) },
+						] }
 					/>
 				</SegmentSettingSection>
 				<SegmentSettingSection
 					title={ __( 'Donation', 'newspack' ) }
 					description={ __( '(if using WooCommerce checkout)', 'newspack' ) }
 				>
-					<CheckboxControl
-						checked={ segmentConfig.is_donor }
-						onChange={ updateSegmentConfig( 'is_donor' ) }
-						label={ __( 'Has donated', 'newspack' ) }
-					/>
-					<CheckboxControl
-						checked={ segmentConfig.is_not_donor }
-						onChange={ updateSegmentConfig( 'is_not_donor' ) }
-						label={ __( "Hasn't donated", 'newspack' ) }
+					<SelectControl
+						onChange={ value => {
+							value = parseInt( value );
+							if ( value === 0 ) {
+								updateSegmentConfig( {
+									is_donor: false,
+									is_not_donor: false,
+								} );
+							} else {
+								updateSegmentConfig( {
+									is_donor: value === 1,
+									is_not_donor: value === 2,
+								} );
+							}
+						} }
+						// eslint-disable-next-line no-nested-ternary
+						value={ segmentConfig.is_donor ? 1 : segmentConfig.is_not_donor ? 2 : 0 }
+						options={ [
+							{ value: 0, label: __( 'N/A', 'newspack' ) },
+							{ value: 1, label: __( 'Has donated', 'newspack' ) },
+							{ value: 2, label: __( "Hasn't donated", 'newspack' ) },
+						] }
 					/>
 				</SegmentSettingSection>
 				<SegmentSettingSection


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves segmentation UI in Campaigns Wizard. Closes #710

### How to test the changes in this Pull Request:

1. Visit the Campaigns Wizard, segmentation tab
2. Observe that the subscriber and donor sections are using selects instead of checkboxes (#710)
3. Use the subscriber and donor sections to edit or create a segment, observe the results are as expected
4. Observe the "Save" button is disabled when there are no changes to the segment
5. Observe that after changes are made to a segment, a prompt will be displayed when trying to navigate away or reloading the page, before saving the changes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->