### PR TITLE
Campaigns Analytics: end date param for report parser

### DIFF
--- a/includes/popups-analytics/class-popups-analytics-utils.php
+++ b/includes/popups-analytics/class-popups-analytics-utils.php
@@ -47,28 +47,19 @@ class Popups_Analytics_Utils {
 	}
 
 	/**
-	 * Date before.
-	 *
-	 * @param string $offset date offset in days.
-	 * @return string formatted date.
-	 */
-	private static function date_before( $offset ) {
-		$today = new \DateTime();
-		$today = $today->modify( '-' . $offset . ' days' );
-		return $today->format( 'Y-m-d' );
-	}
-
-	/**
 	 * Fill in dates.
 	 *
 	 * @param array  $input array of days.
 	 * @param string $offset date offset in days.
+	 * @param string $end_date end date.
 	 * @return array array of dates.
 	 */
-	private static function fill_in_dates( $input, $offset ) {
-		$all_days = self::get_dates_in_range(
-			self::date_before( $offset ),
-			self::date_before( '1' )
+	private static function fill_in_dates( $input, $offset, $end_date ) {
+		$range_begin = new \DateTime( $end_date );
+		$range_end   = new \DateTime( $end_date );
+		$all_days    = self::get_dates_in_range(
+			$range_begin->modify( '-' . $offset . ' days' )->format( 'Y-m-d' ),
+			$range_end->modify( '-1 days' )->format( 'Y-m-d' )
 		);
 
 		$days_filled = array_map(
@@ -260,6 +251,11 @@ class Popups_Analytics_Utils {
 		$offset         = $options['offset'];
 		$event_label_id = $options['event_label_id'];
 		$event_action   = $options['event_action'];
+		if ( isset( $options['end_date'] ) ) {
+			$end_date = $options['end_date'];
+		} else {
+			$end_date = 'now';
+		}
 
 		if ( is_wp_error( $ga_data_rows ) ) {
 			return $ga_data_rows;
@@ -370,7 +366,7 @@ class Popups_Analytics_Utils {
 		);
 
 		return array(
-			'report'         => self::fill_in_dates( $ga_data_days, $offset ),
+			'report'         => self::fill_in_dates( $ga_data_days, $offset, $end_date ),
 			'actions'        => $all_actions,
 			'labels'         => array_values( $all_labels ),
 			'key_metrics'    => $key_metrics,

--- a/tests/unit-tests/popups-analytics.php
+++ b/tests/unit-tests/popups-analytics.php
@@ -37,6 +37,7 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 				'offset'         => '3',
 				'event_label_id' => '',
 				'event_action'   => '',
+				'end_date'       => '2021-03-19',
 			]
 		);
 		self::assertEquals(
@@ -113,6 +114,7 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 				'offset'         => '3',
 				'event_label_id' => '',
 				'event_action'   => '',
+				'end_date'       => '2021-03-19',
 			]
 		);
 		self::assertEquals(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#914 introduced a test which depended on server time, which cause it to fail depending on the current date. 

### How to test the changes in this Pull Request:

1. Observe the Campaigns Analytics report chart loading with data, as before 
2. Observe tests passing 👇

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->