### PR TITLE
fix(stripe): error namespace, listing webhooks condition

### DIFF
--- a/includes/class-stripe-connection.php
+++ b/includes/class-stripe-connection.php
@@ -90,7 +90,8 @@ class Stripe_Connection {
 	public static function get_stripe_data() {
 		$stripe_data             = self::get_saved_stripe_data();
 		$stripe_data['webhooks'] = [];
-		if ( self::get_stripe_secret_key() ) {
+		// Currently, the Stripe integration that requires webhooks will only work with NRH, since NRH handles recurring charges.
+		if ( self::get_stripe_secret_key() && Donations::is_platform_nrh() ) {
 			$stripe_data['webhooks'] = self::list_webhooks();
 		}
 		return $stripe_data;
@@ -180,7 +181,7 @@ class Stripe_Connection {
 			case 'charge.failed':
 				break;
 			default:
-				return new WP_Error( 'newspack_unsupported_webhook' );
+				return new \WP_Error( 'newspack_unsupported_webhook' );
 		}
 	}
 
@@ -200,7 +201,7 @@ class Stripe_Connection {
 				]
 			);
 		} catch ( \Exception $e ) {
-			return new WP_Error( 'newspack_plugin_webhooks', __( 'Problem creating webhooks.', 'newspack' ), $e->getMessage() );
+			return new \WP_Error( 'newspack_plugin_webhooks', __( 'Problem creating webhooks.', 'newspack' ), $e->getMessage() );
 		}
 		return self::list_webhooks();
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the same fix as #1070 to other instances of `WP_Error`, and ensures that webhooks are listed only if the donation platform is NRH.

### How to test the changes in this Pull Request:

1. Set the Reader Revenue platform to NRH and verify webhooks are listed in the Reader Revenue Wizard, Stripe Settings section
2. Set the platform to Newspack, observe that [this line](https://github.com/Automattic/newspack-plugin/blob/311a84cdde5239f020ec15cf0d33fd406076cb9f/includes/class-stripe-connection.php#L95) is not executed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->