### PR TITLE
fix(reader-activation): add metadata to reader registered on donation

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -804,7 +804,7 @@ class Stripe_Connection {
 			$payment_method_id = $config['payment_method_id'];
 
 			if ( ! isset( $client_metadata['userId'] ) && Reader_Activation::is_enabled() ) {
-				$user_id = Reader_Activation::register_reader( $email_address, $full_name, true, false );
+				$user_id = Reader_Activation::register_reader( $email_address, $full_name, true, $client_metadata );
 				if ( ! \is_wp_error( $user_id ) && false !== $user_id ) {
 					$client_metadata['userId'] = $user_id;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. On `master`,
2. With Reader Activation configured, ActiveCamapaign set as ESP, and Stripe set as the Reader Revenue platform, make a donation as an anonymous reader
3. Observe the `NP_Signup page` is set to an WP JSON API URL
4. Switch to this branch
5. Switch Blocks to `fix/donate-block-metadata` branch
6. Observe the signup URL metadata is correct after an anonymous donation

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->