### PR TITLE
feat: add web stories to supported plugin list

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -449,6 +449,14 @@ class Plugin_Manager {
 				'PluginURI'   => 'https://wordpress.org/plugins/wp-user-avatar/',
 				'Download'    => 'wporg',
 			],
+			'web-stories'                   => [
+				'Name'        => 'Web Stories',
+				'Description' => 'Visual storytelling for WordPress.',
+				'Author'      => 'Google',
+				'AuthorURI'   => 'https://opensource.google.com/',
+				'PluginURI'   => 'https://wp.stories.google/',
+				'Download'    => 'wporg',
+			],
 		];
 
 		$default_info = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds Google Web Stories plugin to supported plugins list: https://wp.stories.google/

### How to test the changes in this Pull Request:

1. Observe Web Stories is on the list of supported plugins, verify installation. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->