### PR TITLE
Parse.ly config manager

### DIFF
--- a/includes/configuration_managers/class-configuration-managers.php
+++ b/includes/configuration_managers/class-configuration-managers.php
@@ -64,6 +64,10 @@ class Configuration_Managers {
 			'filename'   => 'class-wordpress-seo-configuration-manager.php',
 			'class_name' => 'WordPress_SEO_Configuration_Manager',
 		],
+		'wp-parsely'            => [
+			'filename'   => 'class-parsely-configuration-manager.php',
+			'class_name' => 'Parsely_Configuration_Manager',
+		],
 	];
 
 	/**

--- a/includes/configuration_managers/class-parsely-configuration-manager.php
+++ b/includes/configuration_managers/class-parsely-configuration-manager.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Parse.ly plugin configuration manager.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
+
+/**
+ * Provide an interface for configuring and querying the configuration of the Parse.ly Plugin.
+ */
+class Parsely_Configuration_Manager extends Configuration_Manager {
+
+	/**
+	 * The slug of the plugin.
+	 *
+	 * @var string
+	 */
+	public $slug = 'wp-parsely';
+
+	/**
+	 * Configure Parse.ly for Newspack use.
+	 *
+	 * @return bool || WP_Error Return true if successful, or WP_Error if not.
+	 */
+	public function configure() {
+		$active = $this->is_active();
+		if ( ! $active || is_wp_error( $active ) ) {
+			return $active;
+		}
+
+		if ( ! class_exists( 'Parsely' ) ) {
+			return new \WP_Error(
+				'newspack_missing_required_plugin',
+				esc_html__( 'Parse.ly plugin is not installed and activated. Install and/or activate it to access this feature.', 'newspack' ),
+				[
+					'status' => 400,
+					'level'  => 'fatal',
+				]
+			);
+		}
+
+		// Set the Parse.ly API key for the site.
+		$parsely_settings = get_option( 'parsely', [] );
+		if ( ! $parsely_settings ) {
+			// Build the default Parse.ly settings if they don't exist yet.
+			// @see https://github.com/Parsely/wp-parsely/blob/64cc83c6ed229c93b9e938cccc37b794a1977e7c/src/class-parsely.php#L38-L56.
+			$parsely_settings = [
+				'apikey'                      => '',
+				'content_id_prefix'           => '',
+				'api_secret'                  => '',
+				'use_top_level_cats'          => false,
+				'custom_taxonomy_section'     => 'category',
+				'cats_as_tags'                => false,
+				'track_authenticated_users'   => true,
+				'lowercase_tags'              => true,
+				'force_https_canonicals'      => false,
+				'track_post_types'            => [ 'post' ],
+				'track_page_types'            => [ 'page' ],
+				'disable_javascript'          => false,
+				'disable_amp'                 => false,
+				'meta_type'                   => 'json_ld',
+				'logo'                        => '',
+				'metadata_secret'             => '',
+				'parsely_wipe_metadata_cache' => false,
+			];
+		}
+
+		// The Site ID field is confusingly stored in the 'apikey' field and is the site's domain.
+		// This is the only non-default field we need to auto-populate.
+		if ( empty( $parsely_settings['apikey'] ) ) {
+			$site_url                   = get_site_url();
+			$site_host                  = wp_parse_url( $site_url, PHP_URL_HOST );
+			$parsely_settings['apikey'] = sanitize_text_field( $site_host );
+			update_option( 'parsely', $parsely_settings );
+		}
+
+		$this->set_newspack_has_configured( true );
+		return true;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR automates some of the Parse.ly setup. The main field we need filled automatically is the Site ID field, then Parse.ly should "just work" on our sites.

### How to test the changes in this Pull Request:

The easiest way to test is probably this:
1.  Add the following code snippet somewhere:
```
add_action( 'init', function(){
	$request = new WP_REST_Request( 'POST', '/newspack/v1/plugins/wp-parsely/configure' );
	$response = rest_do_request( $request );
} );
```
2. Refresh the page. Parse.ly will likely crash on this first request because [the way it's built can't really handle if the plugin is activated after plugins have loaded](https://github.com/Parsely/wp-parsely/blob/develop/wp-parsely.php#L45-L51). Not sure if it's worth worrying about it, as it crashes after the configuration manager has run and seems like it needs a tricky refactor to solve the underlying issue. 🙁 
3. Parse.ly plugin should have installed and activated. Go to Settings > Parse.ly and observe the Site ID field is populated with the hostname:
<img width="656" alt="Screen Shot 2021-10-29 at 9 54 08 AM" src="https://user-images.githubusercontent.com/7317227/139473679-77f4c901-859c-4986-a98c-12cdf30ad30a.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->