### PR TITLE
fix: stricter plugin area restriction

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -199,15 +199,23 @@ final class Newspack {
 	/**
 	 * Restrict access to certain pages for non-whitelisted users.
 	 */
-	public static function restrict_user_access() {
+	public static function restrict_user_access( $current_screen ) {
 		if ( ! defined( 'NEWSPACK_ALLOWED_PLUGIN_EDITORS' ) ) {
 			return;
 		}
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+
+		$plugin_screens = [
+			'plugins',
+			'plugin-install',
+			'plugin-editor',
+		];
 
 		$current_user = wp_get_current_user();
-		if ( ! in_array( $current_user->user_login, NEWSPACK_ALLOWED_PLUGIN_EDITORS ) ) {
-			$current_page = get_current_screen();
-			if ( 'plugins' === $current_page->id ) {
+		if ( 0 !== $current_user->ID && ! in_array( $current_user->user_login, NEWSPACK_ALLOWED_PLUGIN_EDITORS ) ) {
+			if ( in_array( $current_screen->base, $plugin_screens ) ) {
 				wp_safe_redirect( get_admin_url() );
 				exit;
 			}

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -198,6 +198,8 @@ final class Newspack {
 
 	/**
 	 * Restrict access to certain pages for non-whitelisted users.
+	 *
+	 * @param WP_Screen $current_screen Current WP_Screen object.
 	 */
 	public static function restrict_user_access( $current_screen ) {
 		if ( ! defined( 'NEWSPACK_ALLOWED_PLUGIN_EDITORS' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The current implementation to restrict plugin access to specific users is causing the following warning in some admin screens:
```
PHP Warning:  Invalid argument supplied for foreach() in wp-admin/includes/plugin.php on line 1758
```

This is likely due to anonymous access to the admin area through the API. This access fires the `current_screen` action but not other protected features, such as menu pages. The attempt to `remove_menu_page()` executes a `foreach()` on `null`.

This PR checks for logged-in users and non-0 user IDs before executing the plugin area restrictions.

It also adds other plugin screens ("edit" and "add new") to the redirectable screens. 

### How to test the changes in this Pull Request:

1. Add the `NEWSPACK_ALLOWED_PLUGIN_EDITORS` config variable, with `[<your-username>]` as value
2. In the master branch, access the Newspack dashboard and observe the warning mentioned above in your PHP logs.
3. Switch to this branch, refresh the page and observe no warnings are shown
4. Repeat steps from #1125 to ensure the expected behaviour is preserved

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->