### PR TITLE
fix: use access token instead of default token

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
           target: minor # includes patch updates.
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.DEPENDABOT_TOKEN }}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The [auto-merge saga](https://github.com/Automattic/newspack-plugin/issues/1323) continues. #1332 implemented auto-merging for minor and patch PRs from Dependabot, and #1341 fixed write permissions for the auto-merge action. However, something is still [missing](https://github.com/Automattic/newspack-plugin/pull/1347#issuecomment-988379465):

<img width="927" alt="Screen Shot 2021-12-07 at 6 11 17 PM" src="https://user-images.githubusercontent.com/2230142/145130521-b7bcc9f7-94b3-4caa-84ca-fc719573d4fe.png">

I believe this error is happening because the workflow uses the default [`secrets.GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication), which by default doesn't grant push permissions. Instead, we need to use a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with `public_repo` push permissions that has been created by a user with push access to the repo (in this case me). I've added this as an [encrypted secret](https://github.com/Automattic/newspack-plugin/settings/secrets/actions) to the repository with the name `DEPENDABOT_TOKEN`.

Let's hope this token can be used by the workflow to auto-merge branches as desired.

### How to test the changes in this Pull Request:

Can't test, must wait for the bots to do their thing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->