### PR TITLE
Fix Campaigns Analytics reporting

### DIFF
--- a/includes/popups-analytics/class-popups-analytics-utils.php
+++ b/includes/popups-analytics/class-popups-analytics-utils.php
@@ -114,7 +114,7 @@ class Popups_Analytics_Utils {
 				// Filter just the popups custom event category.
 				$dimension_category_filter = new Google_Service_AnalyticsReporting_SegmentDimensionFilter();
 				$dimension_category_filter->setDimensionName( 'ga:eventCategory' );
-				$dimension_category_filter->setOperator( 'EXACT' );
+				$dimension_category_filter->setOperator( 'IN_LIST' );
 				$dimension_category_filter->setExpressions( self::EVENT_CATEGORIES );
 
 				// Create the DimensionFilterClauses.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In #914, the GA report fetching was [changed to accommodate both legacy and new event category](https://github.com/Automattic/newspack-plugin/pull/914/files#diff-dcf593d710ae2fbb84ba284a1878a96389c35e092f59c5fd1cda39942dafb9fcL27-R30), but the [operator on the event category](https://github.com/Automattic/newspack-plugin/pull/914/files#diff-dcf593d710ae2fbb84ba284a1878a96389c35e092f59c5fd1cda39942dafb9fcR117) query was not updated, which results in a bad query.

### How to test the changes in this Pull Request:

The error would cause no events to show up after the latest release.

1. Visit the Campaigns Wizard, Analytics screen
2. You should see both old and new events on the chart

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->