### PR TITLE
fix: fatal in RR wizard if not passing all params

### DIFF
--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -185,21 +185,21 @@ class Reader_Revenue_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
 					'amounts'             => [
-						'required' => true,
+						'required' => false,
 					],
 					'tiered'              => [
-						'required'          => true,
+						'required'          => false,
 						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
 					],
 					'defaultFrequency'    => [
-						'required'          => true,
+						'required'          => false,
 						'sanitize_callback' => 'sanitize_text_field',
 					],
 					'disabledFrequencies' => [
-						'required' => true,
+						'required' => false,
 					],
 					'platform'            => [
-						'required'          => true,
+						'required'          => false,
 						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor bug I noticed while testing something unrelated. If you try to `POST` to the `donations` endpoint without including all of the required params, it will throw a fatal error—this situation happens if you have missing or misconfigured donation products and try to save the Reader Revenue donation settings to restore or repair the products.

### How to test the changes in this Pull Request:

1. On `master`, while using the "Newspack" reader revenue platform, delete the Donate products in the **Products** dashboard.
2. Go back to the Newspack > Reader Revenue wizard and note the error message stating "Misconfigured donation product. Save the donation settings to fix it."
3. Observe an error message when you try to save donation settings as instructed:

<img width="730" alt="Screen Shot 2022-07-13 at 11 16 18 AM" src="https://user-images.githubusercontent.com/2230142/178792471-93ddec3d-9c45-486d-966b-32a8512a3d72.png">

4. Check out this branch and try again. Confirm that the donation settings save successfully and the Donate products are recreated in WooCommerce.
5. Confirm that you can still update settings in the Reader Revenue wizard and the updates are saved successfully.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->