### PR TITLE
Add sticky position to TabbedNavigation

### DIFF
--- a/assets/components/src/tabbed-navigation/style.scss
+++ b/assets/components/src/tabbed-navigation/style.scss
@@ -6,6 +6,19 @@
 @import '../../../shared/scss/colors';
 
 .newspack-tabbed-navigation {
+	background: white;
+	width: 100%;
+
+	@media only screen and ( min-width: 600px ) {
+		position: sticky;
+		top: 46px;
+		z-index: 3;
+	}
+
+	@media only screen and ( min-width: 783px ) {
+		top: 32px;
+	}
+
 	ul {
 		box-shadow: 0 -1px 0 inset $gray-300;
 		display: flex;

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -83,14 +83,15 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 								{ subHeaderText && <span>{ subHeaderText }</span> }
 							</div>
 						</div>
-						{ tabbedNavigation && (
-							<TabbedNavigation
-								disableUpcoming={ disableUpcomingInTabbedNavigation }
-								items={ tabbedNavigation.filter( item => ! item.isHiddenInNav ) }
-							/>
-						) }
 					</div>
 				</div>
+
+				{ tabbedNavigation && (
+					<TabbedNavigation
+						disableUpcoming={ disableUpcomingInTabbedNavigation }
+						items={ tabbedNavigation.filter( item => ! item.isHiddenInNav ) }
+					/>
+				) }
 
 				<div className={ classnames( 'newspack-wizard newspack-wizard__content', className ) }>
 					{ typeof renderAboveContent === 'function' ? renderAboveContent() : null }

--- a/assets/components/src/wizard/index.js
+++ b/assets/components/src/wizard/index.js
@@ -101,9 +101,11 @@ const Wizard = ( {
 									{ subHeaderText && <span>{ subHeaderText }</span> }
 								</div>
 							</div>
-							{ displayedSections.length > 1 && <TabbedNavigation items={ displayedSections } /> }
 						</div>
 					</div>
+
+					{ displayedSections.length > 1 && <TabbedNavigation items={ displayedSections } /> }
+
 					<Switch>
 						{ displayedSections.map( ( section, index ) => {
 							const SectionComponent = section.render;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The TabbedNavigation will be fixed at the top of the screen.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Test every screens of the plugin

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->