### PR TITLE
Increase segment border colour and increase add prompt button width

### DIFF
--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { useContext, useEffect, useState } from '@wordpress/element';
+import { useContext, useEffect, useState, Fragment } from '@wordpress/element';
 import { Icon, plusCircle } from '@wordpress/icons';
 
 /**
@@ -110,7 +110,7 @@ const SegmentGroup = props => {
 			</Card>
 			{ prompts.length < 1 ? <p>{ emptySegmentText }</p> : '' }
 			{ 'unassigned' !== campaignId && (
-				<div className="newspack-campaigns__segment-group__add-new-wrap">
+				<Fragment>
 					<Button
 						isSmall
 						isQuaternary
@@ -155,7 +155,7 @@ const SegmentGroup = props => {
 							</Card>
 						</Modal>
 					) }
-				</div>
+				</Fragment>
 			) }
 		</Card>
 	);

--- a/assets/wizards/popups/components/segment-group/style.scss
+++ b/assets/wizards/popups/components/segment-group/style.scss
@@ -17,8 +17,11 @@
 		display: block;
 		font-size: 12px;
 		font-weight: normal;
+		line-height: 16px;
 	}
 	&__card {
+		border-color: $light-gray-500;
+
 		& > &__segment {
 			margin: -16px -16px 16px !important;
 			padding: 8px 16px;
@@ -27,7 +30,7 @@
 		&__segment {
 			align-items: center;
 			background: $light-gray-100;
-			border-bottom: 1px solid $light-gray-200;
+			border-bottom: 1px solid $light-gray-500;
 			display: flex;
 			justify-content: space-between;
 
@@ -40,10 +43,12 @@
 					color: $primary-500;
 				}
 			}
+		}
 
-			button {
-				margin-left: 12px;
-			}
+		body[class*='admin-color-'] & > .newspack-button.has-icon:not( .has-text ) {
+			display: flex;
+			margin-top: 16px;
+			width: 100%;
 		}
 	}
 
@@ -66,12 +71,6 @@
 				margin-bottom: 0;
 			}
 		}
-	}
-
-	&__add-new-wrap {
-		display: flex;
-		justify-content: center;
-		margin-top: 16px;
 	}
 
 	&__add-new-button {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

2 small changes to the campaigns wizard:

* The "Add New Prompt" button is now full width
* The border around a segment is slightly darker to differentiate it from a prompt.

### How to test the changes in this Pull Request:

1. Check the campaigns wizard
2. Switch to this branch
3. Refresh wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->