### PR TITLE
chore: update ads api

### DIFF
--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -9,7 +9,7 @@ namespace Newspack;
 
 use \WP_Error;
 
-use Newspack_Ads\Model;
+use Newspack_Ads\Providers\GAM_Model;
 use Newspack_Ads\Providers\GAM_API;
 
 defined( 'ABSPATH' ) || exit;
@@ -34,7 +34,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Whether Newspack Ads is installed and activated.
 	 */
 	public function is_configured() {
-		return class_exists( '\Newspack_Ads\Model' );
+		return class_exists( '\Newspack_Ads\Providers\GAM_Model' );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function setup_gam() {
 		return $this->is_configured() ?
-			Model::setup_gam() :
+			GAM_Model::setup_gam() :
 			$this->unconfigured_error();
 	}
 
@@ -79,7 +79,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_ad_units() {
 		return $this->is_configured() ?
-			Model::get_ad_units() :
+			GAM_Model::get_ad_units() :
 			$this->unconfigured_error();
 	}
 
@@ -92,7 +92,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_ad_unit_for_display( $id, $placement = null ) {
 		return $this->is_configured() ?
-			Model::get_ad_unit_for_display( $id, $placement ) :
+			GAM_Model::get_ad_unit_for_display( $id, $placement ) :
 			$this->unconfigured_error();
 	}
 
@@ -104,7 +104,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function add_ad_unit( $ad_unit ) {
 		return $this->is_configured() ?
-			Model::add_ad_unit( $ad_unit ) :
+			GAM_Model::add_ad_unit( $ad_unit ) :
 			$this->unconfigured_error();
 	}
 
@@ -116,7 +116,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function update_ad_unit( $ad_unit ) {
 		return $this->is_configured() ?
-			Model::update_ad_unit( $ad_unit ) :
+			GAM_Model::update_ad_unit( $ad_unit ) :
 			$this->unconfigured_error();
 	}
 
@@ -128,7 +128,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function delete_ad_unit( $id ) {
 		return $this->is_configured() ?
-			Model::delete_ad_unit( $id ) :
+			GAM_Model::delete_ad_unit( $id ) :
 			$this->unconfigured_error();
 	}
 
@@ -139,7 +139,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function is_gam_connected() {
 		return $this->is_configured() ?
-			Model::is_gam_connected() :
+			GAM_Model::is_gam_connected() :
 			$this->unconfigured_error();
 	}
 
@@ -150,7 +150,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_gam_connection_status() {
 		return $this->is_configured() ?
-			Model::get_gam_connection_status() :
+			GAM_Model::get_gam_connection_status() :
 			$this->unconfigured_error();
 	}
 
@@ -161,7 +161,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_gam_available_networks() {
 		return $this->is_configured() ?
-			Model::get_gam_available_networks() :
+			GAM_Model::get_gam_available_networks() :
 			$this->unconfigured_error();
 	}
 
@@ -172,7 +172,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_suppression_config() {
 		return $this->is_configured() ?
-			Model::get_suppression_config() :
+			GAM_Model::get_suppression_config() :
 			$this->unconfigured_error();
 	}
 
@@ -184,7 +184,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function update_suppression_config( $config ) {
 		return $this->is_configured() ?
-			Model::update_suppression_config( $config ) :
+			GAM_Model::update_suppression_config( $config ) :
 			$this->unconfigured_error();
 	}
 

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -9,6 +9,9 @@ namespace Newspack;
 
 use \WP_Error;
 
+use Newspack_Ads\Model;
+use Newspack_Ads\Providers\GAM_API;
+
 defined( 'ABSPATH' ) || exit;
 
 require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
@@ -31,7 +34,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Whether Newspack Ads is installed and activated.
 	 */
 	public function is_configured() {
-		return class_exists( 'Newspack_Ads_Model' );
+		return class_exists( '\Newspack_Ads\Model' );
 	}
 
 	/**
@@ -41,7 +44,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function setup_gam() {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::setup_gam() :
+			Model::setup_gam() :
 			$this->unconfigured_error();
 	}
 
@@ -54,7 +57,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function update_gam_credentials( $credentials ) {
 		return $this->is_configured() ?
-			\Newspack_Ads_GAM::update_gam_credentials( $credentials ) :
+			GAM_API::update_gam_credentials( $credentials ) :
 			$this->unconfigured_error();
 	}
 
@@ -65,7 +68,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function remove_gam_credentials() {
 		return $this->is_configured() ?
-			\Newspack_Ads_GAM::remove_gam_credentials() :
+			GAM_API::remove_gam_credentials() :
 			$this->unconfigured_error();
 	}
 
@@ -76,7 +79,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_ad_units() {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::get_ad_units() :
+			Model::get_ad_units() :
 			$this->unconfigured_error();
 	}
 
@@ -89,7 +92,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_ad_unit_for_display( $id, $placement = null ) {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::get_ad_unit_for_display( $id, $placement ) :
+			Model::get_ad_unit_for_display( $id, $placement ) :
 			$this->unconfigured_error();
 	}
 
@@ -101,7 +104,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function add_ad_unit( $ad_unit ) {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::add_ad_unit( $ad_unit ) :
+			Model::add_ad_unit( $ad_unit ) :
 			$this->unconfigured_error();
 	}
 
@@ -113,7 +116,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function update_ad_unit( $ad_unit ) {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::update_ad_unit( $ad_unit ) :
+			Model::update_ad_unit( $ad_unit ) :
 			$this->unconfigured_error();
 	}
 
@@ -125,7 +128,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function delete_ad_unit( $id ) {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::delete_ad_unit( $id ) :
+			Model::delete_ad_unit( $id ) :
 			$this->unconfigured_error();
 	}
 
@@ -136,7 +139,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function is_gam_connected() {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::is_gam_connected() :
+			Model::is_gam_connected() :
 			$this->unconfigured_error();
 	}
 
@@ -147,7 +150,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_gam_connection_status() {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::get_gam_connection_status() :
+			Model::get_gam_connection_status() :
 			$this->unconfigured_error();
 	}
 
@@ -158,7 +161,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_gam_available_networks() {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::get_gam_available_networks() :
+			Model::get_gam_available_networks() :
 			$this->unconfigured_error();
 	}
 
@@ -169,7 +172,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_suppression_config() {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::get_suppression_config() :
+			Model::get_suppression_config() :
 			$this->unconfigured_error();
 	}
 
@@ -181,7 +184,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function update_suppression_config( $config ) {
 		return $this->is_configured() ?
-			\Newspack_Ads_Model::update_suppression_config( $config ) :
+			Model::update_suppression_config( $config ) :
 			$this->unconfigured_error();
 	}
 

--- a/includes/oauth/class-fivetran-connection.php
+++ b/includes/oauth/class-fivetran-connection.php
@@ -111,9 +111,9 @@ class Fivetran_Connection {
 		// For Google Ad Manager (aka double_click_publishers) - if Newspack Ads knows the network code, let's use it.
 		if (
 			'double_click_publishers' === $service &&
-			method_exists( 'Newspack_Ads_Model', 'get_active_network_code' )
+			method_exists( 'Newspack_Ads\Model', 'get_active_network_code' )
 		) {
-			$network_code = \Newspack_Ads_Model::get_active_network_code();
+			$network_code = \Newspack_Ads\Model::get_active_network_code();
 			if ( ! empty( $network_code ) ) {
 				$service_data['double_click_publishers'] = [
 					'network_code' => $network_code,

--- a/includes/oauth/class-fivetran-connection.php
+++ b/includes/oauth/class-fivetran-connection.php
@@ -111,9 +111,9 @@ class Fivetran_Connection {
 		// For Google Ad Manager (aka double_click_publishers) - if Newspack Ads knows the network code, let's use it.
 		if (
 			'double_click_publishers' === $service &&
-			method_exists( 'Newspack_Ads\Model', 'get_active_network_code' )
+			method_exists( 'Newspack_Ads\Providers\GAM_Model', 'get_active_network_code' )
 		) {
-			$network_code = \Newspack_Ads\Model::get_active_network_code();
+			$network_code = \Newspack_Ads\Providers\GAM_Model::get_active_network_code();
 			if ( ! empty( $network_code ) ) {
 				$service_data['double_click_publishers'] = [
 					'network_code' => $network_code,

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -342,9 +342,9 @@ class Advertising_Wizard extends Wizard {
 	public function api_update_network_code( $request ) {
 		// Update GAM or legacy network code.
 		if ( $request['is_gam'] ) {
-			update_option( \Newspack_Ads_Model::OPTION_NAME_GAM_NETWORK_CODE, $request['network_code'] );
+			update_option( \Newspack_Ads\Model::OPTION_NAME_GAM_NETWORK_CODE, $request['network_code'] );
 		} else {
-			update_option( \Newspack_Ads_Model::OPTION_NAME_LEGACY_NETWORK_CODE, $request['network_code'] );
+			update_option( \Newspack_Ads\Model::OPTION_NAME_LEGACY_NETWORK_CODE, $request['network_code'] );
 		}
 		return \rest_ensure_response( [] );
 	}

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -342,9 +342,9 @@ class Advertising_Wizard extends Wizard {
 	public function api_update_network_code( $request ) {
 		// Update GAM or legacy network code.
 		if ( $request['is_gam'] ) {
-			update_option( \Newspack_Ads\Model::OPTION_NAME_GAM_NETWORK_CODE, $request['network_code'] );
+			update_option( \Newspack_Ads\Providers\GAM_Model::OPTION_NAME_GAM_NETWORK_CODE, $request['network_code'] );
 		} else {
-			update_option( \Newspack_Ads\Model::OPTION_NAME_LEGACY_NETWORK_CODE, $request['network_code'] );
+			update_option( \Newspack_Ads\Providers\GAM_Model::OPTION_NAME_LEGACY_NETWORK_CODE, $request['network_code'] );
 		}
 		return \rest_ensure_response( [] );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update Ads methods to match https://github.com/Automattic/newspack-ads/pull/348

### How to test the changes in this Pull Request:

1. Without connecting to GAM make sure you are able to edit the network ID and manage legacy ad units
2. Connect to GAM and make sure you are able to edit ad units
3. Modify suppression settings and make sure they are applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->