### PR TITLE
feat: register anonymous single donors

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -68,6 +68,7 @@ class Donations {
 			add_action( 'wp_loaded', [ __CLASS__, 'process_donation_form' ], 99 );
 			add_action( 'woocommerce_checkout_update_order_meta', [ __CLASS__, 'woocommerce_checkout_update_order_meta' ] );
 			add_filter( 'woocommerce_billing_fields', [ __CLASS__, 'woocommerce_billing_fields' ] );
+			add_filter( 'pre_option_woocommerce_enable_guest_checkout', [ __CLASS__, 'disable_guest_checkout' ] );
 			add_filter( 'amp_skip_post', [ __CLASS__, 'should_skip_amp' ], 10, 2 );
 		}
 	}
@@ -764,6 +765,22 @@ class Donations {
 		}
 
 		return $form_fields;
+	}
+
+	/**
+	 * If Reader Activation is enabled, the reader will be registered upon donation.
+	 * Disable the guest checkout option in the checkout form.
+	 *
+	 * @param string $value Value of the guest checkout option from WC settings. Can be 'yes' or 'no'.
+	 *
+	 * @return string Filtered value.
+	 */
+	public static function disable_guest_checkout( $value ) {
+		if ( Reader_Activation::is_enabled() ) {
+			$value = 'no';
+		}
+
+		return $value;
 	}
 
 	/**

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -22,7 +22,7 @@ class WooCommerce_Connection {
 	 */
 	public static function init() {
 		\add_action( 'admin_init', [ __CLASS__, 'disable_woocommerce_setup' ] );
-		\add_action( 'woocommerce_checkout_order_created', [ __CLASS__, 'register_donor' ] );
+		\add_action( 'woocommerce_checkout_order_created', [ __CLASS__, 'register_reader' ] );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class WooCommerce_Connection {
 	 * @param number $amount Donation amount.
 	 */
 	private static function get_donation_order_item( $frequency, $amount = 0 ) {
-		$product_id = \Donations::get_donation_product( $frequency );
+		$product_id = Donations::get_donation_product( $frequency );
 		if ( false === $product_id ) {
 			return false;
 		}
@@ -61,14 +61,13 @@ class WooCommerce_Connection {
 	 *
 	 * @param WC_Order $order Order object.
 	 */
-	public static function register_donor( $order ) {
+	public static function register_reader( $order ) {
 		if ( Reader_Activation::is_enabled() ) {
 			$email_address = $order->get_billing_email();
 			$first_name    = $order->get_billing_first_name();
 			$last_name     = $order->get_billing_last_name();
 			$full_name     = "$first_name $last_name";
 
-			Logger::log( 'Registering Reader 1' );
 			Reader_Activation::register_reader( $email_address, $full_name );
 		}
 	}
@@ -99,7 +98,6 @@ class WooCommerce_Connection {
 		}
 		if ( $should_create_account ) {
 			if ( Reader_Activation::is_enabled() ) {
-				Logger::log( 'Registering Reader 2' );
 				$user_id = Reader_Activation::register_reader( $email_address, $full_name );
 				if ( \is_wp_error( $user_id ) ) {
 					return $user_id;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Readers are registered via Reader Activation when they subscribe to a newsletter, make a recurring WooCommerce donation, or a single or recurring Stripe donation. They are currently NOT registered when making a single WooCommerce donation. This closes that loop and registers those readers as well.

Closes #1791.

### How to test the changes in this Pull Request:

1. Check out this branch, ensure that reader activation is enabled on your site.
2. In new browser sessions, make several single and recurring donations with both WooCommerce and Stripe platforms.
3. Ensure that you're registered and pre-authenticated in each case.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->