### PR TITLE
feat(ads): stick to top placements

### DIFF
--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -20,6 +20,7 @@ import { settings } from '@wordpress/icons';
  */
 import {
 	ActionCard,
+	CheckboxControl,
 	Modal,
 	Card,
 	Notice,
@@ -212,6 +213,24 @@ const Placements = ( { adUnits } ) => {
 								</>
 							);
 						} ) }
+					{ placement.supports?.indexOf( 'stick_to_top' ) > -1 && (
+						<CheckboxControl
+							label={ __( 'Stick to top', 'newspack' ) }
+							checked={ !! placement.data?.stick_to_top }
+							onChange={ value => {
+								setPlacements( {
+									...placements,
+									[ editingPlacement ]: {
+										...placements[ editingPlacement ],
+										data: {
+											...placements[ editingPlacement ].data,
+											stick_to_top: value,
+										},
+									},
+								} );
+							} }
+						/>
+					) }
 					<Card buttonsCard noBorder className="justify-end">
 						<Button
 							isSecondary

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -6,6 +6,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { set } from 'lodash/fp';
 
 /**
  * WordPress dependencies
@@ -218,16 +219,9 @@ const Placements = ( { adUnits } ) => {
 							label={ __( 'Stick to top', 'newspack' ) }
 							checked={ !! placement.data?.stick_to_top }
 							onChange={ value => {
-								setPlacements( {
-									...placements,
-									[ editingPlacement ]: {
-										...placements[ editingPlacement ],
-										data: {
-											...placements[ editingPlacement ].data,
-											stick_to_top: value,
-										},
-									},
-								} );
+								setPlacements(
+									set( [ editingPlacement, 'data', 'stick_to_top' ], value, placements )
+								);
 							} }
 						/>
 					) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the checkbox for toggling "Stick to top" for https://github.com/Automattic/newspack-ads/pull/265

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

Instructions are at https://github.com/Automattic/newspack-ads/pull/265

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->