### PR TITLE
fix: react router crash from useLocation in HOC

### DIFF
--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -17,7 +17,7 @@ import Router from '../proxied-imports/router';
 import { buttonProps } from '../../../shared/js/';
 import './style.scss';
 
-const { useLocation } = Router;
+const { withRouter } = Router;
 
 /**
  * Higher-Order Component to provide plugin management and error handling to Newspack Wizards.
@@ -35,6 +35,7 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 			secondaryButtonText,
 			secondaryButtonAction,
 			routes,
+			location = {},
 		} = props;
 		const retrievedButtonProps = buttonProps( buttonAction );
 		const retrievedSecondaryButtonProps = buttonProps( secondaryButtonAction );
@@ -58,7 +59,8 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 					{ ...overridingProps }
 				/>
 			);
-		const { pathname } = useLocation();
+
+		const { pathname } = location;
 		useEffect( () => {
 			window.scrollTo( 0, 0 );
 		}, [ pathname ] );
@@ -100,5 +102,5 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 			</>
 		);
 	};
-	return WrappedWithWizardScreen;
+	return withRouter( WrappedWithWizardScreen );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids the use of the `useLocation` hook from #1157 in order to avoid an occasional crash due to using a hook inside a higher-order component.

### How to test the changes in this Pull Request:

1. On `master`,  navigate to `https://<siteurl>/wp-admin/admin.php?page=newspack-setup-wizard#/settings` and observe a JS crash with the following error: https://reactjs.org/docs/error-decoder.html/?invariant=321

```
Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons: 1. You might have mismatching versions of React and the renderer (such as React DOM) 2. You might be breaking the Rules of Hooks 3. You might have more than one copy of React in the same app See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.
```

2. Check out and build this branch, refresh, confirm that the crash no longer occurs.
3. Navigate through the various Newspack wizard screens and confirm no crashes occur and navigation still works as expected. Also confirm that the testing steps from #1157 are still valid.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->