### PR TITLE
fix: restore accidentally-deleted rest route

### DIFF
--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -245,6 +245,16 @@ class Reader_Revenue_Wizard extends Wizard {
 				],
 			]
 		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/newspack-donations-wizard/donation/',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_donation_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I got a bit overzealous in #1429 with deleting REST API route handlers in the Reader Revenue wizard class. This resulted in accidentally deleting the endpoint for getting donation settings. This PR restores the missing endpoint.

### How to test the changes in this Pull Request:

1. On `master`, add a Donate block to a post or page. Observe that the block shows an error message and that the API request to the `/newspack/v1/wizard/newspack-donations-wizard/donation` endpoint fails with a `rest_no_route` error.

<img width="825" alt="Screen Shot 2022-01-14 at 1 38 18 PM" src="https://user-images.githubusercontent.com/2230142/149582113-d1876c5d-8bcc-4cf6-8825-190807b54cf1.png">

2. Check out this branch, refresh, confirm that the error no longer occurs and the Donate block renders correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->