### PR TITLE
fix: bug preventing new segments from being savable

### DIFF
--- a/assets/components/src/hooks/usePrompt.js
+++ b/assets/components/src/hooks/usePrompt.js
@@ -14,7 +14,6 @@ const { useHistory } = Router;
 
 export default ( when, message ) => {
 	const history = useHistory();
-
 	const self = useRef( null );
 
 	const onWindowOrTabClose = event => {
@@ -36,18 +35,13 @@ export default ( when, message ) => {
 	useEffect( () => {
 		if ( when ) {
 			self.current = history.block( message );
-		} else {
-			self.current = null;
+			window.addEventListener( 'beforeunload', onWindowOrTabClose );
 		}
-
-		window.addEventListener( 'beforeunload', onWindowOrTabClose );
 
 		return () => {
 			if ( self.current ) {
 				self.current();
-				self.current = null;
 			}
-
 			window.removeEventListener( 'beforeunload', onWindowOrTabClose );
 		};
 	}, [ message, when ] );

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -56,6 +56,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 		return setSegmentConfig( { ...segmentConfig, ...keyOrPartialUpdate } );
 	};
 	const [ name, setName ] = useState( '' );
+	const [ nameInitially, setNameInitially ] = useState( '' );
 	const [ isFetchingReach, setIsFetchingReach ] = useState( { total: 0, in_segment: 0 } );
 	const [ reach, setReach ] = useState( { total: 0, in_segment: 0 } );
 	const history = useHistory();
@@ -64,8 +65,8 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 
 	const [ segmentInitially, setSegmentInitially ] = useState( null );
 	const isDirty =
-		segmentInitially !== null &&
-		JSON.stringify( segmentInitially ) !== JSON.stringify( segmentConfig );
+		JSON.stringify( segmentInitially ) !== JSON.stringify( segmentConfig ) ||
+		nameInitially !== name;
 	const isEmpty = JSON.stringify( segmentConfig ) === JSON.stringify( DEFAULT_CONFIG );
 
 	const unblock = hooks.usePrompt(
@@ -88,6 +89,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					setSegmentConfig( segmentConfigurationWithDefaults );
 					setSegmentInitially( segmentConfigurationWithDefaults );
 					setName( foundSegment.name );
+					setNameInitially( foundSegment.name );
 				}
 			} );
 		}

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -61,15 +61,15 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	const [ reach, setReach ] = useState( { total: 0, in_segment: 0 } );
 	const history = useHistory();
 
-	const isSegmentValid = name.length > 0;
+	const isSegmentValid =
+		name.length > 0 && JSON.stringify( segmentConfig ) !== JSON.stringify( DEFAULT_CONFIG );
 
 	const [ segmentInitially, setSegmentInitially ] = useState( null );
 	const isDirty =
 		JSON.stringify( segmentInitially ) !== JSON.stringify( segmentConfig ) ||
 		nameInitially !== name;
-	const isEmpty = JSON.stringify( segmentConfig ) === JSON.stringify( DEFAULT_CONFIG );
 
-	const unBlockUI = hooks.usePrompt(
+	const unblock = hooks.usePrompt(
 		isDirty,
 		__( 'There are unsaved changes to this segment. Discard changes?', 'newspack' )
 	);
@@ -114,7 +114,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	}, [ JSON.stringify( segmentConfig ) ] );
 
 	const saveSegment = () => {
-		unBlockUI();
+		unblock();
 		const path = isNew
 			? `/newspack/v1/wizard/newspack-popups-wizard/segmentation`
 			: `/newspack/v1/wizard/newspack-popups-wizard/segmentation/${ segmentId }`;
@@ -299,7 +299,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 
 			<div className="newspack-buttons-card">
 				<Button
-					disabled={ ! isSegmentValid || ! isDirty || isEmpty }
+					disabled={ ! isSegmentValid || ( ! isNew && ! isDirty ) }
 					isPrimary
 					onClick={ saveSegment }
 				>

--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -69,7 +69,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 		nameInitially !== name;
 	const isEmpty = JSON.stringify( segmentConfig ) === JSON.stringify( DEFAULT_CONFIG );
 
-	const unblock = hooks.usePrompt(
+	const unBlockUI = hooks.usePrompt(
 		isDirty,
 		__( 'There are unsaved changes to this segment. Discard changes?', 'newspack' )
 	);
@@ -114,7 +114,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	}, [ JSON.stringify( segmentConfig ) ] );
 
 	const saveSegment = () => {
-		unblock();
+		unBlockUI();
 		const path = isNew
 			? `/newspack/v1/wizard/newspack-popups-wizard/segmentation`
 			: `/newspack/v1/wizard/newspack-popups-wizard/segmentation/${ segmentId }`;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug where the "Save" button can never become enabled when creating a new segment. Also enables the "Save" button if changing only the title on an existing segment—this allows segments to be renamed without changing any config options.

Lastly, fixes a bug in which trying to save a segment before any history changes are made can result in a JS console error. To replicate this on `master`:

* Edit any segment and immediately refresh the page so the initial render is the single segment page.
* Make the segment dirty by changing any config option.
* Click "Save" and observe a console error that prevents the segment from being saved: `SingleSegment.js:161 Uncaught TypeError: unblock is not a function`
* Note that this bug occurs intermittently, and only occurs if you haven't navigated to the single segment page from anywhere else.

### How to test the changes in this Pull Request:

1. On `master`, try to create a new segment. Observe that no matter what you do here, the "Save" button never becomes enabled, blocking you from creating the segment.
2. Edit an existing segment. Change the name and observe that the "Save" button remains disabled unless you change any config option first.
3. Check out this branch and run `npm run build`.
4. Try to create a new segment again. Confirm that the "Save" button becomes enabled once you a.) Add a name, and b.) Change at least one config option from the default. Click "Save" and confirm that the segment is successfully created.
5. Edit the segment and change only the name. Observe that the "Save" button becomes enabled without having to change anything else, and that clicking the button saves the segment with the new name.
6. Edit any existing segment, then immediately refresh the page so that the initial render is the single segment page.
7. Make the segment dirty (change the title or any config options) and then click "save". Confirm that you don't see any prompt about unsaved changes, don't see any JS console errors, and the segment saves the new info.
  - **Note:** If you try to navigate away from a dirty segment by clicking "Cancel" or the browser's back button, then click "Cancel" on the prompt, then subsequently save the segment with changes, you may see a bug in which the URL updates back to the segment list when the prompt appears even before you click "cancel." Saving afterward will result in a JS console warning and you will not be automatically re-routed back to the segment list. However, you can still cancel out of the single segment or navigate manually to the segment list by clicking the Segments tab. I believe this is due to [a bug in the current version of React Router History](https://github.com/ReactTraining/history/issues/589#issuecomment-393041665).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->