### PR TITLE
feat/gam service account connection

### DIFF
--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -224,6 +224,7 @@ class AdvertisingWizard extends Component {
 									secondaryButtonAction="#/"
 									wizardApiFetch={ wizardApiFetch }
 									fetchAdvertisingData={ this.fetchAdvertisingData }
+									updateWithAPI={ this.updateWithAPI }
 									updateAdUnit={ adUnit => {
 										this.onAdUnitChange( adUnit );
 										this.saveAdUnit( adUnit.id );

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -56,117 +56,58 @@ class AdvertisingWizard extends Component {
 		this.fetchAdvertisingData();
 	};
 
-	/**
-	 * Retrieve advertising data
-	 */
-	fetchAdvertisingData = ( quiet = false ) => {
-		const { setError, wizardApiFetch } = this.props;
-		return wizardApiFetch( { path: '/newspack/v1/wizard/advertising', quiet } )
-			.then( advertisingData => {
-				return new Promise( resolve => {
-					this.setState(
-						{
-							advertisingData: this.prepareData( advertisingData ),
-						},
-						() => {
-							setError();
-							resolve( this.state );
-						}
-					);
-				} );
-			} )
-			.catch( error => {
-				setError( error );
-			} );
-	};
+	updateWithAPI = requestConfig =>
+		this.props
+			.wizardApiFetch( requestConfig )
+			.then(
+				response =>
+					new Promise( resolve => {
+						this.setState(
+							{
+								advertisingData: {
+									...response,
+									adUnits: response.ad_units.reduce( ( result, value ) => {
+										result[ value.id ] = value;
+										return result;
+									}, {} ),
+								},
+							},
+							() => {
+								this.props.setError();
+								resolve( this.state );
+							}
+						);
+					} )
+			)
+			.catch( this.props.setError );
 
-	/**
-	 * Toggle advertising service.
-	 */
-	toggleService( service, enabled ) {
-		const { setError, wizardApiFetch } = this.props;
-		return wizardApiFetch( {
+	fetchAdvertisingData = ( quiet = false ) =>
+		this.updateWithAPI( { path: '/newspack/v1/wizard/advertising', quiet } );
+
+	toggleService = ( service, enabled ) =>
+		this.updateWithAPI( {
 			path: '/newspack/v1/wizard/advertising/service/' + service,
 			method: enabled ? 'POST' : 'DELETE',
 			quiet: true,
-		} )
-			.then( advertisingData => {
-				return new Promise( resolve => {
-					this.setState(
-						{
-							advertisingData: this.prepareData( advertisingData ),
-						},
-						() => {
-							setError();
-							resolve( this.state );
-						}
-					);
-				} );
-			} )
-			.catch( error => {
-				setError( error );
-			} );
-	}
+		} );
 
-	/**
-	 * Toggle placement.
-	 */
-	togglePlacement( placement, enabled ) {
-		const { setError, wizardApiFetch } = this.props;
-		return wizardApiFetch( {
+	togglePlacement = ( placement, enabled ) =>
+		this.updateWithAPI( {
 			path: '/newspack/v1/wizard/advertising/placement/' + placement,
 			method: enabled ? 'POST' : 'DELETE',
 			quiet: true,
-		} )
-			.then( advertisingData => {
-				return new Promise( resolve => {
-					this.setState(
-						{
-							advertisingData: this.prepareData( advertisingData ),
-						},
-						() => {
-							setError();
-							resolve( this.state );
-						}
-					);
-				} );
-			} )
-			.catch( error => {
-				setError( error );
-			} );
-	}
-
-	/**
-	 * Save placement.
-	 */
-	savePlacement = ( placement, data ) => {
-		const { setError, wizardApiFetch } = this.props;
-		return new Promise( ( resolve, reject ) => {
-			wizardApiFetch( {
-				path: '/newspack/v1/wizard/advertising/placement/' + placement,
-				method: 'post',
-				data: {
-					ad_unit: data.adUnit,
-					service: data.service,
-				},
-				quiet: true,
-			} )
-				.then( advertisingData => {
-					this.setState(
-						{
-							advertisingData: this.prepareData( advertisingData ),
-						},
-						() => {
-							setError();
-							resolve( this.state );
-						}
-					);
-				} )
-				.catch( error => {
-					setError( error ).then( () => reject( error ) );
-				} );
 		} );
-	};
+
+	savePlacement = ( placement, data ) =>
+		this.updateWithAPI( {
+			path: '/newspack/v1/wizard/advertising/placement/' + placement,
+			method: 'post',
+			data: {
+				ad_unit: data.adUnit,
+				service: data.service,
+			},
+			quiet: true,
+		} );
 
 	/**
 	 * Update a single ad unit.
@@ -177,97 +118,37 @@ class AdvertisingWizard extends Component {
 		this.setState( { advertisingData } );
 	};
 
-	/**
-	 * Save the fields to an ad unit.
-	 */
-	saveAdUnit( id ) {
-		const { setError, wizardApiFetch } = this.props;
-		const { adUnits } = this.state.advertisingData;
-		return new Promise( ( resolve, reject ) => {
-			wizardApiFetch( {
-				path: '/newspack/v1/wizard/advertising/ad_unit/' + ( id || 0 ),
-				method: 'post',
-				data: adUnits[ id ],
-				quiet: true,
-			} )
-				.then( advertisingData => {
-					this.setState(
-						{
-							advertisingData: this.prepareData( advertisingData ),
-						},
-						() => {
-							setError();
-							resolve( this.state );
-						}
-					);
-				} )
-				.catch( error => {
-					setError( error ).then( () => reject( error ) );
-				} );
+	saveAdUnit = id =>
+		this.updateWithAPI( {
+			path: '/newspack/v1/wizard/advertising/ad_unit/' + ( id || 0 ),
+			method: 'post',
+			data: this.state.advertisingData.adUnits[ id ],
+			quiet: true,
 		} );
-	}
 
 	/**
 	 * Delete an ad unit.
 	 *
 	 * @param {number} id Ad Unit ID.
 	 */
-	deleteAdUnit( id ) {
-		const { setError, wizardApiFetch } = this.props;
+	deleteAdUnit = id => {
 		// eslint-disable-next-line no-alert
 		if ( confirm( __( 'Are you sure you want to archive this ad unit?', 'newspack' ) ) ) {
-			wizardApiFetch( {
+			return this.updateWithAPI( {
 				path: '/newspack/v1/wizard/advertising/ad_unit/' + id,
 				method: 'delete',
 				quiet: true,
-			} )
-				.then( advertisingData => {
-					this.setState(
-						{
-							advertisingData: this.prepareData( advertisingData ),
-						},
-						() => {
-							setError();
-						}
-					);
-				} )
-				.catch( error => {
-					setError( error );
-				} );
+			} );
 		}
-	}
+	};
 
-	/**
-	 * Update ad suppression settings.
-	 */
-	updateAdSuppression( suppressionConfig ) {
-		const { setError, wizardApiFetch } = this.props;
-		wizardApiFetch( {
+	updateAdSuppression = suppressionConfig =>
+		this.updateWithAPI( {
 			path: '/newspack/v1/wizard/advertising/suppression',
 			method: 'post',
 			data: { config: suppressionConfig },
 			quiet: true,
-		} )
-			.then( advertisingData => {
-				this.setState(
-					{
-						advertisingData: this.prepareData( advertisingData ),
-					},
-					setError
-				);
-			} )
-			.catch( setError );
-	}
-
-	prepareData = data => {
-		return {
-			...data,
-			adUnits: data.ad_units.reduce( ( result, value ) => {
-				result[ value.id ] = value;
-				return result;
-			}, {} ),
-		};
-	};
+		} );
 
 	/**
 	 * Render

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -45,9 +45,9 @@ class AdUnit extends Component {
 	 * Render.
 	 */
 	render() {
-		const { adUnit, onSave, service, serviceData = {} } = this.props;
+		const { adUnit, onSave, service } = this.props;
 		const { id, code, fluid = false, name = '' } = adUnit;
-		const isLegacy = false === serviceData.status?.can_connect || adUnit.is_legacy;
+		const isLegacy = adUnit.is_legacy;
 		const isExistingAdUnit = id !== 0;
 		const sizes = adUnit.sizes && Array.isArray( adUnit.sizes ) ? adUnit.sizes : [];
 		const isInvalidSize = ! fluid && sizes.length === 0;

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -143,6 +143,7 @@ const AdUnits = ( {
 			</p>
 			<Card noBorder>
 				{ Object.values( adUnits )
+					.filter( adUnit => adUnit.id !== 0 )
 					.sort( ( a, b ) => b.name.localeCompare( a.name ) )
 					.sort( a => ( a.is_legacy ? 1 : -1 ) )
 					.map( adUnit => {

--- a/assets/wizards/advertising/views/ad-units/service-account-connection.js
+++ b/assets/wizards/advertising/views/ad-units/service-account-connection.js
@@ -1,0 +1,87 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Notice, Button, ButtonCard } from '../../../../components/src';
+
+const ServiceAccountConnection = ( { updateWithAPI, isConnected, ...props } ) => {
+	const credentialsInputFile = useRef( null );
+	const [ fileError, setFileError ] = useState( '' );
+
+	const updateGAMCredentials = credentials =>
+		updateWithAPI( {
+			path: '/newspack/v1/wizard/advertising/credentials',
+			method: 'post',
+			data: { credentials },
+			quiet: true,
+		} );
+	const removeGAMCredentials = () =>
+		updateWithAPI( {
+			path: '/newspack/v1/wizard/advertising/credentials',
+			method: 'delete',
+			quiet: true,
+		} );
+
+	const handleCredentialsFile = event => {
+		if ( event.target.files.length && event.target.files[ 0 ] ) {
+			const reader = new FileReader();
+			reader.readAsText( event.target.files[ 0 ], 'UTF-8' );
+			reader.onload = function ( ev ) {
+				let credentials;
+				try {
+					credentials = JSON.parse( ev.target.result );
+				} catch ( error ) {
+					setFileError( __( 'Invalid JSON file', 'newspack' ) );
+					return;
+				}
+				updateGAMCredentials( credentials );
+			};
+			reader.onerror = function () {
+				setFileError( __( 'Unable to read file', 'newspack' ) );
+			};
+		}
+	};
+
+	return (
+		<div { ...props }>
+			<h2>{ __( 'Service Account connection', 'newspack' ) }</h2>
+			{ isConnected ? (
+				<div className="mb3">
+					<Button onClick={ () => credentialsInputFile.current.click() } isSecondary>
+						{ __( 'Update Service Account credentials', 'newspack' ) }
+					</Button>
+					<Button className="ml3" onClick={ removeGAMCredentials } isDestructive>
+						{ __( 'Remove Service Account credentials', 'newspack' ) }
+					</Button>
+				</div>
+			) : (
+				<ButtonCard
+					onClick={ () => credentialsInputFile.current.click() }
+					title={ __( 'Connect your Google Ad Manager account', 'newspack' ) }
+					desc={ [
+						__(
+							'Upload your Service Account credentials file to connect your GAM account with Newspack Ads.',
+							'newspack'
+						),
+						fileError && <Notice noticeText={ fileError } isError />,
+					] }
+					chevron
+				/>
+			) }
+			<input
+				type="file"
+				accept=".json"
+				ref={ credentialsInputFile }
+				style={ { display: 'none' } }
+				onChange={ handleCredentialsFile }
+			/>
+		</div>
+	);
+};
+
+export default ServiceAccountConnection;

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -46,6 +46,30 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Update GAM credentials.
+	 *
+	 * @param array $credentials Credentials to update.
+	 *
+	 * @return object|WP_Error Connection status or error if it fails.
+	 */
+	public function update_gam_credentials( $credentials ) {
+		return $this->is_configured() ?
+			\Newspack_Ads_GAM::update_gam_credentials( $credentials ) :
+			$this->unconfigured_error();
+	}
+
+	/**
+	 * Remove GAM credentials.
+	 *
+	 * @return object|WP_Error Connection status or error if it fails.
+	 */
+	public function remove_gam_credentials() {
+		return $this->is_configured() ?
+			\Newspack_Ads_GAM::remove_gam_credentials() :
+			$this->unconfigured_error();
+	}
+
+	/**
 	 * Get the ad units from our saved option.
 	 *
 	 * @return array | WP_Error Array of ad units or WP_Error if Newspack Ads isn't installed and activated.

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -179,6 +179,75 @@ class Advertising_Wizard extends Wizard {
 			]
 		);
 
+		// Update GAM credentials.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/credentials',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_gam_credentials' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'credentials' => [
+						'type'       => 'object',
+						'properties' => [
+							'type'                        => [
+								'required' => true,
+								'type'     => 'string',
+							],
+							'project_id'                  => [
+								'required' => true,
+								'type'     => 'string',
+							],
+							'private_key_id'              => [
+								'required' => true,
+								'type'     => 'string',
+							],
+							'private_key'                 => [
+								'required' => true,
+								'type'     => 'string',
+							],
+							'client_email'                => [
+								'required' => true,
+								'type'     => 'string',
+							],
+							'client_id'                   => [
+								'required' => true,
+								'type'     => 'string',
+							],
+							'auth_uri'                    => [
+								'required' => true,
+								'type'     => 'string',
+							],
+							'token_uri'                   => [
+								'required' => true,
+								'type'     => 'string',
+							],
+							'auth_provider_x509_cert_url' => [
+								'required' => true,
+								'type'     => 'string',
+							],
+							'client_x509_cert_url'        => [
+								'required' => true,
+								'type'     => 'string',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		// Remove GAM credentials.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/advertising/credentials',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'api_remove_gam_credentials' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
 		// Save a ad unit.
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,
@@ -386,6 +455,39 @@ class Advertising_Wizard extends Wizard {
 			$sitekit_manager->deactivate_module( 'adsense' );
 		}
 
+		return \rest_ensure_response( $this->retrieve_data() );
+	}
+
+	/**
+	 * Update GAM credentials.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response containing current GAM status.
+	 */
+	public function api_update_gam_credentials( $request ) {
+		$params                = $request->get_params();
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+		$response              = $configuration_manager->update_gam_credentials( $params['credentials'] );
+
+		if ( \is_wp_error( $response ) ) {
+			return \rest_ensure_response( $response );
+		}
+		return \rest_ensure_response( $this->retrieve_data() );
+	}
+
+	/**
+	 * Remove GAM credentials.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response containing current GAM status.
+	 */
+	public function api_remove_gam_credentials( $request ) {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+		$response              = $configuration_manager->remove_gam_credentials();
+
+		if ( \is_wp_error( $response ) ) {
+			return \rest_ensure_response( $response );
+		}
 		return \rest_ensure_response( $this->retrieve_data() );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Reinstates Service Account GAM connection (https://github.com/Automattic/newspack-plugin/discussions/1190). Also refactors some of the Ads wizard code.

### How to test the changes in this Pull Request:

First, switch `newspack-ads` to `feat/gam-service-account` branch (https://github.com/Automattic/newspack-ads/pull/216).

There are a few possible states here: 

1. Legacy, without any connection possible. No notices are displayed, it's just legacy mode.
2. OAuth connection possible (`NEWSPACK_GOOGLE_OAUTH_PROXY` set) but not connected - a notice about missing credentials displayed
3. Service Account connection possible (`NEWSPACK_GOOGLE_OAUTH_PROXY` **not** set) but not connected - a notice about missing credentials displayed
4. OAuth or Service Account connected - no notices
5. Both OAuth or Service Account connected - Service Account connection is ignored

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->