### PR TITLE
fix: loading quiet anim time/height and margin when admin menu is folded

### DIFF
--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -206,11 +206,11 @@ svg {
 		}
 
 		&::before {
-			animation: loading-quiet 1s ease-in-out infinite;
+			animation: loading-quiet 1.25s ease-in-out infinite;
 			background: $primary-500;
 			content: '';
 			display: block;
-			height: 16px;
+			height: 8px;
 			left: 0;
 			position: fixed;
 			right: 100%;
@@ -221,7 +221,8 @@ svg {
 				top: 32px;
 				margin-left: 160px;
 
-				body.auto-fold & {
+				body.auto-fold &,
+				body.folded & {
 					margin-left: 36px;
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a tiny PR that changes a few things for `loading-quiet`

1. Reduces the height of the loading bar to 8px
2. Increases the time of the animation to 1.25s
3. Makes sure the correct `margin-left` is applied when user collapses the admin menu sidebar

### How to test the changes in this Pull Request:

1. Open any wizard
2. Change `newspack-wizard__is-loaded` to `newspack-wizard__is-loaded newspack-wizard__is-loading-quiet`
3. Collapse the sidebar menu
4. See error
5. Switch to this branch
6. Refresh wizard and reapply class
7. Error should be fixed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->