### PR TITLE
fix: plugin settings section toggle on `null` active

### DIFF
--- a/assets/components/src/plugin-settings/SettingsSection.js
+++ b/assets/components/src/plugin-settings/SettingsSection.js
@@ -73,8 +73,8 @@ const SettingsSection = ( {
 			title={ title }
 			description={ description }
 			toggleChecked={ active }
-			hasGreyHeader={ active !== null }
-			toggleOnChange={ value => onUpdate( { active: value } ) }
+			hasGreyHeader={ true }
+			toggleOnChange={ active !== null ? value => onUpdate( { active: value } ) : null }
 		>
 			{ ( active || active === null ) && (
 				<Fragment>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix the `<PluginSettings.Section />` when the `active` property is `null`, meaning it shouldn't display the toggle button. Also sets the grey header regardless of the `active` value.

### How to test the changes in this Pull Request:

Follow instructions at https://github.com/Automattic/newspack-ads/pull/224 and observe section has the correct layout.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->