### PR TITLE
fix(ads): check plugin before using method

### DIFF
--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -579,7 +579,7 @@ class Advertising_Wizard extends Wizard {
 			'newspack-advertising-wizard',
 			'newspack_ads_wizard',
 			array(
-				'iab_sizes' => \Newspack_Ads\get_iab_sizes(),
+				'iab_sizes' => function_exists( '\Newspack_Ads\get_iab_sizes' ) ? \Newspack_Ads\get_iab_sizes() : [],
 			)
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure plugin method exists before using it.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. While on the master branch, visit the Advertising wizard with the Ads plugin inactive
2. Confirm the error message
3. Check out this branch, refresh the wizard and confirm you see the activation component

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->