### PR TITLE
Display all newsletter providers during the onboarding

### DIFF
--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -28,8 +28,6 @@ import {
 } from '../../../../components/src';
 import { fetchJetpackMailchimpStatus } from '../../../../utils';
 
-const stripHTML = ( string = '' ) => string.replace( /(<([^>]+)>)/gi, '' );
-
 export const NewspackNewsletters = ( { className, onUpdate, isOnboarding = true } ) => {
 	const [ config, updateConfig ] = hooks.useObjectState( {} );
 	const performConfigUpdate = update => {

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -30,7 +30,7 @@ import { fetchJetpackMailchimpStatus } from '../../../../utils';
 
 const stripHTML = ( string = '' ) => string.replace( /(<([^>]+)>)/gi, '' );
 
-export const NewspackNewsletters = ( { className, onUpdate, mailchimpOnly = true } ) => {
+export const NewspackNewsletters = ( { className, onUpdate, isOnboarding = true } ) => {
 	const [ config, updateConfig ] = hooks.useObjectState( {} );
 	const performConfigUpdate = update => {
 		updateConfig( update );
@@ -47,7 +47,8 @@ export const NewspackNewsletters = ( { className, onUpdate, mailchimpOnly = true
 	const getSettingProps = key => ( {
 		value: config.settings[ key ]?.value || '',
 		checked: Boolean( config.settings[ key ]?.value ),
-		label: stripHTML( config.settings[ key ]?.description ),
+		label: config.settings[ key ]?.description,
+		placeholder: config.settings[ key ]?.placeholder,
 		options:
 			config.settings[ key ]?.options?.map( option => ( {
 				value: option.value,
@@ -56,28 +57,6 @@ export const NewspackNewsletters = ( { className, onUpdate, mailchimpOnly = true
 		onChange: value => performConfigUpdate( { settings: { [ key ]: { value } } } ),
 	} );
 
-	const renderMailchimpSettings = () => (
-		<>
-			<SectionHeader
-				title={ __( 'Mailchimp', 'newspack' ) }
-				description={ () => (
-					<>
-						{ __( 'Configure Mailchimp and enter your API key', 'newspack' ) }
-						{ ' – ' }
-						<ExternalLink href="https://mailchimp.com/help/about-api-keys/#Find_or_generate_your_API_key">
-							{ __( 'learn how', 'newspack' ) }
-						</ExternalLink>
-					</>
-				) }
-			/>
-			<Grid gutter={ 32 } columns={ 2 }>
-				<TextControl
-					label={ __( 'Application ID', 'newspack' ) }
-					{ ...getSettingProps( 'newspack_mailchimp_api_key' ) }
-				/>
-			</Grid>
-		</>
-	);
 	const renderProviderSettings = () => {
 		const providerSelectProps = getSettingProps( 'newspack_newsletters_service_provider' );
 		return (
@@ -85,6 +64,9 @@ export const NewspackNewsletters = ( { className, onUpdate, mailchimpOnly = true
 				{ values( config.settings )
 					.filter( setting => ! setting.provider || setting.provider === providerSelectProps.value )
 					.map( setting => {
+						if ( isOnboarding && ! setting.onboarding ) {
+							return null;
+						}
 						switch ( setting.type ) {
 							case 'select':
 								return <SelectControl key={ setting.key } { ...getSettingProps( setting.key ) } />;
@@ -93,7 +75,18 @@ export const NewspackNewsletters = ( { className, onUpdate, mailchimpOnly = true
 									<CheckboxControl key={ setting.key } { ...getSettingProps( setting.key ) } />
 								);
 							default:
-								return <TextControl key={ setting.key } { ...getSettingProps( setting.key ) } />;
+								return (
+									<Grid columns={ 1 } gutter={ '0' }>
+										<TextControl key={ setting.key } { ...getSettingProps( setting.key ) } />
+										{ setting.help && setting.helpURL && (
+											<p>
+												<ExternalLink href={ setting.helpURL }>
+													{ setting.help }
+												</ExternalLink>
+											</p>
+										) }
+									</Grid>
+								);
 						}
 					} ) }
 			</Grid>
@@ -109,11 +102,7 @@ export const NewspackNewsletters = ( { className, onUpdate, mailchimpOnly = true
 					onStatus={ ( { complete } ) => complete && fetchConfiguration() }
 				/>
 			) }
-			{ config.configured === true && (
-				<Fragment>
-					{ mailchimpOnly ? renderMailchimpSettings() : renderProviderSettings() }
-				</Fragment>
-			) }
+			{ config.configured === true && renderProviderSettings() }
 		</div>
 	);
 };
@@ -173,7 +162,7 @@ const Newsletters = () => {
 			) }
 			<SectionHeader title={ __( 'Authoring', 'newspack' ) } />
 			<NewspackNewsletters
-				mailchimpOnly={ false }
+				isOnboarding={ false }
 				onUpdate={ config => updateConfiguration( { newslettersConfig: config } ) }
 			/>
 			<div className="newspack-buttons-card">

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -80,9 +80,7 @@ export const NewspackNewsletters = ( { className, onUpdate, isOnboarding = true 
 										<TextControl key={ setting.key } { ...getSettingProps( setting.key ) } />
 										{ setting.help && setting.helpURL && (
 											<p>
-												<ExternalLink href={ setting.helpURL }>
-													{ setting.help }
-												</ExternalLink>
+												<ExternalLink href={ setting.helpURL }>{ setting.help }</ExternalLink>
 											</p>
 										) }
 									</Grid>

--- a/assets/wizards/setup/views/services/index.js
+++ b/assets/wizards/setup/views/services/index.js
@@ -31,7 +31,7 @@ const SERVICES_LIST = {
 	newsletters: {
 		label: __( 'Newsletters', 'newspack' ),
 		description: __(
-			'Create email newsletters and send them to your Mailchimp mail lists, all without leaving your website',
+			'Create email newsletters and send them to your mail lists, all without leaving your website',
 			'newspack'
 		),
 		Component: NewspackNewsletters,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds all the various Newsletter providers to the onboarding instead of restricting it to Mailchimp.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-newsletters/pull/694

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->