### PR TITLE
feat(reader-activation): restricted reader roles

### DIFF
--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -160,6 +160,7 @@ final class Reader_Activation {
 	 */
 	public static function is_user_reader( $user ) {
 		$is_reader = (bool) \get_user_meta( $user->ID, self::READER, true );
+		$user_data = \get_userdata( $user->ID );
 
 		if ( false === $is_reader ) {
 			/**
@@ -169,9 +170,18 @@ final class Reader_Activation {
 			 */
 			$reader_roles = \apply_filters( 'newspack_reader_user_roles', [ 'subscriber', 'customer' ] );
 			if ( ! empty( $reader_roles ) ) {
-				$user_data = \get_userdata( $user->ID );
 				$is_reader = ! empty( array_intersect( $reader_roles, $user_data->roles ) );
 			}
+		}
+
+		/**
+		 * Filters roles that restricts a user from being a reader.
+		 *
+		 * @param string[] $roles Array of user roles that restrict a user from being a reader.
+		 */
+		$restricted_roles = \apply_filters( 'newspack_reader_restricted_roles', [ 'administrator', 'editor' ] );
+		if ( ! empty( $restricted_roles ) && $is_reader && ! empty( array_intersect( $restricted_roles, $user_data->roles ) ) ) {
+			$is_reader = false;
 		}
 
 		/**
@@ -180,7 +190,7 @@ final class Reader_Activation {
 		 * @param bool     $is_reader Whether the user is a reader.
 		 * @param \WP_User $user      User object.
 		 */
-		return \apply_filters( 'newspack_is_user_reader', $is_reader, $user );
+		return (bool) \apply_filters( 'newspack_is_user_reader', $is_reader, $user );
 	}
 
 	/**

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -130,5 +130,6 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		// Admins cannot be readers.
 		$user->set_role( 'administrator' );
 		$this->assertFalse( Reader_Activation::is_user_reader( $user ) );
+		wp_delete_user( $reader_id ); // Clean up.
 	}
 }

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -124,7 +124,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		// Editors cannot be readers.
 		$user->set_role( 'editor' );
 		$this->assertFalse( Reader_Activation::is_user_reader( $user ) );
-		// Editors can be readers.
+		// Authors can be readers.
 		$user->set_role( 'author' );
 		$this->assertTrue( Reader_Activation::is_user_reader( $user ) );
 		// Admins cannot be readers.

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -102,7 +102,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$this->assertFalse( Reader_Activation::is_user_reader( get_user_by( 'id', $admin_id ) ) );
 		wp_delete_user( $admin_id ); // Clean up.
 
-		// Subsriber should be a reader.
+		// Subscriber should be a reader.
 		$subscriber_id = wp_insert_user(
 			[
 				'user_login' => 'sample-subscriber',
@@ -112,5 +112,23 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		);
 		$this->assertTrue( Reader_Activation::is_user_reader( get_user_by( 'id', $subscriber_id ) ) );
 		wp_delete_user( $subscriber_id ); // Clean up.
+	}
+
+	/**
+	 * Test restricted roles for reader.
+	 */
+	public function test_restricted_roles() {
+		$reader_id = self::register_sample_reader();
+		$user      = get_user_by( 'id', $reader_id );
+		$this->assertTrue( Reader_Activation::is_user_reader( $user ) );
+		// Editors cannot be readers.
+		$user->set_role( 'editor' );
+		$this->assertFalse( Reader_Activation::is_user_reader( $user ) );
+		// Editors can be readers.
+		$user->set_role( 'author' );
+		$this->assertTrue( Reader_Activation::is_user_reader( $user ) );
+		// Admins cannot be readers.
+		$user->set_role( 'administrator' );
+		$this->assertFalse( Reader_Activation::is_user_reader( $user ) );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Restrict specific user roles (admin and editors) from being identified as readers. This could happen if a user is initially created through reader registration and later updated to a different role. This PR ensures that a restricted role check is prioritized over other checks.

### How to test the changes in this Pull Request:

Unit test for `Reader_Activation::is_user_reader()` method should pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->