### PR TITLE
fix: preview functionality by campaign/group

### DIFF
--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -55,6 +55,7 @@ const SegmentGroup = props => {
 	const [ categories, setCategories ] = useState( [] );
 	const { label, id, prompts } = segment;
 	const allPrompts = useContext( CampaignsContext );
+	const campaignToPreview = 'unassigned' !== campaignId ? parseInt( campaignId ) : -1;
 
 	useEffect( () => {
 		updateCategories();
@@ -86,9 +87,9 @@ const SegmentGroup = props => {
 					</span>
 				</a>
 				<SegmentationPreview
-					campaignId={ [ campaignId ] }
+					campaign={ campaignId ? campaignToPreview : false }
 					segment={ id }
-					showUnpublished={ true } // Do we need a control for this?
+					showUnpublished={ !! campaignId } // Only if previewing a specific campaign/group.
 					renderButton={ ( { showPreview } ) => (
 						<Button isTertiary isSmall isLink onClick={ () => showPreview() }>
 							{ __( 'Preview', 'newspack' ) }

--- a/assets/wizards/popups/components/segmentation-preview/index.js
+++ b/assets/wizards/popups/components/segmentation-preview/index.js
@@ -18,7 +18,7 @@ const SegmentationPreview = props => {
 	const frontendUrl = window?.newspack_popups_wizard_data?.frontend_url || '/';
 
 	const {
-		campaignGroups = [],
+		campaign = false,
 		onLoad = () => {},
 		segment = '',
 		showUnpublished = false,
@@ -32,9 +32,9 @@ const SegmentationPreview = props => {
 			view_as.push( 'show_unpublished:true' );
 		}
 
-		// If passed group IDs, get only campaigns matching those groups. Otherwise, get all campaigns.
-		if ( 0 < campaignGroups.length ) {
-			view_as.push( `groups:${ sanitizeTerms( campaignGroups ).join( ',' ) }` );
+		// If passed campaign ID, get only campaigns matching that campaign. Otherwise, get all campaigns.
+		if ( campaign ) {
+			view_as.push( `campaign:${ campaign }` );
 		} else {
 			view_as.push( 'all' );
 		}
@@ -53,20 +53,6 @@ const SegmentationPreview = props => {
 			onLoad( iframeEl );
 		}
 	};
-
-	const sanitizeTerms = items =>
-		( Array.isArray( items ) ? items : [ items ] ).map( item => {
-			switch ( typeof item ) {
-				case 'number':
-					return item;
-				case 'object':
-					if ( item.id ) {
-						return item.id;
-					}
-					break;
-			}
-			return null;
-		} );
 
 	return <WebPreview { ...props } onLoad={ onWebPreviewLoad } url={ decorateURL( url ) } />;
 };

--- a/assets/wizards/popups/components/segmentation-preview/index.js
+++ b/assets/wizards/popups/components/segmentation-preview/index.js
@@ -26,7 +26,7 @@ const SegmentationPreview = props => {
 	} = props;
 
 	const decorateURL = urlToDecorate => {
-		const view_as = segment.length ? [ `segment:${ segment }` ] : [ 'all' ];
+		const view_as = segment.length ? [ `segment:${ segment }` ] : [ 'segment:everyone' ];
 
 		if ( showUnpublished ) {
 			view_as.push( 'show_unpublished:true' );

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -118,7 +118,7 @@ const Campaigns = props => {
 
 	const allPrompts = useContext( CampaignsContext );
 	const prompts = filterByCampaign( allPrompts, campaignId );
-	const hasUnassigned = filterByCampaign( prompts, 'unassigned' ).length;
+	const hasUnassigned = filterByCampaign( allPrompts, 'unassigned' ).length;
 
 	useEffect( () => {
 		if ( modalVisible ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-popups/pull/438, fixes previewing logic when previewing prompts within a single campaign, when previewing active prompts, or when previewing unassigned prompts.

Currently, when previewing a segment within a campaign, you will see all prompts assigned to that segment, even if they're not in the currently viewed campaign.

Also fixes a minor bug where the "Unassigned" option disappears if you're viewing the Campaigns tab while filtered by a campaign, even if there are unassigned prompts.

### How to test the changes in this Pull Request:

#### Previewing a single campaign

1. Create several ~campaigns~ (doh) prompts of all types (inline, overlay, above-header) and assign to a campaign. Make sure at least one prompt is unpublished (draft, pending or scheduled).
2. In the Campaigns tab, filter the view by your campaign.
3. Preview any segment containing prompts. Confirm that you see published and unpublished prompts:
  a. within the current campaign
  b. with the selected segment OR default/no segment, and
  c. with any segment that overlaps with the selected segment
4. Confirm that you do NOT see any prompts that are not assigned the currently viewed campaign.

#### Previewing active prompts

1. In the Campaigns tab with the same set of prompts, filter by Active Prompts.
2. Preview any segment. Confirm that you see only published prompts:
  a. with the selected segment OR default/no segment
  b. with any segment that overlaps with the selected segment, and
  c. within any campaign

#### Previewing unassigned prompts

1.  In the Campaigns tab with the same set of prompts, make sure at least a few prompts have no assigned campaign.
2. In the Campaign select dropdown, confirm that you see Unassigned Prompts no matter the current filter view.
3. Filter by Unassigned Prompts. Preview any segment and confirm that you see published and unpublished prompts:
  a. with the selected segment OR default/no segment
  b. with any segment that overlaps with the selected segment, and
  c. without any campaign
4. Confirm that you do NOT see any prompts that have an assigned campaign.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->