### PR TITLE
fix(engagement-wizard): grid columns and provider selector

### DIFF
--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -1,12 +1,12 @@
 /**
  * Internal dependencies
  */
-import { values, startCase, uniq, mapValues, property } from 'lodash';
+import { values, mapValues, property } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, Fragment } from '@wordpress/element';
+import { useEffect, Fragment } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -30,7 +30,6 @@ import { fetchJetpackMailchimpStatus } from '../../../../utils';
 
 export const NewspackNewsletters = ( { className, onUpdate, mailchimpOnly = true } ) => {
 	const [ config, updateConfig ] = hooks.useObjectState( {} );
-	const [ allProviders, setAllProviders ] = useState( [] );
 	const performConfigUpdate = update => {
 		updateConfig( update );
 		if ( onUpdate ) {
@@ -41,11 +40,6 @@ export const NewspackNewsletters = ( { className, onUpdate, mailchimpOnly = true
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/newsletters',
 		} ).then( res => {
-			setAllProviders(
-				uniq( res.settings.reduce( ( acc, setting ) => [ ...acc, setting.provider ], [] ) ).filter(
-					Boolean
-				)
-			);
 			performConfigUpdate( {
 				...res,
 				settings: res.settings.reduce(
@@ -60,6 +54,11 @@ export const NewspackNewsletters = ( { className, onUpdate, mailchimpOnly = true
 		value: config.settings[ key ]?.value || '',
 		checked: Boolean( config.settings[ key ]?.value ),
 		label: config.settings[ key ]?.description,
+		options:
+			config.settings[ key ]?.options?.map( option => ( {
+				value: option.value,
+				label: option.name,
+			} ) ) || null,
 		onChange: value => performConfigUpdate( { settings: { [ key ]: { value } } } ),
 	} );
 
@@ -88,17 +87,13 @@ export const NewspackNewsletters = ( { className, onUpdate, mailchimpOnly = true
 	const renderProviderSettings = () => {
 		const providerSelectProps = getSettingProps( 'newspack_newsletters_service_provider' );
 		return (
-			<Grid gutter={ 32 } columns={ 2 }>
-				<SelectControl
-					label={ __( 'Service Provider', 'newspack' ) }
-					options={ allProviders.map( value => ( { value, label: startCase( value ) } ) ) }
-					{ ...providerSelectProps }
-				/>
-				<br />
+			<Grid gutter={ 32 } columns={ 1 }>
 				{ values( config.settings )
-					.filter( setting => setting.provider === providerSelectProps.value )
+					.filter( setting => ! setting.provider || setting.provider === providerSelectProps.value )
 					.map( setting => {
 						switch ( setting.type ) {
+							case 'select':
+								return <SelectControl key={ setting.key } { ...getSettingProps( setting.key ) } />;
 							case 'checkbox':
 								return (
 									<CheckboxControl key={ setting.key } { ...getSettingProps( setting.key ) } />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Closes #1044.

Our checkbox component does not seem to support being in a grid with other controls that contain label structure. For that reason, this PR proposes we use 1 column grid for this form.

I've also changed the form to a more generic approach. This allows integrating the latest "manual" provider and the "Public Newsletter Posts Slug" field.

![image](https://user-images.githubusercontent.com/820752/126213695-07ccc00b-7f1c-4065-9cf1-1f7f3d50bbe6.png)


### How to test the changes in this Pull Request:

1. Switch to this branch and run `npm run build`
2. Visit the Engagement wizard and verify the new grid, updated provider options, and "Public Newsletter Posts Slug" field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->