### PR TITLE
fix(ads): handle units from disconnected gam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.83.2-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.83.1...v1.83.2-hotfix.1) (2022-06-02)
+
+
+### Bug Fixes
+
+* **ads:** handle units from disconnected gam ([a7236d7](https://github.com/Automattic/newspack-plugin/commit/a7236d7e194ce52168c29ab8387c10e3f0d2be7a))
+
 ## [1.83.1](https://github.com/Automattic/newspack-plugin/compare/v1.83.0...v1.83.1) (2022-05-30)
 
 

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -69,6 +69,14 @@ const AdUnits = ( {
 	const { can_use_service_account, can_use_oauth, connection_mode } = serviceData.status;
 	const isLegacy = 'legacy' === connection_mode;
 
+	const isDisconnectedGAM = adUnit => {
+		return isLegacy && ! adUnit.is_legacy;
+	};
+
+	const canEdit = adUnit => {
+		return ! isDisconnectedGAM( adUnit );
+	};
+
 	return (
 		<>
 			<Card noBorder>
@@ -166,12 +174,17 @@ const AdUnits = ( {
 								key={ adUnit.id }
 								title={ adUnit.name }
 								isSmall
-								titleLink={ editLink }
+								titleLink={ canEdit( adUnit ) && editLink }
 								description={ () => (
 									<span>
 										{ adUnit.is_legacy ? (
 											<>
 												<i>{ __( 'Legacy ad unit.', 'newspack' ) }</i> |{ ' ' }
+											</>
+										) : null }
+										{ isDisconnectedGAM( adUnit ) ? (
+											<>
+												<i>{ __( 'Disconnected from GAM.', 'newspack' ) }</i> |{ ' ' }
 											</>
 										) : null }
 										{ adUnit.sizes?.length || adUnit.fluid ? (
@@ -186,10 +199,12 @@ const AdUnits = ( {
 									</span>
 								) }
 								actionText={
-									<OptionsPopover
-										deleteLink={ () => onDelete( adUnit.id ) }
-										editLink={ editLink }
-									/>
+									canEdit( adUnit ) && (
+										<OptionsPopover
+											deleteLink={ () => onDelete( adUnit.id ) }
+											editLink={ editLink }
+										/>
+									)
 								}
 							/>
 						);

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.83.1
+ * Version: 1.83.2-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.83.1",
+  "version": "1.83.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.83.1",
+      "version": "1.83.2-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.17.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.83.1",
+  "version": "1.83.2-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Handles uneditable units coming from disconnected 

### How to test the changes in this Pull Request:

Instructions at https://github.com/Automattic/newspack-ads/pull/428

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->