### PR TITLE
fix: remove missing CSS from Engagement wizard

### DIFF
--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -224,15 +224,6 @@ class Engagement_Wizard extends Wizard {
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/engagement.js' ),
 			true
 		);
-
-		\wp_register_style(
-			'newspack-engagement-wizard',
-			Newspack::plugin_url() . '/dist/engagement.css',
-			$this->get_style_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/engagement.css' )
-		);
-		\wp_style_add_data( 'newspack-engagement-wizard', 'rtl', 'replace' );
-		\wp_enqueue_style( 'newspack-engagement-wizard' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Remove missing CSS from the Engagement wizard.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. In the master branch, run `npm run clean && npm run build`
2. Visit the Engagement page and observe the PHP warning and 404 error on the browser for the CSS file
3. Switch to this branch and refresh

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->