### PR TITLE
Disable WooCommerce image regeneration

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -22,6 +22,9 @@ class Patches {
 		add_action( 'admin_menu', [ __CLASS__, 'add_reusable_blocks_menu_link' ] );
 		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
 		add_filter( 'map_meta_cap', [ __CLASS__, 'prevent_accidental_page_deletion' ], 10, 4 );
+
+		// Disable WooCommerce image regeneration to prevent regenerating thousands of images.
+		add_filter( 'woocommerce_background_image_regeneration', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR disables [WooCommerce's automatic image regeneration](https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-regenerate-images.php). The feature is intended as a convenience to automate product image regeneration when switching themes (because different themes use different thumbnail sizes), however on our sites that can be thousands and thousands of images and causes infrastructure issues. Theme switching happens often when using the Site Design wizard.

There is a [check already to disable the feature when Photon is active](https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-regenerate-images.php#L42), but this is necessary just in case. :) 

### How to test the changes in this Pull Request:

1. Before applying this patch, activate WooCommerce. Switch to a non-Newspack theme. Check WooCommerce > Status > Logs. In the logs viewer, there should be an image resize log:

<img width="1653" alt="Screen Shot 2021-08-20 at 3 03 28 PM" src="https://user-images.githubusercontent.com/7317227/130299713-79d19668-07b1-4c4d-badc-fa651f09c886.png">


2. Apply this patch. Switch to a different non-Newspack theme. Confirm no new entries are added to the log.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->