### PR TITLE
fix(parsely): configuring Parse.ly

### DIFF
--- a/includes/configuration_managers/class-parsely-configuration-manager.php
+++ b/includes/configuration_managers/class-parsely-configuration-manager.php
@@ -34,7 +34,7 @@ class Parsely_Configuration_Manager extends Configuration_Manager {
 			return $active;
 		}
 
-		if ( ! class_exists( 'Parsely' ) ) {
+		if ( ! is_plugin_active( 'wp-parsely/wp-parsely.php' ) ) {
 			return new \WP_Error(
 				'newspack_missing_required_plugin',
 				esc_html__( 'Parse.ly plugin is not installed and activated. Install and/or activate it to access this feature.', 'newspack' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with Parse.ly config manager (#1207). Instead of checking if `Parsely` class has loaded, use WP core `is_plugin_active` function.

### How to test the changes in this Pull Request:

A full test would involve configuring the Parse.ly plugin via Newspack Manager, but I think the changes here is pretty self-explanatory.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->