### PR TITLE
feat: prompt duplication UI in a modal in the Campaigns wizard

### DIFF
--- a/assets/components/src/notice/style.scss
+++ b/assets/components/src/notice/style.scss
@@ -63,4 +63,8 @@
 			margin: 0;
 		}
 	}
+
+	& + & {
+		margin-top: -16px;
+	}
 }

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -123,7 +123,10 @@ const PromptActionCard = props => {
 						<>
 							<Notice
 								isSuccess
-								noticeText={ sprintf( __( 'Duplicate of “%s” created as a draft.', 'newspack' ), title ) }
+								noticeText={ sprintf(
+									__( 'Duplicate of “%s” created as a draft.', 'newspack' ),
+									title
+								) }
 							/>
 							{ ! campaignGroups && (
 								<Notice

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -46,10 +46,10 @@ const PromptActionCard = props => {
 	const getDefaultDupicateTitle = () => {
 		const promptToDuplicate = parseInt( prompt?.duplicate_of || prompt.id );
 		const originalPrompt =
-			prompts.find( _prompt => parseInt( _prompt.id ) === promptToDuplicate ) || {};
+			prompts?.find( _prompt => parseInt( _prompt.id ) === promptToDuplicate ) || {};
 		const baseTitle = sprintf( __( '%s copy' ), originalPrompt?.title || title );
 		const existingDuplicates =
-			prompts.filter( _prompt => -1 < _prompt.title.indexOf( baseTitle ) ) || [];
+			prompts?.filter( _prompt => -1 < _prompt.title.indexOf( baseTitle ) ) || [];
 
 		return (
 			baseTitle + ( 0 < existingDuplicates.length ? ' ' + ( existingDuplicates.length + 1 ) : '' )

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -121,14 +121,20 @@ const PromptActionCard = props => {
 				>
 					{ duplicated ? (
 						<>
+							<Notice
+								isSuccess
+								noticeText={ sprintf( __( 'Duplicate of “%s” created as a draft.', 'newspack' ), title ) }
+							/>
 							{ ! campaignGroups && (
 								<Notice
 									isWarning
 									noticeText={ __( 'The prompt is currently unassigned.', 'newspack' ) }
 								/>
 							) }
-							<p>{ sprintf( __( 'Duplicate of “%s” created as a draft.', 'newspack' ), title ) }</p>
 							<div className="newspack-buttons-card">
+								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
+									{ __( 'Edit', 'newspack' ) }
+								</Button>
 								<Button
 									isSecondary
 									onClick={ () => {
@@ -138,9 +144,6 @@ const PromptActionCard = props => {
 									} }
 								>
 									{ __( 'Close', 'newspack' ) }
-								</Button>
-								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
-									{ __( 'Edit', 'newspack' ) }
 								</Button>
 							</div>
 						</>
@@ -154,11 +157,21 @@ const PromptActionCard = props => {
 							) }
 							<TextControl
 								disabled={ inFlight || null === duplicateTitle }
-								label={ __( 'New Title', 'newspack' ) }
+								label={ __( 'Title', 'newspack' ) }
 								value={ duplicateTitle }
 								onChange={ value => setDuplicateTitle( value ) }
 							/>
 							<div className="newspack-buttons-card">
+								<Button
+									disabled={ inFlight || null === duplicateTitle }
+									isPrimary
+									onClick={ () => {
+										const titleForDuplicate = duplicateTitle.trim() || getDefaultDupicateTitle();
+										duplicatePopup( id, titleForDuplicate );
+									} }
+								>
+									{ __( 'Duplicate', 'newspack' ) }
+								</Button>
 								<Button
 									disabled={ inFlight }
 									isSecondary
@@ -169,16 +182,6 @@ const PromptActionCard = props => {
 									} }
 								>
 									{ __( 'Cancel', 'newspack' ) }
-								</Button>
-								<Button
-									disabled={ inFlight || null === duplicateTitle }
-									isPrimary
-									onClick={ () => {
-										const titleForDuplicate = duplicateTitle.trim() || getDefaultDupicateTitle();
-										duplicatePopup( id, titleForDuplicate );
-									} }
-								>
-									{ __( 'Duplicate', 'newspack' ) }
 								</Button>
 							</div>
 						</>

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -131,7 +131,10 @@ const PromptActionCard = props => {
 							{ ! campaignGroups && (
 								<Notice
 									isWarning
-									noticeText={ __( 'This prompt is currently not assigned to any campaign.', 'newspack' ) }
+									noticeText={ __(
+										'This prompt is currently not assigned to any campaign.',
+										'newspack'
+									) }
 								/>
 							) }
 							<div className="newspack-buttons-card">

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -5,15 +5,15 @@
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
-import { useState, Fragment } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
+import { useEffect, useState, Fragment } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { moreVertical, settings } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
  */
-import { ActionCard, Button } from '../../../../components/src';
+import { ActionCard, Button, Modal, Notice, TextControl } from '../../../../components/src';
 import PrimaryPromptPopover from '../prompt-popovers/primary';
 import SecondaryPromptPopover from '../prompt-popovers/secondary';
 import { placementForPopup } from '../../utils';
@@ -22,58 +22,160 @@ import './style.scss';
 const PromptActionCard = props => {
 	const [ categoriesVisibility, setCategoriesVisibility ] = useState( false );
 	const [ popoverVisibility, setPopoverVisibility ] = useState( false );
+	const [ modalVisible, setModalVisible ] = useState( false );
+	const [ duplicateTitle, setDuplicateTitle ] = useState( null );
 
-	const { className, description, prompt = {}, segments, warning } = props;
-	const { id, edit_link: editLink, title } = prompt;
+	const {
+		className,
+		description,
+		duplicated,
+		duplicatePopup,
+		inFlight,
+		resetDuplicated,
+		prompt = {},
+		prompts,
+		segments,
+		warning,
+	} = props;
+	const { campaign_groups: campaignGroups, id, edit_link: editLink, title } = prompt;
+
+	useEffect( () => {
+		setDuplicateTitle( getDefaultDupicateTitle() );
+	}, [ prompts, title ] );
+
+	const getDefaultDupicateTitle = () => {
+		const promptToDuplicate = parseInt( prompt?.duplicate_of || prompt.id );
+		const originalPrompt =
+			prompts.find( _prompt => parseInt( _prompt.id ) === promptToDuplicate ) || {};
+		const baseTitle = sprintf( __( '%s copy' ), originalPrompt?.title || title );
+		const existingDuplicates =
+			prompts.filter( _prompt => -1 < _prompt.title.indexOf( baseTitle ) ) || [];
+
+		return (
+			baseTitle + ( 0 < existingDuplicates.length ? ' ' + ( existingDuplicates.length + 1 ) : '' )
+		);
+	};
+
 	return (
-		<ActionCard
-			isSmall
-			badge={ placementForPopup( prompt ) }
-			className={ className }
-			title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack' ) }
-			titleLink={ decodeEntities( editLink ) }
-			key={ id }
-			description={ description }
-			notification={ warning }
-			notificationLevel="error"
-			actionText={
-				<Fragment>
-					<Button
-						isQuaternary
-						isSmall
-						className={ categoriesVisibility && 'popover-active' }
-						onClick={ () => setCategoriesVisibility( ! categoriesVisibility ) }
-						icon={ settings }
-						label={ __( 'Category filtering and campaigns', 'newspack' ) }
-						tooltipPosition="bottom center"
-					/>
-					<Button
-						isQuaternary
-						isSmall
-						className={ popoverVisibility && 'popover-active' }
-						onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
-						icon={ moreVertical }
-						label={ __( 'More options', 'newspack' ) }
-						tooltipPosition="bottom center"
-					/>
-					{ popoverVisibility && (
-						<PrimaryPromptPopover
-							onFocusOutside={ () => setPopoverVisibility( false ) }
-							prompt={ prompt }
-							{ ...props }
+		<>
+			<ActionCard
+				isSmall
+				badge={ placementForPopup( prompt ) }
+				className={ className }
+				title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack' ) }
+				titleLink={ decodeEntities( editLink ) }
+				key={ id }
+				description={ description }
+				notification={ warning }
+				notificationLevel="error"
+				actionText={
+					<Fragment>
+						<Button
+							isQuaternary
+							isSmall
+							className={ categoriesVisibility && 'popover-active' }
+							onClick={ () => setCategoriesVisibility( ! categoriesVisibility ) }
+							icon={ settings }
+							label={ __( 'Category filtering and campaigns', 'newspack' ) }
+							tooltipPosition="bottom center"
 						/>
-					) }
-					{ categoriesVisibility && (
-						<SecondaryPromptPopover
-							onFocusOutside={ () => setCategoriesVisibility( false ) }
-							prompt={ prompt }
-							segments={ segments }
-							{ ...props }
+						<Button
+							isQuaternary
+							isSmall
+							className={ popoverVisibility && 'popover-active' }
+							onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
+							icon={ moreVertical }
+							label={ __( 'More options', 'newspack' ) }
+							tooltipPosition="bottom center"
 						/>
+						{ popoverVisibility && (
+							<PrimaryPromptPopover
+								onFocusOutside={ () => setPopoverVisibility( false ) }
+								prompt={ prompt }
+								setModalVisible={ setModalVisible }
+								{ ...props }
+							/>
+						) }
+						{ categoriesVisibility && (
+							<SecondaryPromptPopover
+								onFocusOutside={ () => setCategoriesVisibility( false ) }
+								prompt={ prompt }
+								segments={ segments }
+								{ ...props }
+							/>
+						) }
+					</Fragment>
+				}
+			/>
+			{ modalVisible && (
+				<Modal
+					className="newspack-popups__duplicate-modal"
+					title={ sprintf( __( 'Duplicate “%s”', 'newspack' ), title ) }
+					onRequestClose={ () => {
+						resetDuplicated();
+						setModalVisible( false );
+					} }
+				>
+					{ duplicated ? (
+						<>
+							<p>{ sprintf( __( 'Duplicate of “%s” created as a draft.', 'newspack' ), title ) }</p>
+							{ ! campaignGroups && (
+								<Notice
+									isWarning
+									noticeText={ __( 'The duplicate is currently unassigned.', 'newspack' ) }
+								/>
+							) }
+							<div className="newspack-buttons-card">
+								<Button
+									isSecondary
+									onClick={ () => {
+										resetDuplicated();
+										setModalVisible( false );
+									} }
+								>
+									{ __( 'Close', 'newspack' ) }
+								</Button>
+								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
+									{ __( 'Edit', 'newspack' ) }
+								</Button>
+							</div>
+						</>
+					) : (
+						<>
+							<TextControl
+								disabled={ inFlight }
+								label={ __( 'New Title', 'newspack' ) }
+								value={ duplicateTitle }
+								onChange={ value => setDuplicateTitle( value ) }
+							/>
+
+							<div className="newspack-buttons-card">
+								<Button
+									disabled={ inFlight }
+									isSecondary
+									onClick={ () => {
+										resetDuplicated();
+										setModalVisible( false );
+									} }
+								>
+									{ __( 'Cancel', 'newspack' ) }
+								</Button>
+								<Button
+									disabled={ inFlight }
+									isPrimary
+									onClick={ () => {
+										const titleForDuplicate = duplicateTitle.trim() || getDefaultDupicateTitle();
+										duplicatePopup( id, titleForDuplicate );
+									} }
+								>
+									{ __( 'Duplicate', 'newspack' ) }
+								</Button>
+							</div>
+						</>
 					) }
-				</Fragment>
-			}
-		/>
+				</Modal>
+			) }
+		</>
 	);
 };
 export default PromptActionCard;

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -131,7 +131,7 @@ const PromptActionCard = props => {
 							{ ! campaignGroups && (
 								<Notice
 									isWarning
-									noticeText={ __( 'The prompt is currently unassigned.', 'newspack' ) }
+									noticeText={ __( 'This prompt is currently not assigned to any campaign.', 'newspack' ) }
 								/>
 							) }
 							<div className="newspack-buttons-card">

--- a/assets/wizards/popups/components/prompt-popovers/primary.js
+++ b/assets/wizards/popups/components/prompt-popovers/primary.js
@@ -18,15 +18,16 @@ import './style.scss';
 
 const PrimaryPromptPopover = ( {
 	deletePopup,
-	duplicatePopup,
+	onFocusOutside,
 	prompt,
 	previewPopup,
-	onFocusOutside,
 	publishPopup,
+	setModalVisible,
 	unpublishPopup,
 } ) => {
-	const { id, edit_link: editLink, status } = prompt;
+	const { id, edit_link: editLink, status, title } = prompt;
 	const isPublished = 'publish' === status;
+
 	return (
 		<Popover
 			position="bottom left"
@@ -49,7 +50,7 @@ const PrimaryPromptPopover = ( {
 			<MenuItem href={ decodeEntities( editLink ) } className="newspack-button" isLink>
 				{ __( 'Edit', 'newspack' ) }
 			</MenuItem>
-			<MenuItem onClick={ () => duplicatePopup( id ) } className="newspack-button">
+			<MenuItem onClick={ () => setModalVisible( true ) } className="newspack-button">
 				{ __( 'Duplicate', 'newspack' ) }
 			</MenuItem>
 			{ ! isPublished && (

--- a/assets/wizards/popups/components/prompt-popovers/primary.js
+++ b/assets/wizards/popups/components/prompt-popovers/primary.js
@@ -25,7 +25,7 @@ const PrimaryPromptPopover = ( {
 	setModalVisible,
 	unpublishPopup,
 } ) => {
-	const { id, edit_link: editLink, status, title } = prompt;
+	const { id, edit_link: editLink, status } = prompt;
 	const isPublished = 'publish' === status;
 
 	return (

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -177,7 +177,12 @@ class PopupsWizard extends Component {
 			quiet: true,
 		} )
 			.then( this.updateAfterAPI )
-			.catch( error => setError( error ) );
+			.catch( () => {
+				setError( {
+					code: 'duplicate_prompt_error',
+					message: __( 'Error duplicating prompt. Please try again later.', 'newspack' ),
+				} );
+			} );
 	};
 
 	previewUrlForPopup = ( { options, id } ) => {

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -302,19 +302,19 @@ const Campaigns = props => {
 							</div>
 							<Card buttonsCard noBorder>
 								<Button
+									isPrimary
+									disabled={ ! campaignName }
+									onClick={ () => submitModal( campaignName ) }
+								>
+									{ modalButton( modalType ) }
+								</Button>
+								<Button
 									isSecondary
 									onClick={ () => {
 										setModalVisible( false );
 									} }
 								>
 									{ __( 'Cancel', 'newspack' ) }
-								</Button>
-								<Button
-									isPrimary
-									disabled={ ! campaignName }
-									onClick={ () => submitModal( campaignName ) }
-								>
-									{ modalButton( modalType ) }
 								</Button>
 							</Card>
 						</Modal>

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -263,6 +263,17 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Get default title for a duplicated prompt.
+	 *
+	 * @param int $id Prompt ID to duplicate.
+	 */
+	public function get_duplicate_title( $id ) {
+		return $this->is_configured() ?
+			\Newspack_Popups::get_duplicate_title( $id ) :
+			$this->unconfigured_error();
+	}
+
+	/**
 	 * Duplicate a prompt.
 	 *
 	 * @param int    $id Prompt ID to duplicate.

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -265,11 +265,12 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	/**
 	 * Duplicate a prompt.
 	 *
-	 * @param int $id Prompt ID.
+	 * @param int    $id Prompt ID to duplicate.
+	 * @param string $title Title to give the duplicated prompt.
 	 */
-	public function duplicate_popup( $id ) {
+	public function duplicate_popup( $id, $title ) {
 		return $this->is_configured() ?
-			\Newspack_Popups::duplicate_popup( $id ) :
+			\Newspack_Popups::duplicate_popup( $id, $title ) :
 			$this->unconfigured_error();
 	}
 

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -116,6 +116,20 @@ class Popups_Wizard extends Wizard {
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/(?P<id>\d+)/duplicate',
 			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_duplicate_title' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'id' => [
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/(?P<id>\d+)/duplicate',
+			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_duplicate_popup' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
@@ -576,6 +590,18 @@ class Popups_Wizard extends Wizard {
 		}
 
 		return $this->api_get_settings();
+	}
+
+	/**
+	 * Get default title for a duplicated prompt.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response with complete info to render the Engagement Wizard.
+	 */
+	public function api_get_duplicate_title( $request ) {
+		$cm            = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
+		$default_title = $cm->get_duplicate_title( $request['id'] );
+		return $default_title;
 	}
 
 	/**

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -120,8 +120,11 @@ class Popups_Wizard extends Wizard {
 				'callback'            => [ $this, 'api_duplicate_popup' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'id' => [
+					'id'    => [
 						'sanitize_callback' => 'absint',
+					],
+					'title' => [
+						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
 			]
@@ -512,6 +515,7 @@ class Popups_Wizard extends Wizard {
 			$response['settings']  = $newspack_popups_configuration_manager->get_settings();
 			$response['campaigns'] = $newspack_popups_configuration_manager->get_campaigns();
 		}
+
 		return rest_ensure_response( $response );
 	}
 
@@ -581,9 +585,9 @@ class Popups_Wizard extends Wizard {
 	 * @return WP_REST_Response with complete info to render the Engagement Wizard.
 	 */
 	public function api_duplicate_popup( $request ) {
-		$cm = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
-		$cm->duplicate_popup( $request['id'] );
-		return $this->api_get_settings();
+		$cm           = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
+		$duplicate_id = $cm->duplicate_popup( $request['id'], $request['title'] );
+		return $this->api_get_settings( [ 'duplicated' => $duplicate_id ] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves the UI for duplicating prompts according to https://github.com/Automattic/newspack-popups/issues/560. When duplicating a prompt from the Campaigns dashboard, you are now presented with a modal with the opportunity to rename the duplicate before creating it, an option to close the modal or edit the duplicate after it's created, and a notice if the duplicate is created without a campaign (which would cause it to be visible in the dashboard only under the "unassigned" filter).

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-popups/pull/564.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->