### PR TITLE
Fix/Reusable Blocks menu item minimum capability

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -81,7 +81,7 @@ class Patches {
 	 * Add a menu link in WP Admin to easily edit and manage reusable blocks.
 	 */
 	public static function add_reusable_blocks_menu_link() {
-		add_submenu_page( 'edit.php', 'manage_reusable_blocks', __( 'Reusable Blocks' ), 'read', 'edit.php?post_type=wp_block', '', 2 );
+		add_submenu_page( 'edit.php', 'manage_reusable_blocks', __( 'Reusable Blocks' ), 'edit_posts', 'edit.php?post_type=wp_block', '', 2 );
 	}
 
 	/**


### PR DESCRIPTION
Changes the capability needed to access the Posts > Reusable Blocks menu item from `read` to `edit_posts`, so that Subscriber-level users can't see it.

### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changes the `add_submenu_page` on line 84 to use `edit_posts` instead of `read` capability.

### How to test the changes in this Pull Request:

1. Log into a Subscriber account.
2. The "Posts" menu item in the WordPress dashboard should be absent.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?