### PR TITLE
fix(reader-revenue): initial order state with total of 0

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -102,7 +102,6 @@ class WooCommerce_Connection {
 	public static function create_transaction( $order_data ) {
 		Logger::log( 'Creating an order' );
 
-		$order     = wc_create_order( [ 'status' => 'completed' ] );
 		$frequency = $order_data['frequency'];
 
 		$item = self::get_donation_order_item( $frequency, $order_data['amount'] );
@@ -110,6 +109,7 @@ class WooCommerce_Connection {
 			return new WP_Error( 'newspack_woocommerce', __( 'Missing donation product.', 'newspack' ) );
 		}
 
+		$order = wc_create_order();
 		$order->add_item( $item );
 		$order->calculate_totals();
 		$order->set_currency( $order_data['currency'] );
@@ -148,6 +148,7 @@ class WooCommerce_Connection {
 		}
 
 		$order->set_created_via( 'newspack-stripe' );
+		$order->set_status( 'completed' );
 		$order->save();
 
 		if ( class_exists( 'WC_Memberships_Membership_Plans' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Because the order was created as completed, an email was sent right away to the site admin, with a 0 as order total.

### How to test the changes in this Pull Request:

1. Choose "Stripe" as the Reader Revenue platform and make sure your site is available publicly (so Stripe webhook can be called)
2. On `master`, make a donation using the Donate block
3. Observe an email is sent to site admin with no order details and 0 as total
4. Switch to this branch, observe the email sent has order details and correct amount

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->