### PR TITLE
Update the Footer to support a simpler style

### DIFF
--- a/assets/components/src/footer/index.js
+++ b/assets/components/src/footer/index.js
@@ -6,7 +6,6 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
 import { ExternalLink } from '@wordpress/components';
 
 /**
@@ -15,86 +14,80 @@ import { ExternalLink } from '@wordpress/components';
 import { PatronsLogo } from '../';
 import './style.scss';
 
-class Footer extends Component {
-	/**
-	 * Render
-	 */
-	render() {
-		const componentsDemo = window && window.newspack_urls && window.newspack_urls.components_demo;
-		const setupWizard = window && window.newspack_urls && window.newspack_urls.setup_wizard;
-		const resetUrl = window && window.newspack_urls && window.newspack_urls.reset_url;
-		const resetWpcomUrl = window && window.newspack_urls && window.newspack_urls.reset_wpcom_url;
-		const pluginVersion = window && window.newspack_urls && window.newspack_urls.plugin_version;
-		const removeStarterContent =
-			window && window.newspack_urls && window.newspack_urls.remove_starter_content;
-		const footerElements = [
-			{
-				label: pluginVersion.label,
-				url: pluginVersion.url,
-			},
-			{
-				label: __( 'About', 'newspack' ),
-				url: 'https://newspack.pub/',
-				external: true,
-			},
-			{
-				label: __( 'Documentation', 'newspack' ),
-				url: 'https://newspack.pub/support/',
-				external: true,
-			},
-		];
-		if ( componentsDemo ) {
-			footerElements.push( {
-				label: __( 'Components Demo', 'newspack' ),
-				url: componentsDemo,
-			} );
-		}
-		if ( setupWizard ) {
-			footerElements.push( {
-				label: __( 'Setup Wizard', 'newspack' ),
-				url: setupWizard,
-			} );
-		}
-		if ( resetUrl ) {
-			footerElements.push( {
-				label: __( 'Reset Newspack', 'newspack' ),
-				url: resetUrl,
-			} );
-		}
-		if ( resetWpcomUrl ) {
-			footerElements.push( {
-				label: __( 'Reset WordPress.com Authentication', 'newspack' ),
-				url: resetWpcomUrl,
-			} );
-		}
-		if ( removeStarterContent ) {
-			footerElements.push( {
-				label: __( 'Remove Starter Content', 'newspack' ),
-				url: removeStarterContent,
-			} );
-		}
-		const { simple } = this.props;
-		return (
-			<div className="newspack-footer">
-				<PatronsLogo />
-				{ ! simple && (
-					<div className="newspack-footer__inner">
-						<ul>
-							{ footerElements.map( ( { url, label, external }, index ) => (
-								<li key={ index }>
-									{ external ? (
-										<ExternalLink href={ url }>{ label }</ExternalLink>
-									) : (
-										<a href={ url }>{ label }</a>
-									) }
-								</li>
-							) ) }
-						</ul>
-					</div>
-				) }
-			</div>
-		);
+const Footer = ( { simple } ) => {
+	const componentsDemo = window && window.newspack_urls && window.newspack_urls.components_demo;
+	const setupWizard = window && window.newspack_urls && window.newspack_urls.setup_wizard;
+	const resetUrl = window && window.newspack_urls && window.newspack_urls.reset_url;
+	const resetWpcomUrl = window && window.newspack_urls && window.newspack_urls.reset_wpcom_url;
+	const pluginVersion = window && window.newspack_urls && window.newspack_urls.plugin_version;
+	const removeStarterContent =
+		window && window.newspack_urls && window.newspack_urls.remove_starter_content;
+	const footerElements = [
+		{
+			label: pluginVersion.label,
+			url: pluginVersion.url,
+		},
+		{
+			label: __( 'About', 'newspack' ),
+			url: 'https://newspack.pub/',
+			external: true,
+		},
+		{
+			label: __( 'Documentation', 'newspack' ),
+			url: 'https://newspack.pub/support/',
+			external: true,
+		},
+	];
+	if ( componentsDemo ) {
+		footerElements.push( {
+			label: __( 'Components Demo', 'newspack' ),
+			url: componentsDemo,
+		} );
 	}
+	if ( setupWizard ) {
+		footerElements.push( {
+			label: __( 'Setup Wizard', 'newspack' ),
+			url: setupWizard,
+		} );
+	}
+	if ( resetUrl ) {
+		footerElements.push( {
+			label: __( 'Reset Newspack', 'newspack' ),
+			url: resetUrl,
+		} );
+	}
+	if ( resetWpcomUrl ) {
+		footerElements.push( {
+			label: __( 'Reset WordPress.com Authentication', 'newspack' ),
+			url: resetWpcomUrl,
+		} );
+	}
+	if ( removeStarterContent ) {
+		footerElements.push( {
+			label: __( 'Remove Starter Content', 'newspack' ),
+			url: removeStarterContent,
+		} );
+	}
+	return (
+		<div className="newspack-footer">
+			<PatronsLogo />
+			{ ! simple && (
+				<div className="newspack-footer__inner">
+					<ul>
+						{ footerElements.map( ( { url, label, external }, index ) => (
+							<li key={ index }>
+								{ external ? (
+									<ExternalLink href={ url }>{ label }</ExternalLink>
+								) : (
+									<a href={ url }>{ label }</a>
+								) }
+							</li>
+						) ) }
+					</ul>
+				</div>
+			) }
+		</div>
+	);
 }
 
 export default Footer;

--- a/assets/components/src/footer/index.js
+++ b/assets/components/src/footer/index.js
@@ -88,6 +88,6 @@ const Footer = ( { simple } ) => {
 			) }
 		</div>
 	);
