### PR TITLE
Fix/theme mods setting

### DIFF
--- a/assets/components/src/textarea-control/style.scss
+++ b/assets/components/src/textarea-control/style.scss
@@ -49,6 +49,10 @@
 			color: $gray-600;
 			cursor: not-allowed;
 		}
+
+		&::placeholder {
+			opacity: 0.5;
+		}
 	}
 
 	// Multiple Textarea Controls

--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -160,16 +160,6 @@ class Starter_Content {
 	}
 
 	/**
-	 * Set theme style.
-	 *
-	 * @param string $style Style id.
-	 */
-	public static function set_theme( $style ) {
-		Theme_Manager::install_activate_theme( $style );
-		return self::get_theme();
-	}
-
-	/**
 	 * Get theme style.
 	 *
 	 * @return string Style id.

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -486,7 +486,11 @@ class Setup_Wizard extends Wizard {
 	public function api_update_theme_with_mods( $request ) {
 		// Set theme before updating theme mods, since a theme might be setting theme mod defaults.
 		$theme = $request['theme'];
-		Starter_Content::set_theme( $theme );
+		Theme_Manager::install_activate_theme( $theme );
+		// If the theme has to be installed, the set_theme_mod calls below will – for some reason – have no effect
+		// If there's a switch_theme call here, even though it's already called in Theme_Manager::install_activate_theme,
+		// correct mods will be saved.
+		switch_theme( $theme );
 
 		// Set homepage pattern.
 		if ( isset( $request['theme_mods']['homepage_pattern_index'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1093.

When Newspack is set up, the parent theme is downloaded and set as theme. Then, when another theme is chosen in Setup (or Design) wizard, the "new" theme has to be downloaded first. When theme mods are set immediately after a theme is downloaded, the mods are not saved. For some reason, this can be resolved by calling `switch_theme` (again) in the function which calls `set_theme_mods`.

Also `TextareaControl` is tweaked a bit, so that the placeholder text does not look like it's the actual text.

### How to test the changes in this Pull Request:

Install the plugin on a fresh site and observe #1093 is not reproducible – make sure to switch theme in the "Design" step of the Setup wizard

On an existing site, the original issue can be reproduced this way, on `master`:

1. Set theme to Newspack Theme
2. Remove all other Newspack themes from `wp-content/themes`
3. Remove all Newspack theme mods (options with `theme_mods_newspack` prefix)
4. Load the Design wizard or Setup wizard, Design step
5. Set the theme to a different Newspack theme (so it will have to be downloaded)
6. Change primary and secondary colors 
7. Save in Design wizard or "Finish" in Setup wizard
8. Observe the colors were not saved

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->