### PR TITLE
feat(oauth): store oauth as option, available to admin users

### DIFF
--- a/assets/wizards/connections/views/main/google.js
+++ b/assets/wizards/connections/views/main/google.js
@@ -123,7 +123,7 @@ const GoogleOAuth = ( { setError, canBeConnected } ) => {
 					isLink
 					isDestructive={ isConnected }
 					onClick={ isConnected ? disconnect : goToAuthPage }
-					disabled={ inFlight || ! canBeConnected }
+					disabled={ inFlight || ( ! isConnected && ! canBeConnected ) }
 				>
 					{ isConnected ? __( 'Disconnect', 'newspack' ) : __( 'Connect', 'newspack' ) }
 				</Button>

--- a/tests/class-newspack-unit-tests-bootstrap.php
+++ b/tests/class-newspack-unit-tests-bootstrap.php
@@ -63,6 +63,8 @@ class Newspack_Unit_Tests_Bootstrap {
 		// Install Newspack.
 		tests_add_filter( 'setup_theme', array( $this, 'install_newspack' ) );
 
+		define( 'NEWSPACK_GOOGLE_OAUTH_PROXY', 'http://dummy.proxy' );
+
 		// Load the WP testing environment.
 		require_once $_tests_dir . '/includes/bootstrap.php';
 	}

--- a/tests/unit-tests/oauth.php
+++ b/tests/unit-tests/oauth.php
@@ -14,7 +14,7 @@ use Newspack\Google_Services_Connection;
  */
 class Newspack_Test_OAuth extends WP_UnitTestCase {
 	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$user_id = $this->factory->user->create( [ 'role' => 'testsistrator' ] );
 		wp_set_current_user( $user_id );
 	}
 
@@ -68,14 +68,23 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 			'expires_at'    => time() + 3600,
 		];
 		Google_OAuth::api_google_auth_save_details( $proxy_response );
-		$auth_data = Google_OAuth::get_google_auth_saved_data();
+
 		self::assertEquals(
-			$auth_data,
+			false,
+			Google_OAuth::get_google_auth_saved_data(),
+			'The auth data is not readable for just anyone.'
+		);
+
+		$administrator_user = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $administrator_user );
+
+		self::assertEquals(
 			[
 				'access_token'  => $proxy_response['access_token'],
 				'refresh_token' => $proxy_response['refresh_token'],
 				'expires_at'    => $proxy_response['expires_at'],
 			],
+			Google_OAuth::get_google_auth_saved_data(),
 			'The saved credentials are as expected.'
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes the method of storing Google OAuth credentials from user meta to option. The option will be available to be read for all admin users.

### How to test the changes in this Pull Request:

1. Reset the OAuth flow (this is not backwards-compatible)
2. Complete the OAuth flow
3. Log in as a different admin user, observe the Google Connection is active and "assigned" to the user who made it 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->