### PR TITLE
feat(rss): add RSS Enhancements plugin to the core

### DIFF
--- a/assets/components/src/wizard/store/index.js
+++ b/assets/components/src/wizard/store/index.js
@@ -57,7 +57,7 @@ const actions = {
 	setError: createAction( 'SET_ERROR' ),
 
 	// Async actions. These will not show up in Redux devtools.
-	*saveWizardSettings( { slug, section = '', payloadPath = [], updatePayload = null } ) {
+	*saveWizardSettings( { slug, section = '', payloadPath = false, updatePayload = null } ) {
 		// Optionally data can be updated before saving - an immediate update case
 		// (without an explicit "save" action).
 		if ( updatePayload ) {
@@ -67,7 +67,7 @@ const actions = {
 		const updatedData = yield actions.fetchFromAPI( {
 			path: `/newspack/v1/wizard/${ slug }/${ section }`,
 			method: 'POST',
-			data: get( wizardState, payloadPath ),
+			data: payloadPath ? get( wizardState, payloadPath ) : wizardState,
 			isQuietFetch: true,
 		} );
 		if ( ! isEmpty( updatedData ) ) {

--- a/assets/wizards/dashboard/index.js
+++ b/assets/wizards/dashboard/index.js
@@ -6,7 +6,6 @@ import '../../shared/js/public-path';
  * WordPress dependencies.
  */
 import { Fragment, render } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.

--- a/assets/wizards/syndication/views/intro/index.js
+++ b/assets/wizards/syndication/views/intro/index.js
@@ -28,6 +28,8 @@ const Intro = () => {
 							path: [ 'module_enabled_rss' ],
 							value,
 						},
+					} ).then( () => {
+						window.location.reload( true );
 					} );
 				} }
 			/>

--- a/assets/wizards/syndication/views/intro/index.js
+++ b/assets/wizards/syndication/views/intro/index.js
@@ -1,45 +1,48 @@
 /**
- * Syndication Intro View
- */
-
-/**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { PluginToggle } from '../../../../components/src';
+import { PluginToggle, ActionCard, Wizard } from '../../../../components/src';
 
-/**
- * Syndication Intro screen.
- */
-class Intro extends Component {
-	/**
-	 * Render.
-	 */
-	render() {
-		return (
-			<Fragment>
-				<PluginToggle
-					plugins={ {
-						'newspack-rss-enhancements': {
-							name: __( 'RSS Enhancements', 'newspack' ),
-							actionText: __( 'Manage', 'newspack' ),
+const Intro = () => {
+	const settingsData = Wizard.useWizardData( 'settings' );
+	const { saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	return (
+		<>
+			<ActionCard
+				title={ __( 'RSS Enhancements', 'newspack' ) }
+				description={ __(
+					'Create and manage customized RSS feeds for syndication partners',
+					'newspack'
+				) }
+				toggleChecked={ Boolean( settingsData.module_enabled_rss ) }
+				toggleOnChange={ value => {
+					saveWizardSettings( {
+						slug: 'newspack-settings-wizard',
+						updatePayload: {
+							path: [ 'module_enabled_rss' ],
+							value,
 						},
-						'publish-to-apple-news': {
-							name: __( 'Apple News', 'newspack' ),
-						},
-						'distributor-stable': {
-							name: __( 'Distributor', 'newspack' ),
-						},
-					} }
-				/>
-			</Fragment>
-		);
-	}
-}
+					} );
+				} }
+			/>
+			<PluginToggle
+				plugins={ {
+					'publish-to-apple-news': {
+						name: __( 'Apple News', 'newspack' ),
+					},
+					'distributor-stable': {
+						name: __( 'Distributor', 'newspack' ),
+					},
+				} }
+			/>
+		</>
+	);
+};
 
 export default Intro;

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -88,6 +88,8 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-mailchimp-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-fivetran-connection.php';
 
+		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-rss.php';
+
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-provider.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-generated.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-wordpress.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -97,6 +97,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
 
 		/* Unified Wizards */
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-settings.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-advertising-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-analytics-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-engagement-wizard.php';

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -150,15 +150,6 @@ class Plugin_Manager {
 				'AuthorURI'   => esc_url( 'https://automattic.com' ),
 				'Download'    => 'https://github.com/Automattic/newspack-popups/releases/latest/download/newspack-popups.zip',
 			],
-			'newspack-rss-enhancements'     => [
-				'Name'        => esc_html__( 'Newspack RSS Enhancements', 'newspack' ),
-				'Description' => esc_html__( 'Create and manage customized RSS feeds for syndication partners', 'newspack' ),
-				'Author'      => esc_html__( 'Automattic', 'newspack' ),
-				'PluginURI'   => esc_url( 'https://newspack.pub' ),
-				'AuthorURI'   => esc_url( 'https://automattic.com' ),
-				'Download'    => 'https://github.com/Automattic/newspack-rss-enhancements/releases/latest/download/newspack-rss-enhancements.zip',
-				'EditPath'    => 'edit.php?post_type=partner_rss_feed',
-			],
 			'newspack-sponsors'             => [
 				'Name'        => esc_html__( 'Newspack Sponsors', 'newspack' ),
 				'Description' => esc_html__( 'Sponsored and underwritten content for Newspack sites.', 'newspack' ),

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -40,6 +40,7 @@ class Wizards {
 			'engagement'      => new Engagement_Wizard(),
 			'popups'          => new Popups_Wizard(),
 			'connections'     => new Connections_Wizard(),
+			'settings'        => new Settings(),
 		];
 	}
 

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -114,27 +114,27 @@ class RSS {
 	 */
 	public static function register_feed_cpt() {
 		$labels = array(
-			'name'               => _x( 'RSS Feeds', 'post type general name', 'newspack-rss-enhancements' ),
-			'singular_name'      => _x( 'RSS Feed', 'post type singular name', 'newspack-rss-enhancements' ),
-			'menu_name'          => _x( 'RSS Feeds', 'admin menu', 'newspack-rss-enhancements' ),
-			'name_admin_bar'     => _x( 'RSS Feed', 'add new on admin bar', 'newspack-rss-enhancements' ),
-			'add_new'            => _x( 'Add New', 'rss feed', 'newspack-rss-enhancements' ),
-			'add_new_item'       => __( 'Add New RSS Feed', 'newspack-rss-enhancements' ),
-			'new_item'           => __( 'New RSS Feed', 'newspack-rss-enhancements' ),
-			'edit_item'          => __( 'Edit RSS Feed', 'newspack-rss-enhancements' ),
-			'view_item'          => __( 'View RSS Feed', 'newspack-rss-enhancements' ),
-			'all_items'          => __( 'All RSS Feeds', 'newspack-rss-enhancements' ),
-			'search_items'       => __( 'Search RSS Feeds', 'newspack-rss-enhancements' ),
-			'parent_item_colon'  => __( 'Parent RSS Feeds:', 'newspack-rss-enhancements' ),
-			'not_found'          => __( 'No RSS feeds found.', 'newspack-rss-enhancements' ),
-			'not_found_in_trash' => __( 'No RSS seeds found in Trash.', 'newspack-rss-enhancements' ),
-			'item_published'     => __( 'RSS Feed published', 'newspack-rss-enhancements' ),
-			'item_updated'       => __( 'RSS Feed updated', 'newspack-rss-enhancements' ),
+			'name'               => _x( 'RSS Feeds', 'post type general name', 'newspack-plugin' ),
+			'singular_name'      => _x( 'RSS Feed', 'post type singular name', 'newspack-plugin' ),
+			'menu_name'          => _x( 'RSS Feeds', 'admin menu', 'newspack-plugin' ),
+			'name_admin_bar'     => _x( 'RSS Feed', 'add new on admin bar', 'newspack-plugin' ),
+			'add_new'            => _x( 'Add New', 'rss feed', 'newspack-plugin' ),
+			'add_new_item'       => __( 'Add New RSS Feed', 'newspack-plugin' ),
+			'new_item'           => __( 'New RSS Feed', 'newspack-plugin' ),
+			'edit_item'          => __( 'Edit RSS Feed', 'newspack-plugin' ),
+			'view_item'          => __( 'View RSS Feed', 'newspack-plugin' ),
+			'all_items'          => __( 'All RSS Feeds', 'newspack-plugin' ),
+			'search_items'       => __( 'Search RSS Feeds', 'newspack-plugin' ),
+			'parent_item_colon'  => __( 'Parent RSS Feeds:', 'newspack-plugin' ),
+			'not_found'          => __( 'No RSS feeds found.', 'newspack-plugin' ),
+			'not_found_in_trash' => __( 'No RSS seeds found in Trash.', 'newspack-plugin' ),
+			'item_published'     => __( 'RSS Feed published', 'newspack-plugin' ),
+			'item_updated'       => __( 'RSS Feed updated', 'newspack-plugin' ),
 		);
 
 		$args = array(
 			'labels'               => $labels,
-			'description'          => __( 'RSS feeds customized for third-party services.', 'newspack-rss-enhancements' ),
+			'description'          => __( 'RSS feeds customized for third-party services.', 'newspack-plugin' ),
 			'public'               => true,
 			'exclude_from_search'  => true,
 			'publicly_queryable'   => false,
@@ -162,7 +162,7 @@ class RSS {
 	 * @return array Modified $columns.
 	 */
 	public static function columns_head( $columns ) {
-		$columns['feed_url'] = __( 'Feed URL', 'newspack-rss-enhancements' );
+		$columns['feed_url'] = __( 'Feed URL', 'newspack-plugin' );
 		return $columns;
 	}
 
@@ -191,19 +191,19 @@ class RSS {
 	public static function add_metaboxes( $feed_post ) {
 		add_meta_box(
 			'partner_rss_feed_url',
-			__( 'Feed URL', 'newspack-rss-enhancements' ),
+			__( 'Feed URL', 'newspack-plugin' ),
 			[ __CLASS__, 'render_url_metabox' ],
 			self::FEED_CPT
 		);
 		add_meta_box(
 			'partner_rss_feed_content_settings',
-			__( 'Content Settings', 'newspack-rss-enhancements' ),
+			__( 'Content Settings', 'newspack-plugin' ),
 			[ __CLASS__, 'render_content_settings_metabox' ],
 			self::FEED_CPT
 		);
 		add_meta_box(
 			'partner_rss_feed_technical_settings',
-			__( 'Technical Settings', 'newspack-rss-enhancements' ),
+			__( 'Technical Settings', 'newspack-plugin' ),
 			[ __CLASS__, 'render_technical_settings_metabox' ],
 			self::FEED_CPT
 		);
@@ -246,7 +246,7 @@ class RSS {
 		if ( 'publish' !== $feed_post->post_status ) {
 			?>
 			<h3>
-				<?php esc_html_e( 'A URL will be generated for this feed once published', 'newspack-rss-enhancements' ); ?>
+				<?php esc_html_e( 'A URL will be generated for this feed once published', 'newspack-plugin' ); ?>
 			</h3>
 			<?php
 			return;
@@ -275,28 +275,28 @@ class RSS {
 		?>
 		<table>
 			<tr>
-				<th><?php esc_html_e( 'Number of posts to display in feed:', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Number of posts to display in feed:', 'newspack-plugin' ); ?></th>
 				<td>
 					<input name="num_items_in_feed" type="number" min="1" value="<?php echo esc_attr( $settings['num_items_in_feed'] ); ?>" />
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Limit timeframe to last # of hours:', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Limit timeframe to last # of hours:', 'newspack-plugin' ); ?></th>
 				<td>
 					<input name="timeframe" type="number" value="<?php echo esc_attr( $settings['timeframe'] ); ?>" />
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Use post full content or excerpt:', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Use post full content or excerpt:', 'newspack-plugin' ); ?></th>
 				<td>
 					<select name="full_content">
-						<option value="1" <?php selected( $settings['full_content'] ); ?> ><?php esc_html_e( 'Full content', 'newspack-rss-enhancements' ); ?></option>
-						<option value="0" <?php selected( ! $settings['full_content'] ); ?> ><?php esc_html_e( 'Excerpt', 'newspack-rss-enhancements' ); ?></option>
+						<option value="1" <?php selected( $settings['full_content'] ); ?> ><?php esc_html_e( 'Full content', 'newspack-plugin' ); ?></option>
+						<option value="0" <?php selected( ! $settings['full_content'] ); ?> ><?php esc_html_e( 'Excerpt', 'newspack-plugin' ); ?></option>
 					</select>
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Include only posts from these categories:', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Include only posts from these categories:', 'newspack-plugin' ); ?></th>
 				<td>
 					<select id="category_include" name="category_include[]" multiple="multiple" style="width:300px">
 						<?php foreach ( $categories as $category ) : ?>
@@ -306,7 +306,7 @@ class RSS {
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Exclude posts from these categories:', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Exclude posts from these categories:', 'newspack-plugin' ); ?></th>
 				<td>
 					<select id="category_exclude" name="category_exclude[]" multiple="multiple" style="width:300px">
 						<?php foreach ( $categories as $category ) : ?>
@@ -338,42 +338,42 @@ class RSS {
 
 		<table>
 			<tr>
-				<th><?php esc_html_e( 'Add post featured images in <image> tags', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Add post featured images in <image> tags', 'newspack-plugin' ); ?></th>
 				<td>
 					<input type="hidden" name="use_image_tags" value="0" />
 					<input type="checkbox" name="use_image_tags" value="1" <?php checked( $settings['use_image_tags'] ); ?>/>
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Add post featured images in <media:> tags', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Add post featured images in <media:> tags', 'newspack-plugin' ); ?></th>
 				<td>
 					<input type="hidden" name="use_media_tags" value="0" />
 					<input type="checkbox" name="use_media_tags" value="1" <?php checked( $settings['use_media_tags'] ); ?> />
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Add post updated time in <updated> tags', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Add post updated time in <updated> tags', 'newspack-plugin' ); ?></th>
 				<td>
 					<input type="hidden" name="use_updated_tags" value="0" />
 					<input type="checkbox" name="use_updated_tags" value="1" <?php checked( $settings['use_updated_tags'] ); ?> />
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Add categories and tags in <tags> element', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Add categories and tags in <tags> element', 'newspack-plugin' ); ?></th>
 				<td>
 					<input type="hidden" name="use_tags_tags" value="0" />
 					<input type="checkbox" name="use_tags_tags" value="1" <?php checked( $settings['use_tags_tags'] ); ?> />
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Add featured image at the top of feed content', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Add featured image at the top of feed content', 'newspack-plugin' ); ?></th>
 				<td>
 					<input type="hidden" name="content_featured_image" value="0" />
 					<input type="checkbox" name="content_featured_image" value="1" <?php checked( $settings['content_featured_image'] ); ?> />
 				</td>
 			</tr>
 			<tr>
-				<th><?php esc_html_e( 'Add Yahoo namespace to RSS namespace: xmlns:media="http://search.yahoo.com/mrss/"', 'newspack-rss-enhancements' ); ?></th>
+				<th><?php esc_html_e( 'Add Yahoo namespace to RSS namespace: xmlns:media="http://search.yahoo.com/mrss/"', 'newspack-plugin' ); ?></th>
 				<td>
 					<input type="hidden" name="yahoo_namespace" value="0" />
 					<input type="checkbox" name="yahoo_namespace" value="1" <?php checked( $settings['yahoo_namespace'] ); ?> />

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -1,0 +1,634 @@
+<?php
+/**
+ * RSS.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * RSS feed enhancements.
+ */
+class RSS {
+	const FEED_CPT           = 'partner_rss_feed';
+	const FEED_QUERY_ARG     = 'partner-feed';
+	const FEED_SETTINGS_META = 'partner_feed_settings';
+
+	/**
+	 * Hooks and filters.
+	 */
+	public static function maybe_init() {
+		add_action( 'init', [ __CLASS__, 'init' ] );
+	}
+
+	/**
+	 * Initialise.
+	 */
+	public static function init() {
+		// If the standalone plugin is active, deactivate it and activate as a module.
+		if ( is_plugin_active( 'newspack-rss-enhancements/newspack-rss-enhancements.php' ) ) {
+			deactivate_plugins( 'newspack-rss-enhancements/newspack-rss-enhancements.php' );
+			Settings::activate_optional_module( 'rss' );
+		}
+
+		if ( ! Settings::is_optional_module_active( 'rss' ) ) {
+			return;
+		}
+
+		// Backend.
+		self::register_feed_cpt();
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_autocomplete_scripts' ] );
+		add_action( 'save_post_' . self::FEED_CPT, [ __CLASS__, 'save_settings' ] );
+		add_filter( 'manage_' . self::FEED_CPT . '_posts_columns', [ __CLASS__, 'columns_head' ] );
+		add_action( 'manage_' . self::FEED_CPT . '_posts_custom_column', [ __CLASS__, 'column_content' ], 10, 2 );
+
+		// Frontend.
+		add_filter( 'option_rss_use_excerpt', [ __CLASS__, 'filter_use_rss_excerpt' ] );
+		add_action( 'pre_get_posts', [ __CLASS__, 'modify_feed_query' ] );
+		add_action( 'rss2_item', [ __CLASS__, 'add_extra_tags' ] );
+		add_filter( 'the_excerpt_rss', [ __CLASS__, 'maybe_remove_content_featured_image' ], 1 );
+		add_filter( 'the_content_feed', [ __CLASS__, 'maybe_remove_content_featured_image' ], 1 );
+		add_filter( 'wpseo_include_rss_footer', [ __CLASS__, 'maybe_suppress_yoast' ] );
+		add_action( 'rss2_ns', [ __CLASS__, 'maybe_inject_yahoo_namespace' ] );
+	}
+
+	/**
+	 * Get URL for a feed.
+	 *
+	 * @param WP_Post $feed_post RSS feed post object.
+	 */
+	public static function get_feed_url( $feed_post ) {
+		$base_feed_url = get_bloginfo( 'rss2_url' );
+		$feed_slug     = is_numeric( $feed_post ) ? get_post_field( 'post_name', $feed_post ) : $feed_post->post_name;
+		return add_query_arg( self::FEED_QUERY_ARG, $feed_slug, $base_feed_url );
+	}
+
+	/**
+	 * Get feed settings array.
+	 *
+	 * @param WP_Post|int $feed_post A feed WP_Post object, post ID. (optional on frontend).
+	 * @return array|false Feed settings or false if no feed found.
+	 */
+	public static function get_feed_settings( $feed_post = null ) {
+		$default_settings = [
+			'category_include'       => [],
+			'category_exclude'       => [],
+			'use_image_tags'         => false,
+			'use_media_tags'         => false,
+			'use_updated_tags'       => false,
+			'use_tags_tags'          => false,
+			'full_content'           => true,
+			'num_items_in_feed'      => 10,
+			'timeframe'              => false,
+			'content_featured_image' => false,
+			'suppress_yoast'         => false,
+			'yahoo_namespace'        => false,
+		];
+
+		if ( ! $feed_post ) {
+			$query_feed = filter_input( INPUT_GET, self::FEED_QUERY_ARG, FILTER_SANITIZE_STRING );
+			if ( ! $query_feed ) {
+				return false;
+			}
+
+			$feed_post = get_page_by_path( sanitize_text_field( $query_feed ), OBJECT, self::FEED_CPT ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_path_get_page_by_path
+			if ( ! $feed_post ) {
+				return false;
+			}
+		}
+
+		$feed_post_id   = is_numeric( $feed_post ) ? $feed_post : $feed_post->ID;
+		$saved_settings = get_post_meta( $feed_post_id, self::FEED_SETTINGS_META, true );
+		if ( ! is_array( $saved_settings ) ) {
+			return $default_settings;
+		}
+
+		return shortcode_atts( $default_settings, $saved_settings );
+	}
+
+	/**
+	 * Register the partner feed CPT.
+	 */
+	public static function register_feed_cpt() {
+		$labels = array(
+			'name'               => _x( 'RSS Feeds', 'post type general name', 'newspack-rss-enhancements' ),
+			'singular_name'      => _x( 'RSS Feed', 'post type singular name', 'newspack-rss-enhancements' ),
+			'menu_name'          => _x( 'RSS Feeds', 'admin menu', 'newspack-rss-enhancements' ),
+			'name_admin_bar'     => _x( 'RSS Feed', 'add new on admin bar', 'newspack-rss-enhancements' ),
+			'add_new'            => _x( 'Add New', 'rss feed', 'newspack-rss-enhancements' ),
+			'add_new_item'       => __( 'Add New RSS Feed', 'newspack-rss-enhancements' ),
+			'new_item'           => __( 'New RSS Feed', 'newspack-rss-enhancements' ),
+			'edit_item'          => __( 'Edit RSS Feed', 'newspack-rss-enhancements' ),
+			'view_item'          => __( 'View RSS Feed', 'newspack-rss-enhancements' ),
+			'all_items'          => __( 'All RSS Feeds', 'newspack-rss-enhancements' ),
+			'search_items'       => __( 'Search RSS Feeds', 'newspack-rss-enhancements' ),
+			'parent_item_colon'  => __( 'Parent RSS Feeds:', 'newspack-rss-enhancements' ),
+			'not_found'          => __( 'No RSS feeds found.', 'newspack-rss-enhancements' ),
+			'not_found_in_trash' => __( 'No RSS seeds found in Trash.', 'newspack-rss-enhancements' ),
+			'item_published'     => __( 'RSS Feed published', 'newspack-rss-enhancements' ),
+			'item_updated'       => __( 'RSS Feed updated', 'newspack-rss-enhancements' ),
+		);
+
+		$args = array(
+			'labels'               => $labels,
+			'description'          => __( 'RSS feeds customized for third-party services.', 'newspack-rss-enhancements' ),
+			'public'               => true,
+			'exclude_from_search'  => true,
+			'publicly_queryable'   => false,
+			'show_ui'              => true,
+			'show_in_menu'         => true,
+			'menu_icon'            => 'dashicons-rss',
+			'query_var'            => true,
+			'capability_type'      => 'post',
+			'has_archive'          => false,
+			'hierarchical'         => false,
+			'menu_position'        => null,
+			'supports'             => array( 'title' ),
+			'rewrite'              => false,
+			'show_in_admin_bar'    => false,
+			'register_meta_box_cb' => [ __CLASS__, 'add_metaboxes' ],
+		);
+
+		register_post_type( self::FEED_CPT, $args );
+	}
+
+	/**
+	 * Add a feed URL column to the Edit RSS Feeds screen.
+	 *
+	 * @param array $columns Screen columns.
+	 * @return array Modified $columns.
+	 */
+	public static function columns_head( $columns ) {
+		$columns['feed_url'] = __( 'Feed URL', 'newspack-rss-enhancements' );
+		return $columns;
+	}
+
+	/**
+	 * Populate feed URL column on Edit RSS Feeds screen.
+	 *
+	 * @param string $column_name The column identifier.
+	 * @param int    $post_id The current element's post ID.
+	 */
+	public static function column_content( $column_name, $post_id ) {
+		if ( 'feed_url' === $column_name ) {
+			$feed_url = self::get_feed_url( $post_id );
+			?>
+			<a href='<?php echo esc_url( $feed_url ); ?>' target='_blank'>
+				<?php echo esc_url( $feed_url ); ?>
+			</a>
+			<?php
+		}
+	}
+
+	/**
+	 * Add metaboxes to CPT screen.
+	 *
+	 * @param WP_Post $feed_post RSS feed post object.
+	 */
+	public static function add_metaboxes( $feed_post ) {
+		add_meta_box(
+			'partner_rss_feed_url',
+			__( 'Feed URL', 'newspack-rss-enhancements' ),
+			[ __CLASS__, 'render_url_metabox' ],
+			self::FEED_CPT
+		);
+		add_meta_box(
+			'partner_rss_feed_content_settings',
+			__( 'Content Settings', 'newspack-rss-enhancements' ),
+			[ __CLASS__, 'render_content_settings_metabox' ],
+			self::FEED_CPT
+		);
+		add_meta_box(
+			'partner_rss_feed_technical_settings',
+			__( 'Technical Settings', 'newspack-rss-enhancements' ),
+			[ __CLASS__, 'render_technical_settings_metabox' ],
+			self::FEED_CPT
+		);
+	}
+
+	/**
+	 * Enqueue autocomplete scripts.
+	 *
+	 * @param string $hook The current screen.
+	 */
+	public static function enqueue_autocomplete_scripts( $hook ) {
+		if ( in_array( $hook, [ 'post.php', 'post-new.php' ] ) ) {
+			$screen = get_current_screen();
+
+			if ( is_object( $screen ) && self::FEED_CPT == $screen->post_type ) {
+				wp_enqueue_style(
+					'newspack-select2',
+					'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.12/css/select2.min.css',
+					[],
+					'4.0.12'
+				);
+
+				wp_enqueue_script(
+					'newspack-select2',
+					'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.12/js/select2.full.min.js',
+					[ 'jquery' ],
+					'4.0.12',
+					false
+				);
+			}
+		}
+	}
+
+	/**
+	 * Render URL metabox for CPT.
+	 *
+	 * @param WP_Post $feed_post RSS feed post object.
+	 */
+	public static function render_url_metabox( $feed_post ) {
+		if ( 'publish' !== $feed_post->post_status ) {
+			?>
+			<h3>
+				<?php esc_html_e( 'A URL will be generated for this feed once published', 'newspack-rss-enhancements' ); ?>
+			</h3>
+			<?php
+			return;
+		}
+
+		$feed_url = self::get_feed_url( $feed_post );
+
+		?>
+		<h3>
+			<a href='<?php echo esc_url( $feed_url ); ?>' target='_blank'>
+				<?php echo esc_url( $feed_url ); ?>
+			</a>
+		</h3>
+		<?php
+	}
+
+	/**
+	 * Render content settings metabox for CPT.
+	 *
+	 * @param WP_Post $feed_post RSS feed post object.
+	 */
+	public static function render_content_settings_metabox( $feed_post ) {
+		$settings   = self::get_feed_settings( $feed_post );
+		$categories = get_categories();
+		wp_nonce_field( 'newspack_rss_enhancements_nonce', 'newspack_rss_enhancements_nonce' );
+		?>
+		<table>
+			<tr>
+				<th><?php esc_html_e( 'Number of posts to display in feed:', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<input name="num_items_in_feed" type="number" min="1" value="<?php echo esc_attr( $settings['num_items_in_feed'] ); ?>" />
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Limit timeframe to last # of hours:', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<input name="timeframe" type="number" value="<?php echo esc_attr( $settings['timeframe'] ); ?>" />
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Use post full content or excerpt:', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<select name="full_content">
+						<option value="1" <?php selected( $settings['full_content'] ); ?> ><?php esc_html_e( 'Full content', 'newspack-rss-enhancements' ); ?></option>
+						<option value="0" <?php selected( ! $settings['full_content'] ); ?> ><?php esc_html_e( 'Excerpt', 'newspack-rss-enhancements' ); ?></option>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Include only posts from these categories:', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<select id="category_include" name="category_include[]" multiple="multiple" style="width:300px">
+						<?php foreach ( $categories as $category ) : ?>
+							<option value="<?php echo esc_attr( $category->term_id ); ?>" <?php selected( in_array( $category->term_id, $settings['category_include'] ) ); ?>><?php echo esc_html( $category->name ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Exclude posts from these categories:', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<select id="category_exclude" name="category_exclude[]" multiple="multiple" style="width:300px">
+						<?php foreach ( $categories as $category ) : ?>
+							<option value="<?php echo esc_attr( $category->term_id ); ?>" <?php selected( in_array( $category->term_id, $settings['category_exclude'] ) ); ?>><?php echo esc_html( $category->name ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</td>
+			</tr>
+		</table>
+
+		<script>
+			jQuery( document ).ready( function() {
+				jQuery( '#category_include' ).select2();
+				jQuery( '#category_exclude' ).select2();
+			} );
+		</script>
+		<?php
+	}
+
+	/**
+	 * Render technical settings metabox for CPT.
+	 *
+	 * @param WP_Post $feed_post RSS feed post object.
+	 */
+	public static function render_technical_settings_metabox( $feed_post ) {
+		$settings = self::get_feed_settings( $feed_post );
+		?>
+		<p><strong>Note:</strong> These settings are for modifying a feed to make it compatible with various integrations (SmartNews, PugPig, etc.). They should only be used if a specific integration requires a non-standard RSS feed. Consult the integration's documentation or support for information about which elements are required.</p>
+
+		<table>
+			<tr>
+				<th><?php esc_html_e( 'Add post featured images in <image> tags', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<input type="hidden" name="use_image_tags" value="0" />
+					<input type="checkbox" name="use_image_tags" value="1" <?php checked( $settings['use_image_tags'] ); ?>/>
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Add post featured images in <media:> tags', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<input type="hidden" name="use_media_tags" value="0" />
+					<input type="checkbox" name="use_media_tags" value="1" <?php checked( $settings['use_media_tags'] ); ?> />
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Add post updated time in <updated> tags', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<input type="hidden" name="use_updated_tags" value="0" />
+					<input type="checkbox" name="use_updated_tags" value="1" <?php checked( $settings['use_updated_tags'] ); ?> />
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Add categories and tags in <tags> element', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<input type="hidden" name="use_tags_tags" value="0" />
+					<input type="checkbox" name="use_tags_tags" value="1" <?php checked( $settings['use_tags_tags'] ); ?> />
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Add featured image at the top of feed content', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<input type="hidden" name="content_featured_image" value="0" />
+					<input type="checkbox" name="content_featured_image" value="1" <?php checked( $settings['content_featured_image'] ); ?> />
+				</td>
+			</tr>
+			<tr>
+				<th><?php esc_html_e( 'Add Yahoo namespace to RSS namespace: xmlns:media="http://search.yahoo.com/mrss/"', 'newspack-rss-enhancements' ); ?></th>
+				<td>
+					<input type="hidden" name="yahoo_namespace" value="0" />
+					<input type="checkbox" name="yahoo_namespace" value="1" <?php checked( $settings['yahoo_namespace'] ); ?> />
+				</td>
+			</tr>
+			<?php if ( defined( 'WPSEO_VERSION' ) && WPSEO_VERSION ) : ?>
+				<tr>
+					<th>
+						<?php
+						echo sprintf(
+						/* translators: %s: URL to Yoast settings */
+							__( 'Suppress <a href="%s">Yoast RSS content at the top and bottom of feed posts</a>' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							admin_url( 'admin.php?page=wpseo_titles#top#rss' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						);
+						?>
+					</th>
+					<td>
+						<input type="hidden" name="suppress_yoast" value="0" />
+						<input type="checkbox" name="suppress_yoast" value="1" <?php checked( $settings['suppress_yoast'] ); ?> />
+					</td>
+				</tr>
+			<?php endif; ?>
+		</table>
+		<?php
+	}
+
+	/**
+	 * Save CPT settings.
+	 *
+	 * @param int $feed_post_id The post ID of feed.
+	 */
+	public static function save_settings( $feed_post_id ) {
+		$nonce = filter_input( INPUT_POST, 'newspack_rss_enhancements_nonce', FILTER_SANITIZE_STRING );
+		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'newspack_rss_enhancements_nonce' ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
+		$settings = self::get_feed_settings( $feed_post_id );
+
+		$use_image_tags             = filter_input( INPUT_POST, 'use_image_tags', FILTER_SANITIZE_NUMBER_INT );
+		$settings['use_image_tags'] = (bool) $use_image_tags;
+
+		$use_media_tags             = filter_input( INPUT_POST, 'use_media_tags', FILTER_SANITIZE_NUMBER_INT );
+		$settings['use_media_tags'] = (bool) $use_media_tags;
+
+		$use_updated_tags             = filter_input( INPUT_POST, 'use_updated_tags', FILTER_SANITIZE_NUMBER_INT );
+		$settings['use_updated_tags'] = (bool) $use_updated_tags;
+
+		$use_updated_tags          = filter_input( INPUT_POST, 'use_tags_tags', FILTER_SANITIZE_NUMBER_INT );
+		$settings['use_tags_tags'] = (bool) $use_updated_tags;
+
+		$full_content             = filter_input( INPUT_POST, 'full_content', FILTER_SANITIZE_NUMBER_INT );
+		$settings['full_content'] = (bool) $full_content;
+
+		$content_featured_image             = filter_input( INPUT_POST, 'content_featured_image', FILTER_SANITIZE_NUMBER_INT );
+		$settings['content_featured_image'] = (bool) $content_featured_image;
+
+		$num_items_in_feed             = filter_input( INPUT_POST, 'num_items_in_feed', FILTER_SANITIZE_NUMBER_INT );
+		$settings['num_items_in_feed'] = absint( $num_items_in_feed );
+
+		$timeframe             = filter_input( INPUT_POST, 'timeframe', FILTER_SANITIZE_NUMBER_INT );
+		$settings['timeframe'] = absint( $timeframe );
+
+		$suppress_yoast             = filter_input( INPUT_POST, 'suppress_yoast', FILTER_SANITIZE_NUMBER_INT );
+		$settings['suppress_yoast'] = (bool) $suppress_yoast;
+
+		$yahoo_namespace             = filter_input( INPUT_POST, 'yahoo_namespace', FILTER_SANITIZE_NUMBER_INT );
+		$settings['yahoo_namespace'] = (bool) $yahoo_namespace;
+
+		$category_settings = filter_input_array(
+			INPUT_POST,
+			[
+				'category_include' => [
+					'filter' => FILTER_SANITIZE_NUMBER_INT,
+					'flags'  => FILTER_REQUIRE_ARRAY,
+				],
+				'category_exclude' => [
+					'filter' => FILTER_SANITIZE_NUMBER_INT,
+					'flags'  => FILTER_REQUIRE_ARRAY,
+				],
+			]
+		);
+		if ( $category_settings ) {
+			if ( isset( $category_settings['category_include'] ) && is_array( $category_settings['category_include'] ) ) {
+				$settings['category_include'] = array_map( 'intval', $category_settings['category_include'] );
+			} else {
+				$settings['category_include'] = [];
+			}
+
+			if ( isset( $category_settings['category_exclude'] ) && is_array( $category_settings['category_exclude'] ) ) {
+				$settings['category_exclude'] = array_map( 'intval', $category_settings['category_exclude'] );
+			} else {
+				$settings['category_exclude'] = [];
+			}
+		}
+
+		update_post_meta( $feed_post_id, self::FEED_SETTINGS_META, $settings );
+		// @todo flush feed cache here.
+	}
+
+	/**
+	 * Apply settings on frontend to WP query.
+	 *
+	 * @param WP_Query $query WP_Query object.
+	 */
+	public static function modify_feed_query( $query ) {
+		if ( ! $query->is_feed() || ! $query->is_main_query() ) {
+			return;
+		}
+
+		$settings = self::get_feed_settings();
+		if ( ! $settings ) {
+			return;
+		}
+
+		$query->set( 'posts_per_rss', absint( $settings['num_items_in_feed'] ) );
+
+		if ( ! empty( $settings['timeframe'] ) ) {
+			$query->set( 'date_query', [ 'after' => gmdate( 'Y-m-d H:i:s', strtotime( '- ' . $settings['timeframe'] . ' hours' ) ) ] );
+		}
+
+		if ( ! empty( $settings['category_include'] ) ) {
+			$query->set( 'category__in', array_map( 'absint', $settings['category_include'] ) );
+		}
+
+		if ( ! empty( $settings['category_exclude'] ) ) {
+			$query->set( 'category__not_in', array_map( 'absint', $settings['category_exclude'] ) );
+		}
+	}
+
+	/**
+	 * Toggle full-content/excerpt display on frontend.
+	 *
+	 * @param bool $value Whether to use excerpt in RSS.
+	 * @return bool Modified $value.
+	 */
+	public static function filter_use_rss_excerpt( $value ) {
+		if ( ! is_feed() ) {
+			return $value;
+		}
+
+		$settings = self::get_feed_settings();
+		if ( ! $settings ) {
+			return $value;
+		}
+
+		return ! $settings['full_content'];
+	}
+
+	/**
+	 * Add extra tags to RSS items on frontend.
+	 */
+	public static function add_extra_tags() {
+		$settings = self::get_feed_settings();
+		if ( ! $settings ) {
+			return;
+		}
+
+		$post = get_post();
+
+		if ( $settings['use_image_tags'] ) {
+			$thumbnail_url = get_the_post_thumbnail_url( $post, 'full' );
+			if ( $thumbnail_url ) :
+				?>
+				<image><?php echo esc_url( $thumbnail_url ); ?></image>
+				<?php
+			endif;
+		}
+
+		if ( $settings['use_updated_tags'] ) {
+			?>
+			<updated><?php echo esc_html( get_the_modified_date( 'Y-m-d\TH:i:s' ) ); ?></updated>
+			<?php
+		}
+
+		if ( $settings['use_tags_tags'] ) {
+			$cats         = get_the_terms( $post, 'category' );
+			$cats         = ( ! is_array( $cats ) ) ? [] : $cats;
+			$tags         = get_the_terms( $post, 'post_tag' );
+			$tags         = ( ! is_array( $tags ) ) ? [] : $tags;
+			$all_terms    = array_merge( $cats, $tags );
+			$terms_string = implode( ',', wp_list_pluck( $all_terms, 'name' ) );
+			?>
+			<tags><?php echo esc_html( $terms_string ); ?></tags>
+			<?php
+		}
+
+		if ( $settings['use_media_tags'] ) {
+			$thumbnail_id = get_post_thumbnail_id();
+			if ( $thumbnail_id ) {
+				$thumbnail_data = wp_get_attachment_image_src( $thumbnail_id, 'full' );
+				if ( $thumbnail_data ) {
+					?>
+					<media:description><?php echo esc_html( get_the_post_thumbnail_caption() ); ?></media:description>
+					<media:thumbnail url="<?php echo esc_url( $thumbnail_data[0] ); ?>" width="<?php echo esc_attr( $thumbnail_data[1] ); ?>" height="<?php echo esc_attr( $thumbnail_data[2] ); ?>" />
+					<media:content type="image/jpeg" url="<?php echo esc_url( $thumbnail_data[0] ); ?>" />
+					<?php
+				}
+			}
+		}
+	}
+
+	/**
+	 * The Newspack Theme adds featured images to the top of feed content by default. This setting toggles whether to do that.
+	 *
+	 * @param string $content Feed content.
+	 * @return string Unmodified $content.
+	 */
+	public static function maybe_remove_content_featured_image( $content ) {
+		$settings = self::get_feed_settings();
+		if ( ! $settings ) {
+			return $content;
+		}
+
+		if ( ! $settings['content_featured_image'] ) {
+			remove_filter( 'the_excerpt_rss', 'newspack_thumbnails_in_rss' );
+			remove_filter( 'the_content_feed', 'newspack_thumbnails_in_rss' );
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Suppress the Yoast prepended and appended content depending on setting.
+	 *
+	 * @param bool $include_yoast Whether to prepand and append content to the feed items.
+	 * @return bool Modified $include_yoast
+	 */
+	public static function maybe_suppress_yoast( $include_yoast ) {
+		$settings = self::get_feed_settings();
+		if ( ! $settings ) {
+			return $include_yoast;
+		}
+
+		return ! (bool) $settings['suppress_yoast'];
+	}
+
+	/**
+	 * Add the 'xmlns:media="http://search.yahoo.com/mrss/"' namespace to feed if setting is checked.
+	 */
+	public static function maybe_inject_yahoo_namespace() {
+		$settings = self::get_feed_settings();
+		if ( ! $settings ) {
+			return;
+		}
+
+		if ( $settings['yahoo_namespace'] ) {
+			?>
+xmlns:media="http://search.yahoo.com/mrss/"
+			<?php
+		}
+	}
+}
+RSS::maybe_init();

--- a/includes/wizards/class-settings.php
+++ b/includes/wizards/class-settings.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Newspack's Settings
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Settings.
+ */
+class Settings extends Wizard {
+	const SETTINGS_OPTION_NAME = 'newspack_settings';
+
+	const MODULE_ENABLED_PREFIX = 'module_enabled_';
+
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-settings-wizard';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+		$this->hidden = true;
+	}
+
+	/**
+	 * Get all settings.
+	 */
+	private static function get_settings() {
+		$default_settings = [
+			self::MODULE_ENABLED_PREFIX . 'rss' => false,
+		];
+		return get_option( self::SETTINGS_OPTION_NAME, $default_settings );
+	}
+
+	/**
+	 * Get the list of available optional modules.
+	 */
+	private static function get_available_optional_modules() {
+		return [ 'rss' ];
+	}
+
+	/**
+	 * Get settings.
+	 */
+	public static function api_get_settings() {
+		return self::get_settings();
+	}
+
+	/**
+	 * Check if an optional module is active.
+	 *
+	 * @param string $module_name Name of the module.
+	 */
+	public static function is_optional_module_active( $module_name ) {
+		$settings     = self::api_get_settings();
+		$setting_name = self::MODULE_ENABLED_PREFIX . $module_name;
+		if ( isset( $settings[ $setting_name ] ) ) {
+			return $settings[ $setting_name ];
+		}
+		return false;
+	}
+
+	/**
+	 * Activate an optional module.
+	 *
+	 * @param string $module_name Name of the module.
+	 */
+	public static function activate_optional_module( $module_name ) {
+		return self::update_setting( self::MODULE_ENABLED_PREFIX . $module_name, true );
+	}
+
+	/**
+	 * Update a single setting value.
+	 *
+	 * @param string $key Setting key.
+	 * @param string $value Setting value.
+	 */
+	private static function update_setting( $key, $value ) {
+		$settings = self::get_settings();
+		if ( isset( $settings[ $key ] ) ) {
+			$settings[ $key ] = $value;
+			update_option( self::SETTINGS_OPTION_NAME, $settings );
+		}
+		return $settings;
+	}
+
+	/**
+	 * Update settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response with the info.
+	 */
+	public static function api_update_settings( $request ) {
+		$settings = self::get_settings();
+		foreach ( self::get_available_optional_modules() as $module_name ) {
+			$setting_name              = self::MODULE_ENABLED_PREFIX . $module_name;
+			$settings[ $setting_name ] = $request->get_param( $setting_name );
+		}
+		update_option( self::SETTINGS_OPTION_NAME, $settings );
+		return self::api_get_settings();
+	}
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public function register_api_endpoints() {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug,
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		$required_args = array_reduce(
+			self::get_available_optional_modules(),
+			function( $acc, $module_name ) {
+				$acc[ self::MODULE_ENABLED_PREFIX . $module_name ] = [
+					'required'          => true,
+					'sanitize_callback' => 'rest_sanitize_boolean',
+				];
+				return $acc;
+			},
+			[]
+		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug,
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => $required_args,
+			]
+		);
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return \esc_html__( 'Settings', 'newspack' );
+	}
+
+	/**
+	 * Get the description of this wizard.
+	 *
+	 * @return string The wizard description.
+	 */
+	public function get_description() {
+		return \esc_html__( 'Configure settings.', 'newspack' );
+	}
+
+	/**
+	 * Get the duration of this wizard.
+	 *
+	 * @return string A description of the expected duration (e.g. '10 minutes').
+	 */
+	public function get_length() {
+		return esc_html__( '10 minutes', 'newspack' );
+	}
+}

--- a/tests/unit-tests/settings.php
+++ b/tests/unit-tests/settings.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Tests the Settings.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Settings;
+
+/**
+ * Tests the Settings.
+ */
+class Newspack_Test_Settings extends WP_UnitTestCase {
+	/**
+	 * Setup for the tests.
+	 */
+	public function setUp() {
+		delete_option( Settings::SETTINGS_OPTION_NAME );
+	}
+
+	/**
+	 * Default settings.
+	 */
+	public function test_settings_defaults() {
+		self::assertEquals(
+			Settings::api_get_settings(),
+			[ 'module_enabled_rss' => false ],
+			'Default settings are as expected.'
+		);
+	}
+
+	/**
+	 * Updating settings.
+	 */
+	public function test_settings_update() {
+		$request = new WP_REST_Request();
+		$request->set_param( 'module_enabled_rss', true );
+		Settings::api_update_settings( $request );
+		self::assertEquals(
+			Settings::api_get_settings(),
+			[ 'module_enabled_rss' => true ],
+			'Settings is updated.'
+		);
+
+		$request->set_param( 'non_existent_setting', true );
+		Settings::api_update_settings( $request );
+		self::assertEquals(
+			Settings::api_get_settings(),
+			[ 'module_enabled_rss' => true ],
+			'A non-existent setting is not saved.'
+		);
+	}
+
+	/**
+	 * Optional modules.
+	 */
+	public function test_settings_optional_modules() {
+		self::assertEquals(
+			Settings::is_optional_module_active( 'rss' ),
+			false,
+			'RSS module is not active by default.'
+		);
+
+		Settings::activate_optional_module( 'rss' );
+
+		self::assertEquals(
+			Settings::is_optional_module_active( 'rss' ),
+			true,
+			'RSS module is active after being activated.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Incorporates [`newspack-rss-enhancements` plugin](https://github.com/Automattic/newspack-rss-enhancements/) into the core plugin, as an optional module.

### How to test the changes in this Pull Request:

1. On a site with no `newspack-rss-enhancements` plugin installed, observe there's no "RSS Feeds" menu item
2. Visit Newspack Settings wizard by following a link in the plugin UI footer
3. Observe the module is turned off by default
4. Turn the module on, after navigating or refreshing the page observe the "RSS Feeds" menu item is available
5. Now on a site with `newspack-rss-enhancements` active, observe the module is turned on by default, but the `newspack-rss-enhancements` plugin has been deactivate on loading admin UI

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->