### PR TITLE
Reorganise reader revenue

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -57,6 +57,7 @@ class ActionCard extends Component {
 			toggleChecked,
 			toggleOnChange,
 			hasGreyHeader,
+			noBorder,
 		} = this.props;
 		const hasChildren = notification || children;
 		const classes = classnames(
@@ -66,6 +67,7 @@ class ActionCard extends Component {
 			hasChildren && 'newspack-card--has-children',
 			isSmall && 'is-small',
 			isMedium && 'is-medium',
+			noBorder && 'newspack-card__no-border',
 			className
 		);
 		const titleProps =

--- a/assets/components/src/settings/SettingsCard.js
+++ b/assets/components/src/settings/SettingsCard.js
@@ -8,12 +8,13 @@ import classnames from 'classnames';
  */
 import { Grid, ActionCard } from '../';
 
-const SettingsCard = ( { children, className, columns, gutter, ...props } ) => {
+const SettingsCard = ( { children, className, columns, gutter, noBorder, ...props } ) => {
 	return (
 		<ActionCard
 			{ ...props }
 			className={ classnames( className, 'newspack-settings__card' ) }
 			notificationLevel="info"
+			noBorder={ noBorder }
 		>
 			<Grid columns={ columns } gutter={ gutter }>
 				{ children }

--- a/assets/components/src/settings/style.scss
+++ b/assets/components/src/settings/style.scss
@@ -18,6 +18,22 @@
 			}
 		}
 
+		// No border
+		&.newspack-card.newspack-card__no-border {
+			.newspack-action-card__region-top {
+				padding: 0 0 32px;
+			}
+
+			.newspack-action-card__region-children {
+				padding: 0;
+			}
+
+			& + & {
+				margin-top: 64px;
+			}
+		}
+
+		// Form Token Field
 		.newspack-form-token-field {
 			margin: 0;
 
@@ -26,6 +42,7 @@
 			}
 		}
 
+		// Section
 		.newspack-settings__section {
 			&__title {
 				display: flex;
@@ -57,6 +74,8 @@
 				}
 			}
 		}
+
+		// Min Max
 		.newspack-settings__min-max {
 			.newspack-checkbox-control {
 				flex: 0 0 64px;

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -184,12 +184,12 @@
 
 	ul {
 		list-style: disc;
-		margin: 0;
+		margin: 32px 0;
 		padding-left: 18px;
 	}
 
 	li {
-		margin-bottom: 0;
+		margin-bottom: 8px;
 	}
 
 	ul:last-child {

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -176,3 +176,54 @@
 		}
 	}
 }
