### PR TITLE
fix(registration-block): render on preview

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -113,8 +113,11 @@ function render_block( $attrs, $content ) {
 
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if (
-		\is_user_logged_in() ||
-		( isset( $_GET['newspack_reader'] ) && absint( $_GET['newspack_reader'] ) )
+		! \is_preview() &&
+		(
+			\is_user_logged_in() ||
+			( isset( $_GET['newspack_reader'] ) && absint( $_GET['newspack_reader'] ) )
+		)
 	) {
 		$registered = true;
 		$message    = $success_message;

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -114,6 +114,7 @@ function render_block( $attrs, $content ) {
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if (
 		! \is_preview() &&
+		( ! method_exists( '\Newspack_Popups', 'is_preview_request' ) || ! \Newspack_Popups::is_preview_request() ) &&
 		(
 			\is_user_logged_in() ||
 			( isset( $_GET['newspack_reader'] ) && absint( $_GET['newspack_reader'] ) )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Render reader registration block on preview.

### How to test the changes in this Pull Request:

1. On master, place a reader registration block to a page and click to preview on a new tab
2. Confirm you see the resolved state
3. Check out this branch and refresh the preview page
4. Confirm you see the block as an unregistered user

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->