### PR TITLE
fix(campaigns): duplicating a prompt needs both original and parent p…

### DIFF
--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -110,7 +110,7 @@ const PromptActionCard = props => {
 		const promptToDuplicate = parseInt( prompt?.duplicate_of || prompt.id );
 		try {
 			const defaultTitle = await apiFetch( {
-				path: `/newspack/v1/wizard/newspack-popups-wizard/${ promptToDuplicate }/duplicate`,
+				path: `/newspack/v1/wizard/newspack-popups-wizard/${ promptToDuplicate }/${ prompt.id }/duplicate`,
 			} );
 
 			setDuplicateTitle( defaultTitle );

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -284,11 +284,12 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	/**
 	 * Get default title for a duplicated prompt.
 	 *
+	 * @param int $original_id Original Prompt ID.
 	 * @param int $id Prompt ID to duplicate.
 	 */
-	public function get_duplicate_title( $id ) {
+	public function get_duplicate_title( $original_id, $id ) {
 		return $this->is_configured() ?
-			\Newspack_Popups::get_duplicate_title( $id ) :
+			\Newspack_Popups::get_duplicate_title( $original_id, $id ) :
 			$this->unconfigured_error();
 	}
 

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -125,13 +125,16 @@ class Popups_Wizard extends Wizard {
 		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/(?P<id>\d+)/duplicate',
+			'/wizard/' . $this->slug . '/(?P<original_id>\d+)/(?P<id>\d+)/duplicate',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_duplicate_title' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'id' => [
+					'original_id' => [
+						'sanitize_callback' => 'absint',
+					],
+					'id'          => [
 						'sanitize_callback' => 'absint',
 					],
 				],
@@ -633,7 +636,7 @@ class Popups_Wizard extends Wizard {
 	 */
 	public function api_get_duplicate_title( $request ) {
 		$cm            = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
-		$default_title = $cm->get_duplicate_title( $request['id'] );
+		$default_title = $cm->get_duplicate_title( $request['original_id'], $request['id'] );
 		return $default_title;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-popups/pull/706 change the way we name a duplicated prompt to be based on the parent prompt title instead of the original one. `get_duplicate_title` needs now both original and parent titles to generate the duplicated prompt title.

### How to test the changes in this Pull Request:

1. If https://github.com/Automattic/newspack-popups/pull/706 is not merged, please pull it.
2. From the prompts list screen `Newspack > Campaigns` create a new prompt with `My Prompt` as the title.
3. Duplicate your newly created prompt, and observe the suggested name is `My Prompt copy`. Change the title to `Second Prompt` before confirming the prompt creation.
4. Duplicate the newly duplicated prompt `Second Prompt` and notice that the suggested title `Second Prompt copy` is based on the parent prompt and not the original prompt.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->