### PR TITLE
refactor(oauth): google oauth handling

### DIFF
--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -384,6 +384,8 @@ class Google_OAuth {
 		$oauth_object->setAccessToken( $auth_data['access_token'] );
 		if ( isset( $auth_data['refresh_token'] ) ) {
 			$oauth_object->setRefreshToken( $auth_data['refresh_token'] );
+		} else {
+			Logger::log( 'Refresh token missing in the credentials – the authorisation will have to be refreshed in an hour.' );
 		}
 		return $oauth_object;
 	}

--- a/tests/unit-tests/oauth.php
+++ b/tests/unit-tests/oauth.php
@@ -44,7 +44,7 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 	/**
 	 * Google OAuth flow.
 	 */
-	public function test_google_oauth() {
+	public function test_oauth_google() {
 		self::expectException( Exception::class );
 		self::assertFalse(
 			OAuth::authenticate_proxy_url( 'google', '/wp-json/newspack-google' ),
@@ -85,7 +85,7 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 		Google_OAuth::api_google_auth_save_details( $proxy_response );
 
 		self::assertEquals(
-			false,
+			[],
 			Google_OAuth::get_google_auth_saved_data(),
 			'The auth data is not readable for just anyone.'
 		);
@@ -133,7 +133,7 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 	/**
 	 * Fivetran OAuth flow.
 	 */
-	public function test_fivetran_oauth() {
+	public function test_oauth_fivetran() {
 		self::expectException( Exception::class );
 		self::assertFalse(
 			OAuth::authenticate_proxy_url( 'fivetran', '/wp-json/newspack-fivetran' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

- Slightly tweaks how Google OAuth credentials retrieval handles failure – always returning an array. 
- Adds some `Logger` statements for easier debugging.

### How to test the changes in this Pull Request:

1. Set `NEWSPACK_LOG_LEVEL` env. variable to `2`
1. Configure site to use Google OAuth and complete the OAuth flow
2. Observe the site logs verbose messages along the way 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->