### PR TITLE
fix(popups): analytics popups report label regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.80.1-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.80.0...v1.80.1-hotfix.1) (2022-04-08)
+
+
+### Bug Fixes
+
+* **popups:** analytics popups report label regex ([56e72f2](https://github.com/Automattic/newspack-plugin/commit/56e72f223cf3c211bac7cb94f37f35d7822136db))
+
 # [1.80.0](https://github.com/Automattic/newspack-plugin/compare/v1.79.1...v1.80.0) (2022-04-05)
 
 

--- a/includes/popups-analytics/class-popups-analytics-utils.php
+++ b/includes/popups-analytics/class-popups-analytics-utils.php
@@ -202,7 +202,7 @@ class Popups_Analytics_Utils {
 		$label         = str_replace( 'Newspack Announcement: ', '', $row['dimensions'][2] );
 		// Extract post id from the label.
 		preg_match(
-			'/\(([0-9]*)\)$/',
+			'/\(([0-9]*)\)/',
 			$label,
 			$id_matches
 		);
@@ -225,7 +225,7 @@ class Popups_Analytics_Utils {
 	 * @param string $name Encoded event name.
 	 */
 	private static function decode_item( $name ) {
-		preg_match( '/(\d*)(\d$)/', $name, $matches );
+		preg_match( '/(\d*)(\d)/', $name, $matches );
 		if ( count( $matches ) === 3 ) {
 			return [
 				'post_id'    => $matches[1],

--- a/includes/popups-analytics/class-popups-analytics-utils.php
+++ b/includes/popups-analytics/class-popups-analytics-utils.php
@@ -202,7 +202,7 @@ class Popups_Analytics_Utils {
 		$label         = str_replace( 'Newspack Announcement: ', '', $row['dimensions'][2] );
 		// Extract post id from the label.
 		preg_match(
-			'/\(([0-9]*)\)$| -/',
+			'/\(([0-9]*)\)/',
 			$label,
 			$id_matches
 		);
@@ -225,7 +225,7 @@ class Popups_Analytics_Utils {
 	 * @param string $name Encoded event name.
 	 */
 	private static function decode_item( $name ) {
-		preg_match( '/(\d*)(\d$| -)/', $name, $matches );
+		preg_match( '/(\d*)(\d$)/', $name, $matches );
 		if ( count( $matches ) === 3 ) {
 			return [
 				'post_id'    => $matches[1],

--- a/includes/popups-analytics/class-popups-analytics-utils.php
+++ b/includes/popups-analytics/class-popups-analytics-utils.php
@@ -206,7 +206,7 @@ class Popups_Analytics_Utils {
 			$label,
 			$id_matches
 		);
-		$post_id      = isset( $id_matches[1] ) ? $id_matches[1] : '';
+		$post_id      = array_pop( $id_matches ) ?? '';
 		$label_object = [
 			// Remove post id in parens.
 			'label' => str_replace( " ($post_id)", '', $label ),

--- a/includes/popups-analytics/class-popups-analytics-utils.php
+++ b/includes/popups-analytics/class-popups-analytics-utils.php
@@ -202,7 +202,7 @@ class Popups_Analytics_Utils {
 		$label         = str_replace( 'Newspack Announcement: ', '', $row['dimensions'][2] );
 		// Extract post id from the label.
 		preg_match(
-			'/\(([0-9]*)\)/',
+			'/\(([0-9]*)\)$| -/',
 			$label,
 			$id_matches
 		);
@@ -225,7 +225,7 @@ class Popups_Analytics_Utils {
 	 * @param string $name Encoded event name.
 	 */
 	private static function decode_item( $name ) {
-		preg_match( '/(\d*)(\d)/', $name, $matches );
+		preg_match( '/(\d*)(\d$| -)/', $name, $matches );
 		if ( count( $matches ) === 3 ) {
 			return [
 				'post_id'    => $matches[1],

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.80.0
+ * Version: 1.80.1-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.80.0",
+  "version": "1.80.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.80.0",
+      "version": "1.80.1-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.80.0",
+  "version": "1.80.1-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/tests/unit-tests/popups-analytics.php
+++ b/tests/unit-tests/popups-analytics.php
@@ -193,6 +193,20 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 					],
 				],
 			],
+			[
+				'dimensions' => [
+					$yesterday->format( 'Ymd' ),
+					'Seen',
+					'Inline: Donate form (955) - Everyone',
+				],
+				'metrics'    => [
+					[
+						'values' => [
+							'3',
+						],
+					],
+				],
+			],
 		];
 
 		$expected_report             = [
@@ -207,7 +221,7 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 			],
 			[
 				$yesterday->format( 'M j' ),
-				4,
+				7,
 			],
 		];
 		$expected_report_actions     = [
@@ -221,9 +235,13 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 				'label' => 'Inline: Newsletter form',
 				'value' => '954',
 			],
+			[
+				'label' => 'Inline: Donate form - Everyone',
+				'value' => '955',
+			],
 		];
 		$expected_report_key_metrics = [
-			'seen'             => 4,
+			'seen'             => 7,
 			'form_submissions' => -1,
 			'link_clicks'      => -1,
 		];
@@ -267,6 +285,9 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 				'report_by_id'   => [
 					'954' => [
 						'seen' => 4,
+					],
+					'955' => [
+						'seen' => 3,
 					],
 				],
 				'actions'        => $expected_report_actions,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-popups/pull/830 added segment names to the `event_label` strings sent with Google Analytics event reporting. This changed the label from a format like this:

```
Above Header: Spring campaign 2022 banner ad (112982)
```

to this:

```
Above Header: Spring campaign 2022 banner ad (112982) - Everyone
```

With the segment(s) coming after the post ID. However, the Campaigns analytics report expects the post ID in parentheses to be the last item in the label, so it's ignoring rows that have the segment names appended—basically all events after https://github.com/Automattic/newspack-popups/pull/830 got deployed. This PR amends the regex patterns to look for the post ID anywhere in the label, not just at the end, which should fix the reporting view.

### How to test the changes in this Pull Request:

It's hard to test this without having access to a site that's connected to GA with active prompts that have been running. However, if you have a test site that has any past events to report, you can mock the names by adding a hardcoded value on [this line](https://github.com/Automattic/newspack-plugin/blob/master/includes/popups-analytics/class-popups-analytics-utils.php#L299):

```php
$row['dimensions'][1] = 'Above Header: Spring campaign 2022 banner ad (112982) - Everyone';
```

1. On `master`, view the **Newspack > Campaigns > Analytics report**. Observe that with the mocked name including segments as above, no events are reported.
2. Check out this branch and confirm that the events are reported.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->