### PR TITLE
feat: reader registration on donate

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -78,6 +78,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-analytics.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-reader-activation.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-stripe-connection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-woocommerce-connection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-reader-revenue-emails.php';

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -178,6 +178,26 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Check if current reader has its email verified.
+	 *
+	 * @param \WP_User $user User object.
+	 *
+	 * @return bool|null Whether the email address is verified, null if invalid user.
+	 */
+	public static function is_reader_verified( $user ) {
+		if ( ! $user ) {
+			return null;
+		}
+
+		/** Should not verify email if user is not a reader. */
+		if ( ! self::is_user_reader( $user ) ) {
+			return null;
+		}
+
+		return (bool) \get_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
+	}
+
+	/**
 	 * Authenticate a reader session given its user ID.
 	 *
 	 * Warning: this method will only verify if the user is a reader in order to

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -268,11 +268,11 @@ final class Reader_Activation {
 			} else {
 				$user_id = \wp_insert_user(
 					[
-						'email'        => $email,
 						'user_login'   => $email,
+						'user_email'   => $email,
 						'user_pass'    => $random_password,
 						'display_name' => $display_name,
-					] 
+					]
 				);
 				if ( $notify ) {
 					\wp_new_user_notification( $user_id, null, 'user' );

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -80,6 +80,15 @@ final class Reader_Activation {
 	 */
 	public static function set_auth_intention( $email ) {
 		/**
+		 * Allows preventing auth cookies from actually being sent to the client.
+		 *
+		 * @param bool $send Whether to send auth cookies to the client.
+		 */
+		if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+			return;
+		}
+
+		/**
 		 * Filters the duration of the auth intention cookie expiration period.
 		 *
 		 * @param int    $length Duration of the expiration period in seconds.

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * Reader Activation.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Reader Activation Class.
+ */
+final class Reader_Activation {
+
+	const AUTH_INTENTION_COOKIE = 'np_auth_intention';
+
+	/**
+	 * Reader user meta keys.
+	 */
+	const READER         = 'np_reader';
+	const EMAIL_VERIFIED = 'np_reader_email_verified';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		if ( self::is_enabled() ) {
+			\add_action( 'clear_auth_cookie', [ __CLASS__, 'clear_auth_intention_cookie' ] );
+			\add_filter( 'login_form_defaults', [ __CLASS__, 'add_auth_intention_to_login_form' ], 20 );
+			\add_action( 'resetpass_form', [ __CLASS__, 'verify_reader_email' ] );
+		}
+	}
+
+	/**
+	 * Whether reader activation is enabled.
+	 *
+	 * @return bool True if reader activation is enabled.
+	 */
+	public static function is_enabled() {
+		$is_enabled = defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) && NEWSPACK_EXPERIMENTAL_READER_ACTIVATION;
+
+		/**
+		 * Filters whether reader activation is enabled.
+		 *
+		 * @param bool $is_enabled Whether reader activation is enabled.
+		 */
+		return \apply_filters( 'newspack_reader_activation_enabled', $is_enabled );
+	}
+
+	/**
+	 * Add auth intention email to login form defaults.
+	 *
+	 * @param array $defaults Login form defaults.
+	 *
+	 * @return array
+	 */
+	public static function add_auth_intention_to_login_form( $defaults ) {
+		$email = self::get_auth_intention();
+		if ( ! empty( $email ) ) {
+			$defaults['label_username'] = __( 'Email address', 'newspack' );
+			$defaults['value_username'] = $email;
+		}
+		return $defaults;
+	}
+
+	/**
+	 * Clear the auth intention cookie.
+	 */
+	public static function clear_auth_intention_cookie() {
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+		setcookie( self::AUTH_INTENTION_COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+	}
+
+	/**
+	 * Set the auth intention cookie.
+	 *
+	 * @param string $email Email address.
+	 */
+	public static function set_auth_intention( $email ) {
+		/**
+		 * Filters the duration of the auth intention cookie expiration period.
+		 *
+		 * @param int    $length Duration of the expiration period in seconds.
+		 * @param string $email  Email address.
+		 */
+		$expire = time() + \apply_filters( 'newspack_auth_intention_expiration', 30 * DAY_IN_SECONDS, $email );
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+		setcookie( self::AUTH_INTENTION_COOKIE, $email, $expire, COOKIEPATH, COOKIE_DOMAIN, true );
+	}
+
+	/**
+	 * Get the auth intention.
+	 *
+	 * @return string|null Email address or null if not set.
+	 */
+	public static function get_auth_intention() {
+		$auth_intention = null;
+		if ( isset( $_COOKIE[ self::AUTH_INTENTION_COOKIE ] ) ) {
+			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+			$auth_intention = \sanitize_email( $_COOKIE[ self::AUTH_INTENTION_COOKIE ] );
+		}
+		/**
+		 * Filters the session auth intention email address.
+		 *
+		 * @param string|null $auth_intention Email address or null if not set.
+		 */
+		return \apply_filters( 'newspack_auth_intention', $auth_intention );
+	}
+
+	/**
+	 * Whether the user is a reader.
+	 *
+	 * @param \WP_User $user User object.
+	 *
+	 * @return bool Whether the user is a reader.
+	 */
+	public static function is_user_reader( $user ) {
+		$is_reader = (bool) \get_user_meta( $user->ID, self::READER, true );
+
+		if ( false === $is_reader ) {
+			/**
+			 * Filters the roles that can determine if a user is a reader.
+			 *
+			 * @param string[] $roles Array of user roles.
+			 */
+			$reader_roles = \apply_filters( 'newspack_reader_user_roles', [ 'subscriber', 'customer' ] );
+			if ( ! empty( $reader_roles ) ) {
+				$user_data = \get_userdata( $user->ID );
+				$is_reader = ! empty( array_intersect( $reader_roles, $user_data->roles ) );
+			}
+		}
+
+		/**
+		 * Filters whether the user is a reader.
+		 *
+		 * @param bool     $is_reader Whether the user is a reader.
+		 * @param \WP_User $user      User object.
+		 */
+		return \apply_filters( 'newspack_is_user_reader', $is_reader, $user );
+	}
+
+	/**
+	 * Verify email address of a reader given the user.
+	 *
+	 * @param \WP_User $user User object.
+	 *
+	 * @return bool Whether the email address was verified.
+	 */
+	public static function verify_reader_email( $user ) {
+		if ( ! $user ) {
+			return false;
+		}
+
+		/** Should not verify email if user is not a reader. */
+		if ( ! self::is_user_reader( $user ) ) {
+			return false;
+		}
+
+		$verified = \get_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
+		if ( $verified ) {
+			return true;
+		}
+
+		\update_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
+
+		return true;
+	}
+
+	/**
+	 * Authenticate a reader session given its user ID.
+	 *
+	 * Warning: this method will only verify if the user is a reader in order to
+	 * authenticate. It will not check for any credentials.
+	 *
+	 * @param int  $user_id      User ID.
+	 * @param bool $verify_email Whether to verify the email address.
+	 *
+	 * @return \WP_User|\WP_Error The authenticated reader or WP_Error if authentication failed.
+	 */
+	private static function set_current_reader( $user_id, $verify_email = false ) {
+		$user_id = \absint( $user_id );
+		if ( empty( $user_id ) ) {
+			return new \WP_Error( 'newspack_authenticate_invalid_user_id', __( 'Invalid user id.', 'newspack' ) );
+		}
+
+		$user = \get_user_by( 'id', $user_id );
+		if ( ! $user || \is_wp_error( $user ) || ! self::is_user_reader( $user ) ) {
+			return new \WP_Error( 'newspack_authenticate_invalid_user', __( 'Invalid user.', 'newspack' ) );
+		}
+
+		if ( true === $verify_email ) {
+			self::verify_reader_email( $user );
+		}
+
+		\wp_clear_auth_cookie();
+		\wp_set_current_user( $user->ID );
+		\wp_set_auth_cookie( $user->ID );
+		\do_action( 'wp_login', $user->user_login, $user );
+
+		return $user;
+	}
+
+	/**
+	 * Register a reader given its email.
+	 *
+	 * Due to authentication or auth intention, this method should be used
+	 * preferably on POST or API requests to avoid issues with caching.
+	 *
+	 * @param string $email        Email address.
+	 * @param string $display_name Reader display name to be used on account creation.
+	 * @param bool   $authenticate Whether to authenticate after registering. Default to true.
+	 * @param bool   $notify       Whether to send email notification to the reader. Default to true.
+	 *
+	 * @return int|false|\WP_Error The created user ID in case of registration, false if the user already exists, or a WP_Error object.
+	 */
+	public static function register_reader( $email, $display_name = '', $authenticate = true, $notify = true ) {
+		if ( ! self::is_enabled() ) {
+			return new \WP_Error( 'newspack_register_reader_disabled', __( 'Registration is disabled.', 'newspack' ) );
+		}
+
+		if ( \is_user_logged_in() ) {
+			return new \WP_Error( 'newspack_register_reader_logged_in', __( 'Cannot register while logged in.', 'newspack' ) );
+		}
+
+		$email = \sanitize_email( $email );
+
+		if ( empty( $email ) ) {
+			return new \WP_Error( 'newspack_register_reader_empty_email', __( 'Please enter a valid email address.', 'newspack' ) );
+		}
+
+		self::set_auth_intention( $email );
+
+		$existing_user = \get_user_by( 'email', $email );
+		if ( \is_wp_error( $existing_user ) ) {
+			return $existing_user;
+		}
+
+		$user_id = false;
+
+		if ( ! $existing_user ) {
+			/**
+			 * Create new reader.
+			 */
+			if ( empty( $display_name ) ) {
+				$display_name = explode( '@', $email, 2 )[0];
+			}
+
+			$random_password = \wp_generate_password();
+
+			if ( function_exists( '\wc_create_new_customer' ) ) {
+				/**
+				 * Create WooCommerce Customer if possible.
+				 *
+				 * Email notification for WooCommerce is handled by the plugin.
+				 */
+				$user_id = \wc_create_new_customer( $email, $email, $random_password, [ 'display_name' => $display_name ] );
+			} else {
+				$user_id = \wp_insert_user(
+					[
+						'email'        => $email,
+						'user_login'   => $email,
+						'user_pass'    => $random_password,
+						'display_name' => $display_name,
+					] 
+				);
+				if ( $notify ) {
+					\wp_new_user_notification( $user_id, null, 'user' );
+				}
+			}
+
+			if ( \is_wp_error( $user_id ) ) {
+				return $user_id;
+			}
+
+			/** Add default reader related meta. */
+			\update_user_meta( $user_id, self::READER, true );
+			\update_user_meta( $user_id, self::EMAIL_VERIFIED, false );
+
+			if ( $authenticate ) {
+				self::set_current_reader( $user_id );
+			}
+		}
+
+		/**
+		 * Action after registering and authenticating a reader.
+		 *
+		 * @param string         $email         Email address.
+		 * @param bool           $authenticate  Whether to authenticate after registering.
+		 * @param false|int      $user_id       The created user id.
+		 * @param false|\WP_User $existing_user The existing user object.
+		 */
+		\do_action( 'newspack_registered_reader', $email, $authenticate, $user_id, $existing_user );
+
+		return $user_id;
+	}
+}
+Reader_Activation::init();

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -689,6 +689,26 @@ class Stripe_Connection {
 			$payment_metadata  = $config['payment_metadata'];
 			$payment_method_id = $config['payment_method_id'];
 
+			if ( \is_user_logged_in() ) {
+				$user_id = \get_current_user_id();
+			} elseif ( Reader_Activation::is_enabled() ) {
+				$user_id = Reader_Activation::register_reader( $email_address, $full_name, true, false );
+				if ( \is_wp_error( $user_id ) ) {
+					return $user_id;
+				}
+				/**
+				 * If the returned value is not the created user ID, do not tie donation
+				 * to the existing reader.
+				 */
+				if ( ! absint( $user_id ) ) {
+					$user_id = null;
+				}
+			}
+
+			if ( ! empty( $user_id ) ) {
+				$client_metadata['userId'] = $user_id;
+			}
+
 			$customer = self::upsert_customer(
 				[
 					'email'    => $email_address,

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -80,16 +80,26 @@ class WooCommerce_Connection {
 			}
 		}
 		if ( $should_create_account ) {
-			Logger::log( 'This order will result in a membership, creating account for user.' );
-			$user_login = sanitize_title( $full_name );
-			$user_id    = wc_create_new_customer( $email_address, $user_login, '', [ 'display_name' => $full_name ] );
-			if ( is_wp_error( $user_id ) ) {
-				return $user_id;
-			}
+			if ( Reader_Activation::is_enabled() ) {
+				$user_id = Reader_Activation::register_reader( $email_address, $full_name );
+				if ( is_wp_error( $user_id ) ) {
+					return $user_id;
+				}
+				if ( ! absint( $user_id ) ) {
+					$user_id = null;
+				}
+			} else {
+				Logger::log( 'This order will result in a membership, creating account for user.' );
+				$user_login = sanitize_title( $full_name );
+				$user_id    = wc_create_new_customer( $email_address, $user_login, '', [ 'display_name' => $full_name ] );
+				if ( is_wp_error( $user_id ) ) {
+					return $user_id;
+				}
 
-			// Log the new user in.
-			wp_set_current_user( $user_id, $user_login );
-			wp_set_auth_cookie( $user_id );
+				// Log the new user in.
+				wp_set_current_user( $user_id, $user_login );
+				wp_set_auth_cookie( $user_id );
+			}
 			return $user_id;
 		}
 	}

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -49,7 +49,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$user_id = self::register_sample_reader();
 		$this->assertIsInt( $user_id );
 		$this->assertInstanceOf( 'WP_User', get_user_by( 'email', self::$reader_email ) );
-		$this->assertInstanceOf( 'WP_User', get_user_by( 'ID', $user_id ) );
+		$this->assertInstanceOf( 'WP_User', get_user_by( 'id', $user_id ) );
 		$this->assertTrue( get_user_meta( $user_id, Reader_Activation::READER, true ) );
 	}
 
