### PR TITLE
Campaigns wizard: handle negative referrer segmentation

### DIFF
--- a/assets/wizards/popups/views/segmentation/SingleSegment.js
+++ b/assets/wizards/popups/views/segmentation/SingleSegment.js
@@ -45,6 +45,7 @@ const DEFAULT_CONFIG = {
 	is_not_donor: false,
 	favorite_categories: [],
 	referrers: '',
+	referrers_not: '',
 };
 
 const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
@@ -270,6 +271,21 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 						help={ __( 'A comma-separated list of domains.', 'newspack' ) }
 						value={ segmentConfig.referrers }
 						onChange={ updateSegmentConfig( 'referrers' ) }
+					/>
+				</SegmentSettingSection>
+				<SegmentSettingSection
+					title={ __( 'Referrer exclusion', 'newspack' ) }
+					description={ __(
+						'Segment based on traffic source - hide campaigns for visitors coming from specific sources.',
+						'newspack'
+					) }
+				>
+					<TextControl
+						isWide
+						placeholder={ __( 'google.com, facebook.com', 'newspack' ) }
+						help={ __( 'A comma-separated list of domains.', 'newspack' ) }
+						value={ segmentConfig.referrers_not }
+						onChange={ updateSegmentConfig( 'referrers_not' ) }
 					/>
 				</SegmentSettingSection>
 				<SegmentSettingSection


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

UI for adding a referrer-based segmentation. 

Do not merge before https://github.com/Automattic/newspack-popups/pull/415 is merged.

### How to test the changes in this Pull Request:

1. Switch Campaign plugin to `add/segmentation-negative-referrrer` branch (https://github.com/Automattic/newspack-popups/pull/415)
1. Create a new segment, observe a new section – "Referrer exclusion"
2. Set the referrer to `google.com`
3. Edit or create a campaign, assign the new segment to it
4. Verify the campaign is displayed when site is visited in a fresh session
5. Spoof the referrer by editing [this line](https://github.com/Automattic/newspack-popups/blob/0493d8db6e3609d95a0409359e1515b5f46259ad/includes/class-newspack-popups-inserter.php#L425) in `class-newspack-popups-inserter.php`
6. Observe that the campaign is not displayed now
7. Create a segment with multiple referrers excluded, repeat the testing steps to verify the condition works for all of them
8. Test with a referrer-less segment (just to see if a lacking referrer does not break things)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->