### PR TITLE
feat(active-campaigns): override is-new-contact for legacy contacts

### DIFF
--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -98,6 +98,10 @@ class Newspack_Newsletters {
 				}
 
 				$is_new_contact = ! $contact['existing_contact_data'];
+				// If the contact exists, but has no account metadata, treat it as a new contact.
+				if ( $contact && isset( $contact['metadata'] ) && ! isset( $contact['metadata']['NP_ACCOUNT'] ) ) {
+					$is_new_contact = true;
+				}
 				if ( $is_new_contact ) {
 					if ( empty( $selected_list_ids ) ) {
 						// Registration only, as a side effect of Reader Activation.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Legacy contacts handling for ActiveCampaign.

### How to test the changes in this Pull Request:

1. Switch Newsletters to `feat/all-details-for-contact` branch
1. Setup a site with ActiveCampaign ESP & Reader Activation
2. Create a contact in AC manually, one which is not on the site
3. Register as this contact
4. Observe the new contact metadata is added in AC – `NP_Account`, registration or signup data, signup page URL

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->