### PR TITLE
chore: remove redundant AMP disabling on WC pages

### DIFF
--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -189,33 +189,5 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 		// Enables checkout without login.
 		update_option( 'woocommerce_enable_guest_checkout', 'yes' );
 		update_option( 'woocommerce_enable_signup_and_login_from_checkout', 'yes' );
-
-		$this->disable_amp_for_woocomm_checkout_page();
-	}
-
-	/**
-	 * Disables AMP for the WooCommerce Checkout page.
-	 */
-	public function disable_amp_for_woocomm_checkout_page() {
-		$checkout_page_id = get_option( 'woocommerce_checkout_page_id' );
-		if ( ! $checkout_page_id ) {
-			return;
-		}
-
-		$this->disable_amp_for_post( $checkout_page_id );
-	}
-
-	/**
-	 * Disables AMP for a specific Post/Page.
-	 *
-	 * @param int $post_id Post ID.
-	 */
-	public function disable_amp_for_post( $post_id ) {
-		$post = get_post( $post_id );
-		if ( ! $post ) {
-			return;
-		}
-
-		update_post_meta( $post_id, 'amp_status', 'disabled' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes redundancy of disabling AMP on WC pages. AMP disabling was added in a more robust way in #1058.

### How to test the changes in this Pull Request:

1. Set up Newspack on a new site 
2. Make a donation on the front-end, observe the "Payment Info" section is interactive

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->