### PR TITLE
feat(popups): add category/tag exclusion fields to campaigns wizard UI

### DIFF
--- a/assets/components/src/category-autocomplete/style.scss
+++ b/assets/components/src/category-autocomplete/style.scss
@@ -5,6 +5,8 @@
 @import '../../../shared/scss/colors';
 
 .newspack-category-autocomplete {
+	position: relative;
+
 	.components-form-token-field__help {
 		display: none;
 	}
@@ -34,5 +36,12 @@
 
 	.newspack-grid & .newspack-form-token-field {
 		margin: 0;
+	}
+
+	// Loading state spinner
+	&__suggestions-spinner {
+		bottom: 0.5em;
+		position: absolute;
+		right: 0;
 	}
 }

--- a/assets/wizards/popups/components/settings-modal/index.js
+++ b/assets/wizards/popups/components/settings-modal/index.js
@@ -31,8 +31,6 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 	const [ promptConfig, setPromptConfig ] = hooks.useObjectState( prompt );
 	const [ showAdvanced, setShowAdvanced ] = useState( false );
 
-	console.log( promptConfig );
-
 	const handleSave = () => {
 		updatePopup( promptConfig ).then( onClose );
 	};

--- a/assets/wizards/popups/components/settings-modal/index.js
+++ b/assets/wizards/popups/components/settings-modal/index.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -28,6 +29,9 @@ const { SettingsCard } = Settings;
 
 const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup } ) => {
 	const [ promptConfig, setPromptConfig ] = hooks.useObjectState( prompt );
+	const [ showAdvanced, setShowAdvanced ] = useState( false );
+
+	console.log( promptConfig );
 
 	const handleSave = () => {
 		updatePopup( promptConfig ).then( onClose );
@@ -155,6 +159,44 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 							'newspack'
 						) }
 					/>
+					<Button isLink onClick={ () => setShowAdvanced( ! showAdvanced ) }>
+						{ sprintf(
+							// Translators: whether to show or hide advanced settings fields.
+							__( '%s Advanced Settings', 'newspack_popups_taxonomy' ),
+							showAdvanced ? __( 'Hide', 'newspack' ) : __( 'Show', 'newspack' )
+						) }
+					</Button>
+					{ showAdvanced && (
+						<>
+							<CategoryAutocomplete
+								label={ __( 'Category Exclusions', 'newspack ' ) }
+								disabled={ disabled }
+								hideHelpFromVision
+								value={ promptConfig.options?.excluded_categories || [] }
+								onChange={ tokens =>
+									setPromptConfig( {
+										options: { excluded_categories: tokens.map( token => token.id ) },
+									} )
+								}
+								description={ __(
+									'Prompt will not appear on posts with the specified categories.',
+									'newspack'
+								) }
+							/>
+							<CategoryAutocomplete
+								label={ __( 'Tag Exclusions', 'newspack ' ) }
+								disabled={ disabled }
+								hideHelpFromVision
+								taxonomy="tags"
+								value={ promptConfig.options?.excluded_tags || [] }
+								onChange={ tokens => setPromptConfig( { options: { excluded_tags: tokens } } ) }
+								description={ __(
+									'Prompt will not appear on posts with the specified tags.',
+									'newspack'
+								) }
+							/>
+						</>
+					) }
 				</SettingsCard>
 			</Grid>
 

--- a/assets/wizards/popups/components/settings-modal/index.js
+++ b/assets/wizards/popups/components/settings-modal/index.js
@@ -29,7 +29,11 @@ const { SettingsCard } = Settings;
 
 const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup } ) => {
 	const [ promptConfig, setPromptConfig ] = hooks.useObjectState( prompt );
-	const [ showAdvanced, setShowAdvanced ] = useState( false );
+	const { excluded_categories: excludedCategories = [], excluded_tags: excludedTags = [] } =
+		promptConfig.options || {};
+	const [ showAdvanced, setShowAdvanced ] = useState(
+		0 < excludedCategories.length || 0 < excludedTags.length || false
+	);
 
 	const handleSave = () => {
 		updatePopup( promptConfig ).then( onClose );
@@ -170,7 +174,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 								label={ __( 'Category Exclusions', 'newspack ' ) }
 								disabled={ disabled }
 								hideHelpFromVision
-								value={ promptConfig.options?.excluded_categories || [] }
+								value={ excludedCategories || [] }
 								onChange={ tokens =>
 									setPromptConfig( {
 										options: { excluded_categories: tokens.map( token => token.id ) },
@@ -186,7 +190,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 								disabled={ disabled }
 								hideHelpFromVision
 								taxonomy="tags"
-								value={ promptConfig.options?.excluded_tags || [] }
+								value={ excludedTags || [] }
 								onChange={ tokens => setPromptConfig( { options: { excluded_tags: tokens } } ) }
 								description={ __(
 									'Prompt will not appear on posts with the specified tags.',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-popups/pull/641 added the ability to specify categories and tags on which a prompt will NOT be shown. However, the fields for these settings exist only in the single prompt block editor, not in the Campaigns wizard UI. This PR adds the fields to the wizard UI.

Closes https://github.com/Automattic/newspack-popups/issues/747.

### How to test the changes in this Pull Request:

1. Check out this branch. Go to **Newspack > Campaigns** and click the settings icon to view settings for a prompt. Confirm that there's a new toggle button in the "Targeting" section:

<img width="1113" alt="Screen Shot 2022-03-10 at 4 24 54 PM" src="https://user-images.githubusercontent.com/2230142/157772608-6335f984-1896-431f-b9ad-d55f43c91ebe.png">

3. Confirm that clicking the button shows and hides the new fields.
4. Start typing category and tag names in each field. Confirm that you're able to search categories and tags, and select one or more for each corresponding field.
5. Save the prompt from the wizard UI. Open the prompt in the block editor and expand the "Advanced Settings" sidebar. Confirm that the categories and tags you selected in the wizard are shown here too:

<img width="280" alt="Screen Shot 2022-03-10 at 4 30 20 PM" src="https://user-images.githubusercontent.com/2230142/157772758-e9f09c4b-12ac-46b2-8bfc-e5ab2aa257d5.png">

6. Edit these fields to remove the saved terms and add different ones, and save the post.
7. Go back to the wizard UI and confirm that the changes are reflected.
8. Smoke test the exclusion logic in a new incognito window by visiting posts with the excluded categories and tags, and ensure that the prompt never gets rendered on these posts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->