### PR TITLE
fix(reader-activation): handle no lists config available

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -106,7 +106,9 @@ function render_block( $attrs, $content ) {
 	/** Setup list subscription */
 	if ( $attrs['newsletterSubscription'] && method_exists( 'Newspack_Newsletters_Subscription', 'get_lists_config' ) ) {
 		$list_config = \Newspack_Newsletters_Subscription::get_lists_config();
-		$lists       = array_intersect_key( $list_config, array_flip( $attrs['lists'] ) );
+		if ( ! \is_wp_error( $list_config ) ) {
+			$lists = array_intersect_key( $list_config, array_flip( $attrs['lists'] ) );
+		}
 	}
 
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -557,7 +557,10 @@ final class Reader_Activation {
 
 		$newsletters_label = self::get_setting( 'newsletters_label' );
 		if ( method_exists( 'Newspack_Newsletters_Subscription', 'get_lists_config' ) ) {
-			$lists = \Newspack_Newsletters_Subscription::get_lists_config();
+			$lists_config = \Newspack_Newsletters_Subscription::get_lists_config();
+			if ( ! \is_wp_error( $lists_config ) ) {
+				$lists = $lists_config;
+			}
 		}
 		$terms_text = self::get_setting( 'terms_text' );
 		$terms_url  = self::get_setting( 'terms_url' );
@@ -723,7 +726,7 @@ final class Reader_Activation {
 			$lists = \Newspack_Newsletters_Subscription::get_lists_config();
 		}
 
-		if ( empty( $lists ) ) {
+		if ( empty( $lists ) || is_wp_error( $lists ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with missing lists config.

### How to test the changes in this Pull Request:

1. On `master`, with Reader Activation configured
1. In the Engagement wizard, set "Manual" as the Newsletters ESP
2. Visit a page with the registration block, observe a PHP Notice being logged
3. Switch Newsletters to `fix/empty-lists-config` branch (https://github.com/Automattic/newspack-newsletters/pull/904)
4. Switch to this branch, observe no notice logged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->