### PR TITLE
Reorganize campaigns settings modal

### DIFF
--- a/assets/components/src/category-autocomplete/index.js
+++ b/assets/components/src/category-autocomplete/index.js
@@ -19,6 +19,7 @@ import './style.scss';
  * External dependencies
  */
 import { debounce, find } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Category autocomplete field component.
@@ -97,10 +98,19 @@ class CategoryAutocomplete extends Component {
 	 * Render the component.
 	 */
 	render() {
-		const { value, label, disabled, description } = this.props;
+		const {
+			className,
+			disabled,
+			description,
+			hideHelpFromVision,
+			hideLabelFromVision,
+			label,
+			value,
+		} = this.props;
 		const { suggestions, allCategories } = this.state;
+		const classes = classnames( 'newspack-category-autocomplete', className );
 		return (
-			<div className="newspack-category-autocomplete">
+			<div className={ classes }>
 				<FormTokenField
 					onInputChange={ input => this.debouncedUpdateSuggestions( input ) }
 					value={ value.reduce( ( acc, item ) => {
@@ -116,6 +126,8 @@ class CategoryAutocomplete extends Component {
 					label={ label }
 					disabled={ disabled }
 					description={ description }
+					hideHelpFromVision={ hideHelpFromVision }
+					hideLabelFromVision={ hideLabelFromVision }
 				/>
 			</div>
 		);

--- a/assets/components/src/form-token-field/index.js
+++ b/assets/components/src/form-token-field/index.js
@@ -23,13 +23,20 @@ class FormTokenField extends Component {
 	 * Render.
 	 */
 	render() {
-		const { className, isHelpTextHidden, description, ...otherProps } = this.props;
+		const {
+			className,
+			description,
+			hideHelpFromVision,
+			hideLabelFromVision,
+			...otherProps
+		} = this.props;
 		const classes = classnames( 'newspack-form-token-field__input-container', className );
 		return (
 			<div
 				className={ classnames(
 					{
-						'newspack-form-token-field--help-hidden': isHelpTextHidden,
+						'newspack-form-token-field--label-hidden': hideLabelFromVision,
+						'newspack-form-token-field--help-hidden': hideHelpFromVision,
 					},
 					'newspack-form-token-field'
 				) }

--- a/assets/components/src/form-token-field/style.scss
+++ b/assets/components/src/form-token-field/style.scss
@@ -116,8 +116,17 @@
 		margin: 0;
 	}
 
+	// Hidden Elements
+
+	&--label-hidden {
+		label {
+			display: none;
+		}
+	}
+
 	&--help-hidden {
-		.components-form-token-field__help {
+		.components-form-token-field__help,
+		div.i {
 			display: none;
 		}
 	}

--- a/assets/components/src/settings/SettingsCard.js
+++ b/assets/components/src/settings/SettingsCard.js
@@ -8,18 +8,22 @@ import classnames from 'classnames';
  */
 import { Grid, ActionCard } from '../';
 
-const SettingsCard = ( { children, className, ...props } ) => {
+const SettingsCard = ( { children, className, columns, ...props } ) => {
 	return (
 		<ActionCard
 			{ ...props }
 			className={ classnames( className, 'newspack-settings__card' ) }
 			notificationLevel="info"
 		>
-			<Grid columns="3" gutter={ 24 }>
+			<Grid columns={ columns } gutter={ 32 }>
 				{ children }
 			</Grid>
 		</ActionCard>
 	);
+};
+
+SettingsCard.defaultProps = {
+	columns: 3,
 };
 
 export default SettingsCard;

--- a/assets/components/src/settings/style.scss
+++ b/assets/components/src/settings/style.scss
@@ -1,5 +1,31 @@
 .newspack-settings {
 	&__card {
+		&.newspack-card.newspack-action-card {
+			.newspack-action-card__region-top {
+				padding: 32px 32px 16px;
+			}
+
+			.newspack-action-card__region-children {
+				padding: 0 32px 32px;
+
+				> .newspack-grid {
+					margin: 0;
+				}
+			}
+
+			.newspack-action-card__notification {
+				padding-bottom: 16px;
+			}
+		}
+
+		.newspack-form-token-field {
+			margin: 0;
+
+			.components-form-token-field {
+				width: 100%;
+			}
+		}
+
 		.newspack-settings__section {
 			&__title {
 				display: flex;
@@ -20,25 +46,10 @@
 						margin: 0;
 					}
 				}
-
-				.newspack-category-autocomplete,
-				.newspack-select-control {
-					margin-top: 12px;
+				.newspack-text-control,
+				.newspack-checkbox-control {
+					margin: 0 !important;
 				}
-
-				.newspack-form-token-field {
-					margin: 12px 0 0 0;
-					.components-form-token-field {
-						width: 100%;
-						&__label {
-							display: none;
-						}
-					}
-				}
-				.newspack-category-autocomplete .newspack-form-token-field {
-					margin-top: 0;
-				}
-
 				.newspack-select-control {
 					.components-base-control {
 						width: 100%;
@@ -47,19 +58,20 @@
 			}
 		}
 		.newspack-settings__min-max {
-			margin-top: 8px;
-
 			.newspack-checkbox-control {
-				flex: 0 0 60px;
+				flex: 0 0 64px;
 			}
 
 			.newspack-text-control {
 				flex: 1 1 auto;
-				margin-left: 8px;
 
 				.components-text-control__input {
 					text-align: right;
 				}
+			}
+
+			+ .newspack-settings__min-max {
+				margin-top: 16px !important;
 			}
 		}
 	}

--- a/assets/wizards/popups/components/settings-modal/index.js
+++ b/assets/wizards/popups/components/settings-modal/index.js
@@ -7,17 +7,19 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import {
+	Button,
+	Card,
 	CategoryAutocomplete,
 	FormTokenField,
+	Grid,
 	Modal,
 	SelectControl,
 	Settings,
-	Button,
 	hooks,
 } from '../../../../components/src';
 import { frequenciesForPopup, isOverlay, placementsForPopups } from '../../utils';
 
-const { SettingsCard, SettingsSection } = Settings;
+const { SettingsCard } = Settings;
 
 const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup } ) => {
 	const [ promptConfig, setPromptConfig ] = hooks.useObjectState( prompt );
@@ -29,29 +31,38 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 	const assignedSegmentsIds = ( promptConfig.options.selected_segment_id || '' ).split( ',' );
 
 	return (
-		<Modal title={ prompt.title } onRequestClose={ onClose }>
+		<Modal title={ prompt.title } onRequestClose={ onClose } isWide>
 			<Button onClick={ () => onClose() } className="screen-reader-text">
 				{ __( 'Close Modal', 'newspack' ) }
 			</Button>
+			<Grid gutter={ 16 } columns={ 1 }>
+				<SettingsCard
+					title={ __( 'Campaigns', 'newspack' ) }
+					description={ __(
+						'Assign a prompt to one or more campaigns for easier management',
+						'newspack'
+					) }
+					columns={ 1 }
+					className="newspack-settings__campaigns"
+				>
+					<CategoryAutocomplete
+						disabled={ disabled }
+						value={ promptConfig.campaign_groups || [] }
+						onChange={ tokens => setPromptConfig( { campaign_groups: tokens } ) }
+						label={ __( 'Campaigns', 'newspack' ) }
+						taxonomy="newspack_popups_taxonomy"
+						hideLabelFromVision
+					/>
+				</SettingsCard>
 
-			<CategoryAutocomplete
-				disabled={ disabled }
-				value={ promptConfig.campaign_groups || [] }
-				onChange={ tokens => setPromptConfig( { campaign_groups: tokens } ) }
-				label={ __( 'Campaigns', 'newspack' ) }
-				taxonomy="newspack_popups_taxonomy"
-				description={ __(
-					'Assign a prompt to one or more campaigns for easier management.',
-					'newspack'
-				) }
-			/>
-
-			<SettingsCard
-				title={ __( 'Settings', 'newspack' ) }
-				description={ __( 'When and how should the prompt be displayed.', 'newspack' ) }
-			>
-				<SettingsSection title={ __( 'Frequency', 'newspack' ) }>
+				<SettingsCard
+					title={ __( 'Settings', 'newspack' ) }
+					description={ __( 'When and how should the prompt be displayed', 'newspack' ) }
+					columns={ 2 }
+					className="newspack-settings__settings"
+				>
 					<SelectControl
+						label={ __( 'Frequency', 'newspack' ) }
 						disabled={ disabled }
 						onChange={ value => {
 							setPromptConfig( { options: { frequency: value } } );
@@ -59,9 +70,8 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 						options={ frequenciesForPopup( prompt ) }
 						value={ promptConfig.options.frequency }
 					/>
-				</SettingsSection>
-				<SettingsSection title={ isOverlay( prompt ) ? __( 'Position' ) : __( 'Placement' ) }>
 					<SelectControl
+						label={ isOverlay( prompt ) ? __( 'Position' ) : __( 'Placement' ) }
 						disabled={ disabled }
 						onChange={ value => {
 							setPromptConfig( { options: { placement: value } } );
@@ -69,20 +79,26 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 						options={ placementsForPopups( prompt ) }
 						value={ promptConfig.options.placement }
 					/>
-				</SettingsSection>
-			</SettingsCard>
+				</SettingsCard>
 
-			<SettingsCard
-				title={ __( 'Targeting', 'newspack' ) }
-				description={ __(
-					'Under which conditions should the prompt be displayed. If multiple conditions are set, all will have to be satisfied in order to display the prompt.',
-					'newspack'
-				) }
-			>
-				<SettingsSection title={ __( 'Segment', 'newspack' ) }>
+				<SettingsCard
+					title={ __( 'Targeting', 'newspack' ) }
+					description={ () => (
+						<>
+							{ __( 'Under which conditions should the prompt be displayed', 'newspack' ) }
+							<br />
+							{ __(
+								'If multiple conditions are set, all will have to be satisfied in order to display the prompt',
+								'newspack'
+							) }
+						</>
+					) }
+					className="newspack-settings__targeting"
+				>
 					<FormTokenField
+						label={ __( 'Segment', 'newspack' ) }
 						disabled={ disabled }
-						isHelpTextHidden
+						hideHelpFromVision
 						value={ segments
 							.filter( ( { id } ) => assignedSegmentsIds.indexOf( id ) > -1 )
 							.map( segment => segment.name ) }
@@ -100,10 +116,10 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 							'newspack'
 						) }
 					/>
-				</SettingsSection>
-				<SettingsSection title={ __( 'Post categories', 'newspack ' ) }>
 					<CategoryAutocomplete
+						label={ __( 'Post categories', 'newspack ' ) }
 						disabled={ disabled }
+						hideHelpFromVision
 						value={ promptConfig.categories || [] }
 						onChange={ tokens => setPromptConfig( { categories: tokens } ) }
 						description={ __(
@@ -111,10 +127,10 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 							'newspack'
 						) }
 					/>
-				</SettingsSection>
-				<SettingsSection title={ __( 'Post tags', 'newspack ' ) }>
 					<CategoryAutocomplete
+						label={ __( 'Post tags', 'newspack ' ) }
 						disabled={ disabled }
+						hideHelpFromVision
 						taxonomy="tags"
 						value={ promptConfig.tags || [] }
 						onChange={ tokens => setPromptConfig( { tags: tokens } ) }
@@ -123,17 +139,17 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 							'newspack'
 						) }
 					/>
-				</SettingsSection>
-			</SettingsCard>
+				</SettingsCard>
+			</Grid>
 
-			<div className="flex justify-between">
+			<Card buttonsCard noBorder className="justify-end">
 				<Button onClick={ onClose } isSecondary>
 					{ __( 'Cancel', 'newspack' ) }
 				</Button>
 				<Button onClick={ handleSave } isPrimary>
 					{ __( 'Save', 'newspack' ) }
 				</Button>
-			</div>
+			</Card>
 		</Modal>
 	);
 };

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -158,7 +158,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 			) }
 			<SettingsCard
 				title={ __( 'Reader Engagement', 'newspack' ) }
-				description={ __( 'Target readers based on their browsing behavior.', 'newspack' ) }
+				description={ __( 'Target readers based on their browsing behavior', 'newspack' ) }
 			>
 				<SettingsSection
 					title={ __( 'Articles read', 'newspack' ) }
@@ -198,12 +198,14 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 							updateSegmentConfig( 'favorite_categories' )( selected.map( item => item.id ) );
 						} }
 						label={ __( 'Favorite Categories', 'newspack ' ) }
+						hideLabelFromVision
 					/>
 				</SettingsSection>
 			</SettingsCard>
 			<SettingsCard
 				title={ __( 'Reader Activity', 'newspack' ) }
-				description={ __( 'Target readers based on their actions.', 'newspack' ) }
+				description={ __( 'Target readers based on their actions', 'newspack' ) }
+				columns={ 2 }
 			>
 				<SettingsSection title={ __( 'Newsletter', 'newspack' ) }>
 					<SelectControl
@@ -262,11 +264,12 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 			</SettingsCard>
 			<SettingsCard
 				title={ __( 'Referrer Sources', 'newspack' ) }
-				description={ __( 'Target readers based on where they’re coming from.', 'newspack' ) }
+				description={ __( 'Target readers based on where they’re coming from', 'newspack' ) }
 				notification={ __(
 					'Segments using these options will apply only to the first page visited after coming from an external source.',
 					'newspack'
 				) }
+				columns={ 2 }
 			>
 				<SettingsSection
 					title={ __( 'Sources to match', 'newspack' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR reorganises the `Modal` in Newspack > Campaigns, including the `Grid` and the various paddings. I've also updated the `FormTokenField` (and `CategoryAutocomplete`) to allow label and help text to be hidden like other Gutenberg components (e.g. `TextControl`)


### How to test the changes in this Pull Request:

1. Go to Campaigns, click on the filter link -- notice the Modal
2. Switch to this branch and refresh wizard
3. Open the Modal again
4. Check if Campaigns > Segments (add new or edit) looks broken (it shouldn't!)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->