### PR TITLE
Fix fatal error when debug mode active

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -28,6 +28,10 @@ class RSS {
 	 * Initialise.
 	 */
 	public static function init() {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		// If the standalone plugin is active, deactivate it and activate as a module.
 		if ( is_plugin_active( 'newspack-rss-enhancements/newspack-rss-enhancements.php' ) ) {
 			deactivate_plugins( 'newspack-rss-enhancements/newspack-rss-enhancements.php' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1735 

By default `is_plugin_active` is only available after the `admin_init` action. We need to include the `plugin.php` file in other contexts if it hasn't been included yet. The reason it was only crashing when debug mode was active is because [this line calls `::get_installed_plugins` when debug mode is not active](https://github.com/Automattic/newspack-plugin/blob/master/includes/class-plugin-manager.php#L359), and `::get_installed_plugins` loads the `plugin.php` file, masking the issue.

### How to test the changes in this Pull Request:

1. Add `define( 'WP_NEWSPACK_DEBUG', true );` to `wp-config.php`.
2. Visit site frontend or backend. Observe fatal error.
3. Apply this patch. Refresh the page. Observe no fatal error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->