### PR TITLE
fix(ads): network code visibility

### DIFF
--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -37,7 +37,7 @@ const AdUnits = ( {
 	fetchAdvertisingData,
 } ) => {
 	const gamErrorMessage = serviceData?.status?.error
-		? `${ __( 'Google Ad Manager Error:', 'newspack' ) }: ${ serviceData.status.error }`
+		? `${ __( 'Google Ad Manager Error', 'newspack' ) }: ${ serviceData.status.error }`
 		: false;
 
 	const [ networkCode, setNetworkCode ] = useState( serviceData.status.network_code );

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -36,8 +36,8 @@ const AdUnits = ( {
 	serviceData,
 	fetchAdvertisingData,
 } ) => {
-	const gamConnectionErrorMessage = serviceData?.status?.error
-		? `${ __( 'Google Ad Manager connection issue', 'newspack' ) }: ${ serviceData.status.error }`
+	const gamErrorMessage = serviceData?.status?.error
+		? `${ __( 'Google Ad Manager Error:', 'newspack' ) }: ${ serviceData.status.error }`
 		: false;
 
 	const [ networkCode, setNetworkCode ] = useState( serviceData.status.network_code );
@@ -69,7 +69,7 @@ const AdUnits = ( {
 					isWarning
 				/>
 			) }
-			{ gamConnectionErrorMessage && <Notice noticeText={ gamConnectionErrorMessage } isError /> }
+			{ gamErrorMessage && <Notice noticeText={ gamErrorMessage } isError /> }
 			{ serviceData.created_targeting_keys?.length > 0 && (
 				<Notice
 					noticeText={ [

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -108,7 +108,7 @@ const AdUnits = ( {
 					</div>
 				</>
 			) }
-			{ ! isLegacy && ! gamConnectionErrorMessage && (
+			{ ! isLegacy && networkCode && (
 				<div>
 					<strong>{ __( 'Connected GAM network code:', 'newspack' ) } </strong>
 					<code>{ networkCode }</code>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The presence of errors shouldn't affect the display of the connected network code. This PR ensures the network code visibility if it exists on the connection data and changes the error message to a broader context.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. On the `newspack-ads` plugin, modify the line 478 on `class-newspack-ads-gam.php` to always throw the exception
2. While on master, visit the `Advertising -> Google Ad Manager` wizard and observe the network code is not visible
3. Check out this branch, run `npm run build`, refresh and observe the network code is displayed regardless of error

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->