### PR TITLE
fix(reader-activation): handle modal conflict when auth is triggered …

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -70,6 +70,16 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			form = initialForm;
 		}
 
+		let currentlyOpenOverlayPrompts = [];
+		const hideCurrentlyOpenOverlayPrompts = () =>
+			currentlyOpenOverlayPrompts.forEach( promptElement =>
+				promptElement.setAttribute( 'amp-access-hide', '' )
+			);
+		const displayCurrentlyOpenOverlayPrompts = () =>
+			currentlyOpenOverlayPrompts.forEach( promptElement =>
+				promptElement.removeAttribute( 'amp-access-hide' )
+			);
+
 		const actionInput = form.querySelector( 'input[name="action"]' );
 		const emailInput = form.querySelector( 'input[name="email"]' );
 		const passwordInput = form.querySelector( 'input[name="password"]' );
@@ -79,6 +89,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			ev.preventDefault();
 			container.classList.remove( 'newspack-reader__auth-form__visible' );
 			container.style.display = 'none';
+			displayCurrentlyOpenOverlayPrompts();
 		} );
 
 		const messageContentElement = container.querySelector(
@@ -140,6 +151,11 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 
 			container.hidden = false;
 			container.style.display = 'flex';
+
+			currentlyOpenOverlayPrompts = document.querySelectorAll(
+				'.newspack-lightbox:not([amp-access-hide])'
+			);
+			hideCurrentlyOpenOverlayPrompts();
 
 			if ( emailInput.value && 'pwd' === actionInput.value ) {
 				passwordInput.focus();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1835.

### How to test the changes in this Pull Request:

1. With Reader Activation enabled, set up an overlay prompt with a Registration block inside
2. Insert the Registration block on a page
3. Visit the page, click on "Sign In" in the "Already have an account? Sign in" message
4. Observe the overlay prompt is not displayed, and an auth modal is displayed
5. Close the auth modal, observe the prompt is visible again 
6. Open the auth modal again, and complete the authentication
7. Observe the prompt is not visible 
8. Observe the Registration block is hidden

The Registration block will display the success state for registered readers on subsequent pageviews. If we'd prefer it to be hidden, that's for another issue. WDYT @Automattic/newspack-product ?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->