### PR TITLE
feat(donations): remove sidebar for default donations page

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -700,7 +700,9 @@ class Donations {
 		$page_id = wp_insert_post( $page_args );
 		if ( is_numeric( $page_id ) ) {
 			self::set_donation_page( $page_id );
+			update_post_meta( $page_id, '_wp_page_template', 'single-feature.php' );
 		}
+
 		return $page_id;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates how the default donations page looks like.

### How to test the changes in this Pull Request:

1. Remove the `newspack_donation_page_id` option to reset the default donations page
2. Visit the Reader Revenue wizard, "Donations" tab. Click "Edit Page" in "Donations landing page" section
3. Publish the page and visit it
4. Observe the page uses a template without the sidebar

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->