### PR TITLE
Reader Activation: auth form with third-party and lists subscriptions

### DIFF
--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -137,7 +137,7 @@ export default function ReaderRegistrationEdit( {
 					<form onSubmit={ ev => ev.preventDefault() }>
 						<div className="newspack-registration__form-content">
 							{ newsletterSubscription && lists.length ? (
-								<div className="newspack-registration__lists">
+								<div className="newspack-reader__lists">
 									{ lists?.length > 1 && (
 										<RichText
 											onChange={ value => setAttributes( { newsletterTitle: value } ) }
@@ -149,12 +149,12 @@ export default function ReaderRegistrationEdit( {
 									<ul>
 										{ lists.map( listId => (
 											<li key={ listId }>
-												<span className="newspack-registration__lists__checkbox">
+												<span className="newspack-reader__lists__checkbox">
 													<input type="checkbox" checked readOnly />
 												</span>
-												<span className="newspack-registration__lists__details">
-													<span className="newspack-registration__lists__label">
-														<span className="newspack-registration__lists__title">
+												<span className="newspack-reader__lists__details">
+													<span className="newspack-reader__lists__label">
+														<span className="newspack-reader__lists__title">
 															{ lists.length === 1 ? (
 																<RichText
 																	onChange={ value => setAttributes( { newsletterLabel: value } ) }
@@ -167,7 +167,7 @@ export default function ReaderRegistrationEdit( {
 															) }
 														</span>
 														{ displayListDescription && (
-															<span className="newspack-registration__lists__description">
+															<span className="newspack-reader__lists__description">
 																{ listConfig[ listId ]?.description }
 															</span>
 														) }

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -196,7 +196,7 @@ export default function ReaderRegistrationEdit( {
 						<form onSubmit={ ev => ev.preventDefault() }>
 							<div className="newspack-registration__form-content">
 								{ newsletterSubscription && lists.length ? (
-									<div className="newspack-registration__lists">
+									<div className="newspack-reader__lists">
 										{ lists?.length > 1 && (
 											<RichText
 												onChange={ value => setAttributes( { newsletterTitle: value } ) }
@@ -254,13 +254,13 @@ export default function ReaderRegistrationEdit( {
 										</div>
 
 										{ newspack_blocks.has_google_oauth && (
-											<div className="newspack-registration__logins">
-												<div className="newspack-registration__logins__separator">
+											<div className="newspack-reader__logins">
+												<div className="newspack-reader__logins__separator">
 													<div />
 													<div>{ __( 'OR', 'newspack' ) }</div>
 													<div />
 												</div>
-												<button className="newspack-registration__logins__google">
+												<button className="newspack-reader__logins__google">
 													<span
 														dangerouslySetInnerHTML={ { __html: newspack_blocks.google_logo_svg } }
 													/>

--- a/assets/blocks/reader-registration/editor.scss
+++ b/assets/blocks/reader-registration/editor.scss
@@ -1,5 +1,5 @@
 @use './style';
-@use '../../reader-activation/auth.scss';
+@use '../../reader-activation/auth';
 @use '~@wordpress/base-styles/colors' as wp-colors;
 
 .newspack-registration {
@@ -67,6 +67,9 @@
 			gap: 4px;
 		}
 	}
+}
+
+.newspack-reader {
 	&__logins {
 		button {
 			padding: 0.76rem 1rem;

--- a/assets/blocks/reader-registration/editor.scss
+++ b/assets/blocks/reader-registration/editor.scss
@@ -1,4 +1,5 @@
 @use './style';
+@use '../../reader-activation/auth.scss';
 
 .newspack-registration {
 	form {

--- a/assets/blocks/reader-registration/index.js
+++ b/assets/blocks/reader-registration/index.js
@@ -11,8 +11,8 @@ import metadata from './block.json';
 
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<path d="M18.5 8V5.5H16V4h2.5V1.5H20V4h2.5v1.5H20V8h-1.5ZM16.75 17v-2A2.75 2.75 0 0 0 14 12.25h-4A2.75 2.75 0 0 0 7.25 15v2h1.5v-2c0-.69.56-1.25 1.25-1.25h4c.69 0 1.25.56 1.25 1.25v2h1.5Z" />
-		<path
+		<Path d="M18.5 8V5.5H16V4h2.5V1.5H20V4h2.5v1.5H20V8h-1.5ZM16.75 17v-2A2.75 2.75 0 0 0 14 12.25h-4A2.75 2.75 0 0 0 7.25 15v2h1.5v-2c0-.69.56-1.25 1.25-1.25h4c.69 0 1.25.56 1.25 1.25v2h1.5Z" />
+		<Path
 			fillRule="evenodd"
 			clipRule="evenodd"
 			d="M14.5 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm-1.5 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -89,38 +89,6 @@
 		}
 	}
 
-	&__logins {
-		margin-top: 0.5rem;
-		&__separator {
-			display: flex;
-			margin-bottom: 0.5rem;
-			div {
-				text-align: center;
-				&:nth-child( 2 ) {
-					padding: 0 0.8em;
-					font-size: 16px;
-				}
-				&:first-child,
-				&:last-child {
-					flex: 1;
-					border-top: 1px solid wp-colors.$gray-400;
-					transform: translateY( 0.7em );
-				}
-			}
-		}
-		button {
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			width: 100%;
-			background-color: wp-colors.$gray-100;
-			color: black;
-			span {
-				padding-left: 10px;
-			}
-		}
-	}
-
 	&--hidden {
 		display: none;
 	}

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -6,7 +6,7 @@
 			.newspack-registration__main {
 				flex: 1 1 55%;
 			}
-			.newspack-registration__lists {
+			.newspack-reader__lists {
 				flex: 1 1 35%;
 				padding: 2rem 0 2rem 2rem;
 				display: flex;
@@ -65,49 +65,6 @@
 		}
 	}
 
-	&__lists {
-		flex: 1 1 100%;
-		font-size: 0.8rem;
-		border: 1px solid wp-colors.$gray-200;
-		border-radius: 2px;
-		padding: 0.5rem 0 0.5rem 1rem;
-		h3 {
-			display: none;
-		}
-		ul {
-			list-style: none;
-			margin: 0;
-			padding: 0;
-			display: flex;
-			flex-wrap: wrap;
-			min-width: 250px;
-			li {
-				flex: 1 1 33.3333%;
-				display: flex;
-				min-width: 200px;
-				box-sizing: border-box;
-				margin: 0;
-				padding: 0.5rem 1rem 0.5rem 0;
-			}
-		}
-
-		&__checkbox {
-			flex: 0 0 auto;
-			margin: 0 0.5rem 0 0;
-		}
-
-		&__title {
-			display: block;
-		}
-
-		&__description {
-			display: block;
-			font-size: 0.8rem;
-			color: #757575;
-			margin: 0;
-		}
-	}
-
 	&__response {
 		margin-top: 0.5rem;
 		font-size: 0.8em;
@@ -129,38 +86,6 @@
 		a,
 		input {
 			pointer-events: none;
-		}
-	}
-
-	&__logins {
-		margin-top: 0.5rem;
-		&__separator {
-			display: flex;
-			margin-bottom: 0.5rem;
-			div {
-				text-align: center;
-				&:nth-child( 2 ) {
-					padding: 0 0.8em;
-					font-size: 16px;
-				}
-				&:first-child,
-				&:last-child {
-					flex: 1;
-					border-top: 1px solid wp-colors.$gray-400;
-					transform: translateY( 0.7em );
-				}
-			}
-		}
-		button {
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			width: 100%;
-			background-color: wp-colors.$gray-100;
-			color: black;
-			span {
-				padding-left: 10px;
-			}
 		}
 	}
 }

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -28,11 +28,16 @@ function domReady( callback ) {
 /**
  * Converts FormData into an object.
  *
- * @param {FormData} formData The form data to convert.
+ * @param {FormData} formData    The form data to convert.
+ * @param {Array}    ignoredKeys Keys to ignore.
+ *
  * @return {Object} The converted form data.
  */
-const convertFormDataToObject = formData =>
+const convertFormDataToObject = ( formData, ignoredKeys = [] ) =>
 	Array.from( formData.entries() ).reduce( ( acc, [ key, val ] ) => {
+		if ( ignoredKeys.includes( key ) ) {
+			return acc;
+		}
 		if ( key.indexOf( '[]' ) > -1 ) {
 			key = key.replace( '[]', '' );
 			acc[ key ] = acc[ key ] || [];
@@ -260,8 +265,15 @@ const convertFormDataToObject = formData =>
 				}
 
 				const metadata = googleLoginForm
-					? convertFormDataToObject( new FormData( googleLoginForm ) )
+					? convertFormDataToObject(
+							new FormData( googleLoginForm, [
+								'email',
+								'_wp_http_referer',
+								'newspack_reader_registration',
+							] )
+					  )
 					: {};
+				metadata.current_page_url = window.location.href;
 				fetch( '/wp-json/newspack/v1/login/google' )
 					.then( res => res.json().then( data => Promise.resolve( { data, status: res.status } ) ) )
 					.then( ( { data, status } ) => {

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -29,7 +29,7 @@ function domReady( callback ) {
  * Converts FormData into an object.
  *
  * @param {FormData} formData The form data to convert.
- * @return object The converted form data.
+ * @return {object} The converted form data.
  */
 const convertFormDataToObject = formData =>
 	Array.from( formData.entries() ).reduce( ( acc, [ key, val ] ) => {
@@ -181,7 +181,7 @@ const convertFormDataToObject = formData =>
 			form.style.opacity = 0.5;
 		};
 
-		form.endLoginFlow = ( message, status, data ) => {
+		form.endLoginFlow = ( message, status, data, redirect ) => {
 			if ( message ) {
 				const messageNode = document.createElement( 'p' );
 				messageNode.textContent = message;
@@ -192,8 +192,8 @@ const convertFormDataToObject = formData =>
 				readerActivation.setReaderEmail( data.email );
 				readerActivation.setAuthenticated( authenticated );
 				if ( authenticated ) {
-					if ( body.get( 'redirect' ) ) {
-						window.location = body.get( 'redirect' );
+					if ( redirect ) {
+						window.location = redirect;
 					}
 				} else {
 					form.replaceWith( messageContentElement.parentNode );
@@ -226,7 +226,7 @@ const convertFormDataToObject = formData =>
 				.then( res => {
 					container.setAttribute( 'data-form-status', res.status );
 					res.json().then( ( { message, data } ) => {
-						form.endLoginFlow( message, res.status, data );
+						form.endLoginFlow( message, res.status, data, body.get( 'redirect' ) );
 					} );
 				} )
 				.catch( err => {

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -25,6 +25,24 @@ function domReady( callback ) {
 	document.addEventListener( 'DOMContentLoaded', callback );
 }
 
+/**
+ * Converts FormData into an object.
+ *
+ * @param {FormData} formData The form data to convert.
+ * @return object The converted form data.
+ */
+const convertFormDataToObject = formData =>
+	Array.from( formData.entries() ).reduce( ( acc, [ key, val ] ) => {
+		if ( key.indexOf( '[]' ) > -1 ) {
+			key = key.replace( '[]', '' );
+			acc[ key ] = acc[ key ] || [];
+			acc[ key ].push( val );
+		} else {
+			acc[ key ] = val;
+		}
+		return acc;
+	}, {} );
+
 ( function ( readerActivation ) {
 	domReady( function () {
 		if ( ! readerActivation ) {
@@ -154,22 +172,50 @@ function domReady( callback ) {
 			} );
 		} );
 
-		/**
-		 * Handle auth form submission.
-		 */
-		form.addEventListener( 'submit', function ( ev ) {
-			ev.preventDefault();
+		form.startLoginFlow = () => {
 			container.removeAttribute( 'data-form-status' );
-			const body = new FormData( ev.target );
-			if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
-				return;
-			}
 			submitButtons.forEach( button => {
 				button.disabled = true;
 			} );
 			messageContentElement.innerHTML = '';
 			form.style.opacity = 0.5;
+		};
+
+		form.endLoginFlow = ( message, status, data ) => {
+			if ( message ) {
+				const messageNode = document.createElement( 'p' );
+				messageNode.textContent = message;
+				messageContentElement.appendChild( messageNode );
+			}
+			if ( status === 200 && data ) {
+				const authenticated = !! data?.authenticated;
+				readerActivation.setReaderEmail( data.email );
+				readerActivation.setAuthenticated( authenticated );
+				if ( authenticated ) {
+					if ( body.get( 'redirect' ) ) {
+						window.location = body.get( 'redirect' );
+					}
+				} else {
+					form.replaceWith( messageContentElement.parentNode );
+				}
+			}
+			form.style.opacity = 1;
+			submitButtons.forEach( button => {
+				button.disabled = false;
+			} );
+		};
+
+		/**
+		 * Handle auth form submission.
+		 */
+		form.addEventListener( 'submit', function ( ev ) {
+			ev.preventDefault();
+			const body = new FormData( ev.target );
+			if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
+				return;
+			}
 			readerActivation.setReaderEmail( body.get( 'email' ) );
+			form.startLoginFlow();
 			fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 				method: 'POST',
 				headers: {
@@ -180,32 +226,69 @@ function domReady( callback ) {
 				.then( res => {
 					container.setAttribute( 'data-form-status', res.status );
 					res.json().then( ( { message, data } ) => {
-						const authenticated = !! data?.authenticated;
-						const messageNode = document.createElement( 'p' );
-						messageNode.textContent = message;
-						messageContentElement.appendChild( messageNode );
-						if ( res.status === 200 ) {
-							readerActivation.setReaderEmail( data.email );
-							readerActivation.setAuthenticated( authenticated );
-							if ( authenticated ) {
-								if ( body.get( 'redirect' ) ) {
-									window.location = body.get( 'redirect' );
-								}
-							} else {
-								form.replaceWith( messageContentElement.parentNode );
-							}
-						}
+						form.endLoginFlow( message, res.status, data );
 					} );
 				} )
 				.catch( err => {
 					throw err;
 				} )
-				.finally( () => {
-					form.style.opacity = 1;
-					submitButtons.forEach( button => {
-						button.disabled = false;
+				.finally( form.endLoginFlow );
+		} );
+
+		/**
+		 * Third party auth.
+		 */
+		const googleLoginElements = document.querySelectorAll( '.newspack-reader__logins__google' );
+		googleLoginElements.forEach( googleLoginElement => {
+			const googleLoginForm = googleLoginElement.closest( 'form' );
+
+			const checkLoginStatus = metadata => {
+				fetch(
+					`/wp-json/newspack/v1/login/google/register?metadata=${ JSON.stringify( metadata ) }`
+				).then( res => {
+					res.json().then( ( { message, data } ) => {
+						if ( googleLoginForm.endLoginFlow ) {
+							googleLoginForm.endLoginFlow( message, res.status, data );
+						}
 					} );
 				} );
+			};
+
+			googleLoginElement.addEventListener( 'click', () => {
+				if ( googleLoginForm?.startLoginFlow ) {
+					googleLoginForm.startLoginFlow();
+				}
+
+				const metadata = googleLoginForm
+					? convertFormDataToObject( new FormData( googleLoginForm ) )
+					: {};
+				fetch( '/wp-json/newspack/v1/login/google' )
+					.then( res => res.json().then( data => Promise.resolve( { data, status: res.status } ) ) )
+					.then( ( { data, status } ) => {
+						if ( status !== 200 ) {
+							if ( googleLoginForm?.endLoginFlow ) {
+								googleLoginForm.endLoginFlow( data.message, status );
+							}
+						} else {
+							const authWindow = window.open(
+								'about:blank',
+								'newspack_google_login',
+								'width=500,height=600'
+							);
+							if ( authWindow ) {
+								authWindow.location = data;
+								const interval = setInterval( () => {
+									if ( authWindow.closed ) {
+										checkLoginStatus( metadata );
+										clearInterval( interval );
+									}
+								}, 500 );
+							} else if ( googleLoginForm?.endLoginFlow ) {
+								googleLoginForm.endLoginFlow();
+							}
+						}
+					} );
+			} );
 		} );
 	} );
 } )( window.newspackReaderActivation );

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -265,13 +265,12 @@ const convertFormDataToObject = ( formData, ignoredKeys = [] ) =>
 				}
 
 				const metadata = googleLoginForm
-					? convertFormDataToObject(
-							new FormData( googleLoginForm, [
-								'email',
-								'_wp_http_referer',
-								'newspack_reader_registration',
-							] )
-					  )
+					? convertFormDataToObject( new FormData( googleLoginForm ), [
+							'email',
+							'password',
+							'_wp_http_referer',
+							'newspack_reader_registration',
+					  ] )
 					: {};
 				metadata.current_page_url = window.location.href;
 				fetch( '/wp-json/newspack/v1/login/google' )

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -29,7 +29,7 @@ function domReady( callback ) {
  * Converts FormData into an object.
  *
  * @param {FormData} formData The form data to convert.
- * @return {object} The converted form data.
+ * @return {Object} The converted form data.
  */
 const convertFormDataToObject = formData =>
 	Array.from( formData.entries() ).reduce( ( acc, [ key, val ] ) => {

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -1,3 +1,5 @@
+@use '~@wordpress/base-styles/colors' as wp-colors;
+
 .newspack-reader {
 	/**
 	 * Account Link
@@ -226,6 +228,87 @@
 			&:focus {
 				outline: 1px solid;
 				outline-offset: -1px;
+			}
+		}
+	}
+
+	/**
+	 * Newsletters subscription lists.
+	 */
+	&__lists {
+		flex: 1 1 100%;
+		font-size: 0.8rem;
+		border: 1px solid wp-colors.$gray-200;
+		border-radius: 2px;
+		padding: 0.5rem 0 0.5rem 1rem;
+		h3 {
+			display: none;
+		}
+		ul {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+			display: flex;
+			flex-wrap: wrap;
+			min-width: 250px;
+			li {
+				flex: 1 1 33.3333%;
+				display: flex;
+				min-width: 200px;
+				box-sizing: border-box;
+				margin: 0;
+				padding: 0.5rem 1rem 0.5rem 0;
+			}
+		}
+
+		&__checkbox {
+			flex: 0 0 auto;
+			margin: 0 0.5rem 0 0;
+		}
+
+		&__title {
+			display: block;
+		}
+
+		&__description {
+			display: block;
+			font-size: 0.8rem;
+			color: #757575;
+			margin: 0;
+		}
+	}
+
+	/**
+	 * Third party auth.
+	 */
+	&__logins {
+		margin-top: 0.5rem;
+		&__separator {
+			display: flex;
+			margin-bottom: 0.5rem;
+			div {
+				text-align: center;
+				&:nth-child( 2 ) {
+					padding: 0 0.8em;
+					font-size: 16px;
+				}
+				&:first-child,
+				&:last-child {
+					flex: 1;
+					border-top: 1px solid wp-colors.$gray-400;
+					transform: translateY( 0.7em );
+				}
+			}
+		}
+		button {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			width: 100%;
+			background-color: wp-colors.$gray-100;
+			color: black;
+			span {
+				padding-left: 10px;
 			}
 		}
 	}

--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -9,7 +9,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Notice, SectionHeader, Waiting } from '../../../../components/src';
+import { Notice, SectionHeader } from '../../../../components/src';
 import Plugins from './plugins';
 import GoogleAuth from './google';
 import Mailchimp from './mailchimp';

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -500,7 +500,7 @@ final class Reader_Activation {
 						</p>
 						<input type="hidden" name="redirect" value="" />
 						<div data-action="register">
-							<p><?php _e( 'Be the first to know about breaking news, articles and updates.', 'newspack' ); ?></p>
+							<p><?php _e( 'Subscribe to our newsletters:', 'newspack' ); ?></p>
 							<?php self::render_subscription_lists_inputs(); ?>
 						</div>
 						<p>

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -718,6 +718,7 @@ final class Reader_Activation {
 		$email    = isset( $_POST['email'] ) ? \sanitize_email( $_POST['email'] ) : '';
 		$password = isset( $_POST['password'] ) ? \sanitize_text_field( $_POST['password'] ) : '';
 		$redirect = isset( $_POST['redirect'] ) ? \esc_url_raw( $_POST['redirect'] ) : '';
+		$lists    = isset( $_POST['lists'] ) ? array_map( 'sanitize_text_field', $_POST['lists'] ) : [];
 		// phpcs:enable
 
 		if ( ! in_array( $action, self::AUTH_FORM_OPTIONS, true ) ) {
@@ -763,7 +764,11 @@ final class Reader_Activation {
 				}
 				return self::send_auth_form_response( $payload, __( "We've sent you an authentication link, please check your inbox.", 'newspack' ), $redirect );
 			case 'register':
-				$user_id = self::register_reader( $email );
+				$metadata = [];
+				if ( ! empty( $lists ) ) {
+					$metadata['lists'] = $lists;
+				}
+				$user_id = self::register_reader( $email, '', true, $metadata );
 				if ( false === $user_id ) {
 					return self::send_auth_form_response( $payload, __( "We've sent you an authentication link, please check your inbox.", 'newspack' ), $redirect );
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements an abstraction for third-party login and lists subscription for the generic authentication/registration form.

<img width="592" alt="image" src="https://user-images.githubusercontent.com/820752/180850940-8c5078eb-4848-46e1-b93c-1cb16ef7b442.png">

<img width="596" alt="image" src="https://user-images.githubusercontent.com/820752/180851014-c0106e3f-4646-471c-9aa7-d172b7cd067a.png">

The customization of text will be tackled next on #1773.

### How to test the changes in this Pull Request:

1. Make sure you have reader activation on and AMP Plus (or AMP off)
2. Make sure you have subscription lists enabled and configured on the Engagement wizard
3. Visit the front page of our site anonymously and open the Sign In modal
4. Click "I don't have an account"
5. Register a new email subscribing to newsletters
6. Confirm you are subscribed
7. On a new session, click on Sign In again and use the Google authentication with newsletters selected
8. Confirm you're signed in and subscribed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->