### PR TITLE
fix(stripe): error handling

### DIFF
--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -11,6 +11,11 @@ import { ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
+ * External dependencies
+ */
+import { values } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import {
@@ -122,6 +127,9 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 			) }
 			{ displayStripeSettingsOnly ? (
 				<>
+					{ data.connection_error !== false && (
+						<Notice isError noticeText={ data.connection_error } />
+					) }
 					<SettingsCard title={ __( 'Settings', 'newspack' ) } columns={ 1 }>
 						{ data.can_use_stripe_platform === false && (
 							<Notice
@@ -162,20 +170,26 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 						columns={ 1 }
 					>
 						<div>
-							{ data.webhooks.length ? (
-								<ul>
-									{ data.webhooks.map( ( webhook, i ) => (
-										<li key={ i }>
-											- <code>{ webhook.url }</code>
-										</li>
-									) ) }
-								</ul>
+							{ data.webhooks?.errors ? (
+								<Notice isError noticeText={ values( data.webhooks.errors ).join( ', ' ) } />
 							) : (
-								<div className="mb3">{ __( 'No webhooks defined.', 'newspack' ) }</div>
+								<>
+									{ data.webhooks.length ? (
+										<ul>
+											{ data.webhooks.map( ( webhook, i ) => (
+												<li key={ i }>
+													- <code>{ webhook.url }</code>
+												</li>
+											) ) }
+										</ul>
+									) : (
+										<div className="mb3">{ __( 'No webhooks defined.', 'newspack' ) }</div>
+									) }
+									<Button isLink disabled={ isLoading } onClick={ createWebhooks } isSecondary>
+										{ __( 'Create webhooks', 'newspack' ) }
+									</Button>
+								</>
 							) }
-							<Button isLink disabled={ isLoading } onClick={ createWebhooks } isSecondary>
-								{ __( 'Create webhooks', 'newspack' ) }
-							</Button>
 						</div>
 					</SettingsCard>
 				</>

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -140,7 +140,7 @@ const StripeSetup = ( { data, onChange, displayStripeSettingsOnly, currencyField
 								) }
 							/>
 						) }
-						<StripeKeysSettings data={ data } />
+						<StripeKeysSettings data={ data } onChange={ onChange } />
 						<SelectControl
 							label={ __( 'Which currency does your business use?', 'newspack' ) }
 							value={ data.currency }

--- a/includes/class-stripe-connection.php
+++ b/includes/class-stripe-connection.php
@@ -119,7 +119,7 @@ class Stripe_Connection {
 		$stripe = self::get_stripe_client();
 		try {
 			return $stripe->webhookEndpoints->all()['data']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			return new \WP_Error( 'stripe_webhooks', __( 'Could not fetch webhooks.', 'newspack' ), $e->getMessage() );
 		}
 	}
@@ -133,7 +133,7 @@ class Stripe_Connection {
 		$stripe = self::get_stripe_client();
 		try {
 			return $stripe->customers->retrieve( $customer_id, [] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			return new \WP_Error( 'stripe_webhooks', __( 'Could not fetch customer.', 'newspack' ), $e->getMessage() );
 		}
 	}
@@ -147,7 +147,7 @@ class Stripe_Connection {
 		$stripe = self::get_stripe_client();
 		try {
 			return $stripe->invoices->retrieve( $invoice_id, [] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			return new \WP_Error( 'stripe_webhooks', __( 'Could not fetch invoice.', 'newspack' ), $e->getMessage() );
 		}
 	}
@@ -171,7 +171,7 @@ class Stripe_Connection {
 				$sig_header,
 				$webhook['secret']
 			);
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			return new \WP_Error( 'newspack_webhook_error' );
 		}
 
@@ -300,7 +300,7 @@ class Stripe_Connection {
 					'secret' => $webhook->secret,
 				]
 			);
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			return new \WP_Error( 'newspack_plugin_stripe', __( 'Webhook creation failed.', 'newspack' ), $e->getMessage() );
 		}
 		return self::list_webhooks();
@@ -399,7 +399,7 @@ class Stripe_Connection {
 				$prices_mapped['year'] = self::create_donation_product( __( 'Newspack Annual Donation', 'newspack' ), 'year' );
 			}
 			return $prices_mapped;
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			return new \WP_Error( 'newspack_plugin_stripe', __( 'Products retrieval failed.', 'newspack' ), $e->getMessage() );
 		}
 	}
@@ -411,6 +411,22 @@ class Stripe_Connection {
 		$secret_key = self::get_stripe_secret_key();
 		if ( $secret_key ) {
 			return new \Stripe\StripeClient( $secret_key );
+		}
+	}
+
+	/**
+	 * Check connection to Stripe.
+	 */
+	public static function get_connection_error() {
+		if ( ! self::get_stripe_secret_key() ) {
+			return __( 'Stripe secret key not provided.', 'newspack' );
+		}
+		$stripe = self::get_stripe_client();
+		try {
+			$products = $stripe->products->all( [ 'limit' => 1 ] );
+			return false;
+		} catch ( \Throwable $e ) {
+			return $e->getMessage();
 		}
 	}
 
@@ -556,7 +572,7 @@ class Stripe_Connection {
 					$response['status'] = 'success';
 				}
 			}
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			$response['error'] = $e->getMessage();
 		}
 		return $response;

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -636,7 +636,8 @@ class Reader_Revenue_Wizard extends Wizard {
 			$nrh_config            = get_option( NEWSPACK_NRH_CONFIG, [] );
 			$args['platform_data'] = wp_parse_args( $nrh_config, $args['platform_data'] );
 		} elseif ( Donations::is_platform_stripe() ) {
-			$args['stripe_data']['webhooks'] = Stripe_Connection::list_webhooks();
+			$args['stripe_data']['webhooks']         = Stripe_Connection::list_webhooks();
+			$args['stripe_data']['connection_error'] = Stripe_Connection::get_connection_error();
 		}
 		return $args;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1116.

### How to test the changes in this Pull Request:

1. On `master`, choose Stripe as the Reader Revenue platform after clearing any Stripe keys*
2. Observe a fatal error (#1116)
3. Switch to this branch, observe an error message in Reader Revenue -> Stripe Settings
4. Provide the Stripe keys, but invalid ones
5. Observe another error message 
6. Provide valid keys
7. Observe the UI without errors

\* `newspack_stripe_data` option and the Stripe keys in WooCommerce settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->