### PR TITLE
fix(setup-wizard): hide navigation on welcome screen

### DIFF
--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -40,58 +40,6 @@ svg {
 	}
 }
 
-// Welcome Screen
-
-.newspack-wizard__welcome {
-	.newspack-wizard__header {
-		display: none;
-	}
-
-	.newspack-icon {
-		margin: 0 auto;
-	}
-
-	.newspack-card {
-		&.loading {
-			cursor: wait;
-		}
-
-		&__footer {
-			align-items: center;
-			display: flex;
-			flex-wrap: wrap;
-			justify-content: flex-end;
-
-			&:empty {
-				margin-top: -32px;
-			}
-
-			.newspack-checkbox-control {
-				margin: 12px 16px 12px 0;
-			}
-
-			.newspack-button {
-				margin-left: auto;
-			}
-		}
-
-		h1 {
-			align-items: center;
-			display: flex;
-			flex-wrap: wrap;
-
-			.newspack--error,
-			.newspack-checkbox-icon {
-				margin-right: 8px;
-			}
-		}
-	}
-
-	.newspack-buttons-card {
-		margin: 0;
-	}
-}
-
 // Blue Screen
 
 .newspack-wizard__blue {

--- a/assets/wizards/setup/style.scss
+++ b/assets/wizards/setup/style.scss
@@ -8,6 +8,59 @@
 	}
 }
 
+// Welcome Screen
+
+.newspack-wizard__welcome {
+	.newspack-wizard__header,
+	.newspack-tabbed-navigation {
+		display: none;
+	}
+
+	.newspack-icon {
+		margin: 0 auto;
+	}
+
+	.newspack-card {
+		&.loading {
+			cursor: wait;
+		}
+
+		&__footer {
+			align-items: center;
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: flex-end;
+
+			&:empty {
+				margin-top: -32px;
+			}
+
+			.newspack-checkbox-control {
+				margin: 12px 16px 12px 0;
+			}
+
+			.newspack-button {
+				margin-left: auto;
+			}
+		}
+
+		h1 {
+			align-items: center;
+			display: flex;
+			flex-wrap: wrap;
+
+			.newspack--error,
+			.newspack-checkbox-icon {
+				margin-right: 8px;
+			}
+		}
+	}
+
+	.newspack-buttons-card {
+		margin: 0;
+	}
+}
+
 .newspack-site-profile {
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug introduced in #1496 (not yet released, but alpha should be updated with these changes).

Also the CSS for this Wizard is moved to the correct place. The only change after the cut-and-paste is line 15.

### How to test the changes in this Pull Request:

1. On `master`, visit the welcome screen of Setup wizard (`/wp-admin/admin.php?page=newspack-setup-wizard#/`)
2. Observe that navigation is visible
3. Switch to this branch, observe the navigation is not visible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->