### PR TITLE
Reduce section-header margin when followed by another component

### DIFF
--- a/assets/components/src/section-header/style.scss
+++ b/assets/components/src/section-header/style.scss
@@ -10,6 +10,10 @@
 		margin: 0 !important;
 	}
 
+	&:not( #{&}--no-margin ) + *:not( #{&} ) {
+		margin-top: -16px !important;
+	}
+
 	.newspack-wizard__content &:first-child {
 		margin-top: 32px;
 	}

--- a/assets/wizards/advertising/views/suppression/index.js
+++ b/assets/wizards/advertising/views/suppression/index.js
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
  */
 import {
 	CategoryAutocomplete,
-	Grid,
 	SectionHeader,
 	ToggleControl,
 	Waiting,
@@ -20,82 +19,78 @@ const Suppression = ( { config, onChange } ) => {
 		return <Waiting />;
 	}
 	return (
-		<Grid columns={ 1 } gutter={ 64 }>
-			<Grid columns={ 1 } gutter={ 16 }>
-				<SectionHeader
-					title={ __( 'Tag Archive Pages', 'newspack' ) }
-					description={ __(
-						'Suppress ads on automatically generated pages displaying a list of posts with a tag.',
-						'newspack'
-					) }
-				/>
-				<CategoryAutocomplete
-					disabled={ config.tag_archive_pages === true }
-					value={ config.specific_tag_archive_pages.map( v => parseInt( v ) ) }
-					onChange={ selected => {
-						onChange( {
-							...config,
-							specific_tag_archive_pages: selected.map( item => item.id ),
-						} );
-					} }
-					label={ __( 'Specific tags archive pages', 'newspack ' ) }
-					taxonomy="tags"
-				/>
-				<ToggleControl
-					disabled={ config === false }
-					checked={ config?.tag_archive_pages }
-					onChange={ tag_archive_pages => {
-						onChange( { ...config, tag_archive_pages } );
-					} }
-					label={ __( 'All tag archive pages', 'newspack' ) }
-				/>
-			</Grid>
-			<Grid columns={ 1 } gutter={ 16 }>
-				<SectionHeader
-					title={ __( 'Category Archive Pages', 'newspack' ) }
-					description={ __(
-						'Suppress ads on automatically generated pages displaying a list of posts of a category.',
-						'newspack'
-					) }
-				/>
-				<CategoryAutocomplete
-					disabled={ config.category_archive_pages === true }
-					value={ config.specific_category_archive_pages.map( v => parseInt( v ) ) }
-					onChange={ selected => {
-						onChange( {
-							...config,
-							specific_category_archive_pages: selected.map( item => item.id ),
-						} );
-					} }
-					label={ __( 'Specific category archive pages', 'newspack ' ) }
-				/>
-				<ToggleControl
-					disabled={ config === false }
-					checked={ config?.category_archive_pages }
-					onChange={ category_archive_pages => {
-						onChange( { ...config, category_archive_pages } );
-					} }
-					label={ __( 'All category archive pages', 'newspack' ) }
-				/>
-			</Grid>
-			<Grid columns={ 1 } gutter={ 16 }>
-				<SectionHeader
-					title={ __( 'Author Archive Pages', 'newspack' ) }
-					description={ __(
-						'Suppress ads on automatically generated pages displaying a list of posts by an author.',
-						'newspack'
-					) }
-				/>
-				<ToggleControl
-					disabled={ config === false }
-					checked={ config?.author_archive_pages }
-					onChange={ author_archive_pages => {
-						onChange( { ...config, author_archive_pages } );
-					} }
-					label={ __( 'Suppress ads on author archive pages', 'newspack' ) }
-				/>
-			</Grid>
-		</Grid>
+		<>
+			<SectionHeader
+				title={ __( 'Tag Archive Pages', 'newspack' ) }
+				description={ __(
+					'Suppress ads on automatically generated pages displaying a list of posts with a tag.',
+					'newspack'
+				) }
+			/>
+			<CategoryAutocomplete
+				disabled={ config.tag_archive_pages === true }
+				value={ config.specific_tag_archive_pages.map( v => parseInt( v ) ) }
+				onChange={ selected => {
+					onChange( {
+						...config,
+						specific_tag_archive_pages: selected.map( item => item.id ),
+					} );
+				} }
+				label={ __( 'Specific tags archive pages', 'newspack ' ) }
+				taxonomy="tags"
+			/>
+			<ToggleControl
+				disabled={ config === false }
+				checked={ config?.tag_archive_pages }
+				onChange={ tag_archive_pages => {
+					onChange( { ...config, tag_archive_pages } );
+				} }
+				label={ __( 'All tag archive pages', 'newspack' ) }
+			/>
+
+			<SectionHeader
+				title={ __( 'Category Archive Pages', 'newspack' ) }
+				description={ __(
+					'Suppress ads on automatically generated pages displaying a list of posts of a category.',
+					'newspack'
+				) }
+			/>
+			<CategoryAutocomplete
+				disabled={ config.category_archive_pages === true }
+				value={ config.specific_category_archive_pages.map( v => parseInt( v ) ) }
+				onChange={ selected => {
+					onChange( {
+						...config,
+						specific_category_archive_pages: selected.map( item => item.id ),
+					} );
+				} }
+				label={ __( 'Specific category archive pages', 'newspack ' ) }
+			/>
+			<ToggleControl
+				disabled={ config === false }
+				checked={ config?.category_archive_pages }
+				onChange={ category_archive_pages => {
+					onChange( { ...config, category_archive_pages } );
+				} }
+				label={ __( 'All category archive pages', 'newspack' ) }
+			/>
+
+			<SectionHeader
+				title={ __( 'Author Archive Pages', 'newspack' ) }
+				description={ __(
+					'Suppress ads on automatically generated pages displaying a list of posts by an author.',
+					'newspack'
+				) }
+			/>
+			<ToggleControl
+				disabled={ config === false }
+				checked={ config?.author_archive_pages }
+				onChange={ author_archive_pages => {
+					onChange( { ...config, author_archive_pages } );
+				} }
+				label={ __( 'Suppress ads on author archive pages', 'newspack' ) }
+			/>
+		</>
 	);
 };
 

--- a/assets/wizards/engagement/views/related-content/index.js
+++ b/assets/wizards/engagement/views/related-content/index.js
@@ -47,7 +47,7 @@ class RelatedContent extends Component {
 
 				{ relatedPostsEnabled && (
 					<Grid>
-						<Card isMedium>
+						<Card noBorder>
 							<TextControl
 								help={ __(
 									'If set, posts will be shown as related content only if published within the past number of months. If 0, any published post can be shown, regardless of publish date.',

--- a/assets/wizards/site-design/views/main/style.scss
+++ b/assets/wizards/site-design/views/main/style.scss
@@ -25,10 +25,6 @@
 }
 
 .newspack-design {
-	.newspack-section-header {
-		margin-bottom: -16px;
-	}
-
 	&__header,
 	&__footer {
 		&__logo {

--- a/assets/wizards/site-design/views/theme-settings/style.scss
+++ b/assets/wizards/site-design/views/theme-settings/style.scss
@@ -18,7 +18,3 @@
 		}
 	}
 }
-
-.newspack-section-header {
-	margin-bottom: -16px;
-}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR reduces the gap between a `SectionHeader` (except if it has `noMargin`) and whichever component is next (except for another `SectionHeader`) to 16px, allowing a better "[principle of proximity](https://uxdesign.cc/how-to-enhance-your-design-with-the-gestalt-principles-of-proximity-a7828452058b)".

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Navigate through all the various screen

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->