### PR TITLE
fix: don't include site domain in linker

### DIFF
--- a/includes/class-nrh.php
+++ b/includes/class-nrh.php
@@ -57,7 +57,6 @@ class NRH {
 		if ( ! isset( $gtag_opt['linker']['domains'] ) ) {
 			$gtag_opt['linker']['domains'] = [];
 		}
-		$gtag_opt['linker']['domains'][]      = self::get_clean_site_url();
 		$gtag_opt['linker']['domains'][]      = 'checkout.fundjournalism.org';
 		$gtag_opt['linker']['decorate_forms'] = true;
 		return $gtag_opt;
@@ -85,7 +84,6 @@ class NRH {
 			$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['domains'] = [];
 		}
 
-		$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['domains'][]      = self::get_clean_site_url();
 		$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['domains'][]      = 'checkout.fundjournalism.org';
 		$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['decorate_forms'] = true;
 		return $gtag_amp_opt;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We've started seeing reports that clicking on the site logo leads to a redirect loop. This seems to be because the linker includes two domains `checkout.fundjournalism.org` as well as the site's domain. Because the site domain is included, the linker param is appended to links, and seems to cause  redirect loop on the home. This is generally reproducible in Safari, and Mobile Safari, but not Chrome. I haven't been able to establish a reliable way to reproduce the issue, but the change should be pretty benign. 

### How to test the changes in this Pull Request:

Verify the `linker` param no longer includes the site's URL.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->