### PR TITLE
feat(reader-revenue): prevent creating duplicate stripe webhooks

### DIFF
--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -115,6 +115,11 @@ const StripeSetup = () => {
 		country_state_fields = [],
 	} = Wizard.useWizardData( 'reader-revenue' );
 
+	const hasWebhook =
+		data.webhook_url &&
+		Array.isArray( data.webhooks ) &&
+		data.webhooks.filter( webhook => webhook.url === data.webhook_url ).length > 0;
+
 	const [ isLoading, setIsLoading ] = useState( false );
 	const createWebhooks = () => {
 		setIsLoading( true );
@@ -257,8 +262,13 @@ const StripeSetup = () => {
 										<Notice isInfo noticeText={ __( 'No webhooks defined.', 'newspack' ) } />
 									) }
 									<Card noBorder buttonsCard>
-										<Button isLink disabled={ isLoading } onClick={ createWebhooks } isSecondary>
-											{ __( 'Create Webhooks', 'newspack' ) }
+										<Button
+											isLink
+											disabled={ isLoading || hasWebhook }
+											onClick={ createWebhooks }
+											isSecondary
+										>
+											{ __( 'Create Webhook', 'newspack' ) }
 										</Button>
 									</Card>
 								</>

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -262,6 +262,9 @@ const StripeSetup = () => {
 										<Notice isInfo noticeText={ __( 'No webhooks defined.', 'newspack' ) } />
 									) }
 									<Card noBorder buttonsCard>
+										{ hasWebhook && (
+											<p>{ __( 'Webhooks have already been created.', 'newspack' ) }</p>
+										) }
 										<Button
 											isLink
 											disabled={ isLoading || hasWebhook }

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -421,6 +421,13 @@ class Stripe_Connection {
 	}
 
 	/**
+	 * Get URL of the webhook for this site.
+	 */
+	public static function get_webhook_url() {
+		return get_rest_url( null, NEWSPACK_API_NAMESPACE . '/stripe/webhook' );
+	}
+
+	/**
 	 * Create Stripe webhooks.
 	 */
 	public static function create_webhooks() {
@@ -428,7 +435,7 @@ class Stripe_Connection {
 		try {
 			$webhook = $stripe->webhookEndpoints->create(
 				[
-					'url'            => get_rest_url( null, NEWSPACK_API_NAMESPACE . '/stripe/webhook' ),
+					'url'            => self::get_webhook_url(),
 					'enabled_events' => [
 						'charge.failed',
 						'charge.succeeded',

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -473,6 +473,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			$args['platform_data'] = wp_parse_args( $nrh_config, $args['platform_data'] );
 		} elseif ( Donations::is_platform_stripe() ) {
 			$args['stripe_data']['webhooks']         = Stripe_Connection::list_webhooks();
+			$args['stripe_data']['webhook_url']      = Stripe_Connection::get_webhook_url();
 			$args['stripe_data']['connection_error'] = Stripe_Connection::get_connection_error();
 		}
 		return $args;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1666.

### How to test the changes in this Pull Request:

1. On a site with Stripe set up a the Reader Revenue platform, visit the Reader Revenue wizard
2. If Stripe webhook exists for the site, confirm that another one can't be added ("Create Webhook" button is disabled)
3. If Stripe webhook does not exist, confirm it can be added

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->