### PR TITLE
chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Automattic/newspack-product


### PR DESCRIPTION
This change should request the @Automattic/newspack-product eyes on every new PR.

> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners