### PR TITLE
Update Ads and Campaigns ActionCards style

### DIFF
--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -156,7 +156,7 @@
 			}
 		}
 		.newspack-action-card__region-top {
-			background-color: $gray-100;
+			background-color: rgba( black, 0.025 );
 		}
 	}
 

--- a/assets/components/src/checkbox-control/style.scss
+++ b/assets/components/src/checkbox-control/style.scss
@@ -50,7 +50,7 @@
 		font-style: italic;
 		line-height: inherit;
 		margin: 0;
-		margin-left: 28px;
+		padding-left: 28px;
 	}
 
 	// Multiple Checkbox Controls

--- a/assets/components/src/plugin-settings/SettingsSection.js
+++ b/assets/components/src/plugin-settings/SettingsSection.js
@@ -91,6 +91,14 @@ const SettingsSection = props => {
 			props
 		);
 	};
+	let columns;
+	if ( fields.length % 3 === 0 ) {
+		columns = 3;
+	} else if ( fields.length % 2 === 0 ) {
+		columns = 2;
+	} else {
+		columns = 1;
+	}
 	return (
 		<ActionCard
 			isMedium
@@ -98,13 +106,29 @@ const SettingsSection = props => {
 			title={ title }
 			description={ description }
 			toggleChecked={ active }
-			hasGreyHeader={ true }
+			hasGreyHeader={ active }
 			toggleOnChange={ active !== null ? value => onUpdate( { active: value } ) : null }
+			actionContent={
+				active &&
+				createFilter(
+					'buttons',
+					<Button
+						isPrimary
+						isSmall
+						disabled={ disabled }
+						onClick={ () => {
+							onUpdate();
+						} }
+					>
+						{ __( 'Save Settings', 'newspack' ) }
+					</Button>
+				)
+			}
 		>
 			{ ( active || active === null ) && (
 				<Fragment>
 					{ createFilter( 'beforeControls' ) }
-					<Grid columns={ fields.length % 3 === 0 ? 3 : 2 } gutter={ 32 }>
+					<Grid columns={ columns } gutter={ 32 }>
 						{ fields.map( ( setting, index ) => {
 							const Control = getControlComponent( setting ); // eslint-disable-line @wordpress/no-unused-vars-before-return, no-unused-vars
 							return applyFilters(
@@ -114,22 +138,6 @@ const SettingsSection = props => {
 							);
 						} ) }
 					</Grid>
-					{ createFilter( 'afterControls' ) }
-					<div className="newspack-buttons-card" style={ { margin: '32px 0 0' } }>
-						{ createFilter(
-							'buttons',
-							<Button
-								isPrimary
-								disabled={ disabled }
-								onClick={ () => {
-									onUpdate();
-								} }
-							>
-								{ __( 'Save settings', 'newspack' ) }
-							</Button>
-						) }
-					</div>
-					{ createFilter( 'afterButtons' ) }
 				</Fragment>
 			) }
 		</ActionCard>

--- a/assets/components/src/plugin-settings/SettingsSection.js
+++ b/assets/components/src/plugin-settings/SettingsSection.js
@@ -3,11 +3,6 @@
  */
 
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
@@ -56,14 +51,18 @@ const getControlType = setting => {
 };
 
 const SettingsSection = props => {
-	const { sectionKey, active, title, description, fields, disabled, onChange, onUpdate } = props;
-	const isSingleLined = index => {
-		const total = fields.length;
-		const hasSingleLinedField = fields.length % 3 !== 0 && fields.length % 2 !== 0;
-		const isLast = index === total - 1;
-		return hasSingleLinedField && isLast;
-	};
-	const getControlProps = ( setting, index ) => ( {
+	const {
+		sectionKey,
+		active,
+		title,
+		description,
+		fields,
+		disabled,
+		onChange,
+		onUpdate,
+		hasGreyHeader,
+	} = props;
+	const getControlProps = setting => ( {
 		disabled,
 		name: `${ setting.section }_${ setting.key }`,
 		type: getControlType( setting ),
@@ -77,9 +76,6 @@ const SettingsSection = props => {
 		value: setting.value,
 		multiple: isSelectControl( setting ) && setting.multiple ? true : null,
 		checked: setting.type === 'boolean' ? !! setting.value : null,
-		className: classnames( {
-			'padded-checkbox': setting.type === 'boolean' && ! isSingleLined( index ),
-		} ),
 		onChange: value => {
 			onChange( setting.key, value );
 		},
@@ -106,10 +102,10 @@ const SettingsSection = props => {
 			title={ title }
 			description={ description }
 			toggleChecked={ active }
-			hasGreyHeader={ active }
+			hasGreyHeader={ active || hasGreyHeader }
 			toggleOnChange={ active !== null ? value => onUpdate( { active: value } ) : null }
 			actionContent={
-				active &&
+				( active || hasGreyHeader ) &&
 				createFilter(
 					'buttons',
 					<Button
@@ -129,12 +125,12 @@ const SettingsSection = props => {
 				<Fragment>
 					{ createFilter( 'beforeControls' ) }
 					<Grid columns={ columns } gutter={ 32 }>
-						{ fields.map( ( setting, index ) => {
+						{ fields.map( setting => {
 							const Control = getControlComponent( setting ); // eslint-disable-line @wordpress/no-unused-vars-before-return, no-unused-vars
 							return applyFilters(
 								`newspack.settingsSection.${ sectionKey }.control`,
-								<Control key={ setting.key } { ...getControlProps( setting, index ) } />,
-								{ sectionKey, setting, index, onChange }
+								<Control key={ setting.key } { ...getControlProps( setting ) } />,
+								{ sectionKey, setting, onChange }
 							);
 						} ) }
 					</Grid>

--- a/assets/components/src/plugin-settings/index.js
+++ b/assets/components/src/plugin-settings/index.js
@@ -168,7 +168,7 @@ class PluginSettings extends Component {
 	 * Render.
 	 */
 	render() {
-		const { title, description } = this.props;
+		const { title, description, hasGreyHeader } = this.props;
 		const { settings, inFlight, error } = this.state;
 		return (
 			<Fragment>
@@ -190,6 +190,7 @@ class PluginSettings extends Component {
 							fields={ this.getSectionFields( sectionKey ) }
 							onChange={ this.handleSettingChange( sectionKey ) }
 							onUpdate={ this.handleSectionUpdate( sectionKey ) }
+							hasGreyHeader={ hasGreyHeader }
 						/>
 					) ) }
 				</div>

--- a/assets/components/src/plugin-settings/style.scss
+++ b/assets/components/src/plugin-settings/style.scss
@@ -1,5 +1,5 @@
-.newspack-checkbox-control.padded-checkbox {
-	@media screen and ( min-width: 744px ) {
-		padding-top: 24px;
+.newspack-action-card__region-children {
+	> .newspack-grid {
+		margin: 32px 0 0 !important;
 	}
 }

--- a/assets/wizards/advertising/components/placement-control/index.js
+++ b/assets/wizards/advertising/components/placement-control/index.js
@@ -50,6 +50,7 @@ const hasAnySize = ( sizes, sizesToCheck ) => {
 };
 
 const PlacementControl = ( {
+	label = __( 'Ad Unit', 'newspack' ),
 	adUnits = {},
 	bidders = {},
 	value = {},
@@ -83,7 +84,7 @@ const PlacementControl = ( {
 	return (
 		<Fragment>
 			<SelectControl
-				label={ __( 'Ad Unit', 'newspack' ) }
+				label={ label }
 				value={ value.ad_unit }
 				options={ getAdUnitsForSelect( adUnits ) }
 				onChange={ data => {

--- a/assets/wizards/advertising/style.scss
+++ b/assets/wizards/advertising/style.scss
@@ -13,14 +13,6 @@
 		line-height: 16px;
 	}
 
-	.newspack-card {
-		&--has-grey-header {
-			.newspack-grid {
-				margin: 32px 0 0 !important;
-			}
-		}
-	}
-
 	.newspack-grid {
 		&__thead,
 		&__tbody {

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -21,11 +21,11 @@ import { settings } from '@wordpress/icons';
  */
 import {
 	ActionCard,
-	CheckboxControl,
-	Modal,
-	Card,
-	Notice,
 	Button,
+	Card,
+	Modal,
+	Notice,
+	ToggleControl,
 	withWizardScreen,
 } from '../../../../components/src';
 import PlacementControl from '../../components/placement-control';
@@ -139,7 +139,6 @@ const Placements = ( { adUnits } ) => {
 							description={ placements[ key ].description }
 							toggleOnChange={ handlePlacementToggle( key ) }
 							toggleChecked={ isEnabled( key ) }
-							hasGreyHeader={ ! isEnabled( key ) }
 							actionText={
 								isEnabled( key ) ? (
 									<Button
@@ -184,22 +183,21 @@ const Placements = ( { adUnits } ) => {
 								...placement.hooks[ hookKey ],
 							};
 							return (
-								<>
-									<h2>{ hook.name }</h2>
+								<Card noBorder key={ hookKey }>
 									<PlacementControl
-										key={ hookKey }
+										label={ hook.name + ' ' + __( 'Ad Unit', 'newspack' ) }
 										adUnits={ adUnits }
 										bidders={ bidders }
 										value={ placement.data?.hooks ? placement.data.hooks[ hookKey ] : {} }
 										disabled={ inFlight }
 										onChange={ handlePlacementChange( editingPlacement, hookKey ) }
 									/>
-								</>
+								</Card>
 							);
 						} ) }
 					{ placement.supports?.indexOf( 'stick_to_top' ) > -1 && (
-						<CheckboxControl
-							label={ __( 'Stick to top', 'newspack' ) }
+						<ToggleControl
+							label={ __( 'Stick to Top', 'newspack' ) }
 							checked={ !! placement.data?.stick_to_top }
 							onChange={ value => {
 								setPlacements(

--- a/assets/wizards/popups/views/settings/index.js
+++ b/assets/wizards/popups/views/settings/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { withWizardScreen, PluginSettings } from '../../../../components/src';
@@ -13,8 +8,8 @@ const Settings = () => {
 		<PluginSettings
 			pluginSlug="newspack-popups-wizard"
 			isWizard={ true }
-			title={ __( 'Campaigns Plugin Settings', 'newspack' ) }
-			description={ __( 'Configure display and advanced settings for your prompts.', 'newspack' ) }
+			title={ null }
+			hasGreyHeader
 		/>
 	);
 };

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -116,6 +116,7 @@ const Salesforce = () => {
 	return (
 		<>
 			<PluginSettings
+				hasGreyHeader
 				afterUpdate={ settings => {
 					let clientId, clientSecret;
 					( settings?.salesforce || [] ).forEach( setting => {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Lightened `hasGreyHeader`
* Moved "Saved Settings" button to top region
* Updated the number of columns
* Removed `hasGreyHeader` from the placement's `ActionCard`s
* Updated `PlacementControl`'s label

__After__

![Screenshot 2022-02-23 at 16 51 23](https://user-images.githubusercontent.com/177929/155367249-834c8bc0-8552-4ffc-a20c-339a144d36e8.png)

__Before__

![Screenshot 2022-02-23 at 16 51 43](https://user-images.githubusercontent.com/177929/155367206-5e7d2053-75fd-4609-be1d-5a3c0140f567.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Go to the Ads Wizard
3. Test the Placements and Settings
4. Go to the Campaigns Wizard
5. Test the settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->