### PR TITLE
Use` http` `og:url` for consistency

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -20,6 +20,7 @@ class Patches {
 		add_filter( 'redirect_canonical', [ __CLASS__, 'patch_redirect_canonical' ], 10, 2 );
 		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_reusable_blocks_menu_link' ] );
+		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
 	}
 
 	/**
@@ -90,6 +91,20 @@ class Patches {
 	 */
 	public static function add_reusable_blocks_menu_link() {
 		add_submenu_page( 'edit.php', 'manage_reusable_blocks', __( 'Reusable Blocks' ), 'read', 'edit.php?post_type=wp_block', '', 2 );  
+	}
+
+	/**
+	 * On Atomic infrastructure, URLs are `http` for Facebook requests.
+	 * This forces the `og:url` to `http` for consistency, to prevent 301 redirect loop issues.
+	 *
+	 * @param string $og_url The opengraph URL.
+	 * @return string modified $og_url
+	 */
+	public static function http_ogurls( $og_url ) {
+		if ( defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID ) {
+			$og_url = str_replace( 'https:', 'http:', $og_url );
+		}
+		return $og_url;
 	}
 }
 Patches::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue where under certain circuimstances, sharing a post to FB previews the post as a card that just says "301 Redirect". See https://wp.me/pamTN9-2NT

### How to test the changes in this Pull Request:

1.  You'll need an Atomic site to test.
2. Use the FB debugger to scrape a post. Verify no redirect warnings are shown and the post's `og:url` field has `http` not `https`.
<img width="1029" alt="Screen Shot 2021-06-28 at 7 22 21 AM" src="https://user-images.githubusercontent.com/7317227/123653856-5eeb6d00-d7e2-11eb-8a99-38e592d55c39.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->