### PR TITLE
Reorganise reader activation wizard with ActionCard

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -10,11 +10,10 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import {
-	Notice,
-	Grid,
-	Card,
+	ActionCard,
 	Button,
-	SectionHeader,
+	Grid,
+	Notice,
 	TextControl,
 	withWizardScreen,
 } from '../../../../components/src';
@@ -68,66 +67,70 @@ export default withWizardScreen( () => {
 					isError
 				/>
 			) }
-			<Card noBorder>
-				<SectionHeader
-					title={ __( 'Reader Activation', 'newspack' ) }
-					description={ __( 'Configure a set of features for reader activation.', 'newspack' ) }
-				/>
-				<CheckboxControl
-					label={ __( 'Enable Reader Activation', 'newspack' ) }
-					help={ __( 'Whether to enable reader activation features for your site.', 'newspack' ) }
-					checked={ !! config.enabled }
-					onChange={ value => updateConfig( 'enabled', value ) }
-				/>
-				<hr />
-				<CheckboxControl
-					label={ __( 'Enable Sign In/Account link', 'newspack' ) }
-					help={ __(
-						'Display an account link in the site header. It will allow readers to register and access their account.',
-						'newspack'
-					) }
-					checked={ !! config.enabled_account_link }
-					onChange={ value => updateConfig( 'enabled_account_link', value ) }
-				/>
-				<TextControl
-					label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
-					help={ __(
-						'The text to display while subscribing to newsletters on the registration modal.',
-						'newspack'
-					) }
-					value={ config.newsletters_label }
-					onChange={ value => updateConfig( 'newsletters_label', value ) }
-				/>
-				<Grid columns={ 2 } gutter={ 16 }>
-					<TextControl
-						label={ __( 'Terms & Conditions Text', 'newspack' ) }
-						help={ __( 'Terms and conditions text to display on registration.', 'newspack' ) }
-						value={ config.terms_text }
-						onChange={ value => updateConfig( 'terms_text', value ) }
-					/>
-					<TextControl
-						label={ __( 'Terms & Conditions URL', 'newspack' ) }
-						help={ __( 'URL to the page containing the terms and conditions.', 'newspack' ) }
-						value={ config.terms_url }
-						onChange={ value => updateConfig( 'terms_url', value ) }
-					/>
-				</Grid>
-			</Card>
-			{ isActiveCampaign && (
-				<ActiveCampaign
-					value={ { masterList: config.active_campaign_master_list } }
-					onChange={ ( key, value ) => {
-						if ( key === 'masterList' ) {
-							updateConfig( 'active_campaign_master_list', value );
-						}
-					} }
-				/>
-			) }
-			<div className="newspack-buttons-card">
-				<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
-					{ __( 'Save Changes', 'newspack' ) }
-				</Button>
-			</div>
+			<ActionCard
+				isMedium
+				title={ __( 'Reader Activation', 'newspack' ) }
+				description={ __( 'Configure a set of features for reader activation.', 'newspack' ) }
+				toggleChecked={ !! config.enabled }
+				toggleOnChange={ value => updateConfig( 'enabled', value ) }
+				hasGreyHeader={ !! config.enabled }
+				disabled={ inFlight }
+				actionContent={
+					<Button variant="primary" disabled={ inFlight } onClick={ saveConfig }>
+						{ __( 'Save Settings', 'newspack' ) }
+					</Button>
+				}
+			>
+				{ !! config.enabled && (
+					<Grid columns={ 1 }>
+						<CheckboxControl
+							label={ __( 'Enable Sign In/Account link', 'newspack' ) }
+							help={ __(
+								'Display an account link in the site header. It will allow readers to register and access their account.',
+								'newspack'
+							) }
+							checked={ !! config.enabled_account_link }
+							onChange={ value => updateConfig( 'enabled_account_link', value ) }
+						/>
+						<TextControl
+							label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
+							help={ __(
+								'The text to display while subscribing to newsletters on the registration modal.',
+								'newspack'
+							) }
+							value={ config.newsletters_label }
+							onChange={ value => updateConfig( 'newsletters_label', value ) }
+						/>
+						<Grid>
+							<TextControl
+								label={ __( 'Terms & Conditions Text', 'newspack' ) }
+								help={ __( 'Terms and conditions text to display on registration.', 'newspack' ) }
+								value={ config.terms_text }
+								onChange={ value => updateConfig( 'terms_text', value ) }
+							/>
+							<TextControl
+								label={ __( 'Terms & Conditions URL', 'newspack' ) }
+								help={ __( 'URL to the page containing the terms and conditions.', 'newspack' ) }
+								value={ config.terms_url }
+								onChange={ value => updateConfig( 'terms_url', value ) }
+							/>
+						</Grid>
+						{ isActiveCampaign && (
+							<>
+								<hr />
+								<ActiveCampaign
+									value={ { masterList: config.active_campaign_master_list } }
+									onChange={ ( key, value ) => {
+										if ( key === 'masterList' ) {
+											updateConfig( 'active_campaign_master_list', value );
+										}
+									} }
+								/>
+							</>
+						) }
+					</Grid>
+				) }
+			</ActionCard>
 		</>
 	);
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of using a section header then a toggle, I combined all the settings into an ActionCard/Toggle card.

![localhost_10004_wp-admin_admin php_page=newspack-engagement-wizard](https://user-images.githubusercontent.com/177929/182840586-93f63c2a-cb88-4391-97b1-6a67b7de5f3e.png)

### How to test the changes in this Pull Request:

1. Check the reader activation wizard
2. Switch to this branch
3. Refresh wizard
4. Test the various settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->