### PR TITLE
fix: a bad merge after the last post-release job

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -22,6 +22,8 @@ class Patches {
 		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
 		add_filter( 'map_meta_cap', [ __CLASS__, 'prevent_accidental_page_deletion' ], 10, 4 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'maybe_display_author_page' ] );
+		add_action( 'pre_get_posts', [ __CLASS__, 'restrict_others_posts' ] );
+		add_filter( 'ajax_query_attachments_args', [ __CLASS__, 'restrict_media_library_access_ajax' ] );
 		add_filter( 'script_loader_tag', [ __CLASS__, 'add_async_defer_support' ], 10, 2 );
 
 		// Disable WooCommerce image regeneration to prevent regenerating thousands of images.
@@ -29,6 +31,10 @@ class Patches {
 
 		// Disable Publicize automated sharing for WooCommerce products.
 		add_action( 'init', [ __CLASS__, 'disable_publicize_for_products' ] );
+
+		// Fix an issue when running The Events Calendar where all posts block items have same date.
+		add_action( 'tribe_events_views_v2_after_make_view', [ __CLASS__, 'remove_tec_extra_excerpt_filtering' ], 1 );
+	}
 
 	/**
 	 * Add async/defer support to `wp_script_add_data()`


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes some issues caused by a bad conflict resolution after the last post-release job.

### How to test the changes in this Pull Request:

Ensure the plugin builds and that the fixes from #1541 and #1518 are intact. Also that all CI jobs below are passing. 👇 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->