### PR TITLE
Hotfix – OAuth logging and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.83.3-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.83.2...v1.83.3-hotfix.1) (2022-06-07)
+
+
+### Bug Fixes
+
+* oauth error handling ([#1687](https://github.com/Automattic/newspack-plugin/issues/1687)) ([d2bfd9f](https://github.com/Automattic/newspack-plugin/commit/d2bfd9f163fe06b439009f8f2a885ea013c489af))
+
 ## [1.83.2](https://github.com/Automattic/newspack-plugin/compare/v1.83.1...v1.83.2) (2022-06-02)
 
 

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -106,6 +106,7 @@ class Google_OAuth {
 	 */
 	public static function permissions_check() {
 		if ( ! current_user_can( 'manage_options' ) || ! self::is_oauth_configured() ) {
+			Logger::log( 'Fail: user failed permissions check.' );
 			return new \WP_Error(
 				'newspack_rest_forbidden',
 				esc_html__( 'You cannot use this resource.', 'newspack' ),
@@ -128,6 +129,7 @@ class Google_OAuth {
 		$saved_csrf_token = OAuth::retrieve_csrf_token( self::CSRF_TOKEN_NAMESPACE );
 
 		if ( $tokens['csrf_token'] !== $saved_csrf_token ) {
+			Logger::log( 'Failed saving credentials - CSRF token mismatch.' );
 			return new \WP_Error( 'newspack_google_oauth', __( 'Session token mismatch.', 'newspack' ) );
 		}
 
@@ -138,6 +140,7 @@ class Google_OAuth {
 			$auth['refresh_token'] = $tokens['refresh_token'];
 		}
 		self::remove_credentials();
+		Logger::log( 'Saving credentials to WP option ' . self::AUTH_DATA_META_NAME );
 		return add_option( self::AUTH_DATA_META_NAME, $auth );
 	}
 
@@ -196,6 +199,7 @@ class Google_OAuth {
 	 * @return WP_REST_Response Response.
 	 */
 	public static function api_google_auth_save_details( $request ) {
+		Logger::log( 'Attempting to save credentials…' );
 		$auth_save_data = [
 			'access_token' => $request['access_token'],
 			'csrf_token'   => $request['csrf_token'],
@@ -205,8 +209,10 @@ class Google_OAuth {
 			$auth_save_data['refresh_token'] = $request['refresh_token'];
 		}
 		if ( self::save_auth_credentials( $auth_save_data ) ) {
+			Logger::log( 'Credentials saved.' );
 			return \rest_ensure_response( [ 'status' => 'ok' ] );
 		} else {
+			Logger::log( 'Failed saving credentials.' );
 			return new \WP_Error( 'newspack_google_oauth', __( 'Could not save auth data for user.', 'newspack' ) );
 		}
 	}
@@ -217,6 +223,7 @@ class Google_OAuth {
 	 * @return WP_REST_Response Response.
 	 */
 	public static function api_google_auth_revoke() {
+		Logger::log( 'Revoking credentials…' );
 		$auth_data = self::get_google_auth_saved_data();
 		if ( ! isset( $auth_data['access_token'] ) ) {
 			return new \WP_Error( 'newspack_google_oauth', __( 'Missing token for user.', 'newspack' ) );
@@ -231,10 +238,12 @@ class Google_OAuth {
 			add_query_arg( [ 'token' => $token ], 'https://oauth2.googleapis.com/revoke' )
 		);
 		if ( 200 === $result['response']['code'] ) {
+			Logger::log( 'Revoking credentials success.' );
 			self::remove_credentials();
 			return \rest_ensure_response( [ 'status' => 'ok' ] );
 		} else {
-			return new \WP_Error( 'newspack_google_oauth', __( 'Could not save auth data for user.', 'newspack' ) );
+			Logger::log( 'Failed revoking credentials.' );
+			return new \WP_Error( 'newspack_google_oauth', __( 'Could not revoke credentials.', 'newspack' ) );
 		}
 	}
 
@@ -263,15 +272,10 @@ class Google_OAuth {
 	 * Get Google authentication details.
 	 */
 	public static function get_google_auth_saved_data() {
-		$is_permitted = self::permissions_check();
-		if ( true !== $is_permitted ) {
-			return false;
+		if ( ! self::permissions_check() ) {
+			return [];
 		}
-		$auth_data = get_option( self::AUTH_DATA_META_NAME, false );
-		if ( $auth_data ) {
-			return $auth_data;
-		}
-		return [];
+		return get_option( self::AUTH_DATA_META_NAME, [] );
 	}
 
 	/**
@@ -319,6 +323,7 @@ class Google_OAuth {
 				];
 			}
 		} else {
+			Logger::log( 'Failed retrieving user info – invalid credentials.' );
 			return new \WP_Error( 'newspack_google_oauth', __( 'Invalid Google credentials. Please reconnect.', 'newspack' ) );
 		}
 
@@ -379,6 +384,8 @@ class Google_OAuth {
 		$oauth_object->setAccessToken( $auth_data['access_token'] );
 		if ( isset( $auth_data['refresh_token'] ) ) {
 			$oauth_object->setRefreshToken( $auth_data['refresh_token'] );
+		} else {
+			Logger::log( 'Refresh token missing in the credentials – the authorisation will have to be refreshed in an hour.' );
 		}
 		return $oauth_object;
 	}
@@ -387,6 +394,7 @@ class Google_OAuth {
 	 * Remove saved credentials.
 	 */
 	public static function remove_credentials() {
+		Logger::log( 'Removing stored credentials.' );
 		delete_option( self::AUTH_DATA_META_NAME );
 	}
 

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.83.2
+ * Version: 1.83.3-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.83.2",
+  "version": "1.83.3-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.83.2",
+      "version": "1.83.3-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.17.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@wordpress/browserslist-config": "^4.1.2",
         "eslint": "^7.32.0",
         "lint-staged": "^12.4.1",
-        "newspack-scripts": "^3.3.0",
+        "newspack-scripts": "^3.3.2",
         "prettier": "npm:wp-prettier@^2.2.1-beta-1",
         "stylelint": "^13.3.1"
       },
@@ -4723,6 +4723,131 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
+      "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.10.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz",
@@ -8924,9 +9049,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -10533,9 +10658,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -10545,7 +10670,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -11324,16 +11449,16 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -17468,13 +17593,12 @@
       "dev": true
     },
     "node_modules/newspack-scripts": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-3.3.0.tgz",
-      "integrity": "sha512-aKkgBinpiIA/TVSqYJJyxl3gKCXoOTu0riTAnQ3fLT8pDwoquhPHrjN/CUgkcXi2ScMfFiIUJbUowEJGvBMYDw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-3.3.2.tgz",
+      "integrity": "sha512-VERTkqJ5qLL7//plGpco2+7a7xyG7EfyXSUqlmdCFXGO+phtMnP7r69jaGYxUCFAcvYTRp1+jlJX/uixxHoUgQ==",
       "dev": true,
       "dependencies": {
         "@automattic/calypso-build": "^10.0.0",
-        "@babel/eslint-parser": "^7.16.3",
         "@babel/preset-env": "^7.16.4",
         "@commitlint/cli": "^15.0.0",
         "@commitlint/config-conventional": "^15.0.0",
@@ -17483,6 +17607,7 @@
         "@testing-library/jest-dom": "^5.15.1",
         "@testing-library/react": "^12.1.2",
         "@types/wordpress__data": "^4.6.10",
+        "@typescript-eslint/parser": "^5.26.0",
         "@wordpress/a11y": "^3.2.4",
         "@wordpress/api-fetch": "^5.2.6",
         "@wordpress/base-styles": "^4.0.4",
@@ -17658,33 +17783,6 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/newspack-scripts/node_modules/@typescript-eslint/parser": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.2.tgz",
-      "integrity": "sha512-JaNYGkaQVhP6HNF+lkdOr2cAs2wdSZBoalE22uYWq8IEv/OVH0RksSGydk+sW8cLoSeYmC+OHvRyv2i4AQ7Czg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.2",
-        "@typescript-eslint/types": "5.10.2",
-        "@typescript-eslint/typescript-estree": "5.10.2",
-        "debug": "^4.3.2"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/newspack-scripts/node_modules/@typescript-eslint/type-utils": {
@@ -18787,21 +18885,18 @@
     },
     "node_modules/npm/node_modules/@gar/promisify": {
       "version": "1.1.2",
-      "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "2.9.0",
-      "integrity": "sha512-21DTow2xC0GlkowlE4zOu99UY21nSymW14fHZmB0yeAqhagmttJPmCUZXU+ngJmJ/Dwe5YP9QJUTgEVRLqnwcg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18848,14 +18943,12 @@
     },
     "node_modules/npm/node_modules/@npmcli/ci-detect": {
       "version": "1.3.0",
-      "integrity": "sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "2.3.0",
-      "integrity": "sha512-yjiC1xv7KTmUTqfRwN2ZL7BHV160ctGF0fLXmKkkMXj40UOvBe45Apwvt5JsFRtXSoHkUYy1ouzscziuWNzklg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18872,7 +18965,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
       "version": "1.0.1",
-      "integrity": "sha512-kQ1aCTTU45mPXN+pdAaRxlxr3OunkyztjbbxDY/aIcPS5CnCUrx+1+NvA6pTcYR7wmLZe37+Mi5v3nfbwPxq3A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18885,7 +18977,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "1.0.0",
-      "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18896,7 +18987,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "2.1.0",
-      "integrity": "sha512-/hBFX/QG1b+N7PZBFs0bi+evgRZcK9nWBxQKZkGoXUT5hJSwl5c4d7y8/hm+NQZRPhQ67RzFaj5UM9YeyKoryw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18913,7 +19003,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "1.0.7",
-      "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18930,7 +19019,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "1.0.4",
-      "integrity": "sha512-wVR8QxhyXsFcD/cORtJwGQodeeaDf0OxcHie8ema4VgFeqwYkFsDPnSrIRSytX8xR6nKPAH89WnwTcaU608b/Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18946,7 +19034,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "1.1.1",
-      "integrity": "sha512-9xe+ZZ1iGVaUovBVFI9h3qW+UuECUzhvZPxK9RaEA2mjU26o5D0JloGYWwLYvQELJNmBdQB6rrpuN8jni6LwzQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18958,7 +19045,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/move-file": {
       "version": "1.1.2",
-      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -18972,21 +19058,18 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "1.0.1",
-      "integrity": "sha512-qq3oEfcLFwNfEYOQ8HLimRGKlD8WSeGEdtUa7hmzpR8Sa7haL1KVQrvgO6wqMjhWFFVjgtrh1gIxDz+P8sjUaA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "1.0.2",
-      "integrity": "sha512-yrJUe6reVMpktcvagumoqD9r08fH1iRo01gn1u0zoCApa9lnZGEigVKUd2hzsCId4gdtkZZIVscLhNxMECKgRg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "1.0.1",
-      "integrity": "sha512-y6jnu76E9C23osz8gEMBayZmaZ69vFOIk8vR1FJL/wbEJ54+9aVG9rLTjQKSXfgYZEr50nw1txBBFfBZZe+bYg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18996,7 +19079,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "1.3.2",
-      "integrity": "sha512-QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19006,7 +19088,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "1.8.6",
-      "integrity": "sha512-e42bVZnC6VluBZBAFEr3YrdqSspG3bgilyg4nSLBJ7TRGNCzxHa92XAHxQBLYg0BmgwO4b2mf3h/l5EkEWRn3g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19019,7 +19100,6 @@
     },
     "node_modules/npm/node_modules/@tootallnate/once": {
       "version": "1.1.2",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19029,14 +19109,12 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "1.1.1",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "6.0.2",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19049,7 +19127,6 @@
     },
     "node_modules/npm/node_modules/agentkeepalive": {
       "version": "4.1.4",
-      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19064,7 +19141,6 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19078,7 +19154,6 @@
     },
     "node_modules/npm/node_modules/ajv": {
       "version": "6.12.6",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19095,7 +19170,6 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19105,7 +19179,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19121,35 +19194,30 @@
     },
     "node_modules/npm/node_modules/ansicolors": {
       "version": "0.3.2",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ansistyles": {
       "version": "0.1.3",
-      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "1.1.6",
-      "integrity": "sha512-+1byPnimWdGcKFRS48zG73nxM08kamPFReUYvEmRXI3E8E4YhF4voMRDaGlfGD1UeRHEgs4NhQCE28KI8JVj1A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19163,14 +19231,12 @@
     },
     "node_modules/npm/node_modules/asap": {
       "version": "2.0.6",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/asn1": {
       "version": "0.2.4",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19180,7 +19246,6 @@
     },
     "node_modules/npm/node_modules/assert-plus": {
       "version": "1.0.0",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19190,14 +19255,12 @@
     },
     "node_modules/npm/node_modules/asynckit": {
       "version": "0.4.0",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/aws-sign2": {
       "version": "0.7.0",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -19207,21 +19270,18 @@
     },
     "node_modules/npm/node_modules/aws4": {
       "version": "1.11.0",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -19231,7 +19291,6 @@
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "2.2.1",
-      "integrity": "sha512-wFzVTqavpgCCYAh8SVBdnZdiQMxTkGR+T3b14CNpBXIBe2neJWaMGAZ55XWWHELJJ89dscuq0VCBqcVaIOgCMg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19249,7 +19308,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.2.0",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19259,7 +19317,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19270,14 +19327,12 @@
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "1.0.3",
-      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "15.3.0",
-      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19307,14 +19362,12 @@
     },
     "node_modules/npm/node_modules/caseless": {
       "version": "0.12.0",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "4.1.2",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19331,7 +19384,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19341,7 +19393,6 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "3.1.1",
-      "integrity": "sha512-RBqYd32aDwbCMFJRL6wHOlDNYJsPNTt8vC82ErHF5vKt8QQzxm1FrkW8s/R5pVrXMf17sba09Uoy91PKiddAsw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -19354,7 +19405,6 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19364,7 +19414,6 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "3.1.2",
-      "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19378,7 +19427,6 @@
     },
     "node_modules/npm/node_modules/cli-table3": {
       "version": "0.6.0",
-      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19395,7 +19443,6 @@
     },
     "node_modules/npm/node_modules/cli-table3/node_modules/ansi-regex": {
       "version": "5.0.0",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19405,7 +19452,6 @@
     },
     "node_modules/npm/node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19415,7 +19461,6 @@
     },
     "node_modules/npm/node_modules/cli-table3/node_modules/string-width": {
       "version": "4.2.2",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19430,7 +19475,6 @@
     },
     "node_modules/npm/node_modules/cli-table3/node_modules/strip-ansi": {
       "version": "6.0.0",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19443,7 +19487,6 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19453,7 +19496,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "4.1.0",
-      "integrity": "sha512-lb9L7EM4I/ZRVuljLPEtUJOP+xiQVknZ4ZMpMgEp4JzNldPb27HU03hi6K1/6CoIuit/Zm/LQXySErFeXxDprw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19466,7 +19508,6 @@
     },
     "node_modules/npm/node_modules/code-point-at": {
       "version": "1.1.0",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19476,7 +19517,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19489,14 +19529,12 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/color-support": {
       "version": "1.1.3",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19506,7 +19544,6 @@
     },
     "node_modules/npm/node_modules/colors": {
       "version": "1.4.0",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19517,7 +19554,6 @@
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.5.4",
-      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19528,7 +19564,6 @@
     },
     "node_modules/npm/node_modules/combined-stream": {
       "version": "1.0.8",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19541,35 +19576,30 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/core-util-is": {
       "version": "1.0.2",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/dashdash": {
       "version": "1.14.1",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19582,7 +19612,6 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.2",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19600,14 +19629,12 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/debuglog": {
       "version": "1.0.1",
-      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19617,7 +19644,6 @@
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.3",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19627,7 +19653,6 @@
     },
     "node_modules/npm/node_modules/delayed-stream": {
       "version": "1.0.0",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19637,14 +19662,12 @@
     },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/depd": {
       "version": "1.1.2",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19654,7 +19677,6 @@
     },
     "node_modules/npm/node_modules/dezalgo": {
       "version": "1.0.3",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19665,7 +19687,6 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.0.0",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -19675,7 +19696,6 @@
     },
     "node_modules/npm/node_modules/ecc-jsbn": {
       "version": "0.1.2",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19686,14 +19706,12 @@
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19704,7 +19722,6 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19714,21 +19731,18 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/extend": {
       "version": "3.0.2",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/extsprintf": {
       "version": "1.3.0",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -19738,28 +19752,24 @@
     },
     "node_modules/npm/node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.12",
-      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/forever-agent": {
       "version": "0.6.1",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -19769,7 +19779,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19782,21 +19791,18 @@
     },
     "node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "3.0.1",
-      "integrity": "sha512-6STz6KdQgxO4S/ko+AbjlFGGdGcknluoqU+79GOFCDqqyYj5OanQf9AjxwN0jCidtT+ziPMmPSt9E4hfQ0CwIQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19817,7 +19823,6 @@
     },
     "node_modules/npm/node_modules/getpass": {
       "version": "0.1.7",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19827,7 +19832,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "7.2.0",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19848,14 +19852,12 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.8",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/har-schema": {
       "version": "2.0.0",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19865,7 +19867,6 @@
     },
     "node_modules/npm/node_modules/har-validator": {
       "version": "5.1.5",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19879,7 +19880,6 @@
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19892,7 +19892,6 @@
     },
     "node_modules/npm/node_modules/has-flag": {
       "version": "4.0.0",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19902,14 +19901,12 @@
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "4.0.2",
-      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19922,14 +19919,12 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.0",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "4.0.1",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19944,7 +19939,6 @@
     },
     "node_modules/npm/node_modules/http-signature": {
       "version": "1.2.0",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19960,7 +19954,6 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "5.0.0",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19974,7 +19967,6 @@
     },
     "node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
-      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19984,7 +19976,6 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19998,7 +19989,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "3.0.4",
-      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20008,7 +19998,6 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20018,7 +20007,6 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20028,14 +20016,12 @@
     },
     "node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20046,14 +20032,12 @@
     },
     "node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
       "version": "2.0.0",
-      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20063,7 +20047,6 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "2.0.5",
-      "integrity": "sha512-u1uGAtEFu3VA6HNl/yUWw57jmKEMx8SKOxHhxjGnOFUiIlFnohKDFg4ZrPpv9wWqk44nDxGJAtqjdQFm+9XXQA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20082,14 +20065,12 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "1.1.5",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "4.3.0",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20099,7 +20080,6 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "4.0.2",
-      "integrity": "sha512-z4a1ENUajDbEl/Q6/pVBpTR1nBjjEE1X7qb7bmWYanNnPoKAvUCPFKeXV6Fe4mgTkWKBqiHIcwsI3SndiO5FeA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -20112,7 +20092,6 @@
     },
     "node_modules/npm/node_modules/is-core-module": {
       "version": "2.7.0",
-      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20125,7 +20104,6 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20135,62 +20113,53 @@
     },
     "node_modules/npm/node_modules/is-lambda": {
       "version": "1.0.1",
-      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/is-typedarray": {
       "version": "1.0.0",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/isstream": {
       "version": "0.1.2",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/jsbn": {
       "version": "0.1.1",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-schema": {
       "version": "0.2.3",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true,
       "inBundle": true
     },
     "node_modules/npm/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20200,14 +20169,12 @@
     },
     "node_modules/npm/node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true,
       "engines": [
         "node >= 0.2.0"
@@ -20217,7 +20184,6 @@
     },
     "node_modules/npm/node_modules/jsprim": {
       "version": "1.4.1",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -20233,21 +20199,18 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "3.1.1",
-      "integrity": "sha512-sdMWKjRq8qWZEjDcVA6llnUT8RDEBIfOiGpYFPYa9u+2c39JCsejktSP7mj5eRid5EIvTzIpQ2kDOCw1Nq9BjQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "3.0.0",
-      "integrity": "sha512-K2MLc+ZC2DVxX4V61bIKPeMUUfj1YYZ3h0myhchDXOW1cKoPZMnjIoNCqv9bF2n5Oob1PFxuR2gVJxkxz4e58w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "4.0.3",
-      "integrity": "sha512-sPeTSNImksm8O2b6/pf3ikv4N567ERYEpeKRPSmqlNt1dTZbvgpJIzg5vAhXHpw2ISBsELFRelk0jEahj1c6nQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20263,7 +20226,6 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "2.0.4",
-      "integrity": "sha512-q3zWePOJLHwsLEUjZw3Kyu/MJMYfl4tWCg78Vl6QGSfm4aXBUSVzMzjJ6jGiyarsT4d+1NH4B1gxfs62/+y9iQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20283,7 +20245,6 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "2.0.1",
-      "integrity": "sha512-4SqBB7eJvJWmUKNF42Q5qTOn20DRjEE4TgvEh2yneKlAiRlwlhuS9MNR45juWwmoURJlf2K43bozlVt7OZiIOw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20306,7 +20267,6 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "1.1.0",
-      "integrity": "sha512-Kfmh3pLS5/RGKG5WXEig8mjahPVOxkik6lsbH4iX0si1xxNi6eeUh/+nF1MD+2cgalsQif3O5qyr6mNz2ryJrQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20316,7 +20276,6 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "6.0.3",
-      "integrity": "sha512-3fmkZJibIybzmAvxJ65PeV3NzRc0m4xmYt6scui5msocThbEp4sKFT80FhgrCERYDjlUuFahU6zFNbJDHbQ++g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20330,7 +20289,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "2.0.3",
-      "integrity": "sha512-JSGl3HFeiRFUZOUlGdiNcUZOsUqkSYrg6KMzvPZ1WVZ478i47OnKSS0vkPmX45Pai5mTKuwIqBMcGWG7O8HfdA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20344,7 +20302,6 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "2.0.1",
-      "integrity": "sha512-He4/jxOwlaQ7YG7sIC1+yNeXeUDQt8RLBvpI68R3RzPMZPa4/VpxhlDo8GtBOBDYoU8eq6v1wKL38sq58u4ibQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20359,7 +20316,6 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "4.0.2",
-      "integrity": "sha512-+AD7A2zbVeGRCFI2aO//oUmapCwy7GHqPXFJh3qpToSRNU+tXKJ2YFUgjt04LPPAf2dlEH95s6EhIHM1J7bmOw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20376,7 +20332,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "3.1.2",
-      "integrity": "sha512-BaQHBjMNnsPYk3Bl6AiOeVuFgp72jviShNBw5aHaHNKWqZxNi38iVNoXbo6bG/Ccc/m1To8s0GtMdtn6xZ1HAw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20389,7 +20344,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "2.0.4",
-      "integrity": "sha512-FPrVJWv820FZFXaflAEVTLRWZrerCvfe7ZHSMzJ/62EBlho2KFlYKjyNEsPW3JiV7TLSXi3vo8u0gMwIkXSMTw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20403,7 +20357,6 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "1.2.1",
-      "integrity": "sha512-AA7x5CFgBFN+L4/JWobnY5t4OAHjQuPbAwUYJ7/NtHuyLut5meb+ne/aj0n7PWNiTGCJcRw/W6Zd2LoLT7EZuQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20417,7 +20370,6 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "6.0.0",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20430,7 +20382,6 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "9.1.0",
-      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20458,7 +20409,6 @@
     },
     "node_modules/npm/node_modules/mime-db": {
       "version": "1.49.0",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20468,7 +20418,6 @@
     },
     "node_modules/npm/node_modules/mime-types": {
       "version": "2.1.32",
-      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20481,7 +20430,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "3.0.4",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20494,7 +20442,6 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "3.1.5",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20507,7 +20454,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "1.0.2",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20520,7 +20466,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "1.4.1",
-      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20538,7 +20483,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20551,7 +20495,6 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
-      "integrity": "sha512-ODqY18UZt/I8k+b7rl2AENgbWE8IDYam+undIJONvigAz8KR5GWblsFTEfQs0WODsjbSXWlm+JHEv8Gr6Tfdbg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20562,7 +20505,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20575,7 +20517,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20588,7 +20529,6 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20602,7 +20542,6 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20615,7 +20554,6 @@
     },
     "node_modules/npm/node_modules/mkdirp-infer-owner": {
       "version": "2.0.0",
-      "integrity": "sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20630,21 +20568,18 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "0.0.8",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.2",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20654,7 +20589,6 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "7.1.2",
-      "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20679,14 +20613,12 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/aproba": {
       "version": "1.2.0",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
       "version": "2.7.4",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20703,7 +20635,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20716,7 +20647,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
       "version": "4.1.2",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20729,7 +20659,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/string-width": {
       "version": "1.0.2",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20744,7 +20673,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "5.0.0",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20760,7 +20688,6 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "3.0.3",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -20776,7 +20703,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "2.1.5",
-      "integrity": "sha512-YB8qOoEmBhUH1UJgh1xFAv7Jg1d+xoNhsDYiFQlEFThEBui0W1vIz2ZK6FVg4WZjwEdl7uBQlm1jy3MUfyHeEw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20789,7 +20715,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "1.1.2",
-      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20799,7 +20724,6 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "4.0.0",
-      "integrity": "sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -20812,14 +20736,12 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "8.1.5",
-      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20834,7 +20756,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "2.2.2",
-      "integrity": "sha512-Jt01acDvJRhJGthnUJVF/w6gumWOZxO7IkpY/lsX9//zqQgnF7OJaxgQXcerd4uQOLu7W5bkb4mChL9mdfm+Zg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20853,7 +20774,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "6.1.1",
-      "integrity": "sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20866,7 +20786,6 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "5.0.4",
-      "integrity": "sha512-OKtU7yoAEBOnc8zJ+/uo5E4ugPp09sopo+6y1njPp+W99P8DvQon3BJYmpvyK2Bf1+3YV5LN1bvgXRoZ1LUJBA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20879,7 +20798,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "11.0.0",
-      "integrity": "sha512-jmlgSxoDNuhAtxUIG6pVwwtz840i994dL14FoNVZisrmZW5kWd63IUTNv1m/hyRSGSqWjCUp/YZlS1BJyNp9XA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20897,14 +20815,12 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "1.0.1",
-      "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "5.0.1",
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20917,7 +20833,6 @@
     },
     "node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
       "version": "2.0.0",
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20931,7 +20846,6 @@
     },
     "node_modules/npm/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20941,7 +20855,6 @@
     },
     "node_modules/npm/node_modules/oauth-sign": {
       "version": "0.9.0",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -20951,7 +20864,6 @@
     },
     "node_modules/npm/node_modules/object-assign": {
       "version": "4.1.1",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20961,7 +20873,6 @@
     },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20971,7 +20882,6 @@
     },
     "node_modules/npm/node_modules/opener": {
       "version": "1.5.2",
-      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
@@ -20981,7 +20891,6 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20997,7 +20906,6 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "11.3.5",
-      "integrity": "sha512-fT375Yczn4zi+6Hkk2TBe1x1sP8FgFsEIZ2/iWaXY2r/NkhDJfxbcn5paz1+RTFCyNf+dPnaoBDJoAxXSU8Bkg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21031,7 +20939,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "1.1.1",
-      "integrity": "sha512-4gySviBiW5TRl7XHvp1agcS7SOe0KZOjC//71dzZVWJrY9hCrgtvl5v3SyIxCZ4fZF47TxD9nfzmxcx76xmbUw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21043,7 +20950,6 @@
     },
     "node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21053,21 +20959,18 @@
     },
     "node_modules/npm/node_modules/performance-now": {
       "version": "2.1.0",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "1.0.0",
-      "integrity": "sha512-aCk8AO51s+4JyuYGg3Q/a6gnrlDO09NpVWePtjp7xwphcoQ04x5WAfCyugcsbLooWcMJ87CLkD4+604IckEdhg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21077,7 +20980,6 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "1.0.1",
-      "integrity": "sha512-3+hgaa19jzCGLuSCbieeRsu5C2joKfYn8pY6JAuXFRVfF4IO+L7UPpFWNTeWT9pM7uhskvbPPd/oEOktCn317Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21087,14 +20989,12 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21108,7 +21008,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "0.3.0",
-      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21118,14 +21017,12 @@
     },
     "node_modules/npm/node_modules/psl": {
       "version": "1.8.0",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/punycode": {
       "version": "2.1.1",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21135,7 +21032,6 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
       "dev": true,
       "inBundle": true,
       "bin": {
@@ -21144,7 +21040,6 @@
     },
     "node_modules/npm/node_modules/qs": {
       "version": "6.5.2",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -21154,7 +21049,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "1.0.7",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21167,14 +21061,12 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "2.0.0",
-      "integrity": "sha512-HJpV9bQpkl6KwjxlJcBoqu9Ba0PQg8TqSNIOrulGt54a0uup0HtevreFHzYzkm0lpnleRdNBzXznKrgxglEHQw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "4.1.1",
-      "integrity": "sha512-P82sbZJ3ldDrWCOSKxJT0r/CXMWR0OR3KRh55SgKo3p91GSIEEC32v3lSHAvO/UcH3/IoL7uqhOFBduAnwdldw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21190,7 +21082,6 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "2.0.3",
-      "integrity": "sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21204,7 +21095,6 @@
     },
     "node_modules/npm/node_modules/readable-stream": {
       "version": "3.6.0",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21219,7 +21109,6 @@
     },
     "node_modules/npm/node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
-      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21232,7 +21121,6 @@
     },
     "node_modules/npm/node_modules/request": {
       "version": "2.88.2",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -21264,7 +21152,6 @@
     },
     "node_modules/npm/node_modules/request/node_modules/form-data": {
       "version": "2.3.3",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21279,7 +21166,6 @@
     },
     "node_modules/npm/node_modules/request/node_modules/tough-cookie": {
       "version": "2.5.0",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -21293,7 +21179,6 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21303,7 +21188,6 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "3.0.2",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21319,7 +21203,6 @@
     },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -21340,14 +21223,12 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.3.5",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21363,21 +21244,18 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "3.0.3",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21388,7 +21266,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.6.1",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21403,7 +21280,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "6.1.0",
-      "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21418,7 +21294,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.1.1",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -21429,14 +21304,12 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21447,14 +21320,12 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.10",
-      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/sshpk": {
       "version": "1.16.1",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21480,7 +21351,6 @@
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "8.0.1",
-      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21493,7 +21363,6 @@
     },
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21503,7 +21372,6 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "2.1.1",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21517,7 +21385,6 @@
     },
     "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
       "version": "3.0.0",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21527,7 +21394,6 @@
     },
     "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
       "version": "4.0.0",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21540,14 +21406,12 @@
     },
     "node_modules/npm/node_modules/stringify-package": {
       "version": "1.0.1",
-      "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21560,7 +21424,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "7.2.0",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21573,7 +21436,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.1.11",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21591,28 +21453,24 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "1.0.4",
-      "integrity": "sha512-whw60l7r+8ZU8Tu/Uc2yxtc4ZTZbR/PF3u1IPNKGQ6p8EICLb3Z2lAgoqw9bqYd8IkgnsaOcLzYHFckjqNsf0g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -21625,14 +21483,12 @@
     },
     "node_modules/npm/node_modules/tweetnacl": {
       "version": "0.14.5",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "inBundle": true,
       "license": "Unlicense"
     },
     "node_modules/npm/node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21642,7 +21498,6 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "1.1.1",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21652,7 +21507,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "2.0.2",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21662,7 +21516,6 @@
     },
     "node_modules/npm/node_modules/uri-js": {
       "version": "4.4.1",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -21672,14 +21525,12 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/uuid": {
       "version": "3.4.0",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21689,7 +21540,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -21700,7 +21550,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "3.0.0",
-      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21710,7 +21559,6 @@
     },
     "node_modules/npm/node_modules/verror": {
       "version": "1.10.0",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -21725,14 +21573,12 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "1.0.0",
-      "integrity": "sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21742,7 +21588,6 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "2.0.2",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21758,7 +21603,6 @@
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.3",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21768,14 +21612,12 @@
     },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "3.0.3",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21788,7 +21630,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -33658,6 +33499,76 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "@typescript-eslint/parser": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
