### PR TITLE
Update "add new prompt" icons to match Gutenberg style

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -228,7 +228,7 @@ body[class*='admin-color-'] {
 			@include button-style( transparent, transparent, $gray-900 );
 			border-style: solid;
 			border-width: 1px;
-			color: $gray-700;
+			color: $gray-900;
 
 			&:hover {
 				border-color: $gray-200;

--- a/assets/wizards/popups/components/segment-group/icons.js
+++ b/assets/wizards/popups/components/segment-group/icons.js
@@ -5,32 +5,37 @@ import { Path, SVG } from '@wordpress/components';
 
 export const iconInline = (
 	<SVG xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-		<Path d="M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z" />
+		<Path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" />
 	</SVG>
 );
-export const iconCenterOverlay = (
+export const iconOverlayBottom = (
 	<SVG xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-		<Path d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h18v14zM7 9h10v6H7V9z" />
+		<Path d="M17 14H7v3h10v-3z" />
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M18 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2zM6 5.5h12a.5.5 0 01.5.5v12a.5.5 0 01-.5.5H6a.5.5 0 01-.5-.5V6a.5.5 0 01.5-.5z"
+		/>
 	</SVG>
 );
-export const iconTopOverlay = (
+export const iconOverlayCenter = (
 	<SVG xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-		<Path d="M3 21h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2zM3 5h18v14H3V5zm16 4H5V6h14v3z" />
+		<Path d="M16 10H8v4h8v-4z" />
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M18 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2zM6 5.5h12a.5.5 0 01.5.5v12a.5.5 0 01-.5.5H6a.5.5 0 01-.5-.5V6a.5.5 0 01.5-.5z"
+		/>
 	</SVG>
 );
-export const iconBottomOverlay = (
+export const iconOverlayTop = (
 	<SVG xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-		<Path d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h18v14zM5 15h14v3H5z" />
-	</SVG>
-);
-export const iconAboveHeader = (
-	<SVG xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-		<Path d="M3 21h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2zM3 8h18v11H3V8z" />
-	</SVG>
-);
-export const iconManualPlacement = (
-	<SVG xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-		<Path d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM3 8h11.5v4.5H3V8zm0 6.5h11.5V19H3v-4.5zM21 19h-4.5V8H21v11z" />
+		<Path d="M17 7H7v3h10V7z" />
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M18 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2zM6 5.5h12a.5.5 0 01.5.5v12a.5.5 0 01-.5.5H6a.5.5 0 01-.5-.5V6a.5.5 0 01.5-.5z"
+		/>
 	</SVG>
 );
 export const iconPreview = (

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -9,7 +9,7 @@ import cookies from 'js-cookie';
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, Fragment } from '@wordpress/element';
-import { Icon, plus } from '@wordpress/icons';
+import { Icon, header, layout, plus } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -27,11 +27,9 @@ import {
 
 import {
 	iconInline,
-	iconCenterOverlay,
-	iconTopOverlay,
-	iconBottomOverlay,
-	iconAboveHeader,
-	iconManualPlacement,
+	iconOverlayBottom,
+	iconOverlayCenter,
+	iconOverlayTop,
 	iconPreview,
 } from './icons';
 import './style.scss';
@@ -165,28 +163,28 @@ const SegmentGroup = props => {
 									shouldCloseOnClickOutside={ false }
 								>
 									<Card buttonsCard noBorder className="newspack-card__buttons-prompt">
+										<Button href={ addNewURL( 'overlay-center', campaignId, id ) }>
+											<Icon icon={ iconOverlayCenter } height={ 48 } width={ 48 } />
+											{ __( 'Center Overlay', 'newspack' ) }
+										</Button>
+										<Button href={ addNewURL( 'overlay-top', campaignId, id ) }>
+											<Icon icon={ iconOverlayTop } height={ 48 } width={ 48 } />
+											{ __( 'Top Overlay', 'newspack' ) }
+										</Button>
+										<Button href={ addNewURL( 'overlay-bottom', campaignId, id ) }>
+											<Icon icon={ iconOverlayBottom } height={ 48 } width={ 48 } />
+											{ __( 'Bottom Overlay', 'newspack' ) }
+										</Button>
 										<Button href={ addNewURL( null, campaignId, id ) }>
 											<Icon icon={ iconInline } height={ 48 } width={ 48 } />
 											{ __( 'Inline', 'newspack' ) }
 										</Button>
-										<Button href={ addNewURL( 'overlay-center', campaignId, id ) }>
-											<Icon icon={ iconCenterOverlay } height={ 48 } width={ 48 } />
-											{ __( 'Center Overlay', 'newspack' ) }
-										</Button>
-										<Button href={ addNewURL( 'overlay-top', campaignId, id ) }>
-											<Icon icon={ iconTopOverlay } height={ 48 } width={ 48 } />
-											{ __( 'Top Overlay', 'newspack' ) }
-										</Button>
-										<Button href={ addNewURL( 'overlay-bottom', campaignId, id ) }>
-											<Icon icon={ iconBottomOverlay } height={ 48 } width={ 48 } />
-											{ __( 'Bottom Overlay', 'newspack' ) }
-										</Button>
 										<Button href={ addNewURL( 'above-header', campaignId, id ) }>
-											<Icon icon={ iconAboveHeader } height={ 48 } width={ 48 } />
+											<Icon icon={ header } height={ 48 } width={ 48 } />
 											{ __( 'Above Header', 'newspack' ) }
 										</Button>
 										<Button href={ addNewURL( 'custom', campaignId, id ) }>
-											<Icon icon={ iconManualPlacement } height={ 48 } width={ 48 } />
+											<Icon icon={ layout } height={ 48 } width={ 48 } />
 											{ __( 'Custom Placement', 'newspack' ) }
 										</Button>
 									</Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Small PR to update the icons used in the "Add New Prompt" modal. At the moment it's based on Material. We've now moved away from it and are using Gutenberg's.

![add-new-prompt-new-icons](https://user-images.githubusercontent.com/177929/122213751-2faf3480-cea1-11eb-958a-5308d3343384.png)

### How to test the changes in this Pull Request:

1. Go to Newspack > Campaigns
2. Click the "+" to add a new prompt, see the old icons
3. Switch to this branch
4. Refresh Wizard and click once again on the "+"
5. Observe the new icons

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->