### PR TITLE
fix(google-auth): don't resolve form on popup error

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -299,8 +299,6 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 										clearInterval( interval );
 									}
 								}, 500 );
-							} else if ( googleLoginForm?.endLoginFlow ) {
-								googleLoginForm.endLoginFlow();
 							}
 						}
 					} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If something blocks the Google auth popup, the reader should handle the browser notice and try to click it again. This PR removes the "end flow" action in case the popup is not detected, in order to allow the reader to try again.

Closes #1825 

### How to test the changes in this Pull Request:

Check out this branch and confirm that #1825 is not reproducible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->