### PR TITLE
feat: add segment descriptions to Campaigns and Segments tabs

### DIFF
--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -15,7 +15,12 @@ import { Icon, plusCircle } from '@wordpress/icons';
 import { Button, Card, Modal } from '../../../../components/src';
 import SegmentationPreview from '../segmentation-preview';
 import PromptActionCard from '../prompt-action-card';
-import { descriptionForPopup, getCardClassName } from '../../utils';
+import {
+	descriptionForPopup,
+	descriptionForSegment,
+	getCardClassName,
+	getFavoriteCategoryNames,
+} from '../../utils';
 
 import {
 	iconInline,
@@ -45,7 +50,12 @@ const addNewURL = ( placement, campaignId, segmentId ) => {
 const SegmentGroup = props => {
 	const { campaignData, campaignId, segment } = props;
 	const [ modalVisible, setModalVisible ] = useState();
-	const { label, id, prompts } = segment;
+	const [ categories, setCategories ] = useState( [] );
+	const { label, id, configuration, prompts } = segment;
+
+	if ( 0 < configuration.favorite_categories?.length ) {
+		getFavoriteCategoryNames( configuration.favorite_categories, categories, setCategories );
+	}
 
 	let emptySegmentText;
 	if ( 'unassigned' === campaignId ) {
@@ -59,8 +69,13 @@ const SegmentGroup = props => {
 	return (
 		<Card isSmall className="newspack-campaigns__segment-group__card">
 			<h3 className="newspack-campaigns__segment-group__card__segment">
-				{ id ? __( 'Segment: ', 'newspack' ) : '' }
-				{ label }
+				<a href={ `#/segments/${ id }` }>
+					{ id ? __( 'Segment: ', 'newspack' ) : '' }
+					{ label }
+					<span className="newspack-campaigns__segment-group__description">
+						{ descriptionForSegment( segment, categories ) }
+					</span>
+				</a>
 				<SegmentationPreview
 					campaignId={ [ campaignId ] }
 					segment={ id }

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { useContext, useState } from '@wordpress/element';
+import { useContext, useEffect, useState } from '@wordpress/element';
 import { Icon, plusCircle } from '@wordpress/icons';
 
 /**
@@ -53,12 +53,18 @@ const SegmentGroup = props => {
 	const { campaignData, campaignId, segment } = props;
 	const [ modalVisible, setModalVisible ] = useState();
 	const [ categories, setCategories ] = useState( [] );
-	const { label, id, configuration, prompts } = segment;
+	const { label, id, prompts } = segment;
 	const allPrompts = useContext( CampaignsContext );
 
-	if ( 0 < configuration.favorite_categories?.length ) {
-		getFavoriteCategoryNames( configuration.favorite_categories, categories, setCategories );
-	}
+	useEffect( () => {
+		if ( 0 < segment.configuration?.favorite_categories?.length ) {
+			getFavoriteCategoryNames(
+				segment.configuration.favorite_categories,
+				categories,
+				setCategories
+			);
+		}
+	}, [ segment ] );
 
 	let emptySegmentText;
 	if ( 'unassigned' === campaignId ) {

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -57,14 +57,14 @@ const SegmentGroup = props => {
 	const allPrompts = useContext( CampaignsContext );
 
 	useEffect( () => {
-		if ( 0 < segment.configuration?.favorite_categories?.length ) {
-			getFavoriteCategoryNames(
-				segment.configuration.favorite_categories,
-				categories,
-				setCategories
-			);
-		}
+		updateCategories();
 	}, [ segment ] );
+
+	const updateCategories = async () => {
+		if ( 0 < segment.configuration?.favorite_categories?.length ) {
+			setCategories( await getFavoriteCategoryNames( segment.configuration.favorite_categories ) );
+		}
+	};
 
 	let emptySegmentText;
 	if ( 'unassigned' === campaignId ) {

--- a/assets/wizards/popups/components/segment-group/style.scss
+++ b/assets/wizards/popups/components/segment-group/style.scss
@@ -12,6 +12,12 @@
 	&__select-control-group-item {
 		padding-left: 36px;
 	}
+	&__description {
+		color: $dark-gray-300;
+		display: block;
+		font-size: 12px;
+		font-weight: normal;
+	}
 	&__card {
 		& > &__segment {
 			margin: -16px -16px 16px !important;
@@ -24,6 +30,17 @@
 			border-bottom: 1px solid $light-gray-200;
 			display: flex;
 			justify-content: space-between;
+
+			a {
+				color: inherit;
+				text-decoration: none;
+
+				&:focus,
+				&:hover {
+					color: $primary-500;
+				}
+			}
+
 			button {
 				margin-left: 12px;
 			}

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -156,19 +156,17 @@ export const descriptionForSegment = ( segment, categories = [] ) => {
 	}
 
 	// Messages for reader activity.
-	if ( is_donor || is_not_donor || is_subscribed || is_not_subscribed ) {
-		if ( is_donor ) {
-			descriptionMessages.push( __( 'Has donated', 'newspack' ) );
-		}
-		if ( is_not_donor ) {
-			descriptionMessages.push( __( 'Has not donated', 'newspack' ) );
-		}
-		if ( is_subscribed ) {
-			descriptionMessages.push( __( 'Has subscribed', 'newspack' ) );
-		}
-		if ( is_not_subscribed ) {
-			descriptionMessages.push( __( 'Has not subscribed', 'newspack' ) );
-		}
+	if ( is_donor ) {
+		descriptionMessages.push( __( 'Has donated', 'newspack' ) );
+	}
+	if ( is_not_donor ) {
+		descriptionMessages.push( __( 'Has not donated', 'newspack' ) );
+	}
+	if ( is_subscribed ) {
+		descriptionMessages.push( __( 'Has subscribed', 'newspack' ) );
+	}
+	if ( is_not_subscribed ) {
+		descriptionMessages.push( __( 'Has not subscribed', 'newspack' ) );
 	}
 
 	// Messages for referrer sources.

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -2,7 +2,7 @@
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
-import { __ } from '@wordpress/i18n';
+import { __. sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 /**

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -2,7 +2,7 @@
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
-import { __. sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 /**

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -93,23 +93,25 @@ export const descriptionForPopup = prompt => {
 	return descriptionMessages.length ? descriptionMessages.join( ' | ' ) : null;
 };
 
-export const getFavoriteCategoryNames = ( favoriteCategories, categories, setCategories ) => {
-	favoriteCategories.forEach( async categoryId => {
-		try {
-			const category = await apiFetch( {
-				path: addQueryArgs( '/wp/v2/categories/' + categoryId, {
-					_fields: 'id,name',
-				} ),
-			} );
+export const getFavoriteCategoryNames = async favoriteCategories => {
+	try {
+		const favoriteCategoryNames = await Promise.all(
+			favoriteCategories.map( async categoryId => {
+				const category = await apiFetch( {
+					path: addQueryArgs( '/wp/v2/categories/' + categoryId, {
+						_fields: 'name',
+					} ),
+				} );
 
-			if ( ! categories.find( cat => cat.id === categoryId ) ) {
-				const { id, name } = category;
-				setCategories( [ ...categories, { id, name } ] );
-			}
-		} catch ( e ) {
-			console.error( e );
-		}
-	} );
+				return category.name;
+			} )
+		);
+
+		return favoriteCategoryNames;
+	} catch ( e ) {
+		console.error( e );
+		return [];
+	}
 };
 
 export const descriptionForSegment = ( segment, categories = [] ) => {
@@ -178,7 +180,7 @@ export const descriptionForSegment = ( segment, categories = [] ) => {
 				sprintf(
 					__( 'Favorite %s: %s', 'newspack' ),
 					categories.length > 1 ? __( 'categories', 'newspack' ) : __( 'category', 'newspack' ),
-					categories.map( cat => cat.name ).join( ', ' )
+					categories.filter( cat => !! cat ).join( ', ' )
 				)
 			);
 		} else {

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -59,9 +59,10 @@ const modalButton = modalType => {
 const groupBySegment = ( segments, prompts ) => {
 	const grouped = [];
 	grouped.push(
-		...segments.map( ( { name: label, id } ) => ( {
+		...segments.map( ( { name: label, id, configuration } ) => ( {
 			label,
 			id,
+			configuration,
 			prompts: prompts.filter(
 				( { options: { selected_segment_id: segment } } ) => segment === id
 			),
@@ -71,6 +72,7 @@ const groupBySegment = ( segments, prompts ) => {
 		label: __( 'Default (no segment)', 'newspack' ),
 		id: '',
 		prompts: prompts.filter( ( { options: { selected_segment_id: segment } } ) => ! segment ),
+		configuration: {},
 	} );
 	return grouped;
 };
@@ -307,7 +309,6 @@ const Campaigns = props => {
 					segment={ segment }
 					campaignId={ campaignId }
 					campaignData={ campaignData }
-					segments={ segments }
 					{ ...props }
 				/>
 			) ) }

--- a/assets/wizards/popups/views/segments/SegmentsList.js
+++ b/assets/wizards/popups/views/segments/SegmentsList.js
@@ -1,10 +1,9 @@
 /**
  * WordPress dependencies.
  */
+import { Tooltip, MenuItem } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { format } from '@wordpress/date';
-import { Tooltip, MenuItem } from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';
 
 /**
@@ -12,13 +11,13 @@ import { ESCAPE } from '@wordpress/keycodes';
  */
 import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
-
 import { Icon, moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
  */
 import { ActionCard, Popover, Button, Router } from '../../../../components/src';
+import { descriptionForSegment, getFavoriteCategoryNames } from '../../utils';
 
 const { NavLink, useHistory } = Router;
 
@@ -32,18 +31,24 @@ const AddNewSegmentLink = () => (
 
 const SegmentActionCard = ( { segment, deleteSegment } ) => {
 	const [ popoverVisibility, setPopoverVisibility ] = useState( false );
+	const [ categories, setCategories ] = useState( [] );
 	const onFocusOutside = () => setPopoverVisibility( false );
 	const history = useHistory();
+
+	if ( 0 < segment.configuration?.favorite_categories?.length ) {
+		getFavoriteCategoryNames(
+			segment.configuration.favorite_categories,
+			categories,
+			setCategories
+		);
+	}
 
 	return (
 		<ActionCard
 			isSmall
 			title={ segment.name }
 			titleLink={ `#/segments/${ segment.id }` }
-			description={ `${ __( 'Created on', 'newspack' ) } ${ format(
-				'Y/m/d',
-				segment.created_at
-			) }` }
+			description={ descriptionForSegment( segment, categories ) }
 			actionText={
 				<>
 					<Tooltip text={ __( 'More options', 'newspack' ) }>

--- a/assets/wizards/popups/views/segments/SegmentsList.js
+++ b/assets/wizards/popups/views/segments/SegmentsList.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Draggable, Tooltip, MenuItem } from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -43,6 +43,16 @@ const SegmentActionCard = ( {
 	const [ popoverVisibility, setPopoverVisibility ] = useState( false );
 	const [ categories, setCategories ] = useState( [] );
 	const [ isDragging, setIsDragging ] = useState( false );
+
+	useEffect( () => {
+		if ( 0 < segment.configuration?.favorite_categories?.length ) {
+			getFavoriteCategoryNames(
+				segment.configuration.favorite_categories,
+				categories,
+				setCategories
+			);
+		}
+	}, [ segment ] );
 
 	const onFocusOutside = () => setPopoverVisibility( false );
 	const history = useHistory();
@@ -131,14 +141,6 @@ const SegmentActionCard = ( {
 
 		resortSegments( target );
 	};
-
-	if ( 0 < segment.configuration?.favorite_categories?.length ) {
-		getFavoriteCategoryNames(
-			segment.configuration.favorite_categories,
-			categories,
-			setCategories
-		);
-	}
 
 	return (
 		<div

--- a/assets/wizards/popups/views/segments/SegmentsList.js
+++ b/assets/wizards/popups/views/segments/SegmentsList.js
@@ -3,7 +3,6 @@
  */
 import { useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { format } from '@wordpress/date';
 import { Draggable, Tooltip, MenuItem } from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';
 import { Icon, chevronDown, chevronUp, dragHandle, moreVertical } from '@wordpress/icons';

--- a/assets/wizards/popups/views/segments/SegmentsList.js
+++ b/assets/wizards/popups/views/segments/SegmentsList.js
@@ -45,14 +45,14 @@ const SegmentActionCard = ( {
 	const [ isDragging, setIsDragging ] = useState( false );
 
 	useEffect( () => {
-		if ( 0 < segment.configuration?.favorite_categories?.length ) {
-			getFavoriteCategoryNames(
-				segment.configuration.favorite_categories,
-				categories,
-				setCategories
-			);
-		}
+		updateCategories();
 	}, [ segment ] );
+
+	const updateCategories = async () => {
+		if ( 0 < segment.configuration?.favorite_categories?.length ) {
+			setCategories( await getFavoriteCategoryNames( segment.configuration.favorite_categories ) );
+		}
+	};
 
 	const onFocusOutside = () => setPopoverVisibility( false );
 	const history = useHistory();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Makes the descriptions for segment action cards in the Segments tab (and segment container headers in the Campaigns tab) more useful. Instead of showing the creation date, it now summarizes the configuration for each segment. This could get slightly redundant if the segments are named after the intended use, but I find it really useful to be able to see at a glance what each segment is without having to visit the edit screen.

Segments tab:

<img width="1049" alt="Screen Shot 2021-02-03 at 2 07 00 PM" src="https://user-images.githubusercontent.com/2230142/106809598-1d86d500-6629-11eb-9730-b324fb5faf4e.png">

Campaigns tab:

<img width="1048" alt="Screen Shot 2021-02-03 at 2 05 49 PM" src="https://user-images.githubusercontent.com/2230142/106809470-f203ea80-6628-11eb-9814-64c821cef72f.png">

Also creates a link from the segments' names in the Campaigns tab to each segment's edit page, for added convenience.

~Question: I tried to make the descriptions as terse as possible so as not to visually muddy the UI, but in some cases the phrasing differs from the option labels—should we ensure that the option names match?~ I think we should, and I implemented as a draft in #848.

### How to test the changes in this Pull Request:

1. Check out this branch, run `npm run build`
2. Visit the Campaigns and Segments tabs.
3. In both tabs, verify that each segment is accompanied by a short summary of its configuration.
4. In the Campaigns tab, verify that clicking on the segment name directs you to that segment's edit page.
5. Create new segments and edit existing segments, using a mix of every available configuration option in some segments and leaving some fields blank in others. Verify that the descriptions accurately portray the configuration for each segment, showing only the options that differ from the default.

Note that for segments with Category Affinity set, it will take a second or two for the category names to appear in the description. This is because the configuration saves category IDs only, so we need to fetch the names via REST.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->