### PR TITLE
fix(ads): update refresh control help text

### DIFF
--- a/assets/wizards/advertising/components/ad-refresh-control/index.js
+++ b/assets/wizards/advertising/components/ad-refresh-control/index.js
@@ -47,7 +47,7 @@ const fields = [
 		type: 'string',
 		description: __( 'Excluded Advertiser IDs', 'newspack' ),
 		help: __(
-			'Prevent ad refreshes for specific advertiser IDs in the format of a comma separated list (e.g., 125,594,293). If an ad slot ever displays an ad creative from one of the listed advertiser IDs then that ad slot will stop refreshing for the remainder of the page view.',
+			'Prevent ad refreshes for specific advertiser IDs in the format of a comma separated list (e.g., 125,594,293). If an ad slot ever displays an ad creative from one of the listed advertiser IDs then that ad slot will stop refreshing for the remainder of the page view. AdSense does not allow their ads to be auto-refreshed. When Newspack detects that AdSense is the advertiser for any given impression, a refresh will not take place.',
 			'newspack'
 		),
 	},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update Ad Refresh Control setting help text according to https://github.com/Automattic/newspack-ads/issues/370

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

Confirm the help text is updated by following the instructions at https://github.com/Automattic/newspack-ads/pull/373

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->