### PR TITLE
fix: lookup user by queried slug, not by login

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -170,7 +170,7 @@ class Patches {
 		}
 
 		$author_name = $query->query_vars['author_name'];
-		$user        = get_user_by( 'login', $author_name );
+		$user        = get_user_by( 'slug', $author_name );
 
 		// For CAP guest authors, $user will be false.
 		if ( ! $user || ! isset( $user->roles ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug introduced in #1474. On author archive pages, the query looks for the user's slug, which is a sanitized form of the user login. For many users slug and login name will look the same, but for users whose slug differs from the login, the fix in #1474 will not work.

### How to test the changes in this Pull Request:

1. Create a subscriber user with spaces in the login name (e.g. "Subscriber User"). Ensure they're not assigned as an author to any posts.
2. On `master`, view their archive page and observe that the page does NOT 404 as it should since #1474.
3. Check out this branch and confirm that their archive page now 404s as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201790554258200