### PR TITLE
feat(ads): standardize ad unit sizes

### DIFF
--- a/assets/wizards/advertising/components/ad-unit-size-control/index.js
+++ b/assets/wizards/advertising/components/ad-unit-size-control/index.js
@@ -47,7 +47,7 @@ const AdUnitSizeControl = ( { value, onChange } ) => {
 						label: `${ size[ 0 ] } x ${ size[ 1 ] }`,
 						value: index,
 					} ) ),
-					{ label: 'Custom', value: -1 },
+					{ label: __( 'Custom', 'newspack' ), value: -1 },
 				] }
 				onChange={ index => {
 					onChange( DEFAULT_SIZES[ index ] || [ 120, 120 ] );

--- a/assets/wizards/advertising/components/ad-unit-size-control/index.js
+++ b/assets/wizards/advertising/components/ad-unit-size-control/index.js
@@ -7,7 +7,7 @@
 /**
  * WordPress dependencies.
  */
-import { Fragment } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -18,7 +18,7 @@ import { Grid, SelectControl, TextControl } from '../../../../components/src';
 /**
  * Interactive Advertising Bureau's standard ad sizes.
  */
-const DEFAULT_SIZES = [
+export const DEFAULT_SIZES = [
 	[ 970, 250 ],
 	[ 970, 90 ],
 	[ 728, 90 ],
@@ -36,6 +36,7 @@ const DEFAULT_SIZES = [
  */
 const AdUnitSizeControl = ( { value, onChange } ) => {
 	const [ width, height ] = value;
+	const [ isCustom, setIsCustom ] = useState( false );
 	const sizeIndex = DEFAULT_SIZES.findIndex( size => size[ 0 ] === width && size[ 1 ] === height );
 	return (
 		<Fragment>
@@ -50,10 +51,12 @@ const AdUnitSizeControl = ( { value, onChange } ) => {
 					{ label: __( 'Custom', 'newspack' ), value: -1 },
 				] }
 				onChange={ index => {
-					onChange( DEFAULT_SIZES[ index ] || [ 120, 120 ] );
+					const size = DEFAULT_SIZES[ index ];
+					setIsCustom( ! size );
+					if ( size ) onChange( size );
 				} }
 			/>
-			{ sizeIndex === -1 && (
+			{ ( isCustom || sizeIndex === -1 ) && (
 				<Grid gutter={ 32 } noMargin>
 					<TextControl
 						label={ __( 'Width', 'newspack' ) }

--- a/assets/wizards/advertising/components/ad-unit-size-control/index.js
+++ b/assets/wizards/advertising/components/ad-unit-size-control/index.js
@@ -1,0 +1,74 @@
+/**
+ * Ad Unit Size Control.
+ *
+ * Select from a subset of sizes, or enter custom width and height.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import { Grid, SelectControl, TextControl } from '../../../../components/src';
+
+/**
+ * IAB Standard Sizes.
+ */
+const DEFAULT_SIZES = [
+	[ 970, 250 ],
+	[ 970, 90 ],
+	[ 728, 90 ],
+	[ 300, 600 ],
+	[ 300, 250 ],
+	[ 300, 1050 ],
+	[ 160, 600 ],
+	[ 320, 50 ],
+	[ 320, 100 ],
+	[ 120, 60 ],
+];
+
+/**
+ * Ad Unit Size Control.
+ */
+const AdUnitSizeControl = ( { value, onChange } ) => {
+	const [ width, height ] = value;
+	const sizeIndex = DEFAULT_SIZES.findIndex( size => size[ 0 ] === width && size[ 1 ] === height );
+	return (
+		<Fragment>
+			<SelectControl
+				label={ __( 'Size', 'newspack' ) }
+				value={ sizeIndex }
+				options={ [
+					...DEFAULT_SIZES.map( ( size, index ) => ( {
+						label: `${ size[ 0 ] } x ${ size[ 1 ] }`,
+						value: index,
+					} ) ),
+					{ label: 'Custom', value: -1 },
+				] }
+				onChange={ index => {
+					onChange( DEFAULT_SIZES[ index ] || [ 120, 120 ] );
+				} }
+			/>
+			{ sizeIndex === -1 && (
+				<Grid gutter={ 32 } noMargin>
+					<TextControl
+						label={ __( 'Width', 'newspack' ) }
+						value={ width }
+						onChange={ newWidth => onChange( [ newWidth, height ] ) }
+					/>
+					<TextControl
+						label={ __( 'Height', 'newspack' ) }
+						value={ height }
+						onChange={ newHeight => onChange( [ width, newHeight ] ) }
+					/>
+				</Grid>
+			) }
+		</Fragment>
+	);
+};
+
+export default AdUnitSizeControl;

--- a/assets/wizards/advertising/components/ad-unit-size-control/index.js
+++ b/assets/wizards/advertising/components/ad-unit-size-control/index.js
@@ -16,7 +16,7 @@ import { __ } from '@wordpress/i18n';
 import { Grid, SelectControl, TextControl } from '../../../../components/src';
 
 /**
- * IAB Standard Sizes.
+ * Interactive Advertising Bureau's standard ad sizes.
  */
 const DEFAULT_SIZES = [
 	[ 970, 250 ],

--- a/assets/wizards/advertising/components/ad-unit-size-control/index.js
+++ b/assets/wizards/advertising/components/ad-unit-size-control/index.js
@@ -7,7 +7,7 @@
 /**
  * WordPress dependencies.
  */
-import { Fragment, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -39,7 +39,7 @@ const AdUnitSizeControl = ( { value, onChange } ) => {
 	const [ isCustom, setIsCustom ] = useState( false );
 	const sizeIndex = DEFAULT_SIZES.findIndex( size => size[ 0 ] === width && size[ 1 ] === height );
 	return (
-		<Fragment>
+		<Grid gutter={ 32 } columns={ 3 } noMargin>
 			<SelectControl
 				label={ __( 'Size', 'newspack' ) }
 				value={ sizeIndex }
@@ -56,21 +56,21 @@ const AdUnitSizeControl = ( { value, onChange } ) => {
 					if ( size ) onChange( size );
 				} }
 			/>
-			{ ( isCustom || sizeIndex === -1 ) && (
-				<Grid gutter={ 32 } noMargin>
-					<TextControl
-						label={ __( 'Width', 'newspack' ) }
-						value={ width }
-						onChange={ newWidth => onChange( [ newWidth, height ] ) }
-					/>
-					<TextControl
-						label={ __( 'Height', 'newspack' ) }
-						value={ height }
-						onChange={ newHeight => onChange( [ width, newHeight ] ) }
-					/>
-				</Grid>
-			) }
-		</Fragment>
+			<TextControl
+				label={ __( 'Width', 'newspack' ) }
+				value={ width }
+				onChange={ newWidth => onChange( [ newWidth, height ] ) }
+				disabled={ ! isCustom && sizeIndex !== -1 }
+				type="number"
+			/>
+			<TextControl
+				label={ __( 'Height', 'newspack' ) }
+				value={ height }
+				onChange={ newHeight => onChange( [ width, newHeight ] ) }
+				disabled={ ! isCustom && sizeIndex !== -1 }
+				type="number"
+			/>
+		</Grid>
 	);
 };
 

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
 import { AdUnit, AdUnits, Placements, Services, Suppression } from './views';
+import { DEFAULT_SIZES as adUnitSizes } from './components/ad-unit-size-control';
 import './style.scss';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
@@ -422,7 +423,7 @@ class AdvertisingWizard extends Component {
 											id: 0,
 											name: '',
 											code: '',
-											sizes: [ [ 120, 120 ] ],
+											sizes: [ adUnitSizes[ 0 ] ],
 										}
 									}
 									service={ 'google_ad_manager' }

--- a/assets/wizards/advertising/style.scss
+++ b/assets/wizards/advertising/style.scss
@@ -2,4 +2,13 @@
 	.newspack-button-card .newspack-notice {
 		margin: 24px 0 0;
 	}
+
+	&__ad-unit-size {
+		margin: 64px 0 16px;
+
+		h2,
+		.newspack-grid {
+			margin: 0;
+		}
+	}
 }

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import { Button, Card, Grid, TextControl, withWizardScreen } from '../../../../components/src';
+import AdUnitSizeControl from '../../components/ad-unit-size-control';
 
 /**
  * New/Edit Ad Unit Screen.
@@ -88,29 +89,16 @@ class AdUnit extends Component {
 								</>
 							) }
 						</div>
-						<Grid gutter={ 32 } noMargin>
-							<TextControl
-								label={ __( 'Width' ) }
-								value={ size[ 0 ] }
-								type="number"
-								onChange={ value => {
-									sizes[ index ][ 0 ] = value;
-									this.handleOnChange( 'sizes', sizes );
-								} }
-							/>
-							<TextControl
-								label={ __( 'Height' ) }
-								value={ size[ 1 ] }
-								type="number"
-								onChange={ value => {
-									sizes[ index ][ 1 ] = value;
-									this.handleOnChange( 'sizes', sizes );
-								} }
-							/>
-						</Grid>
+						<AdUnitSizeControl
+							value={ size }
+							onChange={ value => {
+								sizes[ index ] = value;
+								this.handleOnChange( 'sizes', sizes );
+							} }
+						/>
 					</Card>
 				) ) }
-				<Button isLink onClick={ () => this.handleOnChange( 'sizes', [ ...sizes, [ 120, 120 ] ] ) }>
+				<Button isLink onClick={ () => this.handleOnChange( 'sizes', [ ...sizes, [ 970, 250 ] ] ) }>
 					{ __( 'Add Size', 'newspack' ) }
 				</Button>
 				<div className="clear" />

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -40,7 +40,8 @@ class AdUnit extends Component {
 		const { id, code, name = '' } = adUnit;
 		const isLegacy = false === serviceData.status?.can_connect || adUnit.is_legacy;
 		const isExistingAdUnit = id !== 0;
-		const sizes = adUnit.sizes && Array.isArray( adUnit.sizes ) ? adUnit.sizes : [ [ 120, 120 ] ];
+		const sizes =
+			adUnit.sizes && Array.isArray( adUnit.sizes ) ? adUnit.sizes : [ adUnitSizes[ 0 ] ];
 		return (
 			<Fragment>
 				<h2>{ __( 'Ad Unit Details', 'newspack' ) }</h2>

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -12,7 +12,9 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import { Button, Card, Grid, TextControl, withWizardScreen } from '../../../../components/src';
-import AdUnitSizeControl from '../../components/ad-unit-size-control';
+import AdUnitSizeControl, {
+	DEFAULT_SIZES as adUnitSizes,
+} from '../../components/ad-unit-size-control';
 
 /**
  * New/Edit Ad Unit Screen.
@@ -98,7 +100,10 @@ class AdUnit extends Component {
 						/>
 					</Card>
 				) ) }
-				<Button isLink onClick={ () => this.handleOnChange( 'sizes', [ ...sizes, [ 970, 250 ] ] ) }>
+				<Button
+					isLink
+					onClick={ () => this.handleOnChange( 'sizes', [ ...sizes, adUnitSizes[ 0 ] ] ) }
+				>
 					{ __( 'Add Size', 'newspack' ) }
 				</Button>
 				<div className="clear" />

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -69,36 +69,38 @@ class AdUnit extends Component {
 					) }
 				</Grid>
 				{ sizes.map( ( size, index ) => (
-					<Card noBorder key={ index }>
-						<div className="flex flex-wrap items-center">
-							<h2>
-								{ sizes.length > 1
-									? __( 'Ad Unit Size #', 'newspack' ) + ( index + 1 )
-									: __( 'Ad Unit Size', 'newspack' ) }
-							</h2>
-							{ sizes.length > 1 && (
-								<>
-									<span className="sep" />
-									<Button
-										isLink
-										isDestructive
-										onClick={ () => {
-											sizes.splice( index, 1 );
-											this.handleOnChange( 'sizes', sizes );
-										} }
-									>
-										{ __( 'Delete', 'newspack' ) }
-									</Button>
-								</>
-							) }
-						</div>
-						<AdUnitSizeControl
-							value={ size }
-							onChange={ value => {
-								sizes[ index ] = value;
-								this.handleOnChange( 'sizes', sizes );
-							} }
-						/>
+					<Card noBorder className="newspack-advertising-wizard__ad-unit-size" key={ index }>
+						<Grid columns={ 1 } gutter={ 16 }>
+							<div className="flex flex-wrap items-center">
+								<h2>
+									{ sizes.length > 1
+										? __( 'Ad Unit Size #', 'newspack' ) + ( index + 1 )
+										: __( 'Ad Unit Size', 'newspack' ) }
+								</h2>
+								{ sizes.length > 1 && (
+									<>
+										<span className="sep" />
+										<Button
+											isLink
+											isDestructive
+											onClick={ () => {
+												sizes.splice( index, 1 );
+												this.handleOnChange( 'sizes', sizes );
+											} }
+										>
+											{ __( 'Delete', 'newspack' ) }
+										</Button>
+									</>
+								) }
+							</div>
+							<AdUnitSizeControl
+								value={ size }
+								onChange={ value => {
+									sizes[ index ] = value;
+									this.handleOnChange( 'sizes', sizes );
+								} }
+							/>
+						</Grid>
 					</Card>
 				) ) }
 				<Button


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements an Ad Unit Size Control component to allow the selection of standardized ad units sizes as specified at https://github.com/Automattic/newspack-ads/issues/187.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-ads/issues/187

### How to test the changes in this Pull Request:

1. Check out this PR and run `npm run build`
2. Visit the Advertising dashboard, edit an existing Ad Unit that has a size outside the range specified at https://github.com/Automattic/newspack-ads/issues/187
3. Observe the select element with selected `Custom` value, along with the previous values preserved
4. Create a new ad unit and add a new size, attempt to select different sizes and save
5. Edit the newly created ad unit, select `Custom` size and save with a random width and height
6. Refresh and confirm the value is saved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->