### PR TITLE
Fix posts block date issues when running The Events Calendar

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -28,6 +28,9 @@ class Patches {
 
 		// Disable Publicize automated sharing for WooCommerce products.
 		add_action( 'init', [ __CLASS__, 'disable_publicize_for_products' ] );
+
+		// Fix an issue when running The Events Calendar where all posts block items have same date.
+		add_action( 'tribe_events_views_v2_after_make_view', [ __CLASS__, 'remove_tec_extra_excerpt_filtering' ], 1 );
 	}
 
 
@@ -240,6 +243,19 @@ class Patches {
 	 */
 	public static function disable_publicize_for_products() {
 		remove_post_type_support( 'product', 'publicize' );
+	}
+
+	/**
+	 * The 'action_include_filters_excerpt' hooked on this action to modify the 'Read More' text by The Events Calendar
+	 * causes issues because of the weird `avoiding_filter_loop` usage in the call stack. It introduces a race condition that
+	 * messes up the query that the posts block uses by resetting the query early, and WP will think the current posts block item is 
+	 * the parent Page that the posts block is embedded on.
+	 *
+	 * @see https://github.com/the-events-calendar/the-events-calendar/blob/0b8caed6049ee6c16bb3d1e06ea9026d995f636e/src/Tribe/Views/V2/Hooks.php#L92
+	 * @see https://github.com/the-events-calendar/the-events-calendar/blob/77910c9de7f5640064d4eef4eb4841a523f27719/src/Tribe/Views/V2/Template/Excerpt.php#L71-L73
+	 */
+	public static function remove_tec_extra_excerpt_filtering() {
+		remove_all_actions( 'tribe_events_views_v2_after_make_view' );
 	}
 }
 Patches::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue on all our sites running The Events Calendar. On those sites, sometimes the same date will show as the published date on all posts block items. I've tracked it down to [some excerpt processing that TEC does](https://github.com/the-events-calendar/the-events-calendar/blob/77910c9de7f5640064d4eef4eb4841a523f27719/src/Tribe/Views/V2/Template/Excerpt.php#L116) while trying to avoid an infinite loop. My understanding reading their source code is that the processing is mainly for the twentyseventeen theme, so shouldn't be an issue to unhook it.

### How to test the changes in this Pull Request:

1. Install and activate The Events Calendar (free version from wporg). In the Display settings, use 'Tribe Event Styles' and 'Default Events Template':

<img width="918" alt="Screen Shot 2022-02-16 at 9 48 58 AM" src="https://user-images.githubusercontent.com/7317227/154325289-d9421173-a179-492d-b37a-518e9c58ff6f.png">

2. Set up a homepage with posts blocks **with excerpts toggled on**. Make sure the homepage Page and the posts have different dates, so you can see if the issue happens (I used Feb 1, 2022 for the homepage and Nov 3, 2021 for the posts in this example)

3. On the frontend, observe that all of the posts with excerpts have the publish date of the homepage:

<img width="1319" alt="Screen Shot 2022-02-16 at 9 30 30 AM" src="https://user-images.githubusercontent.com/7317227/154325999-2562e01b-81d0-4e34-9de8-49592e6ccb50.png">

4. Apply this patch. Refresh the page. Observe that the posts have the correct publish dates:

<img width="1344" alt="Screen Shot 2022-02-16 at 9 34 51 AM" src="https://user-images.githubusercontent.com/7317227/154326088-609ae2c4-0d6a-40e3-a48f-8118a0803faf.png">



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->