### PR TITLE
AutomateWoo linkfix

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -403,7 +403,7 @@ class Plugin_Manager {
 				'Name'        => 'AutomateWoo',
 				'Description' => esc_html__( 'Convert and retain customers with automated marketing that does the hard work for you.', 'newspack' ),
 				'Author'      => 'WooCommerce',
-				'PluginURI'   => 'https://woocommerce.com/products/woocommerce-subscriptions/',
+				'PluginURI'   => 'https://woocommerce.com/products/automatewoo/',
 				'AuthorURI'   => 'https://woocommerce.com/',
 			],
 			'automatewoo-refer-a-friend'    => [


### PR DESCRIPTION
Fixing the URL for the [AutomateWoo](https://woocommerce.com/products/automatewoo/) extension for WooCommerce; it currently points to [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/) instead.