### PR TITLE
feat(ads): global ad suppression settings

### DIFF
--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { AdUnit, AdUnits, Placements, Services } from './views';
+import { AdUnit, AdUnits, Placements, Services, Suppression } from './views';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 const CREATE_AD_ID_PARAM = 'create';
@@ -40,6 +40,7 @@ class AdvertisingWizard extends Component {
 					google_adsense: {},
 					wordads: {},
 				},
+				suppression: false,
 			},
 		};
 	}
@@ -232,6 +233,28 @@ class AdvertisingWizard extends Component {
 		}
 	}
 
+	/**
+	 * Update ad suppression settings.
+	 */
+	updateAdSuppression( suppressionConfig ) {
+		const { setError, wizardApiFetch } = this.props;
+		wizardApiFetch( {
+			path: '/newspack/v1/wizard/advertising/suppression',
+			method: 'post',
+			data: { config: suppressionConfig },
+			quiet: true,
+		} )
+			.then( advertisingData => {
+				this.setState(
+					{
+						advertisingData: this.prepareData( advertisingData ),
+					},
+					setError
+				);
+			} )
+			.catch( setError );
+	}
+
 	prepareData = data => {
 		return {
 			...data,
@@ -258,6 +281,10 @@ class AdvertisingWizard extends Component {
 			{
 				label: __( 'Global Settings', 'newspack' ),
 				path: '/ad-placements',
+			},
+			{
+				label: __( 'Suppression', 'newspack' ),
+				path: '/suppression',
 			},
 		];
 		return (
@@ -373,6 +400,21 @@ class AdvertisingWizard extends Component {
 									/>
 								);
 							} }
+						/>
+						<Route
+							path="/suppression"
+							render={ () => (
+								<Suppression
+									headerText={ __( 'Ad Suppression', 'newspack' ) }
+									subHeaderText={ __(
+										'Allows you to manage site-wide ad suppression.',
+										'newspack'
+									) }
+									tabbedNavigation={ tabs }
+									config={ advertisingData.suppression }
+									onChange={ config => this.updateAdSuppression( config ) }
+								/>
+							) }
 						/>
 						<Redirect to="/" />
 					</Switch>

--- a/assets/wizards/advertising/views/index.js
+++ b/assets/wizards/advertising/views/index.js
@@ -2,3 +2,4 @@ export { default as Services } from './services';
 export { default as Placements } from './placements';
 export { default as AdUnits } from './ad-units';
 export { default as AdUnit } from './ad-unit';
+export { default as Suppression } from './suppression';

--- a/assets/wizards/advertising/views/suppression/index.js
+++ b/assets/wizards/advertising/views/suppression/index.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Settings, CheckboxControl, withWizardScreen } from '../../../../components/src';
+
+const { SettingsCard } = Settings;
+
+const Suppression = ( { config, onChange } ) => {
+	return (
+		<SettingsCard
+			title={ __( 'Archive pages', 'newspack' ) }
+			description={ __(
+				'Suppress ads on automatically generated pages which display lists of posts, e.g. tag archives.',
+				'newspack'
+			) }
+			columns={ 1 }
+		>
+			<CheckboxControl
+				disabled={ config === false }
+				checked={ config?.tag_archive_pages }
+				onChange={ tag_archive_pages => {
+					onChange( { ...config, tag_archive_pages } );
+				} }
+				label={ __( 'Suppress ads on tag archive pages', 'newspack' ) }
+			/>
+			<CheckboxControl
+				disabled={ config === false }
+				checked={ config?.category_archive_pages }
+				onChange={ category_archive_pages => {
+					onChange( { ...config, category_archive_pages } );
+				} }
+				label={ __( 'Suppress ads on category archive pages', 'newspack' ) }
+			/>
+			<CheckboxControl
+				disabled={ config === false }
+				checked={ config?.author_archive_pages }
+				onChange={ author_archive_pages => {
+					onChange( { ...config, author_archive_pages } );
+				} }
+				label={ __( 'Suppress ads on author archive pages', 'newspack' ) }
+			/>
+		</SettingsCard>
+	);
+};
+
+export default withWizardScreen( Suppression );

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -115,6 +115,29 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Get ad suppression config.
+	 *
+	 * @return bool | WP_Error Returns object, or error if the plugin is not active.
+	 */
+	public function get_suppression_config() {
+		return $this->is_configured() ?
+			\Newspack_Ads_Model::get_suppression_config() :
+			$this->unconfigured_error();
+	}
+
+	/**
+	 * Update ad suppression config.
+	 *
+	 * @param array $config Updated config.
+	 * @return bool | WP_Error Returns object, or error if the plugin is not active.
+	 */
+	public function update_suppression_config( $config ) {
+		return $this->is_configured() ?
+			\Newspack_Ads_Model::update_suppression_config( $config ) :
+			$this->unconfigured_error();
+	}
+
+	/**
 	 * Check whether the current screen should show ads.
 	 *
 	 * @return bool Returns true if ads should be shown.

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -235,6 +235,17 @@ class Advertising_Wizard extends Wizard {
 				],
 			]
 		);
+
+		// Update global ad suppression.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/suppression',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_ad_suppression' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
 	}
 
 	/**
@@ -246,6 +257,18 @@ class Advertising_Wizard extends Wizard {
 	public function api_update_network_code( $request ) {
 		update_option( \Newspack_Ads_Model::OPTION_NAME_NETWORK_CODE, $request['network_code'] );
 		return \rest_ensure_response( [] );
+	}
+
+	/**
+	 * Update global ad suppression settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response containing ad units info.
+	 */
+	public function api_update_ad_suppression( $request ) {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+		$configuration_manager->update_suppression_config( $request['config'] );
+		return \rest_ensure_response( $this->retrieve_data() );
 	}
 
 	/**
@@ -413,6 +436,7 @@ class Advertising_Wizard extends Wizard {
 			'placements'            => $placements,
 			'ad_units'              => $ad_units,
 			'gam_connection_status' => $configuration_manager->get_gam_connection_status(),
+			'suppression'           => $configuration_manager->get_suppression_config(),
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ad wizard - handling of global suppression settings.
Nothing controversial on the UI front, but please have a look @thomasguillot : 

<img width="912" alt="image" src="https://user-images.githubusercontent.com/7383192/129704691-d7c44211-b096-49b4-934c-f41b1912c691.png">


### How to test the changes in this Pull Request:

1. Switch `newspack-ads` to `feat/global-ad-suppression` branch
2. Visit the Advertising wizard, "Suppression" tab
3. Observe three settings for global suppression - on tag, category, and author archive pages
4. Test all, observing that after switching one on, the ads are not displayed on respective archive pages

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->