### PR TITLE
Update focus/focus-visible on buttons (+ small fix)

### DIFF
--- a/assets/components/src/button/style.scss
+++ b/assets/components/src/button/style.scss
@@ -230,12 +230,14 @@ body[class*='admin-color-'] {
 			border-width: 1px;
 			color: $gray-900;
 
+			&:focus,
 			&:hover {
 				border-color: $gray-200;
+				box-shadow: none;
 				color: $primary-500;
 			}
 
-			&:focus {
+			&:focus-visible {
 				border-color: $primary-500;
 				box-shadow: inset 0 0 0 1px $primary-500;
 				color: $primary-500;
@@ -281,10 +283,11 @@ body[class*='admin-color-'] {
 			&:focus:enabled,
 			&.is-destructive:not( :disabled ):hover {
 				box-shadow: none;
+				outline: none;
 			}
 
-			&:focus,
-			&:focus:enabled {
+			&:focus-visible,
+			&:focus-visible:enabled {
 				outline: 2px solid $primary-500;
 				outline-offset: 2px;
 			}

--- a/assets/components/src/tabbed-navigation/style.scss
+++ b/assets/components/src/tabbed-navigation/style.scss
@@ -48,6 +48,9 @@
 
 		&:focus {
 			box-shadow: none;
+		}
+
+		&:focus-visible {
 			outline: 1px solid;
 			outline-offset: 16px;
 		}

--- a/assets/wizards/popups/components/prompt-action-card/style.scss
+++ b/assets/wizards/popups/components/prompt-action-card/style.scss
@@ -27,7 +27,7 @@
 	}
 
 	&__buttons {
-		.newspack-button + .newspack-button {
+		> .newspack-button + .newspack-button {
 			margin-left: 2px;
 		}
 	}

--- a/assets/wizards/popups/views/segments/SegmentsList.js
+++ b/assets/wizards/popups/views/segments/SegmentsList.js
@@ -191,6 +191,7 @@ const SegmentActionCard = ( {
 									onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
 									label={ __( 'More options', 'newspack' ) }
 									icon={ moreVertical }
+									className={ popoverVisibility && 'popover-active' }
 								/>
 								{ popoverVisibility && (
 									<Popover

--- a/assets/wizards/popups/views/segments/style.scss
+++ b/assets/wizards/popups/views/segments/style.scss
@@ -8,6 +8,10 @@
 		&.is-loading {
 			pointer-events: none;
 		}
+
+		.newspack-popover {
+			margin-left: -4px;
+		}
 	}
 	&__header {
 		align-items: center;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use `:focus-visible` for TabbedNavigation, Quaternary and isLink instead of `:focus`. It looks better without compromising on accessibility.

This PR also fixes a misalignment with the popover for campaigns and segments.

### How to test the changes in this Pull Request:

1. Play with TabbedNavigation
2. Go to Newspack > Campaigns and check the popover (use `:focus` to see issue with menu items)
3. Switch to this branch
4. Repeat 1 and 2, using your mouse then your keyboard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->