### PR TITLE
chore: bump NPM version number for newspack-components

### DIFF
--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-components",
-  "version": "1.4.0",
+  "version": "1.5.1",
   "description": "Newspack design system components",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#952 added a new component to the `newspack-components` package which has since been published to NPM. This PR bumps the version number to match the published package.

* 1.5.0 includes the new `AutocompleteWithSuggestions` component
* 1.5.1 is no different, but was published as part of trying to fix build issues when importing the component to a different repo

Note that repos that import components from the NPM package and update to 1.5.X may need to explicitly run `npm install --save @babel/runtime` if that package isn't a first-class dependency, due to a bug [described in this thread](https://github.com/babel/babel/issues/11318#issuecomment-602410789).

### How to test the changes in this Pull Request:

No functional changes in this PR, so no testing required.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->