### PR TITLE
feat/connections view

### DIFF
--- a/assets/components/src/footer/index.js
+++ b/assets/components/src/footer/index.js
@@ -18,7 +18,6 @@ const Footer = ( { simple } ) => {
 	const componentsDemo = window && window.newspack_urls && window.newspack_urls.components_demo;
 	const setupWizard = window && window.newspack_urls && window.newspack_urls.setup_wizard;
 	const resetUrl = window && window.newspack_urls && window.newspack_urls.reset_url;
-	const resetWpcomUrl = window && window.newspack_urls && window.newspack_urls.reset_wpcom_url;
 	const pluginVersion = window && window.newspack_urls && window.newspack_urls.plugin_version;
 	const removeStarterContent =
 		window && window.newspack_urls && window.newspack_urls.remove_starter_content;
@@ -54,12 +53,6 @@ const Footer = ( { simple } ) => {
 		footerElements.push( {
 			label: __( 'Reset Newspack', 'newspack' ),
 			url: resetUrl,
-		} );
-	}
-	if ( resetWpcomUrl ) {
-		footerElements.push( {
-			label: __( 'Reset WordPress.com Authentication', 'newspack' ),
-			url: resetWpcomUrl,
 		} );
 	}
 	if ( removeStarterContent ) {

--- a/assets/components/src/waiting/index.js
+++ b/assets/components/src/waiting/index.js
@@ -34,14 +34,13 @@ class Waiting extends Component {
 	 * Render
 	 */
 	render() {
-		const { className, isRight, isLeft } = this.props;
-		const classes = classnames(
-			'newspack-is-waiting',
-			className,
-			isRight && 'newspack-is-waiting__is-right',
-			isLeft && 'newspack-is-waiting__is-left'
-		);
-		return <Icon icon={ icon } className={ classes } />;
+		const { className, isRight, isLeft, isCenter, size } = this.props;
+		const classes = classnames( 'newspack-is-waiting', className, {
+			'newspack-is-waiting__is-right': isRight,
+			'newspack-is-waiting__is-left': isLeft,
+			'newspack-is-waiting__is-center': isCenter,
+		} );
+		return <Icon icon={ icon } size={ size } className={ classes } />;
 	}
 }
 

--- a/assets/components/src/waiting/style.scss
+++ b/assets/components/src/waiting/style.scss
@@ -22,6 +22,10 @@
 			order: 1;
 		}
 	}
