### PR TITLE
fix(setup-wizard): hide header on completed step

### DIFF
--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -50,13 +50,6 @@ const ROUTES = [
 ];
 
 const SetupWizard = ( { wizardApiFetch, setError } ) => {
-	const sharedProps = {
-		wizardApiFetch,
-		setError,
-		disableUpcomingInTabbedNavigation: true,
-		tabbedNavigation: ROUTES,
-	};
-
 	return (
 		<Fragment>
 			<HashRouter hashType="slash">
@@ -74,7 +67,10 @@ const SetupWizard = ( { wizardApiFetch, setError } ) => {
 							exact={ route.path === '/' }
 							render={ () =>
 								route.render( {
-									...sharedProps,
+									wizardApiFetch,
+									setError,
+									disableUpcomingInTabbedNavigation: true,
+									tabbedNavigation: ROUTES,
 									headerText: route.label,
 									subHeaderText: route.subHeaderText,
 									buttonText: nextRoute ? route.buttonText || __( 'Continue' ) : __( 'Finish' ),

--- a/assets/wizards/setup/style.scss
+++ b/assets/wizards/setup/style.scss
@@ -8,14 +8,17 @@
 	}
 }
 
-// Welcome Screen
-
-.newspack-wizard__welcome {
+.newspack-wizard__welcome,
+.newspack-wizard__completed {
 	.newspack-wizard__header,
 	.newspack-tabbed-navigation {
 		display: none;
 	}
+}
 
+// Welcome Screen
+
+.newspack-wizard__welcome {
 	.newspack-icon {
 		margin: 0 auto;
 	}

--- a/assets/wizards/setup/views/completed/index.js
+++ b/assets/wizards/setup/views/completed/index.js
@@ -23,8 +23,10 @@ import {
 
 const Completed = () => {
 	useEffect( () => {
-		document.body.classList.add( 'newspack-wizard__blue' );
+		document.body.classList.add( 'newspack-wizard__completed', 'newspack-wizard__blue' );
 		document.querySelector( '.newspack-wizard__header' ).remove();
+		return () =>
+			document.body.classList.remove( 'newspack-wizard__completed', 'newspack-wizard__blue' );
 	}, [] );
 
 	const cardClasses = classnames( 'flex', 'flex-column', 'justify-between' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hides the navigation on the last step of the Setup wizard.

### How to test the changes in this Pull Request:

1. On `master`, visit the last step of the Setup wizard (`wp-admin/admin.php?page=newspack-setup-wizard#/completed`)
2. Observe a navigation bar, which should not be there
3. Switch to this branch, rebuild, observe there's no navigation bar on first and last steps of the Setup wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->