### PR TITLE
CI: change MySQL version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
   test-php:
     docker:
       - image: circleci/php:7.2
-      - image: circleci/mysql:5.6
+      - image: circleci/mysql:5.6.50
     environment:
       - WP_TESTS_DIR: '/tmp/wordpress-tests-lib'
       - WP_CORE_DIR: '/tmp/wordpress/'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Something in the newest (5.6.51) version causes the image to fail with a `MYSQL_PASSWORD cannot be used for the root user` error.

### How to test the changes in this Pull Request:

1. Observe latest `test-php` job on `master` branch failing 
2. Observe the job succeeding on this branch 👇

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->