@@ -59,7 +59,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	public function test_verify_reader_email() {
 		$user_id = self::register_sample_reader();
 		$this->assertFalse( get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) );
-		$verified = verify_reader_email( get_user_by( 'ID', $user_id ) );
+		$verified = Reader_Activation::verify_reader_email( get_user_by( 'id', $user_id ) );
 		$this->assertTrue( $verified );
 		$this->assertTrue( get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) );
 	}
@@ -86,9 +86,9 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 				'role'       => 'administrator',
 			]
 		);
-		$this->assertFalse( Reader_Activation::is_user_reader( $user_id ) );
+		$this->assertFalse( Reader_Activation::is_user_reader( get_user_by( 'id', $user_id ) ) );
 
 		$reader_id = self::register_sample_reader();
-		$this->assertTrue( Reader_Activation::is_user_reader( $reader_id ) );
+		$this->assertTrue( Reader_Activation::is_user_reader( get_user_by( 'id', $reader_id ) ) );
 	}
 }

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -58,7 +58,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	 */
 	public function test_verify_reader_email() {
 		$user_id = self::register_sample_reader();
-		$this->assertEmpty( get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) );
+		$this->assertFalse( get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) );
 		$verified = verify_reader_email( get_user_by( 'ID', $user_id ) );
 		$this->assertTrue( $verified );
 		$this->assertTrue( get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) );
