### PR TITLE
feat(salesforce): ability to manually sync WC orders to salesforce

### DIFF
--- a/assets/other-scripts/salesforce/index.js
+++ b/assets/other-scripts/salesforce/index.js
@@ -3,7 +3,7 @@
 /**
  * WordPress imports.
  */
-const { __ } = wp.i18n;
+import { __ } from '@wordpress/i18n';
 
 ( function () {
 	const statusMarker = document.getElementById( 'newspack-salesforce-sync-status' );
@@ -12,10 +12,15 @@ const { __ } = wp.i18n;
 		base_url: baseUrl,
 		order_id: orderId,
 		salesforce_url: salesforceUrl,
+		nonce,
 	} = newspack_salesforce_data;
 
 	if ( statusMarker ) {
-		fetch( `${ baseUrl }newspack/salesforce/v1/order?orderId=${ orderId }` )
+		fetch( `${ baseUrl }newspack/salesforce/v1/order?orderId=${ orderId }`, {
+			headers: {
+				'X-WP-Nonce': nonce,
+			},
+		} )
 			.then( response => response.json() )
 			.then( opportunityId => {
 				if ( false === opportunityId ) {

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -117,7 +117,9 @@ class Salesforce {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_order_status' ],
-				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+				'permission_callback' => function() {
+					return current_user_can( 'edit_others_shop_orders' );
+				},
 			]
 		);
 

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -334,7 +334,6 @@ class Salesforce {
 	/**
 	 * API endpoint for checking validity of a Salesforce refresh token.
 	 *
-	 * @throws \WP_Error Error message.
 	 * @return WP_REST_Response with the active status.
 	 */
 	public static function api_check_salesforce_connection_status() {
@@ -443,7 +442,6 @@ class Salesforce {
 	 * API endpoint for getting Salesforce API tokens.
 	 *
 	 * @param WP_REST_Request $request Request containing settings.
-	 * @throws \WP_Error Error message.
 	 * @return WP_REST_Response with the latest settings.
 	 */
 	public static function api_get_salesforce_tokens( $request ) {
@@ -452,9 +450,11 @@ class Salesforce {
 
 		// Must have a valid API key and secret.
 		if ( empty( $settings['client_id'] ) || empty( $settings['client_secret'] ) ) {
-			throw new \WP_Error(
-				'newspack_salesforce_invalid_credentials',
-				__( 'Invalid Consumer Key or Secret.', 'newspack' )
+			return \rest_ensure_response(
+				new \WP_Error(
+					'newspack_salesforce_invalid_credentials',
+					__( 'Invalid Consumer Key or Secret.', 'newspack' )
+				)
 			);
 		}
 
@@ -1149,7 +1149,6 @@ class Salesforce {
 	/**
 	 * Get a new Salesforce token using a valid refresh token.
 	 *
-	 * @throws \WP_Error Error message.
 	 * @return string The new access token.
 	 */
 	private static function refresh_salesforce_token() {
@@ -1157,7 +1156,7 @@ class Salesforce {
 
 		// Must have a valid API key and secret.
 		if ( empty( $settings['client_id'] ) || empty( $settings['client_secret'] ) ) {
-			throw new \WP_Error(
+			return new \WP_Error(
 				'newspack_salesforce_invalid_credentials',
 				__( 'Invalid Consumer Key or Secret.', 'newspack' )
 			);
@@ -1165,7 +1164,7 @@ class Salesforce {
 
 		// Must have a valid refresh token.
 		if ( empty( $settings['refresh_token'] ) ) {
-			throw new \WP_Error(
+			return new \WP_Error(
 				'newspack_salesforce_invalid_connection',
 				__( 'Invalid refresh token.', 'newspack' )
 			);

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -966,13 +966,16 @@ class Salesforce {
 
 		// If the order has opportunity IDs saved in post meta, query using those IDs.
 		// Otherwise, we'll have to query by matching order details.
-		$opportunities   = get_post_meta( $order_id, 'newspack_salesforce_opportunities', true );
-		$opportunities   = array_map(
-			function( $opportunity_id ) {
-				return "'$opportunity_id'";
-			},
-			$opportunities
-		);
+		$opportunities = get_post_meta( $order_id, 'newspack_salesforce_opportunities', true );
+		if ( is_array( $opportunities ) ) {
+			$opportunities = array_map(
+				function( $opportunity_id ) {
+					return "'$opportunity_id'";
+				},
+				$opportunities
+			);
+		}
+
 		$opportunity_ids = is_array( $opportunities ) && ! empty( $opportunities ) ? implode( ',', $opportunities ) : false;
 
 		$name        = $order_item['Name'];

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -752,7 +752,13 @@ class Salesforce {
 
 		// If our access token has expired, let's get a refresh token and retry.
 		if ( wp_remote_retrieve_response_code( $response ) === 401 ) {
-			$request['headers']['Authorization'] = 'Bearer ' . self::refresh_salesforce_token();
+			$token = self::refresh_salesforce_token();
+
+			if ( is_wp_error( $token ) ) {
+				return $token;
+			}
+
+			$request['headers']['Authorization'] = 'Bearer ' . $token;
 			$response                            = wp_safe_remote_request( $url, $request );
 		}
 

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -117,7 +117,7 @@ class Salesforce {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_order_status' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
 			]
 		);
 
@@ -199,11 +199,12 @@ class Salesforce {
 		}
 
 		$settings = self::get_salesforce_settings();
+		Newspack::load_common_assets();
 
 		wp_enqueue_script(
 			'newspack-salesforce-sync-status',
 			Newspack::plugin_url() . '/dist/other-scripts/salesforce.js',
-			[ 'wp-i18n' ],
+			[],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/other-scripts/salesforce.js' ),
 			true
 		);
@@ -215,6 +216,7 @@ class Salesforce {
 				'base_url'       => get_rest_url(),
 				'order_id'       => get_the_id(),
 				'salesforce_url' => $settings['instance_url'],
+				'nonce'          => wp_create_nonce( 'wp_rest' ),
 			]
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

~Not to merged before #1429.~ Ready for review! Extends the WooCommerce admin UI for orders to more conveniently show the orders' sync status with Salesforce, as well as allow admins to manually sync or resync single orders with a button click.

### How to test the changes in this Pull Request:

1. Set up a Salesforce connection on your test site (follow instructions on [this page](https://newspack.pub/support/reader-revenue/) to set up a connection, and DM me if you need a Salesforce dev account).
2. Make a test donation as a reader and wait a few minutes.
3. In WP admin > WooCommerce > Orders, find the order corresponding to your test donation.
4. In the Order Actions metabox, verify that you see a new "Salesforce sync status" message with the sync status of your order (will only appear if you have an active Salesforce connection). Also verify that if the order shows a "synced" status, that it's clickable to the Salesforce Opportunity record:

<img width="285" alt="Screen Shot 2022-01-07 at 11 34 19 AM" src="https://user-images.githubusercontent.com/2230142/148590549-3ea75689-f1b2-4774-86aa-45a899dabc26.png">

5. Also observe that on successful or failed sync, a message is added to the "Order notes" metabox (this is to add some slightly more user-friendly sync logging outside of the WooCommerce webhook logs):

<img width="287" alt="Screen Shot 2022-01-07 at 11 34 56 AM" src="https://user-images.githubusercontent.com/2230142/148590636-4beaa75a-e85b-45b0-a64a-68d357ac0b10.png">

7. In the Order Actions metabox, expand the "Choose an action..." dropdown. Confirm that there's a new action to "Sync order to Salesforce" (will only appear if you have an active Salesforce connection):

<img width="309" alt="Screen Shot 2022-01-07 at 11 36 04 AM" src="https://user-images.githubusercontent.com/2230142/148590767-40bcd06b-ee45-4e19-b07d-2cb8762edf5f.png">

8. Select the new option and click the [>] button to execute the action. For already-synced orders, this will resync the order to the existing Opportunity record in Salesforce. Only billing info and close date will be updated, as the other order data is not updateable in WooCommerce. For orders that have not been synced for whatever reason, it will create a new Opportunity record in Salesforce.
9. Log into Salesforce and confirm that the manual sync action successfully updated or created the opportunity record.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->