### PR TITLE
Update PWA config to use defaults

### DIFF
--- a/includes/class-pwa.php
+++ b/includes/class-pwa.php
@@ -7,7 +7,7 @@
 
 namespace Newspack;
 
-use \WP_Error, \WP_Service_Worker_Caching_Routes;
+use \WP_Error;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -20,9 +20,8 @@ class PWA {
 	 * Add hooks.
 	 */
 	public static function init() {
-		add_action( 'wp_front_service_worker', [ __CLASS__, 'register_caching_routes' ] );
-		add_filter( 'wp_service_worker_navigation_caching_strategy', [ __CLASS__, 'caching_strategy' ] );
-		add_filter( 'wp_service_worker_navigation_caching_strategy_args', [ __CLASS__, 'caching_strategy_args' ] );
+		// For backwards compatibility and because there's no reason not to, always and automatically enable offline browsing.
+		add_filter( 'pre_option_offline_browsing', '__return_true' );
 	}
 
 	/**
@@ -70,70 +69,6 @@ class PWA {
 		} else {
 			delete_option( 'site_icon' );
 		}
-	}
-
-	/**
-	 * Cache images for offline use.
-	 *
-	 * @param object $scripts PWA scripts object.
-	 */
-	public static function register_caching_routes( $scripts ) {
-		// Cache images.
-		$scripts->caching_routes()->register(
-			'.*\.(?:png|gif|jpg|jpeg|svg|webp)(\?.*)?$', // @todo make sure this isn't caching Photon pixel.
-			[
-				'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST,
-				'cacheName' => 'images',
-				'plugins'   => [
-					'expiration' => [
-						'maxEntries'    => 60,
-						'maxAgeSeconds' => 60 * 60 * 24,
-					],
-				],
-			]
-		);
-
-		// Cache theme assets.
-		$theme_directory_uri_patterns = [
-			preg_quote( trailingslashit( get_template_directory_uri() ), '/' ),
-		];
-		if ( get_template() !== get_stylesheet() ) {
-			$theme_directory_uri_patterns[] = preg_quote( trailingslashit( get_stylesheet_directory_uri() ), '/' );
-		}
-		$scripts->caching_routes()->register(
-			'^(' . implode( '|', $theme_directory_uri_patterns ) . ').*',
-			[
-				'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST,
-				'cacheName' => 'theme-assets',
-				'plugins'   => [
-					'expiration' => [
-						'maxEntries' => 25,
-					],
-				],
-			]
-		);
-	}
-
-	/**
-	 * Use network-first caching strategy.
-	 *
-	 * @param string $strategy Caching strategy.
-	 * @return string caching strategy
-	 */
-	public static function caching_strategy( $strategy ) {
-		return WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST;
-	}
-
-	/**
-	 * Cache pages for offline use.
-	 *
-	 * @param array $args Caching strategy args.
-	 * @return array $args
-	 */
-	public static function caching_strategy_args( $args ) {
-		$args['cacheName']                           = 'pages';
-		$args['plugins']['expiration']['maxEntries'] = 50;
-		return $args;
 	}
 }
 PWA::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR updates our PWA config to work better with the latest versions of the PWA plugin. Previously, we were throwing a lot of these errors/deprecation notices:

`
WP_Service_Worker_Caching_Routes::register was called <strong>incorrectly</strong>. The plugins configuration key is obsolete. Define Workbox plugin configuration at the top level
`

The latest version of PWA provides [a default offline browsing config out-of-the-box](https://github.com/GoogleChromeLabs/pwa-wp/wiki/Service-Worker#offline-browsing), and it's the same config we had in here, so I've just removed our config, and we'll use the default config. 

In the new version of PWA, offline browsing can be enabled/disabled using a checkbox on the Reading settings screen. So that people don't have to go into their settings and check the "Enable offline browsing" checkbox after our next Newspack release, I've added a filter that forces offline browsing to always be enabled. If there's a reason somebody wouldn't want offline browsing enabled, let me know, and we can revise that, but I couldn't think of any! :)

### How to test the changes in this Pull Request:

1. For PWA to work, you'll need a site with a valid `https` connection.
2. Open Chrome dev console. Go to Application > Service Workers. Unregister the existing service worker (top right corner in the screenshot)

<img width="674" alt="Screen Shot 2021-08-11 at 10 06 36 AM" src="https://user-images.githubusercontent.com/7317227/129075180-f75879bc-deb9-48e3-b402-3dd47b5c2cba.png">

3. Visit a post. Either check the Offline checkbox in Application > Service Workers (top-middle in screenshot below) or turn your internet off. Refresh the page so you view the post with your internet turned off. You should see the post served. If you visit the homepage, you should see an Offline page.

<img width="1649" alt="Screen Shot 2021-08-11 at 10 07 49 AM" src="https://user-images.githubusercontent.com/7317227/129075469-b8a60bbe-d091-4cdb-9a40-946616db671a.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->