### PR TITLE
Fix handoff banner style when admin has meta links

### DIFF
--- a/assets/wizards/handoff-banner/style.scss
+++ b/assets/wizards/handoff-banner/style.scss
@@ -9,7 +9,7 @@
 	background: $primary-500;
 	display: block;
 	margin: 0 0 0 -10px;
-	padding: 4px;
+	padding: 4px 16px;
 	position: relative;
 
 	@media screen and ( min-width: 783px ) {
@@ -17,41 +17,16 @@
 	}
 
 	// Dismissed
-
 	&:empty {
 		display: none;
 	}
 
-	// Help Tabs
-
-	&.has-help-tabs {
-		margin-top: 40px;
-
-		@media screen and ( min-width: 783px ) {
-			margin-top: 30px;
-		}
-
-		&::before {
-			background: $primary-500;
-			content: '';
-			display: block;
-			height: 100vh;
-			left: 0;
-			position: absolute;
-			right: 0;
-			top: -100vh;
-			z-index: -1;
-		}
-	}
-
 	// Jetpack
-
 	.jetpack-pagestyles & {
 		margin-left: 0;
 	}
 
 	// Google Site Kit
-
 	.site-kit_page_googlesitekit-splash & {
 		margin-bottom: -25px;
 	}
@@ -72,7 +47,6 @@
 	}
 
 	// Text
-
 	.newspack-handoff-banner__text {
 		align-items: center;
 		display: flex;
@@ -93,7 +67,6 @@
 	}
 
 	// Buttons
-
 	.newspack-handoff-banner__buttons {
 		display: flex;
 		flex-wrap: wrap;
@@ -124,5 +97,25 @@
 				}
 			}
 		}
+	}
+}
+
+#screen-meta-links {
+	margin-bottom: 4px;
+	position: relative;
+	z-index: 2;
+}
+
+#screen-meta {
+	&::before {
+		background: $primary-500;
+		bottom: 0;
+		content: '';
+		display: block;
+		left: -100vw;
+		position: absolute;
+		right: -100vw;
+		top: 0;
+		z-index: -1;
 	}
 }

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -34,18 +34,11 @@ class Handoff_Banner {
 	 * @return void.
 	 */
 	public function insert_handoff_banner() {
-		$classes        = [];
-		$screen         = get_current_screen();
-		$help_tab_count = count( $screen->get_help_tabs() );
-		$is_jetpack     = strrpos( $screen->base, 'jetpack' );
-		if ( $help_tab_count > 0 && false === $is_jetpack ) {
-			$classes[] = 'has-help-tabs';
-		}
 		if ( ! self::needs_handoff_return_ui() ) {
 			return;
 		}
-		$newspack_handoff_return_url = get_option( NEWSPACK_HANDOFF_RETURN_URL );
-		echo sprintf( "<div id='newspack-handoff-banner' data-primary_button_url='%s' class='%s'></div>", esc_attr( $newspack_handoff_return_url ), esc_attr( implode( ' ', $classes ) ) );
+
+		echo sprintf( "<div id='newspack-handoff-banner' data-primary_button_url='%s'></div>", esc_url( get_option( NEWSPACK_HANDOFF_RETURN_URL ) ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

At the moment, when redirected to wp-admin via a handoff button, if the screen has help tabs, they will be hidden. For some reason `count( $screen->get_help_tabs() )` doesn't return the correct number anymore.

This PR simplifies it and only uses css

### How to test the changes in this Pull Request:

1. Navigate to a screen with an handoff button (e.g. Syndication)
2. Click on one of the buttons
3. Once redirected, check the banner (do you see the "Screen Options" button?)
4. Switch to this branch
5. Refresh

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->