### PR TITLE
Send user metadata to AC

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -315,8 +315,9 @@ function process_form() {
 	if ( ! empty( $lists ) ) {
 		$metadata['lists'] = $lists;
 	}
+	$metadata['current_page_url'] = home_url( add_query_arg( array(), \wp_get_referer() ) );
+	$email                        = \sanitize_email( $_REQUEST['email'] );
 
-	$email   = \sanitize_email( $_REQUEST['email'] );
 	$user_id = Reader_Activation::register_reader( $email, '', true, $metadata );
 
 	/**

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -117,6 +117,7 @@ const convertFormDataToObject = formData =>
 					startLoginFlow();
 
 					const metadata = convertFormDataToObject( new FormData( form ) );
+					metadata.currentUrl = window.location.href;
 					const checkLoginStatus = () => {
 						fetch(
 							`/wp-json/newspack/v1/login/google/register?metadata=${ JSON.stringify( metadata ) }`

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -25,8 +25,11 @@ function domReady( callback ) {
 	document.addEventListener( 'DOMContentLoaded', callback );
 }
 
-const convertFormDataToObject = formData =>
+const convertFormDataToObject = ( formData, ignoredKeys = [] ) =>
 	Array.from( formData.entries() ).reduce( ( acc, [ key, val ] ) => {
+		if ( ignoredKeys.includes( key ) ) {
+			return acc;
+		}
 		if ( key.indexOf( '[]' ) > -1 ) {
 			key = key.replace( '[]', '' );
 			acc[ key ] = acc[ key ] || [];
@@ -116,8 +119,12 @@ const convertFormDataToObject = formData =>
 				googleLoginElement.addEventListener( 'click', () => {
 					startLoginFlow();
 
-					const metadata = convertFormDataToObject( new FormData( form ) );
-					metadata.currentUrl = window.location.href;
+					const metadata = convertFormDataToObject( new FormData( form ), [
+						'email',
+						'_wp_http_referer',
+						'newspack_reader_registration',
+					] );
+					metadata.current_page_url = window.location.href;
 					const checkLoginStatus = () => {
 						fetch(
 							`/wp-json/newspack/v1/login/google/register?metadata=${ JSON.stringify( metadata ) }`

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -126,10 +126,11 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-amp-enhancements.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-newspack-image-credits.php';
 
-		// Integrations w/ third-party plugins.
+		/* Integrations with other plugins. */
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-jetpack.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-gravityforms.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-newspack-newsletters.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
 

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -61,12 +61,6 @@ final class Reader_Activation {
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
 			\add_action( 'newspack_newsletters_add_contact', [ __CLASS__, 'register_newsletters_contact' ], 10, 2 );
 			\add_filter( 'newspack_newsletters_active_campaign_add_contact_data', [ __CLASS__, 'newsletters_active_campaign_add_contact_data' ], 10, 3 );
-			\add_filter(
-				'newspack_newsletters_active_campaign_metadata_prefix',
-				function() {
-					return 'NP_';
-				}
-			);
 		}
 	}
 