+
+// Details
+
+.newspack-details {
+	margin: 32px 0;
+
+	ul {
+		list-style: disc;
+		margin: 0;
+		padding-left: 18px;
+	}
+
+	li {
+		margin-bottom: 0;
+	}
+
+	ul:last-child {
+		margin-bottom: 0;
+	}
+
+	svg {
+		color: $gray-900;
+		display: block;
+		margin-left: 3px;
+		transition: transform 125ms ease-in-out;
+	}
+
+	&[open] {
+		svg {
+			transform: rotate( 180deg );
+		}
+	}
+
+	summary {
+		align-items: center;
+		cursor: pointer;
+		display: inline-flex;
+
+		h2 {
+			margin: 0;
+		}
+
+		&:focus {
+			outline: none;
+		}
+
+		&::-webkit-details-marker {
+			display: none;
+		}
+	}
+}

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -192,7 +192,6 @@ class ReaderRevenueWizard extends Component {
 				return [];
 			}
 			return [
-				platformField,
 				donationField,
 				{
 					label: __( 'Stripe Gateway', 'newspack' ),
@@ -207,25 +206,26 @@ class ReaderRevenueWizard extends Component {
 					label: __( 'Address', 'newspack' ),
 					path: '/location-setup',
 				},
+				platformField,
 			];
 		} else if ( NRH === platform ) {
 			return [
-				platformField,
 				donationField,
 				{
 					label: __( 'NRH Settings', 'newspack' ),
 					path: '/settings',
 					exact: true,
 				},
+				platformField,
 			];
 		} else if ( STRIPE === platform ) {
 			return [
-				platformField,
 				donationField,
 				{
 					label: __( 'Stripe Settings', 'newspack' ),
 					path: '/stripe-setup',
 				},
+				platformField,
 			];
 		}
 		return [];

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -178,12 +178,9 @@ class ReaderRevenueWizard extends Component {
 	navigationForPlatform = ( platform, data ) => {
 		const platformField = {
 			label: __( 'Platform', 'newspack' ),
-			path: '/',
+			path: '/platform',
 			exact: true,
 		};
-		if ( ! platform ) {
-			return [ platformField ];
-		}
 		const donationField = {
 			label: __( 'Donations', 'newspack' ),
 			path: '/donations',
@@ -260,7 +257,7 @@ class ReaderRevenueWizard extends Component {
 					<Switch>
 						{ pluginRequirements }
 						<Route
-							path="/"
+							path="/platform"
 							exact
 							render={ () => (
 								<Platform
@@ -371,7 +368,7 @@ class ReaderRevenueWizard extends Component {
 								/>
 							) }
 						/>
-						<Redirect to="/" />
+						<Redirect to="/donations" />
 					</Switch>
 				</HashRouter>
 			</Fragment>

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -21,7 +21,7 @@ import { NEWSPACK, NRH, STRIPE } from './constants';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 const headerText = __( 'Reader revenue', 'newspack' );
-const subHeaderText = __( 'Generate revenue from your customers.', 'newspack' );
+const subHeaderText = __( 'Generate revenue from your customers', 'newspack' );
 
 class ReaderRevenueWizard extends Component {
 	/**
@@ -195,6 +195,7 @@ class ReaderRevenueWizard extends Component {
 				return [];
 			}
 			return [
+				platformField,
 				donationField,
 				{
 					label: __( 'Stripe Gateway', 'newspack' ),
@@ -209,26 +210,25 @@ class ReaderRevenueWizard extends Component {
 					label: __( 'Address', 'newspack' ),
 					path: '/location-setup',
 				},
-				platformField,
 			];
 		} else if ( NRH === platform ) {
 			return [
+				platformField,
 				donationField,
 				{
 					label: __( 'NRH Settings', 'newspack' ),
 					path: '/settings',
 					exact: true,
 				},
-				platformField,
 			];
 		} else if ( STRIPE === platform ) {
 			return [
+				platformField,
 				donationField,
 				{
 					label: __( 'Stripe Settings', 'newspack' ),
 					path: '/stripe-setup',
 				},
-				platformField,
 			];
 		}
 		return [];
@@ -285,7 +285,7 @@ class ReaderRevenueWizard extends Component {
 									headerText={ headerText }
 									subHeaderText={ subHeaderText }
 									tabbedNavigation={ tabbedNavigation }
-									buttonText={ __( 'Update', 'newspack' ) }
+									buttonText={ __( 'Save Settings', 'newspack' ) }
 									buttonAction={ () => this.update( '', platformData ) }
 									onChange={ _platformData =>
 										this.setState( { data: { ...data, platformData: _platformData } } )
@@ -334,10 +334,8 @@ class ReaderRevenueWizard extends Component {
 							render={ () => (
 								<Donation
 									data={ donationData }
-									headerText={ __( 'Set up donations' ) }
-									subHeaderText={ __(
-										'Configure your landing page and your suggested donation presets.'
-									) }
+									headerText={ headerText }
+									subHeaderText={ subHeaderText }
 									donationPage={ donationPage }
 									buttonText={ __( 'Save Settings' ) }
 									buttonAction={ () => this.update( 'donations', donationData ) }
@@ -354,12 +352,9 @@ class ReaderRevenueWizard extends Component {
 								<Salesforce
 									routeProps={ routeProps }
 									data={ salesforceData }
-									headerText={ __( 'Configure Salesforce', 'newspack' ) }
+									headerText={ headerText }
 									isConnected={ salesforceIsConnected }
-									subHeaderText={ __(
-										'Connect your site with a Salesforce account to capture donor contact information.',
-										'newspack'
-									) }
+									subHeaderText={ subHeaderText }
 									buttonText={
 										salesforceIsConnected ? __( 'Reset', 'newspack' ) : __( 'Connect', 'newspack' )
 									}

--- a/assets/wizards/readerRevenue/views/donation/index.js
+++ b/assets/wizards/readerRevenue/views/donation/index.js
@@ -21,6 +21,7 @@ import {
 	Grid,
 	Button,
 	Notice,
+	SectionHeader,
 	ToggleControl,
 	withWizardScreen,
 } from '../../../../components/src';
@@ -35,54 +36,67 @@ export const DontationAmounts = ( { data, onChange } ) => {
 
 	return (
 		<>
-			<h2>{ __( 'Suggested donations' ) }</h2>
-			<p>
-				{ __(
-					'Set suggested monthly donation amounts. The one-time and annual suggested donation amount will be adjusted according to the monthly amount.'
+			<SectionHeader
+				title={ __( 'Suggested Donations' ) }
+				description={ () => (
+					<>
+						{ __( 'Set suggested monthly donation amounts', 'newspack' ) }
+						<br />
+						{ __(
+							'The one-time and annual suggested donation amount will be adjusted according to the monthly amount',
+							'newspack'
+						) }
+					</>
 				) }
-			</p>
-			<ToggleControl
-				label={ __( 'Set exact monthly donation tiers' ) }
-				checked={ tiered }
-				onChange={ _tiered => onChange( { ...data, tiered: _tiered } ) }
 			/>
-			{ tiered ? (
-				<Grid columns={ 3 } gutter={ 8 }>
-					<MoneyInput
-						currencySymbol={ currencySymbol }
-						label={ __( 'Low-tier' ) }
-						value={ suggestedAmounts[ 0 ] }
-						onChange={ value =>
-							onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 0: value } } )
-						}
-					/>
-					<MoneyInput
-						currencySymbol={ currencySymbol }
-						label={ __( 'Mid-tier' ) }
-						value={ suggestedAmounts[ 1 ] }
-						onChange={ value =>
-							onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 1: value } } )
-						}
-					/>
-					<MoneyInput
-						currencySymbol={ currencySymbol }
-						label={ __( 'High-tier' ) }
-						value={ suggestedAmounts[ 2 ] }
-						onChange={ value =>
-							onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 2: value } } )
-						}
-					/>
-				</Grid>
-			) : (
-				<MoneyInput
-					currencySymbol={ currencySymbol }
-					label={ __( 'Suggested donation amount per month' ) }
-					value={ suggestedAmountUntiered }
-					onChange={ _suggestedAmountUntiered =>
-						onChange( { ...data, suggestedAmountUntiered: _suggestedAmountUntiered } )
-					}
+			<Grid columns={ 1 } gutter={ 16 }>
+				<ToggleControl
+					label={ __( 'Set exact monthly donation tiers' ) }
+					checked={ tiered }
+					onChange={ _tiered => onChange( { ...data, tiered: _tiered } ) }
 				/>
-			) }
+				<Grid columns={ 2 } gutter={ 32 }>
+					<Grid columns={ 3 } gutter={ 8 }>
+						{ tiered ? (
+							<>
+								<MoneyInput
+									currencySymbol={ currencySymbol }
+									label={ __( 'Low-tier', 'newspack' ) }
+									value={ suggestedAmounts[ 0 ] }
+									onChange={ value =>
+										onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 0: value } } )
+									}
+								/>
+								<MoneyInput
+									currencySymbol={ currencySymbol }
+									label={ __( 'Mid-tier', 'newspack' ) }
+									value={ suggestedAmounts[ 1 ] }
+									onChange={ value =>
+										onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 1: value } } )
+									}
+								/>
+								<MoneyInput
+									currencySymbol={ currencySymbol }
+									label={ __( 'High-tier', 'newspack' ) }
+									value={ suggestedAmounts[ 2 ] }
+									onChange={ value =>
+										onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 2: value } } )
+									}
+								/>
+							</>
+						) : (
+							<MoneyInput
+								currencySymbol={ currencySymbol }
+								label={ __( 'Amount', 'newspack' ) }
+								value={ suggestedAmountUntiered }
+								onChange={ _suggestedAmountUntiered =>
+									onChange( { ...data, suggestedAmountUntiered: _suggestedAmountUntiered } )
+								}
+							/>
+						) }
+					</Grid>
+				</Grid>
+			</Grid>
 		</>
 	);
 };
@@ -102,32 +116,34 @@ const Donation = ( { data = {}, onChange = () => null, donationPage } ) => {
 	return (
 		<>
 			{ renderErrorNotices() }
-			<Grid>
-				{ donationPage && (
-					<Card noBorder>
-						<h2>{ __( 'Donations landing page' ) }</h2>
-						{ 'publish' === donationPage.status ? (
-							<Notice
-								isSuccess
-								noticeText={ __( 'Your donations landing page is set up and published.' ) }
-							/>
-						) : (
-							<Notice
-								isError
-								noticeText={ __(
-									"Your donations landing page has been created, but is not yet published. You can now edit it and publish when you're ready."
-								) }
-							/>
-						) }
-						<Button isSecondary href={ donationPage.editUrl }>
-							{ __( 'Edit Page' ) }
+			{ donationPage && (
+				<Card noBorder>
+					<Card headerActions noBorder>
+						<h2>{ __( 'Donations Landing Page', 'newspack' ) }</h2>
+						<Button isSecondary isSmall href={ donationPage.editUrl }>
+							{ __( 'Edit Page', 'newspack' ) }
 						</Button>
 					</Card>
-				) }
-				<Card noBorder>
-					<DontationAmounts data={ data } onChange={ onChange } />
+					{ 'publish' === donationPage.status ? (
+						<Notice
+							isSuccess
+							noticeText={ __(
+								'Your donations landing page is set up and published.',
+								'newspack'
+							) }
+						/>
+					) : (
+						<Notice
+							isError
+							noticeText={ __(
+								"Your donations landing page has been created, but is not yet published. You can now edit it and publish when you're ready.",
+								'newspack'
+							) }
+						/>
+					) }
 				</Card>
-			</Grid>
+			) }
+			<DontationAmounts data={ data } onChange={ onChange } />
 		</>
 	);
 };

--- a/assets/wizards/readerRevenue/views/donation/index.js
+++ b/assets/wizards/readerRevenue/views/donation/index.js
@@ -8,11 +8,6 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * External dependencies.
- */
-import { values } from 'lodash';
-
-/**
  * Internal dependencies.
  */
 import { MoneyInput } from '../../components/';
@@ -104,18 +99,10 @@ export const DontationAmounts = ( { data, onChange } ) => {
 /**
  * Donation Settings Screen Component
  */
-const Donation = ( { data = {}, onChange = () => null, donationPage } ) => {
-	const renderErrorNotices = () => {
-		if ( data.errors && values( data.errors ).length ) {
-			return values( data.errors ).map( ( error, i ) => (
-				<Notice key={ i } isError noticeText={ error } />
-			) );
-		}
-	};
-
+const Donation = ( { data = {}, renderError, onChange = () => null, donationPage } ) => {
 	return (
 		<>
-			{ renderErrorNotices() }
+			{ renderError() }
 			{ donationPage && (
 				<Card noBorder>
 					<Card headerActions noBorder>

--- a/assets/wizards/readerRevenue/views/donation/index.js
+++ b/assets/wizards/readerRevenue/views/donation/index.js
@@ -30,7 +30,7 @@ export const DontationAmounts = ( { data, onChange } ) => {
 	} = data;
 
 	return (
-		<>
+		<div>
 			<SectionHeader
 				title={ __( 'Suggested Donations' ) }
 				description={ () => (
@@ -50,49 +50,45 @@ export const DontationAmounts = ( { data, onChange } ) => {
 					checked={ tiered }
 					onChange={ _tiered => onChange( { ...data, tiered: _tiered } ) }
 				/>
-				<Grid columns={ 2 } gutter={ 32 }>
+				{ tiered ? (
 					<Grid columns={ 3 } gutter={ 8 }>
-						{ tiered ? (
-							<>
-								<MoneyInput
-									currencySymbol={ currencySymbol }
-									label={ __( 'Low-tier', 'newspack' ) }
-									value={ suggestedAmounts[ 0 ] }
-									onChange={ value =>
-										onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 0: value } } )
-									}
-								/>
-								<MoneyInput
-									currencySymbol={ currencySymbol }
-									label={ __( 'Mid-tier', 'newspack' ) }
-									value={ suggestedAmounts[ 1 ] }
-									onChange={ value =>
-										onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 1: value } } )
-									}
-								/>
-								<MoneyInput
-									currencySymbol={ currencySymbol }
-									label={ __( 'High-tier', 'newspack' ) }
-									value={ suggestedAmounts[ 2 ] }
-									onChange={ value =>
-										onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 2: value } } )
-									}
-								/>
-							</>
-						) : (
-							<MoneyInput
-								currencySymbol={ currencySymbol }
-								label={ __( 'Amount', 'newspack' ) }
-								value={ suggestedAmountUntiered }
-								onChange={ _suggestedAmountUntiered =>
-									onChange( { ...data, suggestedAmountUntiered: _suggestedAmountUntiered } )
-								}
-							/>
-						) }
+						<MoneyInput
+							currencySymbol={ currencySymbol }
+							label={ __( 'Low-tier', 'newspack' ) }
+							value={ suggestedAmounts[ 0 ] }
+							onChange={ value =>
+								onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 0: value } } )
+							}
+						/>
+						<MoneyInput
+							currencySymbol={ currencySymbol }
+							label={ __( 'Mid-tier', 'newspack' ) }
+							value={ suggestedAmounts[ 1 ] }
+							onChange={ value =>
+								onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 1: value } } )
+							}
+						/>
+						<MoneyInput
+							currencySymbol={ currencySymbol }
+							label={ __( 'High-tier', 'newspack' ) }
+							value={ suggestedAmounts[ 2 ] }
+							onChange={ value =>
+								onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 2: value } } )
+							}
+						/>
 					</Grid>
