### PR TITLE
fix: oauth error handling

### DIFF
--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -276,11 +276,8 @@ class Google_OAuth {
 		if ( is_wp_error( $user_info_data ) ) {
 			return $user_info_data;
 		}
-		return \rest_ensure_response(
-			[
-				'user_basic_info' => $user_info_data,
-			]
-		);
+		$response['user_basic_info'] = $user_info_data;
+		return \rest_ensure_response( $response );
 	}
 
 	/**

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -389,7 +389,6 @@ class Google_OAuth {
 					if ( is_wp_error( $auth_save_result ) ) {
 						return $auth_save_result;
 					}
-					self::save_auth_credentials( $response_body );
 					$auth_data = self::get_google_auth_saved_data();
 				} else {
 					Logger::log( 'Access token missing from the response.' );

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -387,7 +387,8 @@ class Google_OAuth {
 					Logger::log( 'Refreshed the token.' );
 					$auth_save_result = self::save_auth_credentials( $response_body );
 					if ( is_wp_error( $auth_save_result ) ) {
-						return $auth_save_result;
+						Logger::log( 'Credentials saving resulted in an error: ' . $auth_save_result->get_error_message() );
+						return false;
 					}
 					$auth_data = self::get_google_auth_saved_data();
 				} else {

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -77,7 +77,6 @@ class Google_OAuth {
 					],
 					'refresh_token' => [
 						'sanitize_callback' => 'sanitize_text_field',
-						'required'          => true,
 					],
 					'csrf_token'    => [
 						'sanitize_callback' => 'sanitize_text_field',
@@ -153,10 +152,12 @@ class Google_OAuth {
 			);
 		}
 
-		$auth                  = self::get_google_auth_saved_data();
-		$auth['access_token']  = $tokens['access_token'];
-		$auth['expires_at']    = $tokens['expires_at'];
-		$auth['refresh_token'] = $tokens['refresh_token'];
+		$auth                 = self::get_google_auth_saved_data();
+		$auth['access_token'] = $tokens['access_token'];
+		$auth['expires_at']   = $tokens['expires_at'];
+		if ( $tokens['refresh_token'] ) {
+			$auth['refresh_token'] = $tokens['refresh_token'];
+		}
 		self::remove_credentials();
 		Logger::log( 'Saving credentials to WP option ' . self::AUTH_DATA_META_NAME );
 		return add_option( self::AUTH_DATA_META_NAME, $auth );
@@ -218,12 +219,14 @@ class Google_OAuth {
 	 */
 	public static function api_google_auth_save_details( $request ) {
 		Logger::log( 'Attempting to save credentials…' );
-		$auth_save_data   = [
-			'access_token'  => $request['access_token'],
-			'refresh_token' => $request['refresh_token'],
-			'csrf_token'    => $request['csrf_token'],
-			'expires_at'    => $request['expires_at'],
+		$auth_save_data = [
+			'access_token' => $request['access_token'],
+			'csrf_token'   => $request['csrf_token'],
+			'expires_at'   => $request['expires_at'],
 		];
+		if ( isset( $request['refresh_token'] ) ) {
+			$auth_save_data['refresh_token'] = $request['refresh_token'];
+		}
 		$auth_save_result = self::save_auth_credentials( $auth_save_data );
 		if ( is_wp_error( $auth_save_result ) ) {
 			return $auth_save_result;

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -155,7 +155,7 @@ class Google_OAuth {
 		$auth                 = self::get_google_auth_saved_data();
 		$auth['access_token'] = $tokens['access_token'];
 		$auth['expires_at']   = $tokens['expires_at'];
-		if ( $tokens['refresh_token'] ) {
+		if ( isset( $tokens['refresh_token'] ) ) {
 			$auth['refresh_token'] = $tokens['refresh_token'];
 		}
 		self::remove_credentials();

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -141,7 +141,7 @@ class Google_OAuth {
 				]
 			);
 		}
-		if ( ! isset( $tokens['access_token'], $tokens['expires_at'], $tokens['refresh_token'] ) ) {
+		if ( ! isset( $tokens['access_token'], $tokens['expires_at'] ) ) {
 			Logger::log( 'Failed saving credentials - missing data.' );
 			return new \WP_Error(
 				'newspack_google_oauth',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes handling of failed OAuth credentials saving.

### How to test the changes in this Pull Request:

1. On `master`, explicitly return a `WP_Error`* from `save_auth_credentials` – try to connect Google via OAuth and observe it failing silently
2. Switch to this branch, observe the error returned to the front-end

\* Comment out the CSRF condition

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->