### PR TITLE
feat(setup): display notice on Setup wizard after setup has been comp…

### DIFF
--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import { Welcome, Settings, Services, Design, Completed } from './views/';
-import { withWizard } from '../../components/src';
+import { withWizard, Notice } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
 import './style.scss';
 
@@ -52,6 +52,14 @@ const ROUTES = [
 const SetupWizard = ( { wizardApiFetch, setError } ) => {
 	return (
 		<Fragment>
+			{ newspack_aux_data.has_completed_setup && (
+				<Notice isWarning>
+					{ __(
+						'Heads up! The setup has already been completed. No need to run it again.',
+						'newspack'
+					) }
+				</Notice>
+			) }
 			<HashRouter hashType="slash">
 				{ ROUTES.map( ( route, index ) => {
 					const nextRoute = ROUTES[ index + 1 ]?.path;

--- a/assets/wizards/setup/index.js
+++ b/assets/wizards/setup/index.js
@@ -53,7 +53,7 @@ const SetupWizard = ( { wizardApiFetch, setError } ) => {
 	return (
 		<Fragment>
 			{ newspack_aux_data.has_completed_setup && (
-				<Notice isWarning>
+				<Notice isWarning className="ma0">
 					{ __(
 						'Heads up! The setup has already been completed. No need to run it again.',
 						'newspack'

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -142,9 +142,10 @@ abstract class Wizard {
 		}
 
 		$aux_data = [
-			'is_e2e'        => Starter_Content::is_e2e(),
-			'is_debug_mode' => Newspack::is_debug_mode(),
-			'site_title'    => get_option( 'blogname' ),
+			'is_e2e'              => Starter_Content::is_e2e(),
+			'is_debug_mode'       => Newspack::is_debug_mode(),
+			'has_completed_setup' => get_option( NEWSPACK_SETUP_COMPLETE ),
+			'site_title'          => get_option( 'blogname' ),
 		];
 
 		if ( class_exists( 'Newspack_Popups_Segmentation' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1561

### How to test the changes in this Pull Request:

1. Remove the `'newspack_setup_complete'` option
2. Visit the Setup wizard, observe that there's no notice above the wizard
3. Complete the setup by clicking "Finish" on the last step (or update the option value in the DB)
4. Visit the Setup wizard, observe a notice about the setup having been completed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->