### PR TITLE
fix(jetpack): modules scripts behind constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.77.2-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.77.1...v1.77.2-hotfix.1) (2022-02-24)
+
+
+### Bug Fixes
+
+* **jetpack:** modules scripts behind constant ([53e088b](https://github.com/Automattic/newspack-plugin/commit/53e088b1c601c8197c41e9c2b8c65ae4ee7675f2))
+
 ## [1.77.1](https://github.com/Automattic/newspack-plugin/compare/v1.77.0...v1.77.1) (2022-02-23)
 
 

--- a/includes/class-jetpack.php
+++ b/includes/class-jetpack.php
@@ -33,6 +33,20 @@ class Jetpack {
 		add_filter( 'newspack_amp_plus_sanitized', [ __CLASS__, 'jetpack_modules_amp_plus' ], 10, 2 );
 	}
 
+	/**
+	 * Whether Jetpack modules scripts should be rendered in AMP Plus.
+	 *
+	 * @return @bool Whether to render scripts.
+	 */
+	private static function should_amp_plus_modules() {
+		if ( ! AMP_Enhancements::should_use_amp_plus() ) {
+			return false;
+		}
+		if ( ! defined( 'NEWSPACK_AMP_PLUS_JETPACK_MODULES' ) || true !== NEWSPACK_AMP_PLUS_JETPACK_MODULES ) {
+			return false;
+		}
+		return true;
+	}
 
 	/**
 	 * Make Jetpack scripts async.
@@ -52,6 +66,9 @@ class Jetpack {
 	 * @return bool Whether the error should be rejected.
 	 */
 	public static function jetpack_modules_amp_plus( $is_sanitized, $error ) {
+		if ( ! self::should_amp_plus_modules() ) {
+			return $is_sanitized;
+		}
 		if ( isset( $error, $error['node_attributes'], $error['node_attributes']['id'] ) ) {
 			$script_has_matching_id = array_reduce(
 				self::$scripts_handles,

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -22,6 +22,7 @@ class Patches {
 		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
 		add_filter( 'map_meta_cap', [ __CLASS__, 'prevent_accidental_page_deletion' ], 10, 4 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'maybe_display_author_page' ] );
+		add_filter( 'script_loader_tag', [ __CLASS__, 'add_async_defer_support' ], 10, 2 );
 
 		// Disable WooCommerce image regeneration to prevent regenerating thousands of images.
 		add_filter( 'woocommerce_background_image_regeneration', '__return_false' );
@@ -29,7 +30,6 @@ class Patches {
 		// Disable Publicize automated sharing for WooCommerce products.
 		add_action( 'init', [ __CLASS__, 'disable_publicize_for_products' ] );
 	}
-
 
 	/**
 	 * Add async/defer support to `wp_script_add_data()`
@@ -57,7 +57,7 @@ class Patches {
 		}
 		return $tag;
 	}
-	
+
 	/**
 	 * Use the Co-Author in Slack preview metadata instead of the regular post author if needed.
 	 *

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.77.1
+ * Version: 1.77.2-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.77.1",
+  "version": "1.77.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.77.1",
+      "version": "1.77.2-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.77.1",
+  "version": "1.77.2-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allow Jetpack modules scripts to render in AMP Plus only when `NEWSPACK_AMP_PLUS_JETPACK_MODULES` constant is defined as `true`.

Also fixes the hook to allow `async`/`defer` script data tags, which was created as a class method but not hooked.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out this branch and with AMP Plus and Jetpack Instant Search toggled on, confirm the script does not render
2. Add `define( 'NEWSPACK_AMP_PLUS_JETPACK_MODULES', true );` to your `wp-config.php` and confirm the scripts render and Instant Search works as expected
3. Confirm the script tag contains the `async` attribute.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->