### PR TITLE
feat: integrate Newspack Scheduled Post Checker into main plugin

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -113,7 +113,7 @@ final class Newspack {
 
 		include_once NEWSPACK_ABSPATH . 'includes/configuration_managers/class-configuration-managers.php';
 
-		// Scheduled post checker CRON job.
+		// Scheduled post checker cron job.
 		include_once NEWSPACK_ABSPATH . 'includes/scheduled-post-checker/scheduled-post-checker.php';
 	}
 

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -112,6 +112,9 @@ final class Newspack {
 		}
 
 		include_once NEWSPACK_ABSPATH . 'includes/configuration_managers/class-configuration-managers.php';
+
+		// Scheduled post checker CRON job.
+		include_once NEWSPACK_ABSPATH . 'includes/scheduled-post-checker/scheduled-post-checker.php';
 	}
 
 	/**

--- a/includes/scheduled-post-checker/scheduled-post-checker.php
+++ b/includes/scheduled-post-checker/scheduled-post-checker.php
@@ -49,23 +49,7 @@ function nspc_run_check() {
 		]
 	);
 
-	if ( function_exists( 'spcl_log_event' ) ) {
-		$message = 'Newspack Scheduled Post Checker running';
-		$data    = [
-			'posts_with_missed_schedule' => $posts_with_missed_schedule,
-			'time'                       => $time,
-		];
-		spcl_log_event( $message, $data );
-	}
-
 	foreach ( $posts_with_missed_schedule as $post_id ) {
-		if ( function_exists( 'spcl_log_event' ) ) {
-			$message = 'Trying to publish post with missed schedule';
-			$data    = [
-				'id' => $post_id,
-			];
-			spcl_log_event( $message, $data );
-		}
 		check_and_publish_future_post( $post_id );
 	}
 }

--- a/includes/scheduled-post-checker/scheduled-post-checker.php
+++ b/includes/scheduled-post-checker/scheduled-post-checker.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Newspack Scheduled Post Checker
+ * Checks to make sure posts haven't missed their schedule, and publishes them if needed.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Scheduled_Post_Checker;
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'NEWSPACK_SCHEDULED_POST_CRON_HOOK', 'newspack_scheduled_post_checker' );
+
+/**
+ * Set up the checking.
+ */
+function nspc_init() {
+	register_deactivation_hook( __FILE__, 'nspc_deactivate' );
+	if ( ! wp_next_scheduled( NEWSPACK_SCHEDULED_POST_CRON_HOOK ) ) {
+		wp_schedule_event( time(), 'fivemins', NEWSPACK_SCHEDULED_POST_CRON_HOOK );
+	}
+}
+add_action( 'init', __NAMESPACE__ . '\nspc_init' );
+
+/**
+ * Clear the cron job when this plugin is deactivated.
+ */
+function nspc_deactivate() {
+	wp_clear_scheduled_hook( NEWSPACK_SCHEDULED_POST_CRON_HOOK );
+}
+
+/**
+ * Check to see if any posts have missed schedule, and try sending them live again if so.
+ */
+function nspc_run_check() {
+	$time = wp_date( 'Y-m-d H:i:s' );
+
+	$posts_with_missed_schedule = get_posts(
+		[
+			'post_status' => 'future',
+			'post_type'   => 'any',
+			'fields'      => 'ids',
+			'date_query'  => [
+				[
+					'before'    => $time,
+					'inclusive' => false,
+				],
+			],
+		]
+	);
+
+	if ( function_exists( 'spcl_log_event' ) ) {
+		$message = 'Newspack Scheduled Post Checker running';
+		$data    = [
+			'posts_with_missed_schedule' => $posts_with_missed_schedule,
+			'time'                       => $time,
+		];
+		spcl_log_event( $message, $data );
+	}
+
+	foreach ( $posts_with_missed_schedule as $post_id ) {
+		if ( function_exists( 'spcl_log_event' ) ) {
+			$message = 'Trying to publish post with missed schedule';
+			$data    = [
+				'id' => $post_id,
+			];
+			spcl_log_event( $message, $data );
+		}
+		check_and_publish_future_post( $post_id );
+	}
+}
+add_action( NEWSPACK_SCHEDULED_POST_CRON_HOOK, __NAMESPACE__ . '\nspc_run_check' );
+
+/**
+ * Add a cron interval for every five minutes.
+ *
+ * @param array $schedules Defined cron schedules.
+ * @return array Modified $schedules.
+ */
+function nspc_add_cron_schedule( $schedules ) {
+	$schedules['fivemins'] = [
+		'interval' => MINUTE_IN_SECONDS * 5,
+		'display'  => 'Every 5 minutes',
+	];
+	return $schedules;
+}
+add_filter( 'cron_schedules', __NAMESPACE__ . '\nspc_add_cron_schedule' ); // phpcs:ignore WordPress.WP.CronInterval.ChangeDetected -- https://github.com/WordPress/WordPress-Coding-Standards/issues/1865

