### PR TITLE
Add menu link to manage reusable blocks

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -19,6 +19,7 @@ class Patches {
 	public static function init() {
 		add_filter( 'redirect_canonical', [ __CLASS__, 'patch_redirect_canonical' ], 10, 2 );
 		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
+		add_action( 'admin_menu', [ __CLASS__, 'add_reusable_blocks_menu_link' ] );
 	}
 
 	/**
@@ -82,6 +83,13 @@ class Patches {
 		}
 
 		return $slack_data;
+	}
+
+	/**
+	 * Add a menu link in WP Admin to easily edit and manage reusable blocks.
+	 */
+	public static function add_reusable_blocks_menu_link() {
+		add_submenu_page( 'edit.php', 'manage_reusable_blocks', __( 'Reusable Blocks' ), 'read', 'edit.php?post_type=wp_block', '', 2 );  
 	}
 }
 Patches::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a menu link for managing reusable blocks. Reusable blocks are an important part of many publishers' workflow, so this link should be widely useful. h/t @gamebits for the suggestion.

### How to test the changes in this Pull Request:

1. In WP Admin > Posts menu section, there should now be a link for Reusable Blocks with all the reusable blocks:

<img width="698" alt="Screen Shot 2021-05-04 at 11 37 11 AM" src="https://user-images.githubusercontent.com/7317227/117053482-df538d00-accd-11eb-9eeb-2a2e7359187b.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->