### PR TITLE
fix: use new shortened preview query keys form Campaigns

### DIFF
--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -208,25 +208,26 @@ class PopupsWizard extends Component {
 
 	previewUrlForPopup = ( { options, id } ) => {
 		const { placement, trigger_type: triggerType } = options;
+		const previewQueryKeys = window.newspack_popups_wizard_data?.preview_query_keys || {};
+		const abbreviatedKeys = {};
+		Object.keys( options ).forEach( key => {
+			if ( previewQueryKeys.hasOwnProperty( key ) ) {
+				abbreviatedKeys[ previewQueryKeys[ key ] ] = options[ key ];
+			}
+		} );
 
 		let previewURL = '/';
-		if (
-			'archives' === placement &&
-			window &&
-			window.newspack_popups_wizard_data &&
-			window.newspack_popups_wizard_data.preview_archive
-		) {
+		if ( 'archives' === placement && window.newspack_popups_wizard_data?.preview_archive ) {
 			previewURL = window.newspack_popups_wizard_data.preview_archive;
 		} else if (
 			( 'inline' === placement || 'scroll' === triggerType ) &&
 			window &&
-			window.newspack_popups_wizard_data &&
-			window.newspack_popups_wizard_data.preview_post
+			window.newspack_popups_wizard_data?.preview_post
 		) {
-			previewURL = window.newspack_popups_wizard_data.preview_post;
+			previewURL = window.newspack_popups_wizard_data?.preview_post;
 		}
 
-		return `${ previewURL }?${ stringify( { ...options, newspack_popups_preview_id: id } ) }`;
+		return `${ previewURL }?${ stringify( { ...abbreviatedKeys, pid: id } ) }`;
 	};
 
 	updateAfterAPI = ( { campaigns, prompts, segments, settings, duplicated = null } ) =>

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -306,6 +306,15 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Get abbreviated query keys for preview requests.
+	 */
+	public function preview_query_keys() {
+		return $this->is_configured() ?
+			\Newspack_Popups::PREVIEW_QUERY_KEYS :
+			$this->unconfigured_error();
+	}
+
+	/**
 	 * Configure Newspack Popups for Newspack use.
 	 *
 	 * @return bool || WP_Error Return true if successful, or WP_Error if not.

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -474,6 +474,7 @@ class Popups_Wizard extends Wizard {
 		$custom_placements                     = $newspack_popups_configuration_manager->get_custom_placements();
 		$overlay_placements                    = $newspack_popups_configuration_manager->get_overlay_placements();
 		$overlay_sizes                         = $newspack_popups_configuration_manager->get_overlay_sizes();
+		$preview_query_keys                    = $newspack_popups_configuration_manager->preview_query_keys();
 
 		\wp_localize_script(
 			'newspack-popups-wizard',
@@ -485,6 +486,7 @@ class Popups_Wizard extends Wizard {
 				'custom_placements'  => $custom_placements,
 				'overlay_placements' => $overlay_placements,
 				'overlay_sizes'      => $overlay_sizes,
+				'preview_query_keys' => $preview_query_keys,
 			]
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Applies the preview-related changes from https://github.com/Automattic/newspack-popups/pull/732 to the Campaigns wizard previewing functionality as well.

### How to test the changes in this Pull Request:

With https://github.com/Automattic/newspack-popups/pull/732 checked out, smoke test previewing various segments (including "Everyone") and singular prompts from the Campaigns wizard. All prompts should be previewable as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->