### PR TITLE
Fix progress-bar radius when using headings

### DIFF
--- a/assets/components/src/progress-bar/index.js
+++ b/assets/components/src/progress-bar/index.js
@@ -58,11 +58,13 @@ class ProgressBar extends Component {
 					</div>
 				) }
 
-				<div
-					className="newspack-progress-bar__bar"
-					style={ barStyle }
-					data-testid="progress-bar-indicator"
-				/>
+				<div className="newspack-progress-bar__container">
+					<div
+						className="newspack-progress-bar__bar"
+						style={ barStyle }
+						data-testid="progress-bar-indicator"
+					/>
+				</div>
 			</div>
 		);
 	}

--- a/assets/components/src/progress-bar/style.scss
+++ b/assets/components/src/progress-bar/style.scss
@@ -7,12 +7,8 @@
 
 .newspack-progress-bar {
 	margin: 32px 0;
-	position: relative;
-	z-index: 1;
-	border-radius: 4px;
-	overflow: hidden;
 
-	.newspack-progress-bar__headings {
+	& &__headings {
 		align-items: center;
 		display: flex;
 		justify-content: space-between;
@@ -20,26 +16,27 @@
 
 		h2,
 		p {
-			margin: 0;
+			margin-bottom: 0;
+			margin-top: 0;
+		}
+
+		p {
+			margin-left: auto;
 		}
 	}
 
-	.newspack-progress-bar__bar {
+	&__container {
+		background-color: $light-gray-200;
+		border-radius: 4px;
+		height: 8px;
+		overflow: hidden;
+		position: relative;
+		z-index: 1;
+	}
+
+	&__bar {
 		background-color: $primary-500;
+		height: 8px;
 		transition: width 125ms ease-in-out;
-
-		&,
-		&::before {
-			height: 8px;
-		}
-
-		&::before {
-			background-color: $light-gray-200;
-			content: '';
-			left: 0;
-			position: absolute;
-			width: 100%;
-			z-index: -1;
-		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Small PR to fix the border radius on the Progress Bar.

You can notice the issue when a Progress Bar is using a label/fraction.

![1-after](https://user-images.githubusercontent.com/177929/118503268-65d28a80-b722-11eb-99c8-4b72ae7ed5ab.png)

![2-before](https://user-images.githubusercontent.com/177929/118503415-81d62c00-b722-11eb-800f-753c50100c60.png)

### How to test the changes in this Pull Request:

1. Check components demo
2. Notice the small bug
3. Switch to this branch
4. Refresh demo
5. Bug should be gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->