### PR TITLE
fix(campaigns-wizard): prompt duplication

### DIFF
--- a/assets/wizards/popups/components/prompt-popovers/primary.js
+++ b/assets/wizards/popups/components/prompt-popovers/primary.js
@@ -23,7 +23,7 @@ const PrimaryPromptPopover = ( {
 	prompt,
 	previewPopup,
 	publishPopup,
-	setModalVisible,
+	setIsDuplicatePromptModalVisible,
 	unpublishPopup,
 } ) => {
 	const { id, edit_link: editLink, status } = prompt;
@@ -63,7 +63,10 @@ const PrimaryPromptPopover = ( {
 					<MenuItem href={ decodeEntities( editLink ) } className="newspack-button" isLink>
 						{ __( 'Edit', 'newspack' ) }
 					</MenuItem>
-					<MenuItem onClick={ () => setModalVisible( true ) } className="newspack-button">
+					<MenuItem
+						onClick={ () => setIsDuplicatePromptModalVisible( true ) }
+						className="newspack-button"
+					>
 						{ __( 'Duplicate', 'newspack' ) }
 					</MenuItem>
 					<MenuItem


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-popups/issues/597 

### How to test the changes in this Pull Request:

1. On `master`, observe prompt duplication in Campaigns wizard is not working
2. Switch to this branch, rebuild, observe it's working

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->