### PR TITLE
feat: reinstate manual-only placement option

### DIFF
--- a/assets/wizards/popups/components/prompt-popovers/secondary.js
+++ b/assets/wizards/popups/components/prompt-popovers/secondary.js
@@ -19,7 +19,7 @@ import {
 	Popover,
 	SelectControl,
 } from '../../../../components/src';
-import { frequenciesForPopup, placementsForPopups } from '../../utils';
+import { frequenciesForPopup, isOverlay, placementsForPopups } from '../../utils';
 import './style.scss';
 
 const SecondaryPromptPopover = ( {
@@ -70,7 +70,7 @@ const SecondaryPromptPopover = ( {
 				} }
 				options={ placementsForPopups( prompt ) }
 				value={ placement }
-				label={ __( 'Placement', 'newspack' ) }
+				label={ isOverlay( prompt ) ? __( 'Position' ) : __( 'Placement' ) }
 			/>
 			<FormTokenField
 				value={ segments

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -46,6 +46,7 @@ const placementMap = {
 	bottom: __( 'Bottom Overlay', 'newspack' ),
 	inline: __( 'Inline', 'newspack' ),
 	above_header: __( 'Above Header', 'newspack' ),
+	manual: __( 'Manual Only', 'newspack' ),
 };
 
 export const placementForPopup = ( { options: { frequency, placement } } ) => {

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -631,7 +631,7 @@ class Popups_Wizard extends Wizard {
 					break;
 				case 'placement':
 					$custom_placement_values = $cm->get_custom_placement_values();
-					if ( ! in_array( $value, array_merge( [ 'center', 'top', 'bottom', 'inline', 'above_header' ], $custom_placement_values ) ) ) {
+					if ( ! in_array( $value, array_merge( [ 'center', 'top', 'bottom', 'inline', 'above_header', 'manual' ], $custom_placement_values ) ) ) {
 						return false;
 					}
 					break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-popups/issues/538.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-popups/pull/547.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->