### PR TITLE
feat: handle new frequency options in Campaigns dashbaord

### DIFF
--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -100,8 +100,22 @@ const frequencyMap = {
 	custom: __( 'Custom frequency (edit prompt to manage)', 'newspack' ),
 };
 
-export const frequenciesForPopup = () => {
-	return Object.keys( frequencyMap ).map( key => ( { label: frequencyMap[ key ], value: key } ) );
+export const frequenciesForPopup = popup => {
+	const { experimental } = window.newspack_popups_wizard_data;
+	const standardKeys = [ 'once', 'daily', 'always' ];
+	return Object.keys( frequencyMap )
+		.filter( key => {
+			if ( experimental ) {
+				return true;
+			}
+
+			if ( isOverlay( popup ) && 'always' === key ) {
+				return false;
+			}
+
+			return -1 < standardKeys.indexOf( key );
+		} )
+		.map( key => ( { label: frequencyMap[ key ], value: key } ) );
 };
 
 export const overlaySizesForPopups = () => {

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -92,15 +92,16 @@ export const placementsForPopups = prompt => {
 };
 
 const frequencyMap = {
-	once: __( 'Once', 'newspack' ),
+	once: __( 'Once a month', 'newspack' ),
+	weekly: __( 'Once a week', 'newspack' ),
 	daily: __( 'Once a day', 'newspack' ),
-	always: __( 'Every page view', 'newspack' ),
+	always: __( 'Every pageview', 'newspack' ),
+	preset_1: __( 'Every 4th pageview, up to 5x per month', 'newspack' ),
+	custom: __( 'Custom frequency (edit prompt to manage)', 'newspack' ),
 };
 
-export const frequenciesForPopup = popup => {
-	return Object.keys( frequencyMap )
-		.filter( key => ! ( 'always' === key && isOverlay( popup ) ) )
-		.map( key => ( { label: frequencyMap[ key ], value: key } ) );
+export const frequenciesForPopup = () => {
+	return Object.keys( frequencyMap ).map( key => ( { label: frequencyMap[ key ], value: key } ) );
 };
 
 export const overlaySizesForPopups = () => {

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -469,6 +469,7 @@ class Popups_Wizard extends Wizard {
 				'overlay_placements' => $overlay_placements,
 				'overlay_sizes'      => $overlay_sizes,
 				'preview_query_keys' => $preview_query_keys,
+				'experimental'       => Reader_Activation::is_enabled(),
 			]
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Handles new frequency options from https://github.com/Automattic/newspack-popups/pull/908 in the Campaigns dashboard UI.

<img width="1210" alt="Screen Shot 2022-07-13 at 2 51 45 PM" src="https://user-images.githubusercontent.com/2230142/178832076-4df161e2-78ee-41b7-8643-f0e1fae16f1d.png">

Eventually we could create UI to manage the "Custom" option settings in the dashboard UI, but since this experimental for now we leave these to be managed in the block editor only.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-popups/pull/908.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->