### PR TITLE
feat(reader-activation): activecampaign master list

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/active-campaign.js
+++ b/assets/wizards/engagement/views/reader-activation/active-campaign.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Notice, SectionHeader, SelectControl } from '../../../../components/src';
+
+export default function ActiveCampaign( { value, onChange } ) {
+	const [ inFlight, setInFlight ] = useState( false );
+	const [ lists, setLists ] = useState( [] );
+	const [ error, setError ] = useState( false );
+	const fetchLists = () => {
+		setError( false );
+		setInFlight( true );
+		apiFetch( {
+			path: '/newspack-newsletters/v1/lists',
+		} )
+			.then( setLists )
+			.catch( setError )
+			.finally( () => setInFlight( false ) );
+	};
+	useEffect( fetchLists, [] );
+	const handleChange = key => val => onChange && onChange( key, val );
+	return (
+		<>
+			{ error && (
+				<Notice
+					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+					isError
+				/>
+			) }
+			<SectionHeader
+				title={ __( 'ActiveCampaign', 'newspack' ) }
+				description={ __( 'Settings for the ActiveCampaign integration.', 'newspack' ) }
+			/>
+			<SelectControl
+				label={ __( 'Master List', 'newspack' ) }
+				help={ __( 'The list to which all registered readers will be added.', 'newspack' ) }
+				disabled={ inFlight }
+				value={ value.masterList }
+				onChange={ handleChange( 'masterList' ) }
+				options={ [
+					{ value: '', label: __( 'None', 'newspack' ) },
+					...lists.map( list => ( { label: list.name, value: list.id } ) ),
+				] }
+			/>
+		</>
+	);
+}

--- a/assets/wizards/engagement/views/reader-activation/active-campaign.js
+++ b/assets/wizards/engagement/views/reader-activation/active-campaign.js
@@ -40,7 +40,7 @@ export default function ActiveCampaign( { value, onChange } ) {
 			/>
 			<SelectControl
 				label={ __( 'Master List', 'newspack' ) }
-				help={ __( 'The list to which all registered readers will be added.', 'newspack' ) }
+				help={ __( 'Choose a list to which all registered readers will be added.', 'newspack' ) }
 				disabled={ inFlight }
 				value={ value.masterList }
 				onChange={ handleChange( 'masterList' ) }

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -18,15 +18,18 @@ import {
 	TextControl,
 	withWizardScreen,
 } from '../../../../components/src';
+import ActiveCampaign from './active-campaign';
 
 export default withWizardScreen( () => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ config, setConfig ] = useState( {} );
-	const [ error, setError ] = useState( null );
+	const [ error, setError ] = useState( false );
+	const [ isActiveCampaign, setIsActiveCampaign ] = useState( false );
 	const updateConfig = ( key, val ) => {
 		setConfig( { ...config, [ key ]: val } );
 	};
 	const fetchConfig = () => {
+		setError( false );
 		setInFlight( true );
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
@@ -36,6 +39,7 @@ export default withWizardScreen( () => {
 			.finally( () => setInFlight( false ) );
 	};
 	const saveConfig = () => {
+		setError( false );
 		setInFlight( true );
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
@@ -47,6 +51,15 @@ export default withWizardScreen( () => {
 			.finally( () => setInFlight( false ) );
 	};
 	useEffect( fetchConfig, [] );
+	useEffect( () => {
+		apiFetch( {
+			path: '/newspack/v1/wizard/newspack-engagement-wizard/newsletters',
+		} ).then( data => {
+			setIsActiveCampaign(
+				data?.settings?.newspack_newsletters_service_provider?.value === 'active_campaign'
+			);
+		} );
+	}, [] );
 	return (
 		<>
 			{ error && (
@@ -100,6 +113,16 @@ export default withWizardScreen( () => {
 					/>
 				</Grid>
 			</Card>
+			{ isActiveCampaign && (
+				<ActiveCampaign
+					value={ { masterList: config.active_campaign_master_list } }
+					onChange={ ( key, value ) => {
+						if ( key === 'masterList' ) {
+							updateConfig( 'active_campaign_master_list', value );
+						}
+					} }
+				/>
+			) }
 			<div className="newspack-buttons-card">
 				<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
 					{ __( 'Save Changes', 'newspack' ) }

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -123,6 +123,7 @@ final class Reader_Activation {
 			'newsletters_label'           => __( 'Subscribe to our newsletters:', 'newspack' ),
 			'terms_text'                  => __( 'By signing up, you agree to our Terms and Conditions.', 'newspack' ),
 			'terms_url'                   => '',
+			'active_campaign_master_list' => '',
 		];
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Implements ActiveCampaign "master list" support as a reader activation feature.

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/820752/181805270-90ba8946-3ffb-42ec-9be9-12d20fc97ce5.png">

This PR also implements the necessary changes required by https://github.com/Automattic/newspack-newsletters/pull/902 and renames the class methods to remove redundancy.

### How to test the changes in this Pull Request:

1. Make sure you have ActiveCampaign as your ESP
2. Check out this branch and https://github.com/Automattic/newspack-newsletters/pull/902, and visit the Engagement wizard
3. Confirm you see the selection as in the image above
4. Select a list and save
5. Register a reader in a new session and don't select any list
6. Confirm on the ESP that the list is selected
7. Repeat step 5 but select a list
8. Confirm the reader is subscribed to both
9. Manage the reader subscription and deselect lists
10. Confirm the master list remained

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->