### PR TITLE
Campaigns wizard: handle donor landing page setting

### DIFF
--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-components",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Newspack design system components",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/assets/wizards/popups/views/settings/index.js
+++ b/assets/wizards/popups/views/settings/index.js
@@ -2,56 +2,59 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
-import { withWizardScreen, CheckboxControl } from '../../../../components/src';
+import { withWizardScreen, CheckboxControl, SelectControl } from '../../../../components/src';
 
 const ENDPOINT = `/newspack/v1/wizard/newspack-popups-wizard/settings`;
 
-const Settings = ( { isLoading, startLoading, doneLoading } ) => {
+const Settings = ( { isLoading, wizardApiFetch } ) => {
 	const [ settings, setSettings ] = useState( [] );
 
 	const handleSettingChange = option_name => option_value => {
-		startLoading();
-		apiFetch( {
+		wizardApiFetch( {
 			path: ENDPOINT,
 			method: 'POST',
+			quiet: true,
 			data: { option_name, option_value },
-		} ).then( response => {
-			setSettings( response );
-			doneLoading();
-		} );
+		} ).then( setSettings );
 	};
 
 	useEffect( () => {
-		startLoading();
-		apiFetch( {
+		wizardApiFetch( {
 			path: ENDPOINT,
 			method: 'GET',
-		} ).then( response => {
-			setSettings( response );
-			doneLoading();
-		} );
+		} ).then( setSettings );
 	}, [] );
 
-	return (
-		<>
-			{ settings.map( setting =>
-				setting.label ? (
-					<CheckboxControl
-						key={ setting.key }
-						label={ setting.label }
-						disabled={ isLoading }
-						checked={ setting.value === '1' }
-						onChange={ handleSettingChange( setting.key ) }
-					/>
-				) : null
-			) }
-		</>
-	);
+	const renderSetting = setting => {
+		if ( setting.label ) {
+			const props = {
+				key: setting.key,
+				label: setting.label,
+				help: setting.help,
+				disabled: isLoading,
+				onChange: handleSettingChange( setting.key ),
+			};
+			switch ( setting.type ) {
+				case 'select':
+					return (
+						<SelectControl
+							{ ...props }
+							value={ setting.value }
+							options={ [ { label: setting.no_option_text, value: '' }, ...setting.options ] }
+						/>
+					);
+				default:
+					return <CheckboxControl { ...props } checked={ setting.value === '1' } />;
+			}
+		}
+		return null;
+	};
+
+	return settings.map( renderSetting );
 };
 
 export default withWizardScreen( Settings );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-popups/issues/377

Also a version bump to [`newspack-components`](https://www.npmjs.com/package/newspack-components) is included in this PR, but I ended up not using the new version in `newspack-popups` since there were too many changes.

### How to test the changes in this Pull Request:

1. Switch `newspack-popups` to branch `add/donor-from-page`
2. Visit the Campaign Wizard, settings tab
3. Observe a new setting - "Donor landing page"
4. Set a page to act as a donor landing page (a "Thank you for donation" page)
5. Create two campaigns, one targeted at donors (A), other at non-donors (B)
6. Visit the site in a new session, observe the B campaign is shown
7. Visit the donation landing page 
8. Observe that campaign A is now shown
9. Deactivate Newspack plugin and verify that you can edit the donor landing page setting in Campaigns plugin settings 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->