### PR TITLE
Apply correct plugin slug for Distributor in the Syndication Wizard

### DIFF
--- a/assets/wizards/syndication/views/intro/index.js
+++ b/assets/wizards/syndication/views/intro/index.js
@@ -39,7 +39,7 @@ class Intro extends Component {
 				/>
 				<PluginToggle
 					plugins={ {
-						distributor: true,
+						'distributor-stable': true,
 					} }
 				/>
 			</Fragment>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the slug for Distributor to `distributor-stable`.

### How to test the changes in this Pull Request:

1. Navigate to Newspack > Syndication
2. Notice the empty `ActionCard` at the bottom, trying to load
3. Switch to this branch and refresh the Wizard
4. You should be able to (de)activate Distributor now!

_Note: The toggle doesn't seem to work (cc @adekbadek or @dkoo)... I get a `newspack_plugin_not_active` error_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->