### PR TITLE
fix(reader-revenue): disable WC email if module will send email

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -880,7 +880,7 @@ class Stripe_Connection {
 	 * @param bool $is_enabled True if enabled.
 	 */
 	public static function is_wc_complete_order_email_enabled( $is_enabled ) {
-		if ( Reader_Revenue_Emails::supports_emails() ) {
+		if ( Donations::is_platform_stripe() && Reader_Revenue_Emails::supports_emails() ) {
 			$is_enabled = false;
 		}
 		return $is_enabled;

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -30,6 +30,7 @@ class Stripe_Connection {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 		add_action( 'init', [ __CLASS__, 'handle_merchant_id_file_request' ] );
 		add_action( 'init', [ __CLASS__, 'register_apple_pay_domain' ] );
+		add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'is_wc_complete_order_email_enabled' ] );
 	}
 
 	/**
@@ -871,6 +872,18 @@ class Stripe_Connection {
 		} catch ( \Exception $e ) {
 			return;
 		}
+	}
+
+	/**
+	 * Disable WC's order complete email, if the email will be sent by this integration.
+	 *
+	 * @param bool $is_enabled True if enabled.
+	 */
+	public static function is_wc_complete_order_email_enabled( $is_enabled ) {
+		if ( Reader_Revenue_Emails::supports_emails() ) {
+			$is_enabled = false;
+		}
+		return $is_enabled;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1699

### How to test the changes in this Pull Request:

1. On `master`, activate WooCommerce and configure Stripe as Reader Revenue platform
2. Make a donation
3. Observe two emails are sent – one from Newspack ("Thank You" subject), and one from WC ("Your <site_title> order is now complete")
4. Switch to this branch, observe only the former is sent

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->