### PR TITLE
fix(reader-activation): initilization on AMP

### DIFF
--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -2,28 +2,7 @@
  * Internal dependencies
  */
 import './style.scss';
-
-/**
- * Specify a function to execute when the DOM is fully loaded.
- *
- * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
- *
- * @param {Function} callback A function to execute after the DOM is ready.
- * @return {void}
- */
-function domReady( callback ) {
-	if ( typeof document === 'undefined' ) {
-		return;
-	}
-	if (
-		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
-		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
-	) {
-		return void callback();
-	}
-	// DOMContentLoaded has not fired yet, delay callback until then.
-	document.addEventListener( 'DOMContentLoaded', callback );
-}
+import domReady from '../../shared/js/dom-ready';
 
 const convertFormDataToObject = formData =>
 	Array.from( formData.entries() ).reduce( ( acc, [ key, val ] ) => {

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -2,28 +2,7 @@
  * Internal dependencies.
  */
 import './auth.scss';
-
-/**
- * Specify a function to execute when the DOM is fully loaded.
- *
- * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
- *
- * @param {Function} callback A function to execute after the DOM is ready.
- * @return {void}
- */
-function domReady( callback ) {
-	if ( typeof document === 'undefined' ) {
-		return;
-	}
-	if (
-		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
-		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
-	) {
-		return void callback();
-	}
-	// DOMContentLoaded has not fired yet, delay callback until then.
-	document.addEventListener( 'DOMContentLoaded', callback );
-}
+import domReady from '../shared/js/dom-ready';
 
 ( function ( readerActivation ) {
 	domReady( function () {

--- a/assets/shared/js/dom-ready.ts
+++ b/assets/shared/js/dom-ready.ts
@@ -1,0 +1,37 @@
+/**
+ * Specify a function to execute when the DOM is fully loaded.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
+ */
+const domReady = ( callback: () => void ): void => {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+
+	const htmlElement = document.querySelector( 'html' );
+	if ( ! htmlElement ) {
+		return;
+	}
+	const isAMP = Boolean( htmlElement.getAttribute( 'amp-version' ) );
+	if ( isAMP ) {
+		// In AMP environment, wait for the 'complete' event. Otherwise AMP might do DOM manipulations
+		// after the event listeners are attached.
+		document.addEventListener( 'readystatechange', () => {
+			if ( document.readyState === 'complete' ) {
+				callback();
+			}
+		} );
+		return;
+	}
+
+	if (
+		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+	) {
+		return void callback();
+	}
+	// DOMContentLoaded has not fired yet, delay callback until then.
+	document.addEventListener( 'DOMContentLoaded', callback );
+};
+
+export default domReady;

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -303,6 +303,7 @@ final class Newspack {
 			true
 		);
 		wp_enqueue_script( 'newspack_commons' );
+		wp_script_add_data( 'newspack_commons', 'amp-plus', true );
 
 		wp_register_style(
 			'newspack-commons',

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -67,6 +67,8 @@ final class Reader_Activation {
 	 * Enqueue front-end scripts.
 	 */
 	public static function enqueue_scripts() {
+		Newspack::load_common_assets();
+
 		\wp_register_script(
 			self::SCRIPT_HANDLE,
 			Newspack::plugin_url() . '/dist/reader-activation.js',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This will load common assets (the [shared JS](https://webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks)) when the auth scripts are loaded. This is not optimal, since the common assets are mostly for the back-end – blocked by https://github.com/Automattic/newspack-plugin/issues/1803

For now the issue has been resolved in #1812

Closes #1792.

### How to test the changes in this Pull Request:

Observe #1792 is not reproducible. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->