### PR TITLE
Campaigns Wizard: fix settings reading

### DIFF
--- a/assets/components/src/checkbox-control/index.js
+++ b/assets/components/src/checkbox-control/index.js
@@ -24,11 +24,11 @@ class CheckboxControl extends Component {
 	 * Render.
 	 */
 	render() {
-		const { className, tooltip, ...otherProps } = this.props;
+		const { className, checked, tooltip, ...otherProps } = this.props;
 		const classes = classnames( 'newspack-checkbox-control', className );
 		return (
 			<div className={ classes }>
-				<BaseComponent { ...otherProps } />
+				<BaseComponent checked={ Boolean( checked ) } { ...otherProps } />
 				{ tooltip && <InfoButton text={ tooltip } /> }
 			</div>
 		);

--- a/assets/wizards/popups/views/settings/index.js
+++ b/assets/wizards/popups/views/settings/index.js
@@ -48,7 +48,7 @@ const Settings = ( { isLoading, wizardApiFetch } ) => {
 						/>
 					);
 				default:
-					return <CheckboxControl { ...props } checked={ setting.value === '1' } />;
+					return <CheckboxControl { ...props } checked={ setting.value } />;
 			}
 		}
 		return null;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes settings reading.

### How to test the changes in this Pull Request:

1. On `master`, visit the Campaigns Wizard, Settings tab
2. Observe that the "Enable non-interactive mode" setting is not displaying an on state after turning on
3. Switch to this branch, observe the issue is resolved

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
