### PR TITLE
feat(donations): remove defaultFrequency from the configuration

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -129,7 +129,6 @@ class Donations {
 				'year'  => [ 84, 180, 360, 180 ],
 			],
 			'tiered'              => false,
-			'defaultFrequency'    => 'month',
 			'disabledFrequencies' => [
 				'once'  => false,
 				'month' => false,

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -191,10 +191,6 @@ class Reader_Revenue_Wizard extends Wizard {
 						'required'          => false,
 						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
 					],
-					'defaultFrequency'    => [
-						'required'          => false,
-						'sanitize_callback' => 'sanitize_text_field',
-					],
 					'disabledFrequencies' => [
 						'required' => false,
 					],

--- a/tests/unit-tests/donations.php
+++ b/tests/unit-tests/donations.php
@@ -39,7 +39,6 @@ class Newspack_Test_Donations extends WP_UnitTestCase {
 			[
 				'amounts',
 				'tiered',
-				'defaultFrequency',
 				'disabledFrequencies',
 				'platform',
 				'currencySymbol',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

It's not configurable. See https://github.com/Automattic/newspack-blocks/pull/1218

### How to test the changes in this Pull Request:

Observe Donation blocks rendering as expected, taking the defaults from the Reader Revenue -> Donations settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->