### PR TITLE
perf: optimize maybe disable ads verification

### DIFF
--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -809,8 +809,8 @@ class Advertising_Wizard extends Wizard {
 			return $should_show_ads;
 		}
 
-		$services = self::get_services();
-		if ( ! $services['google_ad_manager']['enabled'] ) {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+		if ( ! $configuration_manager->is_service_enabled( 'google_ad_manager' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `maybe_disable_gam_ads()` method is called on every page load and is currently fetching all services data without necessity.

This PR optimizes the method by verifying if the service is enabled directly through the `Configuration_Managers` class.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

Check out this branch and make sure toggling GAM through the Ads wizard still behaves as expected for disabling Ads.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->