### PR TITLE
Add NTG social event for reddit and telegram

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -237,6 +237,24 @@ class Analytics {
 					'event_label'    => 'linkedin',
 					'event_category' => 'NTG social',
 				],
+				[
+					'id'             => self::get_uniqid(),
+					'on'             => 'click',
+					'element'        => 'a.share-reddit',
+					'amp_element'    => 'amp-social-share[type="reddit"]',
+					'event_name'     => 'social share',
+					'event_label'    => 'reddit',
+					'event_category' => 'NTG social',
+				],
+				[
+					'id'             => self::get_uniqid(),
+					'on'             => 'click',
+					'element'        => 'a.share-telegram',
+					'amp_element'    => 'amp-social-share[type="telegram"]',
+					'event_name'     => 'social share',
+					'event_label'    => 'telegram',
+					'event_category' => 'NTG social',
+				],
 			];
 
 			if ( ! is_front_page() && ! is_archive() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add NTG social event analytics for Reddit and Telegram. These are also used quite often by publishers and are supported by Jetpack.

### How to test the changes in this Pull Request:

1. Check out this PR
2. Enable Reddit and Telegram in Jetpack sharing configuration
2. Click on Reddit and Telegram icon on post/page to see event sent to analytics

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->