### PR TITLE
chore: update wording in "unassigned" message

### DIFF
--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -158,7 +158,7 @@ const PromptActionCard = props => {
 							{ ! campaignGroups && (
 								<Notice
 									isWarning
-									noticeText={ __( 'This prompt will be unassigned.', 'newspack' ) }
+									noticeText={ __( 'This prompt will not be assigned to any campaign.', 'newspack' ) }
 								/>
 							) }
 							<TextControl


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the wording in a user-facing message according to https://github.com/Automattic/newspack-plugin/pull/1012#discussion_r660387483. I missed one instance in the UI in that PR.

### How to test the changes in this Pull Request:

Just a wording change, no functional changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->