### PR TITLE
fix: prevent external links from ad dashboard UI

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -70,6 +70,7 @@ class ActionCard extends Component {
 			toggleOnChange && ! titleLink && ! disabled
 				? { onClick: () => toggleOnChange( ! toggleChecked ), tabIndex: '0' }
 				: {};
+		const hasInternalLink = href && href.indexOf( 'http' ) !== 0;
 		return (
 			<Card className={ classes } onClick={ simple && onClick }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
@@ -106,7 +107,7 @@ class ActionCard extends Component {
 								<Handoff plugin={ handoff } editLink={ editLink } compact isLink>
 									{ actionText }
 								</Handoff>
-							) : onClick ? (
+							) : onClick || hasInternalLink ? (
 								<Button
 									isLink
 									href={ href }

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ActionCard, Router, withWizardScreen } from '../../../../components/src';
+import { ActionCard, withWizardScreen } from '../../../../components/src';
 
 /**
  * Advertising management screen.

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -5,46 +5,46 @@
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { ActionCard, withWizardScreen } from '../../../../components/src';
+import { ActionCard, Router, withWizardScreen } from '../../../../components/src';
+
+/**
+ * Router component for managing single-page app nav.
+ */
+const { useHistory } = Router;
 
 /**
  * Advertising management screen.
  */
-class AdUnits extends Component {
-	/**
-	 * Render.
-	 */
-	render() {
-		const { adUnits, onDelete, service } = this.props;
+const AdUnits = ( { adUnits, onDelete, service } ) => {
+	const history = useHistory();
 
-		return (
-			<Fragment>
-				<p>
-					{ __(
-						'Set up multiple ad units to use on your homepage, articles and other places throughout your site. You can place ads through our Newspack Ad Block in the Editor.'
-					) }
-				</p>
-				{ Object.values( adUnits ).map( ( { id, name } ) => {
-					return (
-						<ActionCard
-							key={ id }
-							title={ name }
-							actionText={ __( 'Edit' ) }
-							href={ `#${ service }/${ id }` }
-							secondaryActionText={ __( 'Delete' ) }
-							onSecondaryActionClick={ () => onDelete( id ) }
-						/>
-					);
-				} ) }
-			</Fragment>
-		);
-	}
-}
+	return (
+		<>
+			<p>
+				{ __(
+					'Set up multiple ad units to use on your homepage, articles and other places throughout your site. You can place ads through our Newspack Ad Block in the Editor.'
+				) }
+			</p>
+			{ Object.values( adUnits ).map( ( { id, name } ) => {
+				return (
+					<ActionCard
+						key={ id }
+						title={ name }
+						actionText={ __( 'Edit' ) }
+						titleLink={ `#${ service }/${ id }` }
+						onClick={ () => history.push( `${ service }/${ id }` ) }
+						secondaryActionText={ __( 'Delete' ) }
+						onSecondaryActionClick={ () => onDelete( id ) }
+					/>
+				);
+			} ) }
+		</>
+	);
+};
 
 export default withWizardScreen( AdUnits );

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -13,16 +13,9 @@ import { __ } from '@wordpress/i18n';
 import { ActionCard, Router, withWizardScreen } from '../../../../components/src';
 
 /**
- * Router component for managing single-page app nav.
- */
-const { useHistory } = Router;
-
-/**
  * Advertising management screen.
  */
 const AdUnits = ( { adUnits, onDelete, service } ) => {
-	const history = useHistory();
-
 	return (
 		<>
 			<p>
@@ -37,7 +30,7 @@ const AdUnits = ( { adUnits, onDelete, service } ) => {
 						title={ name }
 						actionText={ __( 'Edit' ) }
 						titleLink={ `#${ service }/${ id }` }
-						onClick={ () => history.push( `${ service }/${ id }` ) }
+						href={ `#${ service }/${ id }` }
 						secondaryActionText={ __( 'Delete' ) }
 						onSecondaryActionClick={ () => onDelete( id ) }
 					/>

--- a/assets/wizards/advertising/views/services/index.js
+++ b/assets/wizards/advertising/views/services/index.js
@@ -5,77 +5,78 @@
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { ActionCard, withWizardScreen } from '../../../../components/src';
+import { ActionCard, Router, withWizardScreen } from '../../../../components/src';
+
+/**
+ * Router component for managing single-page app nav.
+ */
+const { useHistory } = Router;
 
 /**
  * Advertising management screen.
  */
-class Services extends Component {
-	/**
-	 * Render.
-	 */
-	render() {
-		const { services, toggleService } = this.props;
-		const { wordads, google_adsense, google_ad_manager } = services;
-		return (
-			<Fragment>
-				<p>
-					{ __( 'Please enable and configure the ad providers you’d like to use to get started.' ) }
-				</p>
-				<ActionCard
-					title={ __( 'WordAds from WordPress.com' ) }
-					badge={ __( 'Jetpack Premium' ) }
-					description={ __(
-						'A managed ad optimization platform where the top 50 ad networks (DSPs and exchanges) compete for your traffic, with flexible placement options, and support from WordPress.com.'
-					) }
-					actionText={ wordads && wordads.enabled && __( 'Configure' ) }
-					toggle
-					toggleChecked={ wordads && wordads.enabled }
-					toggleOnChange={ value => toggleService( 'wordads', value ) }
-					href={ wordads && '#/ad-placements' }
-					notification={
-						wordads.upgrade_required && [
-							__( 'Upgrade Jetpack to enable WordAds.' ) + '\u00A0',
-							<ExternalLink href="/wp-admin/admin.php?page=jetpack#/plans" key="jetpack-link">
-								{ __( 'Click to upgrade' ) }
-							</ExternalLink>,
-						]
-					}
-					notificationLevel={ 'info' }
-				/>
-				<ActionCard
-					title={ __( 'Google AdSense' ) }
-					description={ __(
-						'A simple way to place adverts on your news site automatically based on where they best perform.'
-					) }
-					actionText={ google_adsense && google_adsense.enabled && __( 'Configure' ) }
-					toggle
-					toggleChecked={ google_adsense && google_adsense.enabled }
-					toggleOnChange={ value => toggleService( 'google_adsense', value ) }
-					handoff="google-site-kit"
-					editLink="admin.php?page=googlesitekit-module-adsense"
-				/>
-				<ActionCard
-					title={ __( 'Google Ad Manager' ) }
-					description={ __(
-						'An advanced ad inventory creation and management platform, allowing you to be specific about ad placements.'
-					) }
-					actionText={ google_ad_manager && google_ad_manager.enabled && __( 'Configure' ) }
-					toggle
-					toggleChecked={ google_ad_manager && google_ad_manager.enabled }
-					toggleOnChange={ value => toggleService( 'google_ad_manager', value ) }
-					href={ google_ad_manager && '#/google_ad_manager' }
-				/>
-			</Fragment>
-		);
-	}
-}
+const Services = ( { services, toggleService } ) => {
+	const { wordads, google_adsense, google_ad_manager } = services;
+	const history = useHistory();
+
+	return (
+		<>
+			<p>
+				{ __( 'Please enable and configure the ad providers you’d like to use to get started.' ) }
+			</p>
+			<ActionCard
+				title={ __( 'WordAds from WordPress.com' ) }
+				badge={ __( 'Jetpack Premium' ) }
+				description={ __(
+					'A managed ad optimization platform where the top 50 ad networks (DSPs and exchanges) compete for your traffic, with flexible placement options, and support from WordPress.com.'
+				) }
+				actionText={ wordads && wordads.enabled && __( 'Configure' ) }
+				toggle
+				toggleChecked={ wordads && wordads.enabled }
+				toggleOnChange={ value => toggleService( 'wordads', value ) }
+				href={ wordads && '#/ad-placements' }
+				notification={
+					wordads.upgrade_required && [
+						__( 'Upgrade Jetpack to enable WordAds.' ) + '\u00A0',
+						<ExternalLink href="/wp-admin/admin.php?page=jetpack#/plans" key="jetpack-link">
+							{ __( 'Click to upgrade' ) }
+						</ExternalLink>,
+					]
+				}
+				notificationLevel={ 'info' }
+			/>
+			<ActionCard
+				title={ __( 'Google AdSense' ) }
+				description={ __(
+					'A simple way to place adverts on your news site automatically based on where they best perform.'
+				) }
+				actionText={ google_adsense && google_adsense.enabled && __( 'Configure' ) }
+				toggle
+				toggleChecked={ google_adsense && google_adsense.enabled }
+				toggleOnChange={ value => toggleService( 'google_adsense', value ) }
+				handoff="google-site-kit"
+				editLink="admin.php?page=googlesitekit-module-adsense"
+			/>
+			<ActionCard
+				title={ __( 'Google Ad Manager' ) }
+				description={ __(
+					'An advanced ad inventory creation and management platform, allowing you to be specific about ad placements.'
+				) }
+				actionText={ google_ad_manager && google_ad_manager.enabled && __( 'Configure' ) }
+				toggle
+				toggleChecked={ google_ad_manager && google_ad_manager.enabled }
+				toggleOnChange={ value => toggleService( 'google_ad_manager', value ) }
+				titleLink={ google_ad_manager ? '#/google_ad_manager' : null }
+				onClick={ () => google_ad_manager && history.push( '/google_ad_manager' ) }
+			/>
+		</>
+	);
+};
 
 export default withWizardScreen( Services );

--- a/assets/wizards/advertising/views/services/index.js
+++ b/assets/wizards/advertising/views/services/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ActionCard, Router, withWizardScreen } from '../../../../components/src';
+import { ActionCard, withWizardScreen } from '../../../../components/src';
 
 /**
  * Advertising management screen.

--- a/assets/wizards/advertising/views/services/index.js
+++ b/assets/wizards/advertising/views/services/index.js
@@ -14,16 +14,10 @@ import { __ } from '@wordpress/i18n';
 import { ActionCard, Router, withWizardScreen } from '../../../../components/src';
 
 /**
- * Router component for managing single-page app nav.
- */
-const { useHistory } = Router;
-
-/**
  * Advertising management screen.
  */
 const Services = ( { services, toggleService } ) => {
 	const { wordads, google_adsense, google_ad_manager } = services;
-	const history = useHistory();
 
 	return (
 		<>
@@ -73,7 +67,7 @@ const Services = ( { services, toggleService } ) => {
 				toggleChecked={ google_ad_manager && google_ad_manager.enabled }
 				toggleOnChange={ value => toggleService( 'google_ad_manager', value ) }
 				titleLink={ google_ad_manager ? '#/google_ad_manager' : null }
-				onClick={ () => google_ad_manager && history.push( '/google_ad_manager' ) }
+				href={ google_ad_manager && '#/google_ad_manager' }
 			/>
 		</>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#870 changed the `ActionCard` component so that if it receives an `href` prop, it renders an `ExternalLink` to that `href` value. This resulted in a few Ads dashboard components rendering external links to internal UI pages, which is an annoying admin experience (clicking each link opens a new tab instead of loading the next view in a single-page app experience as expected). This change invokes the `Router` to turn those links into internal routes instead of external links.

### How to test the changes in this Pull Request:

1. In Newspack > Advertising, confirm that the Google Ad Manager action card no longer has the external link icon next to the "Configure" link:
 
<img width="979" alt="Screen Shot 2021-05-21 at 2 53 48 PM" src="https://user-images.githubusercontent.com/2230142/119197020-5d40c380-ba44-11eb-8a00-4aae48c149c9.png">

2. Confirm that clicking on either "Configure" or the "Google Ad Manager" title loads the GAM view with the list of ad units directly in the same tab, without refreshing the page.
3. In the Ads Units list, confirm that the ad unit title and the "Edit" link load the edit page for that ad unit in the same browser tab, without refreshing the page, and that the "Edit" link no longer has an external link icon.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->