### PR TITLE
fix: update ci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/php:7.2-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -24,7 +24,7 @@ jobs:
   # JS & SCSS Jobs
   lint-js-scss:
     docker:
-      - image: circleci/php:7.2-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -33,7 +33,7 @@ jobs:
 
   test-js:
     docker:
-      - image: circleci/php:7.2-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -43,7 +43,7 @@ jobs:
   # PHP jobs
   lint-php:
     docker:
-      - image: circleci/php:7.2
+      - image: cimg/php:7.4
     steps:
       - checkout
       - run:
@@ -54,7 +54,7 @@ jobs:
 
   test-php:
     docker:
-      - image: circleci/php:7.2
+      - image: cimg/php:7.4
       - image: circleci/mysql:5.6.50
     environment:
       - WP_TESTS_DIR: '/tmp/wordpress-tests-lib'
@@ -69,9 +69,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            sudo apt-get update && sudo apt-get install subversion
-            sudo -E docker-php-ext-install mysqli
-            sudo apt-get update && sudo apt-get install default-mysql-client
+            sudo apt-get update && sudo apt-get install -y subversion default-mysql-client
       - run:
           name: Run Tests
           command: |
@@ -84,12 +82,12 @@ jobs:
   # Release job
   release:
     docker:
-      - image: circleci/php:7.2-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
           name: Install rsync
-          command: sudo apt install rsync
+          command: sudo apt-get update && sudo apt-get install rsync
       - run:
           name: Install PHP packages
           command: composer install --no-dev --no-scripts
@@ -100,7 +98,7 @@ jobs:
   # Reset alpha branch after a release
   post_release:
     docker:
-      - image: circleci/php:7.2-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout
       - run:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As seen on https://github.com/Automattic/newspack-ads/pull/214, recent changes made to `circleci/php` resulted in our builds fail due to an incompatibility with our `node-sass` dependency.

[`circleci/` images are being deprecated and will lose support starting December 2021](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034). We should start moving towards maintained images.

This PR implements the use of `cimg/` images.

### How to test the changes in this Pull Request:

CI tasks must pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->