### PR TITLE
fix: deactivate Salesforce syncing if RR platform is not Newspack

### DIFF
--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -857,6 +857,11 @@ class Salesforce {
 	 * @return void
 	 */
 	private static function create_webhook() {
+		// Failsafe in case WC isn't active.
+		if ( ! class_exists( 'WC_Webhook' ) ) {
+			return;
+		}
+
 		$webhook = new \WC_Webhook();
 		$webhook->set_name( 'Sync Salesforce on order checkout' );
 		$webhook->set_topic( 'order.created' ); // Trigger on checkout.

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -41,11 +41,30 @@ class Salesforce {
 	 * Add hooks.
 	 */
 	public static function init() {
+		add_action( 'init', [ __CLASS__, 'platform_check' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'register_admin_scripts' ] );
 		add_action( 'woocommerce_order_actions_start', [ __CLASS__, 'wc_order_show_sync_status' ] );
 		add_filter( 'woocommerce_order_actions', [ __CLASS__, 'wc_order_manual_sync' ] );
 		add_action( 'woocommerce_order_action_newspack_sync_order_to_salesforce', [ __CLASS__, 'wc_order_manual_sync_action' ] );
+	}
+
+	/**
+	 * Check if Newspack is the current Reader Revenue platform.
+	 * If not, disable syncing. If so and the required webhook
+	 * doesn't exist, create it.
+	 */
+	public static function platform_check() {
+		$platform   = Donations::get_platform_slug();
+		$webhook_id = self::get_webhook();
+
+		if ( 'wc' !== $platform && $webhook_id ) {
+			self::delete_webhook( $webhook_id );
+		}
+
+		if ( 'wc' === $platform && ! $webhook_id ) {
+			self::create_webhook();
+		}
 	}
 
 	/**
@@ -184,7 +203,7 @@ class Salesforce {
 		$webhook_id = $request->get_header( 'X-WC-Webhook-ID' );
 
 		if ( $webhook_id ) {
-			$is_valid = (int) get_option( self::SALESFORCE_WEBHOOK_ID, 0 ) === (int) $webhook_id;
+			$is_valid = self::get_webhook() === (int) $webhook_id;
 		}
 
 		if ( $is_valid ) {
@@ -352,7 +371,7 @@ class Salesforce {
 		$settings = self::get_salesforce_settings();
 
 		// Check if the webhook is configured.
-		$webhook_id = get_option( self::SALESFORCE_WEBHOOK_ID, 0 );
+		$webhook_id = self::get_webhook();
 		$webhook    = wc_get_webhook( $webhook_id );
 		if ( null == $webhook ) {
 			return \rest_ensure_response(
@@ -612,11 +631,11 @@ class Salesforce {
 			// Create new contact.
 			$contact_response = self::create_contact( $contact );
 
-			if ( is_wp_error( $contact_response ) ) {
+			if ( is_wp_error( $contact_response ) || ! isset( $contact_response->id ) ) {
 				return \rest_ensure_response(
 					new \WP_Error(
 						'newspack_salesforce_contact_failure',
-						$contact_response->get_error_message()
+						isset( $contact_response->get_error_message ) ? $contact_response->get_error_message() : __( 'Error creating contact.', 'newspack' )
 					)
 				);
 			}
@@ -650,11 +669,11 @@ class Salesforce {
 					$opportunity_response = self::create_opportunity( $order_item );
 				}
 
-				if ( is_wp_error( $opportunity_response ) ) {
+				if ( is_wp_error( $opportunity_response ) || ! isset( $opportunity_response->id ) ) {
 					return \rest_ensure_response(
 						new \WP_Error(
 							'newspack_salesforce_opportunity_failure',
-							$opportunity_response->get_error_message()
+							isset( $opportunity_response->get_error_message ) ? $opportunity_response->get_error_message() : __( 'Error creating opportunity.', 'newspack' )
 						)
 					);
 				}
@@ -808,7 +827,7 @@ class Salesforce {
 		}
 
 		// Get webhook id.
-		$webhook_id = get_option( self::SALESFORCE_WEBHOOK_ID, 0 );
+		$webhook_id = self::get_webhook();
 
 		// If we're establishing a new connection and don't have an existing webhook, create a new one.
 		if ( empty( $webhook_id ) && ! empty( $args['refresh_token'] ) ) {
@@ -821,6 +840,15 @@ class Salesforce {
 		}
 
 		return self::get_salesforce_settings();
+	}
+
+	/**
+	 * Get ID for the WooCommerce webhook.
+	 *
+	 * @return int ID of the webhook, 0 if none.
+	 */
+	private static function get_webhook() {
+		return (int) get_option( self::SALESFORCE_WEBHOOK_ID, 0 );
 	}
 
 	/**
@@ -848,7 +876,7 @@ class Salesforce {
 	 * @return void
 	 */
 	private static function delete_webhook( $webhook_id ) {
-		update_option( self::SALESFORCE_WEBHOOK_ID, '' );
+		delete_option( self::SALESFORCE_WEBHOOK_ID );
 		$webhook = wc_get_webhook( $webhook_id );
 		if ( null !== $webhook ) {
 			$webhook->delete( true );

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -55,16 +55,25 @@ class Salesforce {
 	 * doesn't exist, create it.
 	 */
 	public static function platform_check() {
-		$platform   = Donations::get_platform_slug();
-		$webhook_id = self::get_webhook();
+		$is_newspack = self::platform_is_newspack();
+		$webhook_id  = self::get_webhook();
 
-		if ( 'wc' !== $platform && $webhook_id ) {
+		if ( ! $is_newspack && $webhook_id ) {
 			self::delete_webhook( $webhook_id );
 		}
 
-		if ( 'wc' === $platform && ! $webhook_id ) {
+		if ( $is_newspack && ! $webhook_id ) {
 			self::create_webhook();
 		}
+	}
+
+	/**
+	 * Check whether Newspack is the currently active Reader Revenue platform.
+	 *
+	 * @return boolean True if Newspack is the active platform.
+	 */
+	public static function platform_is_newspack() {
+		return 'wc' === Donations::get_platform_slug();
 	}
 
 	/**
@@ -223,7 +232,7 @@ class Salesforce {
 	 * Register admin scripts for Salesforce functionality.
 	 */
 	public static function register_admin_scripts() {
-		if ( 'shop_order' !== get_post_type() ) {
+		if ( 'shop_order' !== get_post_type() || ! self::platform_is_newspack() ) {
 			return;
 		}
 
@@ -1258,7 +1267,7 @@ class Salesforce {
 	 * @param int $order_id ID of the order being edited.
 	 */
 	public static function wc_order_show_sync_status( $order_id ) {
-		if ( ! self::is_connected() ) {
+		if ( ! self::is_connected() || ! self::platform_is_newspack() ) {
 			return;
 		}
 		?>

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -55,7 +55,7 @@ class Salesforce {
 	 * doesn't exist, create it.
 	 */
 	public static function platform_check() {
-		$is_newspack = self::platform_is_newspack();
+		$is_newspack = Donations::is_platform_wc();
 		$webhook_id  = self::get_webhook();
 
 		if ( ! $is_newspack && $webhook_id ) {
@@ -65,15 +65,6 @@ class Salesforce {
 		if ( $is_newspack && ! $webhook_id ) {
 			self::create_webhook();
 		}
-	}
-
-	/**
-	 * Check whether Newspack is the currently active Reader Revenue platform.
-	 *
-	 * @return boolean True if Newspack is the active platform.
-	 */
-	public static function platform_is_newspack() {
-		return 'wc' === Donations::get_platform_slug();
 	}
 
 	/**
@@ -232,7 +223,7 @@ class Salesforce {
 	 * Register admin scripts for Salesforce functionality.
 	 */
 	public static function register_admin_scripts() {
-		if ( 'shop_order' !== get_post_type() || ! self::platform_is_newspack() ) {
+		if ( 'shop_order' !== get_post_type() || ! Donations::is_platform_wc() ) {
 			return;
 		}
 
@@ -1267,7 +1258,7 @@ class Salesforce {
 	 * @param int $order_id ID of the order being edited.
 	 */
 	public static function wc_order_show_sync_status( $order_id ) {
-		if ( ! self::is_connected() || ! self::platform_is_newspack() ) {
+		if ( ! self::is_connected() || ! Donations::is_platform_wc() ) {
 			return;
 		}
 		?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue where if you had previously set up a Salesforce integration on the Newspack Reader Revenue platform, then changed to a different platform that still uses WooCommerce (e.g. Stripe), the Salesforce webhooks would still fire and attempt to sync, but fail because the orders don't contain the expected data. This fixes the issue by deactivating the webhooks if the wrong Reader Revenue platform is active, which should help clean up the debug log.

### How to test the changes in this Pull Request:

1. On `master`, make sure WooCommerce and all required extensions are installed and active. Set your Reader Revenue platform to "Newspack" and set up a [Salesforce integration](https://newspack.pub/support/reader-revenue/salesforce/). Ping me if you need test credentials. 
2. Change your platform to Stripe and complete Stripe configuration. Make sure to create the required webhooks.
3. On the front-end, make a donation via Stripe.
4. After a few minutes, observe fatals in your debug.log indicating a failed sync. In the WP dashboard, go to **WooCommerce > Orders** and find the order corresponding to your Stripe donation. Observe a "Salesforce sync status" message notice in the Order Actions panel indicating a failed sync.
5. Check out this branch, repeat step 3. This time, confirm there are no PHP errors thrown after the WC order is created, and confirm that the "Salesforce sync status" messaging is no longer shown in WC order pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->