### PR TITLE
fix(reader-revenue): return saved settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.77.1-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.77.0...v1.77.1-hotfix.1) (2022-02-23)
+
+
+### Bug Fixes
+
+* **reader-revenue:** return saved settings ([1a81dae](https://github.com/Automattic/newspack-plugin/commit/1a81daec62d5db062751fa41e4257581e1aade57))
+
 # [1.77.0](https://github.com/Automattic/newspack-plugin/compare/v1.76.0...v1.77.0) (2022-02-22)
 
 

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -243,7 +243,7 @@ class Donations {
 			$saved_settings = get_option( self::DONATION_NON_WC_SETTINGS_OPTION, [] );
 			$defaults       = self::get_donation_default_settings( true );
 			// Get only the saved settings matching keys from default settings.
-			$valid_saved_settings       = array_intersect_key( $defaults, $saved_settings );
+			$valid_saved_settings       = array_intersect_key( $saved_settings, $defaults );
 			$settings                   = wp_parse_args( $valid_saved_settings, $defaults );
 			$settings['currencySymbol'] = $currency_symbol;
 			return $settings;

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.77.0
+ * Version: 1.77.1-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.77.0",
+  "version": "1.77.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.77.0",
+      "version": "1.77.1-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.77.0",
+  "version": "1.77.1-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the use of `array_intersect_key()` for ensuring the settings keys. The `$defaults` are passed as the first argument, so it always returns the default values instead of the saved settings.

### How to test the changes in this Pull Request:

1. While on master, visit the Reader Revenue -> Donations wizard and attempt to edit the "Suggested donations"
2. Observe the changes do not persist on the wizard without presenting any errors
3. Check out this branch and confirm the changes are saved and updated on the wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->