### PR TITLE
Use guest authors in Slack preview when needed

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -18,6 +18,7 @@ class Patches {
 	 */
 	public static function init() {
 		add_filter( 'redirect_canonical', [ __CLASS__, 'patch_redirect_canonical' ], 10, 2 );
+		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
 	}
 
 	/**
@@ -67,6 +68,20 @@ class Patches {
 
 		// Otherwise, do redirect.
 		return $redirect_url;
+	}
+
+	/**
+	 * Use the Co-Author in Slack preview metadata instead of the regular post author if needed.
+	 *
+	 * @param array $slack_data Array of data which will be output in twitter:data tags.
+	 * @return array Modified $slack_data
+	 */
+	public static function use_cap_for_slack_preview( $slack_data ) {
+		if ( function_exists( 'coauthors' ) && is_single() && isset( $slack_data[ __( 'Written by', 'wordpress-seo' ) ] ) ) {
+			$slack_data[ __( 'Written by', 'wordpress-seo' ) ] = coauthors( null, null, null, null, false );
+		}
+
+		return $slack_data;
 	}
 }
 Patches::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #946 

This PR integrates with Yoast to display the guest author in the `twitter:data1` tag which Slack uses in its previews. For the second part of #946 (Integrating CAP with Yoast schema data), there's [an open issue at the CAP repo](https://github.com/Automattic/Co-Authors-Plus/issues/710), so it should be handled in CAP at some point (hopefully soon now that Yoast is adding a filter in the next release for modifying the data).

### How to test the changes in this Pull Request:

1. Before applying this patch, add a guest author to a post and view the page source. In the `<meta name="twitter:data1" content="AUTHORNAME">` tag, you should see the name of the "real" post author, not the guest author.
2. Apply this patch. Refresh the page. In the `<meta name="twitter:data1" content="GUESTAUTHORNAME">` you should see the name of the guest author.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->