### PR TITLE
Fix Google token refreshing 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           name: Run Tests
           command: |
             composer install
-            composer global require "phpunit/phpunit=5.7.*"
+            composer global require "phpunit/phpunit=7.5.*"
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 5.8.1
             phpunit

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -342,6 +342,7 @@ class Google_OAuth {
 			// Refresh the access token.
 			try {
 				$url    = OAuth::authenticate_proxy_url(
+					'google',
 					'/wp-json/newspack-oauth-proxy/v1/refresh-token',
 					[
 						'refresh_token' => $auth_data['refresh_token'],

--- a/includes/oauth/class-oauth.php
+++ b/includes/oauth/class-oauth.php
@@ -54,11 +54,12 @@ class OAuth {
 	 *
 	 * @param string $type 'google' or 'fivetran' for now.
 	 * @param string $path Path to append to base URL.
-	 * @param object $query_args Query params.
+	 * @param array  $query_args Query params.
+	 * @throws \Exception If trying to authenticate a non-existent proxy.
 	 */
-	public static function authenticate_proxy_url( $type, $path = '', $query_args = [] ) {
+	public static function authenticate_proxy_url( string $type, string $path = '', array $query_args = [] ) {
 		if ( ! self::is_proxy_configured( $type ) ) {
-			return false;
+			throw new \Exception( "Unknown proxy type: $type" );
 		}
 		return add_query_arg(
 			array_merge(

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -32,7 +32,7 @@
 	</rule>
 
 	<rule ref="PHPCompatibilityWP"/>
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.2-"/>
 
 	<arg name="extensions" value="php"/>
 

--- a/tests/unit-tests/oauth.php
+++ b/tests/unit-tests/oauth.php
@@ -67,9 +67,10 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 	 * Google OAuth flow.
 	 */
 	public function test_google_oauth() {
+		self::expectException( Exception::class );
 		self::assertFalse(
 			OAuth::authenticate_proxy_url( 'google', '/wp-json/newspack-google' ),
-			'Proxy URL is false until configured.'
+			'Proxy URL getting throws until configured.'
 		);
 
 		self::set_api_key();
@@ -155,9 +156,10 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 	 * Fivetran OAuth flow.
 	 */
 	public function test_fivetran_oauth() {
+		self::expectException( Exception::class );
 		self::assertFalse(
 			OAuth::authenticate_proxy_url( 'fivetran', '/wp-json/newspack-fivetran' ),
-			'Proxy URL is false until configured.'
+			'Proxy URL getting throws until configured.'
 		);
 		self::set_api_key();
 		if ( ! defined( 'NEWSPACK_FIVETRAN_PROXY' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug introduced in https://github.com/Automattic/newspack-plugin/pull/1247 

PHPCS config & PHPUnit version were updated: to handle function types, and expecting a function to throw, respectively.

### How to test the changes in this Pull Request:

1. On `master`, configure Newspack to use Google OAuth via a proxy
2. Authenticate with Google 
3. Observe the access token can't be obtained*
4. Switch to this branch, observe the token can be obtained

\* e.g. edit the value of `_newspack_google_oauth` option, `expires_at` timestamp 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->