### PR TITLE
feat(active-campaigns): remove usage of "NP_Newsletter Signup Date" f…

### DIFF
--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -99,13 +99,7 @@ class Newspack_Newsletters {
 
 				$is_new_contact = ! $contact['existing_contact_data'];
 				if ( $is_new_contact ) {
-					if ( empty( $selected_list_ids ) ) {
-						// Registration only, as a side effect of Reader Activation.
-						$contact['metadata']['NP_Registration Date'] = gmdate( 'm/d/Y' );
-					} else {
-						// Registration and signup, the former implicit.
-						$contact['metadata']['NP_Newsletter Signup Date'] = gmdate( 'm/d/Y' );
-					}
+					$contact['metadata']['NP_Registration Date'] = gmdate( 'm/d/Y' );
 
 					// Add some context on the signup/registration.
 					if ( ! $signup_page_url ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-issues/issues/244

### How to test the changes in this Pull Request:

1. Register as a new reader 
2. Observe the `NP_Registration Date` field is set

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->