### PR TITLE
feat: magic links

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -530,30 +530,35 @@ final class Magic_Link {
 			);
 		}
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! isset( $_GET['action'] ) || self::AUTH_ACTION !== $_GET['action'] ) {
 			return;
 		}
 
 		$errored = false;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! isset( $_GET['token'] ) || ! isset( $_GET['email'] ) ) {
 			$errored = true;
 		}
 
-		$email = \sanitize_email( $_GET['email'] );
-		if ( $email ) {
-			$user = \get_user_by( 'email', $email );
-			if ( ! $user ) {
+		if ( ! $errored ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$email = \sanitize_email( $_GET['email'] );
+			if ( $email ) {
+				$user = \get_user_by( 'email', $email );
+				if ( ! $user ) {
+					$errored = true;
+				}
+			} else {
 				$errored = true;
 			}
-		} else {
-			$errored = true;
 		}
-		$token = \sanitize_text_field( \wp_unslash( $_GET['token'] ) );
-		// phpcs:enable
 
 		$authenticated = false;
+
 		if ( ! $errored ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$token         = \sanitize_text_field( \wp_unslash( $_GET['token'] ) );
 			$authenticated = self::authenticate( $user->ID, $token );
 		}
 

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -254,7 +254,7 @@ final class Magic_Link {
 		}
 
 		/** Generate the new token. */
-		$token       = \wp_hash( \wp_generate_password() );
+		$token       = \wp_generate_password( 60, false, false );
 		$client_hash = self::get_client_hash( $user, true );
 		$token_data  = [
 			'token'  => $token,

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -640,14 +640,14 @@ final class Magic_Link {
 	 * @return string Admin URL to perform an admin action.
 	 */
 	private static function get_admin_action_url( $action, $user_id ) {
-		if ( ! is_admin() ) {
+		if ( ! \is_admin() ) {
 			return '';
 		}
 		if ( ! isset( self::ADMIN_ACTIONS[ $action ] ) ) {
 			return '';
 		}
 		$admin_action = self::ADMIN_ACTIONS[ $action ];
-		return add_query_arg(
+		return \add_query_arg(
 			[
 				'action'   => $admin_action,
 				'uid'      => $user_id,

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -163,7 +163,7 @@ final class Magic_Link {
 			return null;
 		}
 
-		/** Don't return client hash if it's not self-served. */
+		/** Return client hash only if it's self-served. */
 		if ( \is_user_logged_in() && \get_current_user_id() !== $user->ID ) {
 			return null;
 		}

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -142,7 +142,7 @@ final class Magic_Link {
 			/** Add an extra 5 minutes to the client secret cookie expiration. */
 			$expiration = time() + self::get_token_expiration_period() + ( 5 * MINUTE_IN_SECONDS );
 
-		  // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
 			setcookie( self::COOKIE, $secret, $expiration, COOKIEPATH, COOKIE_DOMAIN, true );
 		}
 

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -150,7 +150,7 @@ final class Magic_Link {
 	}
 
 	/**
-	 * Get client hash for the current session.
+	 * Get client hash for the current session, if self-served.
 	 *
 	 * @param \WP_User $user         User the client hash is being generated for.
 	 * @param bool     $reset_secret Whether to reset the stored client secret.

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -673,16 +673,16 @@ final class Magic_Link {
 			$message = '';
 			switch ( $update ) {
 				case $actions['send']:
-					$message = __( 'Magic link sent.', 'newspack' );
+					$message = __( 'Authentication link sent.', 'newspack' );
 					break;
 				case $actions['clear']:
-					$message = __( 'All magic link tokens were removed.', 'newspack' );
+					$message = __( 'All authentication link tokens were removed.', 'newspack' );
 					break;
 				case $actions['disable']:
-					$message = __( 'Magic links are now disabled.', 'newspack' );
+					$message = __( 'Authentication links are now disabled.', 'newspack' );
 					break;
 				case $actions['enable']:
-					$message = __( 'Magic links are now enabled.', 'newspack' );
+					$message = __( 'Authentication links are now enabled.', 'newspack' );
 					break;
 			}
 			if ( ! empty( $message ) ) {
@@ -764,21 +764,21 @@ final class Magic_Link {
 		$disabled = (bool) \get_user_meta( $user->ID, self::DISABLED_META, true );
 		?>
 		<div class="newspack-magic-link-management">
-			<h2><?php _e( 'Magic Link Management', 'newspack' ); ?></h2>
+			<h2><?php _e( 'Passwordless Authentication Management', 'newspack' ); ?></h2>
 			<table class="form-table" role="presentation">
 				<tr id="newspack-magic-link-support">
-					<th><label><?php _e( 'Magic Link Support', 'newspack' ); ?></label></th>
+					<th><label><?php _e( 'Authentication Link Support', 'newspack' ); ?></label></th>
 					<td>
 						<?php if ( $disabled ) : ?>
-							<a class="button" href="<?php echo \esc_url( self::get_admin_action_url( 'enable', $user->ID ) ); ?>"><?php _e( 'Enable Magic Links' ); ?></a>
+							<a class="button" href="<?php echo \esc_url( self::get_admin_action_url( 'enable', $user->ID ) ); ?>"><?php _e( 'Enable Authentication Links' ); ?></a>
 						<?php else : ?>
-							<a class="button" href="<?php echo \esc_url( self::get_admin_action_url( 'disable', $user->ID ) ); ?>"><?php _e( 'Disable Magic Links' ); ?></a>
+							<a class="button" href="<?php echo \esc_url( self::get_admin_action_url( 'disable', $user->ID ) ); ?>"><?php _e( 'Disable Authentication Links' ); ?></a>
 						<?php endif; ?>
 						<p class="description">
 								<?php
 								printf(
 									/* translators: %1$s: Disabled or enabled. %2$s: User's display name. */
-									\esc_html__( 'Magic link authentication is currently %1$s for %2$s.', 'newspack' ),
+									\esc_html__( 'Authentication links support is currently %1$s for %2$s.', 'newspack' ),
 									$disabled ? \esc_html__( 'disabled', 'newspack' ) : \esc_html__( 'enabled', 'newspack' ),
 									\esc_html( $user->display_name )
 								);
@@ -788,9 +788,9 @@ final class Magic_Link {
 				</tr>
 				<?php if ( ! $disabled ) : ?>
 					<tr id="newspack-magic-link-send">
-						<th><label><?php _e( 'Send Magic Link', 'newspack' ); ?></label></th>
+						<th><label><?php _e( 'Send Authentication Link', 'newspack' ); ?></label></th>
 						<td>
-							<a class="button" href="<?php echo \esc_url( self::get_admin_action_url( 'send', $user->ID ) ); ?>"><?php _e( 'Send Magic Link' ); ?></a>
+							<a class="button" href="<?php echo \esc_url( self::get_admin_action_url( 'send', $user->ID ) ); ?>"><?php _e( 'Send Authentication Link' ); ?></a>
 							<p class="description">
 								<?php
 								printf(
@@ -811,7 +811,7 @@ final class Magic_Link {
 								<?php
 								printf(
 									/* translators: %s: User's display name. */
-									\esc_html__( 'Clear all existing magic link tokens for %s.', 'newspack' ),
+									\esc_html__( 'Clear all existing authentication link tokens for %s.', 'newspack' ),
 									\esc_html( $user->display_name )
 								);
 								?>

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -652,7 +652,7 @@ final class Magic_Link {
 		}
 		if ( self::can_magic_link( $user->ID ) && \current_user_can( 'edit_user', $user->ID ) ) {
 			$url                                 = self::get_admin_action_url( 'send', $user->ID );
-			$actions['newspack-magic-link-send'] = '<a href="' . $url . '">' . \esc_html__( 'Send magic link', 'newspack' ) . '</a>';
+			$actions['newspack-magic-link-send'] = '<a href="' . $url . '">' . \esc_html__( 'Send authentication link', 'newspack' ) . '</a>';
 		}
 		return $actions;
 	}

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -214,7 +214,7 @@ final class Magic_Link {
 		 */
 		do_action( 'newspack_magic_link_user_tokens_cleared', $user );
 	}
-	
+
 	/**
 	 * Generate magic link token.
 	 *
@@ -384,7 +384,7 @@ final class Magic_Link {
 
 	/**
 	 * Verify and returns the valid token given a user, token and client.
-	 * 
+	 *
 	 * This method cleans up expired tokens and returns the token data for
 	 * immediate use.
 	 *
@@ -723,7 +723,7 @@ final class Magic_Link {
 
 	/**
 	 * Magic link management for the user profile editor page.
-	 * 
+	 *
 	 * @param WP_User $user The current WP_User object.
 	 */
 	public static function edit_user_profile( $user ) {

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -183,7 +183,7 @@ final class Magic_Link {
 		/**
 		 * Filters whether to use a locally stored secret as a client hash argument.
 		 *
-		 * @param bool $use_cookie Whether to use a locally stored secret as a client hash argument.
+		 * @param bool $use_secret Whether to use a locally stored secret as a client hash argument.
 		 */
 		if ( true === \apply_filters( 'newspack_magic_link_use_secret', true ) ) {
 			$hash_args['secret'] = self::get_client_secret( $reset_secret );
@@ -253,14 +253,14 @@ final class Magic_Link {
 		}
 
 		/** Generate the new token. */
-		$token      = \wp_hash( \wp_generate_password() );
-		$client     = self::get_client_hash( $user, true );
-		$token_data = [
+		$token       = \wp_hash( \wp_generate_password() );
+		$client_hash = self::get_client_hash( $user, true );
+		$token_data  = [
 			'token'  => $token,
-			'client' => ! empty( $client ) ? $client : '',
+			'client' => ! empty( $client_hash ) ? $client_hash : '',
 			'time'   => $now,
 		];
-		$tokens[]   = $token_data;
+		$tokens[]    = $token_data;
 		\update_user_meta( $user->ID, self::TOKENS_META, $tokens );
 		return $token_data;
 	}
@@ -468,8 +468,8 @@ final class Magic_Link {
 			return new \WP_Error( 'invalid_user', __( 'User not found.', 'newspack' ) );
 		}
 
-		$client     = self::get_client_hash( $user );
-		$token_data = self::validate_token( $user_id, $client, $token );
+		$client_hash = self::get_client_hash( $user );
+		$token_data  = self::validate_token( $user_id, $client_hash, $token );
 
 		if ( \is_wp_error( $token_data ) ) {
 			return $token_data;

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -441,7 +441,7 @@ final class Magic_Link {
 		}
 
 		if ( empty( $valid_token ) ) {
-			$errors->add( 'expired_token', __( 'Token has expired.', 'newspack' ) );
+			$errors->add( 'invalid_token', __( 'Invalid token.', 'newspack' ) );
 		}
 		self::clear_client_secret_cookie();
 

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -126,7 +126,7 @@ final class Magic_Link {
 
 		/** Fetch cookie if available. */
 		if ( empty( $secret ) && isset( $_COOKIE[ self::COOKIE ] ) ) {
-		  // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 			$secret = \sanitize_text_field( \wp_unslash( $_COOKIE[ self::COOKIE ] ) );
 		}
 

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -1,0 +1,801 @@
+<?php
+/**
+ * Newspack Magic Links functionality.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Magic Links class.
+ */
+final class Magic_Link {
+
+	const ADMIN_ACTIONS = [
+		'send'    => 'np_magic_link_send',
+		'clear'   => 'np_magic_link_clear',
+		'disable' => 'np_magic_link_disable',
+		'enable'  => 'np_magic_link_enable',
+	];
+
+	const TOKENS_META   = 'np_magic_link_tokens';
+	const DISABLED_META = 'np_magic_link_disabled';
+
+	const AUTH_ACTION = 'np_auth_link';
+	const COOKIE      = 'np_auth_link';
+
+	/**
+	 * Current session secret.
+	 *
+	 * @var string
+	 */
+	private static $session_secret = '';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+
+		/** Authentication hooks */
+		\add_action( 'clear_auth_cookie', [ __CLASS__, 'clear_client_secret_cookie' ] );
+		\add_action( 'set_auth_cookie', [ __CLASS__, 'clear_client_secret_cookie' ] );
+		\add_action( 'template_redirect', [ __CLASS__, 'process_token_request' ] );
+
+		/** Admin functionality */
+		\add_action( 'init', [ __CLASS__, 'wp_cli' ] );
+		\add_action( 'admin_init', [ __CLASS__, 'process_admin_action' ] );
+		\add_filter( 'user_row_actions', [ __CLASS__, 'user_row_actions' ], 10, 2 );
+		\add_action( 'edit_user_profile', [ __CLASS__, 'edit_user_profile' ] );
+
+	}
+
+	/**
+	 * Whether a user can use magic links.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return bool Whether the user can use magic links.
+	 */
+	public static function can_magic_link( $user_id ) {
+		if ( ! Reader_Activation::is_enabled() ) {
+			return false;
+		}
+
+		$user = \get_user_by( 'id', $user_id );
+
+		if ( ! $user || \is_wp_error( $user ) ) {
+			return false;
+		}
+
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			return false;
+		}
+
+		$can_magic_link = ! (bool) \get_user_meta( $user_id, self::DISABLED_META, true );
+
+		/**
+		 * Filters whether the user can use magic links.
+		 *
+		 * @param bool     $can_magic_link Whether the user can use magic links.
+		 * @param \WP_User $user           User object.
+		 */
+		return \apply_filters( 'newspack_can_magic_link', $can_magic_link, $user );
+	}
+
+	/**
+	 * Get magic link token expiration period.
+	 *
+	 * @return int Expiration in seconds.
+	 */
+	private static function get_token_expiration_period() {
+		/**
+		 * Filters the duration of the magic link token expiration period.
+		 *
+		 * @param int    $length Duration of the expiration period in seconds.
+		 */
+		return \apply_filters( 'newspack_magic_link_token_expiration', 30 * MINUTE_IN_SECONDS );
+	}
+
+	/**
+	 * Clear client secret cookie.
+	 */
+	public static function clear_client_secret_cookie() {
+		/** This filter is documented in wp-includes/pluggable.php */
+		if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+			return;
+		}
+
+		if ( ! isset( $_COOKIE[ self::COOKIE ] ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+		setcookie( self::COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+	}
+
+	/**
+	 * Get locally stored secret to be used as part of the client hash.
+	 *
+	 * @param bool $reset Whether to generate a new secret.
+	 */
+	private static function get_client_secret( $reset = false ) {
+		$secret = self::$session_secret;
+
+		/** Fetch cookie if available. */
+		if ( empty( $secret ) && isset( $_COOKIE[ self::COOKIE ] ) ) {
+		  // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+			$secret = \sanitize_text_field( \wp_unslash( $_COOKIE[ self::COOKIE ] ) );
+		}
+
+		/** Regenerate if empty or resetting. */
+		if ( empty( $secret ) || true === $reset ) {
+			$secret = \wp_generate_password( 43, false, false );
+		}
+
+		self::$session_secret = $secret;
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		if ( \apply_filters( 'send_auth_cookies', true ) ) {
+			/** Add an extra 5 minutes to the client secret cookie expiration. */
+			$expiration = time() + self::get_token_expiration_period() + ( 5 * MINUTE_IN_SECONDS );
+
+		  // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+			setcookie( self::COOKIE, $secret, $expiration, COOKIEPATH, COOKIE_DOMAIN, true );
+		}
+
+		return $secret;
+	}
+
+	/**
+	 * Get client hash for the current session.
+	 *
+	 * @param \WP_User $user         User the client hash is being generated for.
+	 * @param bool     $reset_secret Whether to reset the stored client secret.
+	 *
+	 * @return string|null Client hash or null if unable to generate one.
+	 */
+	private static function get_client_hash( $user, $reset_secret = false ) {
+		/** Don't return client hash from CLI command */
+		if ( defined( 'WP_CLI' ) ) {
+			return null;
+		}
+
+		/** Don't return client hash if it's not self-served. */
+		if ( \is_user_logged_in() && \get_current_user_id() !== $user->ID ) {
+			return null;
+		}
+
+		$hash_args = [];
+
+		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		if ( isset( $_SERVER['REMOTE_ADDR'] ) && ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+			// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+			$hash_args['ip'] = \wp_unslash( $_SERVER['REMOTE_ADDR'] );
+		}
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && ! empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+			$hash_args['user_agent'] = \wp_unslash( $_SERVER['HTTP_USER_AGENT'] );
+		}
+
+		/**
+		 * Filters whether to use a locally stored secret as a client hash argument.
+		 *
+		 * @param bool $use_cookie Whether to use a locally stored secret as a client hash argument.
+		 */
+		if ( true === \apply_filters( 'newspack_magic_link_use_secret', true ) ) {
+			$hash_args['secret'] = self::get_client_secret( $reset_secret );
+		}
+
+		/**
+		 * Filters the client hash arguments for the current session.
+		 *
+		 * @param string[] $hash_args Client hash arguments.
+		 */
+		$hash_args = \apply_filters( 'newspack_magic_link_client_hash_args', $hash_args );
+
+		return ! empty( $hash_args ) ? \wp_hash( implode( '', $hash_args ) ) : null;
+	}
+
+	/**
+	 * Clear all user tokens.
+	 *
+	 * @param \WP_User $user User to clear tokens for.
+	 */
+	public static function clear_user_tokens( $user ) {
+		\delete_user_meta( $user->ID, self::TOKENS_META );
+
+		/**
+		 * Fires after all user tokens are cleared.
+		 *
+		 * @param \WP_User $user User for which tokens were cleared.
+		 */
+		do_action( 'newspack_magic_link_user_tokens_cleared', $user );
+	}
+	
+	/**
+	 * Generate magic link token.
+	 *
+	 * @param \WP_User $user User to generate the magic link token for.
+	 *
+	 * @return array|\WP_Error {
+	 *   Magic link token data.
+	 *
+	 *   @type string $token  The token.
+	 *   @type string $client Origin IP hash.
+	 *   @type string $time   Token creation time.
+	 * }
+	 */
+	public static function generate_token( $user ) {
+		if ( ! self::can_magic_link( $user->ID ) ) {
+			return new \WP_Error( 'newspack_magic_link_invalid_user', __( 'Invalid user.', 'newspack' ) );
+		}
+
+		$now    = time();
+		$tokens = \get_user_meta( $user->ID, self::TOKENS_META, true );
+		if ( empty( $tokens ) ) {
+			$tokens = [];
+		}
+
+		$expire = $now - self::get_token_expiration_period();
+		if ( ! empty( $tokens ) ) {
+			/** Limit maximum tokens to 5. */
+			$tokens = array_slice( $tokens, -4, 4 );
+			/** Clear expired tokens. */
+			foreach ( $tokens as $index => $token_data ) {
+				if ( $token_data['time'] < $expire ) {
+					unset( $tokens[ $index ] );
+				}
+			}
+			$tokens = array_values( $tokens );
+		}
+
+		/** Generate the new token. */
+		$token      = \wp_hash( \wp_generate_password() );
+		$client     = self::get_client_hash( $user, true );
+		$token_data = [
+			'token'  => $token,
+			'client' => ! empty( $client ) ? $client : '',
+			'time'   => $now,
+		];
+		$tokens[]   = $token_data;
+		\update_user_meta( $user->ID, self::TOKENS_META, $tokens );
+		return $token_data;
+	}
+
+	/**
+	 * Generate a magic link.
+	 *
+	 * @param \WP_User $user User to generate the magic link for.
+	 * @param string   $url  Destination url. Default is home_url().
+	 *
+	 * @return string|\WP_Error Magic link url or WP_Error if token generation failed.
+	 */
+	private static function generate_url( $user, $url = '' ) {
+		$token_data = self::generate_token( $user );
+
+		if ( \is_wp_error( $token_data ) ) {
+			return $token_data;
+		}
+
+		return \add_query_arg(
+			[
+				'action' => self::AUTH_ACTION,
+				'uid'    => $user->ID,
+				'token'  => $token_data['token'],
+			],
+			! empty( $url ) ? $url : \home_url()
+		);
+	}
+
+	/**
+	 * Get a magic link email arguments given a user.
+	 *
+	 * @param \WP_User $user        User to generate the magic link for.
+	 * @param string   $redirect_to Which page to redirect the reader after authenticating.
+	 *
+	 * @return array|\WP_Error $email Email arguments or error. {
+	 *   Used to build wp_mail().
+	 *
+	 *   @type string $to      The intended recipient - New user email address.
+	 *   @type string $subject The subject of the email.
+	 *   @type string $message The body of the email.
+	 *   @type string $headers The headers of the email.
+	 * }
+	 */
+	public static function generate_email( $user, $redirect_to = '' ) {
+		if ( ! self::can_magic_link( $user->ID ) ) {
+			return new \WP_Error( 'newspack_magic_link_invalid_user', __( 'Invalid user.', 'newspack' ) );
+		}
+
+		$magic_link_url = self::generate_url( $user, $redirect_to );
+
+		if ( \is_wp_error( $magic_link_url ) ) {
+			return $magic_link_url;
+		}
+
+		$blogname = \wp_specialchars_decode( \get_option( 'blogname' ), ENT_QUOTES );
+
+		$switched_locale = \switch_to_locale( \get_user_locale( $user ) );
+
+		/* translators: %s: Site title. */
+		$message  = sprintf( __( 'Welcome back to %s!', 'newspack' ), $blogname ) . "\r\n\r\n";
+		$message .= __( 'Authenticate your account by visiting the following address:', 'newspack' ) . "\r\n\r\n";
+		$message .= $magic_link_url . "\r\n";
+
+		$email = [
+			'to'      => $user->user_email,
+			/* translators: %s Site title. */
+			'subject' => __( '[%s] Authentication link', 'newspack' ),
+			'message' => $message,
+			'headers' => '',
+		];
+
+		if ( $switched_locale ) {
+			\restore_previous_locale();
+		}
+
+		/**
+		 * Filters the magic link email.
+		 *
+		 * @param array    $email          Email arguments. {
+		 *   Used to build wp_mail().
+		 *
+		 *   @type string $to      The intended recipient - New user email address.
+		 *   @type string $subject The subject of the email.
+		 *   @type string $message The body of the email.
+		 *   @type string $headers The headers of the email.
+		 * }
+		 * @param \WP_User $user           User to send the magic link to.
+		 * @param string   $magic_link_url Magic link url.
+		 */
+		return \apply_filters( 'newspack_magic_link_email', $email, $user, $magic_link_url );
+	}
+
+	/**
+	 * Send magic link email to reader.
+	 *
+	 * @param \WP_User $user        User to send the magic link to.
+	 * @param string   $redirect_to Which page to redirect the reader after authenticating.
+	 *
+	 * @return bool|\WP_Error Whether the email was sent or WP_Error if sending failed.
+	 */
+	public static function send_email( $user, $redirect_to = '' ) {
+		$email = self::generate_email( $user, $redirect_to );
+
+		if ( \is_wp_error( $email ) ) {
+			return $email;
+		}
+
+		$blogname = \wp_specialchars_decode( \get_option( 'blogname' ), ENT_QUOTES );
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+		$sent = \wp_mail(
+			$email['to'],
+			\wp_specialchars_decode( sprintf( $email['subject'], $blogname ) ),
+			$email['message'],
+			$email['headers']
+		);
+
+		return $sent;
+	}
+
+	/**
+	 * Verify and returns the valid token given a user, token and client.
+	 * 
+	 * This method cleans up expired tokens and returns the token data for
+	 * immediate use.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $client  Client hash.
+	 * @param string $token   Token to verify.
+	 *
+	 * @return array|\WP_Error {
+	 *   Token data.
+	 *
+	 *   @type string $token  The token.
+	 *   @type string $client Client hash.
+	 *   @type string $time   Token creation time.
+	 * }
+	 */
+	public static function validate_token( $user_id, $client, $token ) {
+		$errors = new \WP_Error();
+		$user   = \get_user_by( 'id', $user_id );
+
+		if ( ! $user ) {
+			$errors->add( 'invalid_user', __( 'User not found.', 'newspack' ) );
+		} elseif ( ! self::can_magic_link( $user->ID ) ) {
+			$errors->add( 'invalid_user_type', __( 'Not allowed for this user', 'newspack' ) );
+		} else {
+			$tokens = \get_user_meta( $user->ID, self::TOKENS_META, true );
+			if ( empty( $tokens ) || empty( $token ) ) {
+				$errors->add( 'invalid_token', __( 'Invalid token.', 'newspack' ) );
+			}
+		}
+
+		$valid_token = false;
+
+		if ( ! $errors->has_errors() ) {
+			$expire = time() - self::get_token_expiration_period();
+
+			foreach ( $tokens as $index => $token_data ) {
+				if ( $token_data['time'] < $expire ) {
+					unset( $tokens[ $index ] );
+
+				} elseif ( $token_data['token'] === $token ) {
+					$valid_token = $token_data;
+
+					/** If token data has a client hash, it must be equal to the user's. */
+					if ( ! empty( $token_data['client'] ) && $token_data['client'] !== $client ) {
+						$errors->add( 'invalid_client', __( 'Invalid client.', 'newspack' ) );
+					}
+
+					unset( $tokens[ $index ] );
+					break;
+				}
+			}
+
+			if ( empty( $valid_token ) ) {
+				$errors->add( 'expired_token', __( 'Token has expired.', 'newspack' ) );
+			}
+			self::clear_client_secret_cookie();
+
+			$tokens = array_values( $tokens );
+			\update_user_meta( $user->ID, self::TOKENS_META, $tokens );
+		}
+
+		return $errors->has_errors() ? $errors : $valid_token;
+	}
+
+	/**
+	 * Handle a reader authentication attempt using magic link token.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $token   Token to authenticate.
+	 *
+	 * @return bool|\WP_Error Whether the user was authenticated or WP_Error.
+	 */
+	private static function authenticate( $user_id, $token ) {
+		if ( \is_user_logged_in() ) {
+			return false;
+		}
+
+		$user = \get_user_by( 'id', $user_id );
+
+		if ( ! $user ) {
+			return new \WP_Error( 'invalid_user', __( 'User not found.', 'newspack' ) );
+		}
+
+		$client     = self::get_client_hash( $user );
+		$token_data = self::validate_token( $user_id, $client, $token );
+
+		if ( \is_wp_error( $token_data ) ) {
+			return $token_data;
+		}
+
+		if ( empty( $token_data ) ) {
+			return false;
+		}
+
+		Reader_Activation::set_reader_verified( $user );
+		Reader_Activation::set_current_reader( $user->ID );
+
+		/**
+		 * Fires after a reader has been authenticated via magic link.
+		 *
+		 * @param \WP_User $user User that has been authenticated.
+		 */
+		do_action( 'newspack_magic_link_authenticated', $user );
+
+		return true;
+	}
+
+	/**
+	 * Process magic link token from request.
+	 */
+	public static function process_token_request() {
+		if ( ! Reader_Activation::is_enabled() ) {
+			return;
+		}
+
+		if ( \is_user_logged_in() ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['action'] ) || self::AUTH_ACTION !== $_GET['action'] ) {
+			return;
+		}
+		if ( ! isset( $_GET['token'] ) || ! isset( $_GET['uid'] ) ) {
+			\wp_die( \esc_html__( 'Invalid request.', 'newspack' ) );
+		}
+
+		$user_id = \absint( \wp_unslash( $_GET['uid'] ) );
+		$token   = \sanitize_text_field( \wp_unslash( $_GET['token'] ) );
+		// phpcs:enable
+
+		$authenticated = self::authenticate( $user_id, $token );
+
+		if ( \is_wp_error( $authenticated ) ) {
+			/** Do not disclose error messages. */
+			\wp_die( \esc_html__( 'We were not able to authenticate through this link.', 'newspack' ) );
+		}
+
+		\wp_safe_redirect( \remove_query_arg( [ 'action', 'uid', 'token' ] ) );
+		exit;
+	}
+
+	/**
+	 * WP CLI Commands.
+	 */
+	public static function wp_cli() {
+		if ( ! defined( 'WP_CLI' ) ) {
+			return;
+		}
+		if ( ! Reader_Activation::is_enabled() ) {
+			return;
+		}
+
+		/**
+		 * Sends a magic link to a reader.
+		 *
+		 * ## OPTIONS
+		 *
+		 * <email_or_id>
+		 * : The email address or user ID of the reader.
+		 *
+		 * ## EXAMPLES
+		 *
+		 *     wp newspack magic-link send 12
+		 *     wp newspack magic-link send john@doe.com
+		 *
+		 * @when after_wp_load
+		 */
+		$send = function( $args, $assoc_args ) {
+			if ( ! isset( $args[0] ) ) {
+				\WP_CLI::error( 'Please provide a user email or ID.' );
+			}
+			$id_or_email = $args[0];
+
+			if ( \absint( $id_or_email ) ) {
+				$user = \get_user_by( 'id', $id_or_email );
+			} else {
+				$user = \get_user_by( 'email', $id_or_email );
+			}
+
+			if ( ! $user || \is_wp_error( $user ) ) {
+				\WP_CLI::error( __( 'User not found.', 'newspack' ) );
+			}
+
+			$result = self::send_email( $user );
+
+			if ( \is_wp_error( $result ) ) {
+				\WP_CLI::error( $result->get_error_message() );
+			}
+
+			// translators: %s is the email address of the user.
+			\WP_CLI::success( sprintf( __( 'Email sent to %s.', 'newspack' ), $user->user_email ) );
+		};
+		\WP_CLI::add_command(
+			'newspack magic-link send',
+			$send,
+			[
+				'shortdesc' => __( 'Send a magic link to a reader.', 'newspack' ),
+			]
+		);
+	}
+
+	/**
+	 * Get url for an admin action.
+	 *
+	 * @param string $action  Which admin action get the URL for.
+	 * @param int    $user_id User to get the URL for.
+	 *
+	 * @return string Admin URL to perform an admin action.
+	 */
+	private static function get_admin_action_url( $action, $user_id ) {
+		if ( ! is_admin() ) {
+			return '';
+		}
+		if ( ! isset( self::ADMIN_ACTIONS[ $action ] ) ) {
+			return '';
+		}
+		$admin_action = self::ADMIN_ACTIONS[ $action ];
+		return add_query_arg(
+			[
+				'action'   => $admin_action,
+				'uid'      => $user_id,
+				'_wpnonce' => \wp_create_nonce( $admin_action ),
+			]
+		);
+	}
+
+	/**
+	 * Adds magic link send action to user row actions.
+	 *
+	 * @param string[] $actions User row actions.
+	 * @param \WP_User $user    User object.
+	 *
+	 * @return string[] User row actions.
+	 */
+	public static function user_row_actions( $actions, $user ) {
+		if ( ! Reader_Activation::is_enabled() ) {
+			return $actions;
+		}
+		if ( self::can_magic_link( $user->ID ) ) {
+			$url                                 = self::get_admin_action_url( 'send', $user->ID );
+			$actions['newspack-magic-link-send'] = '<a href="' . $url . '">' . \esc_html__( 'Send magic link', 'newspack' ) . '</a>';
+		}
+		return $actions;
+	}
+
+	/**
+	 * Process admin action request.
+	 */
+	public static function process_admin_action() {
+		if ( ! Reader_Activation::is_enabled() ) {
+			return;
+		}
+
+		$actions = self::ADMIN_ACTIONS;
+
+		/** Add notice if admin action was successful. */
+		if ( isset( $_GET['update'] ) && in_array( $_GET['update'], $actions, true ) ) {
+			$update = \sanitize_text_field( \wp_unslash( $_GET['update'] ) );
+			\add_action(
+				'admin_notices',
+				function() use ( $actions, $update ) {
+					$message = '';
+					switch ( $update ) {
+						case $actions['send']:
+							$message = __( 'Magic link sent.', 'newspack' );
+							break;
+						case $actions['clear']:
+							$message = __( 'All magic link tokens were removed.', 'newspack' );
+							break;
+						case $actions['disable']:
+							$message = __( 'Magic links are now disabled.', 'newspack' );
+							break;
+						case $actions['enable']:
+							$message = __( 'Magic links are now enabled.', 'newspack' );
+							break;
+					}
+					if ( ! empty( $message ) ) {
+						?>
+						<div id="message" class="updated notice is-dismissible"><p><?php echo \esc_html( $message ); ?></p></div>
+						<?php
+					}
+				}
+			);
+		}
+
+		if ( ! isset( $_GET['action'] ) || ! in_array( $_GET['action'], $actions, true ) ) {
+			return;
+		}
+
+		$action = \sanitize_text_field( \wp_unslash( $_GET['action'] ) );
+
+		if ( ! isset( $_GET['uid'] ) ) {
+			\wp_die( \esc_html__( 'Invalid request.', 'newspack' ) );
+		}
+
+		if ( ! \check_admin_referer( $action ) ) {
+			\wp_die( \esc_html__( 'Invalid request.', 'newspack' ) );
+		}
+
+		$user_id = \absint( \wp_unslash( $_GET['uid'] ) );
+
+		if ( ! \current_user_can( 'edit_user', $user_id ) ) {
+			\wp_die( \esc_html__( 'You do not have permission to do that.', 'newspack' ) );
+		}
+
+		$user = \get_user_by( 'id', $user_id );
+
+		if ( ! $user || \is_wp_error( $user ) ) {
+			\wp_die( \esc_html__( 'User not found.', 'newspack' ) );
+		}
+
+		switch ( $action ) {
+			case $actions['send']:
+				$result = self::send_email( $user );
+				if ( \is_wp_error( $result ) ) {
+					\wp_die( $result ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				}
+				break;
+			case $actions['clear']:
+				self::clear_user_tokens( $user );
+				break;
+			case $actions['disable']:
+				self::clear_user_tokens( $user );
+				\update_user_meta( $user_id, self::DISABLED_META, true );
+				break;
+			case $actions['enable']:
+				\delete_user_meta( $user_id, self::DISABLED_META );
+				break;
+		}
+
+		$redirect = \add_query_arg( [ 'update' => $action ], \remove_query_arg( [ 'action', 'uid', '_wpnonce' ] ) );
+		\wp_safe_redirect( $redirect );
+		exit;
+	}
+
+	/**
+	 * Magic link management for the user profile editor page.
+	 * 
+	 * @param WP_User $user The current WP_User object.
+	 */
+	public static function edit_user_profile( $user ) {
+		if ( ! Reader_Activation::is_enabled() ) {
+			return;
+		}
+
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			return;
+		}
+
+		$disabled = (bool) \get_user_meta( $user->ID, self::DISABLED_META, true );
+		?>
+		<div class="newspack-magic-link-management">
+			<h2><?php _e( 'Magic Link Management', 'newspack' ); ?></h2>
+			<table class="form-table" role="presentation">
+				<tr id="newspack-magic-link-support">
+					<th><label><?php _e( 'Magic Link Support', 'newspack' ); ?></label></th>
+					<td>
+						<?php if ( $disabled ) : ?>
+							<a class="button" href="<?php echo \esc_url( self::get_admin_action_url( 'enable', $user->ID ) ); ?>"><?php _e( 'Enable Magic Links' ); ?></a>
+						<?php else : ?>
+							<a class="button" href="<?php echo \esc_url( self::get_admin_action_url( 'disable', $user->ID ) ); ?>"><?php _e( 'Disable Magic Links' ); ?></a>
+						<?php endif; ?>
+						<p class="description">
+								<?php
+								printf(
+									/* translators: %1$s: Disabled or enabled. %2$s: User's display name. */
+									\esc_html__( 'Magic link authentication is currently %1$s for %2$s.', 'newspack' ),
+									$disabled ? \esc_html__( 'disabled', 'newspack' ) : \esc_html__( 'enabled', 'newspack' ),
+									\esc_html( $user->display_name )
+								);
+								?>
+							</p>
+					</td>
+				</tr>
+				<?php if ( ! $disabled ) : ?>
+					<tr id="newspack-magic-link-send">
+						<th><label><?php _e( 'Send Magic Link', 'newspack' ); ?></label></th>
+						<td>
+							<a class="button" href="<?php echo \esc_url( self::get_admin_action_url( 'send', $user->ID ) ); ?>"><?php _e( 'Send Magic Link' ); ?></a>
+							<p class="description">
+								<?php
+								printf(
+									/* translators: %1$s: User's display name. %2$d is the expiration period in minutes. */
+									\esc_html__( 'Generate and send a new link to %1$s, which will authenticate them instantly. The link will be valid for %2$d minutes after its creation.', 'newspack' ),
+									\esc_html( $user->display_name ),
+									\esc_html( \absint( self::get_token_expiration_period() ) / MINUTE_IN_SECONDS )
+								);
+								?>
+							</p>
+						</td>
+					</tr>
+					<tr id="newspack-magic-link-clear">
+						<th><label><?php _e( 'Clear All Tokens', 'newspack' ); ?></label></th>
+						<td>
+							<a class="button" href="<?php echo \esc_url( self::get_admin_action_url( 'clear', $user->ID ) ); ?>"><?php _e( 'Clear All Tokens' ); ?></a>
+							<p class="description">
+								<?php
+								printf(
+									/* translators: %s: User's display name. */
+									\esc_html__( 'Clear all existing magic link tokens for %s.', 'newspack' ),
+									\esc_html( $user->display_name )
+								);
+								?>
+							</p>
+						</td>
+					</tr>
+				<?php endif; ?>
+			</table>
+		</div>
+		<?php
+	}
+}
+Magic_Link::init();

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -224,7 +224,7 @@ final class Magic_Link {
 	 *   Magic link token data.
 	 *
 	 *   @type string $token  The token.
-	 *   @type string $client Origin IP hash.
+	 *   @type string $client Client hash.
 	 *   @type string $time   Token creation time.
 	 * }
 	 */

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -508,8 +508,8 @@ final class Magic_Link {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET[ self::AUTH_ACTION_RESULT ] ) && 0 === absint( $_GET[ self::AUTH_ACTION_RESULT ] ) ) {
-			add_action(
+		if ( isset( $_GET[ self::AUTH_ACTION_RESULT ] ) && 0 === \absint( $_GET[ self::AUTH_ACTION_RESULT ] ) ) {
+			\add_action(
 				'before_header',
 				function () {
 					?>
@@ -522,7 +522,7 @@ final class Magic_Link {
 						}
 					</style>
 					<div class="newspack-magic-link-error">
-						<?php esc_html_e( 'We were not able to authenticate your account through this link. Please generate a new one.', 'newspack' ); ?>
+						<?php \esc_html_e( 'We were not able to authenticate your account through this link. Please generate a new one.', 'newspack' ); ?>
 					</div>
 					<?php
 				},

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -643,32 +643,32 @@ final class Magic_Link {
 
 		/** Add notice if admin action was successful. */
 		if ( isset( $_GET['update'] ) && in_array( $_GET['update'], $actions, true ) ) {
-			$update = \sanitize_text_field( \wp_unslash( $_GET['update'] ) );
-			\add_action(
-				'admin_notices',
-				function() use ( $actions, $update ) {
-					$message = '';
-					switch ( $update ) {
-						case $actions['send']:
-							$message = __( 'Magic link sent.', 'newspack' );
-							break;
-						case $actions['clear']:
-							$message = __( 'All magic link tokens were removed.', 'newspack' );
-							break;
-						case $actions['disable']:
-							$message = __( 'Magic links are now disabled.', 'newspack' );
-							break;
-						case $actions['enable']:
-							$message = __( 'Magic links are now enabled.', 'newspack' );
-							break;
-					}
-					if ( ! empty( $message ) ) {
+			$update  = \sanitize_text_field( \wp_unslash( $_GET['update'] ) );
+			$message = '';
+			switch ( $update ) {
+				case $actions['send']:
+					$message = __( 'Magic link sent.', 'newspack' );
+					break;
+				case $actions['clear']:
+					$message = __( 'All magic link tokens were removed.', 'newspack' );
+					break;
+				case $actions['disable']:
+					$message = __( 'Magic links are now disabled.', 'newspack' );
+					break;
+				case $actions['enable']:
+					$message = __( 'Magic links are now enabled.', 'newspack' );
+					break;
+			}
+			if ( ! empty( $message ) ) {
+				\add_action(
+					'admin_notices',
+					function() use ( $message ) {
 						?>
 						<div id="message" class="updated notice is-dismissible"><p><?php echo \esc_html( $message ); ?></p></div>
 						<?php
 					}
-				}
-			);
+				);
+			}
 		}
 
 		if ( ! isset( $_GET['action'] ) || ! in_array( $_GET['action'], $actions, true ) ) {

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -624,7 +624,7 @@ final class Magic_Link {
 		if ( ! Reader_Activation::is_enabled() ) {
 			return $actions;
 		}
-		if ( self::can_magic_link( $user->ID ) ) {
+		if ( self::can_magic_link( $user->ID ) && \current_user_can( 'edit_user', $user->ID ) ) {
 			$url                                 = self::get_admin_action_url( 'send', $user->ID );
 			$actions['newspack-magic-link-send'] = '<a href="' . $url . '">' . \esc_html__( 'Send magic link', 'newspack' ) . '</a>';
 		}

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -417,34 +417,36 @@ final class Magic_Link {
 
 		$valid_token = false;
 
-		if ( ! $errors->has_errors() ) {
-			$expire = time() - self::get_token_expiration_period();
-
-			foreach ( $tokens as $index => $token_data ) {
-				if ( $token_data['time'] < $expire ) {
-					unset( $tokens[ $index ] );
-
-				} elseif ( $token_data['token'] === $token ) {
-					$valid_token = $token_data;
-
-					/** If token data has a client hash, it must be equal to the user's. */
-					if ( ! empty( $token_data['client'] ) && $token_data['client'] !== $client ) {
-						$errors->add( 'invalid_client', __( 'Invalid client.', 'newspack' ) );
-					}
-
-					unset( $tokens[ $index ] );
-					break;
-				}
-			}
-
-			if ( empty( $valid_token ) ) {
-				$errors->add( 'expired_token', __( 'Token has expired.', 'newspack' ) );
-			}
-			self::clear_client_secret_cookie();
-
-			$tokens = array_values( $tokens );
-			\update_user_meta( $user->ID, self::TOKENS_META, $tokens );
+		if ( $errors->has_errors() ) {
+			return $errors;
 		}
+
+		$expire = time() - self::get_token_expiration_period();
+
+		foreach ( $tokens as $index => $token_data ) {
+			if ( $token_data['time'] < $expire ) {
+				unset( $tokens[ $index ] );
+
+			} elseif ( $token_data['token'] === $token ) {
+				$valid_token = $token_data;
+
+				/** If token data has a client hash, it must be equal to the user's. */
+				if ( ! empty( $token_data['client'] ) && $token_data['client'] !== $client ) {
+					$errors->add( 'invalid_client', __( 'Invalid client.', 'newspack' ) );
+				}
+
+				unset( $tokens[ $index ] );
+				break;
+			}
+		}
+
+		if ( empty( $valid_token ) ) {
+			$errors->add( 'expired_token', __( 'Token has expired.', 'newspack' ) );
+		}
+		self::clear_client_secret_cookie();
+
+		$tokens = array_values( $tokens );
+		\update_user_meta( $user->ID, self::TOKENS_META, $tokens );
 
 		return $errors->has_errors() ? $errors : $valid_token;
 	}

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -79,6 +79,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-analytics.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-reader-activation.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-magic-link.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-stripe-connection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-woocommerce-connection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-reader-revenue-emails.php';

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -210,7 +210,7 @@ final class Reader_Activation {
 	 *
 	 * @return \WP_User|\WP_Error The authenticated reader or WP_Error if authentication failed.
 	 */
-	private static function set_current_reader( $user_id ) {
+	public static function set_current_reader( $user_id ) {
 		$user_id = \absint( $user_id );
 		if ( empty( $user_id ) ) {
 			return new \WP_Error( 'newspack_authenticate_invalid_user_id', __( 'Invalid user id.', 'newspack' ) );
@@ -265,7 +265,9 @@ final class Reader_Activation {
 
 		$user_id = false;
 
-		if ( ! $existing_user ) {
+		if ( $existing_user ) {
+			Magic_Link::send_email( $existing_user );
+		} else {
 			/**
 			 * Create new reader.
 			 */

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -47,7 +47,13 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 
 		// Create a secondary sample reader.
 		if ( empty( self::$secondary_user_id ) ) {
-			self::$secondary_user_id = Reader_Activation::register_reader( 'secondary@test.com', 'Secondary Reader' );
+			self::$secondary_user_id = wp_insert_user(
+				[
+					'user_login' => 'secondary-user',
+					'user_pass'  => wp_generate_password(),
+					'user_email' => 'secondary@test.com',
+				]
+			);
 		}
 
 		// Create sample admin.
@@ -172,6 +178,17 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 		$validation   = Magic_Link::validate_token( self::$user_id, $token_data['client'], $random_token );
 		$this->assertTrue( is_wp_error( $validation ) );
 		$this->assertEquals( 'invalid_token', $validation->get_error_code() );
+	}
+
+	/**
+	 * Test invalid client hash.
+	 */
+	public function test_invalid_client_hash() {
+		$token_data         = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$random_client_hash = wp_generate_password( 32 );
+		$validation         = Magic_Link::validate_token( self::$user_id, $random_client_hash, $token_data['token'] );
+		$this->assertTrue( is_wp_error( $validation ) );
+		$this->assertEquals( 'invalid_client', $validation->get_error_code() );
 	}
 
 	/**

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Tests the Magic Link functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Magic_Link;
+use Newspack\Reader_Activation;
+
+/**
+ * Tests the Magic Link functionality.
+ */
+class Newspack_Test_Magic_Link extends WP_UnitTestCase {
+	/**
+	 * Reader user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id = null;
+
+	/**
+	 * Admin user id.
+	 *
+	 * @var int
+	 */
+	private static $admin_id = null;
+
+	/**
+	 * Setup for the tests.
+	 */
+	public function setUp() {
+		// Enable reader activation.
+		add_filter( 'newspack_reader_activation_enabled', '__return_true' );
+
+		// Create sample reader.
+		if ( empty( self::$user_id ) ) {
+			self::$user_id = Reader_Activation::register_reader( 'reader@test.com', 'Test Reader' );
+		}
+
+		// Create sample admin.
+		if ( empty( self::$admin_id ) ) {
+			self::$admin_id = wp_insert_user(
+				[
+					'user_login' => 'sample-admin',
+					'user_pass'  => wp_generate_password(),
+					'user_email' => 'admin@test.com',
+					'role'       => 'administrator',
+				]
+			);
+		}
+	}
+
+	/**
+	 * Assert valid token.
+	 *
+	 * @param array $token_data Token data. {
+	 *   The token data.
+	 *
+	 *   @type string $token  The token.
+	 *   @type string $client Client hash.
+	 *   @type string $time   Token creation time.
+	 * }
+	 */
+	public function assertToken( $token_data ) {
+		$this->assertFalse( is_wp_error( $token_data ) );
+		$this->assertIsString( $token_data['token'] );
+		$this->assertIsString( $token_data['client'] );
+		$this->assertIsInt( $token_data['time'] );
+	}
+
+	/**
+	 * Test simple token generation.
+	 */
+	public function test_generate_token() {
+		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$this->assertToken( $token_data );
+	}
+
+	/**
+	 * Test simple token validation.
+	 */
+	public function test_validate_token() {
+		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$this->assertToken( Magic_Link::validate_token( self::$user_id, $token_data['client'], $token_data['token'] ) );
+	}
+
+	/**
+	 * Test single-use quality of a token.
+	 */
+	public function test_single_use_token() {
+		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+
+		// First use should be valid.
+		$first_validation = Magic_Link::validate_token( self::$user_id, $token_data['client'], $token_data['token'] );
+		$this->assertToken( $first_validation );
+
+		// Second use should error with "expired_token", since it was deleted by previous use.
+		$second_validation = Magic_Link::validate_token( self::$user_id, $token_data['client'], $token_data['token'] );
+		$this->assertTrue( is_wp_error( $second_validation ) );
+		$this->assertEquals( 'expired_token', $second_validation->get_error_code() );
+	}
+
+	/**
+	 * Test that generating a token for an admin returns an error.
+	 */
+	public function test_generate_token_for_admin() {
+		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$admin_id ) );
+		$this->assertTrue( is_wp_error( $token_data ) );
+		$this->assertEquals( 'newspack_magic_link_invalid_user', $token_data->get_error_code() );
+	}
+
+	/**
+	 * Test that generating a token for a user with disabled magic links returns
+	 * an error.
+	 */
+	public function test_generate_token_for_disabled_user() {
+		update_user_meta( self::$user_id, Magic_Link::DISABLED_META, true );
+		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$this->assertTrue( is_wp_error( $token_data ) );
+		$this->assertEquals( 'newspack_magic_link_invalid_user', $token_data->get_error_code() );
+		delete_user_meta( self::$user_id, Magic_Link::DISABLED_META ); // Clean up.
+	}
+
+	/**
+	 * Test that a self-served (unauthenticated) generated token contains a client
+	 * hash for validation.
+	 */
+	public function test_generate_self_served_token() {
+		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$this->assertNotEmpty( $token_data['client'] );
+	}
+
+	/**
+	 * Test that an admin generated token does not contain a client hash for
+	 * validation.
+	 */
+	public function test_generate_admin_token() {
+		wp_set_current_user( self::$admin_id );
+		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$this->assertEmpty( $token_data['client'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements magic link functionality that should only be available to a "reader", as implemented by #1655.

Magic links are single-use authentication links that are sent to the user's registered email.

This implementation limits the number of simultaneous valid tokens to 5, which should be a safe amount in case the reader attempts to authenticate multiple devices at once. The limit is also a safety measure, because magic link creation, naturally, does not require authentication.

Also as a safety measure, magic links expire 30 minutes after creation.

This feature should only be available with reader activation enabled.

# Self-Served vs. Admin-Generated

Magic links can be generated and sent by an anonymous user, these are self-served. Self-served links have a salted client hash attached to them. They are formed by the following arguments:
- Random secret
- IP
- User-agent

The random secret is stored locally through a cookie for client hash validation. If the client hash does not match, the magic link fails to authenticate.

Admin-generated links do not have a client hash and can be used by anyone.

# Email

<img width="840" alt="image" src="https://user-images.githubusercontent.com/820752/170741200-c6ea44f5-3df4-4593-abad-c399057d5482.png">

The sent email is minimalistic, filterable, and highly inspired by WP's [`wp_new_user_notification()`](https://github.com/WordPress/wordpress-develop/blob/6.0/src/wp-includes/pluggable.php#L2098-L2217). It serves the purpose of the functionality but for the "reader activation" project, all reader-related messaging should be tackled separately in a unified cohesive effort.

# Management

There are a few tools available for the management of a user's magic link support. An admin can:
- Manually send a new magic link to the user
- Clear all existing tokens for a user
- Disable/enable magic link support for a user

## Dashboard

<img width="285" alt="image" src="https://user-images.githubusercontent.com/820752/170734360-77d94dd4-82a3-4b38-aba1-7b90ff2656de.png">

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/820752/170734471-c93282f6-a108-4c8a-8ad5-02e29ba6a2e2.png">

## CLI

A magic link can also be sent with WP-CLI:

```
NAME

  wp newspack magic-link send

DESCRIPTION

  Send a magic link to a reader.

SYNOPSIS

  wp newspack magic-link send <email_or_id>

OPTIONS

  <email_or_id>
    The email address or user ID of the reader.

EXAMPLES

    wp newspack magic-link send 12
    wp newspack magic-link send john@doe.com

```

### How to test the changes in this Pull Request:

Make sure you have AMP Plus on, reader revenue configured with WooCommerce and a valid Stripe test account, and the experimental reader activation flag on your `wp-config.php`:

```php
define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );
```

Also confirm you have a way to intercept sent emails, either through Mailhog or a configured SMTP.

## Admin-generated

The quickest simple test to a magic link is by sending as an admin:

1. While logged in as admin, visit the users' dashboard and mouse over a subscriber or customer (create one if you don't have any)
2. Confirm you see the "Send magic link" option
3. Click to send
4. Confirm the email was sent
5. Copy the link and paste it into an unauthenticated session (incognito)
6. Confirm you are authenticated by visiting WC's `my-account` page

## Admin management

### Clearing tokens

1. Click to edit the subscriber and scroll to "Magic Link Management"
2. Send another magic link through this page and confirm the email was sent
3. Before using the link on a new session, click on "Clear All Tokens"
4. Attempt to use the sent link and confirm you receive the generic error message

### Disabling magic links for a user

1. Send another magic link as above
2. Before using the link, click on "Disable Magic Links"
3. Confirm the "Magic Link Management" section of the page now only have a button to enable support
4. Navigate back to the users' dashboard and confirm that hovering the user does not show the "Send Magic Link" link
5. Attempt to use the previously sent link and confirm you receive the generic error message

### CLI

1. Make sure you have Magic Links enabled for the user
2. Open your instance CLI and type `wp newspack magic-link send –help` and confirm you see appropriate instructions
3. Send a magic link using the user email: `wp newspack magic-link send {email}`
4. Now the same using the user ID:  `wp newspack magic-link send {user_id}`
5. Confirm both emails are sent

## Self-served tokens

1. While unauthenticated, visit a page with the donation block
2. Send a test donation using an existing reader's email
3. Check your cookies and confirm you have a hashed value named `np_auth_link`
4. Confirm the email was sent, copy and paste it on the session above and confirm you're authenticated by accessing WC's `my-account` page

### Client hash validation

1. Repeat the steps above, but now paste the link on a new unauthenticated session (without the `np_auth_link` cookie)
2. Confirm you get the generic error message

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->