### PR TITLE
Fix Site Kit integration

### DIFF
--- a/includes/popups-analytics/class-popups-analytics-utils.php
+++ b/includes/popups-analytics/class-popups-analytics-utils.php
@@ -127,7 +127,7 @@ class Popups_Analytics_Utils {
 				$label_dimension->setName( 'ga:eventLabel' );
 
 				// Create the ReportRequest object.
-				$profile_id = $analytics->get_data( 'profile-id' );
+				$profile_id = $analytics->get_settings()->get()['profileID'];
 				$request    = new Google_Service_AnalyticsReporting_ReportRequest();
 				$request->setViewId( $profile_id );
 				$request->setDateRanges( $date_range );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In version 1.25.0 of the Site Kit plugin, a way of getting profile ID [was removed](https://github.com/google/site-kit-wp/issues/2507). This PR changes it to use a supported way.

### How to test the changes in this Pull Request:

1. On `master`, set Site Kit to version 1.25.0
2. Observe the Campaign Wizard's Analytics view is erroring out
3. Switch to this branch
4. Observe the Analytics view loading
5. Switch Site Kit to an earlier version, observe the view still loading as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