+      "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+          "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/visitor-keys": "5.27.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+          "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+          "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/visitor-keys": "5.27.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+          "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "@typescript-eslint/scope-manager": {
       "version": "5.10.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz",
@@ -37026,9 +36937,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -38292,9 +38203,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -38906,16 +38817,16 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "dependencies": {
@@ -43579,13 +43490,12 @@
       "dev": true
     },
     "newspack-scripts": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-3.3.0.tgz",
-      "integrity": "sha512-aKkgBinpiIA/TVSqYJJyxl3gKCXoOTu0riTAnQ3fLT8pDwoquhPHrjN/CUgkcXi2ScMfFiIUJbUowEJGvBMYDw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-3.3.2.tgz",
+      "integrity": "sha512-VERTkqJ5qLL7//plGpco2+7a7xyG7EfyXSUqlmdCFXGO+phtMnP7r69jaGYxUCFAcvYTRp1+jlJX/uixxHoUgQ==",
       "dev": true,
       "requires": {
         "@automattic/calypso-build": "^10.0.0",
-        "@babel/eslint-parser": "^7.16.3",
         "@babel/preset-env": "^7.16.4",
         "@commitlint/cli": "^15.0.0",
         "@commitlint/config-conventional": "^15.0.0",
@@ -43594,6 +43504,7 @@
         "@testing-library/jest-dom": "^5.15.1",
         "@testing-library/react": "^12.1.2",
         "@types/wordpress__data": "^4.6.10",
+        "@typescript-eslint/parser": "^5.26.0",
         "@wordpress/a11y": "^3.2.4",
         "@wordpress/api-fetch": "^5.2.6",
         "@wordpress/base-styles": "^4.0.4",
@@ -43722,18 +43633,6 @@
           "dev": true,
           "requires": {
             "@typescript-eslint/utils": "5.10.2"
-          }
-        },
-        "@typescript-eslint/parser": {
-          "version": "5.10.2",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.2.tgz",
-          "integrity": "sha512-JaNYGkaQVhP6HNF+lkdOr2cAs2wdSZBoalE22uYWq8IEv/OVH0RksSGydk+sW8cLoSeYmC+OHvRyv2i4AQ7Czg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/scope-manager": "5.10.2",
-            "@typescript-eslint/types": "5.10.2",
-            "@typescript-eslint/typescript-estree": "5.10.2",
-            "debug": "^4.3.2"
           }
         },
         "@typescript-eslint/type-utils": {
@@ -44488,19 +44387,16 @@
       "dependencies": {
         "@gar/promisify": {
           "version": "1.1.2",
-          "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
           "bundled": true,
           "dev": true
         },
         "@isaacs/string-locale-compare": {
           "version": "1.1.0",
-          "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
           "bundled": true,
           "dev": true
         },
         "@npmcli/arborist": {
           "version": "2.9.0",
-          "integrity": "sha512-21DTow2xC0GlkowlE4zOu99UY21nSymW14fHZmB0yeAqhagmttJPmCUZXU+ngJmJ/Dwe5YP9QJUTgEVRLqnwcg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44540,13 +44436,11 @@
         },
         "@npmcli/ci-detect": {
           "version": "1.3.0",
-          "integrity": "sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==",
           "bundled": true,
           "dev": true
         },
         "@npmcli/config": {
           "version": "2.3.0",
-          "integrity": "sha512-yjiC1xv7KTmUTqfRwN2ZL7BHV160ctGF0fLXmKkkMXj40UOvBe45Apwvt5JsFRtXSoHkUYy1ouzscziuWNzklg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44559,7 +44453,6 @@
         },
         "@npmcli/disparity-colors": {
           "version": "1.0.1",
-          "integrity": "sha512-kQ1aCTTU45mPXN+pdAaRxlxr3OunkyztjbbxDY/aIcPS5CnCUrx+1+NvA6pTcYR7wmLZe37+Mi5v3nfbwPxq3A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44568,7 +44461,6 @@
         },
         "@npmcli/fs": {
           "version": "1.0.0",
-          "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44578,7 +44470,6 @@
         },
         "@npmcli/git": {
           "version": "2.1.0",
-          "integrity": "sha512-/hBFX/QG1b+N7PZBFs0bi+evgRZcK9nWBxQKZkGoXUT5hJSwl5c4d7y8/hm+NQZRPhQ67RzFaj5UM9YeyKoryw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44594,7 +44485,6 @@
         },
         "@npmcli/installed-package-contents": {
           "version": "1.0.7",
-          "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44604,7 +44494,6 @@
         },
         "@npmcli/map-workspaces": {
           "version": "1.0.4",
-          "integrity": "sha512-wVR8QxhyXsFcD/cORtJwGQodeeaDf0OxcHie8ema4VgFeqwYkFsDPnSrIRSytX8xR6nKPAH89WnwTcaU608b/Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44616,7 +44505,6 @@
         },
         "@npmcli/metavuln-calculator": {
           "version": "1.1.1",
-          "integrity": "sha512-9xe+ZZ1iGVaUovBVFI9h3qW+UuECUzhvZPxK9RaEA2mjU26o5D0JloGYWwLYvQELJNmBdQB6rrpuN8jni6LwzQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44627,7 +44515,6 @@
         },
         "@npmcli/move-file": {
           "version": "1.1.2",
-          "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44637,19 +44524,16 @@
         },
         "@npmcli/name-from-folder": {
           "version": "1.0.1",
-          "integrity": "sha512-qq3oEfcLFwNfEYOQ8HLimRGKlD8WSeGEdtUa7hmzpR8Sa7haL1KVQrvgO6wqMjhWFFVjgtrh1gIxDz+P8sjUaA==",
           "bundled": true,
           "dev": true
         },
         "@npmcli/node-gyp": {
           "version": "1.0.2",
-          "integrity": "sha512-yrJUe6reVMpktcvagumoqD9r08fH1iRo01gn1u0zoCApa9lnZGEigVKUd2hzsCId4gdtkZZIVscLhNxMECKgRg==",
           "bundled": true,
           "dev": true
         },
         "@npmcli/package-json": {
           "version": "1.0.1",
-          "integrity": "sha512-y6jnu76E9C23osz8gEMBayZmaZ69vFOIk8vR1FJL/wbEJ54+9aVG9rLTjQKSXfgYZEr50nw1txBBFfBZZe+bYg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44658,7 +44542,6 @@
         },
         "@npmcli/promise-spawn": {
           "version": "1.3.2",
-          "integrity": "sha512-QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44667,7 +44550,6 @@
         },
         "@npmcli/run-script": {
           "version": "1.8.6",
-          "integrity": "sha512-e42bVZnC6VluBZBAFEr3YrdqSspG3bgilyg4nSLBJ7TRGNCzxHa92XAHxQBLYg0BmgwO4b2mf3h/l5EkEWRn3g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44679,19 +44561,16 @@
         },
         "@tootallnate/once": {
           "version": "1.1.2",
-          "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
           "bundled": true,
           "dev": true
         },
         "abbrev": {
           "version": "1.1.1",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "dev": true
         },
         "agent-base": {
           "version": "6.0.2",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44700,7 +44579,6 @@
         },
         "agentkeepalive": {
           "version": "4.1.4",
-          "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44711,7 +44589,6 @@
         },
         "aggregate-error": {
           "version": "3.1.0",
-          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44721,7 +44598,6 @@
         },
         "ajv": {
           "version": "6.12.6",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44733,13 +44609,11 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44748,31 +44622,26 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "bundled": true,
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "2.0.0",
-          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
           "bundled": true,
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "bundled": true,
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.6",
-          "integrity": "sha512-+1byPnimWdGcKFRS48zG73nxM08kamPFReUYvEmRXI3E8E4YhF4voMRDaGlfGD1UeRHEgs4NhQCE28KI8JVj1A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44782,13 +44651,11 @@
         },
         "asap": {
           "version": "2.0.6",
-          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
           "bundled": true,
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44797,37 +44664,31 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "bundled": true,
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "bundled": true,
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
           "bundled": true,
           "dev": true
         },
         "aws4": {
           "version": "1.11.0",
-          "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
           "bundled": true,
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.2",
-          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
           "bundled": true,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44836,7 +44697,6 @@
         },
         "bin-links": {
           "version": "2.2.1",
-          "integrity": "sha512-wFzVTqavpgCCYAh8SVBdnZdiQMxTkGR+T3b14CNpBXIBe2neJWaMGAZ55XWWHELJJ89dscuq0VCBqcVaIOgCMg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44850,13 +44710,11 @@
         },
         "binary-extensions": {
           "version": "2.2.0",
-          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
           "bundled": true,
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44866,13 +44724,11 @@
         },
         "builtins": {
           "version": "1.0.3",
-          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "bundled": true,
           "dev": true
         },
         "cacache": {
           "version": "15.3.0",
-          "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44898,13 +44754,11 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "bundled": true,
           "dev": true
         },
         "chalk": {
           "version": "4.1.2",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44914,13 +44768,11 @@
         },
         "chownr": {
           "version": "2.0.0",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
           "bundled": true,
           "dev": true
         },
         "cidr-regex": {
           "version": "3.1.1",
-          "integrity": "sha512-RBqYd32aDwbCMFJRL6wHOlDNYJsPNTt8vC82ErHF5vKt8QQzxm1FrkW8s/R5pVrXMf17sba09Uoy91PKiddAsw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44929,13 +44781,11 @@
         },
         "clean-stack": {
           "version": "2.2.0",
-          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
           "bundled": true,
           "dev": true
         },
         "cli-columns": {
           "version": "3.1.2",
-          "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44945,7 +44795,6 @@
         },
         "cli-table3": {
           "version": "0.6.0",
-          "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -44956,19 +44805,16 @@
           "dependencies": {
             "ansi-regex": {
               "version": "5.0.0",
-              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "3.0.0",
-              "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
               "bundled": true,
               "dev": true
             },
             "string-width": {
               "version": "4.2.2",
-              "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -44979,7 +44825,6 @@
             },
             "strip-ansi": {
               "version": "6.0.0",
-              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -44990,13 +44835,11 @@
         },
         "clone": {
           "version": "1.0.4",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "bundled": true,
           "dev": true
         },
         "cmd-shim": {
           "version": "4.1.0",
-          "integrity": "sha512-lb9L7EM4I/ZRVuljLPEtUJOP+xiQVknZ4ZMpMgEp4JzNldPb27HU03hi6K1/6CoIuit/Zm/LQXySErFeXxDprw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45005,13 +44848,11 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45020,26 +44861,22 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "bundled": true,
           "dev": true
         },
         "color-support": {
           "version": "1.1.3",
-          "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
           "bundled": true,
           "dev": true
         },
         "colors": {
           "version": "1.4.0",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45049,7 +44886,6 @@
         },
         "combined-stream": {
           "version": "1.0.8",
-          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45058,31 +44894,26 @@
         },
         "common-ancestor-path": {
           "version": "1.0.1",
-          "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
           "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "bundled": true,
           "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45091,7 +44922,6 @@
         },
         "debug": {
           "version": "4.3.2",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45100,7 +44930,6 @@
           "dependencies": {
             "ms": {
               "version": "2.1.2",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
               "bundled": true,
               "dev": true
             }
@@ -45108,13 +44937,11 @@
         },
         "debuglog": {
           "version": "1.0.1",
-          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
           "bundled": true,
           "dev": true
         },
         "defaults": {
           "version": "1.0.3",
-          "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45123,25 +44950,21 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "bundled": true,
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "bundled": true,
           "dev": true
         },
         "depd": {
           "version": "1.1.2",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
           "bundled": true,
           "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45151,13 +44974,11 @@
         },
         "diff": {
           "version": "5.0.0",
-          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
           "bundled": true,
           "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45167,13 +44988,11 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "bundled": true,
           "dev": true
         },
         "encoding": {
           "version": "0.1.13",
-          "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -45183,55 +45002,46 @@
         },
         "env-paths": {
           "version": "2.2.1",
-          "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
           "bundled": true,
           "dev": true
         },
         "err-code": {
           "version": "2.0.3",
-          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
           "bundled": true,
           "dev": true
         },
         "extend": {
           "version": "3.0.2",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
           "bundled": true,
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
           "bundled": true,
           "dev": true
         },
         "fast-deep-equal": {
           "version": "3.1.3",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "bundled": true,
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
-          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
           "bundled": true,
           "dev": true
         },
         "fastest-levenshtein": {
           "version": "1.0.12",
-          "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
           "bundled": true,
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "bundled": true,
           "dev": true
         },
         "fs-minipass": {
           "version": "2.1.0",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45240,19 +45050,16 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "dev": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
           "bundled": true,
           "dev": true
         },
         "gauge": {
           "version": "3.0.1",
-          "integrity": "sha512-6STz6KdQgxO4S/ko+AbjlFGGdGcknluoqU+79GOFCDqqyYj5OanQf9AjxwN0jCidtT+ziPMmPSt9E4hfQ0CwIQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45269,7 +45076,6 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45278,7 +45084,6 @@
         },
         "glob": {
           "version": "7.2.0",
-          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45292,19 +45097,16 @@
         },
         "graceful-fs": {
           "version": "4.2.8",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
           "bundled": true,
           "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
           "bundled": true,
           "dev": true
         },
         "har-validator": {
           "version": "5.1.5",
-          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45314,7 +45116,6 @@
         },
         "has": {
           "version": "1.0.3",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45323,19 +45124,16 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "bundled": true,
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
           "version": "4.0.2",
-          "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45344,13 +45142,11 @@
         },
         "http-cache-semantics": {
           "version": "4.1.0",
-          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
           "bundled": true,
           "dev": true
         },
         "http-proxy-agent": {
           "version": "4.0.1",
-          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45361,7 +45157,6 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45372,7 +45167,6 @@
         },
         "https-proxy-agent": {
           "version": "5.0.0",
-          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45382,7 +45176,6 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45391,7 +45184,6 @@
         },
         "iconv-lite": {
           "version": "0.6.3",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -45401,7 +45193,6 @@
         },
         "ignore-walk": {
           "version": "3.0.4",
-          "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45410,25 +45201,21 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "bundled": true,
           "dev": true
         },
         "indent-string": {
           "version": "4.0.0",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
           "bundled": true,
           "dev": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
           "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45438,19 +45225,16 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "2.0.0",
-          "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
           "bundled": true,
           "dev": true
         },
         "init-package-json": {
           "version": "2.0.5",
-          "integrity": "sha512-u1uGAtEFu3VA6HNl/yUWw57jmKEMx8SKOxHhxjGnOFUiIlFnohKDFg4ZrPpv9wWqk44nDxGJAtqjdQFm+9XXQA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45465,19 +45249,16 @@
         },
         "ip": {
           "version": "1.1.5",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
           "bundled": true,
           "dev": true
         },
         "ip-regex": {
           "version": "4.3.0",
-          "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
           "bundled": true,
           "dev": true
         },
         "is-cidr": {
           "version": "4.0.2",
-          "integrity": "sha512-z4a1ENUajDbEl/Q6/pVBpTR1nBjjEE1X7qb7bmWYanNnPoKAvUCPFKeXV6Fe4mgTkWKBqiHIcwsI3SndiO5FeA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45486,7 +45267,6 @@
         },
         "is-core-module": {
           "version": "2.7.0",
-          "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45495,79 +45275,66 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "bundled": true,
           "dev": true
         },
         "is-lambda": {
           "version": "1.0.1",
-          "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
           "bundled": true,
           "dev": true
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "bundled": true,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "bundled": true,
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "bundled": true,
           "dev": true
         },
         "json-parse-even-better-errors": {
           "version": "2.3.1",
-          "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
           "bundled": true,
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "bundled": true,
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "bundled": true,
           "dev": true
         },
         "json-stringify-nice": {
           "version": "1.1.4",
-          "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
           "bundled": true,
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "bundled": true,
           "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "bundled": true,
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45579,19 +45346,16 @@
         },
         "just-diff": {
           "version": "3.1.1",
-          "integrity": "sha512-sdMWKjRq8qWZEjDcVA6llnUT8RDEBIfOiGpYFPYa9u+2c39JCsejktSP7mj5eRid5EIvTzIpQ2kDOCw1Nq9BjQ==",
           "bundled": true,
           "dev": true
         },
         "just-diff-apply": {
           "version": "3.0.0",
-          "integrity": "sha512-K2MLc+ZC2DVxX4V61bIKPeMUUfj1YYZ3h0myhchDXOW1cKoPZMnjIoNCqv9bF2n5Oob1PFxuR2gVJxkxz4e58w==",
           "bundled": true,
           "dev": true
         },
         "libnpmaccess": {
           "version": "4.0.3",
-          "integrity": "sha512-sPeTSNImksm8O2b6/pf3ikv4N567ERYEpeKRPSmqlNt1dTZbvgpJIzg5vAhXHpw2ISBsELFRelk0jEahj1c6nQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45603,7 +45367,6 @@
         },
         "libnpmdiff": {
           "version": "2.0.4",
-          "integrity": "sha512-q3zWePOJLHwsLEUjZw3Kyu/MJMYfl4tWCg78Vl6QGSfm4aXBUSVzMzjJ6jGiyarsT4d+1NH4B1gxfs62/+y9iQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45619,7 +45382,6 @@
         },
         "libnpmexec": {
           "version": "2.0.1",
-          "integrity": "sha512-4SqBB7eJvJWmUKNF42Q5qTOn20DRjEE4TgvEh2yneKlAiRlwlhuS9MNR45juWwmoURJlf2K43bozlVt7OZiIOw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45638,7 +45400,6 @@
         },
         "libnpmfund": {
           "version": "1.1.0",
-          "integrity": "sha512-Kfmh3pLS5/RGKG5WXEig8mjahPVOxkik6lsbH4iX0si1xxNi6eeUh/+nF1MD+2cgalsQif3O5qyr6mNz2ryJrQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45647,7 +45408,6 @@
         },
         "libnpmhook": {
           "version": "6.0.3",
-          "integrity": "sha512-3fmkZJibIybzmAvxJ65PeV3NzRc0m4xmYt6scui5msocThbEp4sKFT80FhgrCERYDjlUuFahU6zFNbJDHbQ++g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45657,7 +45417,6 @@
         },
         "libnpmorg": {
           "version": "2.0.3",
-          "integrity": "sha512-JSGl3HFeiRFUZOUlGdiNcUZOsUqkSYrg6KMzvPZ1WVZ478i47OnKSS0vkPmX45Pai5mTKuwIqBMcGWG7O8HfdA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45667,7 +45426,6 @@
         },
         "libnpmpack": {
           "version": "2.0.1",
-          "integrity": "sha512-He4/jxOwlaQ7YG7sIC1+yNeXeUDQt8RLBvpI68R3RzPMZPa4/VpxhlDo8GtBOBDYoU8eq6v1wKL38sq58u4ibQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45678,7 +45436,6 @@
         },
         "libnpmpublish": {
           "version": "4.0.2",
-          "integrity": "sha512-+AD7A2zbVeGRCFI2aO//oUmapCwy7GHqPXFJh3qpToSRNU+tXKJ2YFUgjt04LPPAf2dlEH95s6EhIHM1J7bmOw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45691,7 +45448,6 @@
         },
         "libnpmsearch": {
           "version": "3.1.2",
-          "integrity": "sha512-BaQHBjMNnsPYk3Bl6AiOeVuFgp72jviShNBw5aHaHNKWqZxNi38iVNoXbo6bG/Ccc/m1To8s0GtMdtn6xZ1HAw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45700,7 +45456,6 @@
         },
         "libnpmteam": {
           "version": "2.0.4",
-          "integrity": "sha512-FPrVJWv820FZFXaflAEVTLRWZrerCvfe7ZHSMzJ/62EBlho2KFlYKjyNEsPW3JiV7TLSXi3vo8u0gMwIkXSMTw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45710,7 +45465,6 @@
         },
         "libnpmversion": {
           "version": "1.2.1",
-          "integrity": "sha512-AA7x5CFgBFN+L4/JWobnY5t4OAHjQuPbAwUYJ7/NtHuyLut5meb+ne/aj0n7PWNiTGCJcRw/W6Zd2LoLT7EZuQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45723,7 +45477,6 @@
         },
         "lru-cache": {
           "version": "6.0.0",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45732,7 +45485,6 @@
         },
         "make-fetch-happen": {
           "version": "9.1.0",
-          "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45756,13 +45508,11 @@
         },
         "mime-db": {
           "version": "1.49.0",
-          "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
           "bundled": true,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.32",
-          "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45771,7 +45521,6 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45780,7 +45529,6 @@
         },
         "minipass": {
           "version": "3.1.5",
-          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45789,7 +45537,6 @@
         },
         "minipass-collect": {
           "version": "1.0.2",
-          "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45798,7 +45545,6 @@
         },
         "minipass-fetch": {
           "version": "1.4.1",
-          "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45810,7 +45556,6 @@
         },
         "minipass-flush": {
           "version": "1.0.5",
-          "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45819,7 +45564,6 @@
         },
         "minipass-json-stream": {
           "version": "1.0.1",
-          "integrity": "sha512-ODqY18UZt/I8k+b7rl2AENgbWE8IDYam+undIJONvigAz8KR5GWblsFTEfQs0WODsjbSXWlm+JHEv8Gr6Tfdbg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45829,7 +45573,6 @@
         },
         "minipass-pipeline": {
           "version": "1.2.4",
-          "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45838,7 +45581,6 @@
         },
         "minipass-sized": {
           "version": "1.0.3",
-          "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45847,7 +45589,6 @@
         },
         "minizlib": {
           "version": "2.1.2",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45857,13 +45598,11 @@
         },
         "mkdirp": {
           "version": "1.0.4",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "bundled": true,
           "dev": true
         },
         "mkdirp-infer-owner": {
           "version": "2.0.0",
-          "integrity": "sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45874,25 +45613,21 @@
         },
         "ms": {
           "version": "2.1.3",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "bundled": true,
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.8",
-          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
           "bundled": true,
           "dev": true
         },
         "negotiator": {
           "version": "0.6.2",
-          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
           "bundled": true,
           "dev": true
         },
         "node-gyp": {
           "version": "7.1.2",
-          "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45910,13 +45645,11 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true
             },
             "gauge": {
               "version": "2.7.4",
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -45932,7 +45665,6 @@
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -45941,7 +45673,6 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -45953,7 +45684,6 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -45966,7 +45696,6 @@
         },
         "nopt": {
           "version": "5.0.0",
-          "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45975,7 +45704,6 @@
         },
         "normalize-package-data": {
           "version": "3.0.3",
-          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45987,7 +45715,6 @@
         },
         "npm-audit-report": {
           "version": "2.1.5",
-          "integrity": "sha512-YB8qOoEmBhUH1UJgh1xFAv7Jg1d+xoNhsDYiFQlEFThEBui0W1vIz2ZK6FVg4WZjwEdl7uBQlm1jy3MUfyHeEw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -45996,7 +45723,6 @@
         },
         "npm-bundled": {
           "version": "1.1.2",
-          "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46005,7 +45731,6 @@
         },
         "npm-install-checks": {
           "version": "4.0.0",
-          "integrity": "sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46014,13 +45739,11 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "bundled": true,
           "dev": true
         },
         "npm-package-arg": {
           "version": "8.1.5",
-          "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46031,7 +45754,6 @@
         },
         "npm-packlist": {
           "version": "2.2.2",
-          "integrity": "sha512-Jt01acDvJRhJGthnUJVF/w6gumWOZxO7IkpY/lsX9//zqQgnF7OJaxgQXcerd4uQOLu7W5bkb4mChL9mdfm+Zg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46043,7 +45765,6 @@
         },
         "npm-pick-manifest": {
           "version": "6.1.1",
-          "integrity": "sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46055,7 +45776,6 @@
         },
         "npm-profile": {
           "version": "5.0.4",
-          "integrity": "sha512-OKtU7yoAEBOnc8zJ+/uo5E4ugPp09sopo+6y1njPp+W99P8DvQon3BJYmpvyK2Bf1+3YV5LN1bvgXRoZ1LUJBA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46064,7 +45784,6 @@
         },
         "npm-registry-fetch": {
           "version": "11.0.0",
-          "integrity": "sha512-jmlgSxoDNuhAtxUIG6pVwwtz840i994dL14FoNVZisrmZW5kWd63IUTNv1m/hyRSGSqWjCUp/YZlS1BJyNp9XA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46078,13 +45797,11 @@
         },
         "npm-user-validate": {
           "version": "1.0.1",
-          "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==",
           "bundled": true,
           "dev": true
         },
         "npmlog": {
           "version": "5.0.1",
-          "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46096,7 +45813,6 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "2.0.0",
-              "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -46108,25 +45824,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
           "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46135,13 +45847,11 @@
         },
         "opener": {
           "version": "1.5.2",
-          "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
           "bundled": true,
           "dev": true
         },
         "p-map": {
           "version": "4.0.0",
-          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46150,7 +45860,6 @@
         },
         "pacote": {
           "version": "11.3.5",
-          "integrity": "sha512-fT375Yczn4zi+6Hkk2TBe1x1sP8FgFsEIZ2/iWaXY2r/NkhDJfxbcn5paz1+RTFCyNf+dPnaoBDJoAxXSU8Bkg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46177,7 +45886,6 @@
         },
         "parse-conflict-json": {
           "version": "1.1.1",
-          "integrity": "sha512-4gySviBiW5TRl7XHvp1agcS7SOe0KZOjC//71dzZVWJrY9hCrgtvl5v3SyIxCZ4fZF47TxD9nfzmxcx76xmbUw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46188,43 +45896,36 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
           "bundled": true,
           "dev": true
         },
         "proc-log": {
           "version": "1.0.0",
-          "integrity": "sha512-aCk8AO51s+4JyuYGg3Q/a6gnrlDO09NpVWePtjp7xwphcoQ04x5WAfCyugcsbLooWcMJ87CLkD4+604IckEdhg==",
           "bundled": true,
           "dev": true
         },
         "promise-all-reject-late": {
           "version": "1.0.1",
-          "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
           "bundled": true,
           "dev": true
         },
         "promise-call-limit": {
           "version": "1.0.1",
-          "integrity": "sha512-3+hgaa19jzCGLuSCbieeRsu5C2joKfYn8pY6JAuXFRVfF4IO+L7UPpFWNTeWT9pM7uhskvbPPd/oEOktCn317Q==",
           "bundled": true,
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
           "bundled": true,
           "dev": true
         },
         "promise-retry": {
           "version": "2.0.1",
-          "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46234,7 +45935,6 @@
         },
         "promzard": {
           "version": "0.3.0",
-          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46243,31 +45943,26 @@
         },
         "psl": {
           "version": "1.8.0",
-          "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
           "bundled": true,
           "dev": true
         },
         "punycode": {
           "version": "2.1.1",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "bundled": true,
           "dev": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
           "bundled": true,
           "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "bundled": true,
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46276,13 +45971,11 @@
         },
         "read-cmd-shim": {
           "version": "2.0.0",
-          "integrity": "sha512-HJpV9bQpkl6KwjxlJcBoqu9Ba0PQg8TqSNIOrulGt54a0uup0HtevreFHzYzkm0lpnleRdNBzXznKrgxglEHQw==",
           "bundled": true,
           "dev": true
         },
         "read-package-json": {
           "version": "4.1.1",
-          "integrity": "sha512-P82sbZJ3ldDrWCOSKxJT0r/CXMWR0OR3KRh55SgKo3p91GSIEEC32v3lSHAvO/UcH3/IoL7uqhOFBduAnwdldw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46294,7 +45987,6 @@
         },
         "read-package-json-fast": {
           "version": "2.0.3",
-          "integrity": "sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46304,7 +45996,6 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46315,7 +46006,6 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
-          "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46327,7 +46017,6 @@
         },
         "request": {
           "version": "2.88.2",
-          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46355,7 +46044,6 @@
           "dependencies": {
             "form-data": {
               "version": "2.3.3",
-              "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -46366,7 +46054,6 @@
             },
             "tough-cookie": {
               "version": "2.5.0",
-              "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -46378,13 +46065,11 @@
         },
         "retry": {
           "version": "0.12.0",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
           "bundled": true,
           "dev": true
         },
         "rimraf": {
           "version": "3.0.2",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46393,19 +46078,16 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "bundled": true,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "dev": true
         },
         "semver": {
           "version": "7.3.5",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46414,25 +46096,21 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.3",
-          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
           "bundled": true,
           "dev": true
         },
         "smart-buffer": {
           "version": "4.2.0",
-          "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
           "bundled": true,
           "dev": true
         },
         "socks": {
           "version": "2.6.1",
-          "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46442,7 +46120,6 @@
         },
         "socks-proxy-agent": {
           "version": "6.1.0",
-          "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46453,7 +46130,6 @@
         },
         "spdx-correct": {
           "version": "3.1.1",
-          "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46463,13 +46139,11 @@
         },
         "spdx-exceptions": {
           "version": "2.3.0",
-          "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
           "bundled": true,
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.1",
-          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46479,13 +46153,11 @@
         },
         "spdx-license-ids": {
           "version": "3.0.10",
-          "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
           "bundled": true,
           "dev": true
         },
         "sshpk": {
           "version": "1.16.1",
-          "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46502,7 +46174,6 @@
         },
         "ssri": {
           "version": "8.0.1",
-          "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46511,7 +46182,6 @@
         },
         "string_decoder": {
           "version": "1.3.0",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46520,7 +46190,6 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46530,13 +46199,11 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -46547,13 +46214,11 @@
         },
         "stringify-package": {
           "version": "1.0.1",
-          "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
           "bundled": true,
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46562,7 +46227,6 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46571,7 +46235,6 @@
         },
         "tar": {
           "version": "6.1.11",
-          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46585,25 +46248,21 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "bundled": true,
           "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
           "bundled": true,
           "dev": true
         },
         "treeverse": {
           "version": "1.0.4",
-          "integrity": "sha512-whw60l7r+8ZU8Tu/Uc2yxtc4ZTZbR/PF3u1IPNKGQ6p8EICLb3Z2lAgoqw9bqYd8IkgnsaOcLzYHFckjqNsf0g==",
           "bundled": true,
           "dev": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46612,13 +46271,11 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "bundled": true,
           "dev": true
         },
         "typedarray-to-buffer": {
           "version": "3.1.5",
-          "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46627,7 +46284,6 @@
         },
         "unique-filename": {
           "version": "1.1.1",
-          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46636,7 +46292,6 @@
         },
         "unique-slug": {
           "version": "2.0.2",
-          "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46645,7 +46300,6 @@
         },
         "uri-js": {
           "version": "4.4.1",
-          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46654,19 +46308,16 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "dev": true
         },
         "uuid": {
           "version": "3.4.0",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "bundled": true,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46676,7 +46327,6 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46685,7 +46335,6 @@
         },
         "verror": {
           "version": "1.10.0",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46696,13 +46345,11 @@
         },
         "walk-up-path": {
           "version": "1.0.0",
-          "integrity": "sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==",
           "bundled": true,
           "dev": true
         },
         "wcwidth": {
           "version": "1.0.1",
-          "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46711,7 +46358,6 @@
         },
         "which": {
           "version": "2.0.2",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46720,7 +46366,6 @@
         },
         "wide-align": {
           "version": "1.1.3",
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46729,13 +46374,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "3.0.3",
-          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -46747,7 +46390,6 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "bundled": true,
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wordpress/browserslist-config": "^4.1.2",
     "eslint": "^7.32.0",
     "lint-staged": "^12.4.1",
-    "newspack-scripts": "^3.3.0",
+    "newspack-scripts": "^3.3.2",
     "prettier": "npm:wp-prettier@^2.2.1-beta-1",
     "stylelint": "^13.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.83.2",
+  "version": "1.83.3-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/tests/unit-tests/oauth.php
+++ b/tests/unit-tests/oauth.php
@@ -44,7 +44,7 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 	/**
 	 * Google OAuth flow.
 	 */
-	public function test_google_oauth() {
+	public function test_oauth_google() {
 		self::expectException( Exception::class );
 		self::assertFalse(
 			OAuth::authenticate_proxy_url( 'google', '/wp-json/newspack-google' ),
@@ -85,7 +85,7 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 		Google_OAuth::api_google_auth_save_details( $proxy_response );
 
 		self::assertEquals(
-			false,
+			[],
 			Google_OAuth::get_google_auth_saved_data(),
 			'The auth data is not readable for just anyone.'
 		);
@@ -133,7 +133,7 @@ class Newspack_Test_OAuth extends WP_UnitTestCase {
 	/**
 	 * Fivetran OAuth flow.
 	 */
-	public function test_fivetran_oauth() {
+	public function test_oauth_fivetran() {
 		self::expectException( Exception::class );
 		self::assertFalse(
 			OAuth::authenticate_proxy_url( 'fivetran', '/wp-json/newspack-fivetran' ),


### PR DESCRIPTION
Combining recently-merged #1682 and #1687 in a hotfix, which improve OAuth error handling and debugging. Also bumping `newspack-scripts` (also merged to `master` in 8e32f7a2e242f3e52fd76bb933f7a7f74a1f597f) – the new version prevents post-hotfix overrides. 