-}
+};
 
 export default Footer;

--- a/assets/components/src/footer/index.js
+++ b/assets/components/src/footer/index.js
@@ -6,6 +6,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 import { ExternalLink } from '@wordpress/components';
 
 /**
@@ -14,78 +15,86 @@ import { ExternalLink } from '@wordpress/components';
 import { PatronsLogo } from '../';
 import './style.scss';
 
-const Footer = () => {
-	const componentsDemo = window && window.newspack_urls && window.newspack_urls.components_demo;
-	const setupWizard = window && window.newspack_urls && window.newspack_urls.setup_wizard;
-	const resetUrl = window && window.newspack_urls && window.newspack_urls.reset_url;
-	const resetWpcomUrl = window && window.newspack_urls && window.newspack_urls.reset_wpcom_url;
-	const pluginVersion = window && window.newspack_urls && window.newspack_urls.plugin_version;
-	const removeStarterContent =
-		window && window.newspack_urls && window.newspack_urls.remove_starter_content;
-	const footerElements = [
-		{
-			label: pluginVersion.label,
-			url: pluginVersion.url,
-		},
-		{
-			label: __( 'About', 'newspack' ),
-			url: 'https://newspack.pub/',
-			external: true,
-		},
-		{
-			label: __( 'Documentation', 'newspack' ),
-			url: 'https://newspack.pub/support/',
-			external: true,
-		},
-	];
-	if ( componentsDemo ) {
-		footerElements.push( {
-			label: __( 'Components Demo', 'newspack' ),
-			url: componentsDemo,
-		} );
-	}
-	if ( setupWizard ) {
-		footerElements.push( {
-			label: __( 'Setup Wizard', 'newspack' ),
-			url: setupWizard,
-		} );
-	}
-	if ( resetUrl ) {
-		footerElements.push( {
-			label: __( 'Reset Newspack', 'newspack' ),
-			url: resetUrl,
-		} );
-	}
-	if ( resetWpcomUrl ) {
-		footerElements.push( {
-			label: __( 'Reset WordPress.com Authentication', 'newspack' ),
-			url: resetWpcomUrl,
-		} );
-	}
-	if ( removeStarterContent ) {
-		footerElements.push( {
-			label: __( 'Remove Starter Content', 'newspack' ),
-			url: removeStarterContent,
-		} );
-	}
-	return (
-		<div className="newspack-footer">
-			<PatronsLogo />
-			<div className="newspack-footer__inner">
-				<ul>
-					{ footerElements.map( ( { url, label, external }, index ) => (
-						<li key={ index }>
-							{ external ? (
-								<ExternalLink href={ url }>{ label }</ExternalLink>
-							) : (
-								<a href={ url }>{ label }</a>
-							) }
-						</li>
-					) ) }
-				</ul>
+class Footer extends Component {
+	/**
+	 * Render
+	 */
+	render() {
+		const componentsDemo = window && window.newspack_urls && window.newspack_urls.components_demo;
+		const setupWizard = window && window.newspack_urls && window.newspack_urls.setup_wizard;
+		const resetUrl = window && window.newspack_urls && window.newspack_urls.reset_url;
+		const resetWpcomUrl = window && window.newspack_urls && window.newspack_urls.reset_wpcom_url;
+		const pluginVersion = window && window.newspack_urls && window.newspack_urls.plugin_version;
+		const removeStarterContent =
+			window && window.newspack_urls && window.newspack_urls.remove_starter_content;
+		const footerElements = [
+			{
+				label: pluginVersion.label,
+				url: pluginVersion.url,
+			},
+			{
+				label: __( 'About', 'newspack' ),
+				url: 'https://newspack.pub/',
+				external: true,
+			},
+			{
+				label: __( 'Documentation', 'newspack' ),
+				url: 'https://newspack.pub/support/',
+				external: true,
+			},
+		];
+		if ( componentsDemo ) {
+			footerElements.push( {
+				label: __( 'Components Demo', 'newspack' ),
+				url: componentsDemo,
+			} );
+		}
+		if ( setupWizard ) {
+			footerElements.push( {
+				label: __( 'Setup Wizard', 'newspack' ),
+				url: setupWizard,
+			} );
+		}
+		if ( resetUrl ) {
+			footerElements.push( {
+				label: __( 'Reset Newspack', 'newspack' ),
+				url: resetUrl,
+			} );
+		}
+		if ( resetWpcomUrl ) {
+			footerElements.push( {
+				label: __( 'Reset WordPress.com Authentication', 'newspack' ),
+				url: resetWpcomUrl,
+			} );
+		}
+		if ( removeStarterContent ) {
+			footerElements.push( {
+				label: __( 'Remove Starter Content', 'newspack' ),
+				url: removeStarterContent,
+			} );
+		}
+		const { simple } = this.props;
+		return (
+			<div className="newspack-footer">
+				<PatronsLogo />
+				{ ! simple && (
+					<div className="newspack-footer__inner">
+						<ul>
+							{ footerElements.map( ( { url, label, external }, index ) => (
+								<li key={ index }>
+									{ external ? (
+										<ExternalLink href={ url }>{ label }</ExternalLink>
+									) : (
+										<a href={ url }>{ label }</a>
+									) }
+								</li>
+							) ) }
+						</ul>
+					</div>
+				) }
 			</div>
-		</div>
-	);
-};
+		);
+	}
+}
 
 export default Footer;

