### PR TITLE
fix(popups): improve formatting of human-readable numbers

### DIFF
--- a/assets/wizards/popups/views/analytics/Info.js
+++ b/assets/wizards/popups/views/analytics/Info.js
@@ -52,7 +52,7 @@ const Info = ( { keyMetrics, filtersState, labelFilters, isLoading, postEditLink
 				{ [
 					{
 						label: __( 'Seen', 'newspack' ),
-						value: humanNumber( seen, limitDecimals ),
+						value: 10000 < seen ? humanNumber( seen, limitDecimals ) : seen.toLocaleString(),
 						withSeparator: true,
 					},
 					{

--- a/assets/wizards/popups/views/analytics/Info.js
+++ b/assets/wizards/popups/views/analytics/Info.js
@@ -36,6 +36,7 @@ const Info = ( { keyMetrics, filtersState, labelFilters, isLoading, postEditLink
 	}
 
 	const notApplicable = __( 'n/a', 'newspack' );
+	const limitDecimals = n => ( 1000000 <= seen ? Math.round( n * 100 ) / 100 : Math.round( n ) );
 	return (
 		<div className="newspack-campaigns-wizard-analytics__info">
 			<h2>
@@ -49,7 +50,11 @@ const Info = ( { keyMetrics, filtersState, labelFilters, isLoading, postEditLink
 			</h2>
 			<div className="newspack-campaigns-wizard-analytics__info__sections">
 				{ [
-					{ label: __( 'Seen', 'newspack' ), value: humanNumber( seen ), withSeparator: true },
+					{
+						label: __( 'Seen', 'newspack' ),
+						value: humanNumber( seen, limitDecimals ),
+						withSeparator: true,
+					},
 					{
 						label: __( 'Conversion Rate', 'newspack' ),
 						value: hasConversionRate ? formatPercentage( form_submissions / seen ) : notApplicable,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Small fix to improve the display formatting of human-readable "Seen" numbers in Campaigns Analytics according to the following rules:

* If the value is less than 10k, shows the absolute value formatted according to the local language via [`toLocaleString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString).
* If the value is greater than 10k but less than 1M, shows a human-readable figure rounded to the nearest integer. e.g. 11,236 becomes `11K` and 157,963 becomes `158K`
* If the value is greater than 1M, shows a human-readable figure rounded to the hundredths. e.g. 1,353,288 becomes `1.35M` and 826,677,234 becomes `826.68M`.

Closes https://github.com/Automattic/newspack-popups/issues/835.

### How to test the changes in this Pull Request:

1. If your test site isn't connected to Google Analytics via Site Kit, you can force the Campaigns Analytics view to display by adding `return [];` at [this line](https://github.com/Automattic/newspack-plugin/blob/master/includes/popups-analytics/class-popups-analytics-utils.php#L166). 
2. Mock various numbers by altering [this line](https://github.com/Automattic/newspack-plugin/blob/master/assets/wizards/popups/views/analytics/Info.js#L26) like so:

```js
const { form_submissions, link_clicks } = keyMetrics;
const seen = 12345; // a number to test.
```

3. Test numbers in the singles, hundreds, thousands, tens of thousands, hundreds of thousands, and millions and confirm that the "Seen" number displayed is human-readable and makes logical sense according to the rules above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->