### PR TITLE
feat: add an AutocompleteWithSuggestions component for reusability

### DIFF
--- a/assets/components/src/autocomplete-tokenfield/index.js
+++ b/assets/components/src/autocomplete-tokenfield/index.js
@@ -73,11 +73,16 @@ class AutocompleteTokenField extends Component {
 	 */
 	getLabelsForValues( values ) {
 		const { validValues } = this.state;
-		return values.reduce(
-			( accumulator, value ) =>
-				validValues[ value ] ? [ ...accumulator, validValues[ value ] ] : accumulator,
-			[]
-		);
+		return values.reduce( ( accumulator, value ) => {
+			if ( ! value ) {
+				return accumulator;
+			}
+			if ( value.label ) {
+				return [ ...accumulator, value.label ];
+			}
+
+			return validValues[ value ] ? [ ...accumulator, validValues[ value ] ] : accumulator;
+		}, [] );
 	}
 
 	/**

--- a/assets/components/src/autocomplete-with-suggestions/index.js
+++ b/assets/components/src/autocomplete-with-suggestions/index.js
@@ -59,7 +59,7 @@ const AutocompleteWithSuggestions = ( {
 					{ __( 'Or, select a recent ', 'newspack' ) + sprintf( ' %s:', postTypeLabel ) }
 				</p>
 				<div className="newspack-autocomplete-with-suggestions__search-suggestions">
-					{ suggestions.map( renderSuggestion.bind( this ) ) }
+					{ suggestions.map( renderSuggestion ) }
 				</div>
 			</>
 		);

--- a/assets/components/src/autocomplete-with-suggestions/index.js
+++ b/assets/components/src/autocomplete-with-suggestions/index.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * External dependencies.
@@ -11,24 +11,29 @@ import { Component } from '@wordpress/element';
 import { AutocompleteTokenField } from '../';
 import './style.scss';
 
-class AutocompleteWithSuggestions extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			suggestions: [],
-		};
-	}
+const AutocompleteWithSuggestions = ( {
+	fetchSavedPosts = false,
+	fetchSuggestions = false,
+	onChange = false,
+	help = __( 'Begin typing search term, click autocomplete result to select.', 'newspack' ),
+	label = __( 'Search', 'newspack' ),
+	postTypeLabel = __( 'post', 'newspack' ),
+	selectedPost = 0,
+} ) => {
+	const [ suggestions, setSuggestions ] = useState( [] );
 
 	/**
 	 * Fetch recent posts to show as suggestions.
 	 */
-	componentDidMount() {
-		this.props.fetchSuggestions().then( suggestions => {
-			if ( 0 < suggestions.length ) {
-				this.setState( { suggestions } );
-			}
-		} );
-	}
+	useEffect( () => {
+		if ( fetchSuggestions ) {
+			fetchSuggestions().then( suggestions => {
+				if ( 0 < suggestions.length ) {
+					setSuggestions( suggestions );
+				}
+			} );
+		}
+	}, [] );
 
 	/**
 	 * Render a single suggestion object that can be clicked to select it immediately.
@@ -36,63 +41,43 @@ class AutocompleteWithSuggestions extends Component {
 	 * @param {Object} suggestion Suggestion object with value and label keys.
 	 * @param {number} index Index of this suggestion in the array.
 	 */
-	renderSuggestion( suggestion, index ) {
-		const { onChange } = this.props;
+	const renderSuggestion = ( suggestion, index ) => {
 		return (
 			<Button isLink key={ index } onClick={ () => onChange( [ suggestion ] ) }>
 				{ suggestion.label }
 			</Button>
 		);
-	}
+	};
 
 	/**
 	 * Render a list of suggestions that can be clicked to select instead of searching by title.
 	 */
-	renderSuggestions() {
-		const { postTypeLabel } = this.props;
-		const { suggestions } = this.state;
-
+	const renderSuggestions = () => {
 		return (
 			<>
 				<p className="newspack-autocomplete-with-suggestions__label">
 					{ __( 'Or, select a recent ', 'newspack' ) + sprintf( ' %s:', postTypeLabel ) }
 				</p>
 				<div className="newspack-autocomplete-with-suggestions__search-suggestions">
-					{ suggestions.map( this.renderSuggestion.bind( this ) ) }
+					{ suggestions.map( renderSuggestion.bind( this ) ) }
 				</div>
 			</>
 		);
-	}
-
-	render = () => {
-		const { fetchSuggestions, fetchSavedPosts, label, help, selectedPost, onChange } = this.props;
-		const { suggestions } = this.state;
-
-		return (
-			<div className="newspack-autocomplete-with-suggestions">
-				<AutocompleteTokenField
-					tokens={ [ selectedPost ] }
-					onChange={ onChange }
-					fetchSuggestions={ fetchSuggestions }
-					fetchSavedInfo={ postIDs => fetchSavedPosts( postIDs ) }
-					label={ label }
-					help={ help }
-				/>
-				{ 0 < suggestions.length && this.renderSuggestions() }
-			</div>
-		);
 	};
-}
 
-AutocompleteWithSuggestions.defaultProps = {
-	fetchSavedPosts: () => false,
-	fetchSuggestions: () => false,
-	onChange: () => false,
-	help: __( 'Begin typing search term, click autocomplete result to select.', 'newspack' ),
-	label: __( 'Search', 'newspack' ),
-	postType: 'post',
-	postTypeLabel: __( 'post', 'newspack' ),
-	selectedPost: 0,
+	return (
+		<div className="newspack-autocomplete-with-suggestions">
+			<AutocompleteTokenField
+				tokens={ [ selectedPost ] }
+				onChange={ onChange }
+				fetchSuggestions={ fetchSuggestions }
+				fetchSavedInfo={ postIDs => fetchSavedPosts( postIDs ) }
+				label={ label }
+				help={ help }
+			/>
+			{ 0 < suggestions.length && renderSuggestions() }
+		</div>
+	);
 };
 
 export default AutocompleteWithSuggestions;

--- a/assets/components/src/autocomplete-with-suggestions/index.js
+++ b/assets/components/src/autocomplete-with-suggestions/index.js
@@ -1,0 +1,98 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+
+/**
+ * External dependencies.
+ */
+import { AutocompleteTokenField } from '../';
+import './style.scss';
+
+class AutocompleteWithSuggestions extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			suggestions: [],
+		};
+	}
+
+	/**
+	 * Fetch recent posts to show as suggestions.
+	 */
+	componentDidMount() {
+		this.props.fetchSuggestions().then( suggestions => {
+			if ( 0 < suggestions.length ) {
+				this.setState( { suggestions } );
+			}
+		} );
+	}
+
+	/**
+	 * Render a single suggestion object that can be clicked to select it immediately.
+	 *
+	 * @param {Object} suggestion Suggestion object with value and label keys.
+	 * @param {number} index Index of this suggestion in the array.
+	 */
+	renderSuggestion( suggestion, index ) {
+		const { onChange } = this.props;
+		return (
+			<Button isLink key={ index } onClick={ () => onChange( [ suggestion.value.toString() ] ) }>
+				{ suggestion.label }
+			</Button>
+		);
+	}
+
+	/**
+	 * Render a list of suggestions that can be clicked to select instead of searching by title.
+	 */
+	renderSuggestions() {
+		const { postTypeLabel } = this.props;
+		const { suggestions } = this.state;
+
+		return (
+			<>
+				<p className="newspack-autocomplete-with-suggestions__label">
+					{ __( 'Or, select a recent ', 'newspack' ) + sprintf( ' %s:', postTypeLabel ) }
+				</p>
+				<div className="newspack-autocomplete-with-suggestions__search-suggestions">
+					{ suggestions.map( this.renderSuggestion.bind( this ) ) }
+				</div>
+			</>
+		);
+	}
+
+	render = () => {
+		const { fetchSuggestions, fetchSavedPosts, label, help, selectedPost, onChange } = this.props;
+		const { suggestions } = this.state;
+
+		return (
+			<div className="newspack-autocomplete-with-suggestions">
+				<AutocompleteTokenField
+					tokens={ [ selectedPost ] }
+					onChange={ onChange }
+					fetchSuggestions={ fetchSuggestions }
+					fetchSavedInfo={ postIDs => fetchSavedPosts( postIDs ) }
+					label={ label }
+					help={ help }
+				/>
+				{ 0 < suggestions.length && this.renderSuggestions() }
+			</div>
+		);
+	};
+}
+
+AutocompleteWithSuggestions.defaultProps = {
+	fetchSavedPosts: () => false,
+	fetchSuggestions: () => false,
+	onChange: () => false,
+	help: __( 'Begin typing search term, click autocomplete result to select.', 'newspack' ),
+	label: __( 'Search', 'newspack' ),
+	postType: 'post',
+	postTypeLabel: __( 'post', 'newspack' ),
+	selectedPost: 0,
+};
+
+export default AutocompleteWithSuggestions;

--- a/assets/components/src/autocomplete-with-suggestions/index.js
+++ b/assets/components/src/autocomplete-with-suggestions/index.js
@@ -27,9 +27,9 @@ const AutocompleteWithSuggestions = ( {
 	 */
 	useEffect( () => {
 		if ( fetchSuggestions ) {
-			fetchSuggestions().then( suggestions => {
-				if ( 0 < suggestions.length ) {
-					setSuggestions( suggestions );
+			fetchSuggestions().then( _suggestions => {
+				if ( 0 < _suggestions.length ) {
+					setSuggestions( _suggestions );
 				}
 			} );
 		}

--- a/assets/components/src/autocomplete-with-suggestions/index.js
+++ b/assets/components/src/autocomplete-with-suggestions/index.js
@@ -39,7 +39,7 @@ class AutocompleteWithSuggestions extends Component {
 	renderSuggestion( suggestion, index ) {
 		const { onChange } = this.props;
 		return (
-			<Button isLink key={ index } onClick={ () => onChange( [ suggestion.value.toString() ] ) }>
+			<Button isLink key={ index } onClick={ () => onChange( [ suggestion ] ) }>
 				{ suggestion.label }
 			</Button>
 		);

--- a/assets/components/src/autocomplete-with-suggestions/style.scss
+++ b/assets/components/src/autocomplete-with-suggestions/style.scss
@@ -25,7 +25,6 @@
 	}
 
 	p.newspack-autocomplete-with-suggestions__label {
-		color: $dark-gray-600;
 		margin-bottom: 8px;
 	}
 

--- a/assets/components/src/autocomplete-with-suggestions/style.scss
+++ b/assets/components/src/autocomplete-with-suggestions/style.scss
@@ -6,6 +6,8 @@
 @import '~@wordpress/base-styles/colors';
 
 .newspack-autocomplete-with-suggestions {
+	width: 100%;
+
 	.components-spinner {
 		position: absolute;
 		top: 2em;

--- a/assets/components/src/autocomplete-with-suggestions/style.scss
+++ b/assets/components/src/autocomplete-with-suggestions/style.scss
@@ -1,0 +1,55 @@
+/**
+* Styles for AutocompleteWithSuggestions component.
+*/
+
+@import '../../../shared/scss/colors';
+@import '~@wordpress/base-styles/colors';
+
+.newspack-autocomplete-with-suggestions {
+	.components-spinner {
+		position: absolute;
+		top: 2em;
+		right: 0;
+	}
+
+	.newspack-autocomplete-tokenfield__help {
+		font-size: 12px;
+	}
+
+	.components-form-token-field__suggestions-list {
+		margin: 4px -4px -4px;
+	}
+
+	.components-form-token-field__suggestion {
+		padding: 8px;
+	}
+
+	p.newspack-autocomplete-with-suggestions__label {
+		color: $dark-gray-600;
+		margin-bottom: 8px;
+	}
+
+	&__search-suggestions {
+		border-radius: 2px;
+		border: 1px solid $dark-gray-600;
+		max-height: 182px;
+		padding: 4px;
+		overflow: scroll;
+
+		.components-button {
+			color: $dark-gray-600;
+			display: block;
+			margin: 0;
+			padding: 10px 12px;
+			text-decoration: none;
+			width: 100%;
+
+			&:active:not( :disabled ),
+			&:hover:not( :disabled ) {
+				background: white;
+				background: var( --wp-admin-theme-color );
+				color: white;
+			}
+		}
+	}
+}

--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -1,6 +1,7 @@
 export { default as ActionCard } from './action-card';
 export { default as AutocompleteTokenField } from './autocomplete-tokenfield';
 export { default as Button } from './button';
+export { default as AutocompleteWithSuggestions } from './autocomplete-with-suggestions';
 export { default as ButtonGroup } from './button-group';
 export { default as Card } from './card';
 export { default as PreviewBox } from './preview-box';

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -85,6 +85,7 @@ class ComponentsDemo extends Component {
 				</div>
 				<div className="newspack-wizard newspack-wizard__content">
 					<Card>
+						<h2>{ __( 'Autocomplete with Suggestions', 'newspack' ) }</h2>
 						<AutocompleteWithSuggestions
 							label={ __( 'Search for a post', 'newspack' ) }
 							help={ __(
@@ -124,8 +125,8 @@ class ComponentsDemo extends Component {
 									return acc;
 								}, [] );
 							} }
-							onChange={ value =>
-								this.setState( { selectedPostForAutocompleteWithSuggestions: parseInt( value ) } )
+							onChange={ items =>
+								this.setState( { selectedPostForAutocompleteWithSuggestions: items.pop() } )
 							}
 							selectedPost={ selectedPostForAutocompleteWithSuggestions }
 						/>

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -85,7 +85,7 @@ class Components_Demo extends Wizard {
 		wp_enqueue_script(
 			'newspack-components-demo',
 			Newspack::plugin_url() . '/dist/componentsDemo.js',
-			$this->get_script_dependencies(),
+			$this->get_script_dependencies( [ 'wp-html-entities' ] ),
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/componentsDemo.js' ),
 			true
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a new component to the Newspack Components library, which is an extension of the `AutocompleteTokenfield` that also renders a list of suggestions to choose from. Takes functions as props for fetching suggestions, fetching saved tokens, and what to do when the `AutocompleteTokenfield` value changes.

This UI pattern is something that @thomasguillot has suggested for several features in progress, including this [Author Profile block](https://github.com/Automattic/newspack-blocks/issues/723) (not yet begun) and the Newspack Listings [parent/child UI](https://github.com/Automattic/newspack-listings/pull/43).

After this lands, we'll want to push a new version of the package to the NPM library.

### How to test the changes in this Pull Request:

It's somewhat hard to test this as an NPM package, but you can test within the Newspack Plugin.

1. In some wizard view, import an `AutocompleteWithSuggestions` component from the `newspack-components` directory. Here's an example of some working code (may need to import additional dependencies such as `apiFetch`, `addQueryArgs`, `decodeEntities`, etc.):

```
<AutocompleteWithSuggestions
	label={ __( 'Search for a post', 'newspack' ) }
	help={ __(
		'Begin typing post title, click autocomplete result to select.',
		'newspack'
	) }
	fetchSavedPosts={ async postIDs => {
		const posts = await apiFetch( {
			path: addQueryArgs( '/wp/v2/posts', {
				per_page: 100,
				include: postIDs.join( ',' ),
				_fields: 'id,title',
			} ),
		} );

		return posts.map( post => ( {
			value: post.id,
			label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
		} ) );
	} }
	fetchSuggestions={ async search => {
		const posts = await apiFetch( {
			path: addQueryArgs( '/wp/v2/posts', {
				search,
				per_page: 10,
				_fields: 'id,title',
			} ),
		} );

		// Format suggestions for FormTokenField display.
		const result = posts.reduce( ( acc, post ) => {
			acc.push( {
				value: post.id,
				label: decodeEntities( post.title.rendered ) || __( '(no title)', 'newspack' ),
			} );

			return acc;
		}, [] );
		return result;
	} }
	postType={ 'post' }
	postTypeLabel={ 'Post' }
	maxLength={ 1 }
	onChange={ _value => console.log( _value ) }
	selectedPost={ null }
/>
```

2. In the editor view, observe a component that looks like this, showing your 10 most recent posts in the suggestions list (as returned by the `fetchSuggestions` prop in the above example):

<img width="1060" alt="Screen Shot 2021-05-06 at 12 48 10 PM" src="https://user-images.githubusercontent.com/2230142/117350061-583b1c00-ae69-11eb-869a-da87593ad519.png">

3. To test as an NPM package, you can fudge it by `cd`ing into the `./assets/components` folder in this repo and running `npm install && run prepublishOnly`. Then, in another repo that already uses components from the `newspack-components` NPM package, copy the contents of the `./assets/components` folder into your `node_modules/newspack-components` folder in the second repo. You can then import like `import { AutocompleteWithSuggestions } from 'newspack-components'` and test using the above example code in an editor page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->