-				</Grid>
+				) : (
+					<MoneyInput
+						currencySymbol={ currencySymbol }
+						label={ __( 'Amount', 'newspack' ) }
+						value={ suggestedAmountUntiered }
+						onChange={ _suggestedAmountUntiered =>
+							onChange( { ...data, suggestedAmountUntiered: _suggestedAmountUntiered } )
+						}
+					/>
+				) }
 			</Grid>
-		</>
+		</div>
 	);
 };
 

--- a/assets/wizards/readerRevenue/views/donation/index.js
+++ b/assets/wizards/readerRevenue/views/donation/index.js
@@ -30,7 +30,7 @@ export const DontationAmounts = ( { data, onChange } ) => {
 	} = data;
 
 	return (
-		<div>
+		<>
 			<SectionHeader
 				title={ __( 'Suggested Donations' ) }
 				description={ () => (
@@ -50,45 +50,47 @@ export const DontationAmounts = ( { data, onChange } ) => {
 					checked={ tiered }
 					onChange={ _tiered => onChange( { ...data, tiered: _tiered } ) }
 				/>
-				{ tiered ? (
-					<Grid columns={ 3 } gutter={ 8 }>
+				<Grid colums={ 2 } gutter={ 32 }>
+					{ tiered ? (
+						<Grid columns={ 3 } gutter={ 8 }>
+							<MoneyInput
+								currencySymbol={ currencySymbol }
+								label={ __( 'Low-tier', 'newspack' ) }
+								value={ suggestedAmounts[ 0 ] }
+								onChange={ value =>
+									onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 0: value } } )
+								}
+							/>
+							<MoneyInput
+								currencySymbol={ currencySymbol }
+								label={ __( 'Mid-tier', 'newspack' ) }
+								value={ suggestedAmounts[ 1 ] }
+								onChange={ value =>
+									onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 1: value } } )
+								}
+							/>
+							<MoneyInput
+								currencySymbol={ currencySymbol }
+								label={ __( 'High-tier', 'newspack' ) }
+								value={ suggestedAmounts[ 2 ] }
+								onChange={ value =>
+									onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 2: value } } )
+								}
+							/>
+						</Grid>
+					) : (
 						<MoneyInput
 							currencySymbol={ currencySymbol }
-							label={ __( 'Low-tier', 'newspack' ) }
-							value={ suggestedAmounts[ 0 ] }
-							onChange={ value =>
-								onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 0: value } } )
+							label={ __( 'Amount', 'newspack' ) }
+							value={ suggestedAmountUntiered }
+							onChange={ _suggestedAmountUntiered =>
+								onChange( { ...data, suggestedAmountUntiered: _suggestedAmountUntiered } )
 							}
 						/>
