### PR TITLE
fix(magic-links): fix email encoding on sent link

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -284,7 +284,7 @@ final class Magic_Link {
 		return \add_query_arg(
 			[
 				'action' => self::AUTH_ACTION,
-				'email'  => $user->user_email,
+				'email'  => urlencode( $user->user_email ),
 				'token'  => $token_data['token'],
 			],
 			! empty( $url ) ? $url : \home_url()


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

URL encode email parameter for the sent authentication link.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1832 

### How to test the changes in this Pull Request:

Check out this branch and confirm that #1832 is no longer reproducible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->