### PR TITLE
feat(ga-events): make NTG events reporting enabled by default

### DIFF
--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -29,7 +29,7 @@ class Analytics_Wizard extends Wizard {
 	public static $custom_events_option_name = 'newspack_analytics_custom_events';
 
 	/**
-	 * NTG eabling option name.
+	 * NTG enabling option name.
 	 *
 	 * @var string
 	 */
@@ -526,7 +526,7 @@ class Analytics_Wizard extends Wizard {
 	 * @return bool Status of NTG events.
 	 */
 	public static function ntg_events_enabled() {
-		return 'enabled' === get_option( self::$ntg_events_option_name, '' );
+		return 'enabled' === get_option( self::$ntg_events_option_name, 'enabled' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Since #944 resolves the issue of too large GA config payload on AMP sites, the change from #924 can be reveted.

### How to test the changes in this Pull Request:

1. Install Newspack on a new site, configure Site Kit w/ Google Analytics
2. Observe the NTG events reporting, in Analytics wizard -> Custom Events, is on by default
3. Observe the NTG events (e.g. article read to 50%) are sent to GA account linked via Site Kit

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->