### PR TITLE
fix: plugin settings checkbox

### DIFF
--- a/assets/components/src/plugin-settings/SettingsSection.js
+++ b/assets/components/src/plugin-settings/SettingsSection.js
@@ -35,6 +35,9 @@ const getControlType = setting => {
 		case 'string':
 		case 'text':
 			return 'text';
+		case 'boolean':
+		case 'checkbox':
+			return 'checkbox';
 		default:
 			return null;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The plugin settings section is not handling boolean/checkbox options properly. The resulting control is a text input due to the missing `type="checkbox"` attribute.

### How to test the changes in this Pull Request:

Follow steps at https://github.com/Automattic/newspack-ads/pull/246

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->