### PR TITLE
fix(reader-activation): reinitialize auth links after DOM load

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -98,9 +98,7 @@ const convertFormDataToObject = ( formData, ignoredKeys = [] ) =>
 		};
 		initLinks();
 		/** Re-initialize links in case the navigation DOM was modified by a third-party. */
-		setTimeout( () => {
-			initLinks();
-		}, 1000 );
+		setTimeout( initLinks, 1000 );
 
 		/**
 		 * Handle reader changes.

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -88,8 +88,19 @@ const convertFormDataToObject = ( formData, ignoredKeys = [] ) =>
 		const authLinkMessage = container.querySelector( '[data-has-auth-link]' );
 		authLinkMessage.hidden = true;
 
-		const accountLinks = document.querySelectorAll( '.newspack-reader__account-link' );
-		const triggerLinks = document.querySelectorAll( '[data-newspack-reader-account-link]' );
+		let accountLinks, triggerLinks;
+		const initLinks = function () {
+			accountLinks = document.querySelectorAll( '.newspack-reader__account-link' );
+			triggerLinks = document.querySelectorAll( '[data-newspack-reader-account-link]' );
+			triggerLinks.forEach( link => {
+				link.addEventListener( 'click', handleAccountLinkClick );
+			} );
+		};
+		initLinks();
+		/** Re-initialize links in case the navigation DOM was modified by a third-party. */
+		setTimeout( () => {
+			initLinks();
+		}, 1000 );
 
 		/**
 		 * Handle reader changes.
@@ -138,9 +149,6 @@ const convertFormDataToObject = ( formData, ignoredKeys = [] ) =>
 				emailInput.focus();
 			}
 		}
-		triggerLinks.forEach( link => {
-			link.addEventListener( 'click', handleAccountLinkClick );
-		} );
 
 		/**
 		 * Handle auth form action selection.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure links are selected and have appropriate event listeners attached in case AMP (or any other third-party) updates DOM nodes at page load.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1792 

### How to test the changes in this Pull Request:

1. Make sure you have reader activation enabled and AMP on with AMP Plus
2. Visit the front-page and confirm the "Sign In" link opens the modal and not redirect to the "My Account" page
3. Open new sessions and test a few refreshes to confirm it persists

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->