### PR TITLE
feat(registration-block): add success icon

### DIFF
--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -66,8 +66,9 @@ export default function ReaderRegistrationEdit( {
 				[
 					'core/paragraph',
 					{
+						align: 'center',
 						content: __(
-							'Thank you for registering! Check your email for a confirmation link.',
+							'Thank you for registering!<br />Check your email for a confirmation link.',
 							'newspack'
 						),
 					},
@@ -299,7 +300,12 @@ export default function ReaderRegistrationEdit( {
 						</form>
 					</div>
 				) }
-				{ editedState === 'success' && <div { ...innerBlocksProps } /> }
+				{ editedState === 'success' && (
+					<>
+						<div className="newspack-registration__icon" />
+						<div { ...innerBlocksProps } />
+					</>
+				) }
 			</div>
 		</>
 	);

--- a/assets/blocks/reader-registration/editor.scss
+++ b/assets/blocks/reader-registration/editor.scss
@@ -77,3 +77,14 @@
 		}
 	}
 }
+
+.wp-block-newspack-reader-registration {
+	.block-editor-block-list__layout {
+		margin: 0 auto;
+		max-width: 780px;
+
+		.block-list-appender {
+			position: relative;
+		}
+	}
+}

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -81,7 +81,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 function render_block( $attrs, $content ) {
 	$registered      = false;
 	$message         = '';
-	$success_message = __( 'Thank you for registering! Check your email for a confirmation link.', 'newspack' );
+	$success_message = __( 'Thank you for registering!', 'newspack' ) . '<br />' . __( 'Check your email for a confirmation link.', 'newspack' );
 
 	$block_id = \wp_rand( 0, 99999 );
 
@@ -127,7 +127,7 @@ function render_block( $attrs, $content ) {
 
 	$success_markup = $content;
 	if ( empty( wp_strip_all_tags( $content ) ) ) {
-		$success_markup = $success_message;
+		$success_markup = '<p class="has-text-align-center">' . $success_message . '</p>';
 	}
 	// phpcs:enable
 
@@ -136,6 +136,7 @@ function render_block( $attrs, $content ) {
 	<div class="newspack-registration <?php echo esc_attr( get_block_classes( $attrs ) ); ?>">
 		<?php if ( $registered ) : ?>
 			<div class="newspack-registration__success">
+				<div class="newspack-registration__icon"></div>
 				<?php echo $success_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
 		<?php else : ?>
@@ -233,6 +234,7 @@ function render_block( $attrs, $content ) {
 				</div>
 			</form>
 			<div class="newspack-registration__success newspack-registration--hidden">
+				<div class="newspack-registration__icon"></div>
 				<?php echo $success_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
 		<?php endif; ?>

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -188,14 +188,19 @@
 		}
 	}
 
-	&__success:not( [class*='--hidden'] ) {
-		.newspack-registration__icon {
-			animation: fadein 125ms ease-in;
+	&__success {
+		margin: 0 auto;
+		max-width: 780px;
 
-			&::before {
-				animation: bounce 125ms ease-in;
-				animation-delay: 500ms;
-				animation-fill-mode: forwards;
+		&:not( [class*='--hidden'] ) {
+			.newspack-registration__icon {
+				animation: fadein 125ms ease-in;
+
+				&::before {
+					animation: bounce 125ms ease-in;
+					animation-delay: 500ms;
+					animation-fill-mode: forwards;
+				}
 			}
 		}
 	}

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -164,7 +164,64 @@
 		}
 	}
 
+	&__icon {
+		align-items: center;
+		animation: fadein 125ms ease-in;
+		background: wp-colors.$alert-green;
+		border-radius: 50%;
+		display: flex;
+		height: 40px;
+		justify-content: center;
+		margin: 0 auto 0.8rem;
+		width: 40px;
+
+		&::before {
+			animation: bounce 125ms ease-in;
+			animation-delay: 500ms;
+			animation-fill-mode: forwards;
+			background-image: url( "data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white'/%3E%3C/svg%3E" );
+			content: '';
+			display: block;
+			height: 24px;
+			transform: scale( 0 );
+			width: 24px;
+		}
+	}
+
+	&__success:not( [class*='--hidden'] ) {
+		.newspack-registration__icon {
+			animation: fadein 125ms ease-in;
+
+			&::before {
+				animation: bounce 125ms ease-in;
+				animation-delay: 500ms;
+				animation-fill-mode: forwards;
+			}
+		}
+	}
+
 	&--hidden {
 		display: none;
+	}
+}
+
+@keyframes fadein {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes bounce {
+	0% {
+		transform: scale( 0 );
+	}
+	90% {
+		transform: scale( 1.4 );
+	}
+	100% {
+		transform: scale( 1 );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a small PR that adds an icon to the success state.

![Screen Recording 2022-07-27 at 12 31 06](https://user-images.githubusercontent.com/177929/181237547-5463cbee-24b1-4a8d-84c9-e6e38c13fc24.gif)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Add reader registration block (don't click on "success")
3. Check front-end
4. On a new page Add reader registration block (and click on "success")
5. Check front-end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->