### PR TITLE
fix(registration-block): don't escape html for sign in labels

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -173,8 +173,8 @@ function render_block( $attrs, $content ) {
 								<?php echo $attrs['privacyLabel']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 							</p>
 							<p>
-								<?php echo \esc_html( $attrs['haveAccountLabel'] ); ?>
-								<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link><?php echo \esc_html( $attrs['signInLabel'] ); ?></a>
+								<?php echo $attrs['haveAccountLabel']; // // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+								<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link><?php echo $attrs['signInLabel']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></a>
 							</p>
 						</div>
 					</div>

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -135,7 +135,7 @@ function render_block( $attrs, $content ) {
 		<?php if ( $registered ) : ?>
 			<div class="newspack-registration__success">
 				<div class="newspack-registration__icon"></div>
-				<?php echo $success_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo \wp_kses_post( $success_markup ); ?>
 			</div>
 		<?php else : ?>
 			<form>
@@ -170,11 +170,13 @@ function render_block( $attrs, $content ) {
 
 						<div class="newspack-registration__help-text">
 							<p>
-								<?php echo $attrs['privacyLabel']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+								<?php echo \wp_kses_post( $attrs['privacyLabel'] ); ?>
 							</p>
 							<p>
-								<?php echo $attrs['haveAccountLabel']; // // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-								<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link><?php echo $attrs['signInLabel']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></a>
+								<?php echo \wp_kses_post( $attrs['haveAccountLabel'] ); ?>
+								<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link>
+									<?php echo \wp_kses_post( $attrs['signInLabel'] ); ?>
+								</a>
 							</p>
 						</div>
 					</div>
@@ -182,7 +184,7 @@ function render_block( $attrs, $content ) {
 			</form>
 			<div class="newspack-registration__success newspack-registration--hidden">
 				<div class="newspack-registration__icon"></div>
-				<?php echo $success_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo \wp_kses_post( $success_markup ); ?>
 			</div>
 		<?php endif; ?>
 	</div>

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -766,7 +766,7 @@ final class Reader_Activation {
 								<span class="<?php echo \esc_attr( $class( 'title' ) ); ?>">
 									<?php
 									if ( 1 === count( $lists ) ) {
-										echo $config['single_label']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+										echo \wp_kses_post( $config['single_label'] );
 									} else {
 										echo \esc_html( $list['title'] );
 									}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The block allows for rich text and they shouldn't be escaped on render.

<img width="731" alt="image" src="https://user-images.githubusercontent.com/820752/182468998-9fa1d2ae-be05-4744-aa6a-75b6bb57b5ea.png">

### How to test the changes in this Pull Request:

1. On master, add a registration block to a page and tweak the styling
2. Visit the page and confirm you see HTML code printed on the page
3. Check out this branch, refresh and see the styles applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->