### PR TITLE
chore: reduce frequency of dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 # Dependabot config.
 # Keep NPM and Composer packages up-to-date.
-# Let's start out with daily updates and then drop back to less frequent intervals after everything is up-to-date.
 
 version: 2
 updates:
@@ -10,7 +9,7 @@ updates:
     directory: '/'
     # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     # Add reviewers
     reviewers:
       - 'Automattic/newspack-product'
@@ -21,7 +20,7 @@ updates:
     directory: '/assets/components'
     # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     # Add reviewers
     reviewers:
       - 'Automattic/newspack-product'
@@ -32,7 +31,7 @@ updates:
     directory: '/'
     # Check for updates every day (weekdays)
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     # Add reviewers
     reviewers:
       - 'Automattic/newspack-product'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We've had Dependabot running for a week now and it's been working as intended. Most of the open PRs now are pretty minor updates, so I think we can safely bump down the frequency of checks to weekly to reduce the noise a bit. 

### How to test the changes in this Pull Request:

Nothing to test, purely workflow-related.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->