### PR TITLE
feat(reader-activation): extended auth expiration

### DIFF
--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -32,6 +32,7 @@ final class Reader_Activation {
 			\add_filter( 'login_form_defaults', [ __CLASS__, 'add_auth_intention_to_login_form' ], 20 );
 			\add_action( 'resetpass_form', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'password_reset', [ __CLASS__, 'set_reader_verified' ] );
+			\add_action( 'auth_cookie_expiration', [ __CLASS__, 'auth_cookie_expiration' ], 10, 3 );
 		}
 	}
 
@@ -178,6 +179,25 @@ final class Reader_Activation {
 		\update_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
 
 		return true;
+	}
+
+	/**
+	 * Set custom auth cookie expiration for readers.
+	 *
+	 * @param int  $length   Duration of the expiration period in seconds.
+	 * @param int  $user_id  User ID.
+	 * @param bool $remember Whether to remember the user login. Default false.
+	 *
+	 * @return int Duration of the expiration period in seconds.
+	 */
+	public static function auth_cookie_expiration( $length, $user_id, $remember ) {
+		if ( true === $remember ) {
+			$user = \get_user_by( 'id', $user_id );
+			if ( self::is_user_reader( $user ) ) {
+				$length = YEAR_IN_SECONDS;
+			}
+		}
+		return $length;
 	}
 
 	/**

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -193,7 +193,7 @@ final class Reader_Activation {
 	public static function auth_cookie_expiration( $length, $user_id, $remember ) {
 		if ( true === $remember ) {
 			$user = \get_user_by( 'id', $user_id );
-			if ( self::is_user_reader( $user ) ) {
+			if ( $user && self::is_user_reader( $user ) ) {
 				$length = YEAR_IN_SECONDS;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Extend the cookie expiration length to 1 year for users identified as readers and the auth option set to "remember".

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1750.

### How to test the changes in this Pull Request:

1. Make sure you have Reader Activation enabled and with AMP Plus+WC+Stripe setup, while logged out donate through the donate block using a new email
2. Verify the generated cookie and confirm it lasts 1 year
3. Log out and authenticate your admin account with the "Remember" option checked
4. Confirm your auth cookie lasts 2 weeks (WP standard)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->