### PR TITLE
feat: disable deactivate and delete for required plugins

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -179,7 +179,6 @@ class Plugin_Manager {
 				'PluginURI'   => esc_url( 'https://www.parsely.com/' ),
 				'AuthorURI'   => esc_url( 'https://www.parsely.com/' ),
 				'Download'    => 'wporg',
-				'AlwaysOn'    => true,
 			],
 			'password-protected'            => [
 				'Name'        => esc_html__( 'Password Protected', 'newspack' ),
@@ -353,7 +352,7 @@ class Plugin_Manager {
 	 *
 	 * @param string $plugin_slug Plugin slug.
 	 */
-	public static function get_managed_plugin_status( $plugin_slug ) {
+	private static function get_managed_plugin_status( $plugin_slug ) {
 		if ( Newspack::is_debug_mode() ) {
 			return 'active';
 		}

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -25,7 +25,6 @@ class Plugin_Manager {
 		'jetpack',
 		'amp',
 		'pwa',
-		'wordpress-seo',
 		'google-site-kit',
 		'newspack-blocks',
 		'wp-parsely',

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -28,6 +28,7 @@ class Plugin_Manager {
 		'wordpress-seo',
 		'google-site-kit',
 		'newspack-blocks',
+		'wp-parsely',
 	];
 
 	/**
@@ -178,6 +179,7 @@ class Plugin_Manager {
 				'PluginURI'   => esc_url( 'https://www.parsely.com/' ),
 				'AuthorURI'   => esc_url( 'https://www.parsely.com/' ),
 				'Download'    => 'wporg',
+				'AlwaysOn'    => true,
 			],
 			'password-protected'            => [
 				'Name'        => esc_html__( 'Password Protected', 'newspack' ),
@@ -351,7 +353,7 @@ class Plugin_Manager {
 	 *
 	 * @param string $plugin_slug Plugin slug.
 	 */
-	private static function get_managed_plugin_status( $plugin_slug ) {
+	public static function get_managed_plugin_status( $plugin_slug ) {
 		if ( Newspack::is_debug_mode() ) {
 			return 'active';
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds `wp-parsely` to the list of "required" plugins for the Newspack platform. Coupled with the PR in the private Manager repository, it makes it difficult to deactivate or delete this plugin from the Plugins dashboard page.

Closes #1702.

### How to test the changes in this Pull Request:

Follow instructions in the private manager plugin repository.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->