### PR TITLE
Adds offset feature to RSS

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -82,6 +82,7 @@ class RSS {
 			'use_tags_tags'          => false,
 			'full_content'           => true,
 			'num_items_in_feed'      => 10,
+			'offset'      			 => 0,
 			'timeframe'              => false,
 			'content_featured_image' => false,
 			'suppress_yoast'         => false,
@@ -281,6 +282,12 @@ class RSS {
 				</td>
 			</tr>
 			<tr>
+				<th><?php esc_html_e( 'Offset posts by:', 'newspack-plugin' ); ?></th>
+				<td>
+					<input name="offset" type="number" min="0" value="<?php echo esc_attr( $settings['offset'] ); ?>" />
+				</td>
+			</tr>
+			<tr>
 				<th><?php esc_html_e( 'Limit timeframe to last # of hours:', 'newspack-plugin' ); ?></th>
 				<td>
 					<input name="timeframe" type="number" value="<?php echo esc_attr( $settings['timeframe'] ); ?>" />
@@ -438,6 +445,9 @@ class RSS {
 		$num_items_in_feed             = filter_input( INPUT_POST, 'num_items_in_feed', FILTER_SANITIZE_NUMBER_INT );
 		$settings['num_items_in_feed'] = absint( $num_items_in_feed );
 
+		$offset                        = filter_input( INPUT_POST, 'offset', FILTER_SANITIZE_NUMBER_INT );
+		$settings['offset'] = absint( $offset );
+
 		$timeframe             = filter_input( INPUT_POST, 'timeframe', FILTER_SANITIZE_NUMBER_INT );
 		$settings['timeframe'] = absint( $timeframe );
 
@@ -494,6 +504,8 @@ class RSS {
 		}
 
 		$query->set( 'posts_per_rss', absint( $settings['num_items_in_feed'] ) );
+		
+		$query->set( 'offset', absint( $settings['offset'] ) );
 
 		if ( ! empty( $settings['timeframe'] ) ) {
 			$query->set( 'date_query', [ 'after' => gmdate( 'Y-m-d H:i:s', strtotime( '- ' . $settings['timeframe'] . ' hours' ) ) ] );

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -82,7 +82,7 @@ class RSS {
 			'use_tags_tags'          => false,
 			'full_content'           => true,
 			'num_items_in_feed'      => 10,
-			'offset'      			 => 0,
+			'offset'                 => 0,
 			'timeframe'              => false,
 			'content_featured_image' => false,
 			'suppress_yoast'         => false,
@@ -445,7 +445,7 @@ class RSS {
 		$num_items_in_feed             = filter_input( INPUT_POST, 'num_items_in_feed', FILTER_SANITIZE_NUMBER_INT );
 		$settings['num_items_in_feed'] = absint( $num_items_in_feed );
 
-		$offset                        = filter_input( INPUT_POST, 'offset', FILTER_SANITIZE_NUMBER_INT );
+		$offset             = filter_input( INPUT_POST, 'offset', FILTER_SANITIZE_NUMBER_INT );
 		$settings['offset'] = absint( $offset );
 
 		$timeframe             = filter_input( INPUT_POST, 'timeframe', FILTER_SANITIZE_NUMBER_INT );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds offset option to the RSS feed.  This allows to display ads "between" stories by offsetting a second feed.

[Post 1]
[Post 2]
[Advertising]
[Post 3]
[Post 4]

### How to test the changes in this Pull Request:

1. Under the RSS enhancement settings, you can compare two feeds both containing 2 posts, one of them offset by 1.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? - In Newspack Staging
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->