@@ -76,7 +76,6 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 			self::$reader_email,
 			'Returned value from registering existing reader is its email'
 		);
-		$this->assertEquals( $reader_email, $email );
 	}
 
 	/**

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -51,6 +51,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_User', get_user_by( 'email', self::$reader_email ) );
 		$this->assertInstanceOf( 'WP_User', get_user_by( 'id', $user_id ) );
 		$this->assertTrue( (bool) get_user_meta( $user_id, Reader_Activation::READER, true ) );
+		wp_delete_user( $user_id );
 	}
 
 	/**
@@ -63,16 +64,17 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$verified = Reader_Activation::verify_reader_email( get_user_by( 'id', $user_id ) );
 		$this->assertTrue( $verified );
 		$this->assertTrue( Reader_Activation::is_reader_verified( $user ) );
+		wp_delete_user( $user_id );
 	}
 
 	/**
 	 * Test that registering an existing reader returns the inserted email.
 	 */
 	public function test_register_existing_reader() {
-		self::register_sample_reader();
-		// Reregister the same reader.
-		$email = self::register_sample_reader();
+		$user_id = self::register_sample_reader();
+		$email   = self::register_sample_reader(); // Reregister the same email.
 		$this->assertEquals( $email, self::$reader_email );
+		wp_delete_user( $user_id );
 	}
 
 	/**
@@ -91,5 +93,8 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 
 		$reader_id = self::register_sample_reader();
 		$this->assertTrue( Reader_Activation::is_user_reader( get_user_by( 'id', $reader_id ) ) );
+
+		wp_delete_user( $user_id );
+		wp_delete_user( $reader_id );
 	}
 }

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -47,9 +47,9 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	 */
 	public function test_register_reader() {
 		$user_id = self::register_sample_reader();
-		$this->assertNotEmpty( $user_id );
-		$this->assertNotEmpty( get_user_by( 'email', self::$reader_email ) );
-		$this->assertNotEmpty( get_user_by( 'ID', $user_id ) );
+		$this->assertIsInt( $user_id );
+		$this->assertInstanceOf( 'WP_User', get_user_by( 'email', self::$reader_email ) );
+		$this->assertInstanceOf( 'WP_User', get_user_by( 'ID', $user_id ) );
 		$this->assertTrue( get_user_meta( $user_id, Reader_Activation::READER, true ) );
 	}
 
