### PR TITLE
fix(health-check): AMP status

### DIFF
--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -117,6 +117,7 @@ class HealthCheckWizard extends Component {
 									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
 									tabbedNavigation={ tabs }
 									configurationStatus={ configurationStatus }
+									missingPlugins={ Object.keys( missingPlugins ) }
 									repairConfiguration={ this.repairConfiguration }
 								/>
 							) }

--- a/assets/wizards/health-check/views/configuration/index.js
+++ b/assets/wizards/health-check/views/configuration/index.js
@@ -21,8 +21,9 @@ class Configuration extends Component {
 	 * Render.
 	 */
 	render() {
-		const { configurationStatus, hasData, repairConfiguration } = this.props;
+		const { configurationStatus, missingPlugins, hasData, repairConfiguration } = this.props;
 		const { amp, jetpack, sitekit } = configurationStatus || {};
+		const isAMPMissing = missingPlugins.indexOf( 'amp' ) !== -1;
 		return (
 			hasData && (
 				<Fragment>
@@ -30,11 +31,14 @@ class Configuration extends Component {
 						className={ amp ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
 						title={ __( 'AMP', 'newspack' ) }
 						description={
-							amp
+							// eslint-disable-next-line no-nested-ternary
+							isAMPMissing
+								? __( 'AMP plugin is not active.', 'newspack' )
+								: amp
 								? __( 'AMP plugin is in standard mode.', 'newspack' )
 								: __( 'AMP plugin is not in standard mode. ', 'newspack' )
 						}
-						actionText={ ! amp && __( 'Repair', 'newspack' ) }
+						actionText={ ! isAMPMissing && ! amp && __( 'Repair', 'newspack' ) }
 						onClick={ () => repairConfiguration( 'amp' ) }
 					/>
 					<ActionCard

--- a/includes/configuration_managers/class-amp-configuration-manager.php
+++ b/includes/configuration_managers/class-amp-configuration-manager.php
@@ -30,14 +30,7 @@ class AMP_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function is_standard_mode() {
 		if ( ! $this->is_configured() ) {
-			return new \WP_Error(
-				'newspack_amp_not_configured',
-				esc_html__( 'The AMP plugin is not configured properly.', 'newspack' ),
-				[
-					'status' => 400,
-					'level'  => 'fatal',
-				]
-			);
+			return false;
 		}
 		return \AMP_Theme_Support::STANDARD_MODE_SLUG === \AMP_Options_Manager::get_option( 'theme_support' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Health Check fix.

### How to test the changes in this Pull Request:

1. On `master`, deactivate AMP
2. Visit Health Check wizard, Configuration tab - observe the AMP status says that AMP is in Standard mode
3. Switch to this branch, observe the AMP status says that the AMP plugin is not active
4. Activate AMP plugin, observe the AMP status displaying correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->