### PR TITLE
fix(reader-activation): ensure scroll on smaller height for auth modal

### DIFF
--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -134,6 +134,8 @@
 			max-width: 544px;
 			background: #fff;
 			position: relative;
+			max-height: 100vh;
+			overflow-y: auto;
 		}
 
 		&__header {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure the auth modal renders scrollbar for smaller heights.

### How to test the changes in this Pull Request:

1. On the master branch, open the Sign In modal and shrink your browser height
2. Observe the modal is centered and the edges are off-screen
3.  Check out this branch and observe the modal renders a scrollbar

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->