### PR TITLE
fix: logic for PluginSettings styles and functionality

### DIFF
--- a/assets/components/src/plugin-settings/SettingsSection.js
+++ b/assets/components/src/plugin-settings/SettingsSection.js
@@ -60,7 +60,7 @@ const SettingsSection = props => {
 		disabled,
 		onChange,
 		onUpdate,
-		hasGreyHeader,
+		hasGreyHeader = true,
 	} = props;
 	const getControlProps = setting => ( {
 		disabled,
@@ -87,12 +87,10 @@ const SettingsSection = props => {
 			props
 		);
 	};
-	let columns;
+	let columns = 2;
 	if ( fields.length % 3 === 0 ) {
 		columns = 3;
-	} else if ( fields.length % 2 === 0 ) {
-		columns = 2;
-	} else {
+	} else if ( fields.length === 1 ) {
 		columns = 1;
 	}
 	return (
@@ -102,10 +100,10 @@ const SettingsSection = props => {
 			title={ title }
 			description={ description }
 			toggleChecked={ active }
-			hasGreyHeader={ active || hasGreyHeader }
+			hasGreyHeader={ hasGreyHeader }
 			toggleOnChange={ active !== null ? value => onUpdate( { active: value } ) : null }
 			actionContent={
-				( active || hasGreyHeader ) &&
+				( active || null === active ) &&
 				createFilter(
 					'buttons',
 					<Button

--- a/assets/wizards/popups/views/settings/index.js
+++ b/assets/wizards/popups/views/settings/index.js
@@ -4,14 +4,7 @@
 import { withWizardScreen, PluginSettings } from '../../../../components/src';
 
 const Settings = () => {
-	return (
-		<PluginSettings
-			pluginSlug="newspack-popups-wizard"
-			isWizard={ true }
-			title={ null }
-			hasGreyHeader
-		/>
-	);
+	return <PluginSettings pluginSlug="newspack-popups-wizard" isWizard={ true } title={ null } />;
 };
 
 export default withWizardScreen( Settings );

--- a/assets/wizards/readerRevenue/views/salesforce/index.js
+++ b/assets/wizards/readerRevenue/views/salesforce/index.js
@@ -116,7 +116,6 @@ const Salesforce = () => {
 	return (
 		<>
 			<PluginSettings
-				hasGreyHeader
 				afterUpdate={ settings => {
 					let clientId, clientSecret;
 					( settings?.salesforce || [] ).forEach( setting => {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I approved https://github.com/Automattic/newspack-plugin/pull/1525 perhaps prematurely. Based on @miguelpeixe's feedback in that thread, there are a couple of logical errors in the columns handling and the use of the grey header style prop to determine functionality. This PR addresses those concerns.

### How to test the changes in this Pull Request:

1. Test the instances of `PluginSettings` in the components demo, **Advertising > Settings**, **Campaigns > Settings**, and **Reader Revenue > Salesforce** contexts. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->