--- a/assets/components/src/footer/style.scss
+++ b/assets/components/src/footer/style.scss
@@ -21,6 +21,7 @@
 	&__inner {
 		border: 0 solid $light-gray-200;
 		border-width: 1px 0;
+		margin-top: 16px;
 	}
 
 	ul {
@@ -54,7 +55,7 @@
 	.patrons-logo {
 		display: block;
 		fill: currentColor;
-		margin: 0 auto 16px;
+		margin: 0 auto;
 		max-height: 24px;
 		max-width: calc( 100% - 64px );
 		width: auto;

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -250,7 +250,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		 * Render.
 		 */
 		render() {
-			const { suppressFooter } = this.props;
+			const { footerSimple, footerSuppress } = this.props;
 			const { loading, quietLoading, error } = this.state;
 			const loadingClasses = [
 				loading ? 'newspack-wizard__is-loading' : 'newspack-wizard__is-loaded',
@@ -276,7 +276,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 							{ ...this.props }
 						/>
 					</div>
-					{ ! suppressFooter && ! loading && <Footer /> }
+					{ ! loading && ! footerSuppress && <Footer simple={ footerSimple } /> }
 				</Fragment>
 			);
 		}

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -250,7 +250,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 		 * Render.
 		 */
 		render() {
-			const { footerSimple, footerSuppress } = this.props;
+			const { simpleFooter } = this.props;
 			const { loading, quietLoading, error } = this.state;
 			const loadingClasses = [
 				loading ? 'newspack-wizard__is-loading' : 'newspack-wizard__is-loaded',
@@ -276,7 +276,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 							{ ...this.props }
 						/>
 					</div>
-					{ ! loading && ! footerSuppress && <Footer simple={ footerSimple } /> }
+					{ ! loading && <Footer simple={ simpleFooter } /> }
 				</Fragment>
 			);
 		}

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -78,8 +78,12 @@ svg {
 		margin: 0;
 	}
 
+	.newspack-footer {
+		color: white;
+	}
+
 	#wpfooter {
-		color: #fff;
+		color: white;
 
 		a {
 			color: inherit;

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -103,6 +103,6 @@ const SetupWizard = ( { wizardApiFetch, setError } ) => {
 };
 
 render(
-	createElement( withWizard( SetupWizard, [] ), { footerSimple: true } ),
+	createElement( withWizard( SetupWizard, [] ), { simpleFooter: true } ),
 	document.getElementById( 'newspack-setup-wizard' )
 );

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -103,6 +103,6 @@ const SetupWizard = ( { wizardApiFetch, setError } ) => {
 };
 
 render(
-	createElement( withWizard( SetupWizard, [] ), { suppressFooter: true } ),
+	createElement( withWizard( SetupWizard, [] ), { footerSimple: true } ),
 	document.getElementById( 'newspack-setup-wizard' )
 );

--- a/assets/wizards/setup/style.scss
+++ b/assets/wizards/setup/style.scss
@@ -3,8 +3,6 @@
  */
 
 #newspack-setup-wizard {
-	position: relative;
-
 	.newspack-wizard__header {
 		h1 {
 			display: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The new `simple` prop added to `Footer` allows wizards to use the `Footer` without all the links and only display the logos of WordPress.com and Google News Initiative.

This is particularly useful for the Onboarding. Currently the `Footer` is being suppressed which is not ideal. With this PR we now have the 2 logos at the bottom.

### How to test the changes in this Pull Request:

1. Go through the Onboarding. Notice there isn't a Footer like on any other Wizard
2. Switch to this branch
3. Go through the Onboarding again, notice the logos at the bottom (no links)
4. Check a different wizard and see if you have the different links in the footer

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->