### PR TITLE
chore(wizards): don't require jetpack for popups (campaigns) wizard

### DIFF
--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -421,6 +421,6 @@ class PopupsWizard extends Component {
 }
 
 render(
-	createElement( withWizard( PopupsWizard, [ 'jetpack', 'newspack-popups' ] ) ),
+	createElement( withWizard( PopupsWizard, [ 'newspack-popups' ] ) ),
 	document.getElementById( 'newspack-popups-wizard' )
 );


### PR DESCRIPTION
Not sure why would Jetpack be required to handle Campaigns.