### PR TITLE
Increase PWA network timeout limit

### DIFF
--- a/includes/class-pwa.php
+++ b/includes/class-pwa.php
@@ -22,6 +22,8 @@ class PWA {
 	public static function init() {
 		// For backwards compatibility and because there's no reason not to, always and automatically enable offline browsing.
 		add_filter( 'pre_option_offline_browsing', '__return_true' );
+
+		add_filter( 'wp_service_worker_navigation_caching', [ __CLASS__, 'increase_network_timeout' ] );
 	}
 
 	/**
@@ -69,6 +71,19 @@ class PWA {
 		} else {
 			delete_option( 'site_icon' );
 		}
+	}
+
+	/**
+	 * By default, PWA serves the offline-cached page if a request takes longer than 2 seconds. 
+	 * This is too short, especially for homepages with a lot of posts blocks.
+	 * 44 seconds is right before the 45-second PHP process timeout.
+	 *
+	 * @param array $config PWA config.
+	 * @return array Modified $config.
+	 */
+	public static function increase_network_timeout( $config ) {
+		$config['network_timeout_seconds'] = 44;
+		return $config;
 	}
 }
 PWA::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue that appeared after https://github.com/Automattic/newspack-plugin/pull/1094: for a lot of sites, people were not getting the latest homepage when visiting the site. 

This is because the default PWA config has a 2-second network timeout, where if a page takes longer than 2 seconds to load, PWA will serve the offline-cached page. This default is there as encouragement for sites to make their pages fast, but it seems too heavy-handed for our users. :) This PR increases the timeout to 44 seconds, which is one second before the PHP process will timeout on our infrastructure.

h/t @westonruter 🙌 

### How to test the changes in this Pull Request:

1. You'll need a site with valid HTTPS to test this PR, otherwise PWA won't work.
2. Add this code snippet somewhere:

```
// Wait 5 seconds.
add_action( 'init', function(){ sleep(5); } );
```

3. Before applying this patch, visit the homepage to prime the offline cache then create a new post. Observe you get served a cached version of the homepage after 2 seconds, and the new post doesn't appear.
4. Apply this patch. Unregister your existing service worker under Chrome dev console > Application > Unregister (top-right)

<img width="514" alt="Screen Shot 2021-08-24 at 11 12 06 AM" src="https://user-images.githubusercontent.com/7317227/130668203-e4c0133a-f5cd-4357-b124-53d44e5df453.png">

5. Visit the homepage to prime the offline cache. Create another new post. Visit the homepage again. Observe you get served an updated homepage with the new post after ~5 seconds.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->