### PR TITLE
feat: remove organic-profile-block from supported plugins

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -271,14 +271,6 @@ class Plugin_Manager {
 				'Description' => 'The Newspack theme.',
 				'Author'      => 'Newspack',
 			],
-			'organic-profile-block'         => [
-				'Name'        => 'Organic Profile Block',
-				'Description' => "The Profile Block is created for the Gutenberg content editor. It displays a profile section with an image, name, subtitle, bio and personal social media links. It's perfect for author biographies, personal profiles, or staff pages.",
-				'Author'      => 'Organic Themes',
-				'PluginURI'   => 'https://organicthemes.com/',
-				'AuthorURI'   => 'https://organicthemes.com/',
-				'Download'    => 'wporg',
-			],
 			'wp-parsely'                    => [
 				'Name'        => 'Parse.ly',
 				'Description' => 'This plugin makes it a snap to add Parse.ly tracking code to your WordPress blog.',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Unlisting the organic-profile-block plugin, because:

1. It has [a bug](https://github.com/Invulu/organic-profile-block/issues/11) that hurts performance severely
2. Newspack Blocks [now features the Author Profile block](https://github.com/Automattic/newspack-blocks/pull/763)

### How to test the changes in this Pull Request:

The organic-profile-block plugin should not be listed in the the plugins view, unless installed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->