### PR TITLE
chore: fix auto-merge worfklow to grant write permissions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,11 +1,13 @@
 on:
-  pull_request:
+  pull_request_target:
+    types: [labeled]
 
 name: Dependabot auto-merge
 jobs:
   auto-merge:
     name: Auto-merge dependabot PRs for minor and patch updates
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1332 implemented an auto-merge workflow to automatically merge minor and patch update PRs from Dependabot. However, this workflow is [broken](https://github.com/Automattic/newspack-plugin/runs/4428099886?check_suite_focus=true) because the workflow does not grant the necessary write permissions to merge PRs. More details here: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

This PR updates the workflow to run on the suggested `pull_request_target` event, which grants write permissions to actions, but also only runs if the pull request has a "dependencies" label applied, which would indicate that the PR has been opened by a privileged user (in this case, Dependabot). This should guard against [potential security vulnerabilities](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) that might result in auto-merging arbitrary PRs.

### How to test the changes in this Pull Request:

Can't test, unfortunately—we'll need to wait until Dependabot opens a new minor or patch PR after this PR is merged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->