### PR TITLE
feat(oauth): use a self-hosted proxy for authenication

### DIFF
--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -275,7 +275,7 @@ class Google_OAuth {
 			)
 		);
 
-		if ( 200 === $token_info_response['response']['code'] ) {
+		if ( 200 === wp_remote_retrieve_response_code( $token_info_response ) ) {
 			$user_info_response = wp_safe_remote_get(
 				add_query_arg(
 					'access_token',
@@ -283,7 +283,7 @@ class Google_OAuth {
 					'https://www.googleapis.com/oauth2/v2/userinfo'
 				)
 			);
-			if ( 200 === $user_info_response['response']['code'] ) {
+			if ( 200 === wp_remote_retrieve_response_code( $user_info_response ) ) {
 				$user_info = json_decode( $user_info_response['body'] );
 				return [
 					'email' => $user_info->email,
@@ -332,8 +332,8 @@ class Google_OAuth {
 				}
 				$response_body = json_decode( $result['body'] );
 
-				if ( isset( $response->access_token ) ) {
-					self::save_auth_credentials( $response->data );
+				if ( isset( $response_body->access_token ) ) {
+					self::save_auth_credentials( $response_body );
 					$auth_data = self::get_google_auth_saved_data();
 				}
 			} catch ( \Exception $e ) {

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -174,10 +174,14 @@ class Google_OAuth {
 	 * @return WP_REST_Response Response with the URL.
 	 */
 	public static function api_google_auth_start() {
+		$wpcom_access_token = WPCOM_OAuth::get_access_token();
+		if ( is_wp_error( $wpcom_access_token ) ) {
+			return $wpcom_access_token;
+		}
 		$proxy_url = self::get_oauth_proxy_url( '/wp-json/newspack-oauth-proxy/v1/start' );
 		try {
 			$query_args                       = self::get_google_auth_url_params();
-			$query_args['wpcom_access_token'] = WPCOM_OAuth::get_access_token();
+			$query_args['wpcom_access_token'] = $wpcom_access_token;
 			$url                              = add_query_arg( $query_args, $proxy_url );
 			$result                           = wp_safe_remote_get( $url );
 			if ( is_wp_error( $result ) ) {

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -150,7 +150,6 @@ class Google_OAuth {
 		$redirect_after = admin_url( 'admin.php?page=newspack' );
 
 		return [
-			'service'        => 'google',
 			'csrf_token'     => self::generate_csrf_token(),
 			'scope'          => implode( ' ', $scopes ),
 			'redirect_after' => $redirect_after,
@@ -158,21 +157,40 @@ class Google_OAuth {
 	}
 
 	/**
+	 * Get the OAuth proxy URL.
+	 *
+	 * @param string $path Path to append to base URL.
+	 */
+	private static function get_oauth_proxy_url( $path = '' ) {
+		if ( ! defined( 'NEWSPACK_GOOGLE_OAUTH_PROXY' ) ) {
+			return false;
+		}
+		return NEWSPACK_GOOGLE_OAUTH_PROXY . $path;
+	}
+
+	/**
 	 * Start the Google OAuth2 flow, which will use WPCOM as a proxy to issue credentials.
 	 *
-	 * @param WP_REST_Request $request Request.
 	 * @return WP_REST_Response Response with the URL.
 	 */
-	public static function api_google_auth_start( $request ) {
+	public static function api_google_auth_start() {
+		$proxy_url = self::get_oauth_proxy_url( '/wp-json/newspack-oauth-proxy/v1/start' );
 		try {
-			$response = WPCOM_OAuth::perform_wpcom_api_request(
-				'rest/v1.1/newspack/oauth',
-				self::get_google_auth_url_params()
-			);
-			return \rest_ensure_response( $response->data->url );
+			$query_args                       = self::get_google_auth_url_params();
+			$query_args['wpcom_access_token'] = WPCOM_OAuth::get_access_token();
+			$url                              = add_query_arg( $query_args, $proxy_url );
+			$result                           = wp_safe_remote_get( $url );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			if ( 200 !== $result['response']['code'] ) {
+				return wp_send_json_error( json_decode( $result['body'] )->data->message, 400 );
+			}
+			$response_body = json_decode( $result['body'] );
+			return \rest_ensure_response( $response_body->url );
 		} catch ( \Exception $e ) {
 			return new WP_Error(
-				'newspack_support_error',
+				'newspack_google_oauth',
 				$e->getMessage()
 			);
 		}
@@ -204,10 +222,18 @@ class Google_OAuth {
 	 * Get Google authentication status.
 	 */
 	public static function api_google_auth_status() {
+		$response        = [
+			'user_basic_info' => false,
+			'can_google_auth' => false,
+		];
+		$can_google_auth = self::is_oauth_configured();
+		if ( false === $can_google_auth ) {
+			return \rest_ensure_response( $response );
+		}
 		return \rest_ensure_response(
 			[
 				'user_basic_info' => self::authenticated_user_basic_information(),
-				'can_google_auth' => self::is_oauth_configured(),
+				'can_google_auth' => $can_google_auth,
 			]
 		);
 	}
@@ -283,22 +309,27 @@ class Google_OAuth {
 		if ( ! isset( $auth_data['access_token'] ) ) {
 			return false;
 		}
-
 		$is_expired = time() > $auth_data['expires_at'];
 
 		if ( $is_expired && isset( $auth_data['refresh_token'] ) ) {
 			// Refresh the access token.
 			try {
-				$response = WPCOM_OAuth::perform_wpcom_api_request(
-					add_query_arg(
-						[
-							'refresh_token' => $auth_data['refresh_token'],
-							'csrf_token'    => self::generate_csrf_token(),
-						],
-						'rest/v1.1/newspack/oauth/refresh-token'
-					)
+				$proxy_url = self::get_oauth_proxy_url( '/wp-json/newspack-oauth-proxy/v1/refresh-token' );
+				$url       = add_query_arg(
+					[
+						'refresh_token'      => $auth_data['refresh_token'],
+						'csrf_token'         => self::generate_csrf_token(),
+						'wpcom_access_token' => WPCOM_OAuth::get_access_token(),
+					],
+					$proxy_url
 				);
-				if ( isset( $response->data->access_token ) ) {
+				$result    = wp_safe_remote_get( $url );
+				if ( 200 !== $result['response']['code'] ) {
+					return wp_send_json_error( json_decode( $result['body'] )->data->message, 400 );
+				}
+				$response_body = json_decode( $result['body'] );
+
+				if ( isset( $response->access_token ) ) {
 					self::save_auth_credentials( $response->data );
 					$auth_data = self::get_google_auth_saved_data();
 				}
@@ -325,11 +356,7 @@ class Google_OAuth {
 	 * Is OAuth2 configured for this instance?
 	 */
 	private static function is_oauth_configured() {
-		$is_enabled = defined( 'NEWSPACK_GOOGLE_OAUTH_ENABLED' ) && NEWSPACK_GOOGLE_OAUTH_ENABLED;
-		if ( ! $is_enabled ) {
-			return false;
-		}
-		return WPCOM_OAuth::is_newspack_customer();
+		return false !== self::get_oauth_proxy_url();
 	}
 }
 new Google_OAuth();

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -167,7 +167,7 @@ class Google_OAuth {
 		}
 		return add_query_arg(
 			[
-				'wpcom_access_token' => WPCOM_OAuth::get_access_token(),
+				'wpcom_access_token' => urlencode( WPCOM_OAuth::get_access_token() ),
 			],
 			NEWSPACK_GOOGLE_OAUTH_PROXY . $path
 		);

--- a/includes/oauth/class-wpcom-oauth.php
+++ b/includes/oauth/class-wpcom-oauth.php
@@ -195,17 +195,5 @@ class WPCOM_OAuth {
 	public static function wpcom_client_id() {
 		return ( defined( 'NEWSPACK_WPCOM_CLIENT_ID' ) && NEWSPACK_WPCOM_CLIENT_ID ) ? NEWSPACK_WPCOM_CLIENT_ID : false;
 	}
-
-	/**
-	 * Is the authenticated user a Newspack customer?
-	 */
-	public static function is_newspack_customer() {
-		try {
-			$response = self::perform_wpcom_api_request( 'rest/v1.1/newspack/is-customer' );
-			return 200 === $response->status;
-		} catch ( \Exception $e ) {
-			return false;
-		}
-	}
 }
 new WPCOM_OAuth();

--- a/tests/unit-tests/oauth.php
+++ b/tests/unit-tests/oauth.php
@@ -50,7 +50,6 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 		self::assertEquals(
 			$consent_page_params,
 			[
-				'service'        => 'google',
 				'scope'          => 'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/analytics.edit https://www.googleapis.com/auth/dfp',
 				'redirect_after' => 'http://example.org/wp-admin/admin.php?page=newspack',
 				'csrf_token'     => $csrf_token,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The OAuth saga continues. With this approach, the OAuth proxy is hosted on an arbitrary site, not wordpress.com. 

### How to test the changes in this Pull Request:

1. Define `NEWSPACK_GOOGLE_OAUTH_PROXY` in the site's environment, ensure WPCOM is authorised (visit the Support wizard to check)
2. To start afresh and get a `refresh_token`, remove Newspack from [authorised Google apps](https://myaccount.google.com/permissions)
3. Also, remove the `_newspack_google_oauth` user meta, if it exists
4. Visit the Newspack dashboard and complete the OAuth flow by clicking on the "Google Connection" tile
5. Check back after at least an hour to see if the token will be refreshed - you should still see "Authorized Google as <email-address>" on the "Google Connection" tile
6. Test some re-authentication scenarios by re-doing steps 2 or 3 (separately) and authenticating again
7. Test as a WPCOM user who is not Newspack customer - you should not be able to complete the OAuth flow

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->