### PR TITLE
Fix fatal error if Newspack reader revenue is selected but WC is deactivated

### DIFF
--- a/includes/class-stripe-connection.php
+++ b/includes/class-stripe-connection.php
@@ -36,7 +36,6 @@ class Stripe_Connection {
 	 * Get Stripe data, either from WC, or saved in options table.
 	 */
 	public static function get_stripe_data() {
-		$stripe_data              = self::get_default_stripe_data();
 		$wc_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
 
 		if ( Donations::is_platform_wc() && $wc_configuration_manager->is_configured() ) {

--- a/includes/class-stripe-connection.php
+++ b/includes/class-stripe-connection.php
@@ -36,11 +36,12 @@ class Stripe_Connection {
 	 * Get Stripe data, either from WC, or saved in options table.
 	 */
 	public static function get_stripe_data() {
-		$stripe_data = self::get_default_stripe_data();
-		if ( Donations::is_platform_wc() ) {
+		$stripe_data              = self::get_default_stripe_data();
+		$wc_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
+
+		if ( Donations::is_platform_wc() && $wc_configuration_manager->is_configured() ) {
 			// If WC is configured, get Stripe data from WC.
-			$wc_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
-			$stripe_data              = $wc_configuration_manager->stripe_data();
+			$stripe_data = $wc_configuration_manager->stripe_data();
 		} else {
 			$stripe_data = get_option( self::STRIPE_DATA_OPTION_NAME, self::get_default_stripe_data() );
 		}

--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -32,7 +32,7 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Whether WooCommerce is active and set up.
 	 */
 	public function is_configured() {
-		return true;
+		return function_exists( 'WC' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue I ran into: on an existing site, if reader revenue is selected but WC is deactivated, there is a fatal error thrown:

<img width="633" alt="Screen Shot 2021-07-15 at 8 56 00 AM" src="https://user-images.githubusercontent.com/7317227/125819510-a68c04e7-4d26-465b-ac56-3044055d7281.png">
<img width="605" alt="Screen Shot 2021-07-15 at 8 51 42 AM" src="https://user-images.githubusercontent.com/7317227/125819521-699e277f-a491-4655-b891-266cdc3ef16d.png">

Closes #1011 

### How to test the changes in this Pull Request:

1. Set up reader revenue using the Newspack reader revenue style
2. Deactivate WC. On the Reader Revenue wizard you should get the Unrecoverable Error modal.
3. Apply this patch. The Reader Revenue wizard should load.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->