### PR TITLE
Fix button group style

### DIFF
--- a/assets/components/src/button-group/style.scss
+++ b/assets/components/src/button-group/style.scss
@@ -8,8 +8,33 @@
 
 	.newspack-button {
 		&:active,
-		&:hover {
+		&:focus,
+		&:hover,
+		&.is-pressed {
 			position: relative;
+		}
+
+		&.is-pressed {
+			z-index: 2;
+		}
+	}
+}
+
+body[class*='admin-color-'] {
+	.newspack-button-group {
+		.newspack-button {
+			border-radius: 0;
+			box-shadow: none;
+
+			&:first-child {
+				border-bottom-left-radius: 3px;
+				border-top-left-radius: 3px;
+			}
+
+			&:last-child {
+				border-bottom-right-radius: 3px;
+				border-top-right-radius: 3px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR applies the correct border-radius to the various buttons within the group and fixes the position on focus/hover/pressed

### How to test the changes in this Pull Request:

1. Find a `ButtonGroup` (e.g. SEO > Separator)
2. Notice how "broken" it looks, mostly the border-radius for mid-children
3. Switch to this branch
4. Refresh your Wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->