### PR TITLE
feat: hide "Uncategorized" category from Campaigns UI

### DIFF
--- a/assets/wizards/popups/components/popup-popover/secondary.js
+++ b/assets/wizards/popups/components/popup-popover/secondary.js
@@ -13,7 +13,7 @@ import { ESCAPE } from '@wordpress/keycodes';
  * Internal dependencies.
  */
 import { CategoryAutocomplete, Popover, SelectControl } from '../../../../components/src';
-import { isOverlay } from '../../utils';
+import { filterOutUncategorized, isOverlay } from '../../utils';
 import './style.scss';
 
 const frequencyMap = {
@@ -86,7 +86,7 @@ const SecondaryPopupPopover = ( {
 			/>
 			{ ! sitewideDefault && (
 				<CategoryAutocomplete
-					value={ categories || [] }
+					value={ filterOutUncategorized( categories ) || [] }
 					onChange={ tokens => setTermsForPopup( id, tokens, 'category' ) }
 					label={ __( 'Category filtering', 'newspack ' ) }
 					disabled={ sitewideDefault }

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -1,2 +1,18 @@
+/**
+ * Check whether the given popup is an overlay.
+ *
+ * @param {object} popup Popup object to check.
+ * @return {boolean} True if the popup is an overlay, otherwise false.
+ */
 export const isOverlay = popup =>
 	[ 'top', 'bottom', 'center' ].indexOf( popup.options.placement ) >= 0;
+
+/**
+ * Filter out "Uncategorized" category, which for purposes of Campaigns behaves identically to no category.
+ *
+ * @param {array} categories Array of category objects.
+ * @return {array} Filtered array of categories, without Uncategorized category.
+ */
+export const filterOutUncategorized = categories => {
+	return categories.filter( category => 'uncategorized' !== category.slug );
+};

--- a/assets/wizards/popups/views/popup-group/index.js
+++ b/assets/wizards/popups/views/popup-group/index.js
@@ -28,7 +28,7 @@ import {
 } from '../../../../components/src';
 import PopupActionCard from '../../components/popup-action-card';
 import SegmentationPreview from '../../components/segmentation-preview';
-import { isOverlay } from '../../utils';
+import { filterOutUncategorized, isOverlay } from '../../utils';
 import './style.scss';
 
 const { useParams } = Router;
@@ -38,6 +38,7 @@ const descriptionForPopup = (
 	segments
 ) => {
 	const segment = find( segments, [ 'id', options.selected_segment_id ] );
+	const filteredCategories = filterOutUncategorized( categories );
 	const descriptionMessages = [];
 	if ( segment ) {
 		descriptionMessages.push( `${ __( 'Segment:', 'newspack' ) } ${ segment.name }` );
@@ -45,9 +46,10 @@ const descriptionForPopup = (
 	if ( sitewideDefault ) {
 		descriptionMessages.push( __( 'Sitewide default', 'newspack' ) );
 	}
-	if ( categories.length > 0 ) {
+	if ( filteredCategories.length > 0 ) {
 		descriptionMessages.push(
-			__( 'Categories: ', 'newspack' ) + categories.map( category => category.name ).join( ', ' )
+			__( 'Categories: ', 'newspack' ) +
+				filteredCategories.map( category => category.name ).join( ', ' )
 		);
 	}
 	if ( 'pending' === status ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Breaking this out to a smaller PR so it's not blocked by the larger segment precedence features.

Cherry-picks the fix from #832 that hides the "Uncategorized" category from all Campaigns UI. Because the Campaigns plugin basically ignores this category, it's meaningless to show it for campaigns, and kind of annoying to see since WP automatically adds it to any post that is published without assigning any categories.

### How to test the changes in this Pull Request:

1. On `master`, assign the "Uncategorized" category to a campaign (or publish a new campaign without assigning any categories—it will be automatically assigned).
2. In the Campaigns tab, observe that the campaign appears with the "Uncategorized" category in the action card and the category autocomplete field.
3. Check out this branch, run `npm run build`. Confirm that the campaign no longer shows "Uncategorized" in either the action card or the category autocomplete field.
4. Test with and without other categories assigned to the same campaign.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->