### PR TITLE
fix(starter-content): prevent starter homepage deletion

### DIFF
--- a/includes/starter_content/class-starter-content-provider.php
+++ b/includes/starter_content/class-starter-content-provider.php
@@ -76,11 +76,6 @@ abstract class Starter_Content_Provider {
 				wp_delete_post( $post_id['post_id'], true );
 			}
 		}
-
-		$homepage_id = $wpdb->get_row( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key=%s;", self::$starter_homepage_meta ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		if ( ! empty( $homepage_id ) ) {
-			wp_delete_post( $homepage_id['post_id'], true );
-		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1538.

Starter homepage still gets a meta assigned, so it's identifiable (and not re-created when re-running the setup). 

### How to test the changes in this Pull Request:

Observe #1538 not reproducible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->