### PR TITLE
feat/supported unmanaged plugins

### DIFF
--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -25,7 +25,8 @@ class HealthCheckWizard extends Component {
 		this.state = {
 			hasData: false,
 			healthCheckData: {
-				unsupportedPlugins: [],
+				unsupported_plugins: {},
+				missing_plugins: {},
 			},
 		};
 	}
@@ -71,6 +72,7 @@ class HealthCheckWizard extends Component {
 		const { hasData, healthCheckData } = this.state;
 		const {
 			unsupported_plugins: unsupportedPlugins,
+			missing_plugins: missingPlugins,
 			configuration_status: configurationStatus,
 		} = healthCheckData;
 		const tabs = [
@@ -97,13 +99,11 @@ class HealthCheckWizard extends Component {
 									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
 									deactivateAllPlugins={ this.deactivateAllPlugins }
 									tabbedNavigation={ tabs }
-									unsupportedPlugins={
-										unsupportedPlugins &&
-										Object.keys( unsupportedPlugins ).map( value => ( {
-											...unsupportedPlugins[ value ],
-											Slug: value,
-										} ) )
-									}
+									missingPlugins={ Object.keys( missingPlugins ) }
+									unsupportedPlugins={ Object.keys( unsupportedPlugins ).map( value => ( {
+										...unsupportedPlugins[ value ],
+										Slug: value,
+									} ) ) }
 								/>
 							) }
 						/>

--- a/assets/wizards/health-check/views/plugins/index.js
+++ b/assets/wizards/health-check/views/plugins/index.js
@@ -11,7 +11,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Notice, withWizardScreen } from '../../../../components/src';
+import {
+	ActionCard,
+	Button,
+	PluginInstaller,
+	Notice,
+	withWizardScreen,
+} from '../../../../components/src';
 
 /**
  * SEO Intro screen.
@@ -21,10 +27,16 @@ class Plugins extends Component {
 	 * Render.
 	 */
 	render() {
-		const { unsupportedPlugins, deactivateAllPlugins } = this.props;
+		const { unsupportedPlugins, missingPlugins, deactivateAllPlugins } = this.props;
 		return (
 			<Fragment>
-				{ unsupportedPlugins && unsupportedPlugins.length > 0 && (
+				{ missingPlugins.length ? (
+					<>
+						<Notice noticeText={ __( 'These plugins shoud be active:' ) } isWarning />
+						<PluginInstaller plugins={ missingPlugins } />
+					</>
+				) : null }
+				{ unsupportedPlugins.length ? (
 					<Fragment>
 						<Notice noticeText={ __( 'Newspack does not support these plugins:' ) } isError />
 						{ unsupportedPlugins.map( unsupportedPlugin => (
@@ -41,8 +53,7 @@ class Plugins extends Component {
 							</Button>
 						</div>
 					</Fragment>
-				) }
-				{ unsupportedPlugins && unsupportedPlugins.length === 0 && (
+				) : (
 					<Fragment>
 						<Notice noticeText={ __( 'No unsupported plugins found.' ) } isSuccess />
 					</Fragment>

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -518,6 +518,7 @@ class Plugin_Manager {
 	 */
 	private static function get_supported_plugins_slugs() {
 		return [
+			'gutenberg',
 			'classic-widgets',
 			'republication-tracker-tool',
 			'the-events-calendar',

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -512,16 +512,34 @@ class Plugin_Manager {
 	}
 
 	/**
+	 * Get the list of plugins which are supported, but not managed.
+	 * These plugins will not be added to the WP Admin plugins screen,
+	 * but installing them will not raise any issues in Health Check.
+	 */
+	private static function get_supported_plugins_slugs() {
+		return [
+			'classic-widgets',
+			'republication-tracker-tool',
+			'the-events-calendar',
+		];
+	}
+
+	/**
 	 * Get info about all the unmanaged plugins that are installed.
 	 *
 	 * @return array of plugin info.
 	 */
-	public static function get_unmanaged_plugins() {
-		$plugins_info      = self::get_installed_plugins_info();
-		$managed_plugins   = self::get_managed_plugins();
-		$unmanaged_plugins = [];
+	public static function get_unsupported_plugins() {
+		$plugins_info            = self::get_installed_plugins_info();
+		$managed_plugins         = self::get_managed_plugins();
+		$supported_plugins_slugs = self::get_supported_plugins_slugs();
+		$unmanaged_plugins       = [];
 		foreach ( $plugins_info as $slug => $info ) {
-			if ( ! isset( $managed_plugins[ $slug ] ) && 0 !== strpos( $slug, 'newspack-' ) && is_plugin_active( $info['Path'] ) ) {
+			$is_managed      = ! isset( $managed_plugins[ $slug ] );
+			$is_not_newspack = 0 !== strpos( $slug, 'newspack-' );
+			$is_active       = is_plugin_active( $info['Path'] );
+			$is_supported    = in_array( $slug, $supported_plugins_slugs );
+			if ( ! $is_supported && $is_managed && $is_not_newspack && $is_active ) {
 				$unmanaged_plugins[ $slug ] = $info;
 			}
 		}

--- a/includes/wizards/class-health-check-wizard.php
+++ b/includes/wizards/class-health-check-wizard.php
@@ -153,6 +153,7 @@ class Health_Check_Wizard extends Wizard {
 
 		return array(
 			'unsupported_plugins'  => Plugin_Manager::get_unmanaged_plugins(),
+			'missing_plugins'      => Plugin_Manager::get_missing_plugins(),
 			'configuration_status' => [
 				'amp'     => $amp_manager->is_standard_mode(),
 				'jetpack' => $jetpack_manager->is_configured(),

--- a/includes/wizards/class-health-check-wizard.php
+++ b/includes/wizards/class-health-check-wizard.php
@@ -134,7 +134,7 @@ class Health_Check_Wizard extends Wizard {
 	 * Delete all unsupported plugins
 	 */
 	public function api_delete_unsupported_plugins() {
-		$unsupported_plugins = Plugin_Manager::get_unmanaged_plugins();
+		$unsupported_plugins = Plugin_Manager::get_unsupported_plugins();
 		foreach ( $unsupported_plugins as $slug => $data ) {
 			Plugin_Manager::deactivate( $slug );
 		}
@@ -152,7 +152,7 @@ class Health_Check_Wizard extends Wizard {
 		$sitekit_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'google-site-kit' );
 
 		return array(
-			'unsupported_plugins'  => Plugin_Manager::get_unmanaged_plugins(),
+			'unsupported_plugins'  => Plugin_Manager::get_unsupported_plugins(),
 			'missing_plugins'      => Plugin_Manager::get_missing_plugins(),
 			'configuration_status' => [
 				'amp'     => $amp_manager->is_standard_mode(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Adds a whitelist of supported, but unmanaged plugins
2. Removes unexecuted code from #240
3. Adds a section with plugins which should be active, but aren't, to Heath Check wizard

### How to test the changes in this Pull Request:

1. On `master`, install the Classic Widgets plugin
2. Observe is does show up in Health Check wizard as an unsupported plugin
3. Switch to this branch, observe it does not anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->