### PR TITLE
Campaigns Wizard: display GA-derived insights

### DIFF
--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -6,6 +6,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
+ * External dependencies.
+ */
+import { memoize } from 'lodash';
+
+/**
  * Array of overlay placements.
  */
 const overlayPlacements = [ 'top', 'bottom', 'center' ];
@@ -129,7 +134,7 @@ export const descriptionForPopup = prompt => {
 	return descriptionMessages.length ? descriptionMessages.join( ' | ' ) : null;
 };
 
-export const getFavoriteCategoryNames = async favoriteCategories => {
+const getFavoriteCategoryNamesFn = async favoriteCategories => {
 	try {
 		const favoriteCategoryNames = await Promise.all(
 			favoriteCategories.map( async categoryId => {
@@ -149,6 +154,7 @@ export const getFavoriteCategoryNames = async favoriteCategories => {
 		return [];
 	}
 };
+export const getFavoriteCategoryNames = memoize( getFavoriteCategoryNamesFn );
 
 export const descriptionForSegment = ( segment, categories = [] ) => {
 	const { configuration } = segment;

--- a/assets/wizards/popups/views/analytics/Info.js
+++ b/assets/wizards/popups/views/analytics/Info.js
@@ -27,8 +27,15 @@ const Info = ( { keyMetrics, filtersState, labelFilters, isLoading, postEditLink
 
 	const hasConversionRate = form_submissions >= 0 && seen > 0;
 	const hasClickThroughRate = link_clicks >= 0 && seen > 0;
-	const notApplicable = __( 'n/a', 'newspack' );
+	const isAllEventFilterOn = filtersState.event_action === '';
 
+	if ( ! isAllEventFilterOn ) {
+		return (
+			<Notice noticeText={ __( 'Choose "All Events" filter to see key metrics.', 'newspack' ) } />
+		);
+	}
+
+	const notApplicable = __( 'n/a', 'newspack' );
 	return (
 		<div className="newspack-campaigns-wizard-analytics__info">
 			<h2>

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -321,14 +321,17 @@ class Popups_Wizard extends Wizard {
 					'callback'            => [ $this, 'get_popups_analytics_report' ],
 					'permission_callback' => [ $this, 'api_permissions_check' ],
 					'args'                => [
-						'offset'         => [
+						'offset'            => [
 							'sanitize_callback' => 'sanitize_text_field',
 						],
-						'event_label_id' => [
+						'event_label_id'    => [
 							'sanitize_callback' => 'sanitize_text_field',
 						],
-						'event_action'   => [
+						'event_action'      => [
 							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'with_report_by_id' => [
+							'sanitize_callback' => 'rest_sanitize_boolean',
 						],
 					],
 				],
@@ -793,9 +796,10 @@ class Popups_Wizard extends Wizard {
 	 */
 	public function get_popups_analytics_report( $request ) {
 		$options = array(
-			'offset'         => $request['offset'],
-			'event_label_id' => $request['event_label_id'],
-			'event_action'   => $request['event_action'],
+			'offset'            => $request['offset'],
+			'event_label_id'    => $request['event_label_id'],
+			'event_action'      => $request['event_action'],
+			'with_report_by_id' => $request['with_report_by_id'],
 		);
 		return rest_ensure_response( \Popups_Analytics_Utils::get_report( $options ) );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #993 

### How to test the changes in this Pull Request:

1. On an instance with Site Kit & GA configured, and some Campaigns-related data already reported, visit the Campaigns Wizard
2. Observe a spinner next to each prompt, and then GA-derived data 
3. If a prompt was active on the site, viewability should be visible
4. If a prompt has a form (most commonly, a newsletter signup form), conversion rate should be visible 
5. If there was an error when fetching the data, an info icon with info in the tooltip should be displayed - this can be checked by logging as another admin, who did not connect Site Kit

#### Also, a small bug is fixed:

1. On `master`, browse around the Campaigns Wizard and observe a lot of duplicated requests to WP REST API `/categories` endpoint
2. Switch to this branch, observe no duplicated requests to `/category` endpoint

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->