### PR TITLE
fix: crashes with autocomplete inputs in Campaigns wizard and CategoryAutocomplete

### DIFF
--- a/assets/components/src/category-autocomplete/index.js
+++ b/assets/components/src/category-autocomplete/index.js
@@ -98,7 +98,8 @@ class CategoryAutocomplete extends Component {
 		// allValues nomalizes the array so that they are all objects.
 		const allValues = tokens
 			.filter( token => 'undefined' !== typeof token ) // Ensure each token is a valid value.
-			.map( token => ( 'string' === typeof token ? suggestions[ token ] : token ) );
+			.map( token => ( 'string' === typeof token ? suggestions[ token ] : token ) )
+			.filter( Boolean );
 		onChange( allValues );
 	};
 

--- a/assets/components/src/category-autocomplete/index.js
+++ b/assets/components/src/category-autocomplete/index.js
@@ -96,9 +96,9 @@ class CategoryAutocomplete extends Component {
 		const { suggestions } = this.state;
 		// Categories that are already will be objects, while new additions will be strings (the name).
 		// allValues nomalizes the array so that they are all objects.
-		const allValues = tokens.map( token =>
-			typeof token === 'string' ? suggestions[ token ] : token
-		);
+		const allValues = tokens
+			.filter( token => 'undefined' !== typeof token ) // Ensure each token is a valid value.
+			.map( token => ( 'string' === typeof token ? suggestions[ token ] : token ) );
 		onChange( allValues );
 	};
 

--- a/assets/components/src/category-autocomplete/index.js
+++ b/assets/components/src/category-autocomplete/index.js
@@ -106,7 +106,9 @@ class CategoryAutocomplete extends Component {
 		const { value } = this.props;
 		const { suggestions } = this.state;
 		const selectedIds = value.reduce( ( acc, item ) => {
-			acc.push( item.id );
+			if ( item?.id ) {
+				acc.push( item.id );
+			}
 			return acc;
 		}, [] );
 		const availableSuggestions = filter(

--- a/assets/wizards/popups/components/settings-modal/index.js
+++ b/assets/wizards/popups/components/settings-modal/index.js
@@ -178,9 +178,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 								onChange={ tokens =>
 									setPromptConfig( {
 										options: {
-											excluded_categories: tokens
-												.filter( token => token?.id )
-												.map( token => token.id ),
+											excluded_categories: tokens.map( token => token.id ),
 										},
 									} )
 								}
@@ -198,7 +196,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 								onChange={ tokens =>
 									setPromptConfig( {
 										options: {
-											excluded_tags: tokens.filter( token => token?.id ).map( token => token.id ),
+											excluded_tags: tokens.map( token => token.id ),
 										},
 									} )
 								}

--- a/assets/wizards/popups/components/settings-modal/index.js
+++ b/assets/wizards/popups/components/settings-modal/index.js
@@ -175,18 +175,15 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 								disabled={ disabled }
 								hideHelpFromVision
 								value={ excludedCategories || [] }
-								onChange={ tokens => {
-									return setPromptConfig( {
+								onChange={ tokens =>
+									setPromptConfig( {
 										options: {
-											excluded_categories: tokens.reduce( ( acc, token ) => {
-												if ( token?.id ) {
-													acc.push( token.id );
-												}
-												return acc;
-											}, [] ),
+											excluded_categories: tokens
+												.filter( token => token?.id )
+												.map( token => token.id ),
 										},
-									} );
-								} }
+									} )
+								}
 								description={ __(
 									'Prompt will not appear on posts with the specified categories.',
 									'newspack'
@@ -198,18 +195,13 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 								hideHelpFromVision
 								taxonomy="tags"
 								value={ excludedTags || [] }
-								onChange={ tokens => {
-									return setPromptConfig( {
+								onChange={ tokens =>
+									setPromptConfig( {
 										options: {
-											excluded_tags: tokens.reduce( ( acc, token ) => {
-												if ( token?.id ) {
-													acc.push( token.id );
-												}
-												return acc;
-											}, [] ),
+											excluded_tags: tokens.filter( token => token?.id ).map( token => token.id ),
 										},
-									} );
-								} }
+									} )
+								}
 								description={ __(
 									'Prompt will not appear on posts with the specified tags.',
 									'newspack'

--- a/assets/wizards/popups/components/settings-modal/index.js
+++ b/assets/wizards/popups/components/settings-modal/index.js
@@ -175,11 +175,18 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 								disabled={ disabled }
 								hideHelpFromVision
 								value={ excludedCategories || [] }
-								onChange={ tokens =>
-									setPromptConfig( {
-										options: { excluded_categories: tokens.map( token => token.id ) },
-									} )
-								}
+								onChange={ tokens => {
+									return setPromptConfig( {
+										options: {
+											excluded_categories: tokens.reduce( ( acc, token ) => {
+												if ( token?.id ) {
+													acc.push( token.id );
+												}
+												return acc;
+											}, [] ),
+										},
+									} );
+								} }
 								description={ __(
 									'Prompt will not appear on posts with the specified categories.',
 									'newspack'
@@ -191,7 +198,18 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, segments, updatePopup
 								hideHelpFromVision
 								taxonomy="tags"
 								value={ excludedTags || [] }
-								onChange={ tokens => setPromptConfig( { options: { excluded_tags: tokens } } ) }
+								onChange={ tokens => {
+									return setPromptConfig( {
+										options: {
+											excluded_tags: tokens.reduce( ( acc, token ) => {
+												if ( token?.id ) {
+													acc.push( token.id );
+												}
+												return acc;
+											}, [] ),
+										},
+									} );
+								} }
 								description={ __(
 									'Prompt will not appear on posts with the specified tags.',
 									'newspack'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two JS errors that result in a hard crash when "selecting" an undefined item in the autocomplete fields in the Campaigns wizard UI. The change to `assets/components/src/category-autocomplete/index.js` will require a new NPM version release to fix in the NPM package.

Closes https://github.com/Automattic/newspack-popups/issues/810.

### How to test the changes in this Pull Request:

1. On `master`, visit the **Newspack > Campaigns** wizard. Click the settings icon to open the settings modal:

<img width="1198" alt="Screen Shot 2022-04-13 at 5 20 06 PM" src="https://user-images.githubusercontent.com/2230142/163285257-52ea3233-e2e5-46d8-9a1e-888ecabf8422.png">

2. In the Category, Tag, or Category/Tag Exclusion fields, start typing in a term and hit enter without having a term highlighted. Observe that the UI crashes with a JS console error.
3. Check out this branch and repeat, confirming that the UI does not crash and that hitting enter is harmless and doesn't result in changing the autocomplete input's value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->