### PR TITLE
feat: prevent accidental deletion of essential pages

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -145,6 +145,12 @@ class Patches {
 			$protected_post_ids[] = $posts_page;
 		}
 
+		// Privacy policy page.
+		$privacy_policy = intval( get_option( 'wp_page_for_privacy_policy', -1 ) );
+		if ( 0 < $privacy_policy ) {
+			$protected_post_ids[] = $privacy_policy;
+		}
+
 		// WooCommerce pages.
 		if ( function_exists( 'wc_get_page_id' ) && function_exists( 'wc_privacy_policy_page_id' ) ) {
 			// WooCommerce myaccount page.
@@ -183,11 +189,10 @@ class Patches {
 				$protected_post_ids[] = $terms;
 			}
 
-			// WooCommerce Privacy Policy page.
-			$privacy_policy = wc_privacy_policy_page_id();
-
-			if ( 0 < $privacy_policy ) {
-				$protected_post_ids[] = $privacy_policy;
+			// WooCommerce privacy policy page.
+			$wc_privacy_policy = wc_privacy_policy_page_id();
+			if ( 0 < $wc_privacy_policy ) {
+				$protected_post_ids[] = $wc_privacy_policy;
 			}
 		}
 

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -146,7 +146,7 @@ class Patches {
 		}
 
 		// WooCommerce pages.
-		if ( function_exists( 'wc_get_page_id' ) ) {
+		if ( function_exists( 'wc_get_page_id' ) && function_exists( 'wc_privacy_policy_page_id' ) ) {
 			// WooCommerce myaccount page.
 			$account_page = wc_get_page_id( 'myaccount' );
 			if ( 0 < $account_page ) {

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -21,6 +21,7 @@ class Patches {
 		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_reusable_blocks_menu_link' ] );
 		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
+		add_filter( 'map_meta_cap', [ __CLASS__, 'prevent_accidental_page_deletion' ], 10, 4 );
 	}
 
 	/**
@@ -90,7 +91,7 @@ class Patches {
 	 * Add a menu link in WP Admin to easily edit and manage reusable blocks.
 	 */
 	public static function add_reusable_blocks_menu_link() {
-		add_submenu_page( 'edit.php', 'manage_reusable_blocks', __( 'Reusable Blocks' ), 'read', 'edit.php?post_type=wp_block', '', 2 );  
+		add_submenu_page( 'edit.php', 'manage_reusable_blocks', __( 'Reusable Blocks' ), 'read', 'edit.php?post_type=wp_block', '', 2 );
 	}
 
 	/**
@@ -105,6 +106,97 @@ class Patches {
 			$og_url = str_replace( 'https:', 'http:', $og_url );
 		}
 		return $og_url;
+	}
+
+	/**
+	 * Prevent deletion of essential pages such as the homepage, blog posts page, and WooCommerce pages.
+	 *
+	 * @param array  $caps Primitive capabilities required of the user.
+	 * @param string $cap Capability being checked.
+	 * @param int    $user_id The user ID.
+	 * @param array  $args Adds context to the capability check, typically starting with an object ID.
+	 *
+	 * @return array Filtered array of capabilities.
+	 */
+	public static function prevent_accidental_page_deletion( $caps, $cap, $user_id, $args ) {
+		// If no $args to check, bail early.
+		if ( empty( $args ) ) {
+			return $caps;
+		}
+
+		$protected_post_ids = [];
+		$post_id            = $args[0]; // First item is usually the post ID.
+
+		// If $post_id isn't a valid post, bail early.
+		if ( false === get_post_status( $post_id ) ) {
+			return $caps;
+		}
+
+		// Dynamically look up post IDs for protected pages.
+		// Homepage.
+		$front_page = intval( get_option( 'page_on_front', -1 ) );
+		if ( 0 < $front_page ) {
+			$protected_post_ids[] = $front_page;
+		}
+
+		// Blog posts page.
+		$posts_page = intval( get_option( 'page_for_posts', -1 ) );
+		if ( 0 < $posts_page ) {
+			$protected_post_ids[] = $posts_page;
+		}
+
+		// WooCommerce pages.
+		if ( function_exists( 'wc_get_page_id' ) ) {
+			// WooCommerce myaccount page.
+			$account_page = wc_get_page_id( 'myaccount' );
+			if ( 0 < $account_page ) {
+				$protected_post_ids[] = $account_page;
+			}
+
+			// WooCommerce shop page.
+			$shop = wc_get_page_id( 'shop' );
+			if ( 0 < $shop ) {
+				$protected_post_ids[] = $shop;
+			}
+
+			// WooCommerce cart page.
+			$cart = wc_get_page_id( 'cart' );
+			if ( 0 < $cart ) {
+				$protected_post_ids[] = $cart;
+			}
+
+			// WooCommerce checkout page.
+			$checkout = wc_get_page_id( 'checkout' );
+			if ( 0 < $checkout ) {
+				$protected_post_ids[] = $checkout;
+			}
+
+			// WooCommerce view_order page.
+			$view_order = wc_get_page_id( 'view_order' );
+			if ( 0 < $view_order ) {
+				$protected_post_ids[] = $view_order;
+			}
+
+			// WooCommerce terms page.
+			$terms = wc_get_page_id( 'terms' );
+			if ( 0 < $terms ) {
+				$protected_post_ids[] = $terms;
+			}
+
+			// WooCommerce Privacy Policy page.
+			$privacy_policy = wc_privacy_policy_page_id();
+
+			if ( 0 < $privacy_policy ) {
+				$protected_post_ids[] = $privacy_policy;
+			}
+		}
+
+		// If the current page ID is protected, and the capability being checked is for deletion, do not allow.
+		if ( 'delete_post' === $cap && in_array( $post_id, $protected_post_ids, true ) ) {
+			$caps[] = 'do_not_allow';
+		}
+
+		return $caps;
 	}
 }
 Patches::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents deletion of pages which are considered "essential" to Newspack sites, if they exist. This includes:

* The homepage
* The blog posts page
* WooCommerce pages: My Account, Shop, Cart, Checkout, View Order, Terms, and Privacy Policy

After this change, no one (not even super admins) will be able to delete the above pages. In order to delete an essential page, another page must be assigned the essential role first.

**Note:** An alternative idea is to make this a standalone plugin in the [custom code repo](https://github.com/Automattic/newspack-custom-code) instead of baking it into the main plugin. I'm open to discussing both options.

### How to test the changes in this Pull Request:

1. Check out this branch. Go to Pages and verify that for all of the pages outlined above, they no longer have a "Trash" link allowing them to be deleted.

<img width="248" alt="Screen Shot 2021-07-02 at 11 20 12 AM" src="https://user-images.githubusercontent.com/2230142/124309129-7e0e3580-db27-11eb-91e3-15e39c21c5bc.png">

2. Click into each page and confirm that there's no longer a "Trash" button in the Status & Visibility sidebar.

<img width="277" alt="Screen Shot 2021-07-02 at 11 19 38 AM" src="https://user-images.githubusercontent.com/2230142/124309054-6767de80-db27-11eb-8144-66c20cc3be96.png">

3. Change some of the above roles to a different page (for front and blog posts pages, go to **Settings > Reading**; for WooCommerce pages, go to **WooCommerce > Settings > Advanced > Page Setup**).
4. Confirm that the "trash" links and buttons are disabled for the new pages that have the essential roles, not any specific pages that once did but no longer have those roles.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->