### PR TITLE
Add multiple support for select-control

### DIFF
--- a/assets/components/src/select-control/style.scss
+++ b/assets/components/src/select-control/style.scss
@@ -55,6 +55,28 @@
 				border-color: $primary-500;
 				box-shadow: inset 0 0 0 2px $primary-500;
 			}
+
+			&[multiple] {
+				height: auto;
+				max-height: 120px;
+				padding: 7px 0;
+
+				option {
+					align-items: center;
+					display: flex;
+					min-height: 24px;
+					padding: 4px 8px;
+
+					&:checked {
+						background: $primary-500 !important;
+						color: white !important;
+					}
+				}
+
+				~ .components-input-control__suffix {
+					display: none;
+				}
+			}
 		}
 	}
 

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -56,6 +56,7 @@ class ComponentsDemo extends Component {
 			selectValue1: '2nd',
 			selectValue2: '',
 			selectValue3: '',
+			selectValues: [],
 			modalShown: false,
 			toggleGroupChecked: false,
 			color1: '#3366ff',
@@ -534,7 +535,7 @@ class ComponentsDemo extends Component {
 							label={ __( 'Label for Select with a preselection', 'newspack' ) }
 							value={ selectValue1 }
 							options={ [
-								{ value: '', label: __( '- Select -', 'newspack' ), disabled: true },
+								{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
 								{ value: '1st', label: __( 'First', 'newspack' ) },
 								{ value: '2nd', label: __( 'Second', 'newspack' ) },
 								{ value: '3rd', label: __( 'Third', 'newspack' ) },
@@ -545,7 +546,7 @@ class ComponentsDemo extends Component {
 							label={ __( 'Label for Select with no preselection', 'newspack' ) }
 							value={ selectValue2 }
 							options={ [
-								{ value: '', label: __( '- Select -', 'newspack' ), disabled: true },
+								{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
 								{ value: '1st', label: __( 'First', 'newspack' ) },
 								{ value: '2nd', label: __( 'Second', 'newspack' ) },
 								{ value: '3rd', label: __( 'Third', 'newspack' ) },
@@ -556,7 +557,7 @@ class ComponentsDemo extends Component {
 							label={ __( 'Label for disabled Select', 'newspack' ) }
 							disabled
 							options={ [
-								{ value: '', label: __( '- Select -', 'newspack' ), disabled: true },
+								{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
 								{ value: '1st', label: __( 'First', 'newspack' ) },
 								{ value: '2nd', label: __( 'Second', 'newspack' ) },
 								{ value: '3rd', label: __( 'Third', 'newspack' ) },
@@ -567,12 +568,37 @@ class ComponentsDemo extends Component {
 							value={ selectValue3 }
 							isSmall
 							options={ [
-								{ value: '', label: __( '- Select -', 'newspack' ), disabled: true },
+								{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
 								{ value: '1st', label: __( 'First', 'newspack' ) },
 								{ value: '2nd', label: __( 'Second', 'newspack' ) },
 								{ value: '3rd', label: __( 'Third', 'newspack' ) },
 							] }
 							onChange={ value => this.setState( { selectValue3: value } ) }
+						/>
+						<SelectControl
+							multiple
+							label={ __( 'Multi-select', 'newspack' ) }
+							value={ this.state.selectValues }
+							options={ [
+								{ value: '1st', label: __( 'First', 'newspack' ) },
+								{ value: '2nd', label: __( 'Second', 'newspack' ) },
+								{ value: '3rd', label: __( 'Third', 'newspack' ) },
+								{ value: '4th', label: __( 'Fourth', 'newspack' ) },
+								{ value: '5th', label: __( 'Fifth', 'newspack' ) },
+								{ value: '6th', label: __( 'Sixth', 'newspack' ) },
+								{ value: '7th', label: __( 'Seventh', 'newspack' ) },
+							] }
+							onChange={ selectValues => this.setState( { selectValues } ) }
+						/>
+						<Notice
+							noticeText={
+								<>
+									{ __( 'Selected:', 'newspack' ) }{ ' ' }
+									{ this.state.selectValues.length > 0
+										? this.state.selectValues.join( ', ' )
+										: __( 'none', 'newspack' ) }
+								</>
+							}
 						/>
 					</Card>
 					<Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add support for `multiple` to `SelectControl`

Closes #1252

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Go to Components Demo

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->