### PR TITLE
feat: handle contact update w/out lists selection

### DIFF
--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -73,7 +73,7 @@ class Newspack_Newsletters {
 						if ( is_wp_error( $existing_contact ) ) {
 							Logger::log( 'Adding metadata to a new contact.' );
 							$is_new_contact = true;
-							if ( false === $selected_list_ids || empty( $selected_list_ids ) ) {
+							if ( empty( $selected_list_ids ) ) {
 								// Registration only, as a side effect of Reader Activation.
 								$contact['metadata']['NP_Registration Date'] = gmdate( 'm/d/Y' );
 							} else {

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -55,7 +55,7 @@ class Newspack_Newsletters {
 	 *    @type string   $name     Contact name. Optional.
 	 *    @type string[] $metadata Contact additional metadata. Optional.
 	 * }
-	 * @param string[]|false $selected_list_ids    Array of list IDs the contact will be susbscribed to, or false.
+	 * @param string[]|false $selected_list_ids    Array of list IDs the contact will be subscribed to, or false.
 	 */
 	public static function newspack_newsletters_contact_data( $provider, $contact, $selected_list_ids ) {
 		switch ( $provider ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with AC metadata updating. 

### How to test the changes in this Pull Request:

1. On `master` branch of this plugin and Newsletters, 
2. as an anonymous reader subscribe to newsletter/s using the Newsletters plugin subscribe block
3. Observe that the `NP_Newsletter Selection` metadata field in AC is blank
1. Switch Newsletters to `feat/contact-adding-without-lists` branch (https://github.com/Automattic/newspack-newsletters/pull/900)
4. Repeat step 2, observe the `NP_Newsletter Selection` is set to current newsletter selection

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->