+
+	&.newspack-is-waiting__is-center {
+		margin: auto;
+	}
 }
 
 @keyframes newspack-is-waiting__animation {

--- a/assets/wizards/connections/index.js
+++ b/assets/wizards/connections/index.js
@@ -1,0 +1,42 @@
+import '../../shared/js/public-path';
+
+/**
+ * WordPress dependencies.
+ */
+import { render, createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import { withWizard, withWizardScreen } from '../../components/src';
+import Router from '../../components/src/proxied-imports/router';
+import { Main } from './views';
+
+const { HashRouter, Redirect, Route, Switch } = Router;
+
+const MainScreen = withWizardScreen( Main );
+
+const ConnectionsWizard = ( { pluginRequirements, wizardApiFetch, startLoading, doneLoading } ) => {
+	const wizardScreenProps = {
+		headerText: __( 'Connections', 'newspack' ),
+		subHeaderText: __( 'Connections to third-party services', 'newspack' ),
+		wizardApiFetch,
+		startLoading,
+		doneLoading,
+	};
+	return (
+		<HashRouter hashType="slash">
+			<Switch>
+				{ pluginRequirements }
+				<Route exact path="/" render={ () => <MainScreen { ...wizardScreenProps } /> } />
+				<Redirect to="/" />
+			</Switch>
+		</HashRouter>
+	);
+};
+
+render(
+	createElement( withWizard( ConnectionsWizard ) ),
+	document.getElementById( 'newspack-connections-wizard' )
+);

--- a/assets/wizards/connections/views/index.js
+++ b/assets/wizards/connections/views/index.js
@@ -1,0 +1,1 @@
+export { default as Main } from './main';

--- a/assets/wizards/connections/views/main/google.js
+++ b/assets/wizards/connections/views/main/google.js
@@ -50,7 +50,7 @@ export const handleGoogleRedirect = ( { setError } ) => {
 	return Promise.resolve();
 };
 
-const GoogleOAuth = ( { canBeConnected } ) => {
+const GoogleOAuth = ( { setError, canBeConnected } ) => {
 	const [ authState, setAuthState ] = useState( {} );
 
 	const userBasicInfo = authState.user_basic_info;
@@ -58,15 +58,18 @@ const GoogleOAuth = ( { canBeConnected } ) => {
 	const canUseOauth = newspack_connections_data.can_connect_google;
 
 	const [ inFlight, setInFlight ] = useState( false );
+	const handleError = res => setError( res.message || __( 'Something went wrong.', 'newspack' ) );
 
 	useEffect( () => {
 		const params = getURLParams();
 		if ( canUseOauth && ! params.access_token ) {
 			setInFlight( true );
-			apiFetch( { path: '/newspack/v1/oauth/google' } ).then( res => {
-				setAuthState( res );
-				setInFlight( false );
-			} );
+			apiFetch( { path: '/newspack/v1/oauth/google' } )
+				.then( res => {
+					setAuthState( res );
+					setInFlight( false );
+				} )
+				.catch( handleError );
 		}
 	}, [] );
 
@@ -79,7 +82,9 @@ const GoogleOAuth = ( { canBeConnected } ) => {
 		setInFlight( true );
 		apiFetch( {
 			path: '/newspack/v1/oauth/google/start',
-		} ).then( url => ( window.location = url ) );
+		} )
+			.then( url => ( window.location = url ) )
+			.catch( handleError );
 	};
 
 	// Redirect user to Google auth screen.
@@ -88,10 +93,12 @@ const GoogleOAuth = ( { canBeConnected } ) => {
 		apiFetch( {
 			path: '/newspack/v1/oauth/google/revoke',
 			method: 'DELETE',
-		} ).then( () => {
-			setAuthState( {} );
-			setInFlight( false );
-		} );
+		} )
+			.then( () => {
+				setAuthState( {} );
+				setInFlight( false );
+			} )
+			.catch( handleError );
 	};
 
 	const getDescription = () => {

--- a/assets/wizards/connections/views/main/google.js
+++ b/assets/wizards/connections/views/main/google.js
@@ -1,0 +1,129 @@
+/* global newspack_connections_data */
+
+/**
+ * External dependencies.
+ */
+import qs from 'qs';
+
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies.
+ */
+import { ActionCard, Button } from '../../../../components/src';
+
+const getURLParams = () => {
+	return qs.parse( window.location.search.replace( /^\?/, '' ) );
+};
+
+export const handleGoogleRedirect = ( { setError } ) => {
+	const params = getURLParams();
+	if ( params.access_token ) {
+		return apiFetch( {
+			path: '/newspack/v1/oauth/google/finish',
+			method: 'POST',
+			data: {
+				access_token: params.access_token,
+				refresh_token: params.refresh_token,
+				csrf_token: params.csrf_token,
+				expires_at: params.expires_at,
+			},
+		} )
+			.then( () => {
+				params.access_token = undefined;
+				params.refresh_token = undefined;
+				params.csrf_token = undefined;
+				params.expires_at = undefined;
+				window.location.search = qs.stringify( params );
+			} )
+			.catch( e => {
+				setError(
+					e.message || __( 'Something went wrong during authentication with Google.', 'newspack' )
+				);
+			} );
+	}
+	return Promise.resolve();
+};
+
+const GoogleOAuth = ( { canBeConnected } ) => {
+	const [ authState, setAuthState ] = useState( {} );
+
+	const userBasicInfo = authState.user_basic_info;
+	const isConnected = Boolean( userBasicInfo && userBasicInfo.email );
+	const canUseOauth = newspack_connections_data.can_connect_google;
+
+	const [ inFlight, setInFlight ] = useState( false );
+
+	useEffect( () => {
+		const params = getURLParams();
+		if ( canUseOauth && ! params.access_token ) {
+			setInFlight( true );
+			apiFetch( { path: '/newspack/v1/oauth/google' } ).then( res => {
+				setAuthState( res );
+				setInFlight( false );
+			} );
+		}
+	}, [] );
+
+	if ( ! canUseOauth ) {
+		return null;
+	}
+
+	// Redirect user to Google auth screen.
+	const goToAuthPage = () => {
+		setInFlight( true );
+		apiFetch( {
+			path: '/newspack/v1/oauth/google/start',
+		} ).then( url => ( window.location = url ) );
+	};
+
+	// Redirect user to Google auth screen.
+	const disconnect = () => {
+		setInFlight( true );
+		apiFetch( {
+			path: '/newspack/v1/oauth/google/revoke',
+			method: 'DELETE',
+		} ).then( () => {
+			setAuthState( {} );
+			setInFlight( false );
+		} );
+	};
+
+	const getDescription = () => {
+		if ( inFlight ) {
+			return __( 'Loading…', 'newspack' );
+		}
+		if ( isConnected ) {
+			return sprintf( __( 'Connected as %s', 'newspack' ), userBasicInfo.email );
+		}
+		if ( ! canBeConnected ) {
+			return __( 'First connect to WordPress.com', 'newspack' );
+		}
+		return __( 'Not connected', 'newspack' );
+	};
+	return (
+		<ActionCard
+			title={ __( 'Google', 'newspack' ) }
+			description={ getDescription() }
+			checkbox={ isConnected ? 'checked' : 'unchecked' }
+			actionText={
+				<Button
+					isLink
+					isDestructive={ isConnected }
+					onClick={ isConnected ? disconnect : goToAuthPage }
+					disabled={ inFlight || ! canBeConnected }
+				>
+					{ isConnected ? __( 'Disconnect', 'newspack' ) : __( 'Connect', 'newspack' ) }
+				</Button>
+			}
+			isMedium
+		/>
+	);
+};
+
+export default GoogleOAuth;

--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -28,7 +28,7 @@ const Main = () => {
 		<>
 			{ error && <Notice isError noticeText={ error } /> }
 			<WPCOMAuth onStatusChange={ setIsWPCOMConnected } />
-			<GoogleAuth canBeConnected={ isWPCOMConnected === true } />
+			<GoogleAuth setError={ setError } canBeConnected={ isWPCOMConnected === true } />
 		</>
 	);
 };

--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -1,0 +1,5 @@
+const Main = () => {
+	return <>{ 'Connections' }</>;
+};
+
+export default Main;

--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -1,5 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import WPCOMAuth from './wpcom';
+
 const Main = () => {
-	return <>{ 'Connections' }</>;
+	return (
+		<>
+			<WPCOMAuth />
+		</>
+	);
 };
 
 export default Main;

--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -1,12 +1,34 @@
 /**
+ * WordPress dependencies.
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
+import { Waiting, Notice } from '../../../../components/src';
 import WPCOMAuth from './wpcom';
+import GoogleAuth, { handleGoogleRedirect } from './google';
 
 const Main = () => {
+	const [ error, setError ] = useState();
+	const [ isResolvingAuth, setIsResolvingAuth ] = useState( true );
+	const [ isWPCOMConnected, setIsWPCOMConnected ] = useState();
+	useEffect( () => {
+		handleGoogleRedirect( { setError } ).finally( () => {
+			setIsResolvingAuth( false );
+		} );
+	}, [] );
+
+	if ( isResolvingAuth ) {
+		return <Waiting isCenter size={ 42 } />;
+	}
+
 	return (
 		<>
-			<WPCOMAuth />
+			{ error && <Notice isError noticeText={ error } /> }
+			<WPCOMAuth onStatusChange={ setIsWPCOMConnected } />
+			<GoogleAuth canBeConnected={ isWPCOMConnected === true } />
 		</>
 	);
 };

--- a/assets/wizards/connections/views/main/wpcom.js
+++ b/assets/wizards/connections/views/main/wpcom.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import withWPCOMAuth from '../../../support/components/withWPCOMAuth';
+
+/**
+ * Internal dependencies.
+ */
+import { Button, ActionCard } from '../../../../components/src';
+
+const WPCOMAuth = ( { shouldAuthenticate, isInFlight, disconnectURL, authURL } ) => {
+	return (
+		<ActionCard
+			title={ __( 'WordPress.com', 'newspack' ) }
+			description={
+				shouldAuthenticate ? __( 'Not connected', 'newspack' ) : __( 'Connected', 'newspack' )
+			}
+			checkbox={ shouldAuthenticate ? 'unchecked' : 'checked' }
+			actionText={
+				<Button
+					isLink
+					isDestructive={ ! isInFlight && ! shouldAuthenticate }
+					href={ shouldAuthenticate ? authURL : disconnectURL }
+					disabled={ isInFlight }
+				>
+					{ shouldAuthenticate ? __( 'Connect', 'newspack' ) : __( 'Disconnect', 'newspack' ) }
+				</Button>
+			}
+			isMedium
+		/>
+	);
+};
+
+export default withWPCOMAuth( null, WPCOMAuth );

--- a/assets/wizards/connections/views/main/wpcom.js
+++ b/assets/wizards/connections/views/main/wpcom.js
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
 import withWPCOMAuth from '../../../support/components/withWPCOMAuth';
 
 /**
@@ -9,12 +10,28 @@ import withWPCOMAuth from '../../../support/components/withWPCOMAuth';
  */
 import { Button, ActionCard } from '../../../../components/src';
 
-const WPCOMAuth = ( { shouldAuthenticate, isInFlight, disconnectURL, authURL } ) => {
+const WPCOMAuth = ( {
+	onStatusChange,
+	shouldAuthenticate,
+	isInFlight,
+	disconnectURL,
+	authURL,
+} ) => {
+	useEffect( () => {
+		if ( ! isInFlight ) {
+			onStatusChange( shouldAuthenticate === false );
+		}
+	}, [ shouldAuthenticate, isInFlight ] );
 	return (
 		<ActionCard
 			title={ __( 'WordPress.com', 'newspack' ) }
 			description={
-				shouldAuthenticate ? __( 'Not connected', 'newspack' ) : __( 'Connected', 'newspack' )
+				// eslint-disable-next-line no-nested-ternary
+				isInFlight
+					? __( 'Loading…', 'newspack' )
+					: shouldAuthenticate
+					? __( 'Not connected', 'newspack' )
+					: __( 'Connected', 'newspack' )
 			}
 			checkbox={ shouldAuthenticate ? 'unchecked' : 'checked' }
 			actionText={

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -3,87 +3,18 @@
 import '../../shared/js/public-path';
 
 /**
- * External dependencies.
- */
-import qs from 'qs';
-
-/**
  * WordPress dependencies.
  */
-import { useEffect, useState, Fragment, render } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
-import { __ } from '@wordpress/i18n';
-import { Icon, plugins } from '@wordpress/icons';
+import { Fragment, render } from '@wordpress/element';
 
 /**
  * Internal dependencies.
  */
-import {
-	GlobalNotices,
-	ButtonCard,
-	Card,
-	Waiting,
-	Footer,
-	Grid,
-	NewspackLogo,
-} from '../../components/src';
+import { GlobalNotices, Footer, Grid, NewspackLogo } from '../../components/src';
 import DashboardCard from './views/dashboardCard';
 import './style.scss';
 
 const Dashboard = ( { items } ) => {
-	const params = qs.parse( window.location.search );
-	const accessTokenInURL = params.access_token;
-	const [ authState, setAuthState ] = useState( {} );
-
-	const userBasicInfo = authState.user_basic_info;
-	const canUseOauth = authState.can_google_auth;
-
-	const displayAuth = canUseOauth && ! accessTokenInURL;
-
-	useEffect( () => {
-		apiFetch( { path: '/newspack/v1/oauth/google' } ).then( setAuthState );
-	}, [] );
-
-	useEffect( () => {
-		if ( canUseOauth && accessTokenInURL ) {
-			apiFetch( {
-				path: '/newspack/v1/oauth/google/finish',
-				method: 'POST',
-				data: {
-					access_token: accessTokenInURL,
-					refresh_token: params.refresh_token,
-					csrf_token: params.csrf_token,
-					expires_at: params.expires_at,
-				},
-			} )
-				.then( () => {
-					window.location =
-						'/wp-admin/admin.php?' +
-						qs.stringify( {
-							page: 'newspack',
-							'newspack-notice': __( 'Successfully authenticated with Google.', 'newspack' ),
-						} );
-				} )
-				.catch( e => {
-					window.location =
-						'/wp-admin/admin.php?' +
-						qs.stringify( {
-							page: 'newspack',
-							'newspack-notice':
-								'_error_' +
-								( e.message ||
-									__( 'Something went wrong during authentication with Google.', 'newspack' ) ),
-						} );
-				} );
-		}
-	}, [ canUseOauth ] );
-
-	const goToAuthPage = () => {
-		apiFetch( {
-			path: '/newspack/v1/oauth/google/start',
-		} ).then( url => ( window.location = url ) );
-	};
-
 	return (
 		<Fragment>
 			<GlobalNotices />
@@ -97,35 +28,6 @@ const Dashboard = ( { items } ) => {
 					{ items.map( card => (
 						<DashboardCard { ...card } key={ card.slug } />
 					) ) }
-					{ accessTokenInURL && (
-						<div className="flex justify-around items-center">
-							<Waiting />
-						</div>
-					) }
-					{ displayAuth ? (
-						<>
-							{ userBasicInfo ? (
-								<Card className="newspack-dashboard-card">
-									<Icon icon={ plugins } height={ 48 } width={ 48 } />
-									<div>
-										<h2>{ __( 'Google Connection' ) }</h2>
-										<p>
-											{ __( 'Authorized Google as', 'newspack' ) }{ ' ' }
-											<strong>{ userBasicInfo.email }</strong>
-										</p>
-									</div>
-								</Card>
-							) : (
-								<ButtonCard
-									onClick={ goToAuthPage }
-									title={ __( 'Google Connection', 'newspack' ) }
-									desc={ __( 'Authorize Newspack with Google', 'newspack' ) }
-									icon={ plugins }
-									tabIndex="0"
-								/>
-							) }
-						</>
-					) : null }
 				</Grid>
 			</div>
 			<Footer />

--- a/assets/wizards/dashboard/views/dashboardCard.js
+++ b/assets/wizards/dashboard/views/dashboardCard.js
@@ -42,6 +42,7 @@ class DashboardCard extends Component {
 			engagement: postComments,
 			popups: megaphone,
 			support: help,
+			connections: plugins,
 		};
 		return (
 			<ButtonCard

--- a/assets/wizards/support/components/withWPCOMAuth.js
+++ b/assets/wizards/support/components/withWPCOMAuth.js
@@ -66,12 +66,15 @@ const withWPCOMAuth = ( WrappedComponent, renderer = false ) => {
 		render() {
 			// If a renderer is provided, use it.
 			if ( renderer ) {
-				return renderer( {
+				const RendererComponent = renderer;
+				const rendererProps = {
 					...this.state,
+					...this.props,
 					authURL: newspack_aux_data.wpcom_auth_url,
 					disconnectURL: newspack_aux_data.wpcom_disconnect_url,
 					token: WPCOM_ACCESS_TOKEN,
-				} );
+				};
+				return <RendererComponent { ...rendererProps } />;
 			}
 			return (
 				<Fragment>

--- a/assets/wizards/support/components/withWPCOMAuth.js
+++ b/assets/wizards/support/components/withWPCOMAuth.js
@@ -1,5 +1,3 @@
-/* global newspack_support_data */
-
 /**
  * WordPress dependencies
  */
@@ -13,9 +11,9 @@ import apiFetch from '@wordpress/api-fetch';
 import { Notice, Button, Waiting } from '../../../components/src';
 import { saveReturnPath } from '../utils';
 
-const { WPCOM_ACCESS_TOKEN } = newspack_support_data;
+const { WPCOM_ACCESS_TOKEN } = newspack_aux_data;
 
-const withWPCOMAuth = WrappedComponent => {
+const withWPCOMAuth = ( WrappedComponent, renderer = false ) => {
 	return class WithWPCOMAuth extends Component {
 		state = {
 			isInFlight: false,
@@ -57,7 +55,7 @@ const withWPCOMAuth = WrappedComponent => {
 						}
 					/>
 					<div className="newspack-buttons-card">
-						<Button href={ newspack_support_data.WPCOM_AUTH_URL } isPrimary>
+						<Button href={ newspack_aux_data.wpcom_auth_url } isPrimary>
 							{ __( 'Authenticate', 'newspack' ) }
 						</Button>
 					</div>
@@ -66,6 +64,15 @@ const withWPCOMAuth = WrappedComponent => {
 				<WrappedComponent token={ WPCOM_ACCESS_TOKEN } { ...this.props } />
 			);
 		render() {
+			// If a renderer is provided, use it.
+			if ( renderer ) {
+				return renderer( {
+					...this.state,
+					authURL: newspack_aux_data.wpcom_auth_url,
+					disconnectURL: newspack_aux_data.wpcom_disconnect_url,
+					token: WPCOM_ACCESS_TOKEN,
+				} );
+			}
 			return (
 				<Fragment>
 					{ this.state.isInFlight ? (

--- a/assets/wizards/support/index.js
+++ b/assets/wizards/support/index.js
@@ -50,9 +50,13 @@ class SupportWizard extends Component {
 				.then( () => {
 					const returnPath = getReturnPath();
 					if ( returnPath ) {
-						// redirect so that Router can take over
-						window.location = returnPath;
-						window.location.reload();
+						if ( returnPath.indexOf( window.location.search ) > 0 ) {
+							window.location = returnPath;
+							// Same page, needs reload for the Router to take over rendering.
+							window.location.reload();
+						} else {
+							window.location = returnPath;
+						}
 					}
 				} )
 				.catch( ( { message: errorMessage } ) => {

--- a/assets/wizards/support/views/create-ticket/index.js
+++ b/assets/wizards/support/views/create-ticket/index.js
@@ -28,6 +28,8 @@ import {
 import './style.scss';
 import withWPCOMAuth from '../../components/withWPCOMAuth';
 
+const { API_URL } = newspack_support_data;
+
 const Footer = props => (
 	<span className="newspack-buttons-card">
 		<Button isPrimary { ...props } />
@@ -47,7 +49,7 @@ const PRIORITY_OPTIONS = [
 class CreateTicket extends Component {
 	state = {
 		isSent: false,
-		errorMessage: false,
+		errorMessage: API_URL ? false : __( 'Missing support API URL.', 'newspack' ),
 		subject: '',
 		priority: PRIORITY_OPTIONS[ 0 ].value,
 		message: RichTextEditor.createEmptyValue(),
@@ -84,7 +86,6 @@ class CreateTicket extends Component {
 
 		const { attachments } = this.state;
 		if ( attachments ) {
-			const { API_URL } = newspack_support_data;
 			const uploadRequests = [ ...attachments ].map( ( { file } ) => {
 				return fetch( `${ API_URL }/uploads.json?filename=${ file.name }`, {
 					method: 'POST',

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -172,10 +172,11 @@ final class Newspack {
 				wp_safe_redirect( admin_url( 'admin.php?page=newspack-setup-wizard' ) );
 				exit;
 			}
-			if ( WPCOM_OAuth::get_wpcom_access_token() && 'reset-wpcom' === $newspack_reset ) {
-				delete_user_meta( get_current_user_id(), WPCOM_OAuth::NEWSPACK_WPCOM_ACCESS_TOKEN );
-				$redirect_url = add_query_arg( 'newspack-notice', __( 'Removed WPCOM Access Token', 'newspack' ), $redirect_url );
-			}
+		}
+		if ( WPCOM_OAuth::get_wpcom_access_token() && 'reset-wpcom' === $newspack_reset ) {
+			delete_user_meta( get_current_user_id(), WPCOM_OAuth::NEWSPACK_WPCOM_ACCESS_TOKEN );
+			delete_user_meta( get_current_user_id(), WPCOM_OAuth::NEWSPACK_WPCOM_EXPIRES_IN );
+			$redirect_url = add_query_arg( 'newspack-notice', __( 'Removed WPCOM Access Token', 'newspack' ), $redirect_url );
 		}
 
 		if ( $newspack_reset ) {

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -176,7 +176,7 @@ final class Newspack {
 		if ( WPCOM_OAuth::get_wpcom_access_token() && 'reset-wpcom' === $newspack_reset ) {
 			delete_user_meta( get_current_user_id(), WPCOM_OAuth::NEWSPACK_WPCOM_ACCESS_TOKEN );
 			delete_user_meta( get_current_user_id(), WPCOM_OAuth::NEWSPACK_WPCOM_EXPIRES_IN );
-			$redirect_url = add_query_arg( 'newspack-notice', __( 'Removed WPCOM Access Token', 'newspack' ), $redirect_url );
+			$redirect_url = Wizards::get_url( 'connections' );
 		}
 
 		if ( $newspack_reset ) {

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -103,6 +103,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-support-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-popups-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-updates-wizard.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-connections-wizard.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-wizards.php';
 

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -41,6 +41,9 @@ class Wizards {
 			'popups'          => new Popups_Wizard(),
 			'updates'         => new Updates_Wizard(),
 		];
+		if ( Connections_Wizard::configured() ) {
+			self::$wizards['connections'] = new Connections_Wizard();
+		}
 		if ( Support_Wizard::configured() ) {
 			self::$wizards['support'] = new Support_Wizard();
 		}

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -373,8 +373,11 @@ class Google_OAuth {
 					$proxy_url
 				);
 				$result    = wp_safe_remote_get( $url );
+				if ( is_wp_error( $result ) ) {
+					return false;
+				}
 				if ( 200 !== $result['response']['code'] ) {
-					return wp_send_json_error( json_decode( $result['body'] )->data->message, 400 );
+					return false;
 				}
 				$response_body = json_decode( $result['body'] );
 

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -181,7 +181,7 @@ class Google_OAuth {
 
 		return add_query_arg(
 			[
-				'wpcom_access_token' => urlencode( WPCOM_OAuth::get_access_token() ),
+				'wpcom_access_token' => urlencode( base64_encode( WPCOM_OAuth::get_access_token() ) ),
 			],
 			NEWSPACK_GOOGLE_OAUTH_PROXY . $path
 		);

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -202,7 +202,15 @@ class Google_OAuth {
 				return $result;
 			}
 			if ( 200 !== $result['response']['code'] ) {
-				return wp_send_json_error( json_decode( $result['body'] )->data->message, 400 );
+				$error_text  = __( 'Request failed.', 'newspack' );
+				$parsed_data = json_decode( $result['body'] );
+				if ( property_exists( $parsed_data, 'message' ) ) {
+					$error_text = $parsed_data->message;
+				}
+				return new WP_Error(
+					'newspack_google_oauth',
+					$error_text
+				);
 			}
 			$response_body = json_decode( $result['body'] );
 			return \rest_ensure_response( $response_body->url );

--- a/includes/wizards/class-connections-wizard.php
+++ b/includes/wizards/class-connections-wizard.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Newspack's Connections Wizard
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error, \WP_Query;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Easy interface for setting up general store info.
+ */
+class Connections_Wizard extends Wizard {
+
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-connections-wizard';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return \esc_html__( 'Connections', 'newspack' );
+	}
+
+	/**
+	 * Get the description of this wizard.
+	 *
+	 * @return string The wizard description.
+	 */
+	public function get_description() {
+		return \esc_html__( 'Connections to third-party services.', 'newspack' );
+	}
+
+	/**
+	 * Get the duration of this wizard.
+	 *
+	 * @return string A description of the expected duration (e.g. '10 minutes').
+	 */
+	public function get_length() {
+		return esc_html__( '10 minutes', 'newspack' );
+	}
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public function register_api_endpoints() {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/connections',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_connections' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/connections/(?P<provider>[\a-z]+)',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_create_connection' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'provider' => [
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'service'  => [
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get all connections.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 */
+	public static function api_get_connections( $request ) {
+		$connections = [];
+		return \rest_ensure_response( $connections );
+	}
+
+	/**
+	 * Create a new connection.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 */
+	public function api_create_connection( $request ) {
+		$provider = $request->get_param( 'provider' );
+		switch ( $provider ) {
+			default:
+				return wp_send_json_error( [ 'message' => __( 'Provider not implemented.', 'newspack' ) ], 404 );
+		}
+	}
+
+	/**
+	 * Enqueue Subscriptions Wizard scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		parent::enqueue_scripts_and_styles();
+
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+			return;
+		}
+
+		\wp_register_script(
+			'newspack-connections-wizard',
+			Newspack::plugin_url() . '/dist/connections.js',
+			$this->get_script_dependencies( [] ),
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/connections.js' ),
+			true
+		);
+		\wp_enqueue_script( 'newspack-connections-wizard' );
+	}
+
+	/**
+	 * Check if wizard is configured and should be displayed.
+	 *
+	 * @return bool True if necessary variables are present.
+	 */
+	public static function configured() {
+		return WPCOM_OAuth::wpcom_client_id();
+	}
+}

--- a/includes/wizards/class-connections-wizard.php
+++ b/includes/wizards/class-connections-wizard.php
@@ -141,6 +141,13 @@ class Connections_Wizard extends Wizard {
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/connections.js' ),
 			true
 		);
+		\wp_localize_script(
+			'newspack-connections-wizard',
+			'newspack_connections_data',
+			[
+				'can_connect_google' => Google_OAuth::is_oauth_configured(),
+			]
+		);
 		\wp_enqueue_script( 'newspack-connections-wizard' );
 	}
 

--- a/includes/wizards/class-connections-wizard.php
+++ b/includes/wizards/class-connections-wizard.php
@@ -33,13 +33,6 @@ class Connections_Wizard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Get the name for this wizard.
 	 *
 	 * @return string The wizard name.

--- a/includes/wizards/class-connections-wizard.php
+++ b/includes/wizards/class-connections-wizard.php
@@ -37,7 +37,6 @@ class Connections_Wizard extends Wizard {
 	 */
 	public function __construct() {
 		parent::__construct();
-		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
 	}
 
 	/**
@@ -65,63 +64,6 @@ class Connections_Wizard extends Wizard {
 	 */
 	public function get_length() {
 		return esc_html__( '10 minutes', 'newspack' );
-	}
-
-	/**
-	 * Register the endpoints needed for the wizard screens.
-	 */
-	public function register_api_endpoints() {
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/connections',
-			[
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'api_get_connections' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-			]
-		);
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/connections/(?P<provider>[\a-z]+)',
-			[
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_create_connection' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'provider' => [
-						'required'          => true,
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'service'  => [
-						'required'          => true,
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-				],
-			]
-		);
-	}
-
-	/**
-	 * Get all connections.
-	 *
-	 * @param WP_REST_Request $request Request.
-	 */
-	public static function api_get_connections( $request ) {
-		$connections = [];
-		return \rest_ensure_response( $connections );
-	}
-
-	/**
-	 * Create a new connection.
-	 *
-	 * @param WP_REST_Request $request Request.
-	 */
-	public function api_create_connection( $request ) {
-		$provider = $request->get_param( 'provider' );
-		switch ( $provider ) {
-			default:
-				return wp_send_json_error( [ 'message' => __( 'Provider not implemented.', 'newspack' ) ], 404 );
-		}
 	}
 
 	/**

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -109,6 +109,14 @@ class Dashboard extends Wizard {
 				'description' => Wizards::get_description( 'popups' ),
 			],
 		];
+		if ( Connections_Wizard::configured() ) {
+			$dashboard[] = [
+				'slug'        => 'connections',
+				'name'        => Wizards::get_name( 'connections' ),
+				'url'         => Wizards::get_url( 'connections' ),
+				'description' => esc_html__( 'Connections to third-party services', 'newspack' ),
+			];
+		}
 
 		if ( Support_Wizard::configured() ) {
 			$dashboard[] = [

--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -135,9 +135,13 @@ class Support_Wizard extends Wizard {
 		}
 
 		if ( is_wp_error( $response ) ) {
+			$message = __( 'Something went wrong.', 'newspack' );
+			if ( self::support_email() ) {
+				$message = __( 'Something went wrong. Please contact us directly at ', 'newspack' ) . '<a href="mailto:' . self::support_email() . '">' . self::support_email() . '</a>';
+			}
 			return new WP_Error(
 				'newspack_invalid_support',
-				__( 'Something went wrong. Please contact us directly at ', 'newspack' ) . '<a href="mailto:' . self::support_email() . '">' . self::support_email() . '</a>'
+				$message
 			);
 		} else {
 			return \rest_ensure_response(
@@ -304,7 +308,7 @@ class Support_Wizard extends Wizard {
 	 * @return bool True if necessary variables are present.
 	 */
 	public static function configured() {
-		return self::support_api_url() && self::support_email() && WPCOM_OAuth::wpcom_client_id();
+		return WPCOM_OAuth::wpcom_client_id();
 	}
 
 	/**

--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -260,21 +260,12 @@ class Support_Wizard extends Wizard {
 			true
 		);
 
-		$client_id    = WPCOM_OAuth::wpcom_client_id();
-		$redirect_uri = admin_url() . 'admin.php?page=' . $this->slug;
-		$access_token = WPCOM_OAuth::get_access_token();
-		$access_token = $access_token ? $access_token : '';
-		if ( is_wp_error( $access_token ) ) {
-			$access_token = '';
-		}
 		wp_localize_script(
 			'newspack-support-wizard',
 			'newspack_support_data',
 			array(
-				'API_URL'            => self::support_api_url(),
-				'WPCOM_AUTH_URL'     => 'https://public-api.wordpress.com/oauth2/authorize?client_id=' . $client_id . '&redirect_uri=' . $redirect_uri . '&response_type=token&scope=global',
-				'WPCOM_ACCESS_TOKEN' => $access_token,
-				'IS_PRE_LAUNCH'      => false !== self::is_pre_launch(),
+				'API_URL'       => self::support_api_url(),
+				'IS_PRE_LAUNCH' => false !== self::is_pre_launch(),
 			)
 		);
 		wp_enqueue_script( 'newspack-support-wizard' );

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -151,20 +151,25 @@ abstract class Wizard {
 					Wizards::get_url( 'dashboard' )
 				)
 			);
-			$urls['reset_wpcom_url'] = esc_url(
+		}
+
+		$client_id = WPCOM_OAuth::wpcom_client_id();
+		// For legacy-support reasons, the redirect URI is to the Support wizard.
+		$redirect_uri = admin_url() . 'admin.php?page=newspack-support-wizard';
+		$aux_data     = [
+			'is_e2e'               => Starter_Content::is_e2e(),
+			'is_debug_mode'        => Newspack::is_debug_mode(),
+			'site_title'           => get_option( 'blogname' ),
+			'wpcom_auth_url'       => 'https://public-api.wordpress.com/oauth2/authorize?client_id=' . $client_id . '&redirect_uri=' . $redirect_uri . '&response_type=token&scope=global',
+			'wpcom_disconnect_url' => esc_url(
 				add_query_arg(
 					array(
 						'newspack_reset' => 'reset-wpcom',
 					),
 					Wizards::get_url( 'dashboard' )
 				)
-			);
-		}
-
-		$aux_data = [
-			'is_e2e'        => Starter_Content::is_e2e(),
-			'is_debug_mode' => Newspack::is_debug_mode(),
-			'site_title'    => get_option( 'blogname' ),
+			),
+			'WPCOM_ACCESS_TOKEN'   => WPCOM_OAuth::get_access_token(),
 		];
 
 		if ( class_exists( 'Newspack_Popups_Segmentation' ) ) {

--- a/tests/unit-tests/oauth.php
+++ b/tests/unit-tests/oauth.php
@@ -51,7 +51,7 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 			$consent_page_params,
 			[
 				'scope'          => 'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/analytics.edit https://www.googleapis.com/auth/dfp',
-				'redirect_after' => 'http://example.org/wp-admin/admin.php?page=newspack',
+				'redirect_after' => 'http://example.org/wp-admin/admin.php?page=newspack-connections-wizard',
 				'csrf_token'     => $csrf_token,
 			],
 			'The consent page request params are as expected.'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a new wizard, called Connections, for managing all third-party authorisations.

@thomasguillot - as per [your suggestion](https://github.com/Automattic/newspack-plugin/issues/984#issuecomment-862321456), this is kept similar to the Integrations step of Setup flow:

<img width="1146" alt="image" src="https://user-images.githubusercontent.com/7383192/133623458-cdd857fc-def3-43b3-abaa-ac410ad2b4f2.png">

Closes #984

### How to test the changes in this Pull Request:

1. On a fresh site, load the Newspack dashboard. Observe there's no "Connections" wizard available
2. Add the `NEWSPACK_WPCOM_CLIENT_ID` environment variable
3. Observe the Connections wizard is now available, and it allows the user to connect the site to WordPress.com
4. Add the `NEWSPACK_GOOGLE_OAUTH_PROXY` environment variable (see #1122 for more details)
5. Observe an additional connection option - Google
6. Observe that the Google option is disabled, with information that first WordPress.com should be connected
7. Authorise WordPress.com
8. Observe that now Google can be authorised - do it
9. Revoke permissions of both, observe the authorisation flow can be followed again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->