### PR TITLE
feat(reader-activation): registration block

### DIFF
--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -1,0 +1,31 @@
+/* globals newspack_blocks */
+
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import * as readerRegistration from './reader-registration';
+
+export const blocks = [ readerRegistration ];
+
+/**
+ * Function to register an individual block.
+ *
+ * @param {Object} block The block to be registered.
+ *
+ */
+const registerBlock = block => {
+	if ( ! block ) {
+		return;
+	}
+	const { metadata, settings, name } = block;
+	registerBlockType( { name, ...metadata }, settings );
+};
+
+for ( const block of blocks ) {
+	registerBlock( block );
+}

--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -12,6 +12,8 @@ import * as readerRegistration from './reader-registration';
 
 export const blocks = [ readerRegistration ];
 
+const readerActivationBlocks = [ 'newspack/reader-registration' ];
+
 /**
  * Function to register an individual block.
  *
@@ -22,7 +24,14 @@ const registerBlock = block => {
 	if ( ! block ) {
 		return;
 	}
+
 	const { metadata, settings, name } = block;
+
+	/** Do not register reader activation blocks if it's disabled. */
+	if ( readerActivationBlocks.includes( name ) && ! newspack_blocks.has_reader_activation ) {
+		return;
+	}
+
 	registerBlockType( { name, ...metadata }, settings );
 };
 

--- a/assets/blocks/reader-registration/block.json
+++ b/assets/blocks/reader-registration/block.json
@@ -18,7 +18,7 @@
 	},
 	"supports": {
 		"html": false,
-		"align": true
-	},
-	"style": "wp-block-newspack-reader-registration"
+		"align": true,
+		"multiple": false
+	}
 }

