### PR TITLE
fix: duplication of segments when dragging while re-sorting

### DIFF
--- a/assets/wizards/popups/views/segments/SegmentsList.js
+++ b/assets/wizards/popups/views/segments/SegmentsList.js
@@ -313,7 +313,10 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 				<h2>{ __( 'Audience segments', 'newspack' ) }</h2>
 				<AddNewSegmentLink />
 			</Card>
-			<div className="newspack-campaigns-wizard-segments__list" ref={ ref }>
+			<div
+				className={ 'newspack-campaigns-wizard-segments__list' + ( inFlight ? ' is-loading' : '' ) }
+				ref={ ref }
+			>
 				{ segmentsToShow.map( ( segment, index ) => (
 					<SegmentActionCard
 						deleteSegment={ deleteSegment }

--- a/assets/wizards/popups/views/segments/style.scss
+++ b/assets/wizards/popups/views/segments/style.scss
@@ -4,6 +4,10 @@
 .newspack-campaigns-wizard-segments {
 	&__list {
 		margin: 32px 0;
+
+		&.is-loading {
+			pointer-events: none;
+		}
 	}
 	&__title {
 		margin: 32px 0 64px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a duplication bug with segments resulting from the sort UI.

If you try to re-sort the segments list (either by dragging and dropping or by clicking the up/down arrow buttons) while a sort request is already in progress, it results in a malformed segments list with duplicate segment items. The duplicated items will have the same ID and configuration, so renaming or deleting one copy will result in the same action being applied to its copies.

This fix can't remedy the bad segments if the issue has already happened, but it will prevent the issue from happening going forward. The only fix for the issue if it's already happened is to delete all bad segment copies and rebuild them from scratch.

### How to test the changes in this Pull Request:

1. On `master`, go to Newspack > Campaigns > Segments and create several segments.
2. Re-sort the list by either dragging and dropping a segment or by clicking the up/down arrow buttons. Very quickly, while the view is still in a loading state, drag and drop another segment or click the up/down arrow buttons to move the segment. Observe that you now have multiple copies of the same segment in the list:

<img width="1398" alt="Screen Shot 2021-02-23 at 6 17 17 PM" src="https://user-images.githubusercontent.com/2230142/108933742-e775b900-7608-11eb-8f16-e09e8edf3da9.png">

3. Also observe in the Campaigns tab that the segment may appear multiple times:

![newspack1 ngrok io_wp-admin_admin php_page=newspack-popups-wizard](https://user-images.githubusercontent.com/2230142/108933703-d62cac80-7608-11eb-874f-4cf55e909257.png)

4. Check out this branch and run `npm run build`.
5. Go back to the Segments tab and attempt to replicate step 2. Confirm that this is now impossible because UI interaction is blocked while the view is in a loading state.
6. Make sure to delete any bad segment copies resulting from step 2 and rebuild, if necessary.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->