### PR TITLE
fix(registration-block): margin for success message

### DIFF
--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -203,9 +203,23 @@
 				}
 			}
 		}
+
+		.wp-block-newspack-reader-registration {
+			> *:first-child {
+				margin-top: 0 !important;
+			}
+
+			> *:last-child {
+				margin-bottom: 0 !important;
+			}
+		}
 	}
 
 	&--hidden {
+		display: none;
+	}
+
+	+ div:empty {
 		display: none;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make sure inner blocks (first and last) don't have a margin top/bottom

(Kind of) Related: https://github.com/Automattic/newspack-theme/pull/1888

### How to test the changes in this Pull Request:

1. Add registration block to a page
2. Check front-end and register
3. Notice margins around the `p` block
4. Switch to this branch and refresh front-end
5. Margins should be gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->