### PR TITLE
feat: allow multiple GAM network codes

### DIFF
--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -55,9 +55,9 @@ class AdvertisingWizard extends Component {
 	/**
 	 * Retrieve advertising data
 	 */
-	fetchAdvertisingData = () => {
+	fetchAdvertisingData = ( quiet = false ) => {
 		const { setError, wizardApiFetch } = this.props;
-		return wizardApiFetch( { path: '/newspack/v1/wizard/advertising' } )
+		return wizardApiFetch( { path: '/newspack/v1/wizard/advertising', quiet } )
 			.then( advertisingData => {
 				return new Promise( resolve => {
 					this.setState(
@@ -339,6 +339,7 @@ class AdvertisingWizard extends Component {
 										secondaryButtonAction="#/"
 										wizardApiFetch={ wizardApiFetch }
 										gamConnectionStatus={ advertisingData.gam_connection_status }
+										fetchAdvertisingData={ this.fetchAdvertisingData }
 										updateAdUnit={ adUnit => {
 											this.onAdUnitChange( adUnit );
 											this.saveAdUnit( adUnit.id );

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -31,6 +31,7 @@ const AdUnits = ( {
 	wizardApiFetch,
 	service,
 	gamConnectionStatus = {},
+	fetchAdvertisingData,
 } ) => {
 	const warningNoticeText = `${ __(
 		'Please connect your Google account using the Newspack dashboard in order to use ad units from your GAM account.',
@@ -48,13 +49,14 @@ const AdUnits = ( {
 		! gamConnectionMessage && false === gamConnectionStatus?.is_network_code_matched;
 
 	const [ networkCode, setNetworkCode ] = useState( gamConnectionStatus.network_code );
-	const saveNetworkCode = () => {
-		wizardApiFetch( {
+	const saveNetworkCode = async () => {
+		await wizardApiFetch( {
 			path: '/newspack/v1/wizard/advertising/network_code/',
 			method: 'POST',
 			data: { network_code: networkCode },
 			quiet: true,
 		} );
+		fetchAdvertisingData( true );
 	};
 
 	return (

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -56,7 +56,7 @@ const AdUnits = ( {
 			data: { network_code: networkCode },
 			quiet: true,
 		} );
-		await fetchAdvertisingData( true );
+		fetchAdvertisingData( true );
 	};
 
 	useEffect( () => {

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { trash, pencil } from '@wordpress/icons';
 
@@ -56,8 +56,12 @@ const AdUnits = ( {
 			data: { network_code: networkCode },
 			quiet: true,
 		} );
-		fetchAdvertisingData( true );
+		await fetchAdvertisingData( true );
 	};
+
+	useEffect( () => {
+		setNetworkCode( gamConnectionStatus.network_code );
+	}, [ gamConnectionStatus.network_code ] );
 
 	return (
 		<>

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -235,7 +235,7 @@ class Advertising_Wizard extends Wizard {
 							$sanitized_codes = array_reduce(
 								$raw_codes,
 								function( $acc, $code ) {
-									$sanitized_code = absint( $code );
+									$sanitized_code = absint( trim( $code ) );
 									if ( ! empty( $sanitized_code ) ) {
 										$acc[] = $sanitized_code;
 									}

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -230,7 +230,17 @@ class Advertising_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
 					'network_code' => [
-						'sanitize_callback' => 'absint',
+						'sanitize_callback' => function( $value ) {
+							$raw_codes       = explode( ',', $value );
+							$sanitized_codes = array_map(
+								function( $code ) {
+									return absint( $code );
+								},
+								$raw_codes
+							);
+
+							return implode( ',', $sanitized_codes );
+						},
 					],
 				],
 			]

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -232,11 +232,16 @@ class Advertising_Wizard extends Wizard {
 					'network_code' => [
 						'sanitize_callback' => function( $value ) {
 							$raw_codes       = explode( ',', $value );
-							$sanitized_codes = array_map(
-								function( $code ) {
-									return absint( $code );
+							$sanitized_codes = array_reduce(
+								$raw_codes,
+								function( $acc, $code ) {
+									$sanitized_code = absint( $code );
+									if ( ! empty( $sanitized_code ) ) {
+										$acc[] = $sanitized_code;
+									}
+									return $acc;
 								},
-								$raw_codes
+								[]
 							);
 
 							return implode( ',', $sanitized_codes );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows the advertising wizard to accept multiple GAM network codes as a comma-delimited string, as specified by MCM.

Closes https://github.com/Automattic/newspack-ads/issues/157.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-ads/pull/169.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->