### PR TITLE
Reorganise reader activation wizard with ActionCard/Toggle

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -76,9 +76,9 @@ export default withWizardScreen( () => {
 				hasGreyHeader={ !! config.enabled }
 				disabled={ inFlight }
 				actionContent={
-						<Button variant="primary" disabled={ inFlight } onClick={ saveConfig }>
-							{ __( 'Save Settings', 'newspack' ) }
-						</Button>
+					<Button variant="primary" disabled={ inFlight } onClick={ saveConfig }>
+						{ __( 'Save Settings', 'newspack' ) }
+					</Button>
 				}
 			>
 				{ !! config.enabled && (

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -10,11 +10,11 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import {
-	Notice,
-	Grid,
-	Card,
+	ActionCard,
 	Button,
-	SectionHeader,
+	Card,
+	Grid,
+	Notice,
 	TextControl,
 	withWizardScreen,
 } from '../../../../components/src';
@@ -55,18 +55,14 @@ export default withWizardScreen( () => {
 					isError
 				/>
 			) }
+			<ActionCard
+				isMedium
+				title={ __( 'Reader Activation', 'newspack' ) }
+				description={ __( 'Configure a set of features for reader activation.', 'newspack' ) }
+				toggleChecked={ !! config.enabled }
+				toggleOnChange={ value => updateConfig( 'enabled', value ) }
+			/>
 			<Card noBorder>
-				<SectionHeader
-					title={ __( 'Reader Activation', 'newspack' ) }
-					description={ __( 'Configure a set of features for reader activation.', 'newspack' ) }
-				/>
-				<CheckboxControl
-					label={ __( 'Enable Reader Activation', 'newspack' ) }
-					help={ __( 'Whether to enable reader activation features for your site.', 'newspack' ) }
-					checked={ !! config.enabled }
-					onChange={ value => updateConfig( 'enabled', value ) }
-				/>
-				<hr />
 				<CheckboxControl
 					label={ __( 'Enable Sign In/Account link', 'newspack' ) }
 					help={ __(
@@ -102,7 +98,7 @@ export default withWizardScreen( () => {
 			</Card>
 			<div className="newspack-buttons-card">
 				<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
-					{ __( 'Save Changes', 'newspack' ) }
+					{ __( 'Save Settings', 'newspack' ) }
 				</Button>
 			</div>
 		</>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -12,7 +12,6 @@ import { useEffect, useState } from '@wordpress/element';
 import {
 	ActionCard,
 	Button,
-	Card,
 	Grid,
 	Notice,
 	TextControl,
@@ -61,46 +60,51 @@ export default withWizardScreen( () => {
 				description={ __( 'Configure a set of features for reader activation.', 'newspack' ) }
 				toggleChecked={ !! config.enabled }
 				toggleOnChange={ value => updateConfig( 'enabled', value ) }
-			/>
-			<Card noBorder>
-				<CheckboxControl
-					label={ __( 'Enable Sign In/Account link', 'newspack' ) }
-					help={ __(
-						'Display an account link in the site header. It will allow readers to register and access their account.',
-						'newspack'
-					) }
-					checked={ !! config.enabled_account_link }
-					onChange={ value => updateConfig( 'enabled_account_link', value ) }
-				/>
-				<TextControl
-					label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
-					help={ __(
-						'The text to display while subscribing to newsletters on the registration modal.',
-						'newspack'
-					) }
-					value={ config.newsletters_label }
-					onChange={ value => updateConfig( 'newsletters_label', value ) }
-				/>
-				<Grid columns={ 2 } gutter={ 16 }>
-					<TextControl
-						label={ __( 'Terms & Conditions Text', 'newspack' ) }
-						help={ __( 'Terms and conditions text to display on registration.', 'newspack' ) }
-						value={ config.terms_text }
-						onChange={ value => updateConfig( 'terms_text', value ) }
-					/>
-					<TextControl
-						label={ __( 'Terms & Conditions URL', 'newspack' ) }
-						help={ __( 'URL to the page containing the terms and conditions.', 'newspack' ) }
-						value={ config.terms_url }
-						onChange={ value => updateConfig( 'terms_url', value ) }
-					/>
-				</Grid>
-			</Card>
-			<div className="newspack-buttons-card">
-				<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
-					{ __( 'Save Settings', 'newspack' ) }
-				</Button>
-			</div>
+				hasGreyHeader={ !! config.enabled }
+				disabled={ inFlight }
+				actionContent={
+						<Button variant="primary" disabled={ inFlight } onClick={ saveConfig }>
+							{ __( 'Save Settings', 'newspack' ) }
+						</Button>
+				}
+			>
+				{ !! config.enabled && (
+					<Grid columns={ 1 }>
+						<CheckboxControl
+							label={ __( 'Enable Sign In/Account link', 'newspack' ) }
+							help={ __(
+								'Display an account link in the site header. It will allow readers to register and access their account.',
+								'newspack'
+							) }
+							checked={ !! config.enabled_account_link }
+							onChange={ value => updateConfig( 'enabled_account_link', value ) }
+						/>
+						<TextControl
+							label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
+							help={ __(
+								'The text to display while subscribing to newsletters on the registration modal.',
+								'newspack'
+							) }
+							value={ config.newsletters_label }
+							onChange={ value => updateConfig( 'newsletters_label', value ) }
+						/>
+						<Grid>
+							<TextControl
+								label={ __( 'Terms & Conditions Text', 'newspack' ) }
+								help={ __( 'Terms and conditions text to display on registration.', 'newspack' ) }
+								value={ config.terms_text }
+								onChange={ value => updateConfig( 'terms_text', value ) }
+							/>
+							<TextControl
+								label={ __( 'Terms & Conditions URL', 'newspack' ) }
+								help={ __( 'URL to the page containing the terms and conditions.', 'newspack' ) }
+								value={ config.terms_url }
+								onChange={ value => updateConfig( 'terms_url', value ) }
+							/>
+						</Grid>
+					</Grid>
+				) }
+			</ActionCard>
 		</>
 	);
 } );

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,11 @@
 				"cat $1 | ./node_modules/.bin/newspack-scripts commitlint"
 			]
 		}
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of using a section header then a toggle, I combined the two in an ActionCard/Toggle card.

<img width="1512" alt="Screenshot 2022-07-29 at 16 43 07" src="https://user-images.githubusercontent.com/177929/181795674-ba33f68f-e480-4e5b-b717-4678818349ee.png">

### How to test the changes in this Pull Request:

1. Check the reader activation wizard
2. Switch to this branch
3. Refresh wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->