### PR TITLE
chore: implement auto-merge for dependabot minor/patch updates

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,6 @@
-on: pull_request
+on:
+  pull_request:
+
 name: Dependabot auto-merge
 jobs:
   auto-merge:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,6 @@
+steps:
+  - uses: actions/checkout@v2
+  - uses: ahmadnassri/action-dependabot-auto-merge@v2
+    with:
+      target: minor # includes patch updates.
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,12 @@
-steps:
-  - uses: actions/checkout@v2
-  - uses: ahmadnassri/action-dependabot-auto-merge@v2
-    with:
-      target: minor # includes patch updates.
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+on: pull_request
+name: Dependabot auto-merge
+jobs:
+  auto-merge:
+    name: Auto-merge dependabot PRs for minor and patch updates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor # includes patch updates.
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Should help make Dependabot PRs more automated. Will automatically merge minor and patch update PRs if all CI jobs pass. Major updates will still require a manual review and merge.

h/t @yogeshbeniwal for the idea.

Closes #1323.

### How to test the changes in this Pull Request:

Nothing to test. Once merged, we should be able to see the workflow in action in the Actions tab.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->