@@ -71,11 +71,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		self::register_sample_reader();
 		// Reregister the same reader.
 		$email = self::register_sample_reader();
-		$this->assertEquals(
-			$email,
-			self::$reader_email,
-			'Returned value from registering existing reader is its email'
-		);
+		$this->assertEquals( $email, self::$reader_email );
 	}
 
 	/**

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -50,7 +50,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$this->assertIsInt( $user_id );
 		$this->assertInstanceOf( 'WP_User', get_user_by( 'email', self::$reader_email ) );
 		$this->assertInstanceOf( 'WP_User', get_user_by( 'id', $user_id ) );
-		$this->assertTrue( get_user_meta( $user_id, Reader_Activation::READER, true ) );
+		$this->assertTrue( (bool) get_user_meta( $user_id, Reader_Activation::READER, true ) );
 	}
 
 	/**
@@ -58,10 +58,11 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	 */
 	public function test_verify_reader_email() {
 		$user_id = self::register_sample_reader();
-		$this->assertFalse( get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) );
+		$user    = get_user_by( 'id', $user_id );
+		$this->assertFalse( Reader_Activation::is_reader_verified( $user ) );
 		$verified = Reader_Activation::verify_reader_email( get_user_by( 'id', $user_id ) );
 		$this->assertTrue( $verified );
