### PR TITLE
fix: display uncategorized category in campaigns wizard

### DIFF
--- a/assets/wizards/popups/components/prompt-popovers/secondary.js
+++ b/assets/wizards/popups/components/prompt-popovers/secondary.js
@@ -13,7 +13,7 @@ import { ESCAPE } from '@wordpress/keycodes';
  * Internal dependencies.
  */
 import { CategoryAutocomplete, Popover, SelectControl } from '../../../../components/src';
-import { filterOutUncategorized, frequenciesForPopup } from '../../utils';
+import { frequenciesForPopup } from '../../utils';
 import './style.scss';
 
 const SecondaryPromptPopover = ( {
@@ -66,7 +66,7 @@ const SecondaryPromptPopover = ( {
 				taxonomy="newspack_popups_taxonomy"
 			/>
 			<CategoryAutocomplete
-				value={ filterOutUncategorized( categories ) || [] }
+				value={ categories || [] }
 				onChange={ tokens => setTermsForPopup( id, tokens, 'category' ) }
 				label={ __( 'Category filtering', 'newspack ' ) }
 			/>

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -22,16 +22,6 @@ export const isOverlay = popup =>
  */
 export const isAboveHeader = popup => 'above_header' === popup.options.placement;
 
-/**
- * Filter out "Uncategorized" category, which for purposes of Campaigns behaves identically to no category.
- *
- * @param {Array} categories Array of category objects.
- * @return {Array} Filtered array of categories, without Uncategorized category.
- */
-export const filterOutUncategorized = categories => {
-	return categories.filter( category => 'uncategorized' !== category.slug );
-};
-
 export const placementForPopup = ( { options: { frequency, placement } } ) => {
 	if ( 'manual' === frequency ) {
 		return __( 'Manual Placement', 'newspack' );
@@ -67,7 +57,7 @@ export const getCardClassName = ( { status } ) => {
 
 export const descriptionForPopup = prompt => {
 	const { categories, campaign_groups: campaigns, status } = prompt;
-	const filteredCategories = filterOutUncategorized( categories );
+	const filteredCategories = categories;
 	const descriptionMessages = [];
 	if ( campaigns.length > 0 ) {
 		const campaignsList = campaigns.map( ( { name } ) => name ).join( ', ' );
@@ -202,9 +192,9 @@ export const warningForPopup = ( prompts, prompt ) => {
 	const warningMessages = [];
 
 	if ( 'publish' === prompt.status && ( isAboveHeader( prompt ) || isOverlay( prompt ) ) ) {
-		const promptCategories = filterOutUncategorized( prompt.categories );
+		const promptCategories = prompt.categories;
 		const conflictingPrompts = prompts.filter( conflict => {
-			const conflictCategories = filterOutUncategorized( conflict.categories );
+			const conflictCategories = conflict.categories;
 
 			// There's a conflict if both campaigns have zero categories, or if they share at least one category.
 			const hasConflictingCategory =


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Partial solution to https://github.com/Automattic/newspack-popups/issues/447. Currently the "Uncategorized" category is suppressed in the Campaigns Wizard, although prompts bearing this category will behave in unexpected ways, most notably by failing to appear pages/posts unless the post also happens to be categorized "Uncategorized." This PR removes the logic so that "Uncategorized" will be visible just like any other category. Ideally we can find a stronger solution that prohibits or ignores this category, but for now this is a good first step because the user will be aware of the undesired category assignment and will be able to remove it.

### How to test the changes in this Pull Request:

1. In the Campaigns Wizard, add "Uncategorized" category to a prompt. 
2. Observe it is visible in the gear icon `PopOver` and in the `ActionCard` description.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->