### PR TITLE
feat(reader-activation): registration auth cookie control

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -462,7 +462,8 @@ final class Magic_Link {
 	 * @return bool|\WP_Error Whether the user was authenticated or WP_Error.
 	 */
 	private static function authenticate( $user_id, $token ) {
-		if ( \is_user_logged_in() ) {
+		/** Refresh reader session if same reader is already authenticated. */
+		if ( \is_user_logged_in() && \get_current_user_id() !== $user_id ) {
 			return false;
 		}
 

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -505,10 +505,6 @@ final class Magic_Link {
 			return;
 		}
 
-		if ( \is_user_logged_in() ) {
-			return;
-		}
-
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET[ self::AUTH_ACTION_RESULT ] ) && 0 === \absint( $_GET[ self::AUTH_ACTION_RESULT ] ) ) {
 			\add_action(

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -24,6 +24,13 @@ final class Reader_Activation {
 	const EMAIL_VERIFIED = 'np_reader_email_verified';
 
 	/**
+	 * Whether the session is authenticating a newly registered reader
+	 *
+	 * @var bool
+	 */
+	private static $is_new_reader_auth = false;
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -238,6 +245,15 @@ final class Reader_Activation {
 				$length = YEAR_IN_SECONDS;
 			}
 		}
+
+		/**
+		 * If the session is authenticating a newly registered reader we want the
+		 * auth cookie to be short lived since the email ownership has not yet been
+		 * verified.
+		 */
+		if ( true === self::$is_new_reader_auth ) {
+			$length = 24 * HOUR_IN_SECONDS;
+		}
 		return $length;
 	}
 
@@ -369,6 +385,7 @@ final class Reader_Activation {
 			Logger::log( 'Created new reader user with ID ' . $user_id );
 
 			if ( $authenticate ) {
+				self::$is_new_reader_auth = true;
 				self::set_current_reader( $user_id );
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make authentication cookies on registration short-lived and magic links a session refresh.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. With Reader Activation enabled, make sure you have a page with the Reader Registration block
2. Visit the page anonymously and register with a new email
3. Check your cookies and confirm your auth cookie (`wordpress_logged_in_`) lasts 24 hours and **keep this session open**
4. While logged in as administrator send a magic link to the recently created user (Dashboard -> Users -> Send authentication link)
5. Copy that link and paste it to the reader session
6. Check the cookies and confirm the cookie now lasts 1 year
7. Send another magic link but this time paste it on your admin session
8. Confirm you see an error since a logged-in user can only use a magic link to refresh your existing session

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->