### PR TITLE
fix: handle Yoast Premium as a replacement for Yoast

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -335,16 +335,9 @@ class Plugin_Manager {
 		];
 
 		// Add plugin status info and fill in defaults.
-		$installed_plugins = self::get_installed_plugins();
 		foreach ( $managed_plugins as $plugin_slug => $managed_plugin ) {
-			$status = 'uninstalled';
-			if ( isset( $installed_plugins[ $plugin_slug ] ) ) {
-				if ( is_plugin_active( $installed_plugins[ $plugin_slug ] ) ) {
-					$status = 'active';
-				} else {
-					$status = 'inactive';
-				}
-			}
+			$status = self::get_managed_plugin_status( $plugin_slug );
+
 			if ( 'newspack-theme' === $plugin_slug ) {
 				if ( 'newspack-theme' === get_stylesheet() ) {
 					$status = 'active';
@@ -353,15 +346,42 @@ class Plugin_Manager {
 			if ( isset( $managed_plugin['WPCore'] ) ) {
 				$status = 'active';
 			}
-			if ( Newspack::is_debug_mode() ) {
-				$status = 'active';
-			}
+
 			$managed_plugins[ $plugin_slug ]['Status']      = $status;
 			$managed_plugins[ $plugin_slug ]['Slug']        = $plugin_slug;
 			$managed_plugins[ $plugin_slug ]['HandoffLink'] = isset( $managed_plugins[ $plugin_slug ]['EditPath'] ) ? admin_url( $managed_plugins[ $plugin_slug ]['EditPath'] ) : null;
 			$managed_plugins[ $plugin_slug ]                = wp_parse_args( $managed_plugins[ $plugin_slug ], $default_info );
 		}
 		return $managed_plugins;
+	}
+
+	/**
+	 * Determine a managed plugin status.
+	 *
+	 * @param string $plugin_slug Plugin slug.
+	 */
+	private static function get_managed_plugin_status( $plugin_slug ) {
+		if ( Newspack::is_debug_mode() ) {
+			return 'active';
+		}
+		$status            = 'uninstalled';
+		$installed_plugins = self::get_installed_plugins();
+		if ( isset( $installed_plugins[ $plugin_slug ] ) ) {
+			if ( is_plugin_active( $installed_plugins[ $plugin_slug ] ) ) {
+				$status = 'active';
+			} else {
+				$status = 'inactive';
+			}
+		}
+
+		// Yoast Premium can be used as a replacement for regular Yoast.
+		if ( 'wordpress-seo' === $plugin_slug && 'active' !== $status && isset( $installed_plugins['wordpress-seo-premium'] ) && $installed_plugins['wordpress-seo-premium'] ) {
+			if ( is_plugin_active( $installed_plugins['wordpress-seo-premium'] ) ) {
+				$status = 'active';
+			};
+		}
+
+		return $status;
 	}
 
 	/**
@@ -375,6 +395,7 @@ class Plugin_Manager {
 			'classic-widgets',
 			'republication-tracker-tool',
 			'the-events-calendar',
+			'wordpress-seo-premium',
 		];
 	}
 
@@ -410,7 +431,7 @@ class Plugin_Manager {
 		$plugins_info    = self::get_installed_plugins_info();
 		$missing_plugins = array();
 		foreach ( self::$required_plugins as $slug ) {
-			if ( ! isset( $plugins_info[ $slug ] ) || ! is_plugin_active( $plugins_info[ $slug ]['Path'] ) ) {
+			if ( 'active' !== self::get_managed_plugin_status( $slug ) ) {
 				$missing_plugins[ $slug ] = $managed_plugins[ $slug ];
 			}
 		}

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -396,6 +396,8 @@ class Plugin_Manager {
 			'republication-tracker-tool',
 			'the-events-calendar',
 			'wordpress-seo-premium',
+			'gravityformspolls',
+			'gravityformsmailchimp',
 		];
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #298

Also adds some GravityForms add-on plugins to the list of supported (but not managed) plugins.

### How to test the changes in this Pull Request:

1. Create a dummy plugin called `wordpress-seo-premium`*
2. Deactivate Yoast and visit the SEO wizard
3. Observe a plugin installation prompt for Yoast 
4. Activate the `wordpress-seo-premium` plugin, reload the wizard, observe the wizard loading (with some issues, but that's cause plugin is a dummy)
5. Visit the Health Check wizard, observe that no issue with Yoast are reported there

\* Add a `wordpress-seo-premium/main.php` [file](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->