### PR TITLE
feat(ads): handle gam default ad units

### DIFF
--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -159,6 +159,7 @@ const AdUnits = ( {
 					.filter( adUnit => adUnit.id !== 0 )
 					.sort( ( a, b ) => b.name.localeCompare( a.name ) )
 					.sort( a => ( a.is_legacy ? 1 : -1 ) )
+					.sort( a => ( a.is_default ? 1 : -1 ) )
 					.map( adUnit => {
 						const editLink = `#${ service }/${ adUnit.id }`;
 						return (
@@ -166,30 +167,45 @@ const AdUnits = ( {
 								key={ adUnit.id }
 								title={ adUnit.name }
 								isSmall
-								titleLink={ editLink }
+								titleLink={ ! adUnit.is_default && editLink }
 								description={ () => (
 									<span>
-										{ adUnit.is_legacy ? (
+										{ adUnit.code ? (
 											<>
-												<i>{ __( 'Legacy ad unit.', 'newspack' ) }</i> |{ ' ' }
+												<i>{ __( 'Code:', 'newspack' ) }</i> <code>{ adUnit.code }</code>
 											</>
 										) : null }
 										{ adUnit.sizes?.length || adUnit.fluid ? (
 											<>
-												{ __( 'Sizes:', 'newspack' ) }{ ' ' }
+												{ ' ' }
+												| { __( 'Sizes:', 'newspack' ) }{ ' ' }
 												{ adUnit.sizes.map( ( size, i ) => (
 													<code key={ i }>{ Array.isArray( size ) ? size.join( 'x' ) : size }</code>
 												) ) }
 												{ adUnit.fluid && <code>{ __( 'Fluid', 'newspack' ) }</code> }
 											</>
 										) : null }
+										{ adUnit.is_legacy ? (
+											<>
+												{ ' ' }
+												| <i>{ __( 'Legacy ad unit.', 'newspack' ) }</i>
+											</>
+										) : null }
+										{ adUnit.is_default ? (
+											<>
+												{ ' ' }
+												| <i>{ __( 'Default ad unit.', 'newspack' ) }</i>
+											</>
+										) : null }
 									</span>
 								) }
 								actionText={
-									<OptionsPopover
-										deleteLink={ () => onDelete( adUnit.id ) }
-										editLink={ editLink }
-									/>
+									! adUnit.is_default && (
+										<OptionsPopover
+											deleteLink={ () => onDelete( adUnit.id ) }
+											editLink={ editLink }
+										/>
+									)
 								}
 							/>
 						);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Wizard changes to properly handle the default ad units implementation from https://github.com/Automattic/newspack-ads/pull/406
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

Testing instructions at https://github.com/Automattic/newspack-ads/pull/406

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->