### PR TITLE
chore: improve asset cache busting

### DIFF
--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -204,7 +204,7 @@ class Admin_Plugins_Screen {
 			'newspack_plugins_screen',
 			Newspack::plugin_url() . '/dist/plugins-screen.js',
 			[ 'jquery', 'mediaelement-core' ],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/plugins-screen.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 
@@ -226,7 +226,7 @@ class Admin_Plugins_Screen {
 			'newspack_plugins_screen',
 			Newspack::plugin_url() . '/dist/plugins-screen.css',
 			[],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/plugins-screen.css' )
+			NEWSPACK_PLUGIN_VERSION
 		);
 		wp_style_add_data( 'newspack_plugins_screen', 'rtl', 'replace' );
 		wp_enqueue_style( 'newspack_plugins_screen' );

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -56,7 +56,7 @@ class Handoff_Banner {
 			$handle,
 			Newspack::plugin_url() . '/assets/wizards/handoff-banner/block-editor.js',
 			[ 'wp-element', 'wp-editor', 'wp-components' ],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/wizards/handoff-banner/block-editor.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 
@@ -81,7 +81,7 @@ class Handoff_Banner {
 			$handle,
 			Newspack::plugin_url() . '/dist/handoff-banner.css',
 			[],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/handoff-banner.css' )
+			NEWSPACK_PLUGIN_VERSION
 		);
 		wp_enqueue_style( $handle );
 
@@ -91,7 +91,7 @@ class Handoff_Banner {
 			$handle,
 			Newspack::plugin_url() . '/dist/handoff-banner.js',
 			[ 'wp-element', 'wp-editor', 'wp-components' ],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/handoff-banner.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 		wp_enqueue_script( $handle );

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -289,7 +289,7 @@ final class Newspack {
 			'newspack_commons',
 			self::plugin_url() . '/dist/commons.js',
 			[],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/commons.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 		wp_enqueue_script( 'newspack_commons' );
@@ -298,7 +298,7 @@ final class Newspack {
 			'newspack-commons',
 			self::plugin_url() . '/dist/commons.css',
 			[ 'wp-components' ],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/commons.css' )
+			NEWSPACK_PLUGIN_VERSION
 		);
 		wp_style_add_data( 'newspack-commons', 'rtl', 'replace' );
 		wp_enqueue_style( 'newspack-commons' );

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -215,7 +215,7 @@ class Salesforce {
 			'newspack-salesforce-sync-status',
 			Newspack::plugin_url() . '/dist/other-scripts/salesforce.js',
 			[],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/other-scripts/salesforce.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 

--- a/includes/reader-revenue/class-reader-revenue-emails.php
+++ b/includes/reader-revenue/class-reader-revenue-emails.php
@@ -123,7 +123,7 @@ class Reader_Revenue_Emails {
 			$handle,
 			Newspack::plugin_url() . '/dist/other-scripts/reader-revenue-emails.js',
 			[],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/other-scripts/reader-revenue-emails.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 		\wp_localize_script(
@@ -139,7 +139,7 @@ class Reader_Revenue_Emails {
 			$handle,
 			Newspack::plugin_url() . '/dist/other-scripts/reader-revenue-emails.css',
 			[],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/other-scripts/reader-revenue-emails.css' )
+			NEWSPACK_PLUGIN_VERSION
 		);
 		\wp_style_add_data( $handle, 'rtl', 'replace' );
 		\wp_enqueue_style( $handle );

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -563,7 +563,7 @@ class Advertising_Wizard extends Wizard {
 			'newspack-advertising-wizard',
 			Newspack::plugin_url() . '/dist/advertising.js',
 			$this->get_script_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/advertising.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 
@@ -571,7 +571,7 @@ class Advertising_Wizard extends Wizard {
 			'newspack-advertising-wizard',
 			Newspack::plugin_url() . '/dist/advertising.css',
 			$this->get_style_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/advertising.css' )
+			NEWSPACK_PLUGIN_VERSION
 		);
 		\wp_style_add_data( 'newspack-advertising-wizard', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-advertising-wizard' );

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -228,7 +228,7 @@ class Analytics_Wizard extends Wizard {
 			'newspack-analytics-wizard',
 			Newspack::plugin_url() . '/dist/analytics.js',
 			[ 'wp-components', 'wp-api-fetch' ],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/analytics.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 		$custom_dimensions          = self::list_custom_dimensions();
@@ -265,7 +265,7 @@ class Analytics_Wizard extends Wizard {
 			'newspack-analytics-wizard',
 			Newspack::plugin_url() . '/dist/analytics.css',
 			$this->get_style_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/analytics.css' )
+			NEWSPACK_PLUGIN_VERSION
 		);
 		\wp_style_add_data( 'newspack-analytics-wizard', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-analytics-wizard' );

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -86,7 +86,7 @@ class Components_Demo extends Wizard {
 			'newspack-components-demo',
 			Newspack::plugin_url() . '/dist/componentsDemo.js',
 			$this->get_script_dependencies( [ 'wp-html-entities' ] ),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/componentsDemo.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 	}

--- a/includes/wizards/class-connections-wizard.php
+++ b/includes/wizards/class-connections-wizard.php
@@ -73,7 +73,7 @@ class Connections_Wizard extends Wizard {
 			'newspack-connections-wizard',
 			Newspack::plugin_url() . '/dist/connections.js',
 			$this->get_script_dependencies( [] ),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/connections.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 		\wp_localize_script(

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -185,7 +185,7 @@ class Dashboard extends Wizard {
 			'newspack-dashboard',
 			Newspack::plugin_url() . '/dist/dashboard.js',
 			$this->get_script_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/dashboard.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 		wp_localize_script( 'newspack-dashboard', 'newspack_dashboard', $this->get_dashboard() );
@@ -195,7 +195,7 @@ class Dashboard extends Wizard {
 			'newspack-dashboard',
 			Newspack::plugin_url() . '/dist/dashboard.css',
 			$this->get_style_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/dashboard.css' )
+			NEWSPACK_PLUGIN_VERSION
 		);
 		wp_style_add_data( 'newspack-dashboard', 'rtl', 'replace' );
 		wp_enqueue_style( 'newspack-dashboard' );

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -253,7 +253,7 @@ class Engagement_Wizard extends Wizard {
 			'newspack-engagement-wizard',
 			Newspack::plugin_url() . '/dist/engagement.js',
 			$this->get_script_dependencies( array( 'wp-html-entities' ) ),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/engagement.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 	}

--- a/includes/wizards/class-health-check-wizard.php
+++ b/includes/wizards/class-health-check-wizard.php
@@ -176,7 +176,7 @@ class Health_Check_Wizard extends Wizard {
 			'newspack-health-check-wizard',
 			Newspack::plugin_url() . '/dist/health-check.js',
 			[ 'wp-components', 'wp-api-fetch' ],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/health-check.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 	}

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -456,7 +456,7 @@ class Popups_Wizard extends Wizard {
 			'newspack-popups-wizard',
 			Newspack::plugin_url() . '/dist/popups.js',
 			$this->get_script_dependencies( [ 'wp-html-entities', 'wp-date' ] ),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/popups.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 
@@ -494,7 +494,7 @@ class Popups_Wizard extends Wizard {
 			'newspack-popups-wizard',
 			Newspack::plugin_url() . '/dist/popups.css',
 			$this->get_style_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/popups.css' )
+			NEWSPACK_PLUGIN_VERSION
 		);
 		\wp_style_add_data( 'newspack-popups-wizard', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-popups-wizard' );

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -527,7 +527,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			'newspack-reader-revenue-wizard',
 			Newspack::plugin_url() . '/dist/readerRevenue.js',
 			$this->get_script_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/readerRevenue.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 		\wp_localize_script(

--- a/includes/wizards/class-seo-wizard.php
+++ b/includes/wizards/class-seo-wizard.php
@@ -204,7 +204,7 @@ class SEO_Wizard extends Wizard {
 			'newspack-seo-wizard',
 			Newspack::plugin_url() . '/dist/seo.js',
 			$this->get_script_dependencies( [ 'wp-html-entities' ] ),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/seo.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 	}

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -600,14 +600,14 @@ class Setup_Wizard extends Wizard {
 			'newspack-setup-wizard',
 			Newspack::plugin_url() . '/dist/setup.js',
 			$this->get_script_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/setup.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 		wp_register_style(
 			'newspack-setup-wizard',
 			Newspack::plugin_url() . '/dist/setup.css',
 			$this->get_style_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/setup.css' )
+			NEWSPACK_PLUGIN_VERSION
 		);
 		wp_style_add_data( 'newspack-setup-wizard', 'rtl', 'replace' );
 		wp_enqueue_style( 'newspack-setup-wizard' );

--- a/includes/wizards/class-site-design-wizard.php
+++ b/includes/wizards/class-site-design-wizard.php
@@ -73,7 +73,7 @@ class Site_Design_Wizard extends Wizard {
 			'newspack-site-design-wizard',
 			Newspack::plugin_url() . '/dist/site-design.js',
 			$this->get_script_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/site-design.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 
@@ -81,7 +81,7 @@ class Site_Design_Wizard extends Wizard {
 			'newspack-site-design-wizard',
 			Newspack::plugin_url() . '/dist/site-design.css',
 			$this->get_style_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/site-design.css' )
+			NEWSPACK_PLUGIN_VERSION
 		);
 		\wp_style_add_data( 'newspack-site-design-wizard', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-site-design-wizard' );

--- a/includes/wizards/class-syndication-wizard.php
+++ b/includes/wizards/class-syndication-wizard.php
@@ -86,7 +86,7 @@ class Syndication_Wizard extends Wizard {
 			'newspack-syndication-wizard',
 			Newspack::plugin_url() . '/dist/syndication.js',
 			$this->get_script_dependencies(),
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/syndication.js' ),
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 	}

--- a/newspack.php
+++ b/newspack.php
@@ -14,6 +14,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+define( 'NEWSPACK_PLUGIN_VERSION', '1.80.0' );
+
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #99

### How to test the changes in this Pull Request:

Visit the wizards and confirm that the JS & CSS assets have the current version appended as the cache-busting parameter.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->