-		$this->assertTrue( get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) );
+		$this->assertTrue( Reader_Activation::is_reader_verified( $user ) );
 	}
 
 	/**

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Tests the Reader Activation functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Activation;
+
+/**
+ * Tests the Reader Activation functionality.
+ */
+class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
+
+	/**
+	 * Test reader email.
+	 *
+	 * @var string
+	 */
+	private static $reader_email = 'reader@test.com';
+
+	/**
+	 * Test reader name.
+	 *
+	 * @var string
+	 */
+	private static $reader_name = 'Reader Test';
+
+	/**
+	 * Setup for the tests.
+	 */
+	public function setUp() {
+		if ( ! defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) ) {
+			define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );
+		}
+	}
+
+	/**
+	 * Helper function to register sample reader
+	 */
+	private static function register_sample_reader() {
+		return Reader_Activation::register_reader( self::$reader_email, self::$reader_name );
+	}
+
+	/**
+	 * Test that registering a reader creates and authenticates a user with reader
+	 * meta.
+	 */
+	public function test_register_reader() {
+		$user_id = self::register_sample_reader();
+		$this->assertNotEmpty( $user_id );
+		$this->assertNotEmpty( get_user_by( 'email', self::$reader_email ) );
+		$this->assertNotEmpty( get_user_by( 'ID', $user_id ) );
+		$this->assertTrue( get_user_meta( $user_id, Reader_Activation::READER, true ) );
+		$auth_cookie = wp_parse_auth_cookie();
+		$this->assertEquals( $reader_email, $auth_cookie['username'] );
+	}
+
+	/**
+	 * Test that verifying a reader register the proper meta.
+	 */
+	public function test_verify_reader_email() {
+		$user_id = self::register_sample_reader();
+		$this->assertEmpty( get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) );
+		$verified = verify_reader_email( get_user_by( 'ID', $user_id ) );
+		$this->assertTrue( $verified );
+		$this->assertTrue( get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) );
+	}
+
+	/**
+	 * Test that registering an existing reader creates auth intention.
+	 */
+	public function test_register_existing_reader() {
+		self::register_sample_reader();
+		// Reregister the same reader.
+		$email = self::register_sample_reader();
+		$this->assertEquals(
+			$email,
+			self::$reader_email,
+			'Returned value from registering existing reader is its email'
+		);
+		$this->assertFalse( is_user_logged_in() );
+		$this->assertEquals( $reader_email, self::get_auth_intention() );
+	}
+
+	/**
+	 * Test method that validates if user is a reader.
+	 */
+	public function test_is_user_reader() {
+		$user_id = wp_insert_user(
+			[
+				'user_login' => 'sample-admin',
+				'user_pass'  => wp_generate_password(),
+				'user_email' => 'test@test.com',
+				'role'       => 'administrator',
+			]
+		);
+		$this->assertFalse( Reader_Activation::is_user_reader( $reader_id ) );
+
+		$reader_id = self::register_sample_reader();
+		$this->assertTrue( Reader_Activation::is_user_reader( $reader_id ) );
+	}
+}

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -13,6 +13,13 @@ use Newspack\Reader_Activation;
 class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 
 	/**
+	 * Test reader ID.
+	 *
+	 * @var string
+	 */
+	private static $reader_id = null;
+
+	/**
 	 * Test reader email.
 	 *
 	 * @var string
@@ -33,6 +40,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		if ( ! defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) ) {
 			define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );
 		}
+		self::$reader_id = self::register_sample_reader();
 	}
 
 	/**
@@ -46,35 +54,29 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	 * Test that registering a reader creates a user with reader meta.
 	 */
 	public function test_register_reader() {
-		$user_id = self::register_sample_reader();
-		$this->assertIsInt( $user_id );
+		$this->assertIsInt( self::$reader_id );
 		$this->assertInstanceOf( 'WP_User', get_user_by( 'email', self::$reader_email ) );
-		$this->assertInstanceOf( 'WP_User', get_user_by( 'id', $user_id ) );
-		$this->assertTrue( (bool) get_user_meta( $user_id, Reader_Activation::READER, true ) );
-		wp_delete_user( $user_id );
+		$this->assertInstanceOf( 'WP_User', get_user_by( 'id', self::$reader_id ) );
+		$this->assertTrue( (bool) get_user_meta( self::$reader_id, Reader_Activation::READER, true ) );
 	}
 
 	/**
 	 * Test that verifying a reader register the proper meta.
 	 */
 	public function test_verify_reader_email() {
-		$user_id = self::register_sample_reader();
-		$user    = get_user_by( 'id', $user_id );
+		$user = get_user_by( 'id', self::$reader_id );
 		$this->assertFalse( Reader_Activation::is_reader_verified( $user ) );
-		$verified = Reader_Activation::verify_reader_email( get_user_by( 'id', $user_id ) );
+		$verified = Reader_Activation::verify_reader_email( $user );
 		$this->assertTrue( $verified );
 		$this->assertTrue( Reader_Activation::is_reader_verified( $user ) );
-		wp_delete_user( $user_id );
 	}
 
 	/**
 	 * Test that registering an existing reader returns the inserted email.
 	 */
 	public function test_register_existing_reader() {
-		$user_id = self::register_sample_reader();
-		$email   = self::register_sample_reader(); // Reregister the same email.
+		$email = self::register_sample_reader(); // Reregister the same email.
 		$this->assertEquals( $email, self::$reader_email );
-		wp_delete_user( $user_id );
 	}
 
 	/**
@@ -91,10 +93,6 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		);
 		$this->assertFalse( Reader_Activation::is_user_reader( get_user_by( 'id', $user_id ) ) );
 
-		$reader_id = self::register_sample_reader();
-		$this->assertTrue( Reader_Activation::is_user_reader( get_user_by( 'id', $reader_id ) ) );
-
-		wp_delete_user( $user_id );
-		wp_delete_user( $reader_id );
+		$this->assertTrue( Reader_Activation::is_user_reader( get_user_by( 'id', self::$reader_id ) ) );
 	}
 }

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -43,8 +43,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that registering a reader creates and authenticates a user with reader
-	 * meta.
+	 * Test that registering a reader creates a user with reader meta.
 	 */
 	public function test_register_reader() {
 		$user_id = self::register_sample_reader();
@@ -52,8 +51,6 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_user_by( 'email', self::$reader_email ) );
 		$this->assertNotEmpty( get_user_by( 'ID', $user_id ) );
 		$this->assertTrue( get_user_meta( $user_id, Reader_Activation::READER, true ) );
