### PR TITLE
Replace CID cookie on preview triggering

### DIFF
--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -113,10 +113,24 @@ const SegmentGroup = props => {
 								isQuaternary
 								isSmall
 								onClick={ () => {
-									cookies.remove( 'newspack-cid' );
-									cookies.set( 'newspack-cid', `preview-${ Date.now() }`, {
-										domain: window.location.host.replace( /[^\.]+\./, '.' ),
-									} );
+									if ( newspack_aux_data.popups_cookie_name ) {
+										// Remove cookies for all possible domains.
+										window.location.host
+											.split( '.' )
+											.reduce( ( acc, _, i, arr ) => {
+												acc.push( arr.slice( -( i + 1 ) ).join( '.' ) );
+												return acc;
+											}, [] )
+											.map( domain =>
+												cookies.remove( newspack_aux_data.popups_cookie_name, {
+													domain: `.${ domain }`,
+												} )
+											);
+
+										cookies.set( newspack_aux_data.popups_cookie_name, `preview-${ Date.now() }`, {
+											domain: '.' + window.location.host,
+										} );
+									}
 
 									showPreview();
 								} }

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -114,7 +114,7 @@ const SegmentGroup = props => {
 								isSmall
 								onClick={ () => {
 									cookies.remove( 'newspack-cid' );
-									cookies.set( 'newspack-cid', `preview-${ Math.round( Math.random() * 9999 ) }`, {
+									cookies.set( 'newspack-cid', `preview-${ Date.now() }`, {
 										domain: window.location.host.replace( /[^\.]+\./, '.' ),
 									} );
 

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -52,6 +52,23 @@ const addNewURL = ( placement, campaignId, segmentId ) => {
 	return base + params.join( '&' );
 };
 
+const removeCIDCookie = () => {
+	if ( newspack_aux_data.popups_cookie_name ) {
+		// Remove cookies for all possible domains.
+		window.location.host
+			.split( '.' )
+			.reduce( ( acc, _, i, arr ) => {
+				acc.push( arr.slice( -( i + 1 ) ).join( '.' ) );
+				return acc;
+			}, [] )
+			.map( domain =>
+				cookies.remove( newspack_aux_data.popups_cookie_name, {
+					domain: `.${ domain }`,
+				} )
+			);
+	}
+};
+
 const SegmentGroup = props => {
 	const { campaignData, campaignId, segment } = props;
 	const [ modalVisible, setModalVisible ] = useState( false );
@@ -108,25 +125,14 @@ const SegmentGroup = props => {
 						campaign={ campaignId ? campaignToPreview : false }
 						segment={ id }
 						showUnpublished={ !! campaignId } // Only if previewing a specific campaign/group.
+						onClose={ removeCIDCookie }
 						renderButton={ ( { showPreview } ) => (
 							<Button
 								isQuaternary
 								isSmall
 								onClick={ () => {
+									removeCIDCookie();
 									if ( newspack_aux_data.popups_cookie_name ) {
-										// Remove cookies for all possible domains.
-										window.location.host
-											.split( '.' )
-											.reduce( ( acc, _, i, arr ) => {
-												acc.push( arr.slice( -( i + 1 ) ).join( '.' ) );
-												return acc;
-											}, [] )
-											.map( domain =>
-												cookies.remove( newspack_aux_data.popups_cookie_name, {
-													domain: `.${ domain }`,
-												} )
-											);
-
 										cookies.set( newspack_aux_data.popups_cookie_name, `preview-${ Date.now() }`, {
 											domain: '.' + window.location.host,
 										} );

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -2,6 +2,8 @@
  * Segment group component.
  */
 
+import cookies from 'js-cookie';
+
 /**
  * WordPress dependencies.
  */
@@ -110,7 +112,14 @@ const SegmentGroup = props => {
 							<Button
 								isQuaternary
 								isSmall
-								onClick={ () => showPreview() }
+								onClick={ () => {
+									cookies.remove( 'newspack-cid' );
+									cookies.set( 'newspack-cid', `preview-${ Math.round( Math.random() * 9999 ) }`, {
+										domain: window.location.host.replace( /[^\.]+\./, '.' ),
+									} );
+
+									showPreview();
+								} }
 								icon={ iconPreview }
 								label={ __( 'Preview Segment', 'newspack' ) }
 								tooltipPosition="bottom center"

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -167,6 +167,10 @@ abstract class Wizard {
 			'site_title'    => get_option( 'blogname' ),
 		];
 
+		if ( class_exists( 'Newspack_Popups_Segmentation' ) ) {
+			$aux_data['popups_cookie_name'] = \Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME;
+		}
+
 		wp_localize_script( 'newspack_data', 'newspack_urls', $urls );
 		wp_localize_script( 'newspack_data', 'newspack_aux_data', $aux_data );
 		wp_enqueue_script( 'newspack_data' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -19587,6 +19587,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
       "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "dompurify": "^2.2.4",
     "happychat-client": "^0.1.0",
     "human-number": "^1.0.5",
+    "js-cookie": "^2.2.1",
     "marked": "^1.2.7",
     "qs": "^6.9.3",
     "react": "^16.12.0",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

On preview, replace the Client ID cookie, so that a preview session is a fresh session.

### How to test the changes in this Pull Request:

1. Use `try/view-as-cookie-spoofing` branch of `newspack-popups` (https://github.com/Automattic/newspack-popups/pull/458)
2. Use the campaign/segment preview feature. Dismiss a campaign permanently and ensure you've seen another one, which is set to "once" frequency
3. Navigate the site in preview window, observe that the two prompts are not visible anymore
4. Close the preview, open it again - observe the prompts are visible again
5. Close the preview, logout, and visit the site - the prompts should behave as in a new session 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
