### PR TITLE
fix: remove animation fill mode for modals

### DIFF
--- a/assets/components/src/modal/style.scss
+++ b/assets/components/src/modal/style.scss
@@ -14,6 +14,7 @@
 	margin: auto;
 	max-height: 100%;
 	width: 100%;
+	animation-fill-mode: none;
 
 	@media screen and ( min-width: 600px ) {
 		border-radius: 3px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a temporary fix until https://github.com/WordPress/gutenberg/pull/38716 is not reviewed/released.

Fixes the positioning of Popovers inside Modals for Chrome and Safari.

With the animation fill mode set to `forwards`, the final step sets `transform` to a defined value. This makes `position: fixed` child elements position from the Modal's edge instead of the viewport.

More on `position` and containing blocks: https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block

| Master | This PR |
| --- | --- |
| <img width="1528" alt="Captura de Tela 2022-02-16 às 14 25 24" src="https://user-images.githubusercontent.com/820752/154321505-c770348d-25bc-4ab4-8e8c-d804fc4912d5.png"> | <img width="918" alt="image" src="https://user-images.githubusercontent.com/820752/154321538-fd08cd48-aa20-4d89-a1ee-2e3f7a4d0322.png"> |


### How to test the changes in this Pull Request:

1. Test a Modal with an inner Popover (available at https://github.com/Automattic/newspack-ads/pull/310 testing instructions)
2. Confirm that on master it's misplaced (invisible due to `overflow: hidden` of Modal container)
3. Check out this branch and confirm it's properly placed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->