### PR TITLE
Fix/ga events server side

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -262,8 +262,9 @@ function process_form() {
 	if ( ! empty( $lists ) ) {
 		$metadata['lists'] = $lists;
 	}
-	$metadata['current_page_url'] = home_url( add_query_arg( array(), \wp_get_referer() ) );
-	$email                        = \sanitize_email( $_REQUEST['email'] );
+	$metadata['current_page_url']    = home_url( add_query_arg( array(), \wp_get_referer() ) );
+	$metadata['registration_method'] = 'registration-block';
+	$email                           = \sanitize_email( $_REQUEST['email'] );
 
 	$user_id = Reader_Activation::register_reader( $email, '', true, $metadata );
 
@@ -280,10 +281,6 @@ function process_form() {
 	}
 
 	$user_logged_in = false !== $user_id;
-
-	if ( $user_logged_in ) {
-		Reader_Activation::save_current_user_login_method( 'registration-block' );
-	}
 
 	return send_form_response(
 		[

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -885,6 +885,10 @@ class Analytics {
 			'action'   => __( 'Registration', 'newspack' ),
 		];
 
+		if ( isset( $metadata['registration_method'] ) ) {
+			$event_spec['action'] .= ' (' . $metadata['registration_method'] . ')';
+		}
+
 		if ( isset( $metadata['lists'] ) ) {
 			$event_spec['label'] = __( 'Signed up for lists:', 'newspack' ) . ' ' . implode( ', ', $metadata['lists'] );
 		}

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -486,7 +486,6 @@ final class Magic_Link {
 
 		Reader_Activation::set_reader_verified( $user );
 		Reader_Activation::set_current_reader( $user->ID );
-		Reader_Activation::save_current_user_login_method( 'magic-link' );
 
 		/**
 		 * Fires after a reader has been authenticated via magic link.

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -23,9 +23,9 @@ final class Reader_Activation {
 	/**
 	 * Reader user meta keys.
 	 */
-	const READER         = 'np_reader';
-	const EMAIL_VERIFIED = 'np_reader_email_verified';
-	const LOGIN_METHOD   = 'np_reader_login_method';
+	const READER              = 'np_reader';
+	const EMAIL_VERIFIED      = 'np_reader_email_verified';
+	const REGISTRATION_METHOD = 'np_reader_registration_method';
 
 	/**
 	 * Auth form.
@@ -1031,6 +1031,11 @@ final class Reader_Activation {
 			}
 		}
 
+		// Note the user's login method for later use.
+		if ( isset( $metadata['registration_method'] ) ) {
+			\update_user_meta( $user_id, self::REGISTRATION_METHOD, $metadata['registration_method'] );
+		}
+
 		/**
 		 * Action after registering and authenticating a reader.
 		 *
@@ -1043,25 +1048,6 @@ final class Reader_Activation {
 		\do_action( 'newspack_registered_reader', $email, $authenticate, $user_id, $existing_user, $metadata );
 
 		return $user_id;
-	}
-
-	/**
-	 * Note reader's login method.
-	 *
-	 * @param int    $user_id User ID.
-	 * @param string $login_method Login method used.
-	 */
-	public static function save_user_login_method( $user_id, $login_method ) {
-		\update_user_meta( $user_id, self::LOGIN_METHOD, $login_method );
-	}
-
-	/**
-	 * Note current reader's login method.
-	 *
-	 * @param string $login_method Login method used.
-	 */
-	public static function save_current_user_login_method( $login_method ) {
-		self::save_user_login_method( \get_current_user_id(), $login_method );
 	}
 
 	/**

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -167,6 +167,7 @@ class Google_Login {
 				// Fail silently.
 			}
 		}
+		$metadata['registration_method'] = 'google';
 		if ( $email ) {
 			$existing_user = \get_user_by( 'email', $email );
 			$message       = __( 'Thank you for registering!', 'newspack' );
@@ -181,7 +182,6 @@ class Google_Login {
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
-			Reader_Activation::save_current_user_login_method( 'google' );
 
 			return \rest_ensure_response(
 				[

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -51,9 +51,10 @@ class Newspack_Newsletters {
 	 * @param array          $contact           {
 	 *          Contact information.
 	 *
-	 *    @type string   $email    Contact email address.
-	 *    @type string   $name     Contact name. Optional.
-	 *    @type string[] $metadata Contact additional metadata. Optional.
+	 *    @type string   $email                 Contact email address.
+	 *    @type string   $name                  Contact name. Optional.
+	 *    @type string   $existing_contact_data Existing contact data, if updating a contact. The hook will be also called when
+	 *    @type string[] $metadata              Contact additional metadata. Optional.
 	 * }
 	 * @param string[]|false $selected_list_ids Array of list IDs the contact will be subscribed to, or false.
 	 * @param string         $provider          The provider name.
@@ -64,30 +65,6 @@ class Newspack_Newsletters {
 				$metadata = [];
 				if ( is_user_logged_in() ) {
 					$metadata['NP_Account'] = get_current_user_id();
-				}
-
-				// If it's a new contact, add a registration or signup date.
-				$is_new_contact = null;
-				try {
-					if ( method_exists( '\Newspack_Newsletters_Subscription', 'get_contact_data' ) ) {
-						$existing_contact = \Newspack_Newsletters_Subscription::get_contact_data( $contact['email'] );
-						if ( is_wp_error( $existing_contact ) ) {
-							Logger::log( 'Adding metadata to a new contact.' );
-							$is_new_contact = true;
-							if ( empty( $selected_list_ids ) ) {
-								// Registration only, as a side effect of Reader Activation.
-								$contact['metadata']['NP_Registration Date'] = gmdate( 'm/d/Y' );
-							} else {
-								// Registration and signup, the former implicit.
-								$contact['metadata']['NP_Newsletter Signup Date'] = gmdate( 'm/d/Y' );
-							}
-						} else {
-							Logger::log( 'Adding metadata to an existing contact.' );
-							$is_new_contact = false;
-						}
-					}
-				} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-					// Move along.
 				}
 
 				// Translate list IDs to list names and store as metadata, if lists are supplied.
@@ -119,8 +96,17 @@ class Newspack_Newsletters {
 					unset( $contact['metadata']['current_page_url'] );
 				}
 
-				// If it's a new contact, add some context on the signup/registration.
+				$is_new_contact = ! $contact['existing_contact_data'];
 				if ( $is_new_contact ) {
+					if ( empty( $selected_list_ids ) ) {
+						// Registration only, as a side effect of Reader Activation.
+						$contact['metadata']['NP_Registration Date'] = gmdate( 'm/d/Y' );
+					} else {
+						// Registration and signup, the former implicit.
+						$contact['metadata']['NP_Newsletter Signup Date'] = gmdate( 'm/d/Y' );
+					}
+
+					// Add some context on the signup/registration.
 					if ( ! $signup_page_url ) {
 						global $wp;
 						$signup_page_url = home_url( add_query_arg( array(), $wp->request ) );
@@ -166,11 +152,12 @@ class Newspack_Newsletters {
 	 *
 	 * @param string[]|false $lists    Array of list IDs the contact will be subscribed to, or false.
 	 * @param array          $contact  {
-	 *          Contact information.
+	 *    Contact information.
 	 *
-	 *    @type string   $email    Contact email address.
-	 *    @type string   $name     Contact name. Optional.
-	 *    @type string[] $metadata Contact additional metadata. Optional.
+	 *    @type string   $email                 Contact email address.
+	 *    @type string   $name                  Contact name. Optional.
+	 *    @type string   $existing_contact_data Existing contact data, if updating a contact. The hook will be also called when
+	 *    @type string[] $metadata              Contact additional metadata. Optional.
 	 * }
 	 * @param string         $provider The provider name.
 	 *

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -449,27 +449,15 @@ class Stripe_Connection {
 				}
 
 				// Send custom event to GA.
-				$analytics = \Newspack\Google_Services_Connection::get_site_kit_analytics_module();
-				if ( $analytics->is_connected() ) {
-					$tracking_id        = $analytics->get_settings()->get()['propertyID'];
-					$analytics_ping_url = 'https://www.google-analytics.com/collect?v=1';
-
-					// Params docs: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters.
-					$analytics_ping_params = array(
-						'tid' => $tracking_id, // Tracking ID/ Web Property ID.
-						'cid' => '555', // Client ID.
-						't'   => 'event', // Hit type.
-						'an'  => 'Newspack', // Application Name.
-						'ec'  => __( 'Newspack Donation', 'newspack' ), // Event Category.
-						'ea'  => __( 'Stripe', 'newspack' ), // Event Action.
-						'el'  => $frequency, // Event Label.
-						'ev'  => $amount_normalised, // Event Value.
-						'dr'  => $referer, // Document Referrer.
-					);
-
-					wp_remote_post( $analytics_ping_url . '&' . http_build_query( $analytics_ping_params ) );
-				}
-
+				\Newspack\Google_Services_Connection::send_custom_event(
+					[
+						'category' => __( 'Newspack Donation', 'newspack' ),
+						'action'   => __( 'Stripe', 'newspack' ),
+						'label'    => $frequency,
+						'value'    => $amount_normalised,
+						'referer'  => $referer,
+					]
+				);
 
 				// Add a transaction to WooCommerce.
 				if ( Donations::is_woocommerce_suite_active() ) {

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -792,7 +792,8 @@ class Stripe_Connection {
 			$payment_method_id = $config['payment_method_id'];
 
 			if ( ! isset( $client_metadata['userId'] ) && Reader_Activation::is_enabled() ) {
-				$user_id = Reader_Activation::register_reader( $email_address, $full_name, true, false );
+				$metadata = [ 'registration_method' => 'stripe-donation' ];
+				$user_id  = Reader_Activation::register_reader( $email_address, $full_name, true, $metadata );
 				if ( ! \is_wp_error( $user_id ) && false !== $user_id ) {
 					$client_metadata['userId'] = $user_id;
 				}

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -69,8 +69,9 @@ class WooCommerce_Connection {
 			$first_name    = $order->get_billing_first_name();
 			$last_name     = $order->get_billing_last_name();
 			$full_name     = "$first_name $last_name";
+			$metadata      = [ 'registration_method' => 'woocommerce-order' ];
 
-			Reader_Activation::register_reader( $email_address, $full_name );
+			Reader_Activation::register_reader( $email_address, $full_name, true, $metadata );
 		}
 	}
 
@@ -100,16 +101,8 @@ class WooCommerce_Connection {
 		}
 		if ( $should_create_account ) {
 			if ( Reader_Activation::is_enabled() ) {
-				$user_id = Reader_Activation::register_reader( $email_address, $full_name );
-				if ( \is_wp_error( $user_id ) ) {
-					return $user_id;
-				}
-				if ( absint( $user_id ) ) {
-					Reader_Activation::save_user_login_method( $user_id, 'woocommerce' );
-				} else {
-					$user_id = null;
-				}
-
+				$metadata = [ 'registration_method' => 'woocommerce-memberships' ];
+				$user_id  = Reader_Activation::register_reader( $email_address, $full_name, true, $metadata );
 				return $user_id;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Refactors how GA server-side event reporting is made. Adds custom events fired when:

- a reader registers via Reader Activation features
    - a custom event (has more contextual data than the NTG standard – login method and )
    - an NTG event, if configured
- a reader signs up for a newsletter - an NTG event, if configured 

Closes https://github.com/Automattic/newspack-issues/issues/235

### How to test the changes in this Pull Request:

1. Ensure your site is connected to GA. _On a local instance you can use the [`googlesitekit_allowed_tag_environment_types` hook](https://github.com/google/site-kit-wp/pull/5349) to make Site Kit behave as in production environment_
3. Ensure "News Tagging Guide custom events" are on in Analytics wizard → Custom Events (is on by default)
4. Register as a new reader using any of: Registration block, authorization modal triggered from site header, a newsletter signup, a donation
5. Observe two custom events is sent to GA: one with "Newspack Reader Activation", one with "NTG account" category
6. As a new reader, sign up for a newsletter using the Newsletters plugin' block. Observe a custom event sent with "NTG newsletter" category.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->