### PR TITLE
feat(woocommerce): hide setup task list

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -16,6 +16,25 @@ defined( 'ABSPATH' ) || exit;
  */
 class WooCommerce_Connection {
 	/**
+	 * Initialize.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function init() {
+		add_action( 'admin_init', [ __CLASS__, 'disable_woocommerce_setup' ] );
+	}
+
+	/**
+	 * Hide WooCommerce's setup task list. Newspack does the setup behind the scenes.
+	 */
+	public static function disable_woocommerce_setup() {
+		if ( class_exists( '\Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists' ) ) {
+			$task_list = \Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists::get_list( 'setup' );
+			$task_list->hide();
+		}
+	}
+
+	/**
 	 * Add a donation transaction to WooCommerce.
 	 *
 	 * @param object $order_data Order data.
@@ -77,3 +96,5 @@ class WooCommerce_Connection {
 		return $order->get_id();
 	}
 }
+
+WooCommerce_Connection::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1156

### How to test the changes in this Pull Request:

1. On `master`, install & activate WooCommerce
2. Observe a "WooCommerce Setup" item in the main WP dashboard
3. Switch to this branch, observe the item is gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->