### PR TITLE
feat/stripe webhooks

### DIFF
--- a/includes/class-stripe-connection.php
+++ b/includes/class-stripe-connection.php
@@ -18,6 +18,58 @@ class Stripe_Connection {
 	const STRIPE_DATA_OPTION_NAME = 'newspack_stripe_data';
 
 	/**
+	 * Initialize.
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public static function register_api_endpoints() {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/stripe/create-webhooks/',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'create_webhooks' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/stripe/webhook',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ __CLASS__, 'receive_webhook' ],
+				'permission_callback' => '__return_true',
+			]
+		);
+	}
+
+	/**
+	 * Check capabilities for using API.
+	 *
+	 * @codeCoverageIgnore
+	 * @param WP_REST_Request $request API request object.
+	 * @return bool|WP_Error
+	 */
+	public static function api_permissions_check( $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				[
+					'status' => 403,
+				]
+			);
+		}
+		return true;
+	}
+
+	/**
 	 * Get Stripe data blueprint.
 	 */
 	public static function get_default_stripe_data() {
@@ -36,16 +88,11 @@ class Stripe_Connection {
 	 * Get Stripe data, either from WC, or saved in options table.
 	 */
 	public static function get_stripe_data() {
-		$stripe_data = self::get_default_stripe_data();
-		if ( Donations::is_platform_wc() ) {
-			// If WC is configured, get Stripe data from WC.
-			$wc_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
-			$stripe_data              = $wc_configuration_manager->stripe_data();
-		} else {
-			$stripe_data = get_option( self::STRIPE_DATA_OPTION_NAME, self::get_default_stripe_data() );
+		$stripe_data             = self::get_saved_stripe_data();
+		$stripe_data['webhooks'] = [];
+		if ( self::get_stripe_secret_key() ) {
+			$stripe_data['webhooks'] = self::list_webhooks();
 		}
-		$stripe_data['usedPublishableKey'] = $stripe_data['testMode'] ? $stripe_data['testPublishableKey'] : $stripe_data['publishableKey'];
-		$stripe_data['usedSecretKey']      = $stripe_data['testMode'] ? $stripe_data['testSecretKey'] : $stripe_data['secretKey'];
 		return $stripe_data;
 	}
 
@@ -65,12 +112,106 @@ class Stripe_Connection {
 	}
 
 	/**
+	 * List Stripe webhooks.
+	 */
+	private static function list_webhooks() {
+		$stripe = self::get_stripe_client();
+		try {
+			return $stripe->webhookEndpoints->all()['data']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		} catch ( \Exception $e ) {
+			return new WP_Error( 'stripe_webhooks', __( 'Could not fetch webhooks.', 'newspack' ), $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Receive Stripe webhook.
+	 */
+	public static function receive_webhook( $request ) {
+		switch ( $request['type'] ) {
+			case 'charge.succeeded':
+				$payment  = $request['data']['object'];
+				$metadata = $payment['metadata'];
+
+				// Update data in Campaigns plugin.
+				if ( isset( $metadata['clientId'] ) && ! empty( $metadata['clientId'] ) && class_exists( 'Newspack_Popups_Segmentation' ) ) {
+					$donation_data = [
+						'stripe_id'     => $payment['id'],
+						'date'          => date( 'Y-m-d H:i:s', $payment['created'] ),
+						'amount'        => $payment['amount'],
+						'receipt_email' => $payment['receipt_email'],
+					];
+					if ( isset( $payment['metadata']['Frequency'] ) ) {
+						$donation_data['frequency'] = $payment['metadata']['Frequency'];
+					}
+					\Newspack_Popups_Segmentation::update_client_data(
+						$metadata['clientId'],
+						[
+							'donation' => $donation_data,
+						]
+					);
+				}
+			case 'charge.failed':
+				break;
+			default:
+				return new WP_Error( 'newspack_unsupported_webhook' );
+		}
+	}
+
+	/**
+	 * Create Stripe webhooks.
+	 */
+	public static function create_webhooks() {
+		$stripe = self::get_stripe_client();
+		try {
+			$stripe->webhookEndpoints->create( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				[
+					'url'            => get_rest_url( null, NEWSPACK_API_NAMESPACE . '/stripe/webhook' ),
+					'enabled_events' => [
+						'charge.failed',
+						'charge.succeeded',
+					],
+				]
+			);
+		} catch ( \Exception $e ) {
+			return new WP_Error( 'newspack_plugin_webhooks', __( 'Problem creating webhooks.', 'newspack' ), $e->getMessage() );
+		}
+		return self::list_webhooks();
+	}
+
+	/**
+	 * Get saved Stripe data.
+	 */
+	private static function get_saved_stripe_data() {
+		$stripe_data = self::get_default_stripe_data();
+		if ( Donations::is_platform_wc() ) {
+			// If WC is configured, get Stripe data from WC.
+			$wc_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
+			$stripe_data              = $wc_configuration_manager->stripe_data();
+		} else {
+			$stripe_data = get_option( self::STRIPE_DATA_OPTION_NAME, self::get_default_stripe_data() );
+		}
+		$stripe_data['usedPublishableKey'] = $stripe_data['testMode'] ? $stripe_data['testPublishableKey'] : $stripe_data['publishableKey'];
+		$stripe_data['usedSecretKey']      = $stripe_data['testMode'] ? $stripe_data['testSecretKey'] : $stripe_data['secretKey'];
+		return $stripe_data;
+	}
+
+	/**
+	 * Get Stripe secret key.
+	 */
+	private static function get_stripe_secret_key() {
+		$stripe_data = self::get_saved_stripe_data();
+		return $stripe_data['usedSecretKey'];
+	}
+
+	/**
 	 * Get Stripe client.
 	 */
 	public static function get_stripe_client() {
-		$secret_key = self::get_stripe_data()['usedSecretKey'];
+		$secret_key = self::get_stripe_secret_key();
 		if ( $secret_key ) {
 			return new \Stripe\StripeClient( $secret_key );
 		}
 	}
 }
+
+Stripe_Connection::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Sends data to Campaigns Plugin and Google Analytics upon successful Stripe charge. For use with the experimental streamlined Donate block (https://github.com/Automattic/newspack-blocks/pull/784)

### How to test the changes in this Pull Request:

1. Set Newspack Blocks to `feat/donate-block-improvements` branch (https://github.com/Automattic/newspack-blocks/pull/806)
1. Choose News Revenue Hub as the donation platform in Reader Revenue wizard and fill in Stripe keys
2. Observe a "Webhooks" section in Reader Revenue -> Stripe Settings and click "Create webhooks". The site should reload and the new webhook listed
2. Set the `NEWSPACK_AMP_PLUS_ENABLED` environment variable to `true`
3. Ensure your instance is set up with Site Kit and GA is connected
4. Ensure Newspack Campaigns plugin is active
5. Create two prompts, both in "Above Header" placement. Set one to a non-donors segment and the other to donors
6. Insert the Donate block, enable "Streamlined mode" in editor sidebar
7. Visit the page in a fresh session. Observe the non-donors prompt above header
8. Submit a payment using the `4242 4242 4242 4242` card
9. After the payment succeeds (give it a sec to process on the backend), navigate to another page - observe the donor-segmented prompt displayed
10. Verify that a custom event was submitted to GA* with `Newspack Donation` category, `Stripe` action, and label of the donation frequency value  
11. Repeat on non-AMP page (or AMP if tested on non-AMP)

\* In GA, navigate to Behaviour->Events->Overview

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->