### PR TITLE
fix: compare both IDs and labels for autocomplete selections

### DIFF
--- a/assets/components/src/autocomplete-with-suggestions/index.js
+++ b/assets/components/src/autocomplete-with-suggestions/index.js
@@ -241,7 +241,9 @@ const AutocompleteWithSuggestions = ( {
 		if ( multiSelect ) {
 			const selections = selectedPost ? [ ...selectedItems, selectedPost ] : [ ...selectedItems ];
 			const isSelected = !! selections.find(
-				_selection => parseInt( _selection.value ) === parseInt( suggestion.value )
+				_selection =>
+					parseInt( _selection.value ) === parseInt( suggestion.value ) &&
+					_selection.label === suggestion.label
 			);
 			return (
 				<CheckboxControl


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Plugs a hole in the functionality of the `AutocompleteWithSuggestions` component. Currently, it shows selected items in the suggestions list based solely on numeric ID; however, it's possible that multiple items in the suggestion list could have the same ID. So this change compares both ID and label values, which should make the selections more accurate.

This is a prerequisite for the fix in https://github.com/Automattic/newspack-blocks/pull/1154. It will need to be released to the `newspack-components` NPM package, and that package will need to be version-bumped in Newspack Blocks.

### How to test the changes in this Pull Request:

Follow the testing instructions in https://github.com/Automattic/newspack-blocks/pull/1154 to confirm that you can select a single item in the suggestions list when multiple suggestions share an ID value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->