### PR TITLE
fix: possible redirect loop when plus sign in query param

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -103,6 +103,8 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-amp-enhancements.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-webhooks.php';
 
+		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
+
 		if ( 'nrh' === get_option( NEWSPACK_READER_REVENUE_PLATFORM ) ) {
 			include_once NEWSPACK_ABSPATH . 'includes/class-nrh.php';
 		}

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Patches for known issues affecting Newspack sites.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Patches {
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_filter( 'redirect_canonical', [ __CLASS__, 'patch_redirect_canonical' ], 10, 2 );
+	}
+
+	/**
+	 * Patches an issue where links to the site's homepage containing a query param with plus characters can cause
+	 * a redirect loop with certain types of cacheing. The most common example of this ocurs when a
+	 * newsletter uses a utm_campaign parameter that contains a space, e.g. utm_campaign=my+campaign
+	 * The causes a redirect loop on the homepage, which often causes the page to fail to load on mobile.
+	 *
+	 * Related: https://core.trac.wordpress.org/ticket/51733#ticket.
+	 *
+	 * @param string $redirect_url The redirect URL.
+	 * @param string $requested_url The requested URL.
+	 *
+	 * @return bool Should redirect be allowed.
+	 */
+	public static function patch_redirect_canonical( $redirect_url, $requested_url ) {
+		$parsed_redirect  = wp_parse_url( $redirect_url );
+		$parsed_requested = wp_parse_url( $requested_url );
+
+		// Scheme changed, do redirect.
+		if ( $parsed_requested['scheme'] !== $parsed_redirect['scheme'] ) {
+			return $redirect_url;
+		}
+
+		// Host changed, do redirect.
+		if ( $parsed_requested['host'] !== $parsed_redirect['host'] ) {
+			return $redirect_url;
+		}
+
+		// Path changed, do redirect.
+		if ( $parsed_requested['path'] !== $parsed_redirect['path'] ) {
+			return $redirect_url;
+		}
+
+		// Parse query args.
+		parse_str( $parsed_redirect['query'], $query_redirect );
+		parse_str( $parsed_requested['query'], $query_request );
+
+		// Sort by keys, if the order changed.
+		ksort( $query_redirect );
+		ksort( $query_request );
+
+		// If parsed query args are the same, skip redirect.
+		if ( $query_redirect === $query_request ) {
+			return false;
+		}
+
+		// Otherwise, do redirect.
+		return $redirect_url;
+	}
+}
+Patches::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Addresses an issue that has come up a few times on Newspack sites, where an inbound link from a newsletter contains a UTM parameter with spaces encoded as plus signs. WordPress rewrites the URL replacing the plus with `%20`. Edge cacheing sees the two URLs as identical, therefore creating a redirect loop. The problem manifests to the end user as failed page loads on mobile when tapping a newsletter link.

Core issue: https://core.trac.wordpress.org/ticket/51733#ticket.

We can leave this fix in place for Newspack sites until there's a more permanent solution. 

Many thanks to @aidvu for the fix!

### How to test the changes in this Pull Request:

1. On `master` navigate to a URL like: `https://mysite.com/?test=a+b+c`. Observe the URL is rewritten to `https://mysite.com??test=a%20b%20c`.
2. Switch to this branch, repeat. Observe the URL is not redirected, and the plus signs are left intact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->