### PR TITLE
fix(stripe): newsletters wizard typo

### DIFF
--- a/assets/wizards/readerRevenue/views/stripe-setup/newsletter-settings.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/newsletter-settings.js
@@ -34,9 +34,9 @@ const NewslettersSettings = ( { listId, onChange } ) => {
 			<Notice
 				noticeText={
 					<span>
-						{ __( 'You can configure Newsletters in', 'newspack' ) }{ ' ' }
+						{ __( 'You can configure Newsletters in the', 'newspack' ) }{ ' ' }
 						<a href="/wp-admin/admin.php?page=newspack-engagement-wizard#/newsletters">
-							{ __( 'Enagement Wizard', 'newspack' ) }
+							{ __( 'Engagement Wizard', 'newspack' ) }
 						</a>
 						.
 					</span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Small typo on the Newsletters section of the Stripe Settings wizard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->