### PR TITLE
fix: relax capabilities required to interact with Newspack

### DIFF
--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -496,7 +496,7 @@ class Plugins_Controller extends WP_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function handoff_item_permissions_check( $request ) {
-		if ( ! current_user_can( 'install_plugins' ) ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
 			return new WP_Error(
 				'newspack_rest_forbidden',
 				esc_html__( 'You cannot use this resource.', 'newspack' ),

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -35,12 +35,13 @@ class Setup_Wizard extends Wizard {
 	 * @var string
 	 */
 	protected $slug = 'newspack-setup-wizard';
+
 	/**
 	 * The capability required to access this wizard.
 	 *
 	 * @var string
 	 */
-	protected $capability = 'install_plugins';
+	protected $capability = 'manage_options';
 
 	/**
 	 * An array of theme mods that are media library IDs.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #543. 

Note that with `DISALLOW_FILE_MODS` the user still won't be able to complete the Setup wizard in Newspack UI only – they'll have to install the required plugins somehow and come back. But the UI is clear on that:

<img width="577" alt="image" src="https://user-images.githubusercontent.com/7383192/162922341-d054f491-df24-4bb8-9ccd-0909d13b90cf.png">
 

### How to test the changes in this Pull Request:

1. While on `master`, add `define('DISALLOW_FILE_MODS',true);` to `wp-config.php`
2. Observe that the Setup wizard is not loadable, the Site Design wizard is throwing an error, and handoff links* to plugins don't work
3. Switch to this branch, observe the issues are gone

\* e.g. Analytics wizard – there's a handoff link to Site Kit 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->