### PR TITLE
fix: enable block-based widgets

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -49,13 +49,6 @@ final class Newspack {
 		add_action( 'network_admin_notices', [ $this, 'remove_notifications' ], -9999 );
 		add_action( 'all_admin_notices', [ $this, 'remove_notifications' ], -9999 );
 		register_activation_hook( NEWSPACK_PLUGIN_FILE, [ $this, 'activation_hook' ] );
-
-		// Disable the block-based widget editing altogether until further notice.
-		// See https://github.com/Automattic/newspack-plugin/issues/1124.
-		// Disables the block editor from managing widgets in the Gutenberg plugin.
-		add_filter( 'gutenberg_use_widgets_block_editor', '__return_false' );
-		// Disables the block editor from managing widgets.
-		add_filter( 'use_widgets_block_editor', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Re-enable the use of block-based widgets. Should be reviewed along with the following:

 - https://github.com/Automattic/super-cool-ad-inserter-plugin/pull/99
 - https://github.com/Automattic/newspack-blocks/pull/1066
 - https://github.com/Automattic/newspack-ads/pull/322

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->