### PR TITLE
Update button-card and button-group focus/pressed style

### DIFF
--- a/assets/components/src/button-card/style.scss
+++ b/assets/components/src/button-card/style.scss
@@ -17,8 +17,20 @@
 	transition: background-color 125ms ease-in-out, border-color 125ms ease-in-out,
 		box-shadow 125ms ease-in-out;
 
-	&:active,
 	&:focus,
+	&.is-pressed {
+		background: white;
+		border-color: $primary-500;
+		box-shadow: inset 0 0 0 2px $primary-500 !important;
+		outline: none !important;
+		position: relative;
+	}
+
+	&.is-pressed:focus-visible {
+		box-shadow: inset 0 0 0 2px $primary-500, 0 0 0 1px white, 0 0 0 2px $primary-500 !important;
+	}
+
+	&:active,
 	&:hover {
 		background-color: $gray-100;
 		color: $primary-600;
@@ -28,13 +40,6 @@
 		.desc {
 			color: inherit;
 		}
-	}
-
-	&:focus {
-		border-color: $primary-500;
-		box-shadow: inset 0 0 0 2px $primary-500 !important;
-		outline: none !important;
-		position: relative;
 	}
 
 	.title,
@@ -84,7 +89,6 @@
 		grid-template-columns: auto 24px;
 
 		&:active,
-		&:focus,
 		&:hover {
 			svg {
 				fill: currentColor;

--- a/assets/components/src/button-group/style.scss
+++ b/assets/components/src/button-group/style.scss
@@ -23,11 +23,16 @@
 		&.is-pressed {
 			position: relative;
 			z-index: 2;
-			background-color: $primary-050 !important;
+			background-color: white !important;
 			color: $gray-900 !important;
 			border: none !important;
 			&:focus {
 				box-shadow: 0 0 0 1px white, 0 0 0 2px $primary-500 !important;
+			}
+			&:active,
+			&:hover {
+				background: $gray-100 !important;
+				color: $primary-500 !important;
 			}
 			&::after {
 				content: '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR simplifies the focus/pressed style of the `ButtonCard` and `ButtonGroup`, removing the `$primary-050` background colour and simply using a tick `$primary-500` border

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Go to the Dashboard or the Components Demo screen
3. Test the various `ButtonCard`s
4. Go to Site Design
5. Test the various `ButtonGroup`s

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->