### PR TITLE
fix(popups): use new Campaigns method for creating donation events on new orders

### DIFF
--- a/includes/configuration_managers/class-newspack-newsletters-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-newsletters-configuration-manager.php
@@ -93,7 +93,7 @@ class Newspack_Newsletters_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function add_contact( $contact, $list_id ) {
 		if ( $this->is_configured() ) {
-			return \Newspack_Newsletters::add_contact( $contact, $list_id );
+			return \Newspack_Newsletters_Subscription::add_contact( $contact, $list_id );
 		}
 	}
 

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -341,18 +341,16 @@ class Stripe_Connection {
 							'amount'             => $amount_normalised,
 							'frequency'          => $frequency,
 						];
-						$client_update = [
-							'donation' => $donation_data,
-						];
-						if ( $was_customer_added_to_mailing_list ) {
-							$client_update['email_subscription'] = [
-								'email' => $customer['email'],
-							];
-						}
-						\Newspack_Popups_Segmentation::update_client_data(
-							$client_id,
-							$client_update
-						);
+
+						/**
+						 * When a new Stripe transaction occurs that can be associated with a client ID,
+						 * fire an action with the client ID and the relevant donation info.
+						 *
+						 * @param string      $client_id Client ID.
+						 * @param array       $donation_data Info about the transaction.
+						 * @param string|null $newsletter_email If the user signed up for a newsletter as part of the transaction, the subscribed email address. Otherwise, null.
+						 */
+						do_action( 'newspack_stripe_new_donation', $client_id, $donation_data, $was_customer_added_to_mailing_list ? $customer['email'] : null );
 					}
 				}
 

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -331,7 +331,7 @@ class Stripe_Connection {
 				}
 
 				// Update data in Campaigns plugin.
