### PR TITLE
fix(amp-plus): handle complianz-gdpr plugin

### DIFF
--- a/includes/class-amp-enhancements.php
+++ b/includes/class-amp-enhancements.php
@@ -83,6 +83,13 @@ class AMP_Enhancements {
 			if ( 0 === strpos( $error['node_attributes']['id'], 'wp-' ) ) {
 				return false;
 			}
+			// Allow Complianz plugin (complianz-gdpr) scripts, unless its AMP integration is enabled.
+			// If it is enabled, `amp-consent` will be used and allowing the script would duplicate the cookie prompt.
+			if ( function_exists( 'cmplz_is_integration_enabled' ) && ! cmplz_is_integration_enabled( 'amp' ) ) {
+				if ( 0 === strpos( $error['node_attributes']['id'], 'cmplz-' ) ) {
+					return false;
+				}
+			}
 		}
 		// Explicitly allowed scripts - with a 'data-amp-plus-allowed' attribute.
 		if ( isset( $error, $error['node_attributes'], $error['node_attributes']['data-amp-plus-allowed'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds Complianz plugin handling to AMP Plus. 

### How to test the changes in this Pull Request:

1. On `master`, enable AMP Plus and set up Complianz plugin
2. In Complianz -> Integrations -> Plugins ensure "AMP" is toggled on
3. Disable AMP on a page
4. Observe that on page with AMP disabled, the non-AMP (more interactive) version of the cookie prompt is displayed 
5. Observe that on an AMP page, the AMP (`amp-consent`) version is displayed
6. Switch to this branch, observe no change in the above behaviour
7. Toggle Complianz's AMP integration off and observe the non-AMP prompt is always displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->