### PR TITLE
Add Google OAuth2 authentication flow 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,17 @@ If you have a patch or have stumbled upon an issue with the Newspack plugin/them
 Some features require environment variables to be set (e.g. in `wp-config.php`):
 
 ```php
-// support
-define('NEWSPACK_SUPPORT_API_URL', 'https://super-tech-support.zendesk.com/api/v2');
-define('NEWSPACK_SUPPORT_EMAIL', 'support@company.com');
-define('NEWSPACK_WPCOM_CLIENT_ID', '12345');
-// optional
-define('NEWSPACK_SUPPORT_IS_PRE_LAUNCH', true);
+// Support
+define( 'NEWSPACK_SUPPORT_API_URL', 'https://super-tech-support.zendesk.com/api/v2' );
+define( 'NEWSPACK_SUPPORT_EMAIL', 'support@company.com' );
+define( 'NEWSPACK_WPCOM_CLIENT_ID', '12345' );
+
+// OAuth2
+define( 'NEWSPACK_GOOGLE_OAUTH_CLIENT_ID', 'abc' );
+define( 'NEWSPACK_GOOGLE_OAUTH_CLIENT_SECRET', 'abc' );
+
+// Optional
+define( 'NEWSPACK_SUPPORT_IS_PRE_LAUNCH', true );
 ```
 
 ## News Consumer Insights integration

