### PR TITLE
fix(ads): handle gam connection error

### DIFF
--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -519,16 +519,20 @@ class Advertising_Wizard extends Wizard {
 		}
 
 		// Verify GAM connection and run initial setup.
-		$gam_connection_status                               = $configuration_manager->get_gam_connection_status();
-		$services['google_ad_manager']['status']             = $gam_connection_status;
-		$services['google_ad_manager']['available_networks'] = $configuration_manager->get_gam_available_networks();
-		if ( true === $gam_connection_status['connected'] && ! isset( $gam_connection_status['error'] ) ) {
-			$services['google_ad_manager']['network_code'] = $gam_connection_status['network_code'];
-			$gam_setup_results                             = $configuration_manager->setup_gam();
-			if ( ! \is_wp_error( $gam_setup_results ) ) {
-				$services['google_ad_manager']['created_targeting_keys'] = $gam_setup_results['created_targeting_keys'];
-			} else {
-				$services['google_ad_manager']['status']['error'] = $gam_setup_results->get_error_message();
+		$gam_connection_status = $configuration_manager->get_gam_connection_status();
+		if ( \is_wp_error( $gam_connection_status ) ) {
+			$services['google_ad_manager']['status']['error'] = $gam_connection_status->get_error_message();
+		} else {
+			$services['google_ad_manager']['status']             = $gam_connection_status;
+			$services['google_ad_manager']['available_networks'] = $configuration_manager->get_gam_available_networks();
+			if ( true === $gam_connection_status['connected'] && ! isset( $gam_connection_status['error'] ) ) {
+				$services['google_ad_manager']['network_code'] = $gam_connection_status['network_code'];
+				$gam_setup_results                             = $configuration_manager->setup_gam();
+				if ( ! \is_wp_error( $gam_setup_results ) ) {
+					$services['google_ad_manager']['created_targeting_keys'] = $gam_setup_results['created_targeting_keys'];
+				} else {
+					$services['google_ad_manager']['status']['error'] = $gam_setup_results->get_error_message();
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Handles GAM error in case the connection status method returns `WP_Error`.

### How to test the changes in this Pull Request:

1. Check out https://github.com/Automattic/newspack-ads/pull/348 to make sure the different method names causes an error
2. While on master visit the Ads wizard and confirm the unhandled error
3. Check out this branch and confirm the error message is appropriate (since the method names changed, it doesn't identify that the plugin is installed and active)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->