### PR TITLE
fix: fatal errors related to debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.85.1-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.85.0...v1.85.1-hotfix.1) (2022-06-28)
+
+
+### Bug Fixes
+
+* restrict debug mode behavior to wizard API requests ([3f9fcab](https://github.com/Automattic/newspack-plugin/commit/3f9fcabe58ab3b2d172df5806a5dad2b3ccd7456))
+* use create_term instead of insert_term to avoid fatal if term already exists ([e4f633e](https://github.com/Automattic/newspack-plugin/commit/e4f633e0c852068f80984076fe2545ae2a52f39d))
+
 # [1.85.0](https://github.com/Automattic/newspack-plugin/compare/v1.84.1...v1.85.0) (2022-06-27)
 
 

--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -193,7 +193,7 @@ class Plugins_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		return rest_ensure_response( Plugin_Manager::get_managed_plugins() );
+		return rest_ensure_response( Plugin_Manager::get_managed_plugins( \Newspack::is_debug_mode() ) );
 	}
 
 	/**
@@ -210,7 +210,7 @@ class Plugins_Controller extends WP_REST_Controller {
 			return $is_valid_plugin;
 		}
 
-		$managed_plugins = Plugin_Manager::get_managed_plugins();
+		$managed_plugins = Plugin_Manager::get_managed_plugins( \Newspack::is_debug_mode() );
 
 		$plugin = $managed_plugins[ $slug ];
 

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -34,10 +34,11 @@ class Plugin_Manager {
 	 * Get info about all the managed plugins and their status.
 	 *
 	 * @todo Define what the structure of this looks like better and load it up from a config or something.
+	 * @param boolean $debug_mode If debug mode, plugin will be assumed to be active.
 	 *
 	 * @return array of plugins info.
 	 */
-	public static function get_managed_plugins() {
+	public static function get_managed_plugins( $debug_mode = false ) {
 		$managed_plugins = [
 			'akismet'                       => [
 				'Name'        => esc_html__( 'Akismet Anti-Spam', 'newspack' ),
@@ -327,7 +328,7 @@ class Plugin_Manager {
 
 		// Add plugin status info and fill in defaults.
 		foreach ( $managed_plugins as $plugin_slug => $managed_plugin ) {
-			$status = self::get_managed_plugin_status( $plugin_slug );
+			$status = self::get_managed_plugin_status( $plugin_slug, $debug_mode );
 
 			if ( 'newspack-theme' === $plugin_slug ) {
 				if ( 'newspack-theme' === get_stylesheet() ) {
@@ -349,10 +350,11 @@ class Plugin_Manager {
 	/**
 	 * Determine a managed plugin status.
 	 *
-	 * @param string $plugin_slug Plugin slug.
+	 * @param string  $plugin_slug Plugin slug.
+	 * @param boolean $debug_mode If debug mode, plugin will be assumed to be active.
 	 */
-	private static function get_managed_plugin_status( $plugin_slug ) {
-		if ( Newspack::is_debug_mode() ) {
+	private static function get_managed_plugin_status( $plugin_slug, $debug_mode = false ) {
+		if ( $debug_mode ) {
 			return 'active';
 		}
 		$status            = 'uninstalled';

--- a/includes/starter_content/class-starter-content-generated.php
+++ b/includes/starter_content/class-starter-content-generated.php
@@ -147,7 +147,8 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 		self::remove_starter_categories();
 		$category_ids = array_map(
 			function( $category ) {
-				$created_category = wp_insert_term( $category, 'category', [ 'slug' => '_newspack_' . $category ] );
+				$created_category = wp_create_term( $category, 'category', [ 'slug' => '_newspack_' . $category ] );
+
 				return $created_category['term_id'];
 			},
 			self::$starter_categories

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.85.0
+ * Version: 1.85.1-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.85.0",
+  "version": "1.85.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.85.0",
+      "version": "1.85.1-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.18.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.85.0",
+  "version": "1.85.1-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two rare fatal errors:

1. When generating starter content, a fatal is thrown if one of the generated categories already exists due to an unhandled error from `wp_insert_term`. This is fixed by using `wp_create_term` instead, which handles that situation more  gracefully by returning the ID of the already-existing term instead of throwing an error.
2. A fatal error due to the plugin manager's handling of the `WP_NEWSPACK_DEBUG` flag. This flag is really only relevant to not gate certain parts of the UI behind a "required plugins" interface, but 

### How to test the changes in this Pull Request:

1.
3.
4.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->