-		$auth_cookie = wp_parse_auth_cookie();
-		$this->assertEquals( $reader_email, $auth_cookie['username'] );
 	}
 
 	/**
@@ -68,7 +65,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that registering an existing reader creates auth intention.
+	 * Test that registering an existing reader returns the inserted email.
 	 */
 	public function test_register_existing_reader() {
 		self::register_sample_reader();
@@ -79,8 +76,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 			self::$reader_email,
 			'Returned value from registering existing reader is its email'
 		);
-		$this->assertFalse( is_user_logged_in() );
-		$this->assertEquals( $reader_email, self::get_auth_intention() );
+		$this->assertEquals( $reader_email, $email );
 	}
 
 	/**
@@ -95,7 +91,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 				'role'       => 'administrator',
 			]
 		);
-		$this->assertFalse( Reader_Activation::is_user_reader( $reader_id ) );
+		$this->assertFalse( Reader_Activation::is_user_reader( $user_id ) );
 
 		$reader_id = self::register_sample_reader();
 		$this->assertTrue( Reader_Activation::is_user_reader( $reader_id ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements reader registration functionality to the donation block.

#### Auth intention

If the reader registration detects an existing user, a cookie stores the auth intention that is accessible through the `Reader_Activation::get_auth_intention()` method. This API can be used across other plugins to improve UX over resolving the reader authentication, subscription, donation, etc.

This PR currently implements the auth intention to the `wp_login_form()` defaults, which is used by the core's Login block. Unfortunately this hook is not applied to the WooCommerce's My Account page login form.

#### The reader

The PR also proposes the definition of a reader user, which can be any user with the `np_reader` meta or within the roles `subscriber` or `customer`. Identifying a reader helps us build flows tied specifically to this type of user, such as the magic link functionality.

#### Email verification

Reader registration aims for a quick user registration and doesn't impose any validation for a new reader to be created and authenticated. The `Reader_Activation::verify_reader_email()` method is public but also executed on the reset password form action hook (`resetpass_form`). Once a registered reader clicks on the reset password link received on their email, it'll trigger the method to make the reader verified.

#### Experimental flag

This PR also proposes that all experimental features related to reader activation should be placed behind `NEWSPACK_EXPERIMENTAL_READER_ACTIVATION`.

### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have the AMP Plus flag and Reader Revenue setup with a test Stripe account
2. Add the experimental flag to your config: `define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );`
3. While logged out, visit a page with the Donate block and send a test donation with an email that does not exist
4. Visit WooCommerce's `my-account/orders` page and confirm you are logged in and you see the donation order
5. Log out, donate again with the same email
6. Attempt to visit `my-account/orders` and confirm you are not authenticated
7. Check the browser cookies and confirm the `np_auth_intention` cookie with the email as the value
8. Logged-in as admin, visit the Orders dashboard and confirm the last donation is not connected to the existing customer

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->