### PR TITLE
feat: validated segmentation sort and error handling

### DIFF
--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -147,7 +147,7 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	/**
 	 * Sort all segments.
 	 *
-	 * @param object $segments Sorted array of segments.
+	 * @param object $segment_ids Sorted array of segment IDs.
 	 */
 	public function sort_segments( $segment_ids ) {
 		return $this->is_configured() ?

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -149,9 +149,9 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	 *
 	 * @param object $segments Sorted array of segments.
 	 */
-	public function sort_segments( $segments ) {
+	public function sort_segments( $segment_ids ) {
 		return $this->is_configured() ?
-			\Newspack_Popups_Segmentation::sort_segments( $segments ) :
+			\Newspack_Popups_Segmentation::sort_segments( $segment_ids ) :
 			$this->unconfigured_error();
 	}
 

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -780,7 +780,7 @@ class Popups_Wizard extends Wizard {
 	 */
 	public function api_sort_segments( $request ) {
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
-		$response                              = $newspack_popups_configuration_manager->sort_segments( $request['segments'] );
+		$response                              = $newspack_popups_configuration_manager->sort_segments( $request['segmentIds'] );
 		return $response;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-popups/pull/455, adds server-side validation of segmentation sort request params. This should prevent most instances of bad client-side data being persisted in the options table. If the Popups API endpoint returns an error, display the error in the UI.

Closes #882.

### How to test the changes in this Pull Request:

Confirm that you can no longer replicate the issue described in #882 either by deleting or adding segments in one tab but not the other.

If you try to sort with outdated data, the error messaging should look like this:

<img width="1043" alt="Screen Shot 2021-02-24 at 11 16 40 AM" src="https://user-images.githubusercontent.com/2230142/109047593-4e3fb480-7693-11eb-90b7-2feb4af94efd.png">

Note that it's still possible to have two tabs open, re-sort in tab 1, then re-sort in tab 2, and have tab 2's sort order override tab 1's. But that's much less of a problem in my mind than creating malformed lists, deleting segments that had been previously added, or bringing back segments that had been deleted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->