### PR TITLE
Add fixed position to TabbedNavigation

### DIFF
--- a/assets/components/src/tabbed-navigation/index.js
+++ b/assets/components/src/tabbed-navigation/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies.
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
  * External dependencies.
  */
 import classnames from 'classnames';
@@ -15,6 +20,38 @@ const { NavLink, useHistory } = Router;
 const TabbedNavigation = ( { items, className, disableUpcoming } ) => {
 	const { location } = useHistory();
 	const currentIndex = findIndex( items, [ 'path', location.pathname ] );
+
+	useEffect( () => {
+		const header = document.querySelector( '.newspack-wizard__header' );
+		const navigation = document.querySelector( '.newspack-tabbed-navigation' );
+		const content = document.querySelector( '.newspack-wizard__content' );
+		const notice = document.querySelector( '.newspack-wizard__above-header' );
+
+		/**
+		 * Toggle an "is-fixed" class to the TabbedNavigation.
+		 */
+		function fixedNavigation() {
+			window.addEventListener( 'scroll', function () {
+				const navigationHeight = navigation.offsetHeight + 32;
+				let scrollHeight = header.offsetHeight;
+
+				if ( notice ) {
+					scrollHeight += notice.offsetHeight;
+				}
+
+				if ( window.scrollY > scrollHeight ) {
+					navigation.classList.add( 'is-fixed' );
+					content.style.paddingTop = navigationHeight + 'px';
+				} else {
+					navigation.classList.remove( 'is-fixed' );
+					content.removeAttribute( 'style' );
+				}
+			} );
+		}
+
+		window.addEventListener( 'resize', fixedNavigation(), true );
+	} );
+
 	return (
 		<div className={ classnames( 'newspack-tabbed-navigation', className ) }>
 			<ul>

--- a/assets/components/src/tabbed-navigation/style.scss
+++ b/assets/components/src/tabbed-navigation/style.scss
@@ -6,6 +6,9 @@
 @import '../../../shared/scss/colors';
 
 .newspack-tabbed-navigation {
+	background: white;
+	width: 100%;
+
 	ul {
 		box-shadow: 0 -1px 0 inset $gray-300;
 		display: flex;
@@ -70,6 +73,15 @@
 			&:hover {
 				color: inherit;
 			}
+		}
+	}
+
+	// Is Fixed
+	&.is-fixed {
+		@media screen and ( min-width: 783px ) {
+			position: fixed;
+			top: 32px;
+			z-index: 3;
 		}
 	}
 }

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -66,29 +66,28 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 					/>
 				) }
 				<div className="newspack-wizard__header">
-					<div className="newspack-wizard__header__inner">
-						<div className="newspack-wizard__title">
-							<Button
-								isLink
-								href={ newspack_urls.dashboard }
-								label={ __( 'Return to Dashboard', 'newspack' ) }
-								showTooltip={ true }
-								icon={ category }
-								iconSize={ 36 }
-							>
-								<NewspackIcon size={ 36 } />
-							</Button>
-							{ headerText && <h1>{ headerText }</h1> }
-							{ subHeaderText && <p className="screen-reader-text">{ subHeaderText }</p> }
-						</div>
-						{ tabbedNavigation && (
-							<TabbedNavigation
-								disableUpcoming={ disableUpcomingInTabbedNavigation }
-								items={ tabbedNavigation.filter( item => ! item.isHiddenInNav ) }
-							/>
-						) }
+					<div className="newspack-wizard__title">
+						<Button
+							isLink
+							href={ newspack_urls.dashboard }
+							label={ __( 'Return to Dashboard', 'newspack' ) }
+							showTooltip={ true }
+							icon={ category }
+							iconSize={ 36 }
+						>
+							<NewspackIcon size={ 36 } />
+						</Button>
+						{ headerText && <h1>{ headerText }</h1> }
+						{ subHeaderText && <p className="screen-reader-text">{ subHeaderText }</p> }
 					</div>
 				</div>
+
+				{ tabbedNavigation && (
+					<TabbedNavigation
+						disableUpcoming={ disableUpcomingInTabbedNavigation }
+						items={ tabbedNavigation.filter( item => ! item.isHiddenInNav ) }
+					/>
+				) }
 
 				<div className={ classnames( 'newspack-wizard newspack-wizard__content', className ) }>
 					{ typeof renderAboveContent === 'function' ? renderAboveContent() : null }

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -78,8 +78,16 @@
 		max-width: 1208px;
 		padding: 0 16px;
 
