### PR TITLE
Leaner GA config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Thumbs.db
 /assets/components/shared
 /assets/components/node_modules
 /assets/release
+
+# Tests
+codecov/

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -18,6 +18,7 @@ body[class*='admin_page_newspack-'] {
 
 	#wpbody-content {
 		padding-bottom: 220px;
+		min-height: 100vh;
 
 		@media screen and ( min-width: 783px ) {
 			padding-bottom: 202px;

--- a/assets/wizards/analytics/views/custom-events/index.js
+++ b/assets/wizards/analytics/views/custom-events/index.js
@@ -294,7 +294,6 @@ class CustomEvents extends Component {
 						'newspack'
 					) }
 				</p>
-				{ console.log( this.state ) }
 				<ToggleControl
 					disabled={ this.state.ntgEventsStatus.enabled === undefined }
 					checked={ this.state.ntgEventsStatus.enabled }

--- a/assets/wizards/popups/views/analytics/index.js
+++ b/assets/wizards/popups/views/analytics/index.js
@@ -23,18 +23,19 @@ import { useFiltersState, useAnalyticsState } from './utils';
 /**
  * Popups Analytics screen.
  */
-const PopupAnalytics = ( { setError, isLoading, startLoading, doneLoading } ) => {
+const PopupAnalytics = ( { setError } ) => {
 	const [ filtersState, dispatchFilter ] = useFiltersState();
 	const [ siteKitWarningText, setSiteKitWarningText ] = useState();
+	const [ isLoading, setIsLoading ] = useState( false );
 	const [ state, updateState ] = useAnalyticsState();
-	const { report, labels, actions, key_metrics, post_edit_link, hasFetchedOnce } = state;
+	const { report, labels, actions, key_metrics, post_edit_link } = state;
 
 	useEffect( () => {
-		startLoading();
+		setIsLoading( true );
 		apiFetch( { path: `/newspack/v1/popups-analytics/report/?${ stringify( filtersState ) }` } )
 			.then( response => {
 				updateState( { type: 'UPDATE_ALL', payload: response } );
-				doneLoading();
+				setIsLoading( false );
 			} )
 			.catch( error => {
 				if (
@@ -42,16 +43,12 @@ const PopupAnalytics = ( { setError, isLoading, startLoading, doneLoading } ) =>
 					error.code === 'newspack_campaign_analytics_sitekit_auth'
 				) {
 					setSiteKitWarningText( error.message );
-					doneLoading();
+					setIsLoading( false );
 				} else {
 					setError( error );
 				}
 			} );
 	}, [ filtersState ] );
-
-	if ( ! hasFetchedOnce && isLoading ) {
-		return null;
-	}
 
 	const handleFilterChange = type => payload => dispatchFilter( { type, payload } );
 

--- a/assets/wizards/popups/views/analytics/utils.js
+++ b/assets/wizards/popups/views/analytics/utils.js
@@ -37,7 +37,6 @@ export const useFiltersState = () => useReducer( filtersReducer, filtersInitialS
 const analyticsInitialState = {
 	labels: [],
 	actions: [],
-	hasFetchedOnce: false,
 };
 
 const analyticsReducer = ( state, action ) => {
@@ -51,9 +50,6 @@ const analyticsReducer = ( state, action ) => {
 				labels: uniqBy( [ ...state.labels, ...labels ], 'value' ),
 				actions: uniqBy( [ ...state.actions, ...actions ], 'value' ),
 			};
-			if ( ! state.hasFetchedOnce ) {
-				newState.hasFetchedOnce = true;
-			}
 			return newState;
 		default:
 			return state;

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -166,6 +166,15 @@ class Analytics {
 	}
 
 	/**
+	 * Get a unique id.
+	 *
+	 * @return string Unique id.
+	 */
+	private static function get_uniqid() {
+		return 'n' . substr( uniqid(), 10 );
+	}
+
+	/**
 	 * Get data about all events.
 	 *
 	 * An event is largely based on the AMP analytics event spec and should contain the following fields:
@@ -184,7 +193,7 @@ class Analytics {
 		if ( Analytics_Wizard::ntg_events_enabled() ) {
 			$events = [
 				[
-					'id'             => 'socialShareClickedFacebook',
+					'id'             => self::get_uniqid(),
 					'on'             => 'click',
 					'element'        => 'a.share-facebook',
 					'amp_element'    => 'amp-social-share[type="facebook"]',
@@ -193,7 +202,7 @@ class Analytics {
 					'event_category' => 'NTG social',
 				],
 				[
-					'id'             => 'socialShareClickedTwitter',
+					'id'             => self::get_uniqid(),
 					'on'             => 'click',
 					'element'        => 'a.share-twitter',
 					'amp_element'    => 'amp-social-share[type="twitter"]',
@@ -202,7 +211,7 @@ class Analytics {
 					'event_category' => 'NTG social',
 				],
 				[
-					'id'             => 'socialShareClickedWhatsApp',
+					'id'             => self::get_uniqid(),
 					'on'             => 'click',
 					'element'        => 'a.share-jetpack-whatsapp',
 					'amp_element'    => 'amp-social-share[type="whatsapp"]',
@@ -211,7 +220,7 @@ class Analytics {
 					'event_category' => 'NTG social',
 				],
 				[
-					'id'             => 'socialShareClickedLinkedIn',
+					'id'             => self::get_uniqid(),
 					'on'             => 'click',
 					'element'        => 'a.share-linkedin',
 					'amp_element'    => 'amp-social-share[type="linkedin"]',
@@ -226,7 +235,7 @@ class Analytics {
 					$events,
 					[
 						[
-							'id'              => 'articleRead25',
+							'id'              => self::get_uniqid(),
 							'on'              => 'scroll',
 							'event_name'      => '25%',
 							'event_value'     => 25,
@@ -238,7 +247,7 @@ class Analytics {
 							],
 						],
 						[
-							'id'              => 'articleRead50',
+							'id'              => self::get_uniqid(),
 							'on'              => 'scroll',
 							'event_name'      => '50%',
 							'event_value'     => 50,
@@ -250,7 +259,7 @@ class Analytics {
 							],
 						],
 						[
-							'id'              => 'articleRead100',
+							'id'              => self::get_uniqid(),
 							'on'              => 'scroll',
 							'event_name'      => '100%',
 							'event_value'     => 100,
@@ -316,13 +325,13 @@ class Analytics {
 	 * @param string $content The block content about to be appended.
 	 */
 	public static function prepare_jetpack_mailchimp_block( $content ) {
-		$block_unique_id = sprintf( 'wp-block-jetpack-mailchimp-%s', uniqid() );
+		$block_unique_id = self::get_uniqid();
 
 		// Wrap the block in amp-layout to enable visibility tracking. Sugggested here: https://github.com/ampproject/amphtml/issues/11678.
 		$content = sprintf( '<amp-layout id="%s">%s</amp-layout>', $block_unique_id, $content );
 
 		self::$ntg_block_events[] = [
-			'id'             => 'newsletterSignup-' . $block_unique_id,
+			'id'             => self::get_uniqid(),
 			'amp_on'         => 'amp-form-submit-success',
 			'on'             => 'submit',
 			'element'        => '#' . $block_unique_id . ' form',
@@ -334,7 +343,7 @@ class Analytics {
 			],
 		];
 		self::$ntg_block_events[] = [
-			'id'              => 'newsletterImpression-' . $block_unique_id,
+			'id'              => self::get_uniqid(),
 			'on'              => 'visible',
 			'element'         => '#' . $block_unique_id,
 			'event_name'      => 'newsletter modal impression ' . self::$block_render_context,
@@ -353,7 +362,7 @@ class Analytics {
 	 */
 	public static function prepare_comment_events() {
 		self::$ntg_block_events[] = [
-			'id'             => 'addComment',
+			'id'             => self::get_uniqid(),
 			'amp_on'         => 'amp-form-submit-success',
 			'on'             => 'submit',
 			'element'        => '#commentform',
@@ -368,7 +377,7 @@ class Analytics {
 	 */
 	public static function prepare_login_events() {
 		self::$ntg_block_events[] = [
-			'id'             => 'loginSuccess',
+			'id'             => self::get_uniqid(),
 			'amp-on'         => 'amp-form-submit-success',
 			'on'             => 'submit',
 			'element'        => '.woocommerce-form-login',
@@ -383,7 +392,7 @@ class Analytics {
 	 */
 	public static function prepare_registration_events() {
 		self::$ntg_block_events[] = [
-			'id'             => 'registrationSuccess',
+			'id'             => self::get_uniqid(),
 			'amp-on'         => 'amp-form-submit-success',
 			'on'             => 'submit',
 			'element'        => '.woocommerce-form-register',
@@ -398,7 +407,7 @@ class Analytics {
 	 */
 	public static function prepare_checkout_registration_events() {
 		self::$ntg_block_events[] = [
-			'id'             => 'registrationSuccess',
+			'id'             => self::get_uniqid(),
 			'amp-on'         => 'amp-form-submit-success',
 			'on'             => 'submit',
 			'element'        => '.woocommerce-checkout',

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -176,7 +176,7 @@ class Analytics {
 	 *    'amp_element'    => string CSS selector for AMP version of element if different.
 	 *    'event_name'     => string Name for event in GA (e.g. 'Clicked').
 	 *    'event_label'    => string Label for event in GA (e.g. 'Popup 1')
-	 *    'event_category' => string Category for event in GA (e.g. 'Newspack Announcements').
+	 *    'event_category' => string Category for event in GA (e.g. 'User Interaction').
 	 * There can also be other fields specific for certain events (e.g. 'scrollSpec' for 'scroll' event listener).
 	 */
 	public static function get_events() {
@@ -427,14 +427,18 @@ class Analytics {
 				'request' => 'event',
 				'on'      => isset( $event['amp_on'] ) ? $event['amp_on'] : $event['on'],
 				'vars'    => [
-					'event_name'      => $event['event_name'],
-					'event_label'     => $event['event_label'],
-					'event_category'  => $event['event_category'],
-					'non_interaction' => ! empty( $event['non_interaction'] ) ? $event['non_interaction'] : false,
+					'event_name'     => $event['event_name'],
+					'event_category' => $event['event_category'],
 				],
 			];
+			if ( isset( $event['non_interaction'] ) && true === $event['non_interaction'] ) {
+				$event_config['vars']['non_interaction'] = $event['non_interaction'];
+			}
 			if ( isset( $event['event_value'] ) ) {
 				$event_config['vars']['value'] = $event['event_value'];
+			}
+			if ( isset( $event['event_label'] ) && ! empty( $event['event_label'] ) ) {
+				$event_config['vars']['event_label'] = $event['event_label'];
 			}
 
 			if ( isset( $event['amp_element'] ) || isset( $event['element'] ) ) {
@@ -443,7 +447,7 @@ class Analytics {
 
 			// Handle other config params e.g. 'scrollSpec'.
 			foreach ( $event as $key => $val ) {
-				if ( ! in_array( $key, [ 'id', 'on', 'amp_on', 'element', 'amp_element', 'event_name', 'event_label', 'event_category' ] ) ) {
+				if ( ! in_array( $key, [ 'id', 'on', 'amp_on', 'element', 'amp_element', 'event_name', 'event_label', 'event_category', 'is_active', 'non_interaction' ] ) ) {
 					$event_config[ $key ] = $val;
 				}
 			}
@@ -529,7 +533,9 @@ class Analytics {
 								'<?php echo esc_attr( $event['event_name'] ); ?>',
 								{
 									event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
-									event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+									<?php if ( isset( $event['event_label'] ) ) : ?>
+										event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+									<?php endif; ?>
 								}
 							);
 						};
@@ -568,7 +574,9 @@ class Analytics {
 							'<?php echo esc_attr( $event['event_name'] ); ?>',
 							{
 								event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
-								event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+								<?php if ( isset( $event['event_label'] ) ) : ?>
+									event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+								<?php endif; ?>
 								value: scrollPercent,
 								non_interaction: <?php echo esc_attr( ! empty( $event['non_interaction'] ) && true === $event['non_interaction'] ? 'true' : 'false' ); ?>,
 							}
@@ -602,7 +610,9 @@ class Analytics {
 							'<?php echo esc_attr( $event['event_name'] ); ?>',
 							{
 								event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
-								event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+								<?php if ( isset( $event['event_label'] ) ) : ?>
+									event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+								<?php endif; ?>
 							}
 						);
 					} );
@@ -666,7 +676,9 @@ class Analytics {
 										'<?php echo esc_attr( $event['event_name'] ); ?>',
 										{
 											event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
-											event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+											<?php if ( isset( $event['event_label'] ) ) : ?>
+												event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+											<?php endif; ?>
 											non_interaction: <?php echo esc_attr( ! empty( $event['non_interaction'] ) && true === $event['non_interaction'] ? 'true' : 'false' ); ?>,
 										}
 									);
@@ -701,7 +713,9 @@ class Analytics {
 						'<?php echo esc_attr( $event['event_name'] ); ?>',
 						{
 							event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
-							event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+							<?php if ( isset( $event['event_label'] ) ) : ?>
+								event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
+							<?php endif; ?>
 							non_interaction: <?php echo esc_attr( ! empty( $event['non_interaction'] ) && true === $event['non_interaction'] ? 'true' : 'false' ); ?>,
 						}
 					);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,6 @@
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
 	verbose="true"
-	syntaxCheck="true"
 	>
 	<testsuites>
 		<testsuite name="Newspack Test Suite">

--- a/tests/unit-tests/popups-analytics.php
+++ b/tests/unit-tests/popups-analytics.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Tests the Campaigns (newspack-popups) Analytics functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Popups_Analytics_Utils;
+
+/**
+ * Tests the Campaigns (newspack-popups) Analytics functionality.
+ */
+class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
+	/**
+	 * Test legacy report generation.
+	 */
+	public function test_report_generation_legacy() {
+		$ga_rows = [
+			[
+				'dimensions' => [
+					'20210318',
+					'Seen',
+					'Newspack Announcement: Newsletter form (954)',
+				],
+				'metrics'    => [
+					[
+						'values' => [
+							'4',
+						],
+					],
+				],
+			],
+		];
+		$report  = \Popups_Analytics_Utils::process_ga_report(
+			$ga_rows,
+			[
+				'offset'         => '3',
+				'event_label_id' => '',
+				'event_action'   => '',
+			]
+		);
+		self::assertEquals(
+			$report,
+			[
+				'report'         =>
+				[
+					[
+						'date'  => '2021-03-16',
+						'value' => 0,
+					],
+					[
+						'date'  => '2021-03-17',
+						'value' => 0,
+					],
+					[
+						'date'  => '2021-03-18',
+						'value' => 4,
+					],
+				],
+				'actions'        =>
+				[
+					[
+						'label' => 'Seen',
+						'value' => 'Seen',
+					],
+				],
+				'labels'         =>
+				[
+					[
+						'label' => 'Newsletter form',
+						'value' => '954',
+					],
+				],
+				'key_metrics'    =>
+				[
+					'seen'             => 4,
+					'form_submissions' => -1,
+					'link_clicks'      => -1,
+				],
+				'post_edit_link' => false,
+			],
+			'Report has expected shape.'
+		);
+	}
+
+	/**
+	 * Test report generation.
+	 */
+	public function test_report_generation() {
+		$popup_title = 'Donations welcome';
+		$event_code  = '1'; // 'Seen'.
+		$popup_id    = wp_insert_post( [ 'post_title' => $popup_title ] );
+
+		$ga_rows = [
+			[
+				'dimensions' => [
+					'20210318',
+					$popup_id . $event_code,
+					'',
+				],
+				'metrics'    => [
+					[
+						'values' => [
+							'4',
+						],
+					],
+				],
+			],
+		];
+		$report  = \Popups_Analytics_Utils::process_ga_report(
+			$ga_rows,
+			[
+				'offset'         => '3',
+				'event_label_id' => '',
+				'event_action'   => '',
+			]
+		);
+		self::assertEquals(
+			$report,
+			[
+				'report'         =>
+				[
+					[
+						'date'  => '2021-03-16',
+						'value' => 0,
+					],
+					[
+						'date'  => '2021-03-17',
+						'value' => 0,
+					],
+					[
+						'date'  => '2021-03-18',
+						'value' => 4,
+					],
+				],
+				'actions'        =>
+				[
+					[
+						'label' => 'Seen',
+						'value' => 'Seen',
+					],
+				],
+				'labels'         =>
+				[
+					[
+						'label' => $popup_title,
+						'value' => $popup_id,
+					],
+				],
+				'key_metrics'    =>
+				[
+					'seen'             => 4,
+					'form_submissions' => -1,
+					'link_clicks'      => -1,
+				],
+				'post_edit_link' => false,
+			],
+			'Report has expected shape.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #911.

### How to test the changes in this Pull Request:

1. On `master`, concoct a big GA config by [enabling NTG events](https://newspack.pub/support/analytics/#ntg-tagging), adding some custom events, and then making it so a ton of prompts is included on a page. You can also inflate the config size by setting a super long title on one of the prompts.
2. Visit a page and observe https://github.com/ampproject/amphtml/issues/32911 - if the GA config is larger than 10kB, the request to `https://www.googletagmanager.com/gtag/amp` should fail, triggering a `Error rewriting configuration` error. Observe the GA events triggered by prompts being loaded, seen, and dismissed, are not sent (query network requests with `collect`)
3. Switch to this branch and also `add/leaner-ga-config` on `newspack-popups`
4. Observe the issues from pt. 2 are gone (unless your config is _still_ >10kB after the changes 😱)
5. After ~24h the new data should be available to Campaigns Wizard's Analytics - verify the new data is there

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->