### PR TITLE
chore: update NPM package version

### DIFF
--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-components",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Newspack design system components",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -31,6 +31,7 @@
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",
 		"qs": "^6.10.1",
+		"react-daterange-picker": "^2.0.1",
 		"react-router-dom": "^5.3.0"
 	},
 	"devDependencies": {

--- a/assets/components/package.json
+++ b/assets/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-components",
-	"version": "1.7.0",
+	"version": "2.0.0",
 	"description": "Newspack design system components",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
BREAKING CHANGE: changes export method of components modules from CommonJS to ES modules.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Version bump of Newspack Components. Instead of a minor version bump, I think this new release warrants a major version bump, as compared to the last release (v1.6.1) it updates many NPM packages as well as switches the module exports from CommonJS modules to ES modules. This can be a potentially breaking change in itself, especially for older browsers.

### How to test the changes in this Pull Request:

Nothing to test here, just a semver bump.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->