--- a/includes/scheduled-post-checker/scheduled-post-checker.php
+++ b/includes/scheduled-post-checker/scheduled-post-checker.php
@@ -9,16 +9,15 @@
 namespace Newspack\Scheduled_Post_Checker;
 
 defined( 'ABSPATH' ) || exit;
-
-define( 'NEWSPACK_SCHEDULED_POST_CRON_HOOK', 'newspack_scheduled_post_checker' );
+define( 'NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK', 'newspack_scheduled_post_checker' );
 
 /**
  * Set up the checking.
  */
 function nspc_init() {
 	register_deactivation_hook( __FILE__, 'nspc_deactivate' );
-	if ( ! wp_next_scheduled( NEWSPACK_SCHEDULED_POST_CRON_HOOK ) ) {
-		wp_schedule_event( time(), 'fivemins', NEWSPACK_SCHEDULED_POST_CRON_HOOK );
+	if ( ! wp_next_scheduled( NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK ) ) {
+		wp_schedule_event( time(), 'fivemins', NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK );
 	}
 }
 add_action( 'init', __NAMESPACE__ . '\nspc_init' );
@@ -27,7 +26,7 @@ add_action( 'init', __NAMESPACE__ . '\nspc_init' );
  * Clear the cron job when this plugin is deactivated.
  */
 function nspc_deactivate() {
-	wp_clear_scheduled_hook( NEWSPACK_SCHEDULED_POST_CRON_HOOK );
+	wp_clear_scheduled_hook( NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK );
 }
 
 /**
@@ -70,7 +69,7 @@ function nspc_run_check() {
 		check_and_publish_future_post( $post_id );
 	}
 }
-add_action( NEWSPACK_SCHEDULED_POST_CRON_HOOK, __NAMESPACE__ . '\nspc_run_check' );
+add_action( NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK, __NAMESPACE__ . '\nspc_run_check' );
 
 /**
  * Add a cron interval for every five minutes.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Pulls in code from the separate [Newspack Scheduled Post Checker plugin](https://github.com/Automattic/newspack-scheduled-post-checker) and integrates it into this main Newspack plugin. After this releases the separate repo can be scheduled (hah) for deprecation.

Note that the integrated version of the code is namespaced and has a slightly different constant name, so that it won't cause conflicts if a site already has the separate plugin installed and activated.

Closes #939.

### How to test the changes in this Pull Request:

1. On `master`, install and activate the [Newspack Scheduled Post Checker plugin](https://github.com/Automattic/newspack-scheduled-post-checker).
2. Using WP CLI, verify that the cron job is scheduled to run every five minutes: `wp cron event list --hook=newspack_scheduled_post_checker`
3. Check out this branch. Verify that the site behaves as expected with no PHP errors or warnings.
4. Also verify that `wp cron event list --hook=newspack_scheduled_post_checker` still shows the same scheduled cron job as before (this change won't overwrite or re-add the job if it already exists).
5. Deactivate the separate Newspack Scheduled Post Checker plugin.
6. Verify that `wp cron event list --hook=newspack_scheduled_post_checker` still shows a scheduled cron job, but with different `next_run_gmt` and `next_run_relative` values (once the other plugin is deactivated, this one will take over and make sure the cron job is scheduled).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->