### PR TITLE
fix/google oauth

### DIFF
--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -334,9 +334,6 @@ class Google_OAuth {
 					'email' => $user_info->email,
 				];
 			}
-		} else {
-			// Credentials are invalid, remove them.
-			self::remove_credentials();
 		}
 
 		return false;
@@ -385,8 +382,6 @@ class Google_OAuth {
 					$auth_data = self::get_google_auth_saved_data();
 				}
 			} catch ( \Exception $e ) {
-				// Credentials might be broken, remove them.
-				self::remove_credentials();
 				return false;
 			}
 		}

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -154,7 +154,6 @@ class Google_OAuth {
 	public static function get_google_auth_url_params() {
 		$scopes         = [
 			'https://www.googleapis.com/auth/userinfo.email', // User's email address.
-			'https://www.googleapis.com/auth/analytics.edit', // Google Analytics.
 			'https://www.googleapis.com/auth/dfp', // Google Ad Manager.
 		];
 		$redirect_after = admin_url( 'admin.php?page=newspack-connections-wizard' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Two tweaks to OAuth flow:

1. Removes `https://www.googleapis.com/auth/analytics.edit` scope, since it's not yet approved in the app and thus would trigger a warning during the oauth process
2. Removes credentials removal on failed requests - this is too heavy-handed. If credentials are bad, user will be prompted to connect anyway, which would reset the credentials.

### How to test the changes in this Pull Request:

Complete Google OAuth flow.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->