### PR TITLE
chore: rename "default/no segment" to "everyone"

### DIFF
--- a/assets/wizards/popups/components/prompt-popovers/secondary.js
+++ b/assets/wizards/popups/components/prompt-popovers/secondary.js
@@ -53,7 +53,7 @@ const SecondaryPromptPopover = ( {
 					onFocusOutside();
 				} }
 				options={ [
-					{ label: __( 'Default (no segment)', 'newspack' ), value: '' },
+					{ label: __( 'Everyone', 'newspack' ), value: '' },
 					...segments.map( ( { name, id: segmentId } ) => ( { label: name, value: segmentId } ) ),
 				] }
 				value={ selectedSegmentId }

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -84,7 +84,7 @@ const groupBySegment = ( segments, prompts ) => {
 		} ) )
 	);
 	grouped.push( {
-		label: __( 'Default (no segment)', 'newspack' ),
+		label: __( 'Everyone', 'newspack' ),
 		id: '',
 		prompts: prompts.filter( ( { options: { selected_segment_id: segment } } ) => ! segment ),
 	} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Renames the "Default/no segment" option to "Everyone" wherever it appears in the UI. Should be coupled with a corresponding change in the Campaigns plugin. Labeling this "On Hold" until we have that.

### How to test the changes in this Pull Request:

Try to find any holdover mentions of "Default/no segment"—they should all be replaced by "Everyone". UI, campaign, segment, and prompt behavior are otherwise unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->