### PR TITLE
fix: include blocks' files in release

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -41,7 +41,8 @@ node_modules
 .circleci
 /tests
 /bin
-/assets
+/assets/**/*.js
+/assets/**/*.scss
 /release
 .cache
 codecov

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -17,7 +17,7 @@ final class Blocks {
 	 * Initialize Hooks.
 	 */
 	public static function init() {
-		require_once NEWSPACK_ABSPATH . '/assets/blocks/reader-registration/index.php';
+		require_once NEWSPACK_ABSPATH . 'assets/blocks/reader-registration/index.php';
 		\add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1724 introduced releasable files in `assets`, but `assets` was not meant for release (just for file from which to build release files). This PR fixes is by excluding only JS/SCSS from `assets`, so PHP and JSON can make it through.

### How to test the changes in this Pull Request:

1. On `master`, build plugin locally (`npm run build && npm run release:archive`), observe it fails to install on a site
1. Build from this branch, observe no installation issues

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->