### PR TITLE
ci: fix WP version at 5.8.1 until the PHPUnit changes are addressed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
             composer install
             composer global require "phpunit/phpunit=5.7.*"
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 5.8.1
             phpunit
 
   # Release job


### PR DESCRIPTION
Let's get these tests passing