### PR TITLE
Analytics: NTG events reporting disabled by default

### DIFF
--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -537,7 +537,7 @@ class Analytics_Wizard extends Wizard {
 	 * @return bool Status of NTG events.
 	 */
 	public static function ntg_events_enabled() {
-		return 'enabled' === get_option( self::$ntg_events_option_name, 'enabled' );
+		return 'enabled' === get_option( self::$ntg_events_option_name, '' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Due to some recently discovered issues around GA configuration size limit (https://github.com/Automattic/newspack-plugin/pull/914), NTG events reporting should be opt-in, so that by default the GA config is smaller. 

### How to test the changes in this Pull Request:

1. Visit Analytics Wizard, Custom Events tab on a fresh Newspack site
2. Observe the "News Tagging Guide custom events" setting is **disabled**
3. Visit the site in incognito, observe the NTG events are not sent*
4. Enable the setting
5. Observe the events are sent

\* Search Network tab in Devtools for `collect` requests

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->