### PR TITLE
Update the style of the Modal component

### DIFF
--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -19,10 +19,12 @@
 	// Buttons Card
 
 	&__buttons-card {
-		margin: 24px -8px;
+		display: flex;
+		flex-wrap: wrap;
+		margin: 32px -8px 16px;
 
 		.newspack-button {
-			margin: 8px;
+			margin: 0 8px 16px;
 		}
 	}
 

--- a/assets/components/src/handoff/index.js
+++ b/assets/components/src/handoff/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { Button, Modal, Waiting } from '../';
+import { Button, Card, Modal, Waiting } from '../';
 
 /**
  * External dependencies.
@@ -141,12 +141,14 @@ class Handoff extends Component {
 						onRequestClose={ () => this.setState( { showModal: false } ) }
 					>
 						<p>{ modalBody }</p>
-						<Button isPrimary onClick={ () => this.goToPlugin( Slug ) }>
-							{ primaryModalButton }
-						</Button>
-						<Button isSecondary onClick={ () => this.setState( { showModal: false } ) }>
-							{ dismissModalButton }
-						</Button>
+						<Card buttonsCard noBorder className="justify-end">
+							<Button isSecondary onClick={ () => this.setState( { showModal: false } ) }>
+								{ dismissModalButton }
+							</Button>
+							<Button isPrimary onClick={ () => this.goToPlugin( Slug ) }>
+								{ primaryModalButton }
+							</Button>
+						</Card>
 					</Modal>
 				) }
 			</Fragment>

--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -16,7 +16,7 @@
 	width: 100%;
 
 	@media screen and ( min-width: 600px ) {
-		border-radius: 4px;
+		border-radius: 3px;
 		max-width: 80%;
 		max-width: calc( 100% - 64px );
 	}
@@ -33,29 +33,30 @@
 	// Header
 
 	.components-modal__header {
+		align-items: flex-start;
 		background: white;
-		border: none;
+		border: 0;
 		height: auto;
-		margin: 0;
-		padding: 64px 0 32px;
+		justify-content: flex-end;
+		margin: 0 -48px;
+		padding: 64px 48px 32px;
+
+		@media screen and ( min-width: 744px ) {
+			margin-left: -64px;
+			margin-right: -64px;
+			padding-left: 64px;
+			padding-right: 64px;
+		}
 
 		.components-modal__header-heading-container {
 			display: block;
+			margin-right: 16px;
 		}
 
 		.components-button.has-icon {
-			height: 48px;
-			justify-content: center;
-			left: auto;
-			padding: 0;
-			position: absolute;
-			right: -40px;
-			top: 8px;
-			width: 48px;
-
-			@media screen and ( min-width: 744px ) {
-				right: -56px;
-			}
+			flex: 0 0 36px;
+			left: 0;
+			margin: -2px 0;
 
 			&:hover,
 			&[aria-expended='true'] {
@@ -78,10 +79,9 @@
 
 		.components-modal__header-heading {
 			color: $gray-900;
-			font-size: 20px;
+			font-size: 21px;
 			font-weight: bold;
-			line-height: 24px;
-			text-align: center;
+			line-height: 32px;
 		}
 	}
 

--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -12,7 +12,8 @@
 	font-size: 14px;
 	line-height: 24px;
 	margin: 0;
-	padding: 0 48px;
+	max-height: 100%;
+	padding: 0 32px;
 	width: 100%;
 
 	@media screen and ( min-width: 600px ) {
@@ -38,8 +39,8 @@
 		border: 0;
 		height: auto;
 		justify-content: flex-end;
-		margin: 0 -48px;
-		padding: 64px 48px 32px;
+		margin: 0 -32px;
+		padding: 64px 32px 32px;
 
 		@media screen and ( min-width: 744px ) {
 			margin-left: -64px;
@@ -89,11 +90,7 @@
 
 	.components-modal__content {
 		margin: -32px 0 0;
-		padding: 0 0 16px;
-
-		@media screen and ( min-width: 744px ) {
-			padding-bottom: 32px;
-		}
+		padding: 0 0 32px;
 	}
 
 	// Typography

--- a/assets/components/src/notice/style.scss
+++ b/assets/components/src/notice/style.scss
@@ -63,4 +63,8 @@
 			margin: 0;
 		}
 	}
+
+	& + & {
+		margin-top: -16px;
+	}
 }

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -8,7 +8,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies.
  */
-import { Button, Modal, Notice, PluginInstaller } from '../';
+import { Button, Card, Modal, Notice, PluginInstaller } from '../';
 import Router from '../proxied-imports/router';
 import Footer from '../footer';
 import './style.scss';
@@ -100,11 +100,11 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 					onRequestClose={ () => ( window.location = fallbackURL ) }
 				>
 					<Notice noticeText={ message } isError rawHTML />
-					<div className="newspack-buttons-card">
+					<Card buttonsCard noBorder className="justify-end">
 						<Button isPrimary href={ fallbackURL }>
-							{ __( 'Return to dashboard' ) }
+							{ __( 'Return to dashboard', 'newspack' ) }
 						</Button>
-					</div>
+					</Card>
 				</Modal>
 			);
 		};

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -33,8 +33,6 @@ class AdvertisingWizard extends Component {
 					global_above_header: {},
 					global_below_header: {},
 					global_above_footer: {},
-					archives: {},
-					search_results: {},
 					sticky: {},
 				},
 				services: {

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -53,14 +53,7 @@ class Placements extends Component {
 	 */
 	render() {
 		const { togglePlacement, placements, adUnits, services, onChange } = this.props;
-		const {
-			global_above_header,
-			global_below_header,
-			global_above_footer,
-			archives,
-			search_results,
-			sticky,
-		} = placements;
+		const { global_above_header, global_below_header, global_above_footer, sticky } = placements;
 
 		return (
 			<Fragment>
@@ -128,40 +121,6 @@ class Placements extends Component {
 							services={ services }
 							value={ global_above_footer }
 							onChange={ value => onChange( 'global_above_footer', value ) }
-						/>
-					) : null }
-				</ActionCard>
-				<ActionCard
-					isMedium
-					title={ __( 'Archives', 'newspack' ) }
-					description={ __( 'Choose an ad unit to display on your archives', 'newspack' ) }
-					toggleChecked={ archives && archives.enabled }
-					hasGreyHeader={ archives && archives.enabled }
-					toggleOnChange={ value => togglePlacement( 'archives', value ) }
-				>
-					{ archives && archives.enabled ? (
-						<AdPicker
-							adUnits={ adUnits }
-							services={ services }
-							value={ archives }
-							onChange={ value => onChange( 'archives', value ) }
-						/>
-					) : null }
-				</ActionCard>
-				<ActionCard
-					isMedium
-					title={ __( 'Search Results', 'newspack' ) }
-					description={ __( 'Choose an ad unit to display on your search results', 'newspack' ) }
-					toggleChecked={ search_results && search_results.enabled }
-					hasGreyHeader={ search_results && search_results.enabled }
-					toggleOnChange={ value => togglePlacement( 'search_results', value ) }
-				>
-					{ search_results && search_results.enabled ? (
-						<AdPicker
-							adUnits={ adUnits }
-							services={ services }
-							value={ search_results }
-							onChange={ value => onChange( 'search_results', value ) }
 						/>
 					) : null }
 				</ActionCard>

--- a/assets/wizards/analytics/views/custom-events/index.js
+++ b/assets/wizards/analytics/views/custom-events/index.js
@@ -19,6 +19,7 @@ import { Icon, check } from '@wordpress/icons';
 import {
 	ActionCard,
 	Button,
+	Card,
 	Grid,
 	Notice,
 	TextControl,
@@ -277,14 +278,7 @@ class CustomEvents extends Component {
 										onChange={ this.updateEditedEvent( 'is_active' ) }
 										label={ __( 'Active', 'newspack' ) }
 									/>
-									<div className="newspack-buttons-card">
-										<Button
-											onClick={ this.handleCustomEventEdit }
-											disabled={ ! validateEvent( editedEvent ) || isLoading }
-											isPrimary
-										>
-											{ isCreatingEvent ? __( 'Add', 'newspack' ) : __( 'Update', 'newspack' ) }
-										</Button>
+									<Card buttonsCard noBorder className="justify-end">
 										{ ! isCreatingEvent && (
 											<Button
 												isSecondary
@@ -298,7 +292,14 @@ class CustomEvents extends Component {
 												{ __( 'Delete', 'newspack' ) }
 											</Button>
 										) }
-									</div>
+										<Button
+											onClick={ this.handleCustomEventEdit }
+											disabled={ ! validateEvent( editedEvent ) || isLoading }
+											isPrimary
+										>
+											{ isCreatingEvent ? __( 'Add', 'newspack' ) : __( 'Update', 'newspack' ) }
+										</Button>
+									</Card>
 								</div>
 							</Modal>
 						) }

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -200,7 +200,7 @@ class ComponentsDemo extends Component {
 						</Card>
 						{ modalShown && (
 							<Modal
-								title="This is the modal title"
+								title={ __( 'This is the modal title', 'newspack' ) }
 								onRequestClose={ () => this.setState( { modalShown: false } ) }
 							>
 								<p>
@@ -208,7 +208,7 @@ class ComponentsDemo extends Component {
 										'Based on industry research, we advise to test the modal component, and continuing this sentence so we can see how the text wraps is one good way of doing that.'
 									) }
 								</p>
-								<Card buttonsCard noBorder>
+								<Card buttonsCard noBorder className="justify-end">
 									<Button isPrimary onClick={ () => this.setState( { modalShown: false } ) }>
 										{ __( 'Dismiss' ) }
 									</Button>

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -14,7 +14,7 @@ import { moreVertical, settings } from '@wordpress/icons';
 /**
  * Internal dependencies.
  */
-import { ActionCard, Button, Modal, Notice, TextControl } from '../../../../components/src';
+import { ActionCard, Button, Card, Modal, Notice, TextControl } from '../../../../components/src';
 import PrimaryPromptPopover from '../prompt-popovers/primary';
 import SecondaryPromptPopover from '../prompt-popovers/secondary';
 import { placementForPopup } from '../../utils';
@@ -137,10 +137,7 @@ const PromptActionCard = props => {
 									) }
 								/>
 							) }
-							<div className="newspack-buttons-card">
-								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
-									{ __( 'Edit', 'newspack' ) }
-								</Button>
+							<Card buttonsCard noBorder className="justify-end">
 								<Button
 									isSecondary
 									onClick={ () => {
@@ -151,7 +148,10 @@ const PromptActionCard = props => {
 								>
 									{ __( 'Close', 'newspack' ) }
 								</Button>
-							</div>
+								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
+									{ __( 'Edit', 'newspack' ) }
+								</Button>
+							</Card>
 						</>
 					) : (
 						<>
@@ -170,17 +170,7 @@ const PromptActionCard = props => {
 								value={ duplicateTitle }
 								onChange={ value => setDuplicateTitle( value ) }
 							/>
-							<div className="newspack-buttons-card">
-								<Button
-									disabled={ inFlight || null === duplicateTitle }
-									isPrimary
-									onClick={ () => {
-										const titleForDuplicate = duplicateTitle.trim() || getDefaultDupicateTitle();
-										duplicatePopup( id, titleForDuplicate );
-									} }
-								>
-									{ __( 'Duplicate', 'newspack' ) }
-								</Button>
+							<Card buttonsCard noBorder className="justify-end">
 								<Button
 									disabled={ inFlight }
 									isSecondary
@@ -192,7 +182,17 @@ const PromptActionCard = props => {
 								>
 									{ __( 'Cancel', 'newspack' ) }
 								</Button>
-							</div>
+								<Button
+									disabled={ inFlight || null === duplicateTitle }
+									isPrimary
+									onClick={ () => {
+										const titleForDuplicate = duplicateTitle.trim() || getDefaultDupicateTitle();
+										duplicatePopup( id, titleForDuplicate );
+									} }
+								>
+									{ __( 'Duplicate', 'newspack' ) }
+								</Button>
+							</Card>
 						</>
 					) }
 				</Modal>

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -158,7 +158,10 @@ const PromptActionCard = props => {
 							{ ! campaignGroups && (
 								<Notice
 									isWarning
-									noticeText={ __( 'This prompt will be unassigned.', 'newspack' ) }
+									noticeText={ __(
+										'This prompt will not be assigned to any campaign.',
+										'newspack'
+									) }
 								/>
 							) }
 							<TextControl

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -5,15 +5,16 @@
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
-import { useState, Fragment } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { sprintf, __ } from '@wordpress/i18n';
+import { useEffect, useState, Fragment } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { moreVertical, settings } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
  */
-import { ActionCard, Button } from '../../../../components/src';
+import { ActionCard, Button, Modal, Notice, TextControl } from '../../../../components/src';
 import PrimaryPromptPopover from '../prompt-popovers/primary';
 import SecondaryPromptPopover from '../prompt-popovers/secondary';
 import { placementForPopup } from '../../utils';
@@ -22,58 +23,178 @@ import './style.scss';
 const PromptActionCard = props => {
 	const [ categoriesVisibility, setCategoriesVisibility ] = useState( false );
 	const [ popoverVisibility, setPopoverVisibility ] = useState( false );
+	const [ modalVisible, setModalVisible ] = useState( false );
+	const [ duplicateTitle, setDuplicateTitle ] = useState( null );
 
-	const { className, description, prompt = {}, segments, warning } = props;
-	const { id, edit_link: editLink, title } = prompt;
+	const {
+		className,
+		description,
+		duplicated,
+		duplicatePopup,
+		inFlight,
+		resetDuplicated,
+		prompt = {},
+		segments,
+		warning,
+	} = props;
+	const { campaign_groups: campaignGroups, id, edit_link: editLink, title } = prompt;
+
+	useEffect( () => {
+		if ( modalVisible && ! duplicateTitle ) {
+			getDefaultDupicateTitle();
+		}
+	}, [ modalVisible ] );
+
+	const getDefaultDupicateTitle = async () => {
+		const promptToDuplicate = parseInt( prompt?.duplicate_of || prompt.id );
+		try {
+			const defaultTitle = await apiFetch( {
+				path: `/newspack/v1/wizard/newspack-popups-wizard/${ promptToDuplicate }/duplicate`,
+			} );
+
+			setDuplicateTitle( defaultTitle );
+		} catch ( e ) {
+			setDuplicateTitle( title + __( ' copy', 'newspack-popups' ) );
+		}
+	};
+
 	return (
-		<ActionCard
-			isSmall
-			badge={ placementForPopup( prompt ) }
-			className={ className }
-			title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack' ) }
-			titleLink={ decodeEntities( editLink ) }
-			key={ id }
-			description={ description }
-			notification={ warning }
-			notificationLevel="error"
-			actionText={
-				<Fragment>
-					<Button
-						isQuaternary
-						isSmall
-						className={ categoriesVisibility && 'popover-active' }
-						onClick={ () => setCategoriesVisibility( ! categoriesVisibility ) }
-						icon={ settings }
-						label={ __( 'Category filtering and campaigns', 'newspack' ) }
-						tooltipPosition="bottom center"
-					/>
-					<Button
-						isQuaternary
-						isSmall
-						className={ popoverVisibility && 'popover-active' }
-						onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
-						icon={ moreVertical }
-						label={ __( 'More options', 'newspack' ) }
-						tooltipPosition="bottom center"
-					/>
-					{ popoverVisibility && (
-						<PrimaryPromptPopover
-							onFocusOutside={ () => setPopoverVisibility( false ) }
-							prompt={ prompt }
-							{ ...props }
+		<>
+			<ActionCard
+				isSmall
+				badge={ placementForPopup( prompt ) }
+				className={ className }
+				title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack' ) }
+				titleLink={ decodeEntities( editLink ) }
+				key={ id }
+				description={ description }
+				notification={ warning }
+				notificationLevel="error"
+				actionText={
+					<Fragment>
+						<Button
+							isQuaternary
+							isSmall
+							className={ categoriesVisibility && 'popover-active' }
+							onClick={ () => setCategoriesVisibility( ! categoriesVisibility ) }
+							icon={ settings }
+							label={ __( 'Category filtering and campaigns', 'newspack' ) }
+							tooltipPosition="bottom center"
 						/>
-					) }
-					{ categoriesVisibility && (
-						<SecondaryPromptPopover
-							onFocusOutside={ () => setCategoriesVisibility( false ) }
-							prompt={ prompt }
-							segments={ segments }
-							{ ...props }
+						<Button
+							isQuaternary
+							isSmall
+							className={ popoverVisibility && 'popover-active' }
+							onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
+							icon={ moreVertical }
+							label={ __( 'More options', 'newspack' ) }
+							tooltipPosition="bottom center"
 						/>
+						{ popoverVisibility && (
+							<PrimaryPromptPopover
+								onFocusOutside={ () => setPopoverVisibility( false ) }
+								prompt={ prompt }
+								setModalVisible={ setModalVisible }
+								{ ...props }
+							/>
+						) }
+						{ categoriesVisibility && (
+							<SecondaryPromptPopover
+								onFocusOutside={ () => setCategoriesVisibility( false ) }
+								prompt={ prompt }
+								segments={ segments }
+								{ ...props }
+							/>
+						) }
+					</Fragment>
+				}
+			/>
+			{ modalVisible && (
+				<Modal
+					className="newspack-popups__duplicate-modal"
+					title={ sprintf( __( 'Duplicate “%s”', 'newspack' ), title ) }
+					onRequestClose={ () => {
+						setModalVisible( false );
+						setDuplicateTitle( null );
+						resetDuplicated();
+					} }
+				>
+					{ duplicated ? (
+						<>
+							<Notice
+								isSuccess
+								noticeText={ sprintf(
+									__( 'Duplicate of “%s” created as a draft.', 'newspack' ),
+									title
+								) }
+							/>
+							{ ! campaignGroups && (
+								<Notice
+									isWarning
+									noticeText={ __(
+										'This prompt is currently not assigned to any campaign.',
+										'newspack'
+									) }
+								/>
+							) }
+							<div className="newspack-buttons-card">
+								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
+									{ __( 'Edit', 'newspack' ) }
+								</Button>
+								<Button
+									isSecondary
+									onClick={ () => {
+										setModalVisible( false );
+										setDuplicateTitle( null );
+										resetDuplicated();
+									} }
+								>
+									{ __( 'Close', 'newspack' ) }
+								</Button>
+							</div>
+						</>
+					) : (
+						<>
+							{ ! campaignGroups && (
+								<Notice
+									isWarning
+									noticeText={ __( 'This prompt will be unassigned.', 'newspack' ) }
+								/>
+							) }
+							<TextControl
+								disabled={ inFlight || null === duplicateTitle }
+								label={ __( 'Title', 'newspack' ) }
+								value={ duplicateTitle }
+								onChange={ value => setDuplicateTitle( value ) }
+							/>
+							<div className="newspack-buttons-card">
+								<Button
+									disabled={ inFlight || null === duplicateTitle }
+									isPrimary
+									onClick={ () => {
+										const titleForDuplicate = duplicateTitle.trim() || getDefaultDupicateTitle();
+										duplicatePopup( id, titleForDuplicate );
+									} }
+								>
+									{ __( 'Duplicate', 'newspack' ) }
+								</Button>
+								<Button
+									disabled={ inFlight }
+									isSecondary
+									onClick={ () => {
+										setModalVisible( false );
+										setDuplicateTitle( null );
+										resetDuplicated();
+									} }
+								>
+									{ __( 'Cancel', 'newspack' ) }
+								</Button>
+							</div>
+						</>
 					) }
-				</Fragment>
-			}
-		/>
+				</Modal>
+			) }
+		</>
 	);
 };
 export default PromptActionCard;

--- a/assets/wizards/popups/components/prompt-popovers/primary.js
+++ b/assets/wizards/popups/components/prompt-popovers/primary.js
@@ -18,15 +18,16 @@ import './style.scss';
 
 const PrimaryPromptPopover = ( {
 	deletePopup,
-	duplicatePopup,
+	onFocusOutside,
 	prompt,
 	previewPopup,
-	onFocusOutside,
 	publishPopup,
+	setModalVisible,
 	unpublishPopup,
 } ) => {
 	const { id, edit_link: editLink, status } = prompt;
 	const isPublished = 'publish' === status;
+
 	return (
 		<Popover
 			position="bottom left"
@@ -49,7 +50,7 @@ const PrimaryPromptPopover = ( {
 			<MenuItem href={ decodeEntities( editLink ) } className="newspack-button" isLink>
 				{ __( 'Edit', 'newspack' ) }
 			</MenuItem>
-			<MenuItem onClick={ () => duplicatePopup( id ) } className="newspack-button">
+			<MenuItem onClick={ () => setModalVisible( true ) } className="newspack-button">
 				{ __( 'Duplicate', 'newspack' ) }
 			</MenuItem>
 			{ ! isPublished && (

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -9,12 +9,12 @@ import cookies from 'js-cookie';
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, Fragment } from '@wordpress/element';
-import { Icon, header, layout, plus } from '@wordpress/icons';
+import { header, layout, plus } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { Button, Card, Modal } from '../../../../components/src';
+import { Button, ButtonCard, Card, Grid, Modal } from '../../../../components/src';
 import SegmentationPreview from '../segmentation-preview';
 import PromptActionCard from '../prompt-action-card';
 import {
@@ -157,37 +157,49 @@ const SegmentGroup = props => {
 							{ modalVisible && (
 								<Modal
 									title={ __( 'Add New Prompt', 'newspack' ) }
-									className="newspack-campaigns__segment-group__add-new-button__modal"
 									onRequestClose={ () => setModalVisible( false ) }
 									shouldCloseOnEsc={ false }
 									shouldCloseOnClickOutside={ false }
+									isWide
 								>
-									<Card buttonsCard noBorder className="newspack-card__buttons-prompt">
-										<Button href={ addNewURL( 'overlay-center', campaignId, id ) }>
-											<Icon icon={ iconOverlayCenter } height={ 48 } width={ 48 } />
-											{ __( 'Center Overlay', 'newspack' ) }
-										</Button>
-										<Button href={ addNewURL( 'overlay-top', campaignId, id ) }>
-											<Icon icon={ iconOverlayTop } height={ 48 } width={ 48 } />
-											{ __( 'Top Overlay', 'newspack' ) }
-										</Button>
-										<Button href={ addNewURL( 'overlay-bottom', campaignId, id ) }>
-											<Icon icon={ iconOverlayBottom } height={ 48 } width={ 48 } />
-											{ __( 'Bottom Overlay', 'newspack' ) }
-										</Button>
-										<Button href={ addNewURL( null, campaignId, id ) }>
-											<Icon icon={ iconInline } height={ 48 } width={ 48 } />
-											{ __( 'Inline', 'newspack' ) }
-										</Button>
-										<Button href={ addNewURL( 'above-header', campaignId, id ) }>
-											<Icon icon={ header } height={ 48 } width={ 48 } />
-											{ __( 'Above Header', 'newspack' ) }
-										</Button>
-										<Button href={ addNewURL( 'custom', campaignId, id ) }>
-											<Icon icon={ layout } height={ 48 } width={ 48 } />
-											{ __( 'Custom Placement', 'newspack' ) }
-										</Button>
-									</Card>
+									<Grid gutter={ 32 } columns={ 3 }>
+										<ButtonCard
+											href={ addNewURL( 'overlay-center', campaignId, id ) }
+											title={ __( 'Center Overlay', 'newspack' ) }
+											desc={ __( 'Fixed at the center of the screen', 'newspack' ) }
+											icon={ iconOverlayCenter }
+										/>
+										<ButtonCard
+											href={ addNewURL( 'overlay-top', campaignId, id ) }
+											title={ __( 'Top Overlay', 'newspack' ) }
+											desc={ __( 'Fixed at the top of the screen', 'newspack' ) }
+											icon={ iconOverlayTop }
+										/>
+										<ButtonCard
+											href={ addNewURL( 'overlay-bottom', campaignId, id ) }
+											title={ __( 'Bottom Overlay', 'newspack' ) }
+											desc={ __( 'Fixed at the bottom of the screen', 'newspack' ) }
+											icon={ iconOverlayBottom }
+										/>
+										<ButtonCard
+											href={ addNewURL( null, campaignId, id ) }
+											title={ __( 'Inline', 'newspack' ) }
+											desc={ __( 'Embedded in content', 'newspack' ) }
+											icon={ iconInline }
+										/>
+										<ButtonCard
+											href={ addNewURL( 'above-header', campaignId, id ) }
+											title={ __( 'Above Header', 'newspack' ) }
+											desc={ __( 'Embedded at the very top of the page', 'newspack' ) }
+											icon={ header }
+										/>
+										<ButtonCard
+											href={ addNewURL( 'custom', campaignId, id ) }
+											title={ __( 'Custom Placement', 'newspack' ) }
+											desc={ __( 'Only appears when placed in content', 'newspack' ) }
+											icon={ layout }
+										/>
+									</Grid>
 								</Modal>
 							) }
 						</Fragment>

--- a/assets/wizards/popups/components/segment-group/style.scss
+++ b/assets/wizards/popups/components/segment-group/style.scss
@@ -91,36 +91,7 @@
 
 	&__add-new-button {
 		&__modal {
-			max-width: 384px;
-			padding: 0 32px;
-
-			.components-modal__content {
-				margin: 0;
-			}
-
-			.components-modal__header {
-				background: transparent;
-				padding-top: 32px;
-
-				.components-button.has-icon {
-					right: -32px;
-				}
-			}
-
-			.newspack-text-control {
-				margin-top: 0;
-			}
-
-			.newspack-card__buttons-card {
-				display: flex;
-				flex-wrap: wrap;
-				justify-content: flex-end;
-				margin: -8px;
-
-				&.newspack-card__buttons-prompt {
-					justify-content: center;
-				}
-			}
+			max-width: 448px;
 		}
 	}
 }

--- a/assets/wizards/popups/components/segment-group/style.scss
+++ b/assets/wizards/popups/components/segment-group/style.scss
@@ -88,10 +88,4 @@
 			}
 		}
 	}
-
-	&__add-new-button {
-		&__modal {
-			max-width: 448px;
-		}
-	}
 }

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -9,6 +9,7 @@ import '../../shared/js/public-path';
  */
 import { Component, render, createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * External dependencies.
@@ -60,6 +61,8 @@ class PopupsWizard extends Component {
 			segments: [],
 			settings: [],
 			previewUrl: null,
+			duplicated: null,
+			inFlight: false,
 		};
 	}
 	onWizardReady = () => {
@@ -161,16 +164,25 @@ class PopupsWizard extends Component {
 	 * Duplicate a popup.
 	 *
 	 * @param {number} popupId ID of the Popup to duplicate.
+	 * @param {string} title Title to give to the duplicated prompt.
 	 */
-	duplicatePopup = popupId => {
+	duplicatePopup = ( popupId, title ) => {
 		const { setError, wizardApiFetch } = this.props;
+		this.setState( { inFlight: true } );
 		return wizardApiFetch( {
-			path: `/newspack/v1/wizard/newspack-popups-wizard/${ popupId }/duplicate`,
+			path: addQueryArgs( `/newspack/v1/wizard/newspack-popups-wizard/${ popupId }/duplicate`, {
+				title,
+			} ),
 			method: 'POST',
 			quiet: true,
 		} )
 			.then( this.updateAfterAPI )
-			.catch( error => setError( error ) );
+			.catch( () => {
+				setError( {
+					code: 'duplicate_prompt_error',
+					message: __( 'Error duplicating prompt. Please try again later.', 'newspack' ),
+				} );
+			} );
 	};
 
 	previewUrlForPopup = ( { options, id } ) => {
@@ -184,8 +196,8 @@ class PopupsWizard extends Component {
 		return `${ previewURL }?${ stringify( { ...options, newspack_popups_preview_id: id } ) }`;
 	};
 
-	updateAfterAPI = ( { campaigns, prompts, segments, settings } ) =>
-		this.setState( { campaigns, prompts, segments, settings } );
+	updateAfterAPI = ( { campaigns, prompts, segments, settings, duplicated = null } ) =>
+		this.setState( { campaigns, prompts, segments, settings, duplicated, inFlight: false } );
 
 	manageCampaignGroup = ( campaigns, method = 'POST' ) => {
 		const { setError, wizardApiFetch } = this.props;
@@ -208,7 +220,7 @@ class PopupsWizard extends Component {
 			startLoading,
 			doneLoading,
 		} = this.props;
-		const { campaigns, prompts, segments, settings, previewUrl } = this.state;
+		const { campaigns, inFlight, prompts, segments, settings, previewUrl, duplicated } = this.state;
 		return (
 			<WebPreview
 				url={ previewUrl }
@@ -222,8 +234,11 @@ class PopupsWizard extends Component {
 						startLoading,
 						doneLoading,
 						wizardApiFetch,
+						prompts,
 						segments,
 						settings,
+						duplicated,
+						inFlight,
 					};
 					const popupManagementSharedProps = {
 						...sharedProps,
@@ -237,6 +252,7 @@ class PopupsWizard extends Component {
 								showPreview()
 							),
 						publishPopup: this.publishPopup,
+						resetDuplicated: () => this.setState( { duplicated: null } ),
 						unpublishPopup: this.unpublishPopup,
 						refetch: this.refetch,
 					};

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -45,7 +45,7 @@ const modalTitle = modalType => {
 	} else if ( MODAL_TYPE_DUPLICATE === modalType ) {
 		return __( 'Duplicate Campaign', 'newspack' );
 	}
-	return __( 'New Campaign', 'newspack' );
+	return __( 'Add New Campaign', 'newspack' );
 };
 
 const modalButton = modalType => {
@@ -282,8 +282,9 @@ const Campaigns = props => {
 					{ modalVisible && (
 						<Modal
 							title={ modalTitle( modalType ) }
-							isDismissible={ false }
-							className="newspack-campaigns__campaign-group__add-new-button__modal"
+							onRequestClose={ () => {
+								setModalVisible( false );
+							} }
 						>
 							<div ref={ modalTextRef }>
 								<TextControl
@@ -300,7 +301,7 @@ const Campaigns = props => {
 									} }
 								/>
 							</div>
-							<Card buttonsCard noBorder>
+							<Card buttonsCard noBorder className="justify-end">
 								<Button
 									isPrimary
 									disabled={ ! campaignName }

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -302,19 +302,19 @@ const Campaigns = props => {
 							</div>
 							<Card buttonsCard noBorder>
 								<Button
+									isPrimary
+									disabled={ ! campaignName }
+									onClick={ () => submitModal( campaignName ) }
+								>
+									{ modalButton( modalType ) }
+								</Button>
+								<Button
 									isSecondary
 									onClick={ () => {
 										setModalVisible( false );
 									} }
 								>
 									{ __( 'Cancel', 'newspack' ) }
-								</Button>
-								<Button
-									isPrimary
-									disabled={ ! campaignName }
-									onClick={ () => submitModal( campaignName ) }
-								>
-									{ modalButton( modalType ) }
 								</Button>
 							</Card>
 						</Modal>

--- a/assets/wizards/popups/views/campaigns/style.scss
+++ b/assets/wizards/popups/views/campaigns/style.scss
@@ -78,41 +78,6 @@
 			}
 		}
 	}
-
-	&__add-new-button {
-		&__modal {
-			max-width: 384px;
-			padding: 0 32px;
-
-			.components-modal__content {
-				margin: 0;
-			}
-
-			.components-modal__header {
-				background: transparent;
-				padding-top: 32px;
-
-				.components-button.has-icon {
-					right: -32px;
-				}
-			}
-
-			.newspack-text-control {
-				margin-top: 0;
-			}
-
-			.newspack-card__buttons-card {
-				display: flex;
-				flex-wrap: wrap;
-				justify-content: flex-end;
-				margin: -8px;
-
-				&.newspack-card__buttons-prompt {
-					justify-content: center;
-				}
-			}
-		}
-	}
 }
 
 .newspack-card__buttons-prompt {
@@ -120,7 +85,7 @@
 		color: $gray-900;
 		display: flex;
 		flex-direction: column;
-		padding: 8px !important;
+		padding: 0 !important;
 		text-align: center;
 		width: 96px;
 
@@ -141,7 +106,7 @@
 			display: block;
 			fill: $primary-500;
 			margin: 0 0 8px;
-			padding: 15px;
+			padding: 23px;
 			transition: background-color 125ms ease-in-out, border-color 125ms ease-in-out;
 		}
 	}

--- a/assets/wizards/popups/views/segments/style.scss
+++ b/assets/wizards/popups/views/segments/style.scss
@@ -13,7 +13,7 @@
 		align-items: center;
 		display: flex;
 		justify-content: center;
-		margin: 32px 0 -24px;
+		margin: 32px 0 -16px;
 
 		> * {
 			margin: 0;
@@ -30,12 +30,6 @@
 				min-height: 36px;
 				padding-bottom: 5px;
 				padding-top: 5px;
-			}
-		}
-
-		.newspack-buttons-card {
-			.newspack-button {
-				margin-left: 8px;
 			}
 		}
 	}

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -223,6 +223,7 @@ class Donations {
 		$parent_product->update_meta_data( self::DONATION_TIERED_META, (bool) $args['tiered'] );
 		$parent_product->set_catalog_visibility( 'hidden' );
 		$parent_product->set_virtual( true );
+		$parent_product->set_downloadable( true );
 		$parent_product->set_sold_individually( true );
 
 		$default_price = $args['tiered'] ? wc_format_decimal( $args['suggestedAmounts'][ floor( count( $args['suggestedAmounts'] ) / 2 ) ] ) : wc_format_decimal( $args['suggestedAmountUntiered'] );
@@ -240,6 +241,7 @@ class Donations {
 		$monthly_product->update_meta_data( '_subscription_period', 'month' );
 		$monthly_product->update_meta_data( '_subscription_period_interval', 1 );
 		$monthly_product->set_virtual( true );
+		$monthly_product->set_downloadable( true );
 		$monthly_product->set_catalog_visibility( 'hidden' );
 		$monthly_product->set_sold_individually( true );
 		$monthly_product->save();
@@ -257,6 +259,7 @@ class Donations {
 		$yearly_product->update_meta_data( '_subscription_period', 'year' );
 		$yearly_product->update_meta_data( '_subscription_period_interval', 1 );
 		$yearly_product->set_virtual( true );
+		$yearly_product->set_downloadable( true );
 		$yearly_product->set_catalog_visibility( 'hidden' );
 		$yearly_product->set_sold_individually( true );
 		$yearly_product->save();
@@ -271,6 +274,7 @@ class Donations {
 		$once_product->update_meta_data( '_min_price', wc_format_decimal( 1.0 ) );
 		$once_product->update_meta_data( '_nyp', 'yes' );
 		$once_product->set_virtual( true );
+		$once_product->set_downloadable( true );
 		$once_product->set_catalog_visibility( 'hidden' );
 		$once_product->set_sold_individually( true );
 		$once_product->save();

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -20,6 +20,7 @@ class Patches {
 		add_filter( 'redirect_canonical', [ __CLASS__, 'patch_redirect_canonical' ], 10, 2 );
 		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_reusable_blocks_menu_link' ] );
+		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
 	}
 
 	/**
@@ -90,6 +91,20 @@ class Patches {
 	 */
 	public static function add_reusable_blocks_menu_link() {
 		add_submenu_page( 'edit.php', 'manage_reusable_blocks', __( 'Reusable Blocks' ), 'read', 'edit.php?post_type=wp_block', '', 2 );  
+	}
+
+	/**
+	 * On Atomic infrastructure, URLs are `http` for Facebook requests.
+	 * This forces the `og:url` to `http` for consistency, to prevent 301 redirect loop issues.
+	 *
+	 * @param string $og_url The opengraph URL.
+	 * @return string modified $og_url
+	 */
+	public static function http_ogurls( $og_url ) {
+		if ( defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID ) {
+			$og_url = str_replace( 'https:', 'http:', $og_url );
+		}
+		return $og_url;
 	}
 }
 Patches::init();

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -122,13 +122,13 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=instant-articles-wizard',
 			],
-			'distributor'                   => [
+			'distributor-stable'            => [
 				'Name'        => 'Distributor',
 				'Description' => 'Makes it easy to distribute and reuse content across your websites, whether inside of a multisite or across the web.',
 				'Author'      => '10up Inc.',
 				'AuthorURI'   => 'https://distributorplugin.com/',
 				'PluginURI'   => 'https://distributorplugin.com/',
-				'Download'    => 'https://github.com/10up/distributor/releases/latest/download/distributor.zip',
+				'Download'    => 'https://github.com/10up/distributor/archive/stable.zip',
 				'EditPath'    => 'admin.php?page=pull',
 			],
 			'google-site-kit'               => [

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -263,13 +263,25 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Get default title for a duplicated prompt.
+	 *
+	 * @param int $id Prompt ID to duplicate.
+	 */
+	public function get_duplicate_title( $id ) {
+		return $this->is_configured() ?
+			\Newspack_Popups::get_duplicate_title( $id ) :
+			$this->unconfigured_error();
+	}
+
+	/**
 	 * Duplicate a prompt.
 	 *
-	 * @param int $id Prompt ID.
+	 * @param int    $id Prompt ID to duplicate.
+	 * @param string $title Title to give the duplicated prompt.
 	 */
-	public function duplicate_popup( $id ) {
+	public function duplicate_popup( $id, $title ) {
 		return $this->is_configured() ?
-			\Newspack_Popups::duplicate_popup( $id ) :
+			\Newspack_Popups::duplicate_popup( $id, $title ) :
 			$this->unconfigured_error();
 	}
 

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -276,7 +276,7 @@ class Google_OAuth {
 	 * is used for authorisation on another site, only access token will be issued.
 	 * More at https://stackoverflow.com/a/10857806/3772847.
 	 *
-	 * @return OAuth2|bool The credentials, or false of the user has not authenticated.
+	 * @return OAuth2|bool The credentials, or false of the user has not authenticated or credentials are not usable.
 	 */
 	public static function get_oauth2_credentials() {
 		$auth_data = self::get_google_auth_saved_data();
@@ -300,6 +300,7 @@ class Google_OAuth {
 				);
 				if ( isset( $response->data->access_token ) ) {
 					self::save_auth_credentials( $response->data );
+					$auth_data = self::get_google_auth_saved_data();
 				}
 			} catch ( \Exception $e ) {
 				// Credentials might be broken, remove them.

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -57,7 +57,7 @@ class Advertising_Wizard extends Wizard {
 	 *
 	 * @var array
 	 */
-	protected $placements = array( 'global_above_header', 'global_below_header', 'global_above_footer', 'archives', 'search_results', 'sticky' );
+	protected $placements = array( 'global_above_header', 'global_below_header', 'global_above_footer', 'sticky' );
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I noticed the `Modal` felt slightly off, especially with the header and the various paddings. This PR restyle it to use a 64px padding around it. It also moves the title more inline with the content. For buttons, we are now using a `buttonsCard`.

I had to reorganise things in the Campaigns to make sure the changes were not breaking the "Add New Prompt" modal. And as an added bonus, I've tweaked the "Add New Prompt" modal to something similar to what was suggested in #861 

### How to test the changes in this Pull Request:

1. Check the various Modals (Components Demo, Campaigns, Analytics -- Custom Events, etc...)
2. Switch to this branch
3. Test again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->