-						<MoneyInput
-							currencySymbol={ currencySymbol }
-							label={ __( 'Mid-tier', 'newspack' ) }
-							value={ suggestedAmounts[ 1 ] }
-							onChange={ value =>
-								onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 1: value } } )
-							}
-						/>
-						<MoneyInput
-							currencySymbol={ currencySymbol }
-							label={ __( 'High-tier', 'newspack' ) }
-							value={ suggestedAmounts[ 2 ] }
-							onChange={ value =>
-								onChange( { ...data, suggestedAmounts: { ...suggestedAmounts, 2: value } } )
-							}
-						/>
-					</Grid>
-				) : (
-					<MoneyInput
-						currencySymbol={ currencySymbol }
-						label={ __( 'Amount', 'newspack' ) }
-						value={ suggestedAmountUntiered }
-						onChange={ _suggestedAmountUntiered =>
-							onChange( { ...data, suggestedAmountUntiered: _suggestedAmountUntiered } )
-						}
-					/>
-				) }
+					) }
+				</Grid>
 			</Grid>
-		</div>
+		</>
 	);
 };
 
@@ -96,7 +98,7 @@ export const DontationAmounts = ( { data, onChange } ) => {
  * Donation Settings Screen Component
  */
 const Donation = ( { data = {}, onChange = () => null, donationPage } ) => (
-	<Grid>
+	<>
 		{ donationPage && (
 			<Card noBorder>
 				<Card headerActions noBorder>
@@ -122,7 +124,7 @@ const Donation = ( { data = {}, onChange = () => null, donationPage } ) => (
 			</Card>
 		) }
 		<DontationAmounts data={ data } onChange={ onChange } />
-	</Grid>
+	</>
 );
 
 export default withWizardScreen( Donation );

--- a/assets/wizards/readerRevenue/views/location-setup/index.js
+++ b/assets/wizards/readerRevenue/views/location-setup/index.js
@@ -6,12 +6,18 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { SelectControl, TextControl, withWizardScreen } from '../../../../components/src';
+import {
+	Card,
+	Grid,
+	SelectControl,
+	TextControl,
+	withWizardScreen,
+} from '../../../../components/src';
 
 /**
  * Location Setup Screen Component
@@ -31,40 +37,44 @@ class LocationSetup extends Component {
 			postcode = '',
 		} = data;
 		return (
-			<Fragment>
-				<SelectControl
-					label={ __( 'Where is your business based?' ) }
-					value={ countrystate }
-					options={ countryStateFields }
-					onChange={ _countrystate => onChange( { ...data, countrystate: _countrystate } ) }
-				/>
-				<TextControl
-					label={ __( 'Address' ) }
-					value={ address1 }
-					onChange={ _address1 => onChange( { ...data, address1: _address1 } ) }
-				/>
-				<TextControl
-					label={ __( 'Address line 2' ) }
-					value={ address2 }
-					onChange={ _address2 => onChange( { ...data, address2: _address2 } ) }
-				/>
-				<TextControl
-					label={ __( 'City' ) }
-					value={ city }
-					onChange={ _city => onChange( { ...data, city: _city } ) }
-				/>
-				<TextControl
-					label={ __( 'Postcode / Zip' ) }
-					value={ postcode }
-					onChange={ _postcode => onChange( { ...data, postcode: _postcode } ) }
-				/>
-				<SelectControl
-					label={ 'Which currency does your business use?' }
-					value={ currency }
-					options={ currencyFields }
-					onChange={ _currency => onChange( { ...data, currency: _currency } ) }
-				/>
-			</Fragment>
+			<Grid gutter={ 32 } rowGap={ 16 }>
+				<Card noBorder>
+					<TextControl
+						label={ __( 'Address', 'newspack' ) }
+						value={ address1 }
+						onChange={ _address1 => onChange( { ...data, address1: _address1 } ) }
+					/>
+					<TextControl
+						label={ __( 'Address line 2', 'newspack' ) }
+						value={ address2 }
+						onChange={ _address2 => onChange( { ...data, address2: _address2 } ) }
+					/>
+					<SelectControl
+						label={ __( 'Country', 'newspack' ) }
+						value={ countrystate }
+						options={ countryStateFields }
+						onChange={ _countrystate => onChange( { ...data, countrystate: _countrystate } ) }
+					/>
+				</Card>
+				<Card noBorder>
+					<TextControl
+						label={ __( 'City', 'newspack' ) }
+						value={ city }
+						onChange={ _city => onChange( { ...data, city: _city } ) }
+					/>
+					<TextControl
+						label={ __( 'Postcode / Zip', 'newspack' ) }
+						value={ postcode }
+						onChange={ _postcode => onChange( { ...data, postcode: _postcode } ) }
+					/>
+					<SelectControl
+						label={ __( 'Currency', 'newspack' ) }
+						value={ currency }
+						options={ currencyFields }
+						onChange={ _currency => onChange( { ...data, currency: _currency } ) }
+					/>
+				</Card>
+			</Grid>
 		);
 	}
 }

--- a/assets/wizards/readerRevenue/views/location-setup/index.js
+++ b/assets/wizards/readerRevenue/views/location-setup/index.js
@@ -27,7 +27,7 @@ class LocationSetup extends Component {
 	 * Render.
 	 */
 	render() {
-		const { countryStateFields, currencyFields, data, onChange } = this.props;
+		const { renderError, countryStateFields, currencyFields, data, onChange } = this.props;
 		const {
 			address1 = '',
 			address2 = '',
@@ -37,44 +37,47 @@ class LocationSetup extends Component {
 			postcode = '',
 		} = data;
 		return (
-			<Grid gutter={ 32 } rowGap={ 16 }>
-				<Card noBorder>
-					<TextControl
-						label={ __( 'Address', 'newspack' ) }
-						value={ address1 }
-						onChange={ _address1 => onChange( { ...data, address1: _address1 } ) }
-					/>
-					<TextControl
-						label={ __( 'Address line 2', 'newspack' ) }
-						value={ address2 }
-						onChange={ _address2 => onChange( { ...data, address2: _address2 } ) }
-					/>
-					<SelectControl
-						label={ __( 'Country', 'newspack' ) }
-						value={ countrystate }
-						options={ countryStateFields }
-						onChange={ _countrystate => onChange( { ...data, countrystate: _countrystate } ) }
-					/>
-				</Card>
-				<Card noBorder>
-					<TextControl
-						label={ __( 'City', 'newspack' ) }
-						value={ city }
-						onChange={ _city => onChange( { ...data, city: _city } ) }
-					/>
-					<TextControl
-						label={ __( 'Postcode / Zip', 'newspack' ) }
-						value={ postcode }
-						onChange={ _postcode => onChange( { ...data, postcode: _postcode } ) }
-					/>
-					<SelectControl
-						label={ __( 'Currency', 'newspack' ) }
-						value={ currency }
-						options={ currencyFields }
-						onChange={ _currency => onChange( { ...data, currency: _currency } ) }
-					/>
-				</Card>
-			</Grid>
+			<>
+				{ renderError() }
+				<Grid gutter={ 32 } rowGap={ 16 }>
+					<Card noBorder>
+						<TextControl
+							label={ __( 'Address', 'newspack' ) }
+							value={ address1 }
+							onChange={ _address1 => onChange( { ...data, address1: _address1 } ) }
+						/>
+						<TextControl
+							label={ __( 'Address line 2', 'newspack' ) }
+							value={ address2 }
+							onChange={ _address2 => onChange( { ...data, address2: _address2 } ) }
+						/>
+						<SelectControl
+							label={ __( 'Country', 'newspack' ) }
+							value={ countrystate }
+							options={ countryStateFields }
+							onChange={ _countrystate => onChange( { ...data, countrystate: _countrystate } ) }
+						/>
+					</Card>
+					<Card noBorder>
+						<TextControl
+							label={ __( 'City', 'newspack' ) }
+							value={ city }
+							onChange={ _city => onChange( { ...data, city: _city } ) }
+						/>
+						<TextControl
+							label={ __( 'Postcode / Zip', 'newspack' ) }
+							value={ postcode }
+							onChange={ _postcode => onChange( { ...data, postcode: _postcode } ) }
+						/>
+						<SelectControl
+							label={ __( 'Currency', 'newspack' ) }
+							value={ currency }
+							options={ currencyFields }
+							onChange={ _currency => onChange( { ...data, currency: _currency } ) }
+						/>
+					</Card>
+				</Grid>
+			</>
 		);
 	}
 }

--- a/assets/wizards/readerRevenue/views/nrh-settings/index.js
+++ b/assets/wizards/readerRevenue/views/nrh-settings/index.js
@@ -24,7 +24,7 @@ class NRHSettings extends Component {
 		const { data, onChange } = this.props;
 		const { nrh_organization_id, nrh_salesforce_campaign_id } = data;
 		return (
-			<Grid>
+			<Grid gutter={ 32 }>
 				<TextControl
 					label={ __( 'NRH Organization ID (required)', 'newspack' ) }
 					value={ nrh_organization_id || '' }

--- a/assets/wizards/readerRevenue/views/platform/index.js
+++ b/assets/wizards/readerRevenue/views/platform/index.js
@@ -24,9 +24,9 @@ const Platform = ( { data, onChange, onReady, pluginStatus } ) => {
 	const { platform } = data;
 	return (
 		<Fragment>
-			<Grid>
+			<Grid gutter={ 32 }>
 				<SelectControl
-					label={ __( 'Select Reader Revenue Platform', 'newspack' ) }
+					label={ __( 'Reader Revenue Platform', 'newspack' ) }
 					value={ platform }
 					options={ [
 						{ label: __( '-- Select Your Platform --', 'newspack' ), value: '' },

--- a/assets/wizards/readerRevenue/views/platform/index.js
+++ b/assets/wizards/readerRevenue/views/platform/index.js
@@ -5,13 +5,12 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { Grid, PluginInstaller, SelectControl, withWizardScreen } from '../../../../components/src';
+import { Grid, SelectControl, withWizardScreen } from '../../../../components/src';
 import Router from '../../../../components/src/proxied-imports/router';
 import { NEWSPACK, NRH, STRIPE } from '../../constants';
 
@@ -20,10 +19,11 @@ const { withRouter } = Router;
 /**
  * Platform Selection  Screen Component
  */
-const Platform = ( { data, onChange, onReady, pluginStatus } ) => {
+const Platform = ( { renderError, data, onChange } ) => {
 	const { platform } = data;
 	return (
-		<Fragment>
+		<>
+			{ renderError() }
 			<Grid gutter={ 32 }>
 				<SelectControl
 					label={ __( 'Reader Revenue Platform', 'newspack' ) }
@@ -54,23 +54,7 @@ const Platform = ( { data, onChange, onReady, pluginStatus } ) => {
 					} }
 				/>
 			</Grid>
-			{ NEWSPACK === platform && ! pluginStatus && (
-				<PluginInstaller
-					plugins={ [
-						'woocommerce',
-						'woocommerce-subscriptions',
-						'woocommerce-name-your-price',
-						'woocommerce-gateway-stripe',
-					] }
-					onStatus={ ( { complete } ) => {
-						if ( complete ) {
-							onReady();
-						}
-					} }
-					withoutFooterButton={ true }
-				/>
-			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -137,7 +137,7 @@ class Salesforce extends Component {
 		const { client_id = '', client_secret = '', error } = data;
 
 		return (
-			<Grid>
+			<Grid gutter={ 32 }>
 				<Card noBorder>
 					{ this.state.error && <Notice noticeText={ this.state.error } isWarning /> }
 

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -31,6 +31,7 @@ import {
 	withWizardScreen,
 } from '../../../../components/src';
 import NewsletterSettings from './newsletter-settings';
+import './style.scss';
 
 const { SettingsCard } = Settings;
 
@@ -128,7 +129,12 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 					{ data.connection_error !== false && (
 						<Notice isError noticeText={ data.connection_error } />
 					) }
-					<SettingsCard title={ __( 'Settings', 'newspack' ) } columns={ 1 } noBorder>
+					<SettingsCard
+						title={ __( 'Settings', 'newspack' ) }
+						className="newspack-settings__stripe"
+						columns={ 1 }
+						noBorder
+					>
 						{ data.can_use_stripe_platform === false && (
 							<Notice
 								isError

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -97,7 +97,13 @@ export const StripeKeysSettings = ( { data, onChange } ) => {
 	);
 };
 
-const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyFields } ) => {
+const StripeSetup = ( {
+	data,
+	onChange,
+	renderError,
+	displayStripeSettingsOnly,
+	currencyFields,
+} ) => {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const createWebhooks = () => {
 		setIsLoading( true );
@@ -109,6 +115,7 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 	};
 	return (
 		<>
+			{ renderError() }
 			{ data.isSSL === false && (
 				<Notice
 					isWarning

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -43,13 +43,6 @@ export const StripeKeysSettings = ( { data, onChange } ) => {
 	} = data;
 	return (
 		<Grid columns={ 1 } gutter={ 16 }>
-			<p>
-				{ __( 'Configure Stripe and enter your API keys' ) }
-				{ ' – ' }
-				<ExternalLink href="https://stripe.com/docs/keys#api-keys">
-					{ __( 'learn how' ) }
-				</ExternalLink>
-			</p>
 			<CheckboxControl
 				label={ __( 'Use Stripe in test mode' ) }
 				checked={ testMode }
@@ -71,7 +64,9 @@ export const StripeKeysSettings = ( { data, onChange } ) => {
 							type="password"
 							value={ testSecretKey }
 							label={ __( 'Test Secret Key' ) }
-							onChange={ _testSecretKey => onChange( { ...data, testSecretKey: _testSecretKey } ) }
+							onChange={ _testSecretKey =>
+								onChange( { ...data, testSecretKey: _testSecretKey } )
+							}
 						/>
 					</>
 				) : (
@@ -127,7 +122,20 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 					{ data.connection_error !== false && (
 						<Notice isError noticeText={ data.connection_error } />
 					) }
-					<SettingsCard title={ __( 'Settings', 'newspack' ) } columns={ 1 }>
+					<SettingsCard
+						title={ __( 'Settings', 'newspack' ) }
+						description={ () => (
+							<>
+								{ __( 'Configure Stripe and enter your API keys', 'newspack' ) }
+								{ ' – ' }
+								<ExternalLink href="https://stripe.com/docs/keys#api-keys">
+									{ __( 'learn how', 'newspack' ) }
+								</ExternalLink>
+							</>
+						) }
+						columns={ 1 }
+						noBorder
+					>
 						{ data.can_use_stripe_platform === false && (
 							<Notice
 								isError
@@ -154,6 +162,7 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 							'newspack'
 						) }
 						columns={ 1 }
+						noBorder
 					>
 						<NewsletterSettings
 							listId={ data.newsletter_list_id }
@@ -167,29 +176,28 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 							'newspack'
 						) }
 						columns={ 1 }
+						noBorder
 					>
-						<div>
-							{ data.webhooks?.errors ? (
-								<Notice isError noticeText={ values( data.webhooks.errors ).join( ', ' ) } />
-							) : (
-								<>
-									{ data.webhooks.length ? (
-										<ul className="newspack-list">
-											{ data.webhooks.map( ( webhook, i ) => (
-												<li key={ i }>
-													<code>{ webhook.url }</code>
-												</li>
-											) ) }
-										</ul>
-									) : (
-										<div className="mb3">{ __( 'No webhooks defined.', 'newspack' ) }</div>
-									) }
-									<Button isLink disabled={ isLoading } onClick={ createWebhooks } isSecondary>
-										{ __( 'Create webhooks', 'newspack' ) }
-									</Button>
-								</>
-							) }
-						</div>
+						{ data.webhooks?.errors ? (
+							<Notice isError noticeText={ values( data.webhooks.errors ).join( ', ' ) } />
+						) : (
+							<div>
+								{ data.webhooks.length ? (
+									<ul className="newspack-list">
+										{ data.webhooks.map( ( webhook, i ) => (
+											<li key={ i }>
+												<code>{ webhook.url }</code>
+											</li>
+										) ) }
+									</ul>
+								) : (
+									<div className="mb3">{ __( 'No webhooks defined.', 'newspack' ) }</div>
+								) }
+								<Button isLink disabled={ isLoading } onClick={ createWebhooks } isSecondary>
+									{ __( 'Create webhooks', 'newspack' ) }
+								</Button>
+							</div>
+						) }
 					</SettingsCard>
 				</>
 			) : (

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -19,6 +19,7 @@ import { values } from 'lodash';
  * Internal dependencies
  */
 import {
+	Card,
 	CheckboxControl,
 	Grid,
 	Button,
@@ -43,6 +44,13 @@ export const StripeKeysSettings = ( { data, onChange } ) => {
 	} = data;
 	return (
 		<Grid columns={ 1 } gutter={ 16 }>
+			<p>
+				{ __( 'Configure Stripe and enter your API keys', 'newspack' ) }
+				{ ' – ' }
+				<ExternalLink href="https://stripe.com/docs/keys#api-keys">
+					{ __( 'learn how', 'newspack' ) }
+				</ExternalLink>
+			</p>
 			<CheckboxControl
 				label={ __( 'Use Stripe in test mode' ) }
 				checked={ testMode }
@@ -120,20 +128,7 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 					{ data.connection_error !== false && (
 						<Notice isError noticeText={ data.connection_error } />
 					) }
-					<SettingsCard
-						title={ __( 'Settings', 'newspack' ) }
-						description={ () => (
-							<>
-								{ __( 'Configure Stripe and enter your API keys', 'newspack' ) }
-								{ ' – ' }
-								<ExternalLink href="https://stripe.com/docs/keys#api-keys">
-									{ __( 'learn how', 'newspack' ) }
-								</ExternalLink>
-							</>
-						) }
-						columns={ 1 }
-						noBorder
-					>
+					<SettingsCard title={ __( 'Settings', 'newspack' ) } columns={ 1 } noBorder>
 						{ data.can_use_stripe_platform === false && (
 							<Notice
 								isError
@@ -179,7 +174,7 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 						{ data.webhooks?.errors ? (
 							<Notice isError noticeText={ values( data.webhooks.errors ).join( ', ' ) } />
 						) : (
-							<div>
+							<>
 								{ data.webhooks.length ? (
 									<ul className="newspack-list">
 										{ data.webhooks.map( ( webhook, i ) => (
@@ -189,12 +184,14 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 										) ) }
 									</ul>
 								) : (
-									<div className="mb3">{ __( 'No webhooks defined.', 'newspack' ) }</div>
+									<Notice isWarning noticeText={ __( 'No webhooks defined.', 'newspack' ) } />
 								) }
-								<Button isLink disabled={ isLoading } onClick={ createWebhooks } isSecondary>
-									{ __( 'Create webhooks', 'newspack' ) }
-								</Button>
-							</div>
+								<Card noBorder>
+									<Button isSecondary isSmall disabled={ isLoading } onClick={ createWebhooks }>
+										{ __( 'Create webhooks', 'newspack' ) }
+									</Button>
+								</Card>
+							</>
 						) }
 					</SettingsCard>
 				</>

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -64,9 +64,7 @@ export const StripeKeysSettings = ( { data, onChange } ) => {
 							type="password"
 							value={ testSecretKey }
 							label={ __( 'Test Secret Key' ) }
-							onChange={ _testSecretKey =>
-								onChange( { ...data, testSecretKey: _testSecretKey } )
-							}
+							onChange={ _testSecretKey => onChange( { ...data, testSecretKey: _testSecretKey } ) }
 						/>
 					</>
 				) : (

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -143,7 +143,7 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 							<ul>
 								{ data.webhooks.map( ( webhook, i ) => (
 									<li key={ i }>
-										- <code>{ webhook.url }</code>
+										<code>{ webhook.url }</code>
 									</li>
 								) ) }
 							</ul>

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -6,15 +6,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { ExternalLink } from '@wordpress/components';
+import { Icon, chevronDown } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import {
-	Card,
 	CheckboxControl,
 	Grid,
 	Button,
@@ -34,25 +34,23 @@ export const StripeKeysSettings = ( { data, onChange } ) => {
 		testSecretKey = '',
 	} = data;
 	return (
-		<Fragment>
-			<Card noBorder>
-				<p className="newspack-payment-setup-screen__api-keys-instruction">
-					{ __( 'Configure Stripe and enter your API keys' ) }
-					{ ' – ' }
-					<ExternalLink href="https://stripe.com/docs/keys#api-keys">
-						{ __( 'learn how' ) }
-					</ExternalLink>
-				</p>
-				<CheckboxControl
-					label={ __( 'Use Stripe in test mode' ) }
-					checked={ testMode }
-					onChange={ _testMode => onChange( { ...data, testMode: _testMode } ) }
-					tooltip="Test mode will not capture real payments. Use it for testing your purchase flow."
-				/>
-			</Card>
-			<Grid noMargin>
+		<Grid columns={ 1 } gutter={ 16 }>
+			<p>
+				{ __( 'Configure Stripe and enter your API keys' ) }
+				{ ' – ' }
+				<ExternalLink href="https://stripe.com/docs/keys#api-keys">
+					{ __( 'learn how' ) }
+				</ExternalLink>
+			</p>
+			<CheckboxControl
+				label={ __( 'Use Stripe in test mode' ) }
+				checked={ testMode }
+				onChange={ _testMode => onChange( { ...data, testMode: _testMode } ) }
+				tooltip="Test mode will not capture real payments. Use it for testing your purchase flow."
+			/>
+			<Grid gutter={ 32 }>
 				{ testMode ? (
-					<Fragment>
+					<>
 						<TextControl
 							type="password"
 							value={ testPublishableKey }
@@ -67,9 +65,9 @@ export const StripeKeysSettings = ( { data, onChange } ) => {
 							label={ __( 'Test Secret Key' ) }
 							onChange={ _testSecretKey => onChange( { ...data, testSecretKey: _testSecretKey } ) }
 						/>
-					</Fragment>
+					</>
 				) : (
-					<Fragment>
+					<>
 						<TextControl
 							type="password"
 							value={ publishableKey }
@@ -84,10 +82,10 @@ export const StripeKeysSettings = ( { data, onChange } ) => {
 							label={ __( 'Secret Key' ) }
 							onChange={ _secretKey => onChange( { ...data, secretKey: _secretKey } ) }
 						/>
-					</Fragment>
+					</>
 				) }
 			</Grid>
-		</Fragment>
+		</Grid>
 	);
 };
 
@@ -102,7 +100,7 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 		} );
 	};
 	return (
-		<Fragment>
+		<>
 			{ data.isSSL === false && (
 				<Notice
 					isWarning
@@ -128,15 +126,18 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 						/>
 					) }
 					<StripeKeysSettings data={ data } onChange={ onChange } />
-					<SelectControl
-						label={ __( 'Which currency does your business use?', 'newspack' ) }
-						value={ data.currency }
-						options={ currencyFields }
-						onChange={ _currency => onChange( { ...data, currency: _currency } ) }
-					/>
-					<details>
+					<Grid gutter={ 32 } style={ { marginTop: -16 } }>
+						<SelectControl
+							label={ __( 'Currency', 'newspack' ) }
+							value={ data.currency }
+							options={ currencyFields }
+							onChange={ _currency => onChange( { ...data, currency: _currency } ) }
+						/>
+					</Grid>
+					<details className="newspack-details" style={ { marginTop: 64 } }>
 						<summary>
-							<h3 className="di">{ __( 'Webhooks', 'newspack' ) }</h3>
+							<h2>{ __( 'Webhooks', 'newspack' ) }</h2>
+							<Icon icon={ chevronDown } size={ 18 } />
 						</summary>
 						{ data.webhooks.length ? (
 							<ul>
@@ -147,37 +148,33 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 								) ) }
 							</ul>
 						) : (
-							<div className="mb3">{ __( 'No webhooks defined.', 'newspack' ) }</div>
+							<Notice isInfo noticeText={ __( 'No webhooks defined.', 'newspack' ) } />
 						) }
-						<Button disabled={ isLoading } onClick={ createWebhooks } isSecondary>
+						<Button disabled={ isLoading } onClick={ createWebhooks } isSecondary isSmall>
 							{ __( 'Create webhooks', 'newspack' ) }
 						</Button>
 					</details>
 				</>
 			) : (
 				<>
-					<Grid>
-						<ToggleControl
-							label={ __( 'Enable Stripe' ) }
-							checked={ data.enabled }
-							onChange={ _enabled => onChange( { ...data, enabled: _enabled } ) }
-						/>
-					</Grid>
+					<ToggleControl
+						label={ __( 'Enable Stripe' ) }
+						checked={ data.enabled }
+						onChange={ _enabled => onChange( { ...data, enabled: _enabled } ) }
+					/>
 					{ data.enabled ? (
 						<StripeKeysSettings data={ data } onChange={ onChange } />
 					) : (
-						<Grid>
-							<p className="newspack-payment-setup-screen__info">
-								{ __( 'Other gateways can be enabled and set up in the ' ) }
-								<ExternalLink href="/wp-admin/admin.php?page=wc-settings&tab=checkout">
-									{ __( 'WooCommerce payment gateway settings' ) }
-								</ExternalLink>
-							</p>
-						</Grid>
+						<p>
+							{ __( 'Other gateways can be enabled and set up in the ' ) }
+							<ExternalLink href="/wp-admin/admin.php?page=wc-settings&tab=checkout">
+								{ __( 'WooCommerce payment gateway settings' ) }
+							</ExternalLink>
+						</p>
 					) }
 				</>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/wizards/readerRevenue/views/stripe-setup/newsletter-settings.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/newsletter-settings.js
@@ -8,7 +8,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { SelectControl, Notice, Waiting } from '../../../../components/src';
+import { Grid, Notice, SelectControl, Waiting } from '../../../../components/src';
 
 const NewslettersSettings = ( { listId, onChange } ) => {
 	const [ newslettersLists, setNewsletterLists ] = useState( false );
@@ -42,15 +42,17 @@ const NewslettersSettings = ( { listId, onChange } ) => {
 					</span>
 				}
 			/>
-			<SelectControl
-				value={ listId }
-				label={ __( 'Chosen list', 'newspack' ) }
-				options={ [
-					{ value: '', label: __( '-- Choose a list --', 'newspack' ) },
-					...newslettersLists.map( item => ( { value: item.id, label: item.name } ) ),
-				] }
-				onChange={ onChange }
-			/>
+			<Grid gutter={ 32 }>
+				<SelectControl
+					value={ listId }
+					label={ __( 'Chosen list', 'newspack' ) }
+					options={ [
+						{ value: '', label: __( '-- Choose a list --', 'newspack' ) },
+						...newslettersLists.map( item => ( { value: item.id, label: item.name } ) ),
+					] }
+					onChange={ onChange }
+				/>
+			</Grid>
 		</>
 	);
 };

--- a/assets/wizards/readerRevenue/views/stripe-setup/style.scss
+++ b/assets/wizards/readerRevenue/views/stripe-setup/style.scss
@@ -1,0 +1,13 @@
+/**
+ * Stripe Setup
+ */
+
+.newspack-settings__stripe {
+	.newspack-action-card__region-top {
+		padding-bottom: 0 !important;
+	}
+
+	.newspack-grid__columns-1 > p:first-of-type {
+		padding-bottom: 16px;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR reorganises the Reader Revenue, displaying the platform screen first and then using `Grid` throughout the various screens

### How to test the changes in this Pull Request:

1. Check the Reader Revenue -- Test all the different platform options and menu items
2. Switch to this branch
3. Repeat 1.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->