### PR TITLE
Reorganise donations wizard and use buttongroup for donation type

### DIFF
--- a/assets/components/src/card/style.scss
+++ b/assets/components/src/card/style.scss
@@ -30,12 +30,19 @@
 		align-items: center;
 		display: flex;
 		flex-wrap: wrap;
+		gap: 8px;
 		justify-content: space-between;
 		margin-bottom: -16px;
 
 		> * {
 			margin-bottom: 0 !important;
 			margin-top: 0 !important;
+		}
+
+		.newspack-select-control {
+			.components-base-control__field {
+				margin-bottom: 0;
+			}
 		}
 	}
 

--- a/assets/components/src/select-control/ButtonGroupControl.js
+++ b/assets/components/src/select-control/ButtonGroupControl.js
@@ -16,6 +16,7 @@ import { hooks } from '..';
 
 const ButtonGroupControl = ( {
 	buttonOptions,
+	buttonSmall,
 	className,
 	hideLabelFromVision,
 	label,
@@ -42,7 +43,9 @@ const ButtonGroupControl = ( {
 						<Button
 							key={ option.value }
 							variant={ isSelected ? 'primary' : null }
+							isPressed={ isSelected }
 							onClick={ () => onChange( option.value ) }
+							isSmall={ buttonSmall }
 						>
 							<Label />
 						</Button>

--- a/assets/components/src/select-control/index.js
+++ b/assets/components/src/select-control/index.js
@@ -25,7 +25,7 @@ class SelectControl extends Component {
 	 * Render.
 	 */
 	render() {
-		const { className, optgroups, buttonOptions, ...otherProps } = this.props;
+		const { className, optgroups, buttonOptions, buttonSmall, ...otherProps } = this.props;
 		const classes = classNames(
 			'newspack-select-control',
 			optgroups && 'newspack-grouped-select-control',
@@ -38,7 +38,11 @@ class SelectControl extends Component {
 				{ optgroups ? (
 					<GroupedSelectControl optgroups={ optgroups } { ...otherProps } />
 				) : buttonOptions ? (
-					<ButtonGroupControl buttonOptions={ buttonOptions } { ...otherProps } />
+					<ButtonGroupControl
+						buttonOptions={ buttonOptions }
+						buttonSmall={ buttonSmall }
+						{ ...otherProps }
+					/>
 				) : (
 					<BaseComponent { ...otherProps } />
 				) }

--- a/assets/wizards/readerRevenue/components/money-input/style.scss
+++ b/assets/wizards/readerRevenue/components/money-input/style.scss
@@ -4,54 +4,49 @@
 
 @use '~@wordpress/base-styles/colors' as wp-colors;
 
-.newspack-donations-wizard__money-input-container {
-	margin-bottom: 10px;
-	p {
-		margin: 0 0 8px;
-	}
-	@media screen and ( min-width: 480px ) {
-		margin-bottom: 0;
-		& + & {
-			margin-left: 16px;
-		}
-	}
-}
-
-.newspack-donations-wizard__money-input {
-	align-items: stretch;
-	display: flex;
-	margin: 8px 0 0;
-
-	.currency {
-		border: 1px solid wp-colors.$gray-700;
-		border-right: 0;
-		align-items: center;
-		background: wp-colors.$gray-100;
-		border-radius: 2px 0 0 2px;
+.newspack-donations-wizard {
+	&__money-input {
+		align-items: stretch;
 		display: flex;
-		flex: 0 0 14px;
-		height: auto;
-		justify-content: center;
-		line-height: 1;
-		margin: 0;
-		padding: 0 8px;
-		text-align: center;
-	}
+		margin: 8px 0 0;
 
-	.newspack-text-control {
-		margin: 0 !important;
-		width: 100%;
-
-		@media screen and ( min-width: 1128px ) {
-			max-width: 100%;
+		.currency {
+			border: 1px solid wp-colors.$gray-700;
+			border-right: 0;
+			align-items: center;
+			background: wp-colors.$gray-100;
+			border-radius: 2px 0 0 2px;
+			display: flex;
+			flex: 0 0 14px;
+			height: auto;
+			justify-content: center;
+			line-height: 1;
+			margin: 0;
+			padding: 0 8px;
+			text-align: center;
 		}
 
-		input[type='number'] {
-			border-radius: 0 2px 2px 0;
+		.newspack-text-control {
+			margin: 0 !important;
+			width: 100%;
+
+			@media screen and ( min-width: 1128px ) {
+				max-width: 100%;
+			}
+
+			input[type='number'] {
+				border-radius: 0 2px 2px 0;
+			}
+
+			.components-base-control__field {
+				margin-bottom: 0;
+			}
 		}
 
-		.components-base-control__field {
-			margin-bottom: 0;
+		&-container {
+			p {
+				margin: 0 0 8px;
+			}
 		}
 	}
 }

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -94,9 +94,7 @@ export const DonationAmounts = () => {
 				/>
 				<SelectControl
 					label={ __( 'Donation Type', 'newspack' ) }
-					onChange={ () =>
-						changeHandler( [ 'tiered' ] )( ! tiered )
-					}
+					onChange={ () => changeHandler( [ 'tiered' ] )( ! tiered ) }
 					buttonOptions={ [
 						{ value: true, label: __( 'Tiered', 'newspack' ) },
 						{ value: false, label: __( 'Untiered', 'newspack' ) },
@@ -114,13 +112,14 @@ export const DonationAmounts = () => {
 							Object.values( disabledFrequencies ).filter( Boolean ).length ===
 							FREQUENCY_SLUGS.length - 1;
 						return (
-							<Card isMedium>
-								<Grid columns={1} gutter={ 16 }>
+							<Card isMedium key={ section.key }>
+								<Grid columns={ 1 } gutter={ 16 }>
 									<ToggleControl
-										key={ section.key }
 										checked={ ! isFrequencyDisabled }
 										onChange={ () =>
-											changeHandler( [ 'disabledFrequencies', section.key ] )( ! isFrequencyDisabled )
+											changeHandler( [ 'disabledFrequencies', section.key ] )(
+												! isFrequencyDisabled
+											)
 										}
 										label={ section.tieredLabel }
 										disabled={ ! isFrequencyDisabled && isOneFrequencyActive }

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -12,10 +12,11 @@ import { MoneyInput } from '../../components';
 import {
 	Button,
 	Card,
+	Grid,
 	Notice,
 	SectionHeader,
+	SelectControl,
 	Wizard,
-	ActionCard,
 } from '../../../../components/src';
 import { READER_REVENUE_WIZARD_SLUG } from '../../constants';
 
@@ -82,71 +83,89 @@ export const DonationAmounts = () => {
 
 	return (
 		<>
-			<SectionHeader
-				title={ __( 'Suggested Donations', 'newspack' ) }
-				description={ __(
-					'Set suggested donation amounts. These will be the default settings for the Donate block.',
-					'newspack'
-				) }
-			/>
-			<ToggleControl
-				label={ __( 'Tiered', 'newspack' ) }
-				checked={ tiered }
-				onChange={ changeHandler( [ 'tiered' ] ) }
-			/>
+			<Card headerActions noBorder>
+				<SectionHeader
+					title={ __( 'Suggested Donations', 'newspack' ) }
+					description={ __(
+						'Set suggested donation amounts. These will be the default settings for the Donate block.',
+						'newspack'
+					) }
+					noMargin
+				/>
+				<SelectControl
+					label={ __( 'Donation Type', 'newspack' ) }
+					onChange={ () =>
+						changeHandler( [ 'tiered' ] )( ! tiered )
+					}
+					buttonOptions={ [
+						{ value: true, label: __( 'Tiered', 'newspack' ) },
+						{ value: false, label: __( 'Untiered', 'newspack' ) },
+					] }
+					buttonSmall
+					value={ tiered }
+					hideLabelFromVision
+				/>
+			</Card>
 			{ tiered ? (
-				availableFrequencies.map( section => {
-					const isFrequencyDisabled = disabledFrequencies[ section.key ];
-					const isOneFrequencyActive =
-						Object.values( disabledFrequencies ).filter( Boolean ).length ===
-						FREQUENCY_SLUGS.length - 1;
-					return (
-						<ActionCard
-							key={ section.key }
-							toggleChecked={ ! isFrequencyDisabled }
-							toggleOnChange={ () =>
-								changeHandler( [ 'disabledFrequencies', section.key ] )( ! isFrequencyDisabled )
-							}
-							title={ section.tieredLabel }
-							disabled={ ! isFrequencyDisabled && isOneFrequencyActive }
-						>
-							{ ! isFrequencyDisabled && (
-								<div className="flex-ns">
-									<MoneyInput
-										currencySymbol={ currencySymbol }
-										label={ __( 'Low-tier' ) }
-										value={ amounts[ section.key ][ 0 ] }
-										onChange={ changeHandler( [ 'amounts', section.key, 0 ] ) }
+				<Grid columns={ 1 } gutter={ 16 }>
+					{ availableFrequencies.map( section => {
+						const isFrequencyDisabled = disabledFrequencies[ section.key ];
+						const isOneFrequencyActive =
+							Object.values( disabledFrequencies ).filter( Boolean ).length ===
+							FREQUENCY_SLUGS.length - 1;
+						return (
+							<Card isMedium>
+								<Grid columns={1} gutter={ 16 }>
+									<ToggleControl
+										key={ section.key }
+										checked={ ! isFrequencyDisabled }
+										onChange={ () =>
+											changeHandler( [ 'disabledFrequencies', section.key ] )( ! isFrequencyDisabled )
+										}
+										label={ section.tieredLabel }
+										disabled={ ! isFrequencyDisabled && isOneFrequencyActive }
 									/>
-									<MoneyInput
-										currencySymbol={ currencySymbol }
-										label={ __( 'Mid-tier' ) }
-										value={ amounts[ section.key ][ 1 ] }
-										onChange={ changeHandler( [ 'amounts', section.key, 1 ] ) }
-									/>
-									<MoneyInput
-										currencySymbol={ currencySymbol }
-										label={ __( 'High-tier' ) }
-										value={ amounts[ section.key ][ 2 ] }
-										onChange={ changeHandler( [ 'amounts', section.key, 2 ] ) }
-									/>
-								</div>
-							) }
-						</ActionCard>
-					);
-				} )
+									{ ! isFrequencyDisabled && (
+										<Grid columns={ 3 } rowGap={ 16 }>
+											<MoneyInput
+												currencySymbol={ currencySymbol }
+												label={ __( 'Low-tier' ) }
+												value={ amounts[ section.key ][ 0 ] }
+												onChange={ changeHandler( [ 'amounts', section.key, 0 ] ) }
+											/>
+											<MoneyInput
+												currencySymbol={ currencySymbol }
+												label={ __( 'Mid-tier' ) }
+												value={ amounts[ section.key ][ 1 ] }
+												onChange={ changeHandler( [ 'amounts', section.key, 1 ] ) }
+											/>
+											<MoneyInput
+												currencySymbol={ currencySymbol }
+												label={ __( 'High-tier' ) }
+												value={ amounts[ section.key ][ 2 ] }
+												onChange={ changeHandler( [ 'amounts', section.key, 2 ] ) }
+											/>
+										</Grid>
+									) }
+								</Grid>
+							</Card>
+						);
+					} ) }
+				</Grid>
 			) : (
-				<div className="flex-ns">
-					{ availableFrequencies.map( section => (
-						<MoneyInput
-							currencySymbol={ currencySymbol }
-							label={ section.staticLabel }
-							value={ amounts[ section.key ][ 3 ] }
-							onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
-							key={ section.key }
-						/>
-					) ) }
-				</div>
+				<Card isMedium>
+					<Grid columns={ 3 } rowGap={ 16 }>
+						{ availableFrequencies.map( section => (
+							<MoneyInput
+								currencySymbol={ currencySymbol }
+								label={ section.staticLabel }
+								value={ amounts[ section.key ][ 3 ] }
+								onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
+								key={ section.key }
+							/>
+						) ) }
+					</Grid>
+				</Card>
 			) }
 		</>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I've reorganised the Donations wizards a little bit with the use of a Select/Button Group to switch between tiered and untiered, added a Grid to the various elements

![Screen Recording 2022-08-01 at 12 06 47](https://user-images.githubusercontent.com/177929/182137617-2990e061-22bb-4163-9354-f3f819b31fa5.gif)

### How to test the changes in this Pull Request:

1. Go to Reader Revenue > Donations
2. Switch to this branch and refresh wizard
3. Check if options are still working

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->