### PR TITLE
fix(salesforce): a PHP warning on sync completion due to incorrect variable

### DIFF
--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -672,7 +672,7 @@ class Salesforce {
 		}
 
 		// Save synced opportunity IDs to order as post meta.
-		self::save_opportunity_ids( $order_id, $response['opportunities'] );
+		self::save_opportunity_ids( $order_id, $opportunities );
 
 		return [
 			'contact'       => $contact_id,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a PHP warning on successful Salesforce sync due to an incorrectly named variable that was also causing some post meta to not be saved.

### How to test the changes in this Pull Request:

1. Set up a WooCommerce/Salesforce connection via Reader Revenue. DM me if you need credentials.
2. Complete any order (donation, product, self-serve listing, etc.) or manually sync an existing order in the Edit Order dashboard page.
3. Observe a PHP warning upon successful Salesforce sync: 

```
PHP Notice:  Undefined variable: response in /wp-content/plugins/newspack-plugin/includes/class-salesforce.php on line 675
```

4. Check out this branch, repeat step 2, and confirm that the warning isn't thrown. Also confirm that the order has an array of Opportunity IDs stored as `newspack_salesforce_opportunities` post meta (via WP CLI: `wp post meta list <order ID>`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->