### PR TITLE
fix: disable Newspack events if Site Kit's GTM module is active

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -545,6 +545,17 @@ class Analytics {
 	}
 
 	/**
+	 * Can we rely on Site Kit's Analytics module?
+	 */
+	private static function can_use_site_kits_analytics() {
+		$sitekit_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'google-site-kit' );
+		return $sitekit_manager->is_module_active( 'analytics' )
+		// If Google Tag Manager module is active, it supersedes the Analytics module.
+		// This means that effectively GTM module being active equals Analytics module being inactive.
+		&& false === $sitekit_manager->is_module_active( 'tagmanager' );
+	}
+
+	/**
 	 * Inject event listeners on non-AMP pages.
 	 */
 	public static function inject_non_amp_events() {
@@ -552,8 +563,7 @@ class Analytics {
 			return;
 		}
 
-		$sitekit_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'google-site-kit' );
-		if ( ! $sitekit_manager->is_module_active( 'analytics' ) ) {
+		if ( ! self::can_use_site_kits_analytics() ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Handles a quick of a possible Site Kit setup – if GTM module is connected, Analytics module will no so what Newspack relies on it to do. In other words, Analytics module might be _activated_, but not _active_.

### How to test the changes in this Pull Request:

1. On `master`,
1. Set up a site with Site Kit, connecting both Analytics & Google Tag Manager modules
2. Visit a page which has AMP disabled
3. Observe `gtag is not defined` errors in the JS console
4. Switch to this branch, observe no errors shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->