### PR TITLE
feat(reader-activation): prevent updating user email in my-account

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -39,6 +39,7 @@ class WooCommerce_My_Account {
 		add_action( 'init', [ __CLASS__, 'add_rewrite_endpoints' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'handle_password_reset_request' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'redirect_to_account_details' ] );
+		add_action( 'template_redirect', [ __CLASS__, 'edit_account_prevent_email_update' ] );
 		add_filter( 'woocommerce_save_account_details_required_fields', [ __CLASS__, 'remove_required_fields' ] );
 	}
 
@@ -222,6 +223,21 @@ class WooCommerce_My_Account {
 			return dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/reader-revenue/templates/myaccount-edit-account.php';
 		}
 		return $template;
+	}
+
+	/**
+	 * Prevent updating email via Edit Account page.
+	 */
+	public static function edit_account_prevent_email_update() {
+		if (
+			! Donations::is_platform_stripe()
+			|| empty( $_POST['account_email'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			|| ! \is_user_logged_in()
+			|| ! Reader_Activation::is_enabled()
+		) {
+			return;
+		}
+		$_POST['account_email'] = wp_get_current_user()->user_email;
 	}
 }
 

--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -21,3 +21,11 @@
 		}
 	}
 }
+
+.edit-account {
+	input {
+		&:disabled {
+			background-color: #f5f5f5;
+		}
+	}
+}

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -49,7 +49,7 @@ endif;
 
 	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
 		<label for="account_email"><?php esc_html_e( 'Email address', 'newspack' ); ?>&nbsp;<span class="required">*</span></label>
-		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo esc_attr( $user->user_email ); ?>" />
+		<input type="email" disabled class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo esc_attr( $user->user_email ); ?>" />
 	</p>
 
 	<?php do_action( 'woocommerce_edit_account_form' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We have not yet implemented email address synchronisation with the ESP and Stripe, and reader email remains a unique identifier for Reader Activation features. To prevent reader data getting out of sync, let's for now disable email updating in My Account page. 

### How to test the changes in this Pull Request:

1. Enable Reader Activation
2. Observe email is not updatable in My Account page, even if the `disabled` attribute is removed by manipulating the DOM

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->