### PR TITLE
fix(jetpack): ensure instant search display filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.79.1-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.79.0...v1.79.1-hotfix.1) (2022-03-23)
+
+
+### Bug Fixes
+
+* **jetpack:** ensure instant search display filters ([8744151](https://github.com/Automattic/newspack-plugin/commit/874415166242199d851dc079812880df20457ea9))
+
 # [1.79.0](https://github.com/Automattic/newspack-plugin/compare/v1.78.0...v1.79.0) (2022-03-22)
 
 

--- a/includes/class-jetpack.php
+++ b/includes/class-jetpack.php
@@ -31,6 +31,7 @@ class Jetpack {
 	public static function init() {
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'jetpack_async_scripts' ], 20 );
 		add_filter( 'newspack_amp_plus_sanitized', [ __CLASS__, 'jetpack_modules_amp_plus' ], 10, 2 );
+		add_action( 'wp_head', [ __CLASS__, 'fix_instant_search_sidebar_display' ], 10 );
 	}
 
 	/**
@@ -99,6 +100,22 @@ class Jetpack {
 			}
 		}
 		return $is_sanitized;
+	}
+
+	/**
+	 * Fix Instant Search Sidebar Display for AMP Plus
+	 */
+	public static function fix_instant_search_sidebar_display() {
+		if ( ! self::should_amp_plus_modules() ) {
+			return;
+		}
+		?>
+		<style>
+			.jetpack-instant-search__widget-area {
+				display: block !important;
+			}
+		</style>
+		<?php
 	}
 }
 Jetpack::init();

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.79.0
+ * Version: 1.79.1-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.79.0",
+  "version": "1.79.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.79.0",
+      "version": "1.79.1-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.79.0",
+  "version": "1.79.1-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensures the Jetpack Instant Search displays its widget area.

The [widget area is initialized with `display: none;`](https://github.com/Automattic/jetpack/blob/af0dda38e06dcc9810aed03d6b582bae8448c091/projects/packages/search/src/class-helper.php#L892-L896) and later [updated through a script](https://github.com/Automattic/jetpack/blob/7b12b291d77c4a9b8eb3d0c060bf9d4042907456/projects/packages/search/src/instant-search/components/widget-area-container.jsx#L24-L27). This script is not handled by AMP, which leaves the div with `display: none` through the `data-amp-original-style` attribute.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. With master, enable Jetpack Instant Search on AMP Plus and confirm you are not able to see any widget placed in "Jetpack Search Sidebar"
2. Check out this branch and confirm the widget area is now visible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->