### PR TITLE
Ad Units: move edit/archive links to popover

### DIFF
--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -217,10 +217,6 @@ class AdvertisingWizard extends Component {
 									service={ 'google_ad_manager' }
 									serviceData={ services.google_ad_manager }
 									onDelete={ id => this.deleteAdUnit( id ) }
-									buttonText={ __( 'Add New Ad Unit', 'newspack' ) }
-									buttonAction={ `#/google_ad_manager/${ CREATE_AD_ID_PARAM }` }
-									secondaryButtonText={ __( 'Back to Ad Providers', 'newspack' ) }
-									secondaryButtonAction="#/"
 									wizardApiFetch={ wizardApiFetch }
 									fetchAdvertisingData={ this.fetchAdvertisingData }
 									updateWithAPI={ this.updateWithAPI }

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -7,33 +7,25 @@
  */
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { ExternalLink, Path, SVG } from '@wordpress/components';
-import { pencil } from '@wordpress/icons';
+import { ExternalLink } from '@wordpress/components';
+import { arrowLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import {
 	ActionCard,
-	TextControl,
-	SelectControl,
 	Button,
 	Card,
 	Notice,
+	SelectControl,
+	TextControl,
 	withWizardScreen,
 } from '../../../../components/src';
 import ServiceAccountConnection from './service-account-connection';
+import OptionsPopover from './options-popover';
 
-export const archive = (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path d="m15.976 14.139-3.988 3.418L8 14.14 8.976 13l2.274 1.949V10.5h1.5v4.429L15 13l.976 1.139Z" />
-		<Path
-			clipRule="evenodd"
-			d="M4 9.232A2 2 0 0 1 3 7.5V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v1.5a2 2 0 0 1-1 1.732V18a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V9.232ZM5 5.5h14a.5.5 0 0 1 .5.5v1.5a.5.5 0 0 1-.5.5H5a.5.5 0 0 1-.5-.5V6a.5.5 0 0 1 .5-.5Zm.5 4V18a.5.5 0 0 0 .5.5h12a.5.5 0 0 0 .5-.5V9.5h-13Z"
-			fillRule="evenodd"
-		/>
-	</SVG>
-);
+const CREATE_AD_ID_PARAM = 'create';
 
 /**
  * Advertising management screen.
@@ -80,6 +72,12 @@ const AdUnits = ( {
 
 	return (
 		<>
+			<Card noBorder>
+				<Button isLink href="#/" icon={ arrowLeft }>
+					{ __( 'Back to Ad Providers', 'newspack' ) }
+				</Button>
+			</Card>
+
 			{ ! isLegacy && networkCode && (
 				<SelectControl
 					label={ __( 'Connected GAM network code', 'newspack' ) }
@@ -150,6 +148,13 @@ const AdUnits = ( {
 					'newspack'
 				) }
 			</p>
+			<Card headerActions noBorder>
+				<div className="flex justify-end w-100">
+					<Button isPrimary isSmall href={ `#/google_ad_manager/${ CREATE_AD_ID_PARAM }` }>
+						{ __( 'Add New Ad Unit', 'newspack' ) }
+					</Button>
+				</div>
+			</Card>
 			<Card noBorder>
 				{ Object.values( adUnits )
 					.filter( adUnit => adUnit.id !== 0 )
@@ -157,18 +162,12 @@ const AdUnits = ( {
 					.sort( a => ( a.is_legacy ? 1 : -1 ) )
 					.map( adUnit => {
 						const editLink = `#${ service }/${ adUnit.id }`;
-						const buttonProps = {
-							isQuaternary: true,
-							isSmall: true,
-							tooltipPosition: 'bottom center',
-						};
 						return (
 							<ActionCard
 								key={ adUnit.id }
 								title={ adUnit.name }
 								isSmall
 								titleLink={ editLink }
-								className="mv0"
 								{ ...( adUnit.is_legacy
 									? {}
 									: {
@@ -193,20 +192,10 @@ const AdUnits = ( {
 									</span>
 								) }
 								actionText={
-									<div className="flex items-center">
-										<Button
-											href={ editLink }
-											icon={ pencil }
-											label={ __( 'Edit Ad Unit', 'newspack' ) }
-											{ ...buttonProps }
-										/>
-										<Button
-											onClick={ () => onDelete( adUnit.id ) }
-											icon={ archive }
-											label={ __( 'Archive Ad Unit', 'newspack' ) }
-											{ ...buttonProps }
-										/>
-									</div>
+									<OptionsPopover
+										deleteLink={ () => onDelete( adUnit.id ) }
+										editLink={ editLink }
+									/>
 								}
 							/>
 						);

--- a/assets/wizards/advertising/views/ad-units/options-popover.js
+++ b/assets/wizards/advertising/views/ad-units/options-popover.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { MenuItem } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
+import { ESCAPE } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Popover } from '../../../../components/src';
+
+const OptionsPopover = props => {
+	const [ isVisible, setIsVisible ] = useState( false );
+	const toggleVisible = () => {
+		setIsVisible( state => ! state );
+	};
+	const { deleteLink, editLink } = props;
+
+	return (
+		<>
+			<Button
+				isQuaternary
+				isSmall
+				className={ isVisible && 'popover-active' }
+				onClick={ toggleVisible }
+				icon={ moreVertical }
+				label={ __( 'More options', 'newspack' ) }
+				tooltipPosition="bottom center"
+			/>
+			{ isVisible && (
+				<Popover
+					position="bottom left"
+					onFocusOutside={ toggleVisible }
+					onKeyDown={ event => ESCAPE === event.keyCode && toggleVisible }
+				>
+					<MenuItem onClick={ toggleVisible } className="screen-reader-text">
+						{ __( 'Close Popover', 'newspack' ) }
+					</MenuItem>
+					<MenuItem href={ editLink } className="newspack-button" isLink>
+						{ __( 'Edit', 'newspack' ) }
+					</MenuItem>
+					<MenuItem onClick={ deleteLink } className="newspack-button">
+						{ __( 'Archive', 'newspack' ) }
+					</MenuItem>
+				</Popover>
+			) }
+		</>
+	);
+};
+
+export default OptionsPopover;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR replaces the two icons (`pencil` + `archive`) in favour of a `moreVertical` where it now triggers a `Popover`. This makes the right hand side of the `ActionCard` less cluttered.

I've also moved the "Back" button to the top of the page and the "Add New" button to the top of the `ActionCards`.

![ad-units](https://user-images.githubusercontent.com/177929/153431903-817dee35-0573-4285-a647-cbd1088c8b51.png)

### How to test the changes in this Pull Request:

1. Swtich to this branch
2. Go to your Ad Units
3. Try to edit/delete and create some new ones

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->