### PR TITLE
fix: use the new token after refreshing

### DIFF
--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -276,7 +276,7 @@ class Google_OAuth {
 	 * is used for authorisation on another site, only access token will be issued.
 	 * More at https://stackoverflow.com/a/10857806/3772847.
 	 *
-	 * @return OAuth2|bool The credentials, or false of the user has not authenticated.
+	 * @return OAuth2|bool The credentials, or false of the user has not authenticated or credentials are not usable.
 	 */
 	public static function get_oauth2_credentials() {
 		$auth_data = self::get_google_auth_saved_data();
@@ -300,6 +300,7 @@ class Google_OAuth {
 				);
 				if ( isset( $response->data->access_token ) ) {
 					self::save_auth_credentials( $response->data );
+					$auth_data = self::get_google_auth_saved_data();
 				}
 			} catch ( \Exception $e ) {
 				// Credentials might be broken, remove them.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a credentials refreshing bug. The old access token was used after refreshing credentials, instead of the newly issued one.

### How to test the changes in this Pull Request:

1. Complete the Google OAuth flow, ensure a refresh token has been issued*
2. Wait for at least an hour, so that the current access token expires
3. Reload the Newspack dashboard, observe the "Google Connection" tile is still displaying your email address.

\* [Revoke permissions](https://myaccount.google.com/permissions) & remove the `_newspack_google_oauth` user meta.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->