### PR TITLE
fix: google auth button type

### DIFF
--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -802,7 +802,7 @@ final class Reader_Activation {
 				</div>
 				<div></div>
 			</div>
-			<button class="<?php echo \esc_attr( $class( 'google' ) ); ?>">
+			<button type="button" class="<?php echo \esc_attr( $class( 'google' ) ); ?>">
 				<?php echo file_get_contents( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/blocks/reader-registration/icons/google.svg' ); // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<span>
 					<?php echo \esc_html__( 'Sign in with Google', 'newspack' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Buttons inside forms must have their `type` explicit in order to not submit the form on click.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1827.

### How to test the changes in this Pull Request:

Check out this branch and confirm that #1827 is not reproducible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->