### PR TITLE
Fix modal style in WordPress 5.8

### DIFF
--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -11,9 +11,8 @@
 	color: $gray-700;
 	font-size: 14px;
 	line-height: 24px;
-	margin: 0;
+	margin: auto;
 	max-height: 100%;
-	padding: 0 32px;
 	width: 100%;
 
 	@media screen and ( min-width: 600px ) {
@@ -24,7 +23,6 @@
 
 	@media screen and ( min-width: 744px ) {
 		max-width: 680px;
-		padding: 0 64px;
 
 		&--wide {
 			max-width: 1168px;
@@ -39,15 +37,8 @@
 		border: 0;
 		height: auto;
 		justify-content: flex-end;
-		margin: 0 -32px;
-		padding: 64px 32px 32px;
-
-		@media screen and ( min-width: 744px ) {
-			margin-left: -64px;
-			margin-right: -64px;
-			padding-left: 64px;
-			padding-right: 64px;
-		}
+		padding: 32px 0 0;
+		position: relative;
 
 		.components-modal__header-heading-container {
 			display: block;
@@ -89,8 +80,16 @@
 	// Content
 
 	.components-modal__content {
-		margin: -32px 0 0;
-		padding: 0 0 32px;
+		margin: 0;
+		padding: 0;
+
+		@media screen and ( min-width: 744px ) {
+			padding: 0 32px;
+		}
+
+		&::before {
+			display: none;
+		}
 	}
 
 	// Typography

--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -37,7 +37,7 @@
 		border: 0;
 		height: auto;
 		justify-content: flex-end;
-		padding: 32px 0 0;
+		padding: 32px 32px 0;
 		position: relative;
 
 		.components-modal__header-heading-container {
@@ -81,10 +81,10 @@
 
 	.components-modal__content {
 		margin: 0;
-		padding: 0;
+		padding: 0 32px;
 
 		@media screen and ( min-width: 744px ) {
-			padding: 0 32px;
+			padding: 32px 64px;
 		}
 
 		&::before {

--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -3,7 +3,7 @@
  */
 import { Component, createRef, Fragment, createPortal } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { close, desktop, mobile, tablet } from '@wordpress/icons';
+import { closeSmall, desktop, mobile, tablet } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -110,7 +110,7 @@ class WebPreview extends Component {
 									this.setState( { isPreviewVisible: false, loaded: false } );
 								} }
 								isSmall
-								icon={ close }
+								icon={ closeSmall }
 								label={ __( 'Close preview', 'newspack' ) }
 							/>
 						</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With WP 5.8 just around the corner, the style for our `Modal` component was broken (using 5.8-RC2-51407).

This PR updates the style to make sure they look OK in 5.8

### How to test the changes in this Pull Request:

1. Make sure you are using WP 5.8
2. Navigate to a page where we have a modal (eg. components demo, campaigns)
3. Open the modal... it should look broken
4. Switch to this branch
5. Refresh page and reopen the modal

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->