### PR TITLE
feat: use PluginSettings components for Campaigns wizard

### DIFF
--- a/assets/components/src/plugin-settings/SettingsSection.js
+++ b/assets/components/src/plugin-settings/SettingsSection.js
@@ -27,6 +27,8 @@ const getControlComponent = setting => {
 		case 'checkbox':
 		case 'boolean':
 			return CheckboxControl;
+		case 'select':
+			return SelectControl;
 		default:
 			return TextControl;
 	}
@@ -46,6 +48,8 @@ const getControlType = setting => {
 		case 'boolean':
 		case 'checkbox':
 			return 'checkbox';
+		case 'select':
+			return 'select';
 		default:
 			return null;
 	}
@@ -75,7 +79,7 @@ const SettingsSection = ( {
 		options:
 			setting.options?.map( option => ( {
 				value: option.value,
-				label: option.name,
+				label: option.name || option.label,
 			} ) ) || null,
 		value: setting.value,
 		checked: setting.type === 'boolean' ? !! setting.value : null,

--- a/assets/components/src/plugin-settings/SettingsSection.js
+++ b/assets/components/src/plugin-settings/SettingsSection.js
@@ -27,8 +27,6 @@ const getControlComponent = setting => {
 		case 'checkbox':
 		case 'boolean':
 			return CheckboxControl;
-		case 'select':
-			return SelectControl;
 		default:
 			return TextControl;
 	}
@@ -48,8 +46,6 @@ const getControlType = setting => {
 		case 'boolean':
 		case 'checkbox':
 			return 'checkbox';
-		case 'select':
-			return 'select';
 		default:
 			return null;
 	}

--- a/assets/components/src/plugin-settings/index.js
+++ b/assets/components/src/plugin-settings/index.js
@@ -27,9 +27,13 @@ class PluginSettings extends Component {
 	}
 
 	fetchSettings = () => {
-		const { afterFetch, pluginSlug } = this.props;
+		const { afterFetch, pluginSlug, isWizard } = this.props;
 		this.setState( { inFlight: true } );
-		apiFetch( { path: `/${ pluginSlug }/v1/settings` } )
+		apiFetch( {
+			path: isWizard
+				? `/newspack/v1/wizard/${ pluginSlug }/settings`
+				: `/${ pluginSlug }/v1/settings`,
+		} )
 			.then( settings => {
 				this.setState( { settings, error: null } );
 
@@ -74,10 +78,12 @@ class PluginSettings extends Component {
 	};
 
 	handleSectionUpdate = sectionKey => data => {
-		const { afterUpdate, pluginSlug } = this.props;
+		const { afterUpdate, pluginSlug, isWizard } = this.props;
 		this.setState( { inFlight: true } );
 		apiFetch( {
-			path: `/${ pluginSlug }/v1/settings`,
+			path: isWizard
+				? `/newspack/v1/wizard/${ pluginSlug }/settings`
+				: `/${ pluginSlug }/v1/settings`,
 			method: 'POST',
 			data: {
 				section: sectionKey,

--- a/assets/components/src/text-control/style.scss
+++ b/assets/components/src/text-control/style.scss
@@ -155,4 +155,8 @@
 		display: block;
 		margin: 0;
 	}
+
+	.components-base-control__help {
+		font-style: italic;
+	}
 }

--- a/assets/wizards/popups/views/settings/index.js
+++ b/assets/wizards/popups/views/settings/index.js
@@ -1,63 +1,21 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { withWizardScreen, CheckboxControl, Grid, SelectControl } from '../../../../components/src';
+import { withWizardScreen, PluginSettings } from '../../../../components/src';
 
-const ENDPOINT = `/newspack/v1/wizard/newspack-popups-wizard/settings`;
-
-const Settings = ( { isLoading, wizardApiFetch } ) => {
-	const [ settings, setSettings ] = useState( [] );
-
-	const handleSettingChange = option_name => option_value => {
-		wizardApiFetch( {
-			path: ENDPOINT,
-			method: 'POST',
-			quiet: true,
-			data: { option_name, option_value },
-		} ).then( setSettings );
-	};
-
-	useEffect( () => {
-		wizardApiFetch( {
-			path: ENDPOINT,
-			method: 'GET',
-		} ).then( setSettings );
-	}, [] );
-
-	const renderSetting = setting => {
-		if ( setting.label ) {
-			const props = {
-				key: setting.key,
-				label: setting.label,
-				help: setting.help,
-				disabled: isLoading,
-				onChange: handleSettingChange( setting.key ),
-			};
-			switch ( setting.type ) {
-				case 'select':
-					return (
-						<SelectControl
-							{ ...props }
-							value={ setting.value }
-							options={ [ { label: setting.no_option_text, value: '' }, ...setting.options ] }
-						/>
-					);
-				default:
-					return <CheckboxControl { ...props } checked={ setting.value } />;
-			}
-		}
-		return null;
-	};
-
+const Settings = () => {
 	return (
-		<Grid gutter={ 32 } rowGap={ 16 }>
-			{ settings.map( renderSetting ) }
-		</Grid>
+		<PluginSettings
+			pluginSlug="newspack-popups-wizard"
+			isWizard={ true }
+			title={ __( 'Campaigns Plugin Settings', 'newspack' ) }
+			description={ __( 'Configure display and advanced settings for your prompts.', 'newspack' ) }
+		/>
 	);
 };
 

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -127,11 +127,11 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
-	 * Set plugin settings.
+	 * Update plugin settings section.
 	 *
 	 * @param object $options options.
 	 */
-	public function set_settings( $options ) {
+	public function update_settings_section( $options ) {
 		return $this->is_configured() ?
 			\Newspack_Popups_Settings::update_section( $options ) :
 			$this->unconfigured_error();

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -77,7 +77,7 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_settings() {
 		return $this->is_configured() ?
-			\Newspack_Popups_Settings::get_settings() :
+			\Newspack_Popups_Settings::get_settings( true ) :
 			$this->unconfigured_error();
 	}
 
@@ -133,7 +133,7 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function set_settings( $options ) {
 		return $this->is_configured() ?
-			\Newspack_Popups_Settings::set_settings( $options ) :
+			\Newspack_Popups_Settings::update_section( $options ) :
 			$this->unconfigured_error();
 	}
 

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -201,7 +201,7 @@ class Popups_Wizard extends Wizard {
 			'/wizard/' . $this->slug . '/settings',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_set_plugin_settings' ],
+				'callback'            => [ $this, 'api_update_settings_section' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
 					'option_name'  => [
@@ -749,9 +749,9 @@ class Popups_Wizard extends Wizard {
 	 *
 	 * @param array $options options.
 	 */
-	public static function api_set_plugin_settings( $options ) {
+	public static function api_update_settings_section( $options ) {
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
-		return $newspack_popups_configuration_manager->set_settings( $options );
+		return $newspack_popups_configuration_manager->update_settings_section( $options );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Refactors the **Campaigns > Settings** wizard page to use the `PluginSettings` component. Requires https://github.com/Automattic/newspack-popups/pull/777.

### How to test the changes in this Pull Request:

1. Make sure your Campaigns repo is checked out with https://github.com/Automattic/newspack-popups/pull/777.
2. Visit **Newspack > Campaigns > Settings**.
3. Confirm you see the new settings UI:

<img width="1065" alt="Screen Shot 2022-01-21 at 1 49 18 PM" src="https://user-images.githubusercontent.com/2230142/150598198-c52b09bf-6590-4730-b829-0ad2d584b4a3.png">

4. Change various settings and save, then refresh the page. Confirm that settings are saved as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->