### PR TITLE
feat(stripe): webhook auto-creation and validation

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -41,14 +41,13 @@ class Stripe_Connection {
 	public static function register_api_endpoints() {
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/stripe/create-webhooks/',
+			'/stripe/reset-webhooks/',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'create_webhooks' ],
+				'callback'            => [ __CLASS__, 'reset_webhooks' ],
 				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
 			]
 		);
-
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/stripe/webhook',
@@ -145,18 +144,6 @@ class Stripe_Connection {
 		}
 		// Save it in options table.
 		return update_option( self::STRIPE_DATA_OPTION_NAME, $updated_stripe_data );
-	}
-
-	/**
-	 * List Stripe webhooks.
-	 */
-	public static function list_webhooks() {
-		$stripe = self::get_stripe_client();
-		try {
-			return $stripe->webhookEndpoints->all()['data'];
-		} catch ( \Throwable $e ) {
-			return new \WP_Error( 'stripe_webhooks', __( 'Could not fetch webhooks.', 'newspack' ), $e->getMessage() );
-		}
 	}
 
 	/**
@@ -429,31 +416,58 @@ class Stripe_Connection {
 	}
 
 	/**
-	 * Create Stripe webhooks.
+	 * Reset Stripe webhooks.
 	 */
-	public static function create_webhooks() {
-		$stripe = self::get_stripe_client();
-		try {
-			$webhook = $stripe->webhookEndpoints->create(
-				[
-					'url'            => self::get_webhook_url(),
-					'enabled_events' => [
-						'charge.failed',
-						'charge.succeeded',
-					],
-				]
-			);
-			update_option(
-				self::STRIPE_WEBHOOK_OPTION_NAME,
-				[
-					'id'     => $webhook->id,
-					'secret' => $webhook->secret,
-				]
-			);
-		} catch ( \Throwable $e ) {
-			return new \WP_Error( 'newspack_plugin_stripe', __( 'Webhook creation failed.', 'newspack' ), $e->getMessage() );
+	public static function reset_webhooks() {
+		delete_option( self::STRIPE_WEBHOOK_OPTION_NAME );
+		return self::validate_webhooks();
+	}
+
+	/**
+	 * Create Stripe webhooks if they are missing. Otherwise, validate the webhhooks.
+	 */
+	public static function validate_webhooks() {
+		$stripe          = self::get_stripe_client();
+		$created_webhook = get_option( self::STRIPE_WEBHOOK_OPTION_NAME );
+		if ( ! $created_webhook ) {
+			Logger::log( 'Creating Stripe webhooks…' );
+			try {
+				$webhook = $stripe->webhookEndpoints->create(
+					[
+						'url'            => self::get_webhook_url(),
+						'enabled_events' => [
+							'charge.failed',
+							'charge.succeeded',
+						],
+					]
+				);
+				update_option(
+					self::STRIPE_WEBHOOK_OPTION_NAME,
+					[
+						'id'     => $webhook->id,
+						'secret' => $webhook->secret,
+					]
+				);
+				return true;
+			} catch ( \Throwable $e ) {
+				return new \WP_Error( 'newspack_plugin_stripe_webhooks', __( 'Webhook creation failed.', 'newspack' ), $e->getMessage() );
+			}
+		} elseif ( isset( $created_webhook['id'] ) ) {
+			try {
+				$webhook = $stripe->webhookEndpoints->retrieve( $created_webhook['id'] );
+			} catch ( \Throwable $e ) {
+				return new \WP_Error( 'newspack_plugin_stripe_webhooks', __( 'Webhook validation failed:', 'newspack' ) . ' ' . $e->getMessage() );
+			}
+			if ( 'enabled' !== $webhook['status'] ) {
+				return new \WP_Error( 'newspack_plugin_stripe_webhooks', __( 'Webhook is disabled.', 'newspack' ) );
+			}
+			if ( self::get_webhook_url() !== $webhook['url'] ) {
+				return new \WP_Error( 'newspack_plugin_stripe_webhooks', __( 'Webhook has incorrect URL.', 'newspack' ) );
+			}
+			return true;
+		} else {
+			return new \WP_Error( 'newspack_plugin_stripe_webhooks', __( 'Invalid saved webhook.', 'newspack' ) );
 		}
-		return self::list_webhooks();
 	}
 
 	/**

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -425,6 +425,7 @@ class Reader_Revenue_Wizard extends Wizard {
 				'platform' => $platform,
 			],
 			'is_ssl'               => is_ssl(),
+			'errors'               => [],
 		];
 		if ( 'wc' === $platform && $wc_installed ) {
 			$plugin_status    = true;
@@ -454,8 +455,13 @@ class Reader_Revenue_Wizard extends Wizard {
 			$nrh_config            = get_option( NEWSPACK_NRH_CONFIG, [] );
 			$args['platform_data'] = wp_parse_args( $nrh_config, $args['platform_data'] );
 		} elseif ( Donations::is_platform_stripe() ) {
-			$args['stripe_data']['webhooks']         = Stripe_Connection::list_webhooks();
-			$args['stripe_data']['webhook_url']      = Stripe_Connection::get_webhook_url();
+			$are_webhooks_valid = Stripe_Connection::validate_webhooks();
+			if ( is_wp_error( $are_webhooks_valid ) ) {
+				$args['errors'][] = [
+					'code'    => $are_webhooks_valid->get_error_code(),
+					'message' => $are_webhooks_valid->get_error_message(),
+				];
+			}
 			$args['stripe_data']['connection_error'] = Stripe_Connection::get_connection_error();
 		}
 		return $args;

--- a/tests/class-stripemockhttpclient.php
+++ b/tests/class-stripemockhttpclient.php
@@ -15,7 +15,6 @@ class StripeMockHTTPClient {
 	 * The database of the mock client.
 	 */ // phpcs:ignore Squiz.Commenting.VariableComment.MissingVar
 	public static $database = [ // phpcs:ignore Squiz.Commenting.VariableComment.Missing
-		'webhooks'  => [],
 		'products'  => [],
 		'customers' => [],
 	];
@@ -57,13 +56,6 @@ class StripeMockHTTPClient {
 		$endpoint = str_replace( 'https://api.stripe.com', '', $path );
 		$response = [ 'status' => 'success' ];
 		switch ( $endpoint ) {
-			case '/v1/webhook_endpoints':
-				switch ( $method ) {
-					case 'get':
-						$response = self::list_response( self::$database['webhooks'] );
-						break;
-				}
-				break;
 			case '/v1/products':
 				switch ( $method ) {
 					case 'get':

--- a/tests/unit-tests/stripe-connection.php
+++ b/tests/unit-tests/stripe-connection.php
@@ -97,18 +97,6 @@ class Newspack_Test_Stripe extends WP_UnitTestCase {
 	}
 
 	/**
-	 * List webhooks.
-	 */
-	public static function test_stripe_list_webhooks() {
-		self::configure_stripe_as_platform();
-		self::assertEquals(
-			[],
-			Stripe_Connection::list_webhooks(),
-			'Empty webhooks list is initially returned.'
-		);
-	}
-
-	/**
 	 * Handling a donation.
 	 */
 	public static function test_stripe_handle_donation() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds auto-setup of Stripe webhook, and validation of it.

### How to test the changes in this Pull Request:

1. Test on a site with Stripe configured as Reader Revenue platform
2. Load Reader Revenue wizard –> Stripe Settings and observe all is well
3. Disable the webhook in Stripe, observe error being shown in the wizard
4. Enable the webhook and change its URL, again observe an appropriate error
5. Remove the webhook in Stripe and observe an appropriate error 
6. Click "Reset webhooks" next to the error message to recreate the webhook – observe the page reloading and now displaying errors
7. Observe the webhook recreated in Stripe 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->