### PR TITLE
test: fix failing analytics tests due to hard-coded dates

### DIFF
--- a/tests/unit-tests/popups-analytics.php
+++ b/tests/unit-tests/popups-analytics.php
@@ -32,7 +32,7 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 				],
 			],
 		];
-		$report  = \Popups_Analytics_Utils::process_ga_report(
+		$report    = \Popups_Analytics_Utils::process_ga_report(
 			$ga_rows,
 			[
 				'offset'         => '3',

--- a/tests/unit-tests/popups-analytics.php
+++ b/tests/unit-tests/popups-analytics.php
@@ -15,10 +15,11 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 	 * Test legacy report generation.
 	 */
 	public function test_report_generation_legacy() {
-		$ga_rows = [
+		$yesterday = ( new \DateTime() )->modify( '-1 days' );
+		$ga_rows   = [
 			[
 				'dimensions' => [
-					'20210318',
+					$yesterday->format( 'Ymd' ),
 					'Seen',
 					'Newspack Announcement: Newsletter form (954)',
 				],
@@ -45,15 +46,15 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 				'report'         =>
 				[
 					[
-						'date'  => '2021-03-16',
+						'date'  => ( new \DateTime() )->modify( '-3 days' )->format( 'Y-m-d' ),
 						'value' => 0,
 					],
 					[
-						'date'  => '2021-03-17',
+						'date'  => ( new \DateTime() )->modify( '-2 days' )->format( 'Y-m-d' ),
 						'value' => 0,
 					],
 					[
-						'date'  => '2021-03-18',
+						'date'  => $yesterday->format( 'Y-m-d' ),
 						'value' => 4,
 					],
 				],
@@ -87,6 +88,7 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 	 * Test report generation.
 	 */
 	public function test_report_generation() {
+		$yesterday   = ( new \DateTime() )->modify( '-1 days' );
 		$popup_title = 'Donations welcome';
 		$event_code  = '1'; // 'Seen'.
 		$popup_id    = wp_insert_post( [ 'post_title' => $popup_title ] );
@@ -94,7 +96,7 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 		$ga_rows = [
 			[
 				'dimensions' => [
-					'20210318',
+					$yesterday->format( 'Ymd' ),
 					$popup_id . $event_code,
 					'',
 				],
@@ -121,15 +123,15 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 				'report'         =>
 				[
 					[
-						'date'  => '2021-03-16',
+						'date'  => ( new \DateTime() )->modify( '-3 days' )->format( 'Y-m-d' ),
 						'value' => 0,
 					],
 					[
-						'date'  => '2021-03-17',
+						'date'  => ( new \DateTime() )->modify( '-2 days' )->format( 'Y-m-d' ),
 						'value' => 0,
 					],
 					[
-						'date'  => '2021-03-18',
+						'date'  => $yesterday->format( 'Y-m-d' ),
 						'value' => 4,
 					],
 				],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes failing unit tests related to new Campaigns analytics helpers. Because [this util relies on relative time](https://github.com/Automattic/newspack-plugin/blob/master/includes/popups-analytics/class-popups-analytics-utils.php#L56) ("today"), while the unit tests have hard-coded dates, the tests will fail unless the tested event dates are relative to today.

### How to test the changes in this Pull Request:

1. On `master`, run `phpunit` to run PHP unit tests. Observe two failing tests with output that looks something like this:

```
There were 2 failures:

1) Newspack_Test_Popups_Analytics::test_report_generation_legacy
Report has expected shape.
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'report' => Array (
         0 => Array (
-            'date' => '2021-03-20'
+            'date' => '2021-03-19'
             'value' => 0
         )
         1 => Array (
-            'date' => '2021-03-21'
+            'date' => '2021-03-17'
             'value' => 0
         )
         2 => Array (
-            'date' => '2021-03-22'
+            'date' => '2021-03-17'
             'value' => 4
         )
     )

/newspack/app/public/wp-content/plugins/newspack-plugin/tests/unit-tests/popups-analytics.php:84

2) Newspack_Test_Popups_Analytics::test_report_generation
Report has expected shape.
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'report' => Array (
         0 => Array (
-            'date' => '2021-03-20'
+            'date' => '2021-03-16'
             'value' => 0
         )
         1 => Array (
-            'date' => '2021-03-21'
+            'date' => '2021-03-17'
             'value' => 0
         )
         2 => Array (
-            'date' => '2021-03-22'
-            'value' => 0
+            'date' => '2021-03-18'
+            'value' => 4
         )
     )
     'actions' => Array (...)
```

2. Check out this branch and run `phpunit` again.
3. Confirm that the tests are now passing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->