### PR TITLE
Feat/registration button

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -249,6 +249,10 @@ const convertFormDataToObject = ( formData, ignoredKeys = [] ) =>
 		/**
 		 * Third party auth.
 		 */
+		const loginsElements = document.querySelectorAll( '.newspack-reader__logins' );
+		[ ...loginsElements ].forEach( element => {
+			element.classList.remove( 'newspack-reader__logins--disabled' );
+		} );
 		const googleLoginElements = document.querySelectorAll( '.newspack-reader__logins__google' );
 		googleLoginElements.forEach( googleLoginElement => {
 			const googleLoginForm = googleLoginElement.closest( 'form' );

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -28,14 +28,14 @@ function domReady( callback ) {
 /**
  * Converts FormData into an object.
  *
- * @param {FormData} formData    The form data to convert.
- * @param {Array}    ignoredKeys Keys to ignore.
+ * @param {FormData} formData       The form data to convert.
+ * @param {Array}    includedFields Form fields to include.
  *
  * @return {Object} The converted form data.
  */
-const convertFormDataToObject = ( formData, ignoredKeys = [] ) =>
+const convertFormDataToObject = ( formData, includedFields = [] ) =>
 	Array.from( formData.entries() ).reduce( ( acc, [ key, val ] ) => {
-		if ( ignoredKeys.includes( key ) ) {
+		if ( ! includedFields.includes( key ) ) {
 			return acc;
 		}
 		if ( key.indexOf( '[]' ) > -1 ) {
@@ -275,12 +275,7 @@ const convertFormDataToObject = ( formData, ignoredKeys = [] ) =>
 				}
 
 				const metadata = googleLoginForm
-					? convertFormDataToObject( new FormData( googleLoginForm ), [
-							'email',
-							'password',
-							'_wp_http_referer',
-							'newspack_reader_registration',
-					  ] )
+					? convertFormDataToObject( new FormData( googleLoginForm ), [ 'lists[]' ] )
 					: {};
 				metadata.current_page_url = window.location.href;
 				fetch( '/wp-json/newspack/v1/login/google' )

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -300,6 +300,12 @@
 				}
 			}
 		}
+		&--disabled {
+			button {
+				opacity: 0.5;
+				pointer-events: none;
+			}
+		}
 		button {
 			display: flex;
 			justify-content: center;
@@ -307,6 +313,7 @@
 			width: 100%;
 			background-color: wp-colors.$gray-100;
 			color: black;
+			transition: all 300ms;
 			span {
 				padding-left: 10px;
 			}

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -676,12 +676,13 @@ final class Reader_Activation {
 		if ( ! Google_OAuth::is_oauth_configured() ) {
 			return;
 		}
-		$class = function( ...$parts ) {
+		$class      = function( ...$parts ) {
 			array_unshift( $parts, 'logins' );
 			return self::get_element_class_name( $parts );
 		};
+		$classnames = implode( ' ', [ $class(), $class() . '--disabled' ] );
 		?>
-		<div class="<?php echo \esc_attr( $class() ); ?>">
+		<div class="<?php echo \esc_attr( $classnames ); ?>">
 			<div class="<?php echo \esc_attr( $class( 'separator' ) ); ?>">
 				<div></div>
 				<div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Adds initial disabling of the 3rd party authentication buttons. If for some reason the JS doesn't load*, the buttons will stay disabled. The first-party signup will fallback to native HTML form submission, so there's no need to disable it initially
2. Switches the 3rd-party related form data parsing from ignored to included keys. This will prevent noise in metadata, and is in line with how [metadata is handled](https://github.com/Automattic/newspack-plugin/blob/153c48ae6f9f91db8c58cb76bdf705023dfc6a76/includes/class-reader-activation.php#L767-L769) on native form submission

\* or there's that hard to reproduce [race condition](https://github.com/Automattic/newspack-plugin/pull/1781#issuecomment-1192719034) happening

### How to test the changes in this Pull Request:

1. Visit a page where registration block is present, or trigger reader auth. modal 
3. Observe the 3rd party login button ("Sign in with Google") initially disabled, but enabled right away
4. In console devtools, block the `reader-activation.js` script
5. Observe the 3rd party login button is disabled indefinitely 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->