### PR TITLE
fix: ensure support variables are configured

### DIFF
--- a/includes/wizards/class-support-wizard.php
+++ b/includes/wizards/class-support-wizard.php
@@ -308,7 +308,7 @@ class Support_Wizard extends Wizard {
 	 * @return bool True if necessary variables are present.
 	 */
 	public static function configured() {
-		return WPCOM_OAuth::wpcom_client_id();
+		return WPCOM_OAuth::wpcom_client_id() && self::support_api_url() && self::support_email();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With the implementation of the new Google OAuth, the Newspack site is required to add the `NEWSPACK_WPCOM_CLIENT_ID` constant, which is currently the only required definition to display the *Support* page link. For the Support page to function properly, it also requires the support API URL and email, which should be verified.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. On the master branch, make sure you have `NEWSPACK_WPCOM_CLIENT_ID` defined
2. Click on Newspack -> Support page
3. Observe the error notice
4. Leave the page, check out this branch, refresh your dashboard
5. Observe the Support page is no longer available
6. Insert proper `NEWSPACK_SUPPORT_API_URL` and `NEWSPACK_SUPPORT_EMAIL`, refresh and confirm the Support page is working as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->