### PR TITLE
Setup Wizard: Remove theme selection from setup wizard

### DIFF
--- a/assets/wizards/site-design/views/main/index.js
+++ b/assets/wizards/site-design/views/main/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, Fragment } from '@wordpress/element';
 import { alignCenter, alignLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -140,11 +140,15 @@ const Main = ( { wizardApiFetch, setError, renderPrimaryButton, isPartOfSetup = 
 
 	return (
 		<Card noBorder className="newspack-design">
-			<SectionHeader
-				title={ __( 'Theme', 'newspack' ) }
-				description={ __( 'Select the theme for your site', 'newspack' ) }
-			/>
-			<ThemeSelection theme={ themeSlug } updateTheme={ updateThemeSlug } />
+			{ ! isPartOfSetup && (
+				<Fragment>
+					<SectionHeader
+						title={ __( 'Theme', 'newspack' ) }
+						description={ __( 'Select the theme for your site', 'newspack' ) }
+					/>
+					<ThemeSelection theme={ themeSlug } updateTheme={ updateThemeSlug } />
+				</Fragment>
+			) }
 			{ isDisplayingHomepageLayoutPicker ? (
 				<>
 					<SectionHeader


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the theme selection step from the Setup Wizard (but keeps it on the regular Site Design screen).

Closes #1544

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Run the Newspack Setup Wizard; confirm that when you get to the Design tab of the setup, it starts with the Homepage Patterns rather than theme selection:

![image](https://user-images.githubusercontent.com/177561/169420144-bca6d8df-ecbe-4f62-987a-2449f21fa0f5.png)

3. Complete the wizard.
4. Navigate to Dashboard > Newspack > Site Design and confirm that the theme selection is still at the top. 

(As an aside, I'd appreciate some feedback on whether `! isPartOfSetup` was a good choice here -- it felt weird to me to test for a `false` since every other check in the file for `isPartOfSetup` was checking for `true`, but I might be overthinking this! 😅). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->