### PR TITLE
Fix starter content issues

### DIFF
--- a/assets/wizards/setup/views/welcome/index.js
+++ b/assets/wizards/setup/views/welcome/index.js
@@ -21,9 +21,11 @@ import {
 	NewspackLogo,
 	ProgressBar,
 	withWizardScreen,
+	CheckboxControl,
 } from '../../../../components/src';
 
 const POST_COUNT = newspack_aux_data.is_e2e ? 12 : 40;
+const STARTER_CONTENT_REQUEST_COUNT = POST_COUNT + 3;
 
 const REQUIRED_SOFTWARE_SLUGS = [
 	'jetpack',
@@ -36,8 +38,6 @@ const REQUIRED_SOFTWARE_SLUGS = [
 	'newspack-newsletters',
 	'newspack-theme',
 ];
-
-const TOTAL = POST_COUNT + 4 + REQUIRED_SOFTWARE_SLUGS.length;
 
 const ERROR_TYPES = {
 	plugin_configuration: { message: __( 'Installation', 'newspack' ) },
@@ -53,9 +53,14 @@ const starterContentFetch = endpoint =>
 const Welcome = ( { buttonAction } ) => {
 	const [ installationProgress, setInstallationProgress ] = useState( 0 );
 	const [ softwareInfo, setSoftwareInfo ] = useState( [] );
+	const [ shouldInstallStarterContent, setShouldInstallStarterContent ] = useState( true );
 	const [ errors, setErrors ] = useState( [] );
 	const addError = errorInfo => error =>
 		setErrors( _errors => [ ..._errors, { ...errorInfo, error } ] );
+
+	const total =
+		( shouldInstallStarterContent ? STARTER_CONTENT_REQUEST_COUNT : 0 ) +
+		REQUIRED_SOFTWARE_SLUGS.length;
 
 	useEffect( () => {
 		document.body.classList.add( 'newspack_page_newspack-setup-wizard__welcome' );
@@ -74,8 +79,6 @@ const Welcome = ( { buttonAction } ) => {
 	const increment = () => setInstallationProgress( progress => progress + 1 );
 
 	const install = async () => {
-		increment();
-
 		// Plugins and theme.
 		const softwarePromises = softwareInfo.map( item => {
 			if ( item.Status === 'active' ) {
@@ -99,48 +102,50 @@ const Welcome = ( { buttonAction } ) => {
 			await softwarePromises[ i ]();
 		}
 
-		// Starter content.
-		await starterContentFetch( `categories` )
-			.then( increment )
-			.catch(
-				addError( {
-					info: ERROR_TYPES.starter_content,
-					item: __( 'Failed to create the categories.', 'newspack' ),
-				} )
+		if ( shouldInstallStarterContent ) {
+			// Starter content.
+			await starterContentFetch( `categories` )
+				.then( increment )
+				.catch(
+					addError( {
+						info: ERROR_TYPES.starter_content,
+						item: __( 'Failed to create the categories.', 'newspack' ),
+					} )
+				);
+			await Promise.allSettled(
+				times( POST_COUNT, n =>
+					starterContentFetch( `post/${ n }` )
+						.then( increment )
+						.catch(
+							addError( {
+								info: ERROR_TYPES.starter_content,
+								item: __( 'Failed to create a post.', 'newspack' ),
+							} )
+						)
+				)
 			);
-		await Promise.allSettled(
-			times( POST_COUNT, n =>
-				starterContentFetch( `post/${ n }` )
-					.then( increment )
-					.catch(
-						addError( {
-							info: ERROR_TYPES.starter_content,
-							item: __( 'Failed to create a post.', 'newspack' ),
-						} )
-					)
-			)
-		);
-		await starterContentFetch( `homepage` )
-			.then( increment )
-			.catch(
-				addError( {
-					info: ERROR_TYPES.starter_content,
-					item: __( 'Failed to create the homepage.', 'newspack' ),
-				} )
-			);
-		await starterContentFetch( `theme` )
-			.then( increment )
-			.catch(
-				addError( {
-					info: ERROR_TYPES.starter_content,
-					item: __( 'Failed to activate the theme.', 'newspack' ),
-				} )
-			);
+			await starterContentFetch( `homepage` )
+				.then( increment )
+				.catch(
+					addError( {
+						info: ERROR_TYPES.starter_content,
+						item: __( 'Failed to create the homepage.', 'newspack' ),
+					} )
+				);
+			await starterContentFetch( `theme` )
+				.then( increment )
+				.catch(
+					addError( {
+						info: ERROR_TYPES.starter_content,
+						item: __( 'Failed to activate the theme.', 'newspack' ),
+					} )
+				);
+		}
 	};
 
 	const hasErrors = errors.length > 0;
 	const isInit = installationProgress === 0;
-	const isDone = installationProgress === TOTAL;
+	const isDone = installationProgress === total;
 
 	const getHeadingText = () => {
 		if ( hasErrors ) {
@@ -171,10 +176,13 @@ const Welcome = ( { buttonAction } ) => {
 		if ( isDone ) {
 			return __( 'Click the button below to start configuring your Newspack site.', 'newspack' );
 		}
-		return __(
-			'We are now installing core plugins and pre-populating your site with categories and placeholder stories to help you pre-configure it. All placeholder content can be deleted later.',
-			'newspack'
-		);
+		if ( shouldInstallStarterContent ) {
+			return __(
+				'We are now installing core plugins and pre-populating your site with categories and placeholder stories to help you pre-configure it. All placeholder content can be deleted later.',
+				'newspack'
+			);
+		}
+		return __( 'We are now installing core plugins.', 'newspack' );
 	};
 
 	const getHeadingIcon = () => {
@@ -204,20 +212,33 @@ const Welcome = ( { buttonAction } ) => {
 					{ getHeadingText() }
 				</h1>
 				{ errors.length === 0 && installationProgress > 0 ? (
-					<ProgressBar completed={ installationProgress } total={ TOTAL } />
+					<ProgressBar completed={ installationProgress } total={ total } />
 				) : null }
 				<p>{ getInfoText() }</p>
 				{ errors.length ? errors.map( renderErrorBox ) : null }
 				{ ( isInit || isDone ) && (
-					<div className="newspack-buttons-card">
-						<Button
-							disabled={ REQUIRED_SOFTWARE_SLUGS.length !== softwareInfo.length }
-							isPrimary
-							onClick={ isInit ? install : null }
-							href={ isDone ? buttonAction.href : null }
-						>
-							{ isInit ? __( 'Start the Installation', 'newspack' ) : __( 'Continue', 'newspack' ) }
-						</Button>
+					<div className="flex items-center justify-between">
+						{ isInit ? (
+							<CheckboxControl
+								checked={ shouldInstallStarterContent }
+								label={ __( 'Install demo content', 'newspack' ) }
+								onChange={ setShouldInstallStarterContent }
+							/>
+						) : (
+							<div />
+						) }
+						<div>
+							<Button
+								disabled={ REQUIRED_SOFTWARE_SLUGS.length !== softwareInfo.length }
+								isPrimary
+								onClick={ isInit ? install : null }
+								href={ isDone ? buttonAction.href : null }
+							>
+								{ isInit
+									? __( 'Start the Installation', 'newspack' )
+									: __( 'Continue', 'newspack' ) }
+							</Button>
+						</div>
 					</div>
 				) }
 			</Card>

--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -126,6 +126,7 @@ class Starter_Content {
 		if ( ! function_exists( 'wp_create_category' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
 		}
+		self::remove_starter_categories();
 		$category_ids = array_map(
 			function( $category ) {
 				$created_category = wp_insert_term( $category, 'category', [ 'slug' => '_newspack_' . $category ] );
@@ -459,16 +460,24 @@ class Starter_Content {
 	}
 
 	/**
-	 * Removes all starter content.
+	 * Removes starter categories.
 	 */
-	public static function remove_starter_content() {
-		$starter_content_data = self::starter_content_data();
-		if ( ! empty( $starter_content_data['category_ids'] ) ) {
-			foreach ( $starter_content_data['category_ids'] as $category_id ) {
+	public static function remove_starter_categories() {
+		$category_ids = get_option( self::$starter_categories_meta, [] );
+		if ( ! empty( $category_ids ) ) {
+			foreach ( $category_ids as $category_id ) {
 				wp_delete_category( $category_id );
 			}
 			delete_option( self::$starter_categories_meta );
 		}
+	}
+
+	/**
+	 * Removes all starter content.
+	 */
+	public static function remove_starter_content() {
+		self::remove_starter_categories();
+		$starter_content_data = self::starter_content_data();
 		if ( ! empty( $starter_content_data['post_ids'] ) ) {
 			foreach ( $starter_content_data['post_ids'] as $post_index => $post_id ) {
 				wp_delete_post( $post_id, true );

--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -128,7 +128,8 @@ class Starter_Content {
 		}
 		$category_ids = array_map(
 			function( $category ) {
-				return wp_create_category( $category );
+				$created_category = wp_insert_term( $category, 'category', [ 'slug' => '_newspack_' . $category ] );
+				return $created_category['term_id'];
 			},
 			self::$starter_categories
 		);

--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -228,10 +228,12 @@ class Starter_Content {
 	 * Set up theme.
 	 */
 	public static function initialize_theme() {
-		$logo_id = self::upload_logo();
-		if ( $logo_id ) {
-			set_theme_mod( 'custom_logo', $logo_id );
-			set_theme_mod( 'logo_size', 0 );
+		if ( false === get_theme_mod( 'custom_logo' ) ) {
+			$logo_id = self::upload_logo();
+			if ( $logo_id ) {
+				set_theme_mod( 'custom_logo', $logo_id );
+				set_theme_mod( 'logo_size', 0 );
+			}
 		}
 		set_theme_mod( 'header_solid_background', true );
 		set_theme_mod( 'header_simplified', true );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #899 
Closes #903 
Closes #904

### How to test the changes in this Pull Request:

1. On a new site, add two categories: "Opinion", "Health"
2. Install the plugin, but don't do the setup just yet. Install & activate Newspack theme.
3. Add a custom logo via Customizer
4. Open the setup wizard. Observe that starter content creation is optional. Uncheck this option and install Newspack
5. Observe no starter content created
6. Go through the installation step again, this time with starter content creation
7. Observe starter content created, but original categories intact - all created categories have prefixed slugs
8. Observe the logo (in Customizer) intact 
9. Remove starter content (first enter debug mode by setting `WP_NEWSPACK_DEBUG` constant)
10. Observe the starter content removed and original categories unaffected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->