### PR TITLE
feat: multiple badges for action card

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -74,7 +74,7 @@ class ActionCard extends Component {
 				: {};
 		const hasInternalLink = href && href.indexOf( 'http' ) !== 0;
 		const isDisplayingSecondaryAction = secondaryActionText && onSecondaryActionClick;
-		const badges = Array.isArray( badge ) ? badge : [ badge ];
+		const badges = ! Array.isArray( badge ) && badge ? [ badge ] : badge;
 		return (
 			<Card className={ classes } onClick={ simple && onClick }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
@@ -113,7 +113,7 @@ class ActionCard extends Component {
 							<span className="newspack-action-card__title" { ...titleProps }>
 								{ titleLink ? <a href={ titleLink }>{ title }</a> : title }
 							</span>
-							{ badges &&
+							{ badges?.length &&
 								badges.map( ( badgeText, i ) => (
 									<span key={ `badge-${ i }` } className="newspack-action-card__badge">
 										{ badgeText }

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -74,6 +74,7 @@ class ActionCard extends Component {
 				: {};
 		const hasInternalLink = href && href.indexOf( 'http' ) !== 0;
 		const isDisplayingSecondaryAction = secondaryActionText && onSecondaryActionClick;
+		const badges = Array.isArray( badge ) ? badge : [ badge ];
 		return (
 			<Card className={ classes } onClick={ simple && onClick }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
@@ -112,7 +113,12 @@ class ActionCard extends Component {
 							<span className="newspack-action-card__title" { ...titleProps }>
 								{ titleLink ? <a href={ titleLink }>{ title }</a> : title }
 							</span>
-							{ badge && <span className="newspack-action-card__badge">{ badge }</span> }
+							{ badges &&
+								badges.map( ( badgeText, i ) => (
+									<span key={ `badge-${ i }` } className="newspack-action-card__badge">
+										{ badgeText }
+									</span>
+								) ) }
 						</h2>
 						<p>
 							{ typeof description === 'string' && description }

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -355,6 +355,10 @@
 		margin: 3px 8px 3px 0;
 		padding: 0 8px;
 		text-transform: uppercase;
+
+		+ .newspack-action-card__badge {
+			margin-left: -4px;
+		}
 	}
 
 	// Description Card

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -413,6 +413,15 @@ class ComponentsDemo extends Component {
 						checkbox="checked"
 					/>
 					<ActionCard
+						badge={ [ __( 'Premium', 'newspack' ), __( 'Archived', 'newspack' ) ] }
+						title={ __( 'Example Fourteen', 'newspack' ) }
+						description={ __( 'An example of an action card with two badges.', 'newspack' ) }
+						actionText={ __( 'Install', 'newspack' ) }
+						onClick={ () => {
+							console.log( 'Install clicked' );
+						} }
+					/>
+					<ActionCard
 						title={ __( 'Handoff', 'newspack' ) }
 						description={ __( 'An example of an action card with Handoff.', 'newspack' ) }
 						actionText={ __( 'Configure', 'newspack' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allow an action card to have multiple badges.

Observe "Example Fourteen" from the image:

![image](https://user-images.githubusercontent.com/820752/134962409-a34287c1-2a60-4029-a445-0f8d38abbf9e.png)

### How to test the changes in this Pull Request:

1. Check out this branch and run `npm run build`
2. Visit the `newspack-components-demo` page
3. Observe the unaltered "Example Ten" works as expected and the "Example Fourteen" displays multiple badges from an array.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->