### PR TITLE
Make auto-created donation products "downloadable" for better checkout

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -223,6 +223,7 @@ class Donations {
 		$parent_product->update_meta_data( self::DONATION_TIERED_META, (bool) $args['tiered'] );
 		$parent_product->set_catalog_visibility( 'hidden' );
 		$parent_product->set_virtual( true );
+		$parent_product->set_downloadable( true );
 		$parent_product->set_sold_individually( true );
 
 		$default_price = $args['tiered'] ? wc_format_decimal( $args['suggestedAmounts'][ floor( count( $args['suggestedAmounts'] ) / 2 ) ] ) : wc_format_decimal( $args['suggestedAmountUntiered'] );
@@ -240,6 +241,7 @@ class Donations {
 		$monthly_product->update_meta_data( '_subscription_period', 'month' );
 		$monthly_product->update_meta_data( '_subscription_period_interval', 1 );
 		$monthly_product->set_virtual( true );
+		$monthly_product->set_downloadable( true );
 		$monthly_product->set_catalog_visibility( 'hidden' );
 		$monthly_product->set_sold_individually( true );
 		$monthly_product->save();
@@ -257,6 +259,7 @@ class Donations {
 		$yearly_product->update_meta_data( '_subscription_period', 'year' );
 		$yearly_product->update_meta_data( '_subscription_period_interval', 1 );
 		$yearly_product->set_virtual( true );
+		$yearly_product->set_downloadable( true );
 		$yearly_product->set_catalog_visibility( 'hidden' );
 		$yearly_product->set_sold_individually( true );
 		$yearly_product->save();
@@ -271,6 +274,7 @@ class Donations {
 		$once_product->update_meta_data( '_min_price', wc_format_decimal( 1.0 ) );
 		$once_product->update_meta_data( '_nyp', 'yes' );
 		$once_product->set_virtual( true );
+		$once_product->set_downloadable( true );
 		$once_product->set_catalog_visibility( 'hidden' );
 		$once_product->set_sold_individually( true );
 		$once_product->save();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR implements a small change @tmmbecker discovered to improve order status in WooCommerce. By making the products both "Virtual" and "Downloadable", orders will be in "Completed" status after checkout instead of "Processing" status. This makes more sense, because a donation doesn't really require any further processing once checkout has happened.

### How to test the changes in this Pull Request:

1. Go to WP Admin > Products. If you have any existing Donate products, delete them (make sure you actually delete them, not just trash them)
2. Go to Newspack > Reader Revenue and Save the screen (this will re-create the Donation products if needed):
<img width="1274" alt="Screen Shot 2021-06-25 at 9 27 51 AM" src="https://user-images.githubusercontent.com/7317227/123456712-02950d00-d598-11eb-8790-ca1647c5d200.png">

3. Go to WP Admin > Products. Verify the "Downloadable" box is checked on the newly-created products:
<img width="862" alt="Screen Shot 2021-06-25 at 9 20 40 AM" src="https://user-images.githubusercontent.com/7317227/123456718-058ffd80-d598-11eb-9e53-e0eca2e726db.png">

4. Purchase a donation. Go to WooCommerce > Orders. Verify the status is "Completed":
<img width="946" alt="Screen Shot 2021-06-25 at 9 22 10 AM" src="https://user-images.githubusercontent.com/7317227/123456733-07f25780-d598-11eb-9cad-34481d5f6d62.png">

5. Go to `/my-account/orders` and view the order. Verify there's no weird artifacts that a user will see from the product being Downloadable (e.g. there's not like some download there)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->