-				if ( isset( $customer['metadata']['clientId'] ) && class_exists( 'Newspack_Popups_Segmentation' ) ) {
+				if ( isset( $customer['metadata']['clientId'] ) ) {
 					$client_id = $customer['metadata']['clientId'];
 					if ( ! empty( $client_id ) ) {
 						$donation_data = [

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -350,7 +350,7 @@ class Stripe_Connection {
 						 * @param array       $donation_data Info about the transaction.
 						 * @param string|null $newsletter_email If the user signed up for a newsletter as part of the transaction, the subscribed email address. Otherwise, null.
 						 */
-						do_action( 'newspack_stripe_new_donation', $client_id, $donation_data, $was_customer_added_to_mailing_list ? $customer['email'] : null );
+						do_action( 'newspack_new_donation_stripe', $client_id, $donation_data, $was_customer_added_to_mailing_list ? $customer['email'] : null );
 					}
 				}
 

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -286,6 +286,7 @@ class Stripe_Connection {
 				$metadata          = $payment['metadata'];
 				$customer          = self::get_customer_by_id( $payment['customer'] );
 				$amount_normalised = self::normalise_amount( $payment['amount'], $payment['currency'] );
+				$client_id         = isset( $customer['metadata']['clientId'] ) ? $customer['metadata']['clientId'] : null;
 
 				$referer = '';
 				if ( isset( $metadata['referer'] ) ) {
@@ -313,45 +314,46 @@ class Stripe_Connection {
 				$stripe_data                        = self::get_stripe_data();
 				if ( ! empty( $stripe_data['newsletter_list_id'] ) && isset( $customer['metadata']['newsletterOptIn'] ) && 'true' === $customer['metadata']['newsletterOptIn'] ) {
 					$newsletters_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-newsletters' );
-					// Note: With Mailchimp, this is adding the contact as 'pending' - the subscriber has to confirm.
-					$newsletters_configuration_manager->add_contact(
-						[
-							'email'    => $customer['email'],
-							'name'     => $customer['name'],
-							'metadata' => [
-								'donation_date'      => gmdate( 'Y-m-d', $payment['created'] ),
-								'donation_amount'    => $amount_normalised,
-								'donation_frequency' => $frequency,
-								'donation_recurring' => 'once' !== $frequency,
-							],
+
+					$contact = [
+						'email'    => $customer['email'],
+						'name'     => $customer['name'],
+						'metadata' => [
+							'donation_date'      => gmdate( 'Y-m-d', $payment['created'] ),
+							'donation_amount'    => $amount_normalised,
+							'donation_frequency' => $frequency,
+							'donation_recurring' => 'once' !== $frequency,
 						],
-						$stripe_data['newsletter_list_id']
-					);
+					];
+
+					if ( ! empty( $client_id ) ) {
+						$contact['client_id'] = $client_id;
+					}
+
+					// Note: With Mailchimp, this is adding the contact as 'pending' - the subscriber has to confirm.
+					$newsletters_configuration_manager->add_contact( $contact, $stripe_data['newsletter_list_id'] );
 					$was_customer_added_to_mailing_list = true;
 				}
 
 				// Update data in Campaigns plugin.
-				if ( isset( $customer['metadata']['clientId'] ) ) {
-					$client_id = $customer['metadata']['clientId'];
-					if ( ! empty( $client_id ) ) {
-						$donation_data = [
-							'stripe_id'          => $payment['id'],
-							'stripe_customer_id' => $customer['id'],
-							'date'               => $payment['created'],
-							'amount'             => $amount_normalised,
-							'frequency'          => $frequency,
-						];
+				if ( ! empty( $client_id ) ) {
+					$donation_data = [
+						'stripe_id'          => $payment['id'],
+						'stripe_customer_id' => $customer['id'],
+						'date'               => $payment['created'],
+						'amount'             => $amount_normalised,
+						'frequency'          => $frequency,
+					];
 
-						/**
-						 * When a new Stripe transaction occurs that can be associated with a client ID,
-						 * fire an action with the client ID and the relevant donation info.
-						 *
-						 * @param string      $client_id Client ID.
-						 * @param array       $donation_data Info about the transaction.
-						 * @param string|null $newsletter_email If the user signed up for a newsletter as part of the transaction, the subscribed email address. Otherwise, null.
-						 */
-						do_action( 'newspack_new_donation_stripe', $client_id, $donation_data, $was_customer_added_to_mailing_list ? $customer['email'] : null );
-					}
+					/**
+					 * When a new Stripe transaction occurs that can be associated with a client ID,
+					 * fire an action with the client ID and the relevant donation info.
+					 *
+					 * @param string      $client_id Client ID.
+					 * @param array       $donation_data Info about the transaction.
+					 * @param string|null $newsletter_email If the user signed up for a newsletter as part of the transaction, the subscribed email address. Otherwise, null.
+					 */
+					do_action( 'newspack_new_donation_stripe', $client_id, $donation_data, $was_customer_added_to_mailing_list ? $customer['email'] : null );
 				}
 
 				// Send custom event to GA.

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -148,9 +148,16 @@ class WooCommerce_Connection {
 		$order->add_meta_data( '_stripe_net', $order_data['stripe_net'] );
 		$order->add_meta_data( '_stripe_currency', $order_data['currency'] );
 
-		// Log a donation event in Campaigns data.
-		if ( ! empty( $order_data['client_id'] ) && class_exists( '\Newspack_Popups_Donations' ) ) {
-			\Newspack_Popups_Donations::create_donation_event( $order->get_id(), $order, $order_data['client_id'] );
+		if ( ! empty( $order_data['client_id'] ) ) {
+			/**
+			 * When a new order is created that can be associated with a client ID,
+			 * fire an action with the client ID and the relevant order info.
+			 *
+			 * @param WC_Order    $order Donation order.
+			 * @param string      $client_id Client ID.
+			 * @param string|null $newsletter_email If the user signed up for a newsletter as part of the transaction, the subscribed email address. Otherwise, null.
+			 */
+			do_action( 'newspack_new_donation_woocommerce', $order, $order_data['client_id'] );
 		}
 
 		$has_user_id = ! empty( $order_data['user_id'] );

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -148,8 +148,9 @@ class WooCommerce_Connection {
 		$order->add_meta_data( '_stripe_net', $order_data['stripe_net'] );
 		$order->add_meta_data( '_stripe_currency', $order_data['currency'] );
 
-		if ( ! empty( $order_data['client_id'] ) ) {
-			$order->add_meta_data( NEWSPACK_CLIENT_ID_COOKIE_NAME, $order_data['client_id'] );
+		// Log a donation event in Campaigns data.
+		if ( ! empty( $order_data['client_id'] ) && class_exists( '\Newspack_Popups_Donations' ) ) {
+			\Newspack_Popups_Donations::create_donation_event( $order->get_id(), $order, $order_data['client_id'] );
 		}
 
 		$has_user_id = ! empty( $order_data['user_id'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures that the method from https://github.com/Automattic/newspack-popups/pull/922 is used to generate donation events when Stripe transactions sync to WooCommerce orders.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-popups/pull/922.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->