### PR TITLE
feat: support multiple control for plugin settings

### DIFF
--- a/assets/components/src/plugin-settings/SettingsSection.js
+++ b/assets/components/src/plugin-settings/SettingsSection.js
@@ -20,8 +20,11 @@ import { __ } from '@wordpress/i18n';
 import { ActionCard, Grid, Button, TextControl, CheckboxControl, SelectControl } from '../';
 import './style.scss';
 
+const isSelectControl = setting => {
+	return Array.isArray( setting.options ) && setting.options.length;
+};
 const getControlComponent = setting => {
-	if ( Array.isArray( setting.options ) && setting.options.length ) {
+	if ( isSelectControl( setting ) ) {
 		return SelectControl;
 	}
 	switch ( setting.type ) {
@@ -72,6 +75,7 @@ const SettingsSection = props => {
 				label: option.name,
 			} ) ) || null,
 		value: setting.value,
+		multiple: isSelectControl( setting ) && setting.multiple ? true : null,
 		checked: setting.type === 'boolean' ? !! setting.value : null,
 		className: classnames( {
 			'padded-checkbox': setting.type === 'boolean' && ! isSingleLined( index ),

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -37,6 +37,7 @@ import {
 	ToggleGroup,
 	WebPreview,
 	AutocompleteWithSuggestions,
+	PluginSettings,
 } from '../../components/src';
 
 class ComponentsDemo extends Component {
@@ -693,6 +694,70 @@ class ComponentsDemo extends Component {
 							chevron
 							isSmall
 							grouped
+						/>
+					</Card>
+					<Card>
+						<h2>{ __( 'Plugin Settings Section', 'newspack' ) }</h2>
+						<PluginSettings.Section
+							sectionKey="example"
+							title={ __( 'Example plugin settings', 'newspack' ) }
+							description={ __( 'Example plugin settings description', 'newspack' ) }
+							active={ true }
+							fields={ [
+								{
+									key: 'example_field',
+									type: 'string',
+									description: 'Example Text Field',
+									help: 'Example text field help text',
+									value: 'Example Value',
+								},
+								{
+									key: 'example_checkbox_field',
+									type: 'boolean',
+									description: 'Example checkbox Field',
+									help: 'Example checkbox field help text',
+									value: false,
+								},
+								{
+									key: 'example_options_field',
+									type: 'string',
+									description: 'Example options field',
+									help: 'Example options field help text',
+									options: [
+										{
+											value: 'example_value_1',
+											name: 'Example Value 1',
+										},
+										{
+											value: 'example_value_2',
+											name: 'Example Value 2',
+										},
+									],
+								},
+								{
+									key: 'example_multi_options_field',
+									type: 'string',
+									description: 'Example multiple options field',
+									help: 'Example multiple options field help text',
+									multiple: true,
+									options: [
+										{
+											value: 'example_value_1',
+											name: 'Example Value 1',
+										},
+										{
+											value: 'example_value_2',
+											name: 'Example Value 2',
+										},
+									],
+								},
+							] }
+							onUpdate={ data => {
+								console.log( 'Plugin Settings Section Updated', data );
+							} }
+							onChange={ ( key, val ) => {
+								console.log( 'Plugin Settings Section Changed', { key, val } );
+							} }
 						/>
 					</Card>
 				</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add support for multiple select (#1287) to the `<PluginSettings.Section />`. A field with `options` and `multiple=true` should render a multiple select.

### How to test the changes in this Pull Request:

1. Switch to this branch, visit the components demo
2. Confirm the multiple select is displayed on the example at the bottom of the page
3. Click on multiple values from the select and confirm on the console log the change event with the array values

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->