### PR TITLE
fix(ads): add-ons download methods

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -301,7 +301,7 @@ class Plugin_Manager {
 				'Author'      => esc_html__( 'INN Labs, Automattic', 'newspack' ),
 				'AuthorURI'   => esc_url( 'https://automattic.com' ),
 				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/super-cool-ad-inserter/' ),
-				'Download'    => esc_url( 'wporg' ),
+				'Download'    => 'wporg',
 			],
 			'ad-refresh-control'            => [
 				'Name'        => esc_html__( 'Ad Refresh Control', 'newspack' ),
@@ -309,7 +309,7 @@ class Plugin_Manager {
 				'Author'      => esc_html__( 'Gary Thayer, David Green, 10up', 'newspack' ),
 				'AuthorURI'   => esc_url( 'https://10up.com' ),
 				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/ad-refresh-control/' ),
-				'Download'    => esc_url( 'wporg' ),
+				'Download'    => 'wporg',
 			],
 			'broadstreet'                   => [
 				'Name'        => esc_html__( 'Broadstreet', 'newspack' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes misconfiguration on Ads Add-Ons introduced by #1564.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. While on master make sure do not having the Add-Ons plugins downloaded (SCAIP and Ad Refresh Control)
2. Attempt to install through the Plugins page, both plugins should be listed and nested inside the Newspack plugin
3. Notice the download error
4. Check out this branch, attempt to download again, and confirm it downloads the latest version from WPOrg

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->