### PR TITLE
fix: restore scroll for wizard screens navigation

### DIFF
--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -1,19 +1,23 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies.
  */
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { Button, Handoff, Notice, TabbedNavigation, WizardPagination } from '../';
+import Router from '../proxied-imports/router';
 import { buttonProps } from '../../../shared/js/';
 import './style.scss';
 
-/**
- * External dependencies
- */
-import classnames from 'classnames';
+const { useLocation } = Router;
 
 /**
  * Higher-Order Component to provide plugin management and error handling to Newspack Wizards.
@@ -54,6 +58,10 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 					{ ...overridingProps }
 				/>
 			);
+		const { pathname } = useLocation();
+		useEffect( () => {
+			window.scrollTo( 0, 0 );
+		}, [ pathname ] );
 		return (
 			<>
 				{ newspack_aux_data.is_debug_mode && (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Wizard screens navigation using react-router is not restoring scroll position, which can be confusing.

This PR implements "scroll to top" to every pathname change for components `withWizardScreen`.

### How to test the changes in this Pull Request:

1. In the master branch, visit the Newspack Ads dashboard
2. Click on the Google Ad Manager "Configure", scroll down and click on the "Back to advertising options" button
3. Observe your scroll is not at the top of the page after the screen change
4. Switch to this branch, run `npm run build`
5. Repeat steps and observe you have been scrolled top, a more predictable behavior.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->