### PR TITLE
chore: only run auto-merge if the PR is not already approved

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,7 +7,9 @@ jobs:
   auto-merge:
     name: Auto-merge dependabot PRs for minor and patch updates
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+    if: |
+      contains( github.event.pull_request.labels.*.name, 'dependencies' )
+      && ! contains( github.event.pull_request.labels.*.name, '[Status] Approved' )
     steps:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The Dependabot auto-merge action is working, but it results an a slightly annoying double comment because of the way we've configured the action. Currently, the auto-merge action is running twice because it's run every time the PR gets labeled, as long as the labels include the `dependencies` label. Auto-merge approves the PR, which results in our other workflow adding a `[Status] Approved` label which in turns triggers the auto-merge action again. `dependencies` still exists as a label on the PR, so the auto-merge action executes again.

This PR attempts to eliminate the second execution by only running if a Dependabot PR has the `dependencies` label and also doesn't have the `[Status] Approved` label.

### How to test the changes in this Pull Request:

Can't test, must let the robots do their thing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->