### PR TITLE
fix: change in how to retrieve property id from site kit

### DIFF
--- a/includes/class-nrh.php
+++ b/includes/class-nrh.php
@@ -76,7 +76,7 @@ class NRH {
 
 		$context          = new \Google\Site_Kit\Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$analytics        = new \Google\Site_Kit\Modules\Analytics( $context );
-		$ga_property_code = $analytics->get_data( 'property-id' );
+		$ga_property_code = $analytics->get_settings()->get()['propertyID'];
 
 		if ( ! isset( $gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker'] ) ) {
 			$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker'] = [];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

A small change in Site Kit 1.25.0 breaks the cross domain tracking handling on AMP pages. This PR resolves it.

### How to test the changes in this Pull Request:

1. Install Site Kite 1.24.0 (e.g. `wp plugin install google-site-kit --version=1.24.0 --force`) and switch `newspack-plugin` to `master`. Put the site in AMP Transitional mode.
2. Set Reader Revenue wizard to News Revenue Hub, use an organization ID from a production site.
3. Add Donate block to a post.
4. View the post (non-AMP), choose a price, click to submit the form. Observe `_gl` parameter with a long random string in the URL.
5. Do the same in non-AMP. Observe there are two identical `_gl` parameters (a Site Kit bug).
6. Upgrade Site Kit to 1.25.0.
7. Repeat the non-AMP flow. Observe there is no longer a `_gl` parameter. 
8. Switch `newspack-plugin` to this branch, try the non-AMP flow again. Observe the `_gl` parameter is back and there is only one. All problems are solved!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->