### PR TITLE
chore: clear up the confusion around "legacy" popups analytics events

### DIFF
--- a/includes/popups-analytics/class-popups-analytics-utils.php
+++ b/includes/popups-analytics/class-popups-analytics-utils.php
@@ -186,15 +186,14 @@ class Popups_Analytics_Utils {
 	}
 
 	/**
-	 * Legacy event format handling - where:
-	 * - category was `Newspack Announcement`
-	 * - label - `Newspack Announcement: <title> <popup-id>`
+	 * GA custom event format handling - where:
+	 * - label - `<type>: <title> (<id>) - <segment>` or `Newspack Announcement: <title> <id>` (old times)
 	 * - action - plain text action (e.g. `Dismissal`, `Seen`)
 	 *
 	 * @param object $row Report result row.
 	 * @return object Action & label objects.
 	 */
-	private static function process_legacy_item( $row ) {
+	private static function process_ga_event_row( $row ) {
 		$action_object = [
 			'label' => $row['dimensions'][1],
 			'value' => $row['dimensions'][1],
@@ -295,10 +294,10 @@ class Popups_Analytics_Utils {
 			$ga_data_rows,
 			function ( $days, $row ) use ( $event_label_id, $options, &$all_actions, &$all_labels, &$aggregate_seen_events, &$aggregate_form_submission_events, &$aggregate_link_click_events, &$post_edit_link, &$report_by_id ) {
 				$label_dimension_value = $row['dimensions'][2];
-				$has_no_label          = '(not set)' !== $label_dimension_value;
+				$has_label             = '(not set)' !== $label_dimension_value;
 
-				if ( $has_no_label ) {
-					$item          = self::process_legacy_item( $row );
+				if ( $has_label ) {
+					$item          = self::process_ga_event_row( $row );
 					$label_object  = $item['label'];
 					$action_object = $item['action'];
 				} else {

--- a/tests/unit-tests/popups-analytics.php
+++ b/tests/unit-tests/popups-analytics.php
@@ -17,86 +17,12 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 		self::$start_date = ( new \DateTime() )->modify( '-3 days' )->format( 'Y-m-d' );
 		self::$end_date   = ( new \DateTime() )->modify( '-1 days' )->format( 'Y-m-d' );
 	}
-	/**
-	 * Test legacy report generation.
-	 */
-	public function test_report_generation_legacy() {
-		$yesterday = ( new \DateTime() )->modify( '-1 days' );
-		$ga_rows   = [
-			[
-				'dimensions' => [
-					$yesterday->format( 'Ymd' ),
-					'Seen',
-					'Newspack Announcement: Newsletter form (954)',
-				],
-				'metrics'    => [
-					[
-						'values' => [
-							'4',
-						],
-					],
-				],
-			],
-		];
-		$report    = \Popups_Analytics_Utils::process_ga_report(
-			$ga_rows,
-			[
-				'start_date'     => self::$start_date,
-				'end_date'       => self::$end_date,
-				'event_label_id' => '',
-				'event_action'   => '',
-			]
-		);
-		self::assertEquals(
-			$report,
-			[
-				'report'         =>
-				[
-					[ 'Date', 'Views' ],
-					[
-						( new \DateTime() )->modify( '-3 days' )->format( 'M j' ),
-						0,
-					],
-					[
-						( new \DateTime() )->modify( '-2 days' )->format( 'M j' ),
-						0,
-					],
-					[
-						$yesterday->format( 'M j' ),
-						4,
-					],
-				],
-				'report_by_id'   => [],
-				'actions'        =>
-				[
-					[
-						'label' => 'Seen',
-						'value' => 'Seen',
-					],
-				],
-				'labels'         =>
-				[
-					[
-						'label' => 'Newsletter form',
-						'value' => '954',
-					],
-				],
-				'key_metrics'    =>
-				[
-					'seen'             => 4,
-					'form_submissions' => -1,
-					'link_clicks'      => -1,
-				],
-				'post_edit_link' => false,
-			],
-			'Report has expected shape.'
-		);
-	}
 
 	/**
 	 * Test encoded report generation.
+	 * For a moment the events were reported as encoded.
 	 */
-	public function test_report_generation_encoded() {
+	public function test_popups_analytics_report_generation_encoded() {
 		$yesterday   = ( new \DateTime() )->modify( '-1 days' );
 		$popup_title = 'Donations welcome';
 		$event_code  = '1'; // 'Seen'.
@@ -174,9 +100,85 @@ class Newspack_Test_Popups_Analytics extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test legacy report generation.
+	 */
+	public function test_popups_analytics_report_generation_legacy() {
+		$yesterday = ( new \DateTime() )->modify( '-1 days' );
+		$ga_rows   = [
+			[
+				'dimensions' => [
+					$yesterday->format( 'Ymd' ),
+					'Seen',
+					'Newspack Announcement: Newsletter form (954)',
+				],
+				'metrics'    => [
+					[
+						'values' => [
+							'4',
+						],
+					],
+				],
+			],
+		];
+		$report    = \Popups_Analytics_Utils::process_ga_report(
+			$ga_rows,
+			[
+				'start_date'     => self::$start_date,
+				'end_date'       => self::$end_date,
+				'event_label_id' => '',
+				'event_action'   => '',
+			]
+		);
+		self::assertEquals(
+			$report,
+			[
+				'report'         =>
+				[
+					[ 'Date', 'Views' ],
+					[
+						( new \DateTime() )->modify( '-3 days' )->format( 'M j' ),
+						0,
+					],
+					[
+						( new \DateTime() )->modify( '-2 days' )->format( 'M j' ),
+						0,
+					],
+					[
+						$yesterday->format( 'M j' ),
+						4,
+					],
+				],
+				'report_by_id'   => [],
+				'actions'        =>
+				[
+					[
+						'label' => 'Seen',
+						'value' => 'Seen',
+					],
+				],
+				'labels'         =>
+				[
+					[
+						'label' => 'Newsletter form',
+						'value' => '954',
+					],
+				],
+				'key_metrics'    =>
+				[
+					'seen'             => 4,
+					'form_submissions' => -1,
+					'link_clicks'      => -1,
+				],
+				'post_edit_link' => false,
+			],
+			'Report has expected shape.'
+		);
+	}
+
+	/**
 	 * Test report generation.
 	 */
-	public function test_report_generation() {
+	public function test_popups_analytics_report_generation() {
 		$yesterday = ( new \DateTime() )->modify( '-1 days' );
 		$ga_rows   = [
 			[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Just a naming/comments refactor. See if it's all clear now. Tests diff is messy since I've moved the tests around, to start with the encoded-events test.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->