### PR TITLE
feat: if registering an email that already has an account, show different message

### DIFF
--- a/assets/blocks/reader-registration/block.json
+++ b/assets/blocks/reader-registration/block.json
@@ -39,7 +39,9 @@
 		"lists": {
 			"type": "array",
 			"default": [],
-			"items": { "type": "string" }
+			"items": {
+				"type": "string"
+			}
 		},
 		"haveAccountLabel": {
 			"type": "string",
@@ -48,6 +50,10 @@
 		"signInLabel": {
 			"type": "string",
 			"default": "Sign in"
+		},
+		"signedInLabel": {
+			"type": "string",
+			"default": "An account was already registered with this email. Please check your inbox for an authentication link."
 		}
 	},
 	"supports": {

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -34,7 +34,8 @@ import './editor.scss';
 
 const editedStateOptions = [
 	{ label: __( 'Initial', 'newspack' ), value: 'initial' },
-	{ label: __( 'Success', 'newspack' ), value: 'success' },
+	{ label: __( 'Registration Success', 'newspack' ), value: 'registration' },
+	{ label: __( 'Login Success', 'newspack' ), value: 'login' },
 ];
 export default function ReaderRegistrationEdit( {
 	setAttributes,
@@ -48,13 +49,13 @@ export default function ReaderRegistrationEdit( {
 		newsletterLabel,
 		haveAccountLabel,
 		signInLabel,
+		signedInLabel,
 		lists,
 		className,
 	},
 } ) {
 	const blockProps = useBlockProps();
 	const [ editedState, setEditedState ] = useState( editedStateOptions[ 0 ].value );
-	const isInitial = editedState === 'initial';
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{},
@@ -176,12 +177,15 @@ export default function ReaderRegistrationEdit( {
 				<div className="newspack-registration__state-bar">
 					<span>{ __( 'Edited State', 'newspack' ) }</span>
 					<div>
-						<Button data-is-active={ isInitial } onClick={ () => setEditedState( 'initial' ) }>
-							{ __( 'Initial', 'newspack' ) }
-						</Button>
-						<Button data-is-active={ ! isInitial } onClick={ () => setEditedState( 'success' ) }>
-							{ __( 'Success', 'newspack' ) }
-						</Button>
+						{ editedStateOptions.map( option => (
+							<Button
+								key={ option.value }
+								data-is-active={ editedState === option.value }
+								onClick={ () => setEditedState( option.value ) }
+							>
+								{ option.label }
+							</Button>
+						) ) }
 					</div>
 				</div>
 				{ editedState === 'initial' && (
@@ -292,10 +296,22 @@ export default function ReaderRegistrationEdit( {
 						</form>
 					</div>
 				) }
-				{ editedState === 'success' && (
+				{ editedState === 'registration' && (
 					<>
 						<div className="newspack-registration__icon" />
 						<div { ...innerBlocksProps } />
+					</>
+				) }
+				{ editedState === 'login' && (
+					<>
+						<div className="newspack-registration__icon" />
+						<RichText
+							align="center"
+							onChange={ value => setAttributes( { signedInLabel: value } ) }
+							placeholder={ __( 'Logged in message…', 'newspack' ) }
+							value={ signedInLabel }
+							tagName="p"
+						/>
 					</>
 				) }
 			</div>

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -303,7 +303,7 @@ function process_form() {
 		[
 			'email'         => $email,
 			'authenticated' => $user_logged_in,
-			'existing_user' => false === $user_id,
+			'existing_user' => ! $user_logged_in,
 		]
 	);
 }

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -90,6 +90,7 @@ function render_block( $attrs, $content ) {
 		'newsletterLabel'  => __( 'Subscribe to our newsletter', 'newspack' ),
 		'haveAccountLabel' => __( 'Already have an account?', 'newspack' ),
 		'signInLabel'      => __( 'Sign in', 'newspack' ),
+		'signedInLabel'    => __( 'An account was already registered with this email. Please check your inbox for an authentication link.', 'newspack' ),
 	];
 	$attrs         = \wp_parse_args( $attrs, $default_attrs );
 	foreach ( $default_attrs as $key => $value ) {
@@ -190,6 +191,10 @@ function render_block( $attrs, $content ) {
 				<div class="newspack-registration__icon"></div>
 				<?php echo \wp_kses_post( $success_markup ); ?>
 			</div>
+			<div class="newspack-login__success newspack-registration--hidden">
+				<div class="newspack-registration__icon"></div>
+				<p class="has-text-align-center"><?php echo \wp_kses_post( $attrs['signedInLabel'] ); ?></p>
+			</div>
 		<?php endif; ?>
 	</div>
 	<?php
@@ -245,6 +250,7 @@ function send_form_response( $data, $message = '' ) {
 				[
 					'newspack_reader' => $is_error ? '0' : '1',
 					'message'         => $message,
+					'existing_user'   => isset( $data['existing_user'] ) && boolval( $data['existing_user'] ) ? 1 : 0,
 				],
 				\remove_query_arg( $args_to_remove )
 			)
@@ -297,6 +303,7 @@ function process_form() {
 		[
 			'email'         => $email,
 			'authenticated' => $user_logged_in,
+			'existing_user' => false === $user_id,
 		]
 	);
 }

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -38,7 +38,7 @@ function domReady( callback ) {
 
 			const messageElement = container.querySelector( '.newspack-registration__response' );
 			const submitElement = form.querySelector( 'input[type="submit"]' );
-			const successElement = container.querySelector( '.newspack-registration__success' );
+			let successElement = container.querySelector( '.newspack-registration__success' );
 
 			readerActivation.on( 'reader', ( { detail: { authenticated } } ) => {
 				if ( authenticated ) {
@@ -58,6 +58,10 @@ function domReady( callback ) {
 					messageNode = document.createElement( 'div' );
 					messageNode.textContent = message;
 				}
+				if ( data?.existing_user ) {
+					successElement = document.querySelector( '.newspack-login__success' );
+				}
+
 				const isSuccess = status === 200;
 				container.classList.add( `newspack-registration--${ isSuccess ? 'success' : 'error' }` );
 				if ( isSuccess ) {

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -984,6 +984,7 @@ final class Reader_Activation {
 		$user_id = false;
 
 		if ( $existing_user ) {
+			Logger::log( "User with $email already exists. Sending magic link." );
 			Magic_Link::send_email( $existing_user );
 		} else {
 			/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Follow-up to https://github.com/Automattic/newspack-plugin/pull/1847#pullrequestreview-1061084857.

If you enter an email address that's already been registered into the Register block form, the `Reader_Activation` class recognizes the existing account and sends a magic link to the email address. However, on the front-end the messaging shows no indication that this has happened. This change displays a different message to the reader in this scenario, which can also be edited in a new, third edited state in the block editor:

<img width="800" alt="Screen Shot 2022-08-03 at 6 40 54 PM" src="https://user-images.githubusercontent.com/2230142/182738790-c0b8466e-f729-4062-8bf2-03cf4fb5c24e.png">

### How to test the changes in this Pull Request:

1. Check out this branch.
2. In the Register block, enter an email address that's already been registered and submit the form.
3. Confirm that the default message is displayed (as above in the editor screenshot).
4. Edit the success message in the block editor and repeat step 3. Confirm that your custom message is displayed:

<img width="782" alt="Screen Shot 2022-08-03 at 6 44 10 PM" src="https://user-images.githubusercontent.com/2230142/182739027-a8f4dc29-ff2c-406f-b414-d81c880554e4.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->