### PR TITLE
Removes Newspack Image Credits

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -202,14 +202,6 @@ class Plugin_Manager {
 				'AuthorURI'   => 'https://automattic.com',
 				'Download'    => 'https://github.com/Automattic/newspack-disqus-amp/releases/latest/download/newspack-disqus-amp.zip',
 			],
-			'newspack-image-credits'        => [
-				'Name'        => 'Newspack Image Credits',
-				'Description' => 'Add photo credit info to images.',
-				'Author'      => 'Automattic, INN Labs, Project Argo',
-				'PluginURI'   => 'https://newspack.pub',
-				'AuthorURI'   => 'https://automattic.com',
-				'Download'    => 'https://github.com/Automattic/newspack-image-credits/releases/latest/download/newspack-image-credits.zip',
-			],
 			'newspack-media-partners'       => [
 				'Name'        => 'Newspack Media Partners',
 				'Description' => 'Add media partners and their logos to posts. Intended for posts published in conjunction with other outlets.',


### PR DESCRIPTION
The standalone Newspack Image Credits plugin has been rolled into the main plugin in https://github.com/Automattic/newspack-plugin/pull/1147 and should no longer be installed separately. This PR removes it from the list of approved/supported plugins.