### PR TITLE
Add reusable blocks extended as supported plugin

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -341,6 +341,14 @@ class Plugin_Manager {
 				'PluginURI'   => 'https://alex.blog/wordpress-plugins/regenerate-thumbnails/',
 				'Download'    => 'wporg',
 			],
+			'reusable-blocks-extended'      => [
+				'Name'        => 'Reusable Blocks Extended',
+				'Description' => 'Extend Gutenberg Reusable Blocks feature with a complete admin panel, widgets, shortcodes and PHP functions.',
+				'Author'      => 'audrasjb',
+				'AuthorURI'   => 'https://jeanbaptisteaudras.com/en',
+				'PluginURI'   => 'https://jeanbaptisteaudras.com/en/2019/09/reusable-block-extended-a-cool-wordpress-plugin-to-extend-gutenberg-reusable-block-feature/',
+				'Download'    => 'wporg',
+			],
 			'super-cool-ad-inserter'        => [
 				'Name'        => __( 'Super Cool Ad Inserter Plugin', 'newspack' ),
 				'Description' => __( 'This WordPress plugin gives site administrators a way to insert widgets such as ads, newsletter signups, or calls to action into posts at set intervals.', 'newspack' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds Reusable Blocks Extended as a supported plugin.

### How to test the changes in this Pull Request:

1. On the Plugins screen under Newspack, install and activate Reusable Blocks Extended using the entry there
2. You should have a new Reusable Blocks screen:
<img width="1505" alt="Screen Shot 2021-05-18 at 1 47 08 PM" src="https://user-images.githubusercontent.com/7317227/118721432-b65bed80-b7df-11eb-9394-03f64e3905ee.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->