--- a/assets/components/src/global-notices/index.js
+++ b/assets/components/src/global-notices/index.js
@@ -13,9 +13,12 @@ const GlobalNotices = () => {
 	if ( ! notice ) {
 		return null;
 	}
-	return notice
-		.split( ',' )
-		.map( ( text, i ) => <Notice isSuccess noticeText={ text } key={ i } /> );
+	return notice.split( ',' ).map( ( text, i ) => {
+		if ( text.indexOf( '_error_' ) === 0 ) {
+			return <Notice isError noticeText={ text.replace( '_error_', '' ) } key={ i } />;
+		}
+		return <Notice isSuccess noticeText={ text } key={ i } />;
+	} );
 };
 
 export default GlobalNotices;

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -124,7 +124,7 @@ const Dashboard = ( { items } ) => {
 										<Icon icon={ plugins } />
 										<div className="newspack-dashboard-card__header">
 											<h2>{ __( 'Google OAuth2' ) }</h2>
-											<p>{ __( 'Authorise Newspack with Google', 'newspack' ) }</p>
+											<p>{ __( 'Authorize Newspack with Google', 'newspack' ) }</p>
 										</div>
 									</div>
 								</Button>

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -3,47 +3,119 @@
 import '../../shared/js/public-path';
 
 /**
+ * External dependencies.
+ */
+import qs from 'qs';
+
+/**
  * WordPress dependencies.
  */
-import { Component, Fragment, render } from '@wordpress/element';
+import { useEffect, useState, Fragment, render } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
  */
-import { GlobalNotices, Footer, Grid, NewspackLogo } from '../../components/src';
+import { GlobalNotices, Button, Waiting, Footer, Grid, NewspackLogo } from '../../components/src';
 import DashboardCard from './views/dashboardCard';
 import './style.scss';
 
-/**
- * Newspack Dashboard.
- */
-class Dashboard extends Component {
-	/**
-	 * Render.
-	 */
-	render() {
-		const { items } = this.props;
+const Dashboard = ( { items } ) => {
+	const params = qs.parse( window.location.search );
+	const authCode = params.code;
+	const [ authState, setAuthState ] = useState( {} );
 
-		return (
-			<Fragment>
-				<div className="newspack-wizard__header">
-					<div className="newspack-wizard__header__inner">
-						<NewspackLogo centered height={ 72 } />
-					</div>
+	const userBasicInfo = authState.user_basic_info;
+	const canUseOauth = authState.can_google_auth;
+
+	const displayAuth = canUseOauth && ! authCode;
+
+	useEffect( () => {
+		apiFetch( { path: '/newspack/v1/oauth/google' } ).then( setAuthState );
+	}, [] );
+
+	useEffect( () => {
+		if ( canUseOauth && authCode ) {
+			apiFetch( {
+				path: '/newspack/v1/oauth/google',
+				method: 'POST',
+				data: {
+					auth_code: authCode,
+					state: params.state,
+				},
+			} )
+				.then( () => {
+					window.location =
+						'/wp-admin/admin.php?' +
+						qs.stringify( {
+							page: 'newspack',
+							'newspack-notice': __( 'Successfully authenticated with Google.', 'newspack' ),
+						} );
+				} )
+				.catch( e => {
+					window.location =
+						'/wp-admin/admin.php?' +
+						qs.stringify( {
+							page: 'newspack',
+							'newspack-notice':
+								'_error_' +
+								( e.message ||
+									__( 'Something went wrong during authentication with Google.', 'newspack' ) ),
+						} );
+				} );
+		}
+	}, [ canUseOauth ] );
+
+	const goToAuthPage = () => {
+		apiFetch( {
+			path: '/newspack/v1/oauth/google/get-url',
+		} ).then( url => ( window.location = url ) );
+	};
+
+	return (
+		<Fragment>
+			<div className="newspack-wizard__header">
+				<div className="newspack-wizard__header__inner">
+					<NewspackLogo centered height={ 72 } />
 				</div>
-				<div className="mw6 mr-auto ml-auto">
-					<GlobalNotices />
+			</div>
+			<div className="mw6 mr-auto ml-auto">
+				<GlobalNotices />
+			</div>
+			{ authCode && (
+				<div className="pt4 flex justify-around">
+					<Waiting />
 				</div>
-				<div className="newspack-wizard newspack-wizard__content">
-					<Grid columns={ 3 } gutter={ 32 }>
-						{ items.map( card => (
-							<DashboardCard { ...card } key={ card.slug } />
-						) ) }
-					</Grid>
+			) }
+			{ displayAuth ? (
+				<div className="pt4 ph3 flex justify-around">
+					{ userBasicInfo ? (
+						<span>
+							{ __( 'Authorized Google as', 'newspack' ) } <strong>{ userBasicInfo.email }</strong>.
+						</span>
+					) : (
+						<div>
+							<p>
+								{ __( 'Click on the button below to authorise Newspack with Google.', 'newspack' ) }
+							</p>
+							<br />
+							<Button isPrimary onClick={ goToAuthPage }>
+								{ __( 'Authorise', 'newspack' ) }
+							</Button>
+						</div>
+					) }
 				</div>
-				<Footer />
-			</Fragment>
-		);
-	}
-}
+			) : null }
+			<div className="newspack-wizard newspack-wizard__content">
+				<Grid columns={ 3 } gutter={ 32 }>
+					{ items.map( card => (
+						<DashboardCard { ...card } key={ card.slug } />
+					) ) }
+				</Grid>
+			</div>
+			<Footer />
+		</Fragment>
+	);
+};
 render( <Dashboard items={ newspack_dashboard } />, document.getElementById( 'newspack' ) );

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -13,13 +13,27 @@ import qs from 'qs';
 import { useEffect, useState, Fragment, render } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
+import { Icon, plugins } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
  */
-import { GlobalNotices, Button, Waiting, Footer, Grid, NewspackLogo } from '../../components/src';
+import {
+	GlobalNotices,
+	Button,
+	Card,
+	Waiting,
+	Footer,
+	Grid,
+	NewspackLogo,
+} from '../../components/src';
 import DashboardCard from './views/dashboardCard';
 import './style.scss';
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
 
 const Dashboard = ( { items } ) => {
 	const params = qs.parse( window.location.search );
@@ -75,43 +89,48 @@ const Dashboard = ( { items } ) => {
 
 	return (
 		<Fragment>
+			<GlobalNotices />
 			<div className="newspack-wizard__header">
 				<div className="newspack-wizard__header__inner">
 					<NewspackLogo centered height={ 72 } />
 				</div>
 			</div>
-			<div className="mw6 mr-auto ml-auto">
-				<GlobalNotices />
-			</div>
-			{ authCode && (
-				<div className="pt4 flex justify-around">
-					<Waiting />
-				</div>
-			) }
-			{ displayAuth ? (
-				<div className="pt4 ph3 flex justify-around">
-					{ userBasicInfo ? (
-						<span>
-							{ __( 'Authorized Google as', 'newspack' ) } <strong>{ userBasicInfo.email }</strong>.
-						</span>
-					) : (
-						<div>
-							<p>
-								{ __( 'Click on the button below to authorise Newspack with Google.', 'newspack' ) }
-							</p>
-							<br />
-							<Button isPrimary onClick={ goToAuthPage }>
-								{ __( 'Authorise', 'newspack' ) }
-							</Button>
-						</div>
-					) }
-				</div>
-			) : null }
 			<div className="newspack-wizard newspack-wizard__content">
 				<Grid columns={ 3 } gutter={ 32 }>
 					{ items.map( card => (
 						<DashboardCard { ...card } key={ card.slug } />
 					) ) }
+					{ authCode && (
+						<div className="flex justify-around items-center">
+							<Waiting />
+						</div>
+					) }
+					{ displayAuth ? (
+						<Card className={ classnames( 'newspack-dashboard-card', 'google-oauth2' ) }>
+							{ userBasicInfo ? (
+								<div className="newspack-dashboard-card__contents">
+									<Icon icon={ plugins } />
+									<div className="newspack-dashboard-card__header">
+										<h2>{ __( 'Google OAuth2' ) }</h2>
+										<p>
+											{ __( 'Authorized Google as', 'newspack' ) }{' '}
+											<strong>{ userBasicInfo.email }</strong>
+										</p>
+									</div>
+								</div>
+							) : (
+								<Button onClick={ goToAuthPage }>
+									<div className="newspack-dashboard-card__contents">
+										<Icon icon={ plugins } />
+										<div className="newspack-dashboard-card__header">
+											<h2>{ __( 'Google OAuth2' ) }</h2>
+											<p>{ __( 'Authorise Newspack with Google', 'newspack' ) }</p>
+										</div>
+									</div>
+								</Button>
+							) }
+						</Card>
+					) : null }
 				</Grid>
 			</div>
 			<Footer />

--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -16,13 +16,17 @@
 		}
 	}
 
-	a {
+	a,
+	body[class*='admin-color-'] & .newspack-button {
 		align-items: center;
 		border-radius: inherit;
 		color: inherit;
 		display: flex;
+		font-weight: inherit;
 		height: 100%;
 		justify-content: space-between;
+		padding: 0;
+		text-align: inherit;
 		text-decoration: none;
 		transition: background-color 125ms ease-in-out, box-shadow 125ms ease-in-out;
 
@@ -31,6 +35,7 @@
 		&:hover {
 			background-color: $light-gray-100;
 			box-shadow: 0 4px 8px rgba( black, 0.08 );
+			color: $primary-600;
 
 			h2 {
 				color: inherit;
@@ -80,4 +85,8 @@
 			margin-left: 8px;
 		}
 	}
+}
+
+.newspack-notice {
+	margin: 0;
 }

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,9 @@
 			"issues": "https://github.com/Automattic/newspack-plugin/issues"
 	},
 	"require"    : {
-			"composer/installers": "~1.6",
-      "joshtronic/php-loremipsum": "^1.0"
+		"composer/installers": "~1.6",
+		"joshtronic/php-loremipsum": "^1.0",
+		"google/auth": "^1.15"
 	},
 	"require-dev": {
 		"brainmaestro/composer-git-hooks": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eff7aaa5501b76640e37c3ebf4aecd29",
+    "content-hash": "4c2db06e3eab226d0061fb3ea6f9b247",
     "packages": [
         {
             "name": "composer/installers",
@@ -144,6 +144,350 @@
             "time": "2020-04-07T06:57:05+00:00"
         },
         {
+            "name": "firebase/php-jwt",
+            "version": "v5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
+                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.8 <=9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v5.2.1"
+            },
+            "time": "2021-02-12T00:02:00+00:00"
+        },
+        {
+            "name": "google/auth",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-auth-library-php.git",
+                "reference": "b346c07de6613e26443d7b4830e5e1933b830dc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/b346c07de6613e26443d7b4830e5e1933b830dc4",
+                "reference": "b346c07de6613e26443d7b4830e5e1933b830dc4",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
+                "guzzlehttp/guzzle": "^5.3.1|^6.2.1|^7.0",
+                "guzzlehttp/psr7": "^1.2",
+                "php": ">=5.4",
+                "psr/cache": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "guzzlehttp/promises": "0.1.1|^1.3",
+                "kelvinmo/simplejwt": "^0.2.5|^0.5.1",
+                "phpseclib/phpseclib": "^2",
+                "phpunit/phpunit": "^4.8.36|^5.7",
+                "sebastian/comparator": ">=1.2.3",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "suggest": {
+                "phpseclib/phpseclib": "May be used in place of OpenSSL for signing strings or for token management. Please require version ^2."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Auth\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google Auth Library for PHP",
+            "homepage": "http://github.com/google/google-auth-library-php",
+            "keywords": [
+                "Authentication",
+                "google",
+                "oauth2"
+            ],
+            "support": {
+                "docs": "https://googleapis.github.io/google-auth-library-php/master/",
+                "issues": "https://github.com/googleapis/google-auth-library-php/issues",
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.15.0"
+            },
+            "time": "2021-02-05T20:50:04+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.4",
+                "guzzlehttp/psr7": "^1.7 || ^2.0",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/alexeyshockov",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/gmponos",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-23T11:33:13+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.4.1"
+            },
+            "time": "2021-03-07T09:25:29+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "35ea11d335fd638b5882ff1725228b3d35496ab1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/35ea11d335fd638b5882ff1725228b3d35496ab1",
+                "reference": "35ea11d335fd638b5882ff1725228b3d35496ab1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/1.8.1"
+            },
+            "time": "2021-03-21T16:25:00+00:00"
+        },
+        {
             "name": "joshtronic/php-loremipsum",
             "version": "1.0.6",
             "source": {
@@ -188,6 +532,204 @@
                 "lorem"
             ],
             "time": "2020-06-02T03:25:24+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/master"
+            },
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
         }
     ],
     "packages-dev": [
@@ -1494,5 +2036,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -75,6 +75,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-analytics.php';
+		include_once NEWSPACK_ABSPATH . 'includes/google/class-google-services-connection.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-dashboard.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -75,6 +75,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-analytics.php';
+		include_once NEWSPACK_ABSPATH . 'includes/google/class-google-oauth.php';
 		include_once NEWSPACK_ABSPATH . 'includes/google/class-google-services-connection.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';

--- a/includes/class-nrh.php
+++ b/includes/class-nrh.php
@@ -68,25 +68,23 @@ class NRH {
 	 * @param array $gtag_amp_opt gtag config options for AMP.
 	 */
 	public static function googlesitekit_amp_gtag_opt( $gtag_amp_opt ) {
+		$analytics = \Newspack\Google_Services_Connection::get_site_kit_analytics_module();
+		if ( $analytics ) {
+			$ga_property_code = $analytics->get_settings()->get()['propertyID'];
 
-		if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
+			if ( ! isset( $gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker'] ) ) {
+				$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker'] = [];
+			}
+			if ( ! isset( $gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['domains'] ) ) {
+				$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['domains'] = [];
+			}
+
+			$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['domains'][]      = 'checkout.fundjournalism.org';
+			$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['decorate_forms'] = true;
+			return $gtag_amp_opt;
+		} else {
 			return $gtag_amp_opt; // If Site Kit isn't installed, bail early.
 		}
-
-		$context          = new \Google\Site_Kit\Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
-		$analytics        = new \Google\Site_Kit\Modules\Analytics( $context );
-		$ga_property_code = $analytics->get_settings()->get()['propertyID'];
-
-		if ( ! isset( $gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker'] ) ) {
-			$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker'] = [];
-		}
-		if ( ! isset( $gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['domains'] ) ) {
-			$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['domains'] = [];
-		}
-
-		$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['domains'][]      = 'checkout.fundjournalism.org';
-		$gtag_amp_opt['vars']['config'][ $ga_property_code ]['linker']['decorate_forms'] = true;
-		return $gtag_amp_opt;
 	}
 
 	/**

--- a/includes/google/class-google-oauth.php
+++ b/includes/google/class-google-oauth.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Newspack's Google OAuth2 handling.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error;
+use Google\Auth\OAuth2;
+use Google\Auth\Credentials\UserRefreshCredentials;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Google OAuth2 flow.
+ */
+class Google_OAuth {
+	const AUTH_DATA_USERMETA_NAME        = '_newspack_google_oauth';
+	const CSRF_TOKEN_TRANSIENT_NAME_BASE = '_newspack_google_oauth_csrf_';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public static function register_api_endpoints() {
+		// Get Google OAuth2 auth URL.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/oauth/google/get-url',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_google_auth_get_url' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+			]
+		);
+		// Get Google OAuth2 auth status.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/oauth/google',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_google_auth_status' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+			]
+		);
+		// Save Google OAuth2 details.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/oauth/google',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ __CLASS__, 'api_google_auth_save_details' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+				'args'                => [
+					'auth_code' => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Check capabilities for using API.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return bool|WP_Error
+	 */
+	public static function api_permissions_check( $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				[
+					'status' => 403,
+				]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Create OAuth2 handler.
+	 *
+	 * @param bool $create_csrf_token Whether to add a CSRF token in state, and save it.
+	 * @return WP_REST_Response Response.
+	 */
+	private static function create_google_oauth2( $create_csrf_token = false ) {
+		$scopes       = [
+			'https://www.googleapis.com/auth/userinfo.email', // User's email address.
+			'https://www.googleapis.com/auth/analytics.edit', // Google Analytics.
+			'https://www.googleapis.com/auth/dfp', // Google Ad Manager.
+		];
+		$redirect_uri = admin_url( 'admin.php?page=newspack' );
+
+		$parameters = [
+			'authorizationUri'   => 'https://accounts.google.com/o/oauth2/v2/auth',
+			'tokenCredentialUri' => 'https://www.googleapis.com/oauth2/v4/token',
+			'redirectUri'        => $redirect_uri,
+			'clientId'           => self::get_client_id(),
+			'clientSecret'       => self::get_client_secret(),
+			'scope'              => implode( ' ', $scopes ),
+		];
+
+		// Save a CSRF token.
+		if ( $create_csrf_token ) {
+			$csrf_token     = sha1( openssl_random_pseudo_bytes( 1024 ) );
+			$transient_name = self::CSRF_TOKEN_TRANSIENT_NAME_BASE . get_current_user_id();
+			set_transient( $transient_name, $csrf_token, 60 );
+			$parameters['state'] = $csrf_token;
+		}
+
+		return new OAuth2(
+			$parameters
+		);
+	}
+
+	/**
+	 * Request Google OAuth2 URL. The user will visit URL to provide consent,
+	 * then they will be redirected back to the site.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return WP_REST_Response Response with the URL.
+	 */
+	public static function api_google_auth_get_url( $request ) {
+		$params        = $request->get_params();
+		$auth_code     = isset( $params['code'] ) ? $params['code'] : false;
+		$google_oauth2 = self::create_google_oauth2( true );
+
+		$url = $google_oauth2->buildFullAuthorizationUri(
+			[
+				'access_type' => 'offline',
+			]
+		);
+		return \rest_ensure_response( $url->__toString() );
+	}
+
+	/**
+	 * Save authentication details in user meta.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return WP_REST_Response Response.
+	 */
+	public static function api_google_auth_save_details( $request ) {
+		$auth_code = $request['auth_code'];
+		$state     = $request['state'];
+
+		$transient_name   = self::CSRF_TOKEN_TRANSIENT_NAME_BASE . get_current_user_id();
+		$saved_csrf_token = get_transient( $transient_name );
+
+		if ( $state !== $saved_csrf_token ) {
+			return new \WP_Error( 'newspack_google_oauth', __( 'Session token mismatch.', 'newspack' ) );
+		}
+
+		$google_oauth2 = self::create_google_oauth2();
+		$google_oauth2->setCode( $auth_code );
+		$auth_data = $google_oauth2->fetchAuthToken();
+
+		// The refresh_token is only provided on the first authorization from the user.
+		// If for some reason the user has authorised the app, but we're missing the creds,
+		// ask the user to revoke access in order to authorise afresh.
+		// https://stackoverflow.com/a/10857806/3772847.
+		if ( ! isset( $auth_data['refresh_token'] ) ) {
+			return new \WP_Error(
+				'newspack_google_oauth',
+				__( 'Refresh token is missing. You may have to remove access to the Newspack app at https://myaccount.google.com/permissions.', 'newspack' ),
+				[ 'status' => 401 ]
+			);
+		}
+		$user_id = get_current_user_id();
+		$auth    = [
+			'access_token'  => $auth_data['access_token'],
+			'refresh_token' => $auth_data['refresh_token'],
+		];
+		if ( update_user_meta( $user_id, self::AUTH_DATA_USERMETA_NAME, $auth ) ) {
+			return \rest_ensure_response(
+				[
+					'status' => 'ok',
+				]
+			);
+		} else {
+			return new \WP_Error( 'newspack_google_oauth', __( 'Could not save auth data for user.', 'newspack' ) );
+		}
+	}
+
+	/**
+	 * Get Google authentication status.
+	 */
+	public static function api_google_auth_status() {
+		return \rest_ensure_response(
+			[
+				'user_basic_info' => self::authenticated_user_basic_information(),
+				'can_google_auth' => self::is_oauth_configured(),
+			]
+		);
+	}
+
+	/**
+	 * Get Google authentication details.
+	 */
+	private static function get_google_auth_saved_data() {
+		$auth_data = get_user_meta( get_current_user_id(), self::AUTH_DATA_USERMETA_NAME, true );
+		if ( $auth_data ) {
+			return $auth_data;
+		}
+		return [];
+	}
+
+	/**
+	 * Authenticated user's basic information.
+	 *
+	 * @return object|bool Basic information, or false if unauthorised.
+	 */
+	private static function authenticated_user_basic_information() {
+		$auth_data = self::get_google_auth_saved_data();
+		if ( ! isset( $auth_data['access_token'] ) ) {
+			return false;
+		}
+
+		// Validate access token.
+		$access_token        = $auth_data['access_token'];
+		$token_info_response = wp_safe_remote_get(
+			add_query_arg(
+				'access_token',
+				$access_token,
+				'https://www.googleapis.com/oauth2/v1/tokeninfo'
+			)
+		);
+
+
+		if ( 200 === $token_info_response['response']['code'] ) {
+			$user_info_response = wp_safe_remote_get(
+				add_query_arg(
+					'access_token',
+					$access_token,
+					'https://www.googleapis.com/oauth2/v2/userinfo'
+				)
+			);
+			if ( 200 === $user_info_response['response']['code'] ) {
+				$user_info = json_decode( $user_info_response['body'] );
+				return [
+					'email' => $user_info->email,
+				];
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get OAuth2 Credentials.
+	 *
+	 * @return UserRefreshCredentials|bool The credentials, or false of the user has not authenticated.
+	 */
+	public static function get_oauth2_credentials() {
+		$auth_data = self::get_google_auth_saved_data();
+		if ( ! isset( $auth_data['refresh_token'] ) ) {
+			return false;
+		}
+		// Generate a refreshable OAuth2 credential for authentication.
+		// https://googleapis.github.io/google-auth-library-php/master/Google/Auth/Credentials/UserRefreshCredentials.html.
+		return new UserRefreshCredentials(
+			null,
+			[
+				'client_id'     => self::get_client_id(),
+				'client_secret' => self::get_client_secret(),
+				'refresh_token' => $auth_data['refresh_token'],
+			]
+		);
+	}
+
+	/**
+	 * Get OAuth2 Client ID.
+	 */
+	private static function get_client_id() {
+		return defined( 'NEWSPACK_GOOGLE_OAUTH_CLIENT_ID' ) ? NEWSPACK_GOOGLE_OAUTH_CLIENT_ID : false;
+	}
+
+	/**
+	 * Get OAuth2 Client Secret.
+	 */
+	private static function get_client_secret() {
+		return defined( 'NEWSPACK_GOOGLE_OAUTH_CLIENT_SECRET' ) ? NEWSPACK_GOOGLE_OAUTH_CLIENT_SECRET : false;
+	}
+
+	/**
+	 * Is OAuth2 configured for this instance?
+	 */
+	private static function is_oauth_configured() {
+		return false !== self::get_client_secret() && false !== self::get_client_id();
+	}
+}
+new Google_OAuth();

--- a/includes/google/class-google-services-connection.php
+++ b/includes/google/class-google-services-connection.php
@@ -33,7 +33,7 @@ class Google_Services_Connection {
 			$authentication = new Authentication( $context, new Options( $context ), new User_Options( $context ) );
 			return $authentication;
 		} else {
-			return new WP_Error( 'newspack_sitekit_disconnectedt', __( 'Connect Site Kit plugin to view Campaign Analytics.', 'newspack' ) );
+			return new WP_Error( 'newspack_sitekit_disconnected', __( 'Connect Site Kit plugin to view Campaign Analytics.', 'newspack' ) );
 		}
 	}
 

--- a/includes/google/class-google-services-connection.php
+++ b/includes/google/class-google-services-connection.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Connection to Google services.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Core\Authentication\Authentication;
+use Google\Site_Kit\Modules\Analytics as SiteKitAnalytics;
+use Google\Auth\Credentials\UserRefreshCredentials;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Google_Services_Connection {
+	/**
+	 * Get Site Kit's authentication.
+	 *
+	 * @return Authentication Site Kit's authentication.
+	 */
+	public static function get_authentication() {
+		if ( defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
+			$context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+			$authentication = new Authentication( $context, new Options( $context ), new User_Options( $context ) );
+			return $authentication;
+		} else {
+			return new WP_Error( 'newspack_sitekit_disconnectedt', __( 'Connect Site Kit plugin to view Campaign Analytics.', 'newspack' ) );
+		}
+	}
+
+	/**
+	 * Get OAuth2 client.
+	 * More at https://googleapis.github.io/google-auth-library-php/master/Google/Auth/OAuth2.html.
+	 *
+	 * @return object Google OAuth2 client.
+	 */
+	public static function get_oauth_client() {
+		return self::get_authentication()->get_oauth_client();
+	}
+
+	/**
+	 * Get Site Kit's Analytics module.
+	 *
+	 * @return object Google OAuth2 client.
+	 */
+	public static function get_site_kit_analytics_module() {
+		if ( defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
+			$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+			return new SiteKitAnalytics( $context );
+		}
+	}
+
+	public static function get_oauth2_credentials() {
+		$client         = self::get_oauth_client();
+		$oauth2_service = $client->get_client()->getOAuth2Service();
+		return new UserRefreshCredentials(
+			null,
+			[
+				'client_id'     => $oauth2_service->getClientId(),
+				'client_secret' => $oauth2_service->getClientSecret(),
+				'refresh_token' => $client->get_refresh_token(),
+			]
+		);
+	}
+}

--- a/includes/google/class-google-services-connection.php
+++ b/includes/google/class-google-services-connection.php
@@ -44,7 +44,7 @@ class Google_Services_Connection {
 	 * @return object Google OAuth2 client.
 	 */
 	public static function get_site_kit_oauth_client() {
-		return self::get_site_kit_authentication()->get_site_kit_oauth_client();
+		return self::get_site_kit_authentication()->get_oauth_client();
 	}
 
 	/**

--- a/includes/google/class-google-services-connection.php
+++ b/includes/google/class-google-services-connection.php
@@ -27,7 +27,7 @@ class Google_Services_Connection {
 	 *
 	 * @return Authentication Site Kit's authentication.
 	 */
-	public static function get_authentication() {
+	public static function get_site_kit_authentication() {
 		if ( defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
 			$context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 			$authentication = new Authentication( $context, new Options( $context ), new User_Options( $context ) );
@@ -43,8 +43,8 @@ class Google_Services_Connection {
 	 *
 	 * @return object Google OAuth2 client.
 	 */
-	public static function get_oauth_client() {
-		return self::get_authentication()->get_oauth_client();
+	public static function get_site_kit_oauth_client() {
+		return self::get_site_kit_authentication()->get_site_kit_oauth_client();
 	}
 
 	/**
@@ -59,16 +59,12 @@ class Google_Services_Connection {
 		}
 	}
 
+	/**
+	 * Get OAuth2 credentials.
+	 *
+	 * @return UserRefreshCredentials Credentials to make requests with.
+	 */
 	public static function get_oauth2_credentials() {
-		$client         = self::get_oauth_client();
-		$oauth2_service = $client->get_client()->getOAuth2Service();
-		return new UserRefreshCredentials(
-			null,
-			[
-				'client_id'     => $oauth2_service->getClientId(),
-				'client_secret' => $oauth2_service->getClientSecret(),
-				'refresh_token' => $client->get_refresh_token(),
-			]
-		);
+		return \Newspack\Google_OAuth::get_oauth2_credentials();
 	}
 }

--- a/includes/popups-analytics/class-popups-analytics-utils.php
+++ b/includes/popups-analytics/class-popups-analytics-utils.php
@@ -131,7 +131,7 @@ class Popups_Analytics_Utils {
 
 		$body = new Google_Service_AnalyticsReporting_GetReportsRequest();
 		$body->setReportRequests( array( $request ) );
-		$client = \Newspack\Google_Services_Connection::get_oauth_client()->get_client();
+		$client = \Newspack\Google_Services_Connection::get_site_kit_oauth_client()->get_client();
 
 		$analyticsreporting = new Google_Service_AnalyticsReporting( $client );
 		// https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet.

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -7,11 +7,6 @@
 
 namespace Newspack;
 
-use Google\Site_Kit\Modules\Analytics as SiteKitAnalytics;
-use Google\Site_Kit\Context;
-use Google\Site_Kit\Core\Storage\Options;
-use Google\Site_Kit\Core\Storage\User_Options;
-use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit_Dependencies\Google_Service_Analytics;
 use Google\Site_Kit_Dependencies\Google_Service_Analytics_CustomDimension;
 
@@ -341,44 +336,38 @@ class Analytics_Wizard extends Wizard {
 	 * @return object authenticated Google_Service_Analytics service and Site Kit settings
 	 */
 	public static function get_ga_utils() {
-		if ( defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
-			$context            = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
-			$site_kit_analytics = new SiteKitAnalytics( $context );
+		$analytics = \Newspack\Google_Services_Connection::get_site_kit_analytics_module();
 
-			if ( $site_kit_analytics->is_connected() ) {
-				$ga_options     = new Options( $context );
-				$user_options   = new User_Options( $context );
-				$authentication = new Authentication( $context, $ga_options, $user_options );
+		if ( $analytics && $analytics->is_connected() ) {
+			$authentication = \Newspack\Google_Services_Connection::get_authentication();
 
-				if ( false === $authentication->is_authenticated() ) {
-					return new WP_Error( 'newspack_analytics_sitekit_authentication', __( 'Please authenticate with the Site Kit plugin.', 'newspack' ) );
-				}
-
-				// A user might have authenticated with Site Kit before this version of the plugin,
-				// which updated authorization scopes, was deployed.
-				$unsatisfied_scopes = $authentication->get_oauth_client()->get_unsatisfied_scopes();
-				if ( 0 !== count( $unsatisfied_scopes ) ) {
-					return new WP_Error(
-						'newspack_analytics_sitekit_unsatisfied_scopes',
-						__( 'Please re-authorize', 'newspack' ) .
-						' <a href="' . get_admin_url() . 'admin.php?page=googlesitekit-dashboard">' .
-						__( 'Site Kit plugin', 'newspack' ) .
-						'</a> ' .
-						__( 'to allow updating Google Analytics settings.', 'newspack' )
-					);
-				}
-
-				$client = $authentication->get_oauth_client()->get_client();
-
-				return [
-					'analytics_service' => new Google_Service_Analytics( $client ),
-					'settings'          => $site_kit_analytics->get_settings()->get(),
-				];
-			} else {
-				return new WP_Error( 'newspack_analytics_sitekit_disconnected', __( 'Please connect Analytics in the Site Kit plugin.', 'newspack' ) );
+			if ( false === $authentication->is_authenticated() ) {
+				return new WP_Error( 'newspack_analytics_sitekit_authentication', __( 'Please authenticate with the Site Kit plugin.', 'newspack' ) );
 			}
+
+			// A user might have authenticated with Site Kit before this version of the plugin,
+			// which updated authorization scopes, was deployed.
+			$unsatisfied_scopes = $authentication->get_oauth_client()->get_unsatisfied_scopes();
+			if ( 0 !== count( $unsatisfied_scopes ) ) {
+				return new WP_Error(
+					'newspack_analytics_sitekit_unsatisfied_scopes',
+					__( 'Please re-authorize', 'newspack' ) .
+					' <a href="' . get_admin_url() . 'admin.php?page=googlesitekit-dashboard">' .
+					__( 'Site Kit plugin', 'newspack' ) .
+					'</a> ' .
+					__( 'to allow updating Google Analytics settings.', 'newspack' )
+				);
+			}
+
+			$client = $authentication->get_oauth_client()->get_client();
+
+			return [
+				'analytics_service' => new Google_Service_Analytics( $client ),
+				'settings'          => $analytics->get_settings()->get(),
+			];
+		} else {
+			return new WP_Error( 'newspack_analytics_sitekit_disconnected', __( 'Please connect Analytics in the Site Kit plugin.', 'newspack' ) );
 		}
-		return new WP_Error( 'newspack_analytics_sitekit_undefined', __( 'Please install the Site Kit plugin.', 'newspack' ) );
 	}
 
 	/**

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -347,7 +347,7 @@ class Analytics_Wizard extends Wizard {
 
 			// A user might have authenticated with Site Kit before this version of the plugin,
 			// which updated authorization scopes, was deployed.
-			$unsatisfied_scopes = $authentication->get_site_kit_oauth_client()->get_unsatisfied_scopes();
+			$unsatisfied_scopes = $authentication->get_oauth_client()->get_unsatisfied_scopes();
 			if ( 0 !== count( $unsatisfied_scopes ) ) {
 				return new WP_Error(
 					'newspack_analytics_sitekit_unsatisfied_scopes',
@@ -359,7 +359,7 @@ class Analytics_Wizard extends Wizard {
 				);
 			}
 
-			$client = $authentication->get_site_kit_oauth_client()->get_client();
+			$client = $authentication->get_oauth_client()->get_client();
 
 			return [
 				'analytics_service' => new Google_Service_Analytics( $client ),

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -339,7 +339,7 @@ class Analytics_Wizard extends Wizard {
 		$analytics = \Newspack\Google_Services_Connection::get_site_kit_analytics_module();
 
 		if ( $analytics && $analytics->is_connected() ) {
-			$authentication = \Newspack\Google_Services_Connection::get_authentication();
+			$authentication = \Newspack\Google_Services_Connection::get_site_kit_authentication();
 
 			if ( false === $authentication->is_authenticated() ) {
 				return new WP_Error( 'newspack_analytics_sitekit_authentication', __( 'Please authenticate with the Site Kit plugin.', 'newspack' ) );
@@ -347,7 +347,7 @@ class Analytics_Wizard extends Wizard {
 
 			// A user might have authenticated with Site Kit before this version of the plugin,
 			// which updated authorization scopes, was deployed.
-			$unsatisfied_scopes = $authentication->get_oauth_client()->get_unsatisfied_scopes();
+			$unsatisfied_scopes = $authentication->get_site_kit_oauth_client()->get_unsatisfied_scopes();
 			if ( 0 !== count( $unsatisfied_scopes ) ) {
 				return new WP_Error(
 					'newspack_analytics_sitekit_unsatisfied_scopes',
@@ -359,7 +359,7 @@ class Analytics_Wizard extends Wizard {
 				);
 			}
 
-			$client = $authentication->get_oauth_client()->get_client();
+			$client = $authentication->get_site_kit_oauth_client()->get_client();
 
 			return [
 				'analytics_service' => new Google_Service_Analytics( $client ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
 
Adds an OAuth2 authentication flow, as a preparation for the upcoming GAM integration.
Currently, Site Kit's authorisation is reused to access user's GA data. Site Kit does not support the scopes necessary to access GAM data, so Newspack has to roll its own authorisation for this purpose.  

UI: I have made it very lightweight purposefully, since this PR is quite large as it is. The UI should probably live in some kind of settings view. cc @thomasguillot 

### How to test the changes in this Pull Request:

1. Nothing should change unless the necessary environment variables are present, so have a look at the Dashboard, Campaigns Analytics, and Analytics wizard - everything should work as before
2. Create a [Google OAuth2 app](https://support.google.com/cloud/answer/6158849?hl=en). Set `<test-site->/wp-admin/admin.php?page=newspack` (e.g. `https://newspack.test/wp-admin/admin.php?page=newspack`) as an Authorized redirect URI.
3. Set client ID and secret of the app as `NEWSPACK_GOOGLE_OAUTH_CLIENT_ID` and `NEWSPACK_GOOGLE_OAUTH_CLIENT_SECRET` environment variables in `wp-config.php`
4. Visit the Dashboard, observe a new section above the wizard links - with an "Authorise" button
5. Click the button and complete the authorisation flow - observe a success message and information "Authorized Google as <email>" in the end
6. This was the happy path, now let's test how it can break. Remove the `_newspack_google_oauth` user meta from the DB
7. Reload the Dasboard, observe initial (pre-authorisation) state. Complete the authorisation from again.
8. Visit your [Google account's permissions screen](https://myaccount.google.com/permissions) and revoke permissions for the app
9. Again, observe the pre-authorisation state and complete the flow again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->