### PR TITLE
feat(amp): enable disallowing explicitly kept scripts, for debugging

### DIFF
--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -72,6 +72,9 @@ class AMP_Enhancements {
 	 * @param object    $error The AMP sanitisation error.
 	 */
 	public static function amp_validation_error_sanitized( $is_sanitized, $error ) {
+		if ( isset( $_GET['newspack-disallow-amp-kept'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			return true;
+		}
 		if ( false === self::should_use_amp_plus() ) {
 			return $is_sanitized;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds handling of a special parameter, for debugging AMP issues. Specifically, this feature will be useful for debugging potential issues caused by AMP Plus mode, which works by marking certain scripts as "kept" in the AMP plugin.

### How to test the changes in this Pull Request:

1. Enable AMP Plus mode* and add the Streamlined Donate block** on a page
2. Visit the page, observe the Donate block behaving as expected
3. Append `?newspack-disallow-amp-kept` to the URL, reload the page
4. Observe the block is not interactive, because JS scripts were not loaded

\* Set `NEWSPACK_AMP_PLUS_ENABLED` env. variable to `true`
\** Set Stripe as the Reader Revenue platform 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->