### PR TITLE
fix(rss-feeds): skip Jetpack lazy loading on RSS feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.82.2-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.82.1...v1.82.2-hotfix.1) (2022-05-23)
+
+
+### Bug Fixes
+
+* **rss-feeds:** skip Jetpack lazy loading on RSS feeds ([58c64bf](https://github.com/Automattic/newspack-plugin/commit/58c64bfc1e73654e135fcc162e2ea5a12e290599))
+
 ## [1.82.1](https://github.com/Automattic/newspack-plugin/compare/v1.82.0...v1.82.1) (2022-05-18)
 
 

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -32,6 +32,20 @@ class Jetpack {
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'jetpack_async_scripts' ], 20 );
 		add_filter( 'newspack_amp_plus_sanitized', [ __CLASS__, 'jetpack_modules_amp_plus' ], 10, 2 );
 		add_action( 'wp_head', [ __CLASS__, 'fix_instant_search_sidebar_display' ], 10 );
+		add_filter( 'jetpack_lazy_images_skip_image_with_attributes', [ __CLASS__, 'skip_lazy_loading_on_feeds' ], 10 );
+	}
+
+	/**
+	 * Skip image lazy-loading on RSS feeds.
+	 *
+	 * @param bool $skip_lazy_loading Whether to skip lazy-loading.
+	 * @return @bool Whether to skip lazy-loading.
+	 */
+	public static function skip_lazy_loading_on_feeds( $skip_lazy_loading ) {
+		if ( is_feed() ) {
+			return true;
+		}
+		return $skip_lazy_loading;
 	}
 
 	/**

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.82.1
+ * Version: 1.82.2-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.82.1",
+  "version": "1.82.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.82.1",
+      "version": "1.82.2-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.17.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.82.1",
+  "version": "1.82.2-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with Jetpack – featured images are lazy-loaded in RSS feeds. Yet to submit a bug on Jetpack.

### How to test the changes in this Pull Request:

1. Install ["Shoyu RSS/Atom Feed Preview" chrome extension](https://chrome.google.com/webstore/detail/shoyu-rssatom-feed-previe/ilicaedjojicckapfpfdoakbehjpfkah) to preview a feed (other RSS viewers seem to handle the lazy-loaded images)
2. On `master`, with Jetpack configured, preview site's feed (`site.com/feed`) and observe the featured images are missing
3. Switch to this branch, observe the featured images are displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->