### PR TITLE
ci: build plugin files and store as artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,20 @@ jobs:
           paths:
             - project
 
+  build-distributable:
+    docker:
+      - image: cimg/php:7.4-browsers
+    steps:
+      - checkout_with_workspace
+      - run:
+          name: Install rsync
+          command: sudo apt-get update && sudo apt-get install rsync
+      - run:
+          name: Build plugin files
+          command: npm run build && npm run release:archive
+      - store_artifacts:
+          path: release/newspack-plugin.zip
+
   # JS & SCSS Jobs
   lint-js-scss:
     docker:
@@ -117,6 +131,9 @@ workflows:
           requires:
             - build
       - test-js:
+          requires:
+            - build
+      - build-distributable:
           requires:
             - build
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,10 @@ workflows:
       - build-distributable:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master
       - release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,10 @@ workflows:
       - build-distributable:
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - master
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ jobs:
           name: Install rsync
           command: sudo apt-get update && sudo apt-get install rsync
       - run:
+          name: Install PHP packages
+          command: composer install --no-dev --no-scripts
+      - run:
           name: Build plugin files
           command: npm run build && npm run release:archive
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,10 @@ workflows:
       - build-distributable:
           requires:
             - build
-          # filters:
-          #   branches:
-          #     only:
-          #       - master
+          filters:
+            branches:
+              only:
+                - master
       - release:
           requires:
             - build


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For E2E testing, it'll be useful to be able to run tests against the `master` branch versions. For that, the distributable plugin files will have to be built and stored on CI environment.

### How to test the changes in this Pull Request:

Since this new job is filtered to be ran on `master` only, so it's not really testable. To verify that it works, I first pushed a commit with the config, before filtering – [visit CI's view of the corresponding build](https://app.circleci.com/pipelines/github/Automattic/newspack-plugin/3523/workflows/0e5d963a-e3af-4079-ae34-e2cf8ae68bbe/jobs/16101/steps), click on the "Artifacts" tab, observe the plugin ZIP is there, available for downloading:

<img width="460" alt="image" src="https://user-images.githubusercontent.com/7383192/153426833-8f25ad4c-ee46-4db3-bcfd-54577a4a15f6.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->