### PR TITLE
Remove WooCommerce One Page Checkout from Newspack distribution

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -391,13 +391,6 @@ class Plugin_Manager {
 				'PluginURI'   => 'https://www.woocommerce.com/products/name-your-price/',
 				'AuthorURI'   => 'https://kathyisawesome.com',
 			],
-			'woocommerce-one-page-checkout' => [
-				'Name'        => __( 'WooCommerce One Page Checkout', 'newspack' ),
-				'Description' => esc_html__( 'Super fast sales with WooCommerce. Add to cart, checkout & pay all on the one page!', 'newspack' ),
-				'Author'      => 'WooCommerce',
-				'PluginURI'   => 'https://woocommerce.com/products/woocommerce-one-page-checkout/',
-				'AuthorURI'   => 'https://woocommerce.com/',
-			],
 			'woocommerce-subscriptions'     => [
 				'Name'        => __( 'WooCommerce Subscriptions', 'newspack' ),
 				'Description' => esc_html__( 'An eCommerce toolkit that helps you sell anything. Beautifully.', 'newspack' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes WooCommerce One Page Checkout from the Newspack distribution. Once this change is shipped, One Page Checkout would no longer appear on the list of plugins included with Newspack. 

**Why remove One Page Checkout?**

Because no Newspack publishers are using it, and it's therefore not needed. 

Originally, we were thinking of having the Donate product page also be the Checkout page, but we didn't end up needing that since we created the Donate Block instead. 

Because WooCommerce One Page Checkout is a premium WooCommerce extension, it cannot be auto-updated. Its removal will make Newspack a little lighter and nimbler. 

### How to test the changes in this Pull Request:

Install the Newspack plugin and verify that One Page Checkout no longer appears as a plugin listed under Newspack (with the &mdash; prefix.) 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?