### PR TITLE
fix(donations): filter saved settings

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -240,9 +240,11 @@ class Donations {
 		$currency_symbol = html_entity_decode( self::get_currency_symbol() );
 
 		if ( ! self::is_platform_wc() ) {
-			$saved_settings             = get_option( self::DONATION_NON_WC_SETTINGS_OPTION, [] );
-			$defaults                   = self::get_donation_default_settings( true );
-			$settings                   = wp_parse_args( $saved_settings, $defaults );
+			$saved_settings = get_option( self::DONATION_NON_WC_SETTINGS_OPTION, [] );
+			$defaults       = self::get_donation_default_settings( true );
+			// Get only the saved settings matching keys from default settings.
+			$valid_saved_settings       = array_intersect_key( $defaults, $saved_settings );
+			$settings                   = wp_parse_args( $valid_saved_settings, $defaults );
 			$settings['currencySymbol'] = $currency_symbol;
 			return $settings;
 		}
@@ -294,6 +296,9 @@ class Donations {
 	 * @return array Updated settings.
 	 */
 	public static function set_donation_settings( $args ) {
+		$defaults = self::get_donation_default_settings();
+		// Filter incoming object, so that is contains only valid keys.
+		$args = array_intersect_key( $args, $defaults );
 		if ( ! self::is_platform_wc() ) {
 			update_option( self::DONATION_NON_WC_SETTINGS_OPTION, $args );
 			return self::get_donation_settings();

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -190,7 +190,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			]
 		);
 
-		// Save a subscription.
+		// Update Donations settings.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/donations/',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1392

### How to test the changes in this Pull Request:

1. On `master`, edit the value of `newspack_donations_settings` option to add some extra (invalid, dummy) keys in there
2. Observe that when visiting the Reader Revenue wizard, the extra keys will be visible in the response from the `/wizard/newspack-reader-revenue-wizard` endpoint
3. Switch to this branch, observe the response does not contain the dummy keys

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->