--- a/assets/blocks/reader-registration/block.json
+++ b/assets/blocks/reader-registration/block.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "newspack/reader-registration",
+	"title": "Reader Registration",
+	"category": "newspack",
+	"description": "Register a reader with their email.",
+	"textdomain": "newspack",
+	"attributes": {
+		"placeholder": {
+			"type": "string",
+			"default": "Enter your email address"
+		},
+		"label": {
+			"type": "string",
+			"default": "Register"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": true
+	},
+	"style": "wp-block-newspack-reader-registration"
+}

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -5,6 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { TextControl, PanelBody } from '@wordpress/components';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
 export default function ReaderRegistrationEdit( {
 	setAttributes,
 	attributes: { placeholder, label },

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -14,8 +14,6 @@ export default function ReaderRegistrationEdit( {
 	setAttributes,
 	attributes: { placeholder, label },
 } ) {
-	const defaultPlaceholder = __( 'Enter your email address', 'newspack' );
-	const defaultLabel = __( 'Register', 'newspack' );
 	const blockProps = useBlockProps();
 	return (
 		<>
@@ -24,13 +22,11 @@ export default function ReaderRegistrationEdit( {
 					<TextControl
 						label={ __( 'Input placeholder', 'newspack' ) }
 						value={ placeholder }
-						placeholder={ defaultPlaceholder }
 						onChange={ value => setAttributes( { placeholder: value } ) }
 					/>
 					<TextControl
 						label={ __( 'Button label', 'newspack' ) }
 						value={ label }
-						placeholder={ defaultLabel }
 						onChange={ value => setAttributes( { label: value } ) }
 					/>
 				</PanelBody>
@@ -38,8 +34,8 @@ export default function ReaderRegistrationEdit( {
 			<div { ...blockProps }>
 				<div className="newspack-reader-registration">
 					<form onSubmit={ ev => ev.preventDefault() }>
-						<input type="email" placeholder={ placeholder || defaultPlaceholder } />
-						<input type="submit" value={ label || defaultLabel } />
+						<input type="email" placeholder={ placeholder } />
+						<input type="submit" value={ label } />
 					</form>
 				</div>
 			</div>

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { TextControl, PanelBody } from '@wordpress/components';
-import { InspectorControls } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -16,6 +16,7 @@ export default function ReaderRegistrationEdit( {
 } ) {
 	const defaultPlaceholder = __( 'Enter your email address', 'newspack' );
 	const defaultLabel = __( 'Register', 'newspack' );
+	const blockProps = useBlockProps();
 	return (
 		<>
 			<InspectorControls>
@@ -34,15 +35,13 @@ export default function ReaderRegistrationEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div className="newspack-reader-registration">
-				<form
-					onSubmit={ ev => {
-						ev.preventDefault();
-					} }
-				>
-					<input type="email" placeholder={ placeholder || defaultPlaceholder } />
-					<button>{ label || defaultLabel }</button>
-				</form>
+			<div { ...blockProps }>
+				<div className="newspack-reader-registration">
+					<form onSubmit={ ev => ev.preventDefault() }>
+						<input type="email" placeholder={ placeholder || defaultPlaceholder } />
+						<input type="submit" value={ label || defaultLabel } />
+					</form>
+				</div>
 			</div>
 		</>
 	);

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { TextControl, PanelBody } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+export default function ReaderRegistrationEdit( {
+	setAttributes,
+	attributes: { placeholder, label },
+} ) {
+	const defaultPlaceholder = __( 'Enter your email address', 'newspack' );
+	const defaultLabel = __( 'Register', 'newspack' );
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Form settings', 'newspack' ) }>
+					<TextControl
+						label={ __( 'Input placeholder', 'newspack' ) }
+						value={ placeholder }
+						placeholder={ defaultPlaceholder }
+						onChange={ value => setAttributes( { placeholder: value } ) }
+					/>
+					<TextControl
+						label={ __( 'Button label', 'newspack' ) }
+						value={ label }
+						placeholder={ defaultLabel }
+						onChange={ value => setAttributes( { label: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div className="newspack-reader-registration">
+				<form
+					onSubmit={ ev => {
+						ev.preventDefault();
+					} }
+				>
+					<input type="email" placeholder={ placeholder || defaultPlaceholder } />
+					<button>{ label || defaultLabel }</button>
+				</form>
+			</div>
+		</>
+	);
+}

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -5,11 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { TextControl, PanelBody } from '@wordpress/components';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 
-/**
- * Internal dependencies
- */
-import './style.scss';
-
 export default function ReaderRegistrationEdit( {
 	setAttributes,
 	attributes: { placeholder, label },

--- a/assets/blocks/reader-registration/editor.scss
+++ b/assets/blocks/reader-registration/editor.scss
@@ -1,0 +1,34 @@
+@import './style.scss';
+
+.newspack-reader-registration {
+	form {
+		input[type='email'] {
+			background: #fff;
+			border: solid 1px #ccc;
+			box-sizing: border-box;
+			outline: none;
+			padding: 0.36rem 0.66rem;
+			-webkit-appearance: none;
+			outline-offset: 0;
+			border-radius: 0;
+		}
+		input[type='submit'] {
+			transition: background 150ms ease-in-out;
+			background: #555;
+			border: none;
+			border-radius: 5px;
+			box-sizing: border-box;
+			display: inline-block;
+			color: #fff;
+			font-family: -apple-system, blinkmacsystemfont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+				'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+			font-size: 0.8em;
+			font-weight: 700;
+			line-height: 1.2;
+			outline: none;
+			padding: 0.76rem 1rem;
+			text-decoration: none;
+			vertical-align: bottom;
+		}
+	}
+}

--- a/assets/blocks/reader-registration/index.js
+++ b/assets/blocks/reader-registration/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { box as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+};

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -141,6 +141,15 @@ function process_form() {
 			$message = $user_id->get_error_message();
 		}
 		\wp_send_json( compact( 'message', 'email' ), \is_wp_error( $user_id ) ? 400 : 200 );
+		exit;
+	} elseif ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) {
+		\wp_safe_redirect(
+			\add_query_arg(
+				[ 'newspack_reader' => is_wp_error( $user_id ) ? '0' : '1' ],
+				\remove_query_arg( [ '_wp_http_referer', 'newspack_reader_registration', 'email' ] )
+			)
+		);
+		exit;
 	}
 }
 add_action( 'template_redirect', __NAMESPACE__ . '\\process_form' );

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -115,9 +115,6 @@ function get_block_classes( $attrs = [] ) {
 	if ( isset( $attrs['className'] ) ) {
 		array_push( $classes, $attrs['className'] );
 	}
-	if ( is_array( $extra ) && ! empty( $extra ) ) {
-		$classes = array_merge( $classes, $extra );
-	}
 	return implode( ' ', $classes );
 }
 

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -83,11 +83,10 @@ function render_block( $attrs ) {
  * Utility to assemble the class for a server-side rendered block.
  *
  * @param array $attrs Block attributes.
- * @param array $extra Additional classes to be added to the class list.
  *
  * @return string Class list separated by spaces.
  */
-function get_block_classes( $attrs = [], $extra = [] ) {
+function get_block_classes( $attrs = [] ) {
 	$classes = [];
 	if ( isset( $attrs['align'] ) && ! empty( $attrs['align'] ) ) {
 		$classes[] = 'align' . $attrs['align'];
@@ -98,10 +97,6 @@ function get_block_classes( $attrs = [], $extra = [] ) {
 	if ( is_array( $extra ) && ! empty( $extra ) ) {
 		$classes = array_merge( $classes, $extra );
 	}
-	if ( ! empty( $attrs['hideControls'] ) ) {
-		$classes[] = 'hide-controls';
-	}
-
 	return implode( ' ', $classes );
 }
 

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Newspack Blocks.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Blocks\ReaderRegistration;
+
+use Newspack\Reader_Activation;
+
+defined( 'ABSPATH' ) || exit;
+
+const FORM_ACTION = 'newspack_reader_registration';
+
+/**
+ * Register block from metadata.
+ */
+function register_block() {
+	register_block_type_from_metadata(
+		__DIR__ . '/block.json',
+		array(
+			'render_callback' => __NAMESPACE__ . '\\render_block',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\\register_block' );
+
+/**
+ * Render Registration Block.
+ *
+ * @param array[] $attrs Block attributes.
+ */
+function render_block( $attrs ) {
+	if ( \is_user_logged_in() || Reader_Activation::get_auth_intention_value() ) {
+		return;
+	}
+	ob_start();
+	?>
+	<div class="newspack-reader-registration">
+		<form method="POST">
+			<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
+			<input type="email" name="email" autocomplete="email" placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>" />
+			<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
+		</form>
+	</div>
+	<?php
+	return ob_get_clean();
+}
+
+/**
+ * Process registration form.
+ */
+function process_form() {
+	if ( ! isset( $_POST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_POST[ FORM_ACTION ] ), FORM_ACTION ) ) {
+		return;
+	}
+
+	if ( ! isset( $_POST['email'] ) || empty( $_POST['email'] ) ) {
+		return;
+	}
+
+	$email  = \sanitize_email( $_POST['email'] );
+	$result = Reader_Activation::register_reader( $email );
+
+	/**
+	 * Fires after a reader is registered through the Reader Registration Block.
+	 *
+	 * @param string               $email  Email address of the reader.
+	 * @param int|string|\WP_Error $result The created user ID in case of registration, the user email if user already exists, or a WP_Error object.
+	 */
+	\do_action( 'newspack_reader_registration_form_processed', $email, $result );
+
+	if ( \wp_is_json_request() ) {
+		if ( ! \is_wp_error( $result ) ) {
+			$message = __( 'Thank you for registering!', 'newspack' );
+		} else {
+			$message = $result->get_error_message();
+		}
+		\wp_send_json( compact( 'message' ), \is_wp_error( $result ) ? 400 : 200 );
+	}
+}
+add_action( 'template_redirect', __NAMESPACE__ . '\\process_form' );

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -44,19 +44,22 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_edit
  * Enqueue front-end scripts.
  */
 function enqueue_scripts() {
+	$handle = 'newspack-reader-registration-block';
 	\wp_enqueue_style(
-		'newspack-reader-registration-block',
+		$handle,
 		\Newspack\Newspack::plugin_url() . '/dist/reader-registration-block.css',
 		[],
 		NEWSPACK_PLUGIN_VERSION
 	);
-	wp_enqueue_script(
-		'newspack-reader-registration-block',
+	\wp_enqueue_script(
+		$handle,
 		\Newspack\Newspack::plugin_url() . '/dist/reader-registration-block.js',
 		[ 'wp-polyfill', 'newspack-reader-activation' ],
 		NEWSPACK_PLUGIN_VERSION,
 		true
 	);
+	\wp_script_add_data( $handle, 'async', true );
+	\wp_script_add_data( $handle, 'amp-plus', true );
 }
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 
@@ -72,7 +75,7 @@ function render_block( $attrs ) {
 	ob_start();
 	?>
 	<div class="newspack-reader-registration <?php echo esc_attr( get_block_classes( $attrs ) ); ?>">
-		<form method="POST" target="_top">
+		<form>
 			<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
 			<input type="email" name="email" autocomplete="email" placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>" />
 			<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
@@ -112,15 +115,15 @@ function get_block_classes( $attrs = [], $extra = [] ) {
  * Process registration form.
  */
 function process_form() {
-	if ( ! isset( $_POST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_POST[ FORM_ACTION ] ), FORM_ACTION ) ) {
+	if ( ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
 		return;
 	}
 
-	if ( ! isset( $_POST['email'] ) || empty( $_POST['email'] ) ) {
+	if ( ! isset( $_REQUEST['email'] ) || empty( $_REQUEST['email'] ) ) {
 		return;
 	}
 
-	$email   = \sanitize_email( $_POST['email'] );
+	$email   = \sanitize_email( $_REQUEST['email'] );
 	$user_id = Reader_Activation::register_reader( $email );
 
 	/**

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -28,13 +28,32 @@ function register_block() {
 add_action( 'init', __NAMESPACE__ . '\\register_block' );
 
 /**
+ * Enqueue block editor assets.
+ */
+function enqueue_block_editor_assets() {
+	\wp_enqueue_style(
+		'newspack-reader-registration-block',
+		\Newspack\Newspack::plugin_url() . '/dist/reader-registration-block.css',
+		[],
+		NEWSPACK_PLUGIN_VERSION
+	);
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_editor_assets' );
+
+/**
  * Enqueue front-end scripts.
  */
 function enqueue_scripts() {
+	\wp_enqueue_style(
+		'newspack-reader-registration-block',
+		\Newspack\Newspack::plugin_url() . '/dist/reader-registration-block.css',
+		[],
+		NEWSPACK_PLUGIN_VERSION
+	);
 	wp_enqueue_script(
 		'newspack-reader-registration-block',
-		\Newspack\Newspack::plugin_url() . '/assets/blocks/reader-registration/view.js',
-		[ 'jquery', 'newspack-reader-activation' ],
+		\Newspack\Newspack::plugin_url() . '/dist/reader-registration-block.js',
+		[ 'wp-polyfill', 'newspack-reader-activation' ],
 		NEWSPACK_PLUGIN_VERSION,
 		true
 	);

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -15,6 +15,13 @@ defined( 'ABSPATH' ) || exit;
 const FORM_ACTION = 'newspack_reader_registration';
 
 /**
+ * Do not register block hooks if Reader Activation is not enabled.
+ */
+if ( ! Reader_Activation::is_enabled() ) {
+	return;
+}
+
+/**
  * Register block from metadata.
  */
 function register_block() {
@@ -26,19 +33,6 @@ function register_block() {
 	);
 }
 add_action( 'init', __NAMESPACE__ . '\\register_block' );
-
-/**
- * Enqueue block editor assets.
- */
-function enqueue_block_editor_assets() {
-	\wp_enqueue_style(
-		'newspack-reader-registration-block',
-		\Newspack\Newspack::plugin_url() . '/dist/reader-registration-block.css',
-		[],
-		NEWSPACK_PLUGIN_VERSION
-	);
-}
-add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_editor_assets' );
 
 /**
  * Enqueue front-end scripts.

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -1,11 +1,13 @@
-.newspack-reader-registration form {
-	width: 100%;
-	display: flex;
-	align-items: center;
-	margin: 0;
-	input[type='email'] {
-		flex: 1 1 100%;
-		min-width: 250px;
-		margin-right: 1em;
+.newspack-reader-registration {
+	form {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		margin: 0;
+		input[type='email'] {
+			flex: 1 1 100%;
+			min-width: 250px;
+			margin-right: 1em;
+		}
 	}
 }

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -1,14 +1,11 @@
 .newspack-reader-registration form {
 	width: 100%;
 	display: flex;
-	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 );
 	align-items: center;
 	margin: 0;
 	input[type='email'] {
-		border: 0;
 		flex: 1 1 100%;
-	}
-	input[type='submit'] {
-		border: 0;
+		min-width: 250px;
+		margin-right: 1em;
 	}
 }

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -1,0 +1,14 @@
+.newspack-reader-registration form {
+	width: 100%;
+	display: flex;
+	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.1 );
+	align-items: center;
+	margin: 0;
+	input[type='email'] {
+		border: 0;
+		flex: 1 1 100%;
+	}
+	input[type='submit'] {
+		border: 0;
+	}
+}

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -16,12 +16,16 @@ import './style.scss';
 		} );
 		form.addEventListener( 'submit', ev => {
 			ev.preventDefault();
+			const body = new FormData( form );
+			if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
+				return;
+			}
 			fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 				method: 'POST',
 				headers: {
 					Accept: 'application/json',
 				},
-				body: new FormData( form ),
+				body,
 			} ).then( res => {
 				res.json().then( ( { message, email } ) => {
 					const messageNode = document.createElement( 'p' );

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -4,6 +4,9 @@
 import './style.scss';
 
 ( function ( readerActivation ) {
+	if ( ! readerActivation ) {
+		return;
+	}
 	[ ...document.querySelectorAll( '.newspack-reader-registration' ) ].forEach( container => {
 		const form = container.querySelector( 'form' );
 		if ( ! form ) {

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -12,6 +12,10 @@ import './style.scss';
 		if ( ! form ) {
 			return;
 		}
+		const messageContainer = container.querySelector(
+			'.newspack-newsletters-registration-response'
+		);
+		const submit = form.querySelector( 'input[type="submit"]' );
 		readerActivation.on( 'reader', ( { detail: { email } } ) => {
 			if ( email ) {
 				form.style.display = 'none';
@@ -23,6 +27,8 @@ import './style.scss';
 			if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
 				return;
 			}
+			submit.disabled = true;
+			messageContainer.innerHTML = '';
 			fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 				method: 'POST',
 				headers: {
@@ -30,13 +36,18 @@ import './style.scss';
 				},
 				body,
 			} ).then( res => {
-				res.json().then( ( { message, email } ) => {
+				submit.disabled = false;
+				res.json().then( ( { message, data } ) => {
 					const messageNode = document.createElement( 'p' );
 					messageNode.innerHTML = message;
 					messageNode.className = `message status-${ res.status }`;
-					container.replaceChild( messageNode, form );
-					if ( res.status === 200 && email ) {
-						readerActivation.setReader( email );
+					if ( res.status === 200 ) {
+						container.replaceChild( messageNode, form );
+						if ( data?.email ) {
+							readerActivation.setReader( data.email );
+						}
+					} else {
+						messageContainer.appendChild( messageNode );
 					}
 				} );
 			} );

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -1,0 +1,27 @@
+( function ( $, readerActivation ) {
+	$( document ).ready( function () {
+		$( '.newspack-reader-registration form' ).on( 'submit', function ( ev ) {
+			ev.preventDefault();
+			const url = $( this ).attr( 'action' ) || window.location.pathname;
+			$.ajax( {
+				url,
+				type: 'POST',
+				data: $( this ).serialize(),
+				dataType: 'json',
+				accepts: {
+					text: 'application/json',
+				},
+				success: ( { message, email } ) => {
+					console.log( message );
+					readerActivation.setReader( { email } );
+				},
+				error: err => {
+					console.log( err );
+				},
+			} );
+		} );
+	} );
+	readerActivation.on( 'reader', function ( ev ) {
+		console.log( ev );
+	} );
+} )( window.jQuery, window.newspackReaderActivation );

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -6,6 +6,12 @@ import './style.scss';
 ( function ( readerActivation ) {
 	[ ...document.querySelectorAll( '.newspack-reader-registration' ) ].forEach( container => {
 		const form = container.querySelector( 'form' );
+		if ( ! form ) {
+			return;
+		}
+		readerActivation.on( 'reader', () => {
+			form.style.display = 'none';
+		} );
 		form.addEventListener( 'submit', ev => {
 			ev.preventDefault();
 			fetch( form.getAttribute( 'action' ) || window.location.pathname, {

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -1,27 +1,30 @@
-( function ( $, readerActivation ) {
-	$( document ).ready( function () {
-		$( '.newspack-reader-registration form' ).on( 'submit', function ( ev ) {
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+( function ( readerActivation ) {
+	[ ...document.querySelectorAll( '.newspack-reader-registration' ) ].forEach( container => {
+		const form = container.querySelector( 'form' );
+		form.addEventListener( 'submit', ev => {
 			ev.preventDefault();
-			const url = $( this ).attr( 'action' ) || window.location.pathname;
-			$.ajax( {
-				url,
-				type: 'POST',
-				data: $( this ).serialize(),
-				dataType: 'json',
-				accepts: {
-					text: 'application/json',
+			fetch( form.getAttribute( 'action' ) || window.location.pathname, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
 				},
-				success: ( { message, email } ) => {
-					console.log( message );
-					readerActivation.setReader( { email } );
-				},
-				error: err => {
-					console.log( err );
-				},
+				body: new FormData( form ),
+			} ).then( res => {
+				res.json().then( ( { message, email } ) => {
+					const messageNode = document.createElement( 'p' );
+					messageNode.innerHTML = message;
+					messageNode.className = `message status-${ res.status }`;
+					container.replaceChild( messageNode, form );
+					if ( res.status === 200 && email ) {
+						readerActivation.setReader( email );
+					}
+				} );
 			} );
 		} );
 	} );
-	readerActivation.on( 'reader', function ( ev ) {
-		console.log( ev );
-	} );
-} )( window.jQuery, window.newspackReaderActivation );
+} )( window.newspackReaderActivation );

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -9,8 +9,10 @@ import './style.scss';
 		if ( ! form ) {
 			return;
 		}
-		readerActivation.on( 'reader', () => {
-			form.style.display = 'none';
+		readerActivation.on( 'reader', ( { detail: { email } } ) => {
+			if ( email ) {
+				form.style.display = 'none';
+			}
 		} );
 		form.addEventListener( 'submit', ev => {
 			ev.preventDefault();

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -1,0 +1,61 @@
+/** globals newspack_reader_activation */
+
+/**
+ * Reader Activation Frontend Library.
+ */
+
+/**
+ * Constants.
+ */
+const EVENT_PREFIX = 'newspack-reader-activation';
+const EVENTS = {
+	reader: 'reader',
+};
+
+/**
+ * Data.
+ */
+const events = Object.values( EVENTS );
+const store = {
+	reader: window.newspack_reader_activation_data?.reader_email || null,
+};
+
+/**
+ * Events.
+ */
+function getEventName( event ) {
+	return `${ EVENT_PREFIX }-${ event }`;
+}
+export function on( eventName, callback ) {
+	if ( events.includes( eventName ) ) {
+		eventName = getEventName( eventName );
+		window.addEventListener( eventName, callback );
+	}
+}
+export function off( eventName, callback ) {
+	if ( events.includes( eventName ) ) {
+		eventName = getEventName( eventName );
+		window.removeEventListener( eventName, callback );
+	}
+}
+
+/**
+ * Reader functions.
+ */
+export function setReader( email ) {
+	store.reader = null;
+	if ( ! email ) {
+		return;
+	}
+	store.reader = { email };
+	/** Emit reader event. */
+	const event = new CustomEvent( getEventName( EVENTS.reader ), { detail: store.reader } );
+	window.dispatchEvent( event );
+}
+export function getReader() {
+	return store.reader;
+}
+
+const readerActivation = { on, off, setReader, getReader };
+window.newspackReaderActivation = readerActivation;
+export default readerActivation;

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -32,7 +32,7 @@ function getCookie( name ) {
 	if ( parts.length === 2 ) return decodeURIComponent( parts.pop().split( ';' ).shift() );
 }
 const data = window.newspack_reader_activation_data;
-const initialEmail = data?.reader_email || getCookie( data?.intention_cookie );
+const initialEmail = data?.reader_email || getCookie( data?.auth_intention_cookie );
 const store = {
 	reader: initialEmail ? { email: initialEmail } : null,
 };

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -108,7 +108,7 @@ export function off( event, callback ) {
  */
 
 /**
- * Set the current reader email.
+ * Set the current reader.
  *
  * @param {string} email Email.
  */
@@ -122,9 +122,9 @@ export function setReader( email ) {
 }
 
 /**
- * Get the current reader email.
+ * Get the current reader.
  *
- * @return {string} Email.
+ * @return {Object} Reader data.
  */
 export function getReader() {
 	return store.reader;

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -1,4 +1,4 @@
-/** globals newspack_reader_activation */
+/** globals newspack_reader_activation_data */
 
 /**
  * Reader Activation Frontend Library.

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -32,8 +32,9 @@ function getCookie( name ) {
 	if ( parts.length === 2 ) return decodeURIComponent( parts.pop().split( ';' ).shift() );
 }
 const data = window.newspack_reader_activation_data;
+const initialEmail = data?.reader_email || getCookie( data?.intention_cookie );
 const store = {
-	reader: data?.reader_email || getCookie( data?.intention_cookie ) || null,
+	reader: initialEmail ? { email: initialEmail } : null,
 };
 
 /**
@@ -109,4 +110,5 @@ export function getReader() {
 
 const readerActivation = { on, off, setReader, getReader };
 window.newspackReaderActivation = readerActivation;
+
 export default readerActivation;

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -84,10 +84,11 @@ function emit( event, data ) {
  * @param {Function} callback Callback.
  */
 export function on( event, callback ) {
-	if ( events.includes( event ) ) {
-		event = getEventName( event );
-		window.addEventListener( event, callback );
+	event = getEventName( event );
+	if ( ! event ) {
+		throw 'Invalid event';
 	}
+	window.addEventListener( event, callback );
 }
 
 /**
@@ -97,10 +98,11 @@ export function on( event, callback ) {
  * @param {Function} callback Callback.
  */
 export function off( event, callback ) {
-	if ( events.includes( event ) ) {
-		event = getEventName( event );
-		window.removeEventListener( event, callback );
+	event = getEventName( event );
+	if ( ! event ) {
+		throw 'Invalid event';
 	}
+	window.removeEventListener( event, callback );
 }
 
 /**

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -15,14 +15,20 @@ const EVENTS = {
 /**
  * Data.
  */
-const events = Object.values( EVENTS );
+function getCookie( name ) {
+	const value = `; ${ document.cookie }`;
+	const parts = value.split( `; ${ name }=` );
+	if ( parts.length === 2 ) return decodeURIComponent( parts.pop().split( ';' ).shift() );
+}
+const data = window.newspack_reader_activation_data;
 const store = {
-	reader: window.newspack_reader_activation_data?.reader_email || null,
+	reader: data?.reader_email || getCookie( data.intention_cookie ) || null,
 };
 
 /**
  * Events.
  */
+const events = Object.values( EVENTS );
 function getEventName( event ) {
 	return `${ EVENT_PREFIX }-${ event }`;
 }

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -13,40 +13,79 @@ const EVENTS = {
 };
 
 /**
- * Data.
+ * Initialize data.
+ */
+
+/**
+ * Get a cookie value given its name.
+ *
+ * @param {string} name Cookie name.
+ *
+ * @return {string} Cookie value or empty string if not found.
  */
 function getCookie( name ) {
+	if ( ! name ) {
+		return '';
+	}
 	const value = `; ${ document.cookie }`;
 	const parts = value.split( `; ${ name }=` );
 	if ( parts.length === 2 ) return decodeURIComponent( parts.pop().split( ';' ).shift() );
 }
 const data = window.newspack_reader_activation_data;
 const store = {
-	reader: data?.reader_email || getCookie( data.intention_cookie ) || null,
+	reader: data?.reader_email || getCookie( data?.intention_cookie ) || null,
 };
 
 /**
- * Events.
+ * Handling events.
  */
 const events = Object.values( EVENTS );
-function getEventName( event ) {
-	return `${ EVENT_PREFIX }-${ event }`;
+
+/**
+ * Get the full event name given its local name.
+ *
+ * @param {string} localEventName Local event name.
+ *
+ * @return {string} Full event name.
+ */
+function getEventName( localEventName ) {
+	return `${ EVENT_PREFIX }-${ localEventName }`;
 }
-export function on( eventName, callback ) {
-	if ( events.includes( eventName ) ) {
-		eventName = getEventName( eventName );
-		window.addEventListener( eventName, callback );
+
+/**
+ * Attach an event listener given a local event name.
+ *
+ * @param {string}   event    Local event name.
+ * @param {Function} callback Callback.
+ */
+export function on( event, callback ) {
+	if ( events.includes( event ) ) {
+		event = getEventName( event );
+		window.addEventListener( event, callback );
 	}
 }
-export function off( eventName, callback ) {
-	if ( events.includes( eventName ) ) {
-		eventName = getEventName( eventName );
-		window.removeEventListener( eventName, callback );
+
+/**
+ * Detach an event listener given a local event name.
+ *
+ * @param {string}   event    Local event name.
+ * @param {Function} callback Callback.
+ */
+export function off( event, callback ) {
+	if ( events.includes( event ) ) {
+		event = getEventName( event );
+		window.removeEventListener( event, callback );
 	}
 }
 
 /**
  * Reader functions.
+ */
+
+/**
+ * Set the current reader email.
+ *
+ * @param {string} email Email.
  */
 export function setReader( email ) {
 	store.reader = null;
@@ -58,6 +97,12 @@ export function setReader( email ) {
 	const event = new CustomEvent( getEventName( EVENTS.reader ), { detail: store.reader } );
 	window.dispatchEvent( event );
 }
+
+/**
+ * Get the current reader email.
+ *
+ * @return {string} Email.
+ */
 export function getReader() {
 	return store.reader;
 }

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Newspack Blocks.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Blocks Class.
+ */
+final class Blocks {
+	/**
+	 * Initialize Hooks.
+	 */
+	public static function init() {
+		require_once NEWSPACK_ABSPATH . '/assets/blocks/reader-registration/index.php';
+		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
+		\add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+	}
+
+	/**
+	 * Enqueue front-end scripts.
+	 */
+	public static function enqueue_scripts() {
+		\wp_enqueue_style(
+			'newspack-blocks',
+			Newspack::plugin_url() . '/dist/blocks.css',
+			[],
+			NEWSPACK_PLUGIN_VERSION
+		);
+	}
+
+	/**
+	 * Enqueue blocks scripts and styles for editor.
+	 */
+	public static function enqueue_block_editor_assets() {
+		Newspack::load_common_assets();
+
+		\wp_enqueue_script(
+			'newspack-blocks',
+			Newspack::plugin_url() . '/dist/blocks.js',
+			[],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+		\wp_localize_script(
+			'newspack-blocks',
+			'newspack_blocks',
+			[
+				'has_reader_activation' => Reader_Activation::is_enabled(),
+			]
+		);
+		\wp_enqueue_style(
+			'newspack-blocks',
+			Newspack::plugin_url() . '/dist/blocks.css',
+			[],
+			NEWSPACK_PLUGIN_VERSION
+		);
+	}
+}
+Blocks::init();

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -18,20 +18,7 @@ final class Blocks {
 	 */
 	public static function init() {
 		require_once NEWSPACK_ABSPATH . '/assets/blocks/reader-registration/index.php';
-		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		\add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
-	}
-
-	/**
-	 * Enqueue front-end scripts.
-	 */
-	public static function enqueue_scripts() {
-		\wp_enqueue_style(
-			'newspack-blocks',
-			Newspack::plugin_url() . '/dist/blocks.css',
-			[],
-			NEWSPACK_PLUGIN_VERSION
-		);
 	}
 
 	/**

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -87,6 +87,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-google-services-connection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-mailchimp-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-fivetran-connection.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-blocks.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-rss.php';
 

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -25,6 +25,7 @@ class Patches {
 		add_action( 'pre_get_posts', [ __CLASS__, 'restrict_others_posts' ] );
 		add_filter( 'ajax_query_attachments_args', [ __CLASS__, 'restrict_media_library_access_ajax' ] );
 		add_filter( 'script_loader_tag', [ __CLASS__, 'add_async_defer_support' ], 10, 2 );
+		add_filter( 'script_loader_tag', [ __CLASS__, 'add_amp_plus_attr_support' ], 10, 2 );
 
 		// Disable WooCommerce image regeneration to prevent regenerating thousands of images.
 		add_filter( 'woocommerce_background_image_regeneration', '__return_false' );
@@ -59,6 +60,27 @@ class Patches {
 			}
 			// Only allow async or defer, not both.
 			break;
+		}
+		return $tag;
+	}
+
+	/**
+	 * Similar to async/defer support from `add_async_defer_support()`, adds
+	 * 'amp-plus' support to `wp_script_add_data()`.
+	 *
+	 * @param string $tag The script tag.
+	 * @param string $handle The script handle.
+	 *
+	 * @return @string Script HTML string.
+	 */
+	public static function add_amp_plus_attr_support( $tag, $handle ) {
+		$data_name = 'amp-plus';
+		$attr      = 'data-amp-plus-allowed';
+		if ( ! wp_scripts()->get_data( $handle, $data_name ) ) {
+			return $tag;
+		}
+		if ( ! preg_match( ":\s$attr(=|>|\s):", $tag ) ) {
+			$tag = preg_replace( ':(?=></script>):', " $attr", $tag, 1 );
 		}
 		return $tag;
 	}

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -55,7 +55,8 @@ final class Reader_Activation {
 			'newspack-reader-activation',
 			'newspack_reader_activation_data',
 			[
-				'reader_email' => $reader_email,
+				'intention_cookie' => self::AUTH_INTENTION_COOKIE,
+				'reader_email'     => $reader_email,
 			]
 		);
 	}

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -27,12 +27,37 @@ final class Reader_Activation {
 	 */
 	public static function init() {
 		if ( self::is_enabled() ) {
+			\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 			\add_action( 'clear_auth_cookie', [ __CLASS__, 'clear_auth_intention_cookie' ] );
 			\add_action( 'set_auth_cookie', [ __CLASS__, 'clear_auth_intention_cookie' ] );
 			\add_filter( 'login_form_defaults', [ __CLASS__, 'add_auth_intention_to_login_form' ], 20 );
 			\add_action( 'resetpass_form', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'password_reset', [ __CLASS__, 'set_reader_verified' ] );
 		}
+	}
+
+	/**
+	 * Enqueue front-end scripts.
+	 */
+	public static function enqueue_scripts() {
+		\wp_register_script(
+			'newspack-reader-activation',
+			Newspack::plugin_url() . '/dist/reader-activation.js',
+			[],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+		$reader_email = '';
+		if ( \is_user_logged_in() && self::is_user_reader( \wp_get_current_user() ) ) {
+			$reader_email = \wp_get_current_user()->user_email;
+		}
+		wp_localize_script(
+			'newspack-reader-activation',
+			'newspack_reader_activation_data',
+			[
+				'reader_email' => $reader_email,
+			]
+		);
 	}
 
 	/**

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -40,8 +40,9 @@ final class Reader_Activation {
 	 * Enqueue front-end scripts.
 	 */
 	public static function enqueue_scripts() {
+		$handle = 'newspack-reader-activation';
 		\wp_register_script(
-			'newspack-reader-activation',
+			$handle,
 			Newspack::plugin_url() . '/dist/reader-activation.js',
 			[],
 			NEWSPACK_PLUGIN_VERSION,
@@ -52,13 +53,15 @@ final class Reader_Activation {
 			$reader_email = \wp_get_current_user()->user_email;
 		}
 		wp_localize_script(
-			'newspack-reader-activation',
+			$handle,
 			'newspack_reader_activation_data',
 			[
 				'intention_cookie' => self::AUTH_INTENTION_COOKIE,
 				'reader_email'     => $reader_email,
 			]
 		);
+		\wp_script_add_data( $handle, 'async', true );
+		\wp_script_add_data( $handle, 'amp-plus', true );
 	}
 
 	/**

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -52,12 +52,12 @@ final class Reader_Activation {
 		if ( \is_user_logged_in() && self::is_user_reader( \wp_get_current_user() ) ) {
 			$reader_email = \wp_get_current_user()->user_email;
 		}
-		wp_localize_script(
+		\wp_localize_script(
 			$handle,
 			'newspack_reader_activation_data',
 			[
-				'intention_cookie' => self::AUTH_INTENTION_COOKIE,
-				'reader_email'     => $reader_email,
+				'auth_intention_cookie' => self::AUTH_INTENTION_COOKIE,
+				'reader_email'          => $reader_email,
 			]
 		);
 		\wp_script_add_data( $handle, 'async', true );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ const webpackConfig = getBaseWebpackConfig(
 		entry: {
 			...wizardsScriptFiles,
 			blocks: path.join( __dirname, 'assets', 'blocks', 'index.js' ),
+			'reader-activation': path.join( __dirname, 'assets', 'reader-activation', 'index.js' ),
 		},
 	}
 );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,13 @@ const webpackConfig = getBaseWebpackConfig(
 			...wizardsScriptFiles,
 			blocks: path.join( __dirname, 'assets', 'blocks', 'index.js' ),
 			'reader-activation': path.join( __dirname, 'assets', 'reader-activation', 'index.js' ),
+			'reader-registration-block': path.join(
+				__dirname,
+				'assets',
+				'blocks',
+				'reader-registration',
+				'view.js'
+			),
 		},
 	}
 );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@
  **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 /* eslint-disable import/no-nodejs-modules */
+/* eslint-disable @typescript-eslint/no-var-requires */
 
 /**
  * External dependencies
@@ -43,7 +44,10 @@ otherScripts.forEach( function ( script ) {
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
-		entry: wizardsScriptFiles,
+		entry: {
+			...wizardsScriptFiles,
+			blocks: path.join( __dirname, 'assets', 'blocks', 'index.js' ),
+		},
 	}
 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements a simple reader registration block integrated with a reader activation frontend js library. The block features should be later expanded to include:

 - Optional newsletter subscription through API provided by newspack-newsletters with:
   - Default list to assign the reader to, or;
   - Allow the reader to select from a list
 - Social login with Google and Facebook

<img width="1520" alt="image" src="https://user-images.githubusercontent.com/820752/175407621-1915d679-ec50-45c9-94c9-5ad9490f7762.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/820752/175407514-3ffd03e2-b50b-4ac8-a2e3-d2f17860aa5e.png">

## Reader Activation Frontend Library

This PR also introduces a small js library to allow easy communication between current and future reader activation front-end components on XHR requests.

Given the optimistic quality of the reader activation's auth intention, once a reader registers through the block, the `readerActivation.setReader( { email } );` is called regardless of authenticating or not. This method dispatches the `reader` event, which can be listened like this:

```js
readerActivation.on( 'reader', ( { detail: { email } } ) => {
	if ( email ) {
		console.log( "Reader updated", email );
	}
} );
```

The library also provides `readerActivation.off( 'reader', cb );` method to remove the listener and `readerActivation.getReader();` to retrieve the currently stored reader data.

In the near future, this library should also be used to update the component that links the user to authenticate or access the reader account page, providing dynamic and appropriate messaging given the authentication state.

## AMP Plus tweak

Similar to what has already been implemented for async/defer, this PR also introduces the support for enabling AMP Plus to a script by using:

```php
\wp_script_add_data( $handle, 'amp-plus', true );
```

This serves as a shortcut to properly add the `data-amp-plus-allowed` attribute to the script.

### How to test the changes in this Pull Request:

1. Confirm you have AMP with AMP Plus enabled and WooCommerce installed for the tests
2. Without `define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );` on your `wp-config.php`, look for the Reader Registration block on a new draft and confirm it's not available, as it shouldn't without reader activation enabled.
3. Add `define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );` and confirm you can add the block
4. Save the page, visit and register an email that doesn't exist on the database
5. Confirm the success message, visit Woo's `my-account` page and confirm you are logged in
6. Log out, register through the block again with the same email
7. Refresh the page and confirm the block does not render, as it identifies you as a registered reader
8. Visit Woo's `my-account` page and confirm you're prompted to authenticate
9. Disable AMP Plus, clear your cookies, register with pure AMP, and confirm you're redirected to a `?newspack_reader=1` page and you're registered (either with auth intention cookie or fully authenticated, depending on the email)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->