### PR TITLE
Simplify handoff banner style

### DIFF
--- a/assets/wizards/handoff-banner/index.js
+++ b/assets/wizards/handoff-banner/index.js
@@ -34,10 +34,10 @@ class HandoffBanner extends Component {
 				<div className="newspack-handoff-banner">
 					<div className="newspack-handoff-banner__text">{ bodyText }</div>
 					<div className="newspack-handoff-banner__buttons">
-						<Button isLink onClick={ () => this.setState( { visibility: false } ) }>
+						<Button isPrimary isSmall onClick={ () => this.setState( { visibility: false } ) }>
 							{ dismissButtonText }
 						</Button>
-						<Button isPrimary href={ primaryButtonURL }>
+						<Button isSecondary isSmall href={ primaryButtonURL }>
 							{ primaryButtonText }
 						</Button>
 					</div>
@@ -48,10 +48,10 @@ class HandoffBanner extends Component {
 }
 
 HandoffBanner.defaultProps = {
-	primaryButtonText: __( 'Back to Newspack' ),
-	dismissButtonText: __( 'Dismiss' ),
+	primaryButtonText: __( 'Back to Newspack', 'newspack' ),
+	dismissButtonText: __( 'Dismiss', 'newspack' ),
 	primaryButtonURL: '/wp-admin/admin.php?page=newspack',
-	bodyText: __( 'Click to return to Newspack after completing configuration' ),
+	bodyText: __( 'Return to Newspack after completing configuration', 'newspack' ),
 };
 
 const el = document.getElementById( 'newspack-handoff-banner' );

--- a/assets/wizards/handoff-banner/style.scss
+++ b/assets/wizards/handoff-banner/style.scss
@@ -9,7 +9,7 @@
 	background: $primary-500;
 	display: block;
 	margin: 0 0 0 -10px;
-	padding: 12px;
+	padding: 4px;
 	position: relative;
 
 	@media screen and ( min-width: 783px ) {

--- a/assets/wizards/handoff-banner/style.scss
+++ b/assets/wizards/handoff-banner/style.scss
@@ -9,7 +9,7 @@
 	background: $primary-500;
 	display: block;
 	margin: 0 0 0 -10px;
-	padding: 20px;
+	padding: 12px;
 	position: relative;
 
 	@media screen and ( min-width: 783px ) {
@@ -59,15 +59,11 @@
 
 .newspack-handoff-banner {
 	align-items: center;
-	background: white;
-	border-radius: 4px;
-	box-shadow: 0 4px 8px rgba( black, 0.08 );
 	box-sizing: border-box;
-	color: $gray-700;
+	color: white;
 	font-size: 14px;
 	justify-content: space-between;
 	line-height: 24px;
-	padding: 4px;
 	margin: 0;
 	width: 100%;
 
@@ -84,13 +80,13 @@
 
 		@media screen and ( min-width: 600px ) {
 			&::before {
-				background-image: url( "data:image/svg+xml,%3Csvg width='32' height='32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M32 16c0 8.836-7.164 16-16 16-8.837 0-16-7.164-16-16S7.164 0 16 0s16 7.164 16 16zm-10.732.623h1.72v-1.125h-2.823l1.103 1.125zm-3.249-3.31h4.97v-1.125h-6.072l1.102 1.124v.001zm-3.248-3.311h8.217V8.878h-9.32l1.103 1.124zM9.01 8.878l13.977 14.245h-4.66l-5.866-5.98v5.98h-3.45V8.878H9.01z' fill='%233366ff' fill-rule='evenodd'/%3E%3C/svg%3E%0A" );
+				background-image: url( "data:image/svg+xml,%3Csvg width='32' height='32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M32 16c0 8.836-7.164 16-16 16-8.837 0-16-7.164-16-16S7.164 0 16 0s16 7.164 16 16zm-10.732.623h1.72v-1.125h-2.823l1.103 1.125zm-3.249-3.31h4.97v-1.125h-6.072l1.102 1.124v.001zm-3.248-3.311h8.217V8.878h-9.32l1.103 1.124zM9.01 8.878l13.977 14.245h-4.66l-5.866-5.98v5.98h-3.45V8.878H9.01z' fill='white' fill-rule='evenodd'/%3E%3C/svg%3E%0A" );
 				background-size: 32px 32px;
 				content: '';
 				display: block;
 				flex: 0 0 auto;
 				height: 32px;
-				margin: 0 8px 0 12px;
+				margin: 0 8px 0 0;
 				width: 32px;
 			}
 		}
@@ -119,16 +115,11 @@
 				}
 			}
 
-			&.is-link {
-				background: transparent;
-				cursor: pointer;
-				padding: 0;
-				text-decoration: underline;
-
+			&.is-secondary {
 				&:active,
 				&:focus,
 				&:hover {
-					text-decoration: none;
+					border-color: $primary-600 !important;
 				}
 			}
 		}

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -68,7 +68,7 @@ class Handoff_Banner {
 		);
 
 		$script_info = [
-			'text'       => __( 'Click to return to Newspack after completing configuration.', 'newspack' ),
+			'text'       => __( 'Return to Newspack after completing configuration', 'newspack' ),
 			'buttonText' => __( 'Back to Newspack', 'newspack' ),
 			'returnURL'  => esc_url( get_option( NEWSPACK_HANDOFF_RETURN_URL, '' ) ),
 		];

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -207,7 +207,7 @@ msgid "Join"
 msgstr ""
 
 #: includes/class-handoff-banner.php:71
-msgid "Click to return to Newspack after completing configuration."
+msgid "Return to Newspack after completing configuration"
 msgstr ""
 
 #: includes/class-handoff-banner.php:72


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the white background when displaying a handoff banner to focus on Newspack's blue. I also reduced some of the paddings so it takes a little bit less space on the screen

### How to test the changes in this Pull Request:

1. Go to a Wizard with a handoff button (e.g Newspack > Engagement > Recirculation > Jetpack Related Posts > "Configure")
2. Click on the button
3. Notice the banner
4. Switch to this branch
5. Refresh page -- you should see the new banner

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->