+		@media screen and ( max-width: 743px ) {
+			padding-top: 0 !important;
+		}
+
 		@media screen and ( min-width: 744px ) {
 			padding: 32px 84px;
+		}
+
+		@media screen and ( min-width: 744px ) and ( max-width: 782px ) {
+			padding-top: 32px !important;
 		}
 
 		// Typography

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -214,24 +214,22 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 						<Fragment>
 							{ complete !== null && (
 								<div className="newspack-wizard__header">
-									<div className="newspack-wizard__header__inner">
-										<div className="newspack-wizard__title">
-											<Button
-												isLink
-												href={ newspack_urls.dashboard }
-												label={ __( 'Return to Dashboard', 'newspack' ) }
-												showTooltip={ true }
-												icon={ home }
-												iconSize={ 36 }
-											>
-												<NewspackIcon size={ 36 } />
-											</Button>
-											<h1>
-												{ requiredPlugins.length > 1
-													? __( 'Required plugins', 'newspack' )
-													: __( 'Required plugin', 'newspack' ) }
-											</h1>
-										</div>
+									<div className="newspack-wizard__title">
+										<Button
+											isLink
+											href={ newspack_urls.dashboard }
+											label={ __( 'Return to Dashboard', 'newspack' ) }
+											showTooltip={ true }
+											icon={ home }
+											iconSize={ 36 }
+										>
+											<NewspackIcon size={ 36 } />
+										</Button>
+										<h1>
+											{ requiredPlugins.length > 1
+												? __( 'Required plugins', 'newspack' )
+												: __( 'Required plugin', 'newspack' ) }
+										</h1>
 									</div>
 								</div>
 							) }

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -47,7 +47,8 @@ svg {
 		background: $primary-500;
 	}
 
-	.newspack-wizard__header {
+	.newspack-wizard__header,
+	.newspack-tabbed-navigation {
 		display: none;
 	}
 

--- a/assets/components/src/wizard/index.js
+++ b/assets/components/src/wizard/index.js
@@ -84,25 +84,23 @@ const Wizard = ( {
 							noticeText={ __( 'Newspack is in debug mode.', 'newspack' ) }
 						/>
 					) }
-					<div className="bg-white">
-						<div className="newspack-wizard__header__inner">
-							<div className="newspack-wizard__title">
-								<Button
-									isLink
-									href={ newspack_urls.dashboard }
-									label={ __( 'Return to Dashboard', 'newspack' ) }
-									showTooltip={ true }
-									icon={ category }
-									iconSize={ 36 }
-								>
-									<NewspackIcon size={ 36 } />
-								</Button>
-								{ headerText && <h1>{ headerText }</h1> }
-								{ subHeaderText && <p className="screen-reader-text">{ subHeaderText }</p> }
-							</div>
-							{ displayedSections.length > 1 && <TabbedNavigation items={ displayedSections } /> }
+					<div className="newspack-wizard__header">
+						<div className="newspack-wizard__title">
+							<Button
+								isLink
+								href={ newspack_urls.dashboard }
+								label={ __( 'Return to Dashboard', 'newspack' ) }
+								showTooltip={ true }
+								icon={ category }
+								iconSize={ 36 }
+							>
+								<NewspackIcon size={ 36 } />
+							</Button>
+							{ headerText && <h1>{ headerText }</h1> }
+							{ subHeaderText && <p className="screen-reader-text">{ subHeaderText }</p> }
 						</div>
 					</div>
+					{ displayedSections.length > 1 && <TabbedNavigation items={ displayedSections } /> }
 					<Switch>
 						{ displayedSections.map( ( section, index ) => {
 							const SectionComponent = section.render;

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -93,20 +93,18 @@ class ComponentsDemo extends Component {
 					/>
 				) }
 				<div className="newspack-wizard__header">
-					<div className="newspack-wizard__header__inner">
-						<div className="newspack-wizard__title">
-							<Button
-								isLink
-								href={ newspack_urls.dashboard }
-								label={ __( 'Return to Dashboard', 'newspack' ) }
-								showTooltip={ true }
-								icon={ home }
-								iconSize={ 36 }
-							>
-								<NewspackIcon size={ 36 } />
-							</Button>
-							<h1>{ __( 'Components Demo', 'newspack' ) }</h1>
-						</div>
+					<div className="newspack-wizard__title">
+						<Button
+							isLink
+							href={ newspack_urls.dashboard }
+							label={ __( 'Return to Dashboard', 'newspack' ) }
+							showTooltip={ true }
+							icon={ home }
+							iconSize={ 36 }
+						>
+							<NewspackIcon size={ 36 } />
+						</Button>
+						<h1>{ __( 'Components Demo', 'newspack' ) }</h1>
 					</div>
 				</div>
 				<div className="newspack-wizard newspack-wizard__content">

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -27,11 +27,9 @@ const Dashboard = ( { items } ) => {
 				/>
 			) }
 			<div className="newspack-wizard__header">
-				<div className="newspack-wizard__header__inner">
-					<div className="newspack-wizard__title">
-						<NewspackIcon size={ 36 } />
-						<h1>{ __( 'Dashboard', 'newspack' ) }</h1>
-					</div>
+				<div className="newspack-wizard__title">
+					<NewspackIcon size={ 36 } />
+					<h1>{ __( 'Dashboard', 'newspack' ) }</h1>
 				</div>
 			</div>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The TabbedNavigation will be fixed at the top of the screen.

![](https://user-images.githubusercontent.com/177929/147264910-2ad7cba4-fad5-453b-9e7f-da71182119d3.gif)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Test every screens of the plugin

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->