### PR TITLE
feat: enable AMP Plus for Jetpack Instant Search

### DIFF
--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -88,7 +88,7 @@ class AMP_Enhancements {
 		if ( isset( $error, $error['node_attributes'], $error['node_attributes']['data-amp-plus-allowed'] ) ) {
 			return false;
 		}
-		return $is_sanitized;
+		return apply_filters( 'newspack_amp_plus_sanitized', $is_sanitized, $error );
 	}
 }
 AMP_Enhancements::init();

--- a/includes/class-jetpack.php
+++ b/includes/class-jetpack.php
@@ -53,14 +53,14 @@ class Jetpack {
 	 */
 	public static function jetpack_modules_amp_plus( $is_sanitized, $error ) {
 		if ( isset( $error, $error['node_attributes'], $error['node_attributes']['id'] ) ) {
-			$has_any_id = array_reduce(
+			$script_has_matching_id = array_reduce(
 				self::$scripts_handles,
 				function( $carry, $id ) use ( $error ) {
 					return $carry || 0 === strpos( $error['node_attributes']['id'], $id ); // Match starting position so it includes `-js`, `-after` and `-before` scripts.
 				},
 				false
 			);
-			if ( $has_any_id ) {
+			if ( $script_has_matching_id ) {
 				$is_sanitized = false;
 			}
 		}
@@ -70,14 +70,14 @@ class Jetpack {
 			'JetpackInstantSearchOptions', // Jetpack Instant Search options.
 		];
 		if ( isset( $error, $error['text'] ) ) {
-			$has_any_text = array_reduce(
+			$script_has_matching_text = array_reduce(
 				$texts,
 				function( $carry, $text ) use ( $error ) {
 					return $carry || false !== strpos( $error['text'], $text );
 				},
 				false
 			);
-			if ( $has_any_text ) {
+			if ( $script_has_matching_text ) {
 				$is_sanitized = false;
 			}
 		}

--- a/includes/class-jetpack.php
+++ b/includes/class-jetpack.php
@@ -52,10 +52,6 @@ class Jetpack {
 	 * @return bool Whether the error should be rejected.
 	 */
 	public static function jetpack_modules_amp_plus( $is_sanitized, $error ) {
-		$texts = [
-			'jetpackSearchModuleSorting',  // Jetpack Search module sorting.
-			'JetpackInstantSearchOptions', // Jetpack Instant Search options.
-		];
 		if ( isset( $error, $error['node_attributes'], $error['node_attributes']['id'] ) ) {
 			$has_any_id = array_reduce(
 				self::$scripts_handles,
@@ -68,6 +64,11 @@ class Jetpack {
 				$is_sanitized = false;
 			}
 		}
+		// Match inline scripts by script text since they don't have IDs.
+		$texts = [
+			'jetpackSearchModuleSorting',  // Jetpack Search module sorting.
+			'JetpackInstantSearchOptions', // Jetpack Instant Search options.
+		];
 		if ( isset( $error, $error['text'] ) ) {
 			$has_any_text = array_reduce(
 				$texts,

--- a/includes/class-jetpack.php
+++ b/includes/class-jetpack.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Jetpack integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Jetpack {
+
+	/**
+	 * Modules scripts handles.
+	 *
+	 * @var string[]
+	 */
+	private static $scripts_handles = [
+		'jp-tracks',              // Tracks analytics library.
+		'jetpack-instant-search', // Jetpack Instant Search.
+		'jetpack-search-widget',  // Jetpack Search widget.
+	];
+
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'jetpack_async_scripts' ], 20 );
+		add_filter( 'newspack_amp_plus_sanitized', [ __CLASS__, 'jetpack_modules_amp_plus' ], 10, 2 );
+	}
+
+
+	/**
+	 * Make Jetpack scripts async.
+	 */
+	public static function jetpack_async_scripts() {
+		foreach ( self::$scripts_handles as $handle ) {
+			wp_script_add_data( $handle, 'async', true );
+		}
+	}
+
+	/**
+	 * Allow Jetpack modules scripts to be loaded in AMP Plus mode.
+	 *
+	 * @param bool|null $is_sanitized If null, the error will be handled. If false, rejected.
+	 * @param object    $error        The AMP sanitisation error.
+	 *
+	 * @return bool Whether the error should be rejected.
+	 */
+	public static function jetpack_modules_amp_plus( $is_sanitized, $error ) {
+		$texts = [
+			'jetpackSearchModuleSorting',  // Jetpack Search module sorting.
+			'JetpackInstantSearchOptions', // Jetpack Instant Search options.
+		];
+		if ( isset( $error, $error['node_attributes'], $error['node_attributes']['id'] ) ) {
+			$has_any_id = array_reduce(
+				self::$scripts_handles,
+				function( $carry, $id ) use ( $error ) {
+					return $carry || 0 === strpos( $error['node_attributes']['id'], $id ); // Match starting position so it includes `-js`, `-after` and `-before` scripts.
+				},
+				false
+			);
+			if ( $has_any_id ) {
+				$is_sanitized = false;
+			}
+		}
+		if ( isset( $error, $error['text'] ) ) {
+			$has_any_text = array_reduce(
+				$texts,
+				function( $carry, $text ) use ( $error ) {
+					return $carry || false !== strpos( $error['text'], $text );
+				},
+				false
+			);
+			if ( $has_any_text ) {
+				$is_sanitized = false;
+			}
+		}
+		return $is_sanitized;
+	}
+}
+Jetpack::init();

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -123,6 +123,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-starter-content.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-amp-enhancements.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-newspack-image-credits.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-jetpack.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
 

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -7,9 +7,6 @@
 
 namespace Newspack;
 
-use Automattic\Jetpack\Search\Helper as JetpackSearchHelper;
-use Automattic\Jetpack\Search\Options as JetpackSearchOptions;
-
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -105,8 +105,8 @@ class Patches {
 				if ( ! widgets.length ) {
 					return;
 				}
-				var isSearch      = <?php echo (int) is_search(); ?>,
-					searchQuery     = decodeURIComponent( '<?php echo rawurlencode( get_query_var( 's', '' ) ); ?>' );
+				var isSearch  = <?php echo (int) is_search(); ?>,
+					searchQuery = decodeURIComponent( '<?php echo rawurlencode( get_query_var( 's', '' ) ); ?>' );
 
 				for( var i = 0, len = widgets.length; i < len; i++ ) {
 					var container     = widgets[ i ],

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -46,6 +46,7 @@ class Patches {
 			'jetpack-instant-search', // Jetpack Instant Search.
 			'jp-tracks',              // Tracks analytics library.
 			'wp-i18n',                // Jetpack Instant Search dependency.
+			'wp-jp-i18n-loader',      // Jetpack i18n dependency.
 			'jetpack-search-widget',  // Jetpack Search widget.
 		];
 		add_filter(

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -46,7 +46,6 @@ class Patches {
 			'jetpack-instant-search', // Jetpack Instant Search.
 			'jp-tracks',              // Tracks analytics library.
 			'wp-i18n',                // Jetpack Instant Search dependency.
-			'wp-jp-i18n-loader',      // Jetpack i18n dependency.
 			'jetpack-search-widget',  // Jetpack Search widget.
 		];
 		add_filter(

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -92,6 +92,9 @@ class Patches {
 	 * See https://github.com/Automattic/jetpack/blob/4ef58afbaba5396902194e5af699c9fe3e520318/projects/packages/search/src/widgets/class-search-widget.php#L531-L544.
 	 */
 	public static function jetpack_search_maybe_render_sort_js() {
+		if ( ! class_exists( 'Automattic\\Jetpack\\Search\\Options' ) ) {
+			return;
+		}
 		if ( JetpackSearchOptions::is_instant_enabled() ) {
 			return;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allow Jetpack Search module to work with AMP Plus.

~~Note that the non-instant search widget filters will continue to not work. Its inputs are controlled through a [hardcoded script](https://github.com/Automattic/jetpack/blob/4ef58afbaba5396902194e5af699c9fe3e520318/projects/packages/search/src/widgets/class-search-widget.php#L544-L595) that we are unable to hook into since it's printed through the widget output.~~

~~Update: d54fd510167de718a8fd3a507affa63001055980 adds full support to the non-instant search widget. It adds AMP Plus attribute to the main `jetpack-search-widget` script and ports a customized script to handle the [sorting controls](https://github.com/Automattic/jetpack/blob/4ef58afbaba5396902194e5af699c9fe3e520318/projects/packages/search/src/widgets/class-search-widget.php#L544-L595).~~

Update: 325b0a3367b5559a3f444fc35cd8c2d5605ba583 adds a filter hook to the sanitization handler and parses the jetpack errors using IDs and texts. Some of the inline scripts do not have ID so it's parsing the script text to match.

### How to test the changes in this Pull Request:

1. Install this branch on a live or JN site
2. Enable the Jetpack Search module (ping me if you need assistance)
3. Make sure you have AMP installed with AMP Plus enabled
4. Visit the homepage, start typing on the search bar
5. Confirm the instant search is working as expected
6. Customize the search experience through the Jetpack dashboard and confirm the changes are applied

#### Non-instant search widget

With Instant Search disabled, the search widget behaves a bit differently with scripts that trigger search on input changes.

1. Keep the search module enabled and disable the instant search
2. Add the Jetpack search widget with extra filters to your search page sidebar
3. Visit the search page ( `?s=` )
4. Change sorting, select taxonomy terms and text search and confirm everything behaves as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->