### PR TITLE
feat(ads): handle multiple GAM accounts

### DIFF
--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -41,24 +41,23 @@ const AdUnits = ( {
 		? `${ __( 'Google Ad Manager Error', 'newspack' ) }: ${ serviceData.status.error }`
 		: false;
 
-	const [ networkCode, setNetworkCode ] = useState( serviceData.status.network_code );
-	const saveNetworkCode = async () => {
+	const updateNetworkCode = async ( value, isGam ) => {
 		await wizardApiFetch( {
 			path: '/newspack/v1/wizard/advertising/network_code/',
 			method: 'POST',
-			data: { network_code: networkCode },
+			data: { network_code: value, is_gam: isGam },
 			quiet: true,
 		} );
 		fetchAdvertisingData( true );
 	};
-	const updateNetworkCode = async value => {
-		await wizardApiFetch( {
-			path: '/newspack/v1/wizard/advertising/network_code/',
-			method: 'POST',
-			data: { network_code: value, is_gam: true },
-			quiet: true,
-		} );
-		fetchAdvertisingData( true );
+
+	const updateGAMNetworkCode = async value => {
+		updateNetworkCode( value, true );
+	};
+
+	const [ networkCode, setNetworkCode ] = useState( serviceData.status.network_code );
+	const updateLegacyNetworkCode = async () => {
+		updateNetworkCode( networkCode, false );
 	};
 
 	useEffect( () => {
@@ -78,7 +77,7 @@ const AdUnits = ( {
 						label: `${ network.name } (${ network.code })`,
 						value: network.code,
 					} ) ) }
-					onChange={ updateNetworkCode }
+					onChange={ updateGAMNetworkCode }
 				/>
 			) }
 			{ false === serviceData.status?.is_network_code_matched && (
@@ -122,7 +121,7 @@ const AdUnits = ( {
 							withMargin={ false }
 						/>
 						<span className="pl3">
-							<Button onClick={ saveNetworkCode } isPrimary>
+							<Button onClick={ updateLegacyNetworkCode } isPrimary>
 								{ __( 'Save', 'newspack' ) }
 							</Button>
 						</span>

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -16,6 +16,7 @@ import { trash, pencil } from '@wordpress/icons';
 import {
 	ActionCard,
 	TextControl,
+	SelectControl,
 	Button,
 	Card,
 	Notice,
@@ -50,6 +51,15 @@ const AdUnits = ( {
 		} );
 		fetchAdvertisingData( true );
 	};
+	const updateNetworkCode = async value => {
+		await wizardApiFetch( {
+			path: '/newspack/v1/wizard/advertising/network_code/',
+			method: 'POST',
+			data: { network_code: value, is_gam: true },
+			quiet: true,
+		} );
+		fetchAdvertisingData( true );
+	};
 
 	useEffect( () => {
 		setNetworkCode( serviceData.status.network_code );
@@ -60,6 +70,17 @@ const AdUnits = ( {
 
 	return (
 		<>
+			{ ! isLegacy && networkCode && (
+				<SelectControl
+					label={ __( 'Connected GAM network code', 'newspack' ) }
+					value={ networkCode }
+					options={ serviceData.available_networks.map( network => ( {
+						label: `${ network.name } (${ network.code })`,
+						value: network.code,
+					} ) ) }
+					onChange={ updateNetworkCode }
+				/>
+			) }
 			{ false === serviceData.status?.is_network_code_matched && (
 				<Notice
 					noticeText={ __(
@@ -107,12 +128,6 @@ const AdUnits = ( {
 						</span>
 					</div>
 				</>
-			) }
-			{ ! isLegacy && networkCode && (
-				<div>
-					<strong>{ __( 'Connected GAM network code:', 'newspack' ) } </strong>
-					<code>{ networkCode }</code>
-				</div>
 			) }
 			<p>
 				{ __(

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -152,6 +152,17 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Get GAM available networks.
+	 *
+	 * @return bool | WP_Error Returns object, or error if the plugin is not active.
+	 */
+	public function get_gam_available_networks() {
+		return $this->is_configured() ?
+			\Newspack_Ads_Model::get_gam_available_networks() :
+			$this->unconfigured_error();
+	}
+
+	/**
 	 * Get ad suppression config.
 	 *
 	 * @return bool | WP_Error Returns object, or error if the plugin is not active.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Handles a user connection that has multiple GAM accounts and the ability to choose which should be used by Newspack Ads.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-ads/pull/251

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->