### PR TITLE
fix(ads): always allow service account credentials

### DIFF
--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -66,7 +66,7 @@ const AdUnits = ( {
 		setNetworkCode( serviceData.status.network_code );
 	}, [ serviceData.status.network_code ] );
 
-	const { can_use_service_account, can_use_oauth, connection_mode } = serviceData.status;
+	const { connection_mode } = serviceData.status;
 	const isLegacy = 'legacy' === connection_mode;
 
 	const isDisconnectedGAM = adUnit => {
@@ -123,12 +123,10 @@ const AdUnits = ( {
 			) }
 			{ isLegacy && serviceData.enabled && (
 				<>
-					{ ( can_use_service_account || can_use_oauth ) && (
-						<Notice
-							noticeText={ __( 'Currently operating in legacy mode.', 'newspack' ) }
-							isWarning
-						/>
-					) }
+					<Notice
+						noticeText={ __( 'Currently operating in legacy mode.', 'newspack' ) }
+						isWarning
+					/>
 					<div className="flex items-end">
 						<TextControl
 							label={ __( 'Network Code', 'newspack' ) }
@@ -225,10 +223,10 @@ const AdUnits = ( {
 						);
 					} ) }
 			</Card>
-			{ can_use_service_account && connection_mode !== 'oauth' && (
+			{ ( connection_mode === 'service_account' || isLegacy ) && (
 				<ServiceAccountConnection
 					updateWithAPI={ updateWithAPI }
-					isConnected={ serviceData.status.connected }
+					isConnected={ connection_mode === 'service_account' && serviceData.status.connected }
 				/>
 			) }
 		</>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Always allow a disconnected GAM client to use service account connection.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

Instructions at https://github.com/Automattic/newspack-ads/pull/433

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->