### PR TITLE
revert scroll restoration in wizards

### DIFF
--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -17,7 +17,7 @@ import Router from '../proxied-imports/router';
 import { buttonProps } from '../../../shared/js/';
 import './style.scss';
 
-const { withRouter } = Router;
+const { useLocation } = Router;
 
 /**
  * Higher-Order Component to provide plugin management and error handling to Newspack Wizards.
@@ -35,7 +35,6 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 			secondaryButtonText,
 			secondaryButtonAction,
 			routes,
-			location = {},
 		} = props;
 		const retrievedButtonProps = buttonProps( buttonAction );
 		const retrievedSecondaryButtonProps = buttonProps( secondaryButtonAction );
@@ -59,8 +58,7 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 					{ ...overridingProps }
 				/>
 			);
-
-		const { pathname } = location;
+		const { pathname } = useLocation();
 		useEffect( () => {
 			window.scrollTo( 0, 0 );
 		}, [ pathname ] );
@@ -102,5 +100,5 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 			</>
 		);
 	};
-	return withRouter( WrappedWithWizardScreen );
+	return WrappedWithWizardScreen;
 }

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -1,23 +1,19 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies.
  */
-import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { Button, Handoff, Notice, TabbedNavigation, WizardPagination } from '../';
-import Router from '../proxied-imports/router';
 import { buttonProps } from '../../../shared/js/';
 import './style.scss';
 
-const { useLocation } = Router;
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
 
 /**
  * Higher-Order Component to provide plugin management and error handling to Newspack Wizards.
@@ -58,10 +54,6 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 					{ ...overridingProps }
 				/>
 			);
-		const { pathname } = useLocation();
-		useEffect( () => {
-			window.scrollTo( 0, 0 );
-		}, [ pathname ] );
 		return (
 			<>
 				{ newspack_aux_data.is_debug_mode && (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1157 introduces a but in the WPCOM authentication flow (which #1165 does not fix). This PR reverts both changes, since the impact of the bug is severe and the feature introduced is not crucial. 

The scroll restoration added in #1157 might have to be implemented at a different level. The issue with the existing approach seems to be (didn't have time to investigate definitely) the assumption that any component wrapped with `withWizard` HOC will return a router. This is not true in the case of [Support wizard during authentication flow](https://github.com/Automattic/newspack-plugin/blob/fa45f45e4cd58e7d79cc88b018f4cc55a923c844/assets/wizards/support/index.js#L66).

### How to test the changes in this Pull Request:

1. On `master`, reset WPCOM auth and try to authenticate by visiting the Support wizard
2. Observe WP admin crashing on redirect
3. Switch to this branch, observe authentication flow working as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->