### PR TITLE
fix: modal header for WP 5.9

### DIFF
--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -41,8 +41,8 @@
 		border: 0;
 		height: auto;
 		justify-content: flex-end;
-		margin: 0 -32px 0;
-		padding: 32px 32px 0;
+		margin: 0;
+		padding: 32px 0 0;
 		position: relative;
 
 		.components-modal__header-heading-container {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Small update the the margin/padding of the `Modal`'s header section

### How to test the changes in this Pull Request:

1. Update your WP install to 5.9
2. Go to Components Demo and open the modal (the header should look slightly broken)
3. Update to this branch and refresh Components Demo
4. Switch back your WP install to 5.8.3
5. Refresh Components Demo and check if the modal looks fine

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->