### PR TITLE
Fix categories handling in segment settings

### DIFF
--- a/assets/components/src/hooks/useObjectState.js
+++ b/assets/components/src/hooks/useObjectState.js
@@ -7,7 +7,7 @@ import { mergeWith, isArray } from 'lodash';
 
 const mergeCustomizer = ( objValue, srcValue ) => {
 	if ( isArray( objValue ) ) {
-		// If it's an array, replace it (instead of contatenating).
+		// If it's an array, replace it (instead of concatenating).
 		return srcValue;
 	}
 };

--- a/assets/components/src/hooks/useObjectState.js
+++ b/assets/components/src/hooks/useObjectState.js
@@ -3,15 +3,24 @@
  */
 import { useState } from '@wordpress/element';
 
-import { merge } from 'lodash';
+import { mergeWith, isArray } from 'lodash';
+
+const mergeCustomizer = ( objValue, srcValue ) => {
+	if ( isArray( objValue ) ) {
+		// If it's an array, replace it (instead of contatenating).
+		return srcValue;
+	}
+};
 
 /**
  * A useState for an object.
+ * Nested objects will be nested, but arrays replaced.
  */
 export default initial => {
 	const [ stateObject, setStateObject ] = useState( initial );
 
-	const runUpdate = update => setStateObject( _stateObject => merge( {}, _stateObject, update ) );
+	const runUpdate = update =>
+		setStateObject( _stateObject => mergeWith( {}, _stateObject, update, mergeCustomizer ) );
 
 	const updateStateObject = keyOrUpdate => {
 		if ( typeof keyOrUpdate === 'string' ) {

--- a/assets/components/src/hooks/useObjectState.test.js
+++ b/assets/components/src/hooks/useObjectState.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import useObjectState from './useObjectState';
+
+const INIT_STATE = { name: 'Foo', widgets: [ 1 ], attributes: { bar: 0, baz: 1 } };
+const TestComponent = () => {
+	const [ state, updateState ] = useObjectState( INIT_STATE );
+	return (
+		<div>
+			<input placeholder="state" onChange={ () => {} } value={ JSON.stringify( state ) } />
+			<button onClick={ () => updateState( { widgets: [] } ) }>Remove widgets</button>
+			<button onClick={ () => updateState( { widgets: [ 1 ] } ) }>Add widget</button>
+			<button onClick={ () => updateState( { attributes: { bar: 2 } } ) }>Nested update</button>
+			<input
+				type="text"
+				value={ state.name }
+				onChange={ e => updateState( { name: e.target.value } ) }
+				placeholder="name"
+			/>
+		</div>
+	);
+};
+
+describe( 'useObjectState', () => {
+	const getState = () =>
+		JSON.parse( screen.getByPlaceholderText( 'state' ).getAttribute( 'value' ) );
+
+	beforeEach( () => {
+		render( <TestComponent /> );
+	} );
+
+	it( 'updates arrays', () => {
+		expect( getState() ).toStrictEqual( INIT_STATE );
+		screen.getByText( 'Remove widgets' ).click();
+		expect( getState() ).toMatchObject( { widgets: [] } );
+		screen.getByText( 'Add widget' ).click();
+		expect( getState() ).toMatchObject( { widgets: [ 1 ] } );
+	} );
+	it( 'updates a simple value', () => {
+		fireEvent.change( screen.getByPlaceholderText( 'name' ), { target: { value: 'Ramon' } } );
+		expect( getState() ).toMatchObject( { name: 'Ramon' } );
+	} );
+	it( 'updates a nested object', () => {
+		screen.getByText( 'Nested update' ).click();
+		expect( getState() ).toMatchObject( { attributes: { bar: 2, baz: 1 } } );
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug & adds tests for `useObjectState` hook.

### How to test the changes in this Pull Request:

1. On `master`, visit Campaigns Wizard and edit a segment
2. Observe that after adding a single category in category affinity criteria, it cannot be removed
3. Switch to this branch, observe the categories can be added and removed as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
