### PR TITLE
Feat/stripe fees setting

### DIFF
--- a/assets/components/src/wizard/store/index.js
+++ b/assets/components/src/wizard/store/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { set, get } from 'lodash';
+import { set, get, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies.
@@ -70,7 +70,9 @@ const actions = {
 			data: get( wizardState, payloadPath ),
 			isQuietFetch: true,
 		} );
-		return actions.setAPIDataForWizard( { slug, data: updatedData } );
+		if ( ! isEmpty( updatedData ) ) {
+			return actions.setAPIDataForWizard( { slug, data: updatedData } );
+		}
 	},
 	*wizardApiFetch( fetchConfig ) {
 		// Just a proxy to fetchFromAPI, but it has to be a generator.

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -192,6 +192,31 @@ const StripeSetup = () => {
 						/>
 					</SettingsCard>
 					<SettingsCard
+						title={ __( 'Fee', 'newspack' ) }
+						description={ __(
+							'If you have a non-default or negotiated fee with Stripe, update its parameters here.',
+							'newspack'
+						) }
+						columns={ 1 }
+					>
+						<Grid noMargin>
+							<TextControl
+								type="number"
+								step="0.1"
+								value={ data.fee_multiplier }
+								label={ __( 'Fee multiplier' ) }
+								onChange={ changeHandler( 'fee_multiplier' ) }
+							/>
+							<TextControl
+								type="number"
+								step="0.1"
+								value={ data.fee_static }
+								label={ __( 'Fee static portion' ) }
+								onChange={ changeHandler( 'fee_static' ) }
+							/>
+						</Grid>
+					</SettingsCard>
+					<SettingsCard
 						title={ __( 'Webhooks', 'newspack' ) }
 						description={ __(
 							'These need to be configured to allow Stripe to communicate with the site.',

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -108,6 +108,14 @@ class Stripe_Connection {
 			$wc_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
 			$wc_configuration_manager->update_wc_stripe_settings( $updated_stripe_data );
 		}
+		if ( isset( $updated_stripe_data['fee_multiplier'] ) ) {
+			update_option( 'newspack_blocks_donate_fee_multiplier', $updated_stripe_data['fee_multiplier'] );
+			unset( $updated_stripe_data['fee_multiplier'] );
+		}
+		if ( isset( $updated_stripe_data['fee_static'] ) ) {
+			update_option( 'newspack_blocks_donate_fee_static', $updated_stripe_data['fee_static'] );
+			unset( $updated_stripe_data['fee_static'] );
+		}
 		// Save it in options table.
 		return update_option( self::STRIPE_DATA_OPTION_NAME, $updated_stripe_data );
 	}
@@ -374,6 +382,9 @@ class Stripe_Connection {
 		}
 		$stripe_data['usedPublishableKey'] = $stripe_data['testMode'] ? $stripe_data['testPublishableKey'] : $stripe_data['publishableKey'];
 		$stripe_data['usedSecretKey']      = $stripe_data['testMode'] ? $stripe_data['testSecretKey'] : $stripe_data['secretKey'];
+		$stripe_data['fee_multiplier']     = get_option( 'newspack_blocks_donate_fee_multiplier', '2.9' );
+		$stripe_data['fee_static']         = get_option( 'newspack_blocks_donate_fee_static', '0.3' );
+
 		return $stripe_data;
 	}
 

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -171,6 +171,21 @@ class Reader_Revenue_Wizard extends Wizard {
 					'newsletter_list_id' => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
+					'fee_multiplier'     => [
+						'sanitize_callback' => 'Newspack\newspack_clean',
+						'validate_callback' => function ( $value ) {
+							if ( (float) $value > 10 ) {
+								return new WP_Error(
+									'newspack_invalid_param',
+									__( 'Fee multiplier must be smaller than 10.', 'newspack' )
+								);
+							};
+							return true;
+						},
+					],
+					'fee_static'         => [
+						'sanitize_callback' => 'Newspack\newspack_clean',
+					],
 				],
 			]
 		);

--- a/tests/unit-tests/stripe-connection.php
+++ b/tests/unit-tests/stripe-connection.php
@@ -21,6 +21,8 @@ class Newspack_Test_Stripe extends WP_UnitTestCase {
 			[
 				'usedPublishableKey' => '',
 				'usedSecretKey'      => '',
+				'fee_multiplier'     => '2.9',
+				'fee_static'         => '0.3',
 			]
 		);
 		self::assertEquals(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds UI to customise parameters for [Stripe fees](https://github.com/Automattic/newspack-blocks/pull/928). 

### How to test the changes in this Pull Request:

1. Set `newspack-blocks` to `feat/handle-zero-fees` branch (https://github.com/Automattic/newspack-blocks/pull/985)
2. Verify the agree-to-pay-fees checkbox input is rendered on the frontend (see https://github.com/Automattic/newspack-blocks/pull/928)
3. Visit the Reader Revenue wizard, ensure platform is set to Stripe
3. Observe a new "Fee" section in "Stripe Settings" tab
4. Set both parameters to 0, observe that the input is not rendered
5. Set parameters to values different than the defaults (2.9 multiplier, 0.3 static portion), observe the fee amount in the input test is updated accordingly   

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->