### PR TITLE
fix: only show sticky ad at mobile viewports

### DIFF
--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -587,9 +587,11 @@ class Advertising_Wizard extends Wizard {
 		}
 
 		if ( 'sticky' === $placement_slug && $is_amp ) : ?>
-			<amp-sticky-ad class='newspack_amp_sticky_ad <?php echo esc_attr( $placement_slug ); ?>' layout="nodisplay">
-				<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-			</amp-sticky-ad>
+			<div class="newspack_amp_sticky_ad__container">
+				<amp-sticky-ad class='newspack_amp_sticky_ad <?php echo esc_attr( $placement_slug ); ?>' layout="nodisplay">
+					<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				</amp-sticky-ad>
+			</div>
 		<?php else : ?>
 			<div class='newspack_global_ad <?php echo esc_attr( $placement_slug ); ?>'>
 				<?php if ( 'sticky' === $placement_slug ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a container element wrapping the sticky ad so it can be controlled via theme CSS.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-theme/pull/1253.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->