### PR TITLE
fix(campaigns-wizard): segmentation configuration

### DIFF
--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -184,6 +184,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 						min={ segmentConfig.min_session_posts }
 						max={ segmentConfig.max_session_posts }
 						onChangeMin={ updateSegmentConfig( 'min_session_posts' ) }
+						onChangeMax={ updateSegmentConfig( 'max_session_posts' ) }
 						minPlaceholder={ __( 'Min posts in session', 'newspack' ) }
 						maxPlaceholder={ __( 'Max posts in session', 'newspack' ) }
 					/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug.

### How to test the changes in this Pull Request:

1. On `master`, create or edit a segment in Campaigns Wizard
2. Observe that the "Articles read in session" -> "Max" setting is not editable
3. Switch to this branch, observe the setting is editable

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->