### PR TITLE
Update Advertizing's Global Settings and use ActionCard

### DIFF
--- a/assets/components/src/toggle-group/style.scss
+++ b/assets/components/src/toggle-group/style.scss
@@ -15,10 +15,14 @@
 		margin: 0;
 	}
 
+	&__description {
+		flex: 1;
+	}
+
 	// Multiple Toogle Groups
 
 	& + & {
 		margin-bottom: 32px;
-		margin-top: -24px;
+		margin-top: -16px;
 	}
 }

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -47,6 +47,7 @@
 		font-size: 14px;
 		line-height: 24px;
 		margin: auto;
+		padding-bottom: 32px;
 		padding-top: 32px;
 
 		// Typography

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -262,7 +262,7 @@ class AdvertisingWizard extends Component {
 	deleteAdUnit( id ) {
 		const { setError, wizardApiFetch } = this.props;
 		// eslint-disable-next-line no-alert
-		if ( confirm( __( 'Are you sure you want to delete this ad unit?' ) ) ) {
+		if ( confirm( __( 'Are you sure you want to delete this ad unit?', 'newspack' ) ) ) {
 			wizardApiFetch( {
 				path: '/newspack/v1/wizard/advertising/ad_unit/' + id,
 				method: 'delete',
@@ -304,22 +304,22 @@ class AdvertisingWizard extends Component {
 		const { services, placements, adUnits } = advertisingData;
 		const tabs = [
 			{
-				label: __( 'Ad Providers' ),
+				label: __( 'Ad Providers', 'newspack' ),
 				path: '/',
 				exact: true,
 			},
 			{
-				label: __( 'Global Settings' ),
+				label: __( 'Global Settings', 'newspack' ),
 				path: '/ad-placements',
 			},
 		];
 		const gam_tabs = [
 			{
-				label: __( 'Individual Ad Units' ),
+				label: __( 'Individual Ad Units', 'newspack' ),
 				path: '/google_ad_manager',
 			},
 			{
-				label: __( 'Global Code' ),
+				label: __( 'Global Code', 'newspack' ),
 				path: '/google_ad_manager-global-codes',
 			},
 		];
@@ -334,7 +334,7 @@ class AdvertisingWizard extends Component {
 							render={ () => (
 								<Services
 									headerText={ __( 'Advertising', 'newspack' ) }
-									subHeaderText={ __( 'Monetize your content through advertising' ) }
+									subHeaderText={ __( 'Monetize your content through advertising', 'newspack' ) }
 									services={ services }
 									toggleService={ ( service, value ) => this.toggleService( service, value ) }
 									tabbedNavigation={ tabs }
@@ -346,7 +346,7 @@ class AdvertisingWizard extends Component {
 							render={ () => (
 								<Placements
 									headerText={ __( 'Advertising', 'newspack' ) }
-									subHeaderText={ __( 'Monetize your content through advertising' ) }
+									subHeaderText={ __( 'Monetize your content through advertising', 'newspack' ) }
 									placements={ placements }
 									adUnits={ adUnits }
 									services={ services }
@@ -364,14 +364,14 @@ class AdvertisingWizard extends Component {
 							render={ () => (
 								<AdUnits
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
-									subHeaderText={ __( 'Monetize your content through advertising' ) }
+									subHeaderText={ __( 'Monetize your content through advertising', 'newspack' ) }
 									adUnits={ adUnits }
 									tabbedNavigation={ gam_tabs }
 									service={ 'google_ad_manager' }
 									onDelete={ id => this.deleteAdUnit( id ) }
-									buttonText={ __( 'Add an individual ad unit' ) }
+									buttonText={ __( 'Add an individual ad unit', 'newspack' ) }
 									buttonAction="#/google_ad_manager/create"
-									secondaryButtonText={ __( 'Back to advertising options' ) }
+									secondaryButtonText={ __( 'Back to advertising options', 'newspack' ) }
 									secondaryButtonAction="#/"
 								/>
 							) }
@@ -382,19 +382,19 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => (
 								<HeaderCode
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
-									subHeaderText={ __( 'Monetize your content through advertising' ) }
+									subHeaderText={ __( 'Monetize your content through advertising', 'newspack' ) }
 									adUnits={ adUnits }
 									code={ advertisingData.services.google_ad_manager.network_code }
 									tabbedNavigation={ gam_tabs }
 									service={ 'google_ad_manager' }
 									onChange={ value => this.updateNetworkCode( value, 'google_ad_manager' ) }
-									buttonText={ __( 'Save' ) }
+									buttonText={ __( 'Save', 'newspack' ) }
 									buttonAction={ () =>
 										this.saveNetworkCode( 'google_ad_manager' ).then( () =>
 											routeProps.history.push( '/google_ad_manager' )
 										)
 									}
-									secondaryButtonText={ __( "I'm done configuring ads" ) }
+									secondaryButtonText={ __( "I'm done configuring ads", 'newspack' ) }
 									secondaryButtonAction="#/google_ad_manager"
 								/>
 							) }
@@ -404,9 +404,10 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => {
 								return (
 									<AdUnit
-										headerText={ __( 'Add an ad unit' ) }
+										headerText={ __( 'Add an ad unit', 'newspack' ) }
 										subHeaderText={ __(
-											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.'
+											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.',
+											'newspack'
 										) }
 										adUnit={
 											adUnits[ 0 ] || {
@@ -432,9 +433,10 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => {
 								return (
 									<AdUnit
-										headerText={ __( 'Edit ad unit' ) }
+										headerText={ __( 'Edit ad unit', 'newspack' ) }
 										subHeaderText={ __(
-											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.'
+											'Setting up individual ad units allows you to place ads on your site through our Google Ad Manager Gutenberg block.',
+											'newspack'
 										) }
 										adUnit={ adUnits[ routeProps.match.params.id ] || {} }
 										service={ 'google_ad_manager' }

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -334,7 +334,7 @@ class AdvertisingWizard extends Component {
 							render={ () => (
 								<Services
 									headerText={ __( 'Advertising', 'newspack' ) }
-									subHeaderText={ __( 'Monetize your content through advertising.' ) }
+									subHeaderText={ __( 'Monetize your content through advertising' ) }
 									services={ services }
 									toggleService={ ( service, value ) => this.toggleService( service, value ) }
 									tabbedNavigation={ tabs }
@@ -346,7 +346,7 @@ class AdvertisingWizard extends Component {
 							render={ () => (
 								<Placements
 									headerText={ __( 'Advertising', 'newspack' ) }
-									subHeaderText={ __( 'Monetize your content through advertising.' ) }
+									subHeaderText={ __( 'Monetize your content through advertising' ) }
 									placements={ placements }
 									adUnits={ adUnits }
 									services={ services }
@@ -355,8 +355,6 @@ class AdvertisingWizard extends Component {
 										this.togglePlacement( placement, value )
 									}
 									tabbedNavigation={ tabs }
-									buttonText={ __( 'Back to ad providers' ) }
-									buttonAction="#/"
 								/>
 							) }
 						/>
@@ -366,7 +364,7 @@ class AdvertisingWizard extends Component {
 							render={ () => (
 								<AdUnits
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
-									subHeaderText={ __( 'Monetize your content through advertising.' ) }
+									subHeaderText={ __( 'Monetize your content through advertising' ) }
 									adUnits={ adUnits }
 									tabbedNavigation={ gam_tabs }
 									service={ 'google_ad_manager' }
@@ -384,7 +382,7 @@ class AdvertisingWizard extends Component {
 							render={ routeProps => (
 								<HeaderCode
 									headerText={ __( 'Google Ad Manager', 'newspack' ) }
-									subHeaderText={ __( 'Monetize your content through advertising.' ) }
+									subHeaderText={ __( 'Monetize your content through advertising' ) }
 									adUnits={ adUnits }
 									code={ advertisingData.services.google_ad_manager.network_code }
 									tabbedNavigation={ gam_tabs }

--- a/assets/wizards/advertising/views/placements/ad-picker/index.js
+++ b/assets/wizards/advertising/views/placements/ad-picker/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { SelectControl } from '../../../../../components/src';
+import { Grid, SelectControl } from '../../../../../components/src';
 import './style.scss';
 
 /**
@@ -68,22 +68,22 @@ class AdPicker extends Component {
 		const { adUnits, onChange, services, value } = this.props;
 		const { service, ad_unit: adUnit } = value;
 		return (
-			<div className="newspack-ad-picker">
+			<Grid gutter={ 32 }>
 				<SelectControl
-					label={ __( 'Ad Provider' ) }
+					label={ __( 'Ad Provider', 'newspack' ) }
 					value={ service || '' }
 					options={ this.adServicesForSelect( services ) }
 					onChange={ _service => onChange( { ...value, service: _service } ) }
 				/>
 				{ this.needsAdUnit( value ) && (
 					<SelectControl
-						label={ __( 'Ad Unit' ) }
+						label={ __( 'Ad Unit', 'newspack' ) }
 						value={ adUnit || '' }
 						options={ this.adUnitsForSelect( adUnits ) }
 						onChange={ _adUnit => onChange( { ...value, adUnit: _adUnit } ) }
 					/>
 				) }
-			</div>
+			</Grid>
 		);
 	}
 }

--- a/assets/wizards/advertising/views/placements/ad-picker/style.scss
+++ b/assets/wizards/advertising/views/placements/ad-picker/style.scss
@@ -2,18 +2,10 @@
  * Ad Picker
  */
 
-.newspack-toggle-group__description {
-	flex: 1;
-
-	.newspack-ad-picker {
-		@media screen and ( min-width: 744px ) {
-			display: flex;
-			justify-content: space-between;
-			width: 100%;
-		}
-
-		.newspack-select-control {
-			margin: 16px 0;
+.newspack-card.newspack-action-card {
+	.newspack-action-card__region-children {
+		.newspack-grid {
+			margin: 32px 0 0;
 		}
 	}
 }

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -21,7 +21,7 @@ class Placements extends Component {
 	adUnitsForSelect = adUnits => {
 		return [
 			{
-				label: __( 'Select an ad unit' ),
+				label: __( 'Select an ad unit', 'newspack' ),
 				value: null,
 			},
 			...Object.values( adUnits ).map( adUnit => {
@@ -36,7 +36,7 @@ class Placements extends Component {
 	adServicesForSelect = services => {
 		return [
 			{
-				label: __( 'Select an ad provider' ),
+				label: __( 'Select an ad provider', 'newspack' ),
 				value: null,
 			},
 			...Object.keys( services ).map( key => {
@@ -82,8 +82,8 @@ class Placements extends Component {
 				/>
 				<ActionCard
 					isMedium
-					title={ __( 'Global: Above Header' ) }
-					description={ __( 'Choose an ad unit to display above the header' ) }
+					title={ __( 'Global: Above Header', 'newspack' ) }
+					description={ __( 'Choose an ad unit to display above the header', 'newspack' ) }
 					toggleChecked={ global_above_header && global_above_header.enabled }
 					hasGreyHeader={ global_above_header && global_above_header.enabled }
 					toggleOnChange={ value => togglePlacement( 'global_above_header', value ) }
@@ -99,7 +99,7 @@ class Placements extends Component {
 				</ActionCard>
 				<ActionCard
 					isMedium
-					title={ __( 'Global: Below Header' ) }
+					title={ __( 'Global: Below Header', 'newspack' ) }
 					description={ __( 'Choose an ad unit to display below the header', 'newspack' ) }
 					toggleChecked={ global_below_header && global_below_header.enabled }
 					hasGreyHeader={ global_below_header && global_below_header.enabled }
@@ -116,8 +116,8 @@ class Placements extends Component {
 				</ActionCard>
 				<ActionCard
 					isMedium
-					title={ __( 'Global: Above Footer' ) }
-					description={ __( 'Choose an ad unit to display above the footer' ) }
+					title={ __( 'Global: Above Footer', 'newspack' ) }
+					description={ __( 'Choose an ad unit to display above the footer', 'newspack' ) }
 					toggleChecked={ global_above_footer && global_above_footer.enabled }
 					hasGreyHeader={ global_above_footer && global_above_footer.enabled }
 					toggleOnChange={ value => togglePlacement( 'global_above_footer', value ) }
@@ -133,8 +133,8 @@ class Placements extends Component {
 				</ActionCard>
 				<ActionCard
 					isMedium
-					title={ __( 'Archives' ) }
-					description={ __( 'Choose an ad unit to display on your archives' ) }
+					title={ __( 'Archives', 'newspack' ) }
+					description={ __( 'Choose an ad unit to display on your archives', 'newspack' ) }
 					toggleChecked={ archives && archives.enabled }
 					hasGreyHeader={ archives && archives.enabled }
 					toggleOnChange={ value => togglePlacement( 'archives', value ) }
@@ -150,8 +150,8 @@ class Placements extends Component {
 				</ActionCard>
 				<ActionCard
 					isMedium
-					title={ __( 'Search Results' ) }
-					description={ __( 'Choose an ad unit to display on your search results' ) }
+					title={ __( 'Search Results', 'newspack' ) }
+					description={ __( 'Choose an ad unit to display on your search results', 'newspack' ) }
 					toggleChecked={ search_results && search_results.enabled }
 					hasGreyHeader={ search_results && search_results.enabled }
 					toggleOnChange={ value => togglePlacement( 'search_results', value ) }
@@ -167,8 +167,11 @@ class Placements extends Component {
 				</ActionCard>
 				<ActionCard
 					isMedium
-					title={ __( 'Sticky' ) }
-					description={ __( 'Choose a sticky ad unit to display at the bottom of the viewport' ) }
+					title={ __( 'Sticky', 'newspack' ) }
+					description={ __(
+						'Choose a sticky ad unit to display at the bottom of the viewport',
+						'newspack'
+					) }
 					toggleChecked={ sticky && sticky.enabled }
 					hasGreyHeader={ sticky && sticky.enabled }
 					toggleOnChange={ value => togglePlacement( 'sticky', value ) }

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ToggleGroup, withWizardScreen } from '../../../../components/src';
+import { ActionCard, SectionHeader, withWizardScreen } from '../../../../components/src';
 import AdPicker from './ad-picker';
 
 /**
@@ -64,90 +64,124 @@ class Placements extends Component {
 
 		return (
 			<Fragment>
-				<h2>{ __( 'Pre-defined ad placements' ) }</h2>
-				<p>
-					{ __(
-						'Define global advertising placements to serve ad units on your site. Enable the individual pre-defined ad placements to select which ads to serve.'
+				<SectionHeader
+					title={ __( 'Pre-defined ad placements', 'newspack' ) }
+					description={ () => (
+						<>
+							{ __(
+								'Define global advertising placements to serve ad units on your site',
+								'newspack'
+							) }
+							<br />
+							{ __(
+								'Enable the individual pre-defined ad placements to select which ads to serve',
+								'newspack'
+							) }
+						</>
 					) }
-				</p>
-				<ToggleGroup
+				/>
+				<ActionCard
+					isMedium
 					title={ __( 'Global: Above Header' ) }
 					description={ __( 'Choose an ad unit to display above the header' ) }
-					checked={ global_above_header && global_above_header.enabled }
-					onChange={ value => togglePlacement( 'global_above_header', value ) }
+					toggleChecked={ global_above_header && global_above_header.enabled }
+					hasGreyHeader={ global_above_header && global_above_header.enabled }
+					toggleOnChange={ value => togglePlacement( 'global_above_header', value ) }
 				>
-					<AdPicker
-						adUnits={ adUnits }
-						services={ services }
-						value={ global_above_header }
-						onChange={ value => onChange( 'global_above_header', value ) }
-					/>
-				</ToggleGroup>
-				<ToggleGroup
+					{ global_above_header && global_above_header.enabled ? (
+						<AdPicker
+							adUnits={ adUnits }
+							services={ services }
+							value={ global_above_header }
+							onChange={ value => onChange( 'global_above_header', value ) }
+						/>
+					) : null }
+				</ActionCard>
+				<ActionCard
+					isMedium
 					title={ __( 'Global: Below Header' ) }
-					description={ __( 'Choose an ad unit to display above the header' ) }
-					checked={ global_below_header && global_below_header.enabled }
-					onChange={ value => togglePlacement( 'global_below_header', value ) }
+					description={ __( 'Choose an ad unit to display below the header' ) }
+					toggleChecked={ global_below_header && global_below_header.enabled }
+					hasGreyHeader={ global_below_header && global_below_header.enabled }
+					toggleOnChange={ value => togglePlacement( 'global_below_header', value ) }
 				>
-					<AdPicker
-						adUnits={ adUnits }
-						services={ services }
-						value={ global_below_header }
-						onChange={ value => onChange( 'global_below_header', value ) }
-					/>
-				</ToggleGroup>
-				<ToggleGroup
+					{ global_below_header && global_below_header.enabled ? (
+						<AdPicker
+							adUnits={ adUnits }
+							services={ services }
+							value={ global_below_header }
+							onChange={ value => onChange( 'global_below_header', value ) }
+						/>
+					) : null }
+				</ActionCard>
+				<ActionCard
+					isMedium
 					title={ __( 'Global: Above Footer' ) }
-					description={ __( 'Choose an ad unit to display above the header' ) }
-					checked={ global_above_footer && global_above_footer.enabled }
-					onChange={ value => togglePlacement( 'global_above_footer', value ) }
+					description={ __( 'Choose an ad unit to display above the footer' ) }
+					toggleChecked={ global_above_footer && global_above_footer.enabled }
+					hasGreyHeader={ global_above_footer && global_above_footer.enabled }
+					toggleOnChange={ value => togglePlacement( 'global_above_footer', value ) }
 				>
-					<AdPicker
-						adUnits={ adUnits }
-						services={ services }
-						value={ global_above_footer }
-						onChange={ value => onChange( 'global_above_footer', value ) }
-					/>
-				</ToggleGroup>
-				<ToggleGroup
+					{ global_above_footer && global_above_footer.enabled ? (
+						<AdPicker
+							adUnits={ adUnits }
+							services={ services }
+							value={ global_above_footer }
+							onChange={ value => onChange( 'global_above_footer', value ) }
+						/>
+					) : null }
+				</ActionCard>
+				<ActionCard
+					isMedium
 					title={ __( 'Archives' ) }
-					description={ __( 'Choose an ad unit to display above the header' ) }
-					checked={ archives && archives.enabled }
-					onChange={ value => togglePlacement( 'archives', value ) }
+					description={ __( 'Choose an ad unit to display on your archives' ) }
+					toggleChecked={ archives && archives.enabled }
+					hasGreyHeader={ archives && archives.enabled }
+					toggleOnChange={ value => togglePlacement( 'archives', value ) }
 				>
-					<AdPicker
-						adUnits={ adUnits }
-						services={ services }
-						value={ archives }
-						onChange={ value => onChange( 'archives', value ) }
-					/>
-				</ToggleGroup>
-				<ToggleGroup
+					{ archives && archives.enabled ? (
+						<AdPicker
+							adUnits={ adUnits }
+							services={ services }
+							value={ archives }
+							onChange={ value => onChange( 'archives', value ) }
+						/>
+					) : null }
+				</ActionCard>
+				<ActionCard
+					isMedium
 					title={ __( 'Search Results' ) }
-					description={ __( 'Choose an ad unit to display above the header' ) }
-					checked={ search_results && search_results.enabled }
-					onChange={ value => togglePlacement( 'search_results', value ) }
+					description={ __( 'Choose an ad unit to display on your search results' ) }
+					toggleChecked={ search_results && search_results.enabled }
+					hasGreyHeader={ search_results && search_results.enabled }
+					toggleOnChange={ value => togglePlacement( 'search_results', value ) }
 				>
-					<AdPicker
-						adUnits={ adUnits }
-						services={ services }
-						value={ search_results }
-						onChange={ value => onChange( 'search_results', value ) }
-					/>
-				</ToggleGroup>
-				<ToggleGroup
+					{ search_results && search_results.enabled ? (
+						<AdPicker
+							adUnits={ adUnits }
+							services={ services }
+							value={ search_results }
+							onChange={ value => onChange( 'search_results', value ) }
+						/>
+					) : null }
+				</ActionCard>
+				<ActionCard
+					isMedium
 					title={ __( 'Sticky' ) }
 					description={ __( 'Choose a sticky ad unit to display at the bottom of the viewport' ) }
-					checked={ sticky && sticky.enabled }
-					onChange={ value => togglePlacement( 'sticky', value ) }
+					toggleChecked={ sticky && sticky.enabled }
+					hasGreyHeader={ sticky && sticky.enabled }
+					toggleOnChange={ value => togglePlacement( 'sticky', value ) }
 				>
-					<AdPicker
-						adUnits={ adUnits }
-						services={ services }
-						value={ sticky }
-						onChange={ value => onChange( 'sticky', value ) }
-					/>
-				</ToggleGroup>
+					{ sticky && sticky.enabled ? (
+						<AdPicker
+							adUnits={ adUnits }
+							services={ services }
+							value={ sticky }
+							onChange={ value => onChange( 'sticky', value ) }
+						/>
+					) : null }
+				</ActionCard>
 			</Fragment>
 		);
 	}

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -100,7 +100,7 @@ class Placements extends Component {
 				<ActionCard
 					isMedium
 					title={ __( 'Global: Below Header' ) }
-					description={ __( 'Choose an ad unit to display below the header' ) }
+					description={ __( 'Choose an ad unit to display below the header', 'newspack' ) }
 					toggleChecked={ global_below_header && global_below_header.enabled }
 					hasGreyHeader={ global_below_header && global_below_header.enabled }
 					toggleOnChange={ value => togglePlacement( 'global_below_header', value ) }

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -87,7 +87,7 @@ class Advertising_Wizard extends Wizard {
 	 * @return string The wizard description.
 	 */
 	public function get_description() {
-		return \esc_html__( 'Monetize your content through advertising.', 'newspack' );
+		return \esc_html__( 'Monetize your content through advertising', 'newspack' );
 	}
 
 	/**

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -2134,7 +2134,7 @@ msgid "Advertising"
 msgstr ""
 
 #: includes/wizards/class-advertising-wizard.php:89
-msgid "Monetize your content through advertising."
+msgid "Monetize your content through advertising"
 msgstr ""
 
 #: includes/wizards/class-advertising-wizard.php:98


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR replaces the `ToggleGroup` used in Global Settings with `ActionCard` to create a more balanced with less white space Wizard.

This is inspired by the Services step of the Onboarding

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Navigate to Advertizing > Global settings
3. Test all the various placements and check if it's saved correctly by checking your front-end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->