### PR TITLE
feat(gam): use oauth; remove service account connection

### DIFF
--- a/assets/components/src/text-control/index.js
+++ b/assets/components/src/text-control/index.js
@@ -36,11 +36,12 @@ class TextControl extends Component {
 	 * Render.
 	 */
 	render() {
-		const { className, required, isSmall, isWide, ...otherProps } = this.props;
+		const { className, required, isSmall, isWide, withMargin = true, ...otherProps } = this.props;
 		const classes = classNames(
 			'newspack-text-control',
 			{ 'newspack-text-control--small': isSmall },
 			{ 'newspack-text-control--wide': isWide },
+			{ 'newspack-text-control--with-margin': withMargin },
 			className
 		);
 		return required ? (

--- a/assets/components/src/text-control/style.scss
+++ b/assets/components/src/text-control/style.scss
@@ -9,7 +9,9 @@
 	color: $gray-700;
 	font-size: 14px;
 	line-height: 24px;
-	margin: 32px 0;
+	&--with-margin {
+		margin: 32px 0;
+	}
 
 	&--wide {
 		flex-wrap: wrap;

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -169,63 +169,6 @@ class AdvertisingWizard extends Component {
 	};
 
 	/**
-	 * Update GAM credentials.
-	 */
-	updateGAMCredentials = credentials => {
-		const { setError, wizardApiFetch } = this.props;
-		return new Promise( ( resolve, reject ) => {
-			wizardApiFetch( {
-				path: '/newspack/v1/wizard/advertising/credentials',
-				method: 'post',
-				data: { credentials },
-				quiet: true,
-			} )
-				.then( advertisingData => {
-					this.setState(
-						{
-							advertisingData: this.prepareData( advertisingData ),
-						},
-						() => {
-							setError();
-							resolve( this.state );
-						}
-					);
-				} )
-				.catch( error => {
-					setError( error ).then( () => reject( error ) );
-				} );
-		} );
-	};
-
-	/**
-	 * Remove GAM credentials.
-	 */
-	removeGAMCredentials = () => {
-		const { setError, wizardApiFetch } = this.props;
-		return new Promise( ( resolve, reject ) => {
-			wizardApiFetch( {
-				path: '/newspack/v1/wizard/advertising/credentials',
-				method: 'delete',
-				quiet: true,
-			} )
-				.then( advertisingData => {
-					this.setState(
-						{
-							advertisingData: this.prepareData( advertisingData ),
-						},
-						() => {
-							setError();
-							resolve( this.state );
-						}
-					);
-				} )
-				.catch( error => {
-					setError( error ).then( () => reject( error ) );
-				} );
-		} );
-	};
-
-	/**
 	 * Update a single ad unit.
 	 */
 	onAdUnitChange = adUnit => {
@@ -399,8 +342,6 @@ class AdvertisingWizard extends Component {
 									secondaryButtonText={ __( 'Back to advertising options', 'newspack' ) }
 									secondaryButtonAction="#/"
 									wizardApiFetch={ wizardApiFetch }
-									updateGAMCredentials={ this.updateGAMCredentials }
-									removeGAMCredentials={ this.removeGAMCredentials }
 									fetchAdvertisingData={ this.fetchAdvertisingData }
 									updateAdUnit={ adUnit => {
 										this.onAdUnitChange( adUnit );

--- a/assets/wizards/advertising/style.scss
+++ b/assets/wizards/advertising/style.scss
@@ -11,35 +11,4 @@
 			margin: 0;
 		}
 	}
-
-	&__network-code {
-		align-items: flex-end;
-		display: flex;
-		flex-wrap: wrap;
-		margin-bottom: -32px;
-
-		.newspack-button-card + & {
-			margin-top: -32px;
-		}
-
-		.newspack-text-control {
-			flex: 1 1 100%;
-			margin-bottom: 8px;
-
-			@media screen and ( min-width: 768px ) {
-				flex-basis: auto;
-				margin-bottom: 32px;
-				margin-right: 8px;
-			}
-		}
-
-		.newspack-card__buttons-card {
-			flex: 0 0 auto;
-			margin-top: 0;
-
-			.newspack-button + .newspack-button {
-				margin-left: 0;
-			}
-		}
-	}
 }

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import { trash, pencil } from '@wordpress/icons';
@@ -15,11 +15,9 @@ import { trash, pencil } from '@wordpress/icons';
  */
 import {
 	ActionCard,
-	ButtonCard,
 	TextControl,
 	Button,
 	Card,
-	Modal,
 	Notice,
 	withWizardScreen,
 } from '../../../../components/src';
@@ -34,24 +32,14 @@ const AdUnits = ( {
 	wizardApiFetch,
 	service,
 	serviceData,
-	updateGAMCredentials,
-	removeGAMCredentials,
 	fetchAdvertisingData,
 } ) => {
-	const warningNoticeText = `${ __(
-		'Please connect your Google account using the Newspack dashboard in order to use ad units from your GAM account.',
-		'newspack'
-	) } ${
-		Object.values( adUnits ).length
-			? __( 'The legacy ad units will continue to work.', 'newspack' )
-			: ''
-	}`;
-	const gamConnectionMessage = serviceData?.status?.error
-		? `${ __( 'Google Ad Manager connection error', 'newspack' ) }: ${ serviceData.status.error }`
+	const gamConnectionErrorMessage = serviceData?.status?.error
+		? `${ __( 'Google Ad Manager connection issue', 'newspack' ) }: ${ serviceData.status.error }`
 		: false;
 
 	const isDisplayingNetworkMismatchNotice =
-		! gamConnectionMessage && false === serviceData.status?.is_network_code_matched;
+		! gamConnectionErrorMessage && false === serviceData.status?.is_network_code_matched;
 
 	const [ networkCode, setNetworkCode ] = useState( serviceData.status.network_code );
 	const saveNetworkCode = async () => {
@@ -64,34 +52,9 @@ const AdUnits = ( {
 		fetchAdvertisingData( true );
 	};
 
-	const [ fileError, setFileError ] = useState( '' );
-	const handleCredentialsFile = event => {
-		if ( event.target.files.length && event.target.files[ 0 ] ) {
-			const reader = new FileReader();
-			reader.readAsText( event.target.files[ 0 ], 'UTF-8' );
-			reader.onload = function ( ev ) {
-				let credentials;
-				try {
-					credentials = JSON.parse( ev.target.result );
-				} catch ( error ) {
-					setFileError( __( 'Invalid JSON file', 'newspack' ) );
-					return;
-				}
-				updateGAMCredentials( credentials );
-			};
-			reader.onerror = function () {
-				setFileError( __( 'Unable to read file', 'newspack' ) );
-			};
-		}
-	};
-
 	useEffect( () => {
 		setNetworkCode( serviceData.status.network_code );
 	}, [ serviceData.status.network_code ] );
-
-	const credentialsInputFile = useRef( null );
-
-	const [ isRemoving, setIsRemoving ] = useState( false );
 
 	return (
 		<>
@@ -106,48 +69,11 @@ const AdUnits = ( {
 							isWarning
 						/>
 					) }
-					{ serviceData.status.connected === false && (
-						<>
-							<Notice
-								noticeText={ gamConnectionMessage || warningNoticeText }
-								isWarning={ ! gamConnectionMessage }
-								isError={ gamConnectionMessage }
-							/>
-							<Button
-								isSecondary
-								onClick={ () => {
-									credentialsInputFile.current.click();
-								} }
-							>
-								{ __( 'Upload new credentials', 'newspack' ) }
-							</Button>
-						</>
+					{ gamConnectionErrorMessage && (
+						<Notice noticeText={ gamConnectionErrorMessage } isError />
 					) }
 				</>
-			) : (
-				<>
-					<Notice
-						noticeText={ __( 'Currently operating in legacy mode.', 'newspack' ) }
-						isWarning
-					/>
-					{ ! serviceData.status.incompatible && (
-						<ButtonCard
-							onClick={ () => {
-								credentialsInputFile.current.click();
-							} }
-							title={ __( 'Connect your Google Ad Manager account', 'newspack' ) }
-							desc={ [
-								__(
-									'Upload your Service Account credentials file to connect your GAM account with Newspack Ads.',
-									'newspack'
-								),
-								fileError && <Notice noticeText={ fileError } isError />,
-							] }
-							chevron
-						/>
-					) }
-				</>
-			) }
+			) : null }
 			{ serviceData.created_targeting_keys?.length > 0 && (
 				<Notice
 					noticeText={ [
@@ -163,67 +89,47 @@ const AdUnits = ( {
 					isSuccess
 				/>
 			) }
-			<div className="newspack-advertising-wizard__network-code">
-				<TextControl
-					label={ __( 'Network Code', 'newspack' ) }
-					value={ networkCode }
-					onChange={ setNetworkCode }
-					disabled={ serviceData.status.connected }
-				/>
-				<Card buttonsCard noBorder>
-					{ ! serviceData.status.connected ? (
+			{ serviceData.status.can_use_oauth && serviceData.status.mode !== 'oauth' && (
+				<Notice isWarning>
+					<>
+						<span>
+							{ __(
+								'You are currently using a legacy version of Google Ad Manager connection. Visit the "Connections" wizard of Newspack plugin to connect your Google account.',
+								'newspack'
+							) }
+						</span>
+						{ serviceData.status.mode === 'service_account' && (
+							<span>
+								{ ' ' }
+								{ __(
+									'Afterwards, remove the service account credentials from the database.',
+									'newspack'
+								) }
+							</span>
+						) }
+					</>
+				</Notice>
+			) }
+			{ serviceData.status.mode === 'legacy' ? (
+				<div className="flex items-end">
+					<TextControl
+						label={ __( 'Network Code', 'newspack' ) }
+						value={ networkCode }
+						onChange={ setNetworkCode }
+						withMargin={ false }
+					/>
+					<span className="pl3">
 						<Button onClick={ saveNetworkCode } isPrimary disabled={ serviceData.status.connected }>
 							{ __( 'Save', 'newspack' ) }
 						</Button>
-					) : (
-						<>
-							<Button
-								onClick={ () => {
-									credentialsInputFile.current.click();
-								} }
-								isSecondary
-							>
-								{ __( 'Upload New Credentials', 'newspack' ) }
-							</Button>
-							<Button
-								onClick={ () => {
-									setIsRemoving( true );
-								} }
-								isDestructive
-							>
-								{ __( 'Remove Credentials', 'newspack' ) }
-							</Button>
-						</>
-					) }
-					{ isRemoving && (
-						<Modal
-							title={ __( 'Remove Service Account Credentials', 'newspack' ) }
-							onRequestClose={ () => setIsRemoving( false ) }
-						>
-							<p>
-								{ __(
-									'The credentials will be removed and Newspack Ads will no longer be connected to this Google Ad Manager account.',
-									'newspack'
-								) }
-							</p>
-							<Card buttonsCard noBorder className="justify-end">
-								<Button isSecondary onClick={ () => setIsRemoving( false ) }>
-									{ __( 'Cancel', 'newspack' ) }
-								</Button>
-								<Button
-									isDestructive
-									onClick={ () => {
-										removeGAMCredentials();
-										setIsRemoving( false );
-									} }
-								>
-									{ __( 'Remove Credentials', 'newspack' ) }
-								</Button>
-							</Card>
-						</Modal>
-					) }
-				</Card>
-			</div>
+					</span>
+				</div>
+			) : (
+				<div className="mb3">
+					<strong>{ __( 'Network code:', 'newspack' ) } </strong>
+					<code>{ networkCode }</code>
+				</div>
+			) }
 			<p>
 				{ __(
 					'Set up multiple ad units to use on your homepage, articles and other places throughout your site.',
@@ -296,13 +202,6 @@ const AdUnits = ( {
 						);
 					} ) }
 			</Card>
-			<input
-				type="file"
-				accept=".json"
-				ref={ credentialsInputFile }
-				style={ { display: 'none' } }
-				onChange={ handleCredentialsFile }
-			/>
 		</>
 	);
 };

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -46,30 +46,6 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
-	 * Update GAM credentials.
-	 *
-	 * @param array $credentials Credentials to update.
-	 *
-	 * @return object|WP_Error Connection status or error if it fails.
-	 */
-	public function update_gam_credentials( $credentials ) {
-		return $this->is_configured() ?
-			\Newspack_Ads_Model::update_gam_credentials( $credentials ) :
-			$this->unconfigured_error();
-	}
-
-	/**
-	 * Remove GAM credentials.
-	 *
-	 * @return object|WP_Error Connection status or error if it fails.
-	 */
-	public function remove_gam_credentials() {
-		return $this->is_configured() ?
-			\Newspack_Ads_Model::remove_gam_credentials() :
-			$this->unconfigured_error();
-	}
-
-	/**
 	 * Get the ad units from our saved option.
 	 *
 	 * @return array | WP_Error Array of ad units or WP_Error if Newspack Ads isn't installed and activated.

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -179,75 +179,6 @@ class Advertising_Wizard extends Wizard {
 			]
 		);
 
-		// Update GAM credentials.
-		\register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/credentials',
-			[
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_update_gam_credentials' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'credentials' => [
-						'type'       => 'object',
-						'properties' => [
-							'type'                        => [
-								'required' => true,
-								'type'     => 'string',
-							],
-							'project_id'                  => [
-								'required' => true,
-								'type'     => 'string',
-							],
-							'private_key_id'              => [
-								'required' => true,
-								'type'     => 'string',
-							],
-							'private_key'                 => [
-								'required' => true,
-								'type'     => 'string',
-							],
-							'client_email'                => [
-								'required' => true,
-								'type'     => 'string',
-							],
-							'client_id'                   => [
-								'required' => true,
-								'type'     => 'string',
-							],
-							'auth_uri'                    => [
-								'required' => true,
-								'type'     => 'string',
-							],
-							'token_uri'                   => [
-								'required' => true,
-								'type'     => 'string',
-							],
-							'auth_provider_x509_cert_url' => [
-								'required' => true,
-								'type'     => 'string',
-							],
-							'client_x509_cert_url'        => [
-								'required' => true,
-								'type'     => 'string',
-							],
-						],
-					],
-				],
-			]
-		);
-
-		// Remove GAM credentials.
-		\register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/credentials',
-			[
-				'methods'             => \WP_REST_Server::DELETABLE,
-				'callback'            => [ $this, 'api_remove_gam_credentials' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-			]
-		);
-
 		// Save a ad unit.
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,
@@ -456,39 +387,6 @@ class Advertising_Wizard extends Wizard {
 	}
 
 	/**
-	 * Update GAM credentials.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response containing current GAM status.
-	 */
-	public function api_update_gam_credentials( $request ) {
-		$params                = $request->get_params();
-		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
-		$response              = $configuration_manager->update_gam_credentials( $params['credentials'] );
-
-		if ( \is_wp_error( $response ) ) {
-			return \rest_ensure_response( $response );
-		}
-		return \rest_ensure_response( $this->retrieve_data() );
-	}
-
-	/**
-	 * Remove GAM credentials.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response containing current GAM status.
-	 */
-	public function api_remove_gam_credentials( $request ) {
-		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
-		$response              = $configuration_manager->remove_gam_credentials();
-
-		if ( \is_wp_error( $response ) ) {
-			return \rest_ensure_response( $response );
-		}
-		return \rest_ensure_response( $this->retrieve_data() );
-	}
-
-	/**
 	 * Create/update a placement
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -578,7 +476,7 @@ class Advertising_Wizard extends Wizard {
 			$message = $error->getMessage();
 			return new WP_Error( 'newspack_ad_units', $message ? $message : __( 'Ad Units failed to fetch.', 'newspack' ) );
 		}
-		
+
 		if ( \is_wp_error( $ad_units ) ) {
 			return $ad_units;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes service account flow in Ads Wizard in favor of OAuth flow. 

### How to test the changes in this Pull Request:

Switch `newspack-ads` to `feat/gam-oauth` branch.

Test the ad unit management (just to see if the expected ad units show up) in a couple of scenarios:

1. _Unconfigured instance_ - Without service account details in the DB and without OAuth possibility* 

<img width="937" alt="image" src="https://user-images.githubusercontent.com/7383192/137800377-ceaf8e27-aa9d-46e5-ab7d-cd606968b5c7.png">

2. _Instance configured with OAuth_ - Without service account details in the DB and with OAuth possibility

<img width="933" alt="image" src="https://user-images.githubusercontent.com/7383192/137800492-c1f0aca0-894e-4fa1-a37e-f47da4da7c37.png">

3. _Using service account_ - With service account, without OAuth  

<img width="936" alt="image" src="https://user-images.githubusercontent.com/7383192/137800887-68ed35d2-f126-480a-b8b5-0d8112736dbd.png">

4. _Migrating from service account to OAuth_ - With service account, with OAuth

<img width="933" alt="image" src="https://user-images.githubusercontent.com/7383192/137801008-27bb74b4-5410-45c6-95fd-d4ca947aee3b.png">

5. _End of happy path_ - Using OAuth, connected

<img width="938" alt="image" src="https://user-images.githubusercontent.com/7383192/137801201-81269d93-726e-4672-897e-ac0a7732fc3a.png">


\* `NEWSPACK_GOOGLE_OAUTH_PROXY` environment variable

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->