@@ -872,7 +866,7 @@ final class Reader_Activation {
 	 */
 	public static function newsletters_active_campaign_add_contact_data( $contact, $list_id, $existing_contact ) {
 		$metadata = [
-			'Newsletter Selection' => $list_id,
+			'NP_Newsletter Selection' => $list_id,
 		];
 		if ( is_user_logged_in() ) {
 			$metadata['Account'] = get_current_user_id();
@@ -880,9 +874,9 @@ final class Reader_Activation {
 
 		if ( false === $existing_contact ) {
 			if ( false === $list_id ) {
-				$contact['metadata']['Registration Date'] = gmdate( 'm/d/Y' );
+				$contact['metadata']['NP_Registration Date'] = gmdate( 'm/d/Y' );
 			} else {
-				$contact['metadata']['Newsletter Signup Date'] = gmdate( 'm/d/Y' );
+				$contact['metadata']['NP_Newsletter Signup Date'] = gmdate( 'm/d/Y' );
 			}
 		}
 

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -897,7 +897,7 @@ final class Reader_Activation {
 			case 'active_campaign':
 				$metadata = [];
 				if ( is_user_logged_in() ) {
-					$metadata['Account'] = get_current_user_id();
+					$metadata['NP_Account'] = get_current_user_id();
 				}
 
 				// If it's a new contact, add a registration or signup date.
@@ -930,6 +930,7 @@ final class Reader_Activation {
 								}
 							}
 						}
+						// Note: this field will be overwritten every time it's updated.
 						$metadata['NP_Newsletter Selection'] = implode( ', ', $lists_names );
 					}
 				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -914,6 +914,9 @@ final class Reader_Activation {
 					// Move along.
 				}
 
+				// Capture current URL.
+				global $wp;
+				$metadata['NP_Signup page'] = home_url( add_query_arg( array(), $wp->request ) );
 				if ( isset( $contact['metadata'] ) ) {
 					$contact['metadata'] = array_merge( $contact['metadata'], $metadata );
 				} else {

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -60,7 +60,7 @@ final class Reader_Activation {
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
 			\add_action( 'newspack_newsletters_add_contact', [ __CLASS__, 'register_newsletters_contact' ], 10, 2 );
-			\add_filter( 'newspack_newsletters_add_contact_data', [ __CLASS__, 'newsletters_add_contact_data' ], 10, 2 );
+			\add_filter( 'newspack_newsletters_active_campaign_add_contact_data', [ __CLASS__, 'newsletters_active_campaign_add_contact_data' ], 10, 3 );
 			\add_filter(
 				'newspack_newsletters_active_campaign_metadata_prefix',
 				function() {
@@ -866,15 +866,24 @@ final class Reader_Activation {
 	/**
 	 * Modify metadata for newsletter contact creation.
 	 *
-	 * @param array $contact  Contact data.
-	 * @param array $list_ids List IDs.
+	 * @param array        $contact  Contact data.
+	 * @param string|false $list_id List ID.
+	 * @param array|false  $existing_contact Existing contact data, if available.
 	 */
-	public static function newsletters_add_contact_data( $contact, $list_ids ) {
+	public static function newsletters_active_campaign_add_contact_data( $contact, $list_id, $existing_contact ) {
 		$metadata = [
-			'Newsletter Selection' => implode( ',', $list_ids ),
+			'Newsletter Selection' => $list_id,
 		];
 		if ( is_user_logged_in() ) {
 			$metadata['Account'] = get_current_user_id();
+		}
+
+		if ( false === $existing_contact ) {
+			if ( false === $list_id ) {
+				$contact['metadata']['Registration Date'] = gmdate( 'm/d/Y' );
+			} else {
+				$contact['metadata']['Newsletter Signup Date'] = gmdate( 'm/d/Y' );
+			}
 		}
 
 		// Field names with special mapping, for Active Campaign.

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -886,10 +886,6 @@ final class Reader_Activation {
 			}
 		}
 
-		// Field names with special mapping, for Active Campaign.
-		$contact['_metadata_fields_active_campaign_map'] = [
-			'Account' => 'ACCT_NAME',
-		];
 
 		if ( isset( $contact['metadata'] ) ) {
 			$contact['metadata'] = array_merge( $contact['metadata'], $metadata );

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -945,7 +945,7 @@ final class Reader_Activation {
 
 				if ( $is_new_contact ) {
 					// It's a form submission, so the URL to look at is the referer.
-					$current_url = \wp_get_referer();
+					$current_url = isset( $contact['passed_metadata'], $contact['passed_metadata']['currentUrl'] ) ? $contact['passed_metadata']['currentUrl'] : \wp_get_referer();
 
 					// Capture current URL.
 					$metadata['NP_Signup page'] = $current_url;

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -59,7 +59,7 @@ final class Reader_Activation {
 			\add_action( 'wp_footer', [ __CLASS__, 'render_auth_form' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
-			\add_action( 'newspack_newsletters_add_contact', [ __CLASS__, 'register_newsletters_contact' ], 10, 2 );
+			\add_action( 'newspack_newsletters_before_add_contact', [ __CLASS__, 'register_newsletters_contact' ], 10, 2 );
 			\add_action( 'newspack_newsletters_update_contact_lists', [ __CLASS__, 'newspack_newsletters_update_contact_lists' ], 10, 5 );
 			\add_filter( 'newspack_newsletters_contact_data', [ __CLASS__, 'newspack_newsletters_contact_data' ], 10, 3 );
 		}
@@ -905,6 +905,7 @@ final class Reader_Activation {
 					if ( method_exists( '\Newspack_Newsletters_Subscription', 'existing_contact_data' ) ) {
 						$existing_contact = \Newspack_Newsletters_Subscription::existing_contact_data( $contact['email'] );
 						if ( is_wp_error( $existing_contact ) ) {
+							Logger::log( 'Adding metadata to a new contact.' );
 							if ( empty( $selected_list_ids ) ) {
 								// Registration only, as a side effect of Reader Activation.
 								$contact['metadata']['NP_Registration Date'] = gmdate( 'm/d/Y' );
@@ -912,6 +913,8 @@ final class Reader_Activation {
 								// Registration and signup, the former implicit.
 								$contact['metadata']['NP_Newsletter Signup Date'] = gmdate( 'm/d/Y' );
 							}
+						} else {
+							Logger::log( 'Adding metadata to an existing contact.' );
 						}
 					}
 				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -928,7 +928,7 @@ final class Reader_Activation {
 				try {
 					if ( method_exists( '\Newspack_Newsletters_Subscription', 'get_lists' ) ) {
 						$lists = \Newspack_Newsletters_Subscription::get_lists();
-						if (! is_wp_error($lists)) {
+						if ( ! is_wp_error( $lists ) ) {
 							$lists_names = [];
 							foreach ( $selected_list_ids as $selected_list_id ) {
 								foreach ( $lists as $list ) {
@@ -946,28 +946,29 @@ final class Reader_Activation {
 				}
 
 				if ( $is_new_contact ) {
-					// It's a form submission, so the URL to look at is the referer.
-					$current_url = isset( $contact['passed_metadata'], $contact['passed_metadata']['currentUrl'] ) ? $contact['passed_metadata']['currentUrl'] : \wp_get_referer();
+					$signup_page_url = isset( $contact['metadata'], $contact['metadata']['current_page_url'] ) ? $contact['metadata']['current_page_url'] : null;
+					if ( $signup_page_url ) {
+						// Rename this metadata field.
+						$metadata['NP_Signup page'] = $signup_page_url;
+						unset( $contact['metadata']['current_page_url'] );
 
-					// Capture current URL.
-					$metadata['NP_Signup page'] = $current_url;
-
-					// Capture UTM params.
-					$parsed_url = \wp_parse_url( $current_url );
-					if ( isset( $parsed_url['query'] ) ) {
-						$url_params = array_reduce(
-							explode( '&', $parsed_url['query'] ),
-							function( $acc, $item ) {
-								$parts            = explode( '=', $item );
-								$acc[ $parts[0] ] = $parts[1];
-								return $acc;
-							},
-							[]
-						);
-						foreach ( [ 'source', 'medium', 'campaign' ] as $value ) {
-							$param = 'utm_' . $value;
-							if ( isset( $url_params[ $param ] ) ) {
-								$metadata[ 'NP_Signup UTM: ' . $value ] = sanitize_text_field( $url_params[ $param ] );
+						// Capture UTM params.
+						$parsed_url = \wp_parse_url( $signup_page_url );
+						if ( isset( $parsed_url['query'] ) ) {
+							$url_params = array_reduce(
+								explode( '&', $parsed_url['query'] ),
+								function( $acc, $item ) {
+									$parts            = explode( '=', $item );
+									$acc[ $parts[0] ] = $parts[1];
+									return $acc;
+								},
+								[]
+							);
+							foreach ( [ 'source', 'medium', 'campaign' ] as $value ) {
+								$param = 'utm_' . $value;
+								if ( isset( $url_params[ $param ] ) ) {
+									$metadata[ 'NP_Signup UTM: ' . $value ] = sanitize_text_field( $url_params[ $param ] );
+								}
 							}
 						}
 					}

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -13,7 +13,6 @@ defined( 'ABSPATH' ) || exit;
  * Reader Activation Class.
  */
 final class Reader_Activation {
-
 	const AUTH_INTENTION_COOKIE = 'np_auth_intention';
 	const SCRIPT_HANDLE         = 'newspack-reader-activation';
 	const AUTH_SCRIPT_HANDLE    = 'newspack-reader-auth';
@@ -59,9 +58,6 @@ final class Reader_Activation {
 			\add_action( 'wp_footer', [ __CLASS__, 'render_auth_form' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
-			\add_action( 'newspack_newsletters_before_add_contact', [ __CLASS__, 'register_newsletters_contact' ], 10, 2 );
-			\add_action( 'newspack_newsletters_update_contact_lists', [ __CLASS__, 'newspack_newsletters_update_contact_lists' ], 10, 5 );
-			\add_filter( 'newspack_newsletters_contact_data', [ __CLASS__, 'newspack_newsletters_contact_data' ], 10, 3 );
 		}
 	}
 
@@ -656,29 +652,6 @@ final class Reader_Activation {
 		}
 	}
 
-	/**
-	 * Register a reader from newsletter signup.
-	 *
-	 * @param string $provider The provider name.
-	 * @param array  $contact  {
-	 *    Contact information.
-	 *
-	 *    @type string   $email    Contact email address.
-	 *    @type string   $name     Contact name. Optional.
-	 *    @type string[] $metadata Contact additional metadata. Optional.
-	 * }
-	 */
-	public static function register_newsletters_contact( $provider, $contact ) {
-		// Bail if already logged in.
-		if ( \is_user_logged_in() ) {
-			return;
-		}
-
-		self::register_reader(
-			$contact['email'],
-			isset( $contact['name'] ) ? $contact['name'] : ''
-		);
-	}
 
 	/**
 	 * Check if current reader has its email verified.
@@ -856,134 +829,6 @@ final class Reader_Activation {
 	public static function get_client_id() {
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		return isset( $_COOKIE[ NEWSPACK_CLIENT_ID_COOKIE_NAME ] ) ? sanitize_text_field( $_COOKIE[ NEWSPACK_CLIENT_ID_COOKIE_NAME ] ) : false;
-	}
-
-	/**
-	 * Update content metadata after a contact's lists are updated.
-	 *
-	 * @param string        $provider        The provider name.
-	 * @param string        $email           Contact email address.
-	 * @param string[]      $lists_to_add    Array of list IDs to subscribe the contact to.
-	 * @param string[]      $lists_to_remove Array of list IDs to remove the contact from.
-	 * @param bool|WP_Error $result          True if the contact was updated or error if failed.
-	 */
-	public static function newspack_newsletters_update_contact_lists( $provider, $email, $lists_to_add, $lists_to_remove, $result ) {
-		switch ( $provider ) {
-			case 'active_campaign':
-				if ( true === $result && method_exists( '\Newspack_Newsletters_Subscription', 'add_contact' ) && method_exists( '\Newspack_Newsletters_Subscription', 'get_contact_lists' ) ) {
-					$current_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $email );
-					// The add_contact method is idempotent, effectively being an upsertion.
-					\Newspack_Newsletters_Subscription::add_contact( [ 'email' => $email ], $current_lists );
-				}
-				break;
-		}
-	}
-
-	/**
-	 * Modify metadata for newsletter contact creation.
-	 *
-	 * @param string   $provider The provider name.
-	 * @param array    $contact  {
-	 *    Contact information.
-	 *
-	 *    @type string   $email    Contact email address.
-	 *    @type string   $name     Contact name. Optional.
-	 *    @type string[] $metadata Contact additional metadata. Optional.
-	 * }
-	 * @param string[] $selected_list_ids    Array of list IDs to subscribe the contact to.
-	 */
-	public static function newspack_newsletters_contact_data( $provider, $contact, $selected_list_ids ) {
-		switch ( $provider ) {
-			case 'active_campaign':
-				$metadata = [];
-				if ( is_user_logged_in() ) {
-					$metadata['NP_Account'] = get_current_user_id();
-				}
-
-				// If it's a new contact, add a registration or signup date.
-				$is_new_contact = null;
-				try {
-					if ( method_exists( '\Newspack_Newsletters_Subscription', 'existing_contact_data' ) ) {
-						$existing_contact = \Newspack_Newsletters_Subscription::existing_contact_data( $contact['email'] );
-						if ( is_wp_error( $existing_contact ) ) {
-							Logger::log( 'Adding metadata to a new contact.' );
-							$is_new_contact = true;
-							if ( empty( $selected_list_ids ) ) {
-								// Registration only, as a side effect of Reader Activation.
-								$contact['metadata']['NP_Registration Date'] = gmdate( 'm/d/Y' );
-							} else {
-								// Registration and signup, the former implicit.
-								$contact['metadata']['NP_Newsletter Signup Date'] = gmdate( 'm/d/Y' );
-							}
-						} else {
-							Logger::log( 'Adding metadata to an existing contact.' );
-							$is_new_contact = false;
-						}
-					}
-				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-					// Move along.
-				}
-
-				// Translate list IDs to list names and store as metadata.
-				try {
-					if ( method_exists( '\Newspack_Newsletters_Subscription', 'get_lists' ) ) {
-						$lists = \Newspack_Newsletters_Subscription::get_lists();
-						if ( ! is_wp_error( $lists ) ) {
-							$lists_names = [];
-							foreach ( $selected_list_ids as $selected_list_id ) {
-								foreach ( $lists as $list ) {
-									if ( $list['id'] === $selected_list_id ) {
-										$lists_names[] = $list['name'];
-									}
-								}
-							}
-							// Note: this field will be overwritten every time it's updated.
-							$metadata['NP_Newsletter Selection'] = implode( ', ', $lists_names );
-						}
-					}
-				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-					// Move along.
-				}
-
-				if ( $is_new_contact ) {
-					$signup_page_url = isset( $contact['metadata'], $contact['metadata']['current_page_url'] ) ? $contact['metadata']['current_page_url'] : null;
-					if ( $signup_page_url ) {
-						// Rename this metadata field.
-						$metadata['NP_Signup page'] = $signup_page_url;
-						unset( $contact['metadata']['current_page_url'] );
-
-						// Capture UTM params.
-						$parsed_url = \wp_parse_url( $signup_page_url );
-						if ( isset( $parsed_url['query'] ) ) {
-							$url_params = array_reduce(
-								explode( '&', $parsed_url['query'] ),
-								function( $acc, $item ) {
-									$parts            = explode( '=', $item );
-									$acc[ $parts[0] ] = $parts[1];
-									return $acc;
-								},
-								[]
-							);
-							foreach ( [ 'source', 'medium', 'campaign' ] as $value ) {
-								$param = 'utm_' . $value;
-								if ( isset( $url_params[ $param ] ) ) {
-									$metadata[ 'NP_Signup UTM: ' . $value ] = sanitize_text_field( $url_params[ $param ] );
-								}
-							}
-						}
-					}
-				}
-
-				if ( isset( $contact['metadata'] ) ) {
-					$contact['metadata'] = array_merge( $contact['metadata'], $metadata );
-				} else {
-					$contact['metadata'] = $metadata;
-				}
-
-				return $contact;
-			default:
-				return $contact;
-		}
 	}
 }
 Reader_Activation::init();

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -927,17 +927,19 @@ final class Reader_Activation {
 				// Translate list IDs to list names and store as metadata.
 				try {
 					if ( method_exists( '\Newspack_Newsletters_Subscription', 'get_lists' ) ) {
-						$lists       = \Newspack_Newsletters_Subscription::get_lists();
-						$lists_names = [];
-						foreach ( $selected_list_ids as $selected_list_id ) {
-							foreach ( $lists as $list ) {
-								if ( $list['id'] === $selected_list_id ) {
-									$lists_names[] = $list['name'];
+						$lists = \Newspack_Newsletters_Subscription::get_lists();
+						if (! is_wp_error($lists)) {
+							$lists_names = [];
+							foreach ( $selected_list_ids as $selected_list_id ) {
+								foreach ( $lists as $list ) {
+									if ( $list['id'] === $selected_list_id ) {
+										$lists_names[] = $list['name'];
+									}
 								}
 							}
+							// Note: this field will be overwritten every time it's updated.
+							$metadata['NP_Newsletter Selection'] = implode( ', ', $lists_names );
 						}
-						// Note: this field will be overwritten every time it's updated.
-						$metadata['NP_Newsletter Selection'] = implode( ', ', $lists_names );
 					}
 				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 					// Move along.

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -61,6 +61,12 @@ final class Reader_Activation {
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
 			\add_action( 'newspack_newsletters_add_contact', [ __CLASS__, 'register_newsletters_contact' ], 10, 2 );
 			\add_filter( 'newspack_newsletters_add_contact_data', [ __CLASS__, 'newsletters_add_contact_data' ], 10, 2 );
+			\add_filter(
+				'newspack_newsletters_active_campaign_metadata_prefix',
+				function() {
+					return 'NP_';
+				}
+			);
 		}
 	}
 

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -93,8 +93,8 @@ class Newspack_Newsletters {
 				// If it's a new contact, add a registration or signup date.
 				$is_new_contact = null;
 				try {
-					if ( method_exists( '\Newspack_Newsletters_Subscription', 'existing_contact_data' ) ) {
-						$existing_contact = \Newspack_Newsletters_Subscription::existing_contact_data( $contact['email'] );
+					if ( method_exists( '\Newspack_Newsletters_Subscription', 'get_contact_data' ) ) {
+						$existing_contact = \Newspack_Newsletters_Subscription::get_contact_data( $contact['email'] );
 						if ( is_wp_error( $existing_contact ) ) {
 							Logger::log( 'Adding metadata to a new contact.' );
 							$is_new_contact = true;

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -18,34 +18,9 @@ class Newspack_Newsletters {
 	 */
 	public static function init() {
 		if ( Reader_Activation::is_enabled() ) {
-			\add_action( 'newspack_newsletters_before_add_contact', [ __CLASS__, 'register_newsletters_contact' ], 10, 2 );
 			\add_action( 'newspack_newsletters_update_contact_lists', [ __CLASS__, 'newspack_newsletters_update_contact_lists' ], 10, 5 );
 			\add_filter( 'newspack_newsletters_contact_data', [ __CLASS__, 'newspack_newsletters_contact_data' ], 10, 3 );
 		}
-	}
-
-	/**
-	 * Register a reader from newsletter signup.
-	 *
-	 * @param string $provider The provider name.
-	 * @param array  $contact  {
-	 *    Contact information.
-	 *
-	 *    @type string   $email    Contact email address.
-	 *    @type string   $name     Contact name. Optional.
-	 *    @type string[] $metadata Contact additional metadata. Optional.
-	 * }
-	 */
-	public static function register_newsletters_contact( $provider, $contact ) {
-		// Bail if already logged in.
-		if ( \is_user_logged_in() ) {
-			return;
-		}
-
-		Reader_Activation::register_reader(
-			$contact['email'],
-			isset( $contact['name'] ) ? $contact['name'] : ''
-		);
 	}
 
 	/**

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Newspack Newsletters integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Newspack_Newsletters {
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		if ( Reader_Activation::is_enabled() ) {
+			\add_action( 'newspack_newsletters_before_add_contact', [ __CLASS__, 'register_newsletters_contact' ], 10, 2 );
+			\add_action( 'newspack_newsletters_update_contact_lists', [ __CLASS__, 'newspack_newsletters_update_contact_lists' ], 10, 5 );
+			\add_filter( 'newspack_newsletters_contact_data', [ __CLASS__, 'newspack_newsletters_contact_data' ], 10, 3 );
+		}
+	}
+
+	/**
+	 * Register a reader from newsletter signup.
+	 *
+	 * @param string $provider The provider name.
+	 * @param array  $contact  {
+	 *    Contact information.
+	 *
+	 *    @type string   $email    Contact email address.
+	 *    @type string   $name     Contact name. Optional.
+	 *    @type string[] $metadata Contact additional metadata. Optional.
+	 * }
+	 */
+	public static function register_newsletters_contact( $provider, $contact ) {
+		// Bail if already logged in.
+		if ( \is_user_logged_in() ) {
+			return;
+		}
+
+		Reader_Activation::register_reader(
+			$contact['email'],
+			isset( $contact['name'] ) ? $contact['name'] : ''
+		);
+	}
+
+	/**
+	 * Update content metadata after a contact's lists are updated.
+	 *
+	 * @param string        $provider        The provider name.
+	 * @param string        $email           Contact email address.
+	 * @param string[]      $lists_to_add    Array of list IDs to subscribe the contact to.
+	 * @param string[]      $lists_to_remove Array of list IDs to remove the contact from.
+	 * @param bool|WP_Error $result          True if the contact was updated or error if failed.
+	 */
+	public static function newspack_newsletters_update_contact_lists( $provider, $email, $lists_to_add, $lists_to_remove, $result ) {
+		switch ( $provider ) {
+			case 'active_campaign':
+				if ( true === $result && method_exists( '\Newspack_Newsletters_Subscription', 'add_contact' ) && method_exists( '\Newspack_Newsletters_Subscription', 'get_contact_lists' ) ) {
+					$current_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $email );
+					// The add_contact method is idempotent, effectively being an upsertion.
+					\Newspack_Newsletters_Subscription::add_contact( [ 'email' => $email ], $current_lists );
+				}
+				break;
+		}
+	}
+
+	/**
+	 * Modify metadata for newsletter contact creation.
+	 *
+	 * @param string   $provider The provider name.
+	 * @param array    $contact  {
+	 *    Contact information.
+	 *
+	 *    @type string   $email    Contact email address.
+	 *    @type string   $name     Contact name. Optional.
+	 *    @type string[] $metadata Contact additional metadata. Optional.
+	 * }
+	 * @param string[] $selected_list_ids    Array of list IDs to subscribe the contact to.
+	 */
+	public static function newspack_newsletters_contact_data( $provider, $contact, $selected_list_ids ) {
+		switch ( $provider ) {
+			case 'active_campaign':
+				$metadata = [];
+				if ( is_user_logged_in() ) {
+					$metadata['NP_Account'] = get_current_user_id();
+				}
+
+				// If it's a new contact, add a registration or signup date.
+				$is_new_contact = null;
+				try {
+					if ( method_exists( '\Newspack_Newsletters_Subscription', 'existing_contact_data' ) ) {
+						$existing_contact = \Newspack_Newsletters_Subscription::existing_contact_data( $contact['email'] );
+						if ( is_wp_error( $existing_contact ) ) {
+							Logger::log( 'Adding metadata to a new contact.' );
+							$is_new_contact = true;
+							if ( empty( $selected_list_ids ) ) {
+								// Registration only, as a side effect of Reader Activation.
+								$contact['metadata']['NP_Registration Date'] = gmdate( 'm/d/Y' );
+							} else {
+								// Registration and signup, the former implicit.
+								$contact['metadata']['NP_Newsletter Signup Date'] = gmdate( 'm/d/Y' );
+							}
+						} else {
+							Logger::log( 'Adding metadata to an existing contact.' );
+							$is_new_contact = false;
+						}
+					}
+				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+					// Move along.
+				}
+
+				// Translate list IDs to list names and store as metadata.
+				try {
+					if ( method_exists( '\Newspack_Newsletters_Subscription', 'get_lists' ) ) {
+						$lists = \Newspack_Newsletters_Subscription::get_lists();
+						if ( ! is_wp_error( $lists ) ) {
+							$lists_names = [];
+							foreach ( $selected_list_ids as $selected_list_id ) {
+								foreach ( $lists as $list ) {
+									if ( $list['id'] === $selected_list_id ) {
+										$lists_names[] = $list['name'];
+									}
+								}
+							}
+							// Note: this field will be overwritten every time it's updated.
+							$metadata['NP_Newsletter Selection'] = implode( ', ', $lists_names );
+						}
+					}
+				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+					// Move along.
+				}
+
+				// If it's a new contact, add some context on the signup/registration.
+				if ( $is_new_contact ) {
+					$signup_page_url = isset( $contact['metadata'], $contact['metadata']['current_page_url'] ) ? $contact['metadata']['current_page_url'] : null;
+					if ( $signup_page_url ) {
+						// Rename this metadata field.
+						$metadata['NP_Signup page'] = $signup_page_url;
+						unset( $contact['metadata']['current_page_url'] );
+
+						// Capture UTM params.
+						$parsed_url = \wp_parse_url( $signup_page_url );
+						if ( isset( $parsed_url['query'] ) ) {
+							$url_params = array_reduce(
+								explode( '&', $parsed_url['query'] ),
+								function( $acc, $item ) {
+									$parts            = explode( '=', $item );
+									$acc[ $parts[0] ] = $parts[1];
+									return $acc;
+								},
+								[]
+							);
+							foreach ( [ 'source', 'medium', 'campaign' ] as $value ) {
+								$param = 'utm_' . $value;
+								if ( isset( $url_params[ $param ] ) ) {
+									$metadata[ 'NP_Signup UTM: ' . $value ] = sanitize_text_field( $url_params[ $param ] );
+								}
+							}
+						}
+					}
+				}
+
+				if ( isset( $contact['metadata'] ) ) {
+					$contact['metadata'] = array_merge( $contact['metadata'], $metadata );
+				} else {
+					$contact['metadata'] = $metadata;
+				}
+
+				return $contact;
+			default:
+				return $contact;
+		}
+	}
+}
+Newspack_Newsletters::init();

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -135,31 +135,35 @@ class Newspack_Newsletters {
 					// Move along.
 				}
 
+				$signup_page_url = isset( $contact['metadata'], $contact['metadata']['current_page_url'] ) ? $contact['metadata']['current_page_url'] : null;
+				if ( $signup_page_url ) {
+					unset( $contact['metadata']['current_page_url'] );
+				}
+
 				// If it's a new contact, add some context on the signup/registration.
 				if ( $is_new_contact ) {
-					$signup_page_url = isset( $contact['metadata'], $contact['metadata']['current_page_url'] ) ? $contact['metadata']['current_page_url'] : null;
-					if ( $signup_page_url ) {
-						// Rename this metadata field.
-						$metadata['NP_Signup page'] = $signup_page_url;
-						unset( $contact['metadata']['current_page_url'] );
+					if ( ! $signup_page_url ) {
+						global $wp;
+						$signup_page_url = home_url( add_query_arg( array(), $wp->request ) );
+					}
+					$metadata['NP_Signup page'] = $signup_page_url;
 
-						// Capture UTM params.
-						$parsed_url = \wp_parse_url( $signup_page_url );
-						if ( isset( $parsed_url['query'] ) ) {
-							$url_params = array_reduce(
-								explode( '&', $parsed_url['query'] ),
-								function( $acc, $item ) {
-									$parts            = explode( '=', $item );
-									$acc[ $parts[0] ] = $parts[1];
-									return $acc;
-								},
-								[]
-							);
-							foreach ( [ 'source', 'medium', 'campaign' ] as $value ) {
-								$param = 'utm_' . $value;
-								if ( isset( $url_params[ $param ] ) ) {
-									$metadata[ 'NP_Signup UTM: ' . $value ] = sanitize_text_field( $url_params[ $param ] );
-								}
+					// Capture UTM params.
+					$parsed_url = \wp_parse_url( $signup_page_url );
+					if ( isset( $parsed_url['query'] ) ) {
+						$url_params = array_reduce(
+							explode( '&', $parsed_url['query'] ),
+							function( $acc, $item ) {
+								$parts            = explode( '=', $item );
+								$acc[ $parts[0] ] = $parts[1];
+								return $acc;
+							},
+							[]
+						);
+						foreach ( [ 'source', 'medium', 'campaign' ] as $value ) {
+							$param = 'utm_' . $value;
+							if ( isset( $url_params[ $param ] ) ) {
+								$metadata[ 'NP_Signup UTM: ' . $value ] = sanitize_text_field( $url_params[ $param ] );
 							}
 						}
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Contact adding/updating (w/ metadata) to ActiveCampaign when registering, updating newsletter preferences, and donating.

Partial of https://github.com/Automattic/newspack-popups/issues/833

### How to test the changes in this Pull Request:

1. Switch Newspack Newsletters to `feat/contact-add-filter` branch (https://github.com/Automattic/newspack-newsletters/pull/897)
1. Set up Newsletters to use Active Campaign ESP
2. Subscribe to the newsletter(s) using the Newsletters plugin subscription block
3. Observe the user added in AC, along with metadata:

<img width="646" alt="image" src="https://user-images.githubusercontent.com/7383192/180982132-9b51f9ae-4182-4180-80fd-c0a37d53cb7e.png">

5. Test with Registration Block (email and Google methods), Signup Block, and Donate block (using Stripe). In all cases supplying an email should result in adding a contact w/ metadata in AC.  

When donating, the following metadata fields should be added as well:

<img width="317" alt="image" src="https://user-images.githubusercontent.com/7383192/181020274-825e10d3-4155-40b5-86fb-08bbaf799394.png">

All fields handled in this PR:

- `NP_Account` – WP user ID
- `NP_Registration Date` – only if registered _without_ signing up for a list
- `NP_Newsletter Signup Date` – only if registered _and_ signed up at the same time
- `NP_Newsletter Selection` – a comma-separated list of lists the user signed up to
- `NP_Signup page`
- `NP_Signup UTM: <source|medium|campaign>` – UTM params, if present in URL
- `NP_Last Payment Date`
- `NP_Last Payment Amount`
- `NP_Billing Cycle`
- `NP_Recurring Payment`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->