### PR TITLE
hotfix: disable author archives for subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.72.1-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.72.0...v1.72.1-hotfix.1) (2022-01-27)
+
+
+### Bug Fixes
+
+* disable author archive pages for non-staff users ([3ec9fc7](https://github.com/Automattic/newspack-plugin/commit/3ec9fc77fe12d6539560b4939dc9d3897f048935))
+
 # [1.72.0](https://github.com/Automattic/newspack-plugin/compare/v1.71.0...v1.72.0) (2022-01-25)
 
 

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -159,29 +159,6 @@ class Patches {
 	}
 
 	/**
-	 * Mimic the "Page not found" document title for 404 pages.
-	 *
-	 * @param string $title Page title.
-	 * @param string $sep Document title separator character. Default '-'.
-	 * @param string $seplocation Location of the separator (left or right). Default 'left'.
-	 *
-	 * @return string Filtered page title.
-	 */
-	public static function set_page_not_found_title( $title, $sep = '-', $seplocation = '' ) {
-		$title_parts = [
-			__( 'Page not found', 'newspack' ),
-			$sep,
-			get_bloginfo( 'name' ),
-		];
-
-		if ( 'right' === $seplocation ) {
-			$title_parts = array_reverse( $title_parts );
-		}
-
-		return implode( ' ', $title_parts );
-	}
-
-	/**
 	 * Force author pages for non-valid author roles to 404.
 	 * Prevents author pages for users like subscribers and donors from being publicly accessible.
 	 *

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.72.0
+ * Version: 1.72.1-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.72.0",
+  "version": "1.72.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.72.0",
+      "version": "1.72.1-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.16.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.72.0",
+  "version": "1.72.1-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids displaying author archive pages for WP users that don't have one of the defined allowed roles, by default:

```
[
	'administrator',
	'editor',
	'author',
	'contributor',
]
```

This array of roles is filtered as `newspack_user_roles_with_author_archives` so other plugins can add/remove roles as needed.

Currently, WP will generate author archive pages for all WP users, including subscribers and WooCommerce customers, which most Newspack publishers won't want.

### How to test the changes in this Pull Request:

1. Create several users: a Co-Authors Plus guest author, an admin user, an editor user, an author user, a contributor user, and a subscriber user.
2. On `master`, view the author archives for each author type (hint: look at the "View" link in WP admin). Observe that the subscriber gets an author archive like all the others.
3. Check out this branch. Confirm that all author archives still work for the CAP guest author, admin, editor, author, and contributor users, but that the subscriber archive is now a 404.

#### Handle outgoing staff writer scenario

Newspack publishers will often convert WP users for outgoing staff to "subscriber" users so that those users no longer have access to the WP admin. In this case we still want the archives to be accessible for those users. Since it's not possible in WP admin to assign subscribers as post authors, we can assume that any subscriber with a post count greater than 0 falls into this scenario.

1. Assign one of the non-subscriber WP users you created above to at least one post.
2. Edit the user in WP admin and change their role to "Subscriber."
3. View the author archive and confirm that the archive is visible with their post(s).
4. Reassign all of their posts to another user and refresh the archive. Confirm that it's now a 404.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->