### PR TITLE
change how we check post validity when preventing page deletion

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -81,7 +81,7 @@ class Patches {
 		$post_id            = $args[0]; // First item is usually the post ID.
 
 		// If $post_id isn't a valid post, bail early.
-		if ( false === get_post_status( $post_id ) ) {
+		if ( is_null( get_post( $post_id ) ) ) {
 			return $caps;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

`get_post_status` is used to check the validity of posts when preventing accidental page deletion
which time out on some publishers' sites. This replaces it with `get_posts` (used internally in
`get_post_status`) but does the work in this case.

### How to test the changes in this Pull Request:

It's a bit hard to reproduce this as it was raised on some publishers sites (e.g. CCP) on the users' list page. `users.php` time out due to the use of `get_post_status` to get the validity of a post when checking user capabilities.

Replacing `get_post_status` by `get_post` fix the timeout. Making sure the `users.php` loads correctly should be enough normally to test this. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->