### PR TITLE
fix(campaigns-wizard): segmentation wording

### DIFF
--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -237,10 +237,10 @@ export const descriptionForSegment = ( segment, categories = [] ) => {
 		descriptionMessages.push( __( 'Has not subscribed', 'newspack' ) );
 	}
 	if ( is_logged_in ) {
-		descriptionMessages.push( __( 'Is logged in', 'newspack' ) );
+		descriptionMessages.push( __( 'Has user account', 'newspack' ) );
 	}
 	if ( is_not_logged_in ) {
-		descriptionMessages.push( __( 'Is not logged in', 'newspack' ) );
+		descriptionMessages.push( __( 'Does not have user account', 'newspack' ) );
 	}
 
 	// Messages for referrer sources.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes misleading wording in segmentation descriptions. As it is in the [segment settings](https://github.com/Automattic/newspack-plugin/blob/39a247459b4151901799093e8bcd311d4f97abe7/assets/wizards/popups/views/segments/SingleSegment.js#L279-L280), the has-user-account segmentation should say "has user account" rather than "is logged in".

### How to test the changes in this Pull Request:

Verify updated wording in the Campaigns Wizard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->