### PR TITLE
fix: timeouts due to use of get_post when checking whether to allow deletion

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -81,7 +81,7 @@ class Patches {
 		$post_id            = $args[0]; // First item is usually the post ID.
 
 		// If $post_id isn't a valid post, bail early.
-		if ( is_null( get_post( $post_id ) ) ) {
+		if ( false === get_post_type( $post_id ) ) {
 			return $caps;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a known 504 timeout on a publisher site that seems to be caused by the use of `get_post` in the capabilities check when checking whether an object can be safely deleted.

### How to test the changes in this Pull Request:

1. Ensure that special pages (privacy policy, homepage, blog posts page, etc.) still can't be deleted from the WP admin UI
2. Ensure that post lists, user lists, and other admin pages that show a lot of rows can still be viewed without triggering a 504 error

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->