### PR TITLE
Campaigns Analytics tweak

### DIFF
--- a/includes/popups-analytics/class-popups-analytics-utils.php
+++ b/includes/popups-analytics/class-popups-analytics-utils.php
@@ -290,7 +290,8 @@ class Popups_Analytics_Utils {
 		$ga_data_days = array_reduce(
 			$ga_data_rows,
 			function ( $days, $row ) use ( $event_label_id, $event_action, &$all_actions, &$all_labels, &$aggregate_seen_events, &$aggregate_form_submission_events, &$aggregate_link_click_events, &$post_edit_link ) {
-				if ( isset( $row['dimensions'][2] ) && strpos( $row['dimensions'][2], 'Newspack Announcement' ) !== false ) {
+				$label = $row['dimensions'][2];
+				if ( '(not set)' !== $label ) {
 					$item          = self::process_legacy_item( $row );
 					$label_object  = $item['label'];
 					$action_object = $item['action'];

--- a/tests/unit-tests/popups-analytics.php
+++ b/tests/unit-tests/popups-analytics.php
@@ -85,9 +85,9 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test report generation.
+	 * Test encoded report generation.
 	 */
-	public function test_report_generation() {
+	public function test_report_generation_encoded() {
 		$yesterday   = ( new \DateTime() )->modify( '-1 days' );
 		$popup_title = 'Donations welcome';
 		$event_code  = '1'; // 'Seen'.
@@ -98,7 +98,7 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 				'dimensions' => [
 					$yesterday->format( 'Ymd' ),
 					$popup_id . $event_code,
-					'',
+					'(not set)',
 				],
 				'metrics'    => [
 					[
@@ -147,6 +147,79 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 					[
 						'label' => $popup_title,
 						'value' => $popup_id,
+					],
+				],
+				'key_metrics'    =>
+				[
+					'seen'             => 4,
+					'form_submissions' => -1,
+					'link_clicks'      => -1,
+				],
+				'post_edit_link' => false,
+			],
+			'Report has expected shape.'
+		);
+	}
+
+	/**
+	 * Test legacy report generation.
+	 */
+	public function test_report_generation() {
+		$yesterday = ( new \DateTime() )->modify( '-1 days' );
+		$ga_rows   = [
+			[
+				'dimensions' => [
+					$yesterday->format( 'Ymd' ),
+					'Seen',
+					'Inline: Newsletter form (954)',
+				],
+				'metrics'    => [
+					[
+						'values' => [
+							'4',
+						],
+					],
+				],
+			],
+		];
+		$report    = \Popups_Analytics_Utils::process_ga_report(
+			$ga_rows,
+			[
+				'offset'         => '3',
+				'event_label_id' => '',
+				'event_action'   => '',
+			]
+		);
+		self::assertEquals(
+			$report,
+			[
+				'report'         =>
+				[
+					[
+						'date'  => ( new \DateTime() )->modify( '-3 days' )->format( 'Y-m-d' ),
+						'value' => 0,
+					],
+					[
+						'date'  => ( new \DateTime() )->modify( '-2 days' )->format( 'Y-m-d' ),
+						'value' => 0,
+					],
+					[
+						'date'  => $yesterday->format( 'Y-m-d' ),
+						'value' => 4,
+					],
+				],
+				'actions'        =>
+				[
+					[
+						'label' => 'Seen',
+						'value' => 'Seen',
+					],
+				],
+				'labels'         =>
+				[
+					[
+						'label' => 'Inline: Newsletter form',
+						'value' => '954',
 					],
 				],
 				'key_metrics'    =>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-popups/pull/535 changed how Campaigns events were sent to GA, ostensibly just reverting the encoding. But the slight change in event label broke the display of Campaigns Analytics.

### How to test the changes in this Pull Request:

1. Test on an instance connected to a GA that has all three possible event formats (I know 🤦‍♂️) - from before encoding (~before March 2021), encoded (~April 2021), and current (after May 4th)
2. Observe that you can see some events from all three periods (that the events sent differently are interpreted correctly)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->