### PR TITLE
chore: bump newspack-components NPM version

### DIFF
--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-components",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Newspack design system components",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Now that #975 has been published to NPM as v1.6.0, we should bump the version number in the repo to match.

### How to test the changes in this Pull Request:

No functional changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->