### PR TITLE
Fix WPCOM token saving

### DIFF
--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -129,7 +129,15 @@ class Support_Wizard extends Wizard {
 	public function api_wpcom_access_token( $request ) {
 		if ( isset( $request['access_token'], $request['expires_in'] ) ) {
 			$user_id = get_current_user_id();
-			update_user_meta( $user_id, self::NEWSPACK_WPCOM_ACCESS_TOKEN, sanitize_text_field( $request['access_token'] ) );
+			update_user_meta(
+				$user_id,
+				self::NEWSPACK_WPCOM_ACCESS_TOKEN,
+				sanitize_meta(
+					self::NEWSPACK_WPCOM_ACCESS_TOKEN,
+					$request['access_token'],
+					'user'
+				) 
+			);
 			update_user_meta( $user_id, self::NEWSPACK_WPCOM_EXPIRES_IN, sanitize_text_field( $request['expires_in'] ) );
 			return \rest_ensure_response(
 				array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The sanitisation used for the WPCOM token stripped `%` characters, which may appear in tokens. This fixes it by switching to a more idiomatic sanitisation method.

### How to test the changes in this Pull Request:

1. Reset your WPCOM token and reauthorise WPCOM in Support wizard
2. Everyhing should go smoothly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->