### PR TITLE
fix: remove 'www' from parse.ly api key generation

### DIFF
--- a/includes/configuration_managers/class-parsely-configuration-manager.php
+++ b/includes/configuration_managers/class-parsely-configuration-manager.php
@@ -74,13 +74,23 @@ class Parsely_Configuration_Manager extends Configuration_Manager {
 		// The Site ID field is confusingly stored in the 'apikey' field and is the site's domain.
 		// This is the only non-default field we need to auto-populate.
 		if ( empty( $parsely_settings['apikey'] ) ) {
-			$site_url                   = get_site_url();
-			$site_host                  = wp_parse_url( $site_url, PHP_URL_HOST );
-			$parsely_settings['apikey'] = sanitize_text_field( $site_host );
+			$parsely_settings['apikey'] = $this->get_api_key();
 			update_option( 'parsely', $parsely_settings );
 		}
 
 		$this->set_newspack_has_configured( true );
 		return true;
+	}
+
+	/**
+	 * Get the appropriate API key for Parse.ly.
+	 * On Newspack-hosted sites, this will be the host without 'http(s)' or 'www' or slashes.
+	 *
+	 * @return string API key.
+	 */
+	public function get_parsely_api_key() {
+		$site_url  = get_site_url();
+		$site_host = wp_parse_url( $site_url, PHP_URL_HOST );
+		return sanitize_text_field( str_replace( 'www.', '', $site_host ) );
 	}
 }

--- a/includes/configuration_managers/class-parsely-configuration-manager.php
+++ b/includes/configuration_managers/class-parsely-configuration-manager.php
@@ -74,7 +74,7 @@ class Parsely_Configuration_Manager extends Configuration_Manager {
 		// The Site ID field is confusingly stored in the 'apikey' field and is the site's domain.
 		// This is the only non-default field we need to auto-populate.
 		if ( empty( $parsely_settings['apikey'] ) ) {
-			$parsely_settings['apikey'] = $this->get_api_key();
+			$parsely_settings['apikey'] = $this->get_parsely_api_key();
 			update_option( 'parsely', $parsely_settings );
 		}
 

--- a/tests/unit-tests/parsely-configuration-manager.php
+++ b/tests/unit-tests/parsely-configuration-manager.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Tests automated Parse.ly setup features.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Configuration_Managers;
+
+/**
+ * Tests Parse.ly config features.
+ */
+class Newspack_Test_Parsely_Configuration_Manager extends WP_UnitTestCase {
+
+	/**
+	 * Test auto-generation of Parse.ly API key.
+	 */
+	public function test_api_key_generation() {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'wp-parsely' );
+
+		update_option( 'siteurl', 'https://example.com' );
+		$this->assertEquals( 'example.com', $configuration_manager->get_parsely_api_key() );
+
+		update_option( 'siteurl', 'https://www.example.com' );
+		$this->assertEquals( 'example.com', $configuration_manager->get_parsely_api_key() );
+
+		update_option( 'siteurl', 'https://news.example.com/' );
+		$this->assertEquals( 'news.example.com', $configuration_manager->get_parsely_api_key() );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1523 .

### How to test the changes in this Pull Request:

1. Unless you want to set up your local environment to support `www` and then test, the simplest way to test is to run the unit tests.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->