### PR TITLE
fix: distributor plugin URL and slug in plugins whitelist

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -128,7 +128,7 @@ class Plugin_Manager {
 				'Author'      => '10up Inc.',
 				'AuthorURI'   => 'https://distributorplugin.com/',
 				'PluginURI'   => 'https://distributorplugin.com/',
-				'Download'    => 'https://github.com/10up/distributor/releases/latest/download/distributor.zip',
+				'Download'    => 'https://github.com/10up/distributor/archive/stable.zip',
 				'EditPath'    => 'admin.php?page=pull',
 			],
 			'google-site-kit'               => [

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -122,7 +122,7 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=instant-articles-wizard',
 			],
-			'distributor'                   => [
+			'distributor-stable'            => [
 				'Name'        => 'Distributor',
 				'Description' => 'Makes it easy to distribute and reuse content across your websites, whether inside of a multisite or across the web.',
 				'Author'      => '10up Inc.',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the URL and plugin slug for the Distributor plugin so that it can be installed from the Plugins dashboard with a single click. **Note:** the plugin slug needed to be updated to `distributor-stable` instead of just `distributor` because that's the name of the stable built plugin .zip file as provided by 10up.

### How to test the changes in this Pull Request:

1. On `master`, go to your Plugins dashboard page. Look for "Distributor" and click "install." Observe that the installation fails with an error message.
2. Check out this branch, refresh Plugins, try again. Confirm that the plugin installs correctly now. 
3. Go to Distributor > External Connections and attempt to connect to Newspack.pub using the Username/Password protocol and the automated wizard. (Must be logged into Newspack.pub to do this)
4. Test that you can push content to and pull content from Newspack.pub.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->