### PR TITLE
fix(analytics): avoid Site Kit crash due to conflict with HandoffBanner

### DIFF
--- a/assets/wizards/handoff-banner/index.js
+++ b/assets/wizards/handoff-banner/index.js
@@ -7,7 +7,7 @@ import '../../shared/js/public-path';
 /**
  * WordPress dependencies.
  */
-import { Component, createElement, render } from '@wordpress/element';
+import { createElement, render, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -16,42 +16,28 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '../../components/src';
 import './style.scss';
 
-class HandoffBanner extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			visibility: true,
-		};
-	}
-	/**
-	 * Render.
-	 */
-	render() {
-		const { bodyText, primaryButtonText, dismissButtonText, primaryButtonURL } = this.props;
-		const { visibility } = this.state;
-		return (
-			visibility && (
-				<div className="newspack-handoff-banner">
-					<div className="newspack-handoff-banner__text">{ bodyText }</div>
-					<div className="newspack-handoff-banner__buttons">
-						<Button isPrimary isSmall onClick={ () => this.setState( { visibility: false } ) }>
-							{ dismissButtonText }
-						</Button>
-						<Button isSecondary isSmall href={ primaryButtonURL }>
-							{ primaryButtonText }
-						</Button>
-					</div>
+const HandoffBanner = ( {
+	bodyText = __( 'Return to Newspack after completing configuration', 'newspack' ),
+	primaryButtonText = __( 'Back to Newspack', 'newspack' ),
+	dismissButtonText = __( 'Dismiss', 'newspack' ),
+	primaryButtonURL = '/wp-admin/admin.php?page=newspack',
+} ) => {
+	const [ visibility, setVisibility ] = useState( true );
+	return (
+		visibility && (
+			<div className="newspack-handoff-banner">
+				<div className="newspack-handoff-banner__text">{ bodyText }</div>
+				<div className="newspack-handoff-banner__buttons">
+					<Button isPrimary isSmall onClick={ () => setVisibility( false ) }>
+						{ dismissButtonText }
+					</Button>
+					<Button isSecondary isSmall href={ primaryButtonURL }>
+						{ primaryButtonText }
+					</Button>
 				</div>
-			)
-		);
-	}
-}
-
-HandoffBanner.defaultProps = {
-	primaryButtonText: __( 'Back to Newspack', 'newspack' ),
-	dismissButtonText: __( 'Dismiss', 'newspack' ),
-	primaryButtonURL: '/wp-admin/admin.php?page=newspack',
-	bodyText: __( 'Return to Newspack after completing configuration', 'newspack' ),
+			</div>
+		)
+	);
 };
 
 const el = document.getElementById( 'newspack-handoff-banner' );

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -25,7 +25,7 @@ class Handoff_Banner {
 		add_action( 'current_screen', [ $this, 'clear_handoff_url' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_styles' ], 1 );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'insert_block_editor_handoff_banner' ] );
-		add_action( 'admin_notices', [ $this, 'insert_handoff_banner' ], -10000 );
+		add_action( 'admin_notices', [ $this, 'insert_handoff_banner' ], -9998 );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids a hard crash in the Site Kit Analytics UI when coming from the Newspack Analytics wizard. Unfortunately, the fix causes the Newspack banner to "return to Newspack" to be invisible, but it at least avoids the crash.

Closes #1529.

### How to test the changes in this Pull Request:

Test that #1529 is no longer reproducible with this branch, and that other `HandoffBanner` instances are unaffected/unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->