### PR TITLE
fix(ads): allow clearing ad refresh control input

### DIFF
--- a/assets/wizards/advertising/components/ad-refresh-control/index.js
+++ b/assets/wizards/advertising/components/ad-refresh-control/index.js
@@ -122,7 +122,7 @@ export default function AdRefreshControlSettings() {
 	}
 	// Apply value to fields.
 	fields.forEach( field => {
-		if ( settings[ field.key ] ) {
+		if ( settings.hasOwnProperty( field.key ) ) {
 			field.value = settings[ field.key ];
 		}
 	} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently, the Ad Refresh Control settings at the Ads wizard are not clearable due to a falsy check on input values.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. While on master, visit the Ads wizard -> Add-Ons and make sure you have Ad Refresh Control toggled on
2. Visit the Settings wizard, write some input values and attempt to remove
3. Confirm you are not able to remove the value
4. Check out this branch, run `npm run build` and confirm you are able to remove

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->