### PR TITLE
feat/campaigns mgmt

### DIFF
--- a/assets/wizards/popups/components/prompt-popovers/primary.js
+++ b/assets/wizards/popups/components/prompt-popovers/primary.js
@@ -18,6 +18,7 @@ import './style.scss';
 
 const PrimaryPromptPopover = ( {
 	deletePopup,
+	restorePopup,
 	onFocusOutside,
 	prompt,
 	previewPopup,
@@ -27,6 +28,7 @@ const PrimaryPromptPopover = ( {
 } ) => {
 	const { id, edit_link: editLink, status } = prompt;
 	const isPublished = 'publish' === status;
+	const isTrash = status === 'trash';
 
 	return (
 		<Popover
@@ -38,46 +40,46 @@ const PrimaryPromptPopover = ( {
 			<MenuItem onClick={ () => onFocusOutside() } className="screen-reader-text">
 				{ __( 'Close Popover', 'newspack' ) }
 			</MenuItem>
-			<MenuItem
-				onClick={ () => {
-					onFocusOutside();
-					previewPopup( prompt );
-				} }
-				className="newspack-button"
-			>
-				{ __( 'Preview', 'newspack' ) }
-			</MenuItem>
-			<MenuItem href={ decodeEntities( editLink ) } className="newspack-button" isLink>
-				{ __( 'Edit', 'newspack' ) }
-			</MenuItem>
-			<MenuItem onClick={ () => setModalVisible( true ) } className="newspack-button">
-				{ __( 'Duplicate', 'newspack' ) }
-			</MenuItem>
-			{ ! isPublished && (
-				<MenuItem
-					onClick={ () => {
-						onFocusOutside();
-						publishPopup( id );
-					} }
-					className="newspack-button"
-				>
-					{ __( 'Activate', 'newspack' ) }
-				</MenuItem>
+			{ isTrash ? (
+				<>
+					<MenuItem onClick={ () => restorePopup( id ) } className="newspack-button">
+						{ __( 'Restore', 'newspack' ) }
+					</MenuItem>
+					<MenuItem onClick={ () => deletePopup( id ) } className="newspack-button">
+						{ __( 'Delete permanently', 'newspack' ) }
+					</MenuItem>
+				</>
+			) : (
+				<>
+					<MenuItem
+						onClick={ () => {
+							onFocusOutside();
+							previewPopup( prompt );
+						} }
+						className="newspack-button"
+					>
+						{ __( 'Preview', 'newspack' ) }
+					</MenuItem>
+					<MenuItem href={ decodeEntities( editLink ) } className="newspack-button" isLink>
+						{ __( 'Edit', 'newspack' ) }
+					</MenuItem>
+					<MenuItem onClick={ () => setModalVisible( true ) } className="newspack-button">
+						{ __( 'Duplicate', 'newspack' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							onFocusOutside();
+							( isPublished ? unpublishPopup : publishPopup )( id );
+						} }
+						className="newspack-button"
+					>
+						{ isPublished ? __( 'Deactivate', 'newspack' ) : __( 'Activate', 'newspack' ) }
+					</MenuItem>
+					<MenuItem onClick={ () => deletePopup( id ) } className="newspack-button">
+						{ __( 'Delete', 'newspack' ) }
+					</MenuItem>
+				</>
 			) }
-			{ isPublished && (
-				<MenuItem
-					onClick={ () => {
-						onFocusOutside();
-						unpublishPopup( id );
-					} }
-					className="newspack-button"
-				>
-					{ __( 'Deactivate', 'newspack' ) }
-				</MenuItem>
-			) }
-			<MenuItem onClick={ () => deletePopup( id ) } className="newspack-button">
-				{ __( 'Delete', 'newspack' ) }
-			</MenuItem>
 			<div className="newspack-popover__campaigns__info">
 				{ __( 'ID:', 'newspack' ) } { id }
 			</div>

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -129,6 +129,22 @@ class PopupsWizard extends Component {
 	};
 
 	/**
+	 * Restore a deleted a popup.
+	 *
+	 * @param {number} popupId ID of the Popup to alter.
+	 */
+	restorePopup = popupId => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: `/newspack/v1/wizard/newspack-popups-wizard/${ popupId }/restore`,
+			method: 'POST',
+			quiet: true,
+		} )
+			.then( this.updateAfterAPI )
+			.catch( error => setError( error ) );
+	};
+
+	/**
 	 * Publish a popup.
 	 *
 	 * @param {number} popupId ID of the Popup to alter.
@@ -246,6 +262,7 @@ class PopupsWizard extends Component {
 						setTermsForPopup: this.setTermsForPopup,
 						updatePopup: this.updatePopup,
 						deletePopup: this.deletePopup,
+						restorePopup: this.restorePopup,
 						duplicatePopup: this.duplicatePopup,
 						previewPopup: popup =>
 							this.setState( { previewUrl: this.previewUrlForPopup( popup ) }, () =>

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -60,18 +60,22 @@ const modalButton = modalType => {
 };
 
 const filterByCampaign = ( prompts, campaignId ) => {
+	if ( 'trash' === campaignId ) {
+		return prompts.filter( ( { status } ) => 'trash' === status );
+	}
+	const notTrashedPrompts = prompts.filter( ( { status } ) => 'trash' !== status );
 	if ( DEFAULT_CAMPAIGNS_FILTER === campaignId ) {
-		return prompts.filter( ( { status } ) => 'publish' === status );
+		return notTrashedPrompts.filter( ( { status } ) => 'publish' === status );
 	}
 	if ( 'all' === campaignId ) {
-		return prompts;
+		return notTrashedPrompts.filter( ( { status } ) => 'trash' !== status );
 	}
 	if ( 'unassigned' === campaignId ) {
-		return prompts.filter(
+		return notTrashedPrompts.filter(
 			( { campaign_groups: campaigns } ) => ! campaigns || ! campaigns.length
 		);
 	}
-	return prompts.filter(
+	return notTrashedPrompts.filter(
 		( { campaign_groups: campaigns } ) =>
 			campaigns && campaigns.find( term => +term.term_id === +campaignId )
 	);
@@ -156,6 +160,10 @@ const Campaigns = props => {
 		{
 			key: 'all',
 			name: __( 'All Prompts', 'newspack' ),
+		},
+		{
+			key: 'trash',
+			name: __( 'Trash', 'newspack' ),
 		},
 		...( hasUnassigned
 			? [

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -38,11 +38,12 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	 * Retrieve all prompt CPTs
 	 *
 	 * @param  boolean $include_unpublished Whether to include unpublished posts.
+	 * @param  boolean $include_trash Whether to include trashed posts.
 	 * @return array All prompts
 	 */
-	public function get_prompts( $include_unpublished = false ) {
+	public function get_prompts( $include_unpublished = false, $include_trash = false ) {
 		return $this->is_configured() ?
-			\Newspack_Popups_Model::retrieve_popups( $include_unpublished ) :
+			\Newspack_Popups_Model::retrieve_popups( $include_unpublished, $include_trash ) :
 			$this->unconfigured_error();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #784
Closes #869 

### How to test the changes in this Pull Request:

1. Switch `newspack-popups` to `feat/trash-retrieval` branch (https://github.com/Automattic/newspack-popups/pull/580)
1. In the Campaigns wizard, observe two new sections - "All Prompts" and "Trash"
2. Observe that "All Prompts" displays all (untrashed) prompts, regardless of status or campaign
3. Delete a prompt via the popover handler - observe it moved to "Trash"
4. Restore the prompt, observe it's restored
5. Delete a prompt and then "Delete permanently" - observe that it's gone forever 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->