### PR TITLE
feat: replace WooCommerce’s login form with our own

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -85,13 +85,16 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 		const passwordInput = form.querySelector( 'input[name="password"]' );
 		const redirectInput = form.querySelector( 'input[name="redirect"]' );
 		const submitButtons = form.querySelectorAll( '[type="submit"]' );
+		const closeButton = container.querySelector( 'button[data-close]' );
 
-		container.querySelector( 'button[data-close]' ).addEventListener( 'click', function ( ev ) {
-			ev.preventDefault();
-			container.classList.remove( 'newspack-reader__auth-form__visible' );
-			container.style.display = 'none';
-			displayCurrentlyOpenOverlayPrompts();
-		} );
+		if ( closeButton ) {
+			closeButton.addEventListener( 'click', function ( ev ) {
+				ev.preventDefault();
+				container.classList.remove( 'newspack-reader__auth-form__visible' );
+				container.style.display = 'none';
+				displayCurrentlyOpenOverlayPrompts();
+			} );
+		}
 
 		const messageContentElement = container.querySelector(
 			'.newspack-reader__auth-form__response__content'

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -96,7 +96,10 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 				const redirectInput = container.querySelector( 'input[name="redirect"]' );
 				const reader = readerActivation.getReader();
 				let redirectAfterLogin = redirectInput && !! redirectInput.value;
-				emailInput.value = reader?.email || '';
+				if ( emailInput ) {
+					emailInput.value = reader?.email || '';
+				}
+
 				if ( accountLinks?.length ) {
 					accountLinks.forEach( link => {
 						/** If there's a pre-auth, signing in redirects to the reader account. */

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -95,7 +95,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 				const emailInput = container.querySelector( 'input[name="email"]' );
 				const redirectInput = container.querySelector( 'input[name="redirect"]' );
 				const reader = readerActivation.getReader();
-				let redirectAfterLogin = !! redirectInput.value;
+				let redirectAfterLogin = redirectInput && !! redirectInput.value;
 				emailInput.value = reader?.email || '';
 				if ( accountLinks?.length ) {
 					accountLinks.forEach( link => {

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -59,8 +59,122 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			return;
 		}
 
+		let currentlyOpenOverlayPrompts = [];
+		const hideCurrentlyOpenOverlayPrompts = () =>
+			currentlyOpenOverlayPrompts.forEach( promptElement =>
+				promptElement.setAttribute( 'amp-access-hide', '' )
+			);
+		const displayCurrentlyOpenOverlayPrompts = () =>
+			currentlyOpenOverlayPrompts.forEach( promptElement =>
+				promptElement.removeAttribute( 'amp-access-hide' )
+			);
+
+		let accountLinks, triggerLinks;
+		const initLinks = function () {
+			accountLinks = document.querySelectorAll( '.newspack-reader__account-link' );
+			triggerLinks = document.querySelectorAll( '[data-newspack-reader-account-link]' );
+			triggerLinks.forEach( link => {
+				link.addEventListener( 'click', handleAccountLinkClick );
+			} );
+		};
+		initLinks();
+		/** Re-initialize links in case the navigation DOM was modified by a third-party. */
+		setTimeout( initLinks, 1000 );
+
+		/**
+		 * Handle reader changes.
+		 */
+		function handleReaderChanges() {
+			const allContainers = [ ...document.querySelectorAll( '.newspack-reader-auth' ) ];
+			/** If no modal login form, bail. */
+			if ( ! allContainers.length ) {
+				return;
+			}
+
+			allContainers.forEach( container => {
+				const emailInput = container.querySelector( 'input[name="email"]' );
+				const redirectInput = container.querySelector( 'input[name="redirect"]' );
+				const reader = readerActivation.getReader();
+				let redirectAfterLogin = !! redirectInput.value;
+				emailInput.value = reader?.email || '';
+				if ( accountLinks?.length ) {
+					accountLinks.forEach( link => {
+						/** If there's a pre-auth, signing in redirects to the reader account. */
+						if ( reader?.email && ! reader?.authenticated ) {
+							link.setAttribute( 'data-redirect', link.getAttribute( 'href' ) );
+							redirectAfterLogin = true;
+						} else {
+							link.removeAttribute( 'data-redirect' );
+						}
+						try {
+							const labels = JSON.parse( link.getAttribute( 'data-labels' ) );
+							link.querySelector( '.newspack-reader__account-link__label' ).textContent =
+								reader?.email ? labels.signedin : labels.signedout;
+						} catch {}
+					} );
+				}
+				if ( reader?.authenticated && ! redirectAfterLogin ) {
+					container.style.display = 'none';
+				}
+			} );
+		}
+		readerActivation.on( 'reader', handleReaderChanges );
+		handleReaderChanges();
+
+		/**
+		 * Handle account links.
+		 */
+		function handleAccountLinkClick( ev ) {
+			const reader = readerActivation.getReader();
+			/** If logged in, bail and allow page redirection. */
+			if ( reader?.authenticated ) {
+				return;
+			}
+
+			const container = document.querySelector(
+				'.newspack-reader-auth:not(.newspack-reader__auth-form__inline)'
+			);
+			/** If no modal login form, bail. */
+			if ( ! container ) {
+				return;
+			}
+
+			ev.preventDefault();
+
+			const authLinkMessage = container.querySelector( '[data-has-auth-link]' );
+			const emailInput = container.querySelector( 'input[name="email"]' );
+			const redirectInput = container.querySelector( 'input[name="redirect"]' );
+			const passwordInput = container.querySelector( 'input[name="password"]' );
+			const actionInput = container.querySelector( 'input[name="action"]' );
+
+			if ( readerActivation.hasAuthLink() ) {
+				authLinkMessage.style.display = 'block';
+			} else {
+				authLinkMessage.style.display = 'none';
+			}
+
+			emailInput.value = reader?.email || '';
+
+			if ( ev.target.getAttribute( 'data-redirect' ) ) {
+				redirectInput.value = ev.target.getAttribute( 'data-redirect' );
+			}
+
+			container.hidden = false;
+			container.style.display = 'flex';
+
+			currentlyOpenOverlayPrompts = document.querySelectorAll(
+				'.newspack-lightbox:not([amp-access-hide])'
+			);
+			hideCurrentlyOpenOverlayPrompts();
+
+			if ( emailInput.value && 'pwd' === actionInput.value ) {
+				passwordInput.focus();
+			} else {
+				emailInput.focus();
+			}
+		}
+
 		containers.forEach( container => {
-			const isInline = container.classList.contains( 'newspack-reader__auth-form__inline' );
 			const initialForm = container.querySelector( 'form' );
 			let form;
 			/** Workaround AMP's enforced XHR strategy. */
@@ -72,20 +186,9 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 				form = initialForm;
 			}
 
-			let currentlyOpenOverlayPrompts = [];
-			const hideCurrentlyOpenOverlayPrompts = () =>
-				currentlyOpenOverlayPrompts.forEach( promptElement =>
-					promptElement.setAttribute( 'amp-access-hide', '' )
-				);
-			const displayCurrentlyOpenOverlayPrompts = () =>
-				currentlyOpenOverlayPrompts.forEach( promptElement =>
-					promptElement.removeAttribute( 'amp-access-hide' )
-				);
-
 			const actionInput = form.querySelector( 'input[name="action"]' );
 			const emailInput = form.querySelector( 'input[name="email"]' );
 			const passwordInput = form.querySelector( 'input[name="password"]' );
-			const redirectInput = form.querySelector( 'input[name="redirect"]' );
 			const submitButtons = form.querySelectorAll( '[type="submit"]' );
 			const closeButton = container.querySelector( 'button[data-close]' );
 
@@ -104,84 +207,6 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 
 			const authLinkMessage = container.querySelector( '[data-has-auth-link]' );
 			authLinkMessage.hidden = true;
-
-			let accountLinks, triggerLinks;
-			const initLinks = function () {
-				accountLinks = document.querySelectorAll( '.newspack-reader__account-link' );
-				triggerLinks = document.querySelectorAll( '[data-newspack-reader-account-link]' );
-				triggerLinks.forEach( link => {
-					link.addEventListener( 'click', handleAccountLinkClick );
-				} );
-			};
-			initLinks();
-			/** Re-initialize links in case the navigation DOM was modified by a third-party. */
-			setTimeout( initLinks, 1000 );
-
-			/**
-			 * Handle reader changes.
-			 */
-			function handleReaderChanges() {
-				const reader = readerActivation.getReader();
-				emailInput.value = reader?.email || '';
-				if ( accountLinks?.length ) {
-					accountLinks.forEach( link => {
-						/** If there's a pre-auth, signing in redirects to the reader account. */
-						if ( reader?.email && ! reader?.authenticated ) {
-							link.setAttribute( 'data-redirect', link.getAttribute( 'href' ) );
-						} else {
-							link.removeAttribute( 'data-redirect' );
-						}
-						try {
-							const labels = JSON.parse( link.getAttribute( 'data-labels' ) );
-							link.querySelector( '.newspack-reader__account-link__label' ).textContent =
-								reader?.email ? labels.signedin : labels.signedout;
-						} catch {}
-					} );
-				}
-				if ( reader?.authenticated && ! isInline ) {
-					container.style.display = 'none';
-				}
-			}
-			readerActivation.on( 'reader', handleReaderChanges );
-			handleReaderChanges();
-
-			/**
-			 * Handle account links.
-			 */
-			function handleAccountLinkClick( ev ) {
-				const reader = readerActivation.getReader();
-				/** If logged in, bail and allow page redirection. */
-				if ( reader?.authenticated ) {
-					return;
-				}
-				ev.preventDefault();
-
-				if ( readerActivation.hasAuthLink() ) {
-					authLinkMessage.style.display = 'block';
-				} else {
-					authLinkMessage.style.display = 'none';
-				}
-
-				emailInput.value = reader?.email || '';
-
-				if ( ev.target.getAttribute( 'data-redirect' ) ) {
-					redirectInput.value = ev.target.getAttribute( 'data-redirect' );
-				}
-
-				container.hidden = false;
-				container.style.display = 'flex';
-
-				currentlyOpenOverlayPrompts = document.querySelectorAll(
-					'.newspack-lightbox:not([amp-access-hide])'
-				);
-				hideCurrentlyOpenOverlayPrompts();
-
-				if ( emailInput.value && 'pwd' === actionInput.value ) {
-					passwordInput.focus();
-				} else {
-					emailInput.focus();
-				}
-			}
 
 			/**
 			 * Handle auth form action selection.
@@ -284,77 +309,75 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 						form.endLoginFlow();
 					} );
 			} );
+		} );
 
-			/**
-			 * Third party auth.
-			 */
-			const loginsElements = document.querySelectorAll( '.newspack-reader__logins' );
-			[ ...loginsElements ].forEach( element => {
-				element.classList.remove( 'newspack-reader__logins--disabled' );
-			} );
-			const googleLoginElements = document.querySelectorAll( '.newspack-reader__logins__google' );
-			googleLoginElements.forEach( googleLoginElement => {
-				const googleLoginForm = googleLoginElement.closest( 'form' );
+		/**
+		 * Third party auth.
+		 */
+		const loginsElements = document.querySelectorAll( '.newspack-reader__logins' );
+		[ ...loginsElements ].forEach( element => {
+			element.classList.remove( 'newspack-reader__logins--disabled' );
+		} );
+		const googleLoginElements = document.querySelectorAll( '.newspack-reader__logins__google' );
+		googleLoginElements.forEach( googleLoginElement => {
+			const googleLoginForm = googleLoginElement.closest( 'form' );
 
-				const checkLoginStatus = metadata => {
-					fetch(
-						`/wp-json/newspack/v1/login/google/register?metadata=${ JSON.stringify( metadata ) }`
-					).then( res => {
-						res.json().then( ( { message, data } ) => {
-							if ( googleLoginForm.endLoginFlow ) {
-								googleLoginForm.endLoginFlow( message, res.status, data );
-							}
-						} );
+			const checkLoginStatus = metadata => {
+				fetch(
+					`/wp-json/newspack/v1/login/google/register?metadata=${ JSON.stringify( metadata ) }`
+				).then( res => {
+					res.json().then( ( { message, data } ) => {
+						if ( googleLoginForm.endLoginFlow ) {
+							googleLoginForm.endLoginFlow( message, res.status, data );
+						}
 					} );
-				};
+				} );
+			};
 
-				googleLoginElement.addEventListener( 'click', () => {
-					if ( googleLoginForm?.startLoginFlow ) {
-						googleLoginForm.startLoginFlow();
-					}
+			googleLoginElement.addEventListener( 'click', () => {
+				if ( googleLoginForm?.startLoginFlow ) {
+					googleLoginForm.startLoginFlow();
+				}
 
-					const metadata = googleLoginForm
-						? convertFormDataToObject( new FormData( googleLoginForm ), [ 'lists[]' ] )
-						: {};
-					metadata.current_page_url = window.location.href;
-					const authWindow = window.open(
-						'about:blank',
-						'newspack_google_login',
-						'width=500,height=600'
-					);
-					fetch( '/wp-json/newspack/v1/login/google' )
-						.then( res =>
-							res.json().then( data => Promise.resolve( { data, status: res.status } ) )
-						)
-						.then( ( { data, status } ) => {
-							if ( status !== 200 ) {
-								if ( authWindow ) {
-									authWindow.close();
-								}
-								if ( googleLoginForm?.endLoginFlow ) {
-									googleLoginForm.endLoginFlow( data.message, status );
-								}
-							} else if ( authWindow ) {
-								authWindow.location = data;
-								const interval = setInterval( () => {
-									if ( authWindow.closed ) {
-										checkLoginStatus( metadata );
-										clearInterval( interval );
-									}
-								}, 500 );
-							} else if ( googleLoginForm?.endLoginFlow ) {
-								googleLoginForm.endLoginFlow();
-							}
-						} )
-						.catch( error => {
-							if ( googleLoginForm?.endLoginFlow ) {
-								googleLoginForm.endLoginFlow( error.message );
-							}
+				const metadata = googleLoginForm
+					? convertFormDataToObject( new FormData( googleLoginForm ), [ 'lists[]' ] )
+					: {};
+				metadata.current_page_url = window.location.href;
+				const authWindow = window.open(
+					'about:blank',
+					'newspack_google_login',
+					'width=500,height=600'
+				);
+				fetch( '/wp-json/newspack/v1/login/google' )
+					.then( res => res.json().then( data => Promise.resolve( { data, status: res.status } ) ) )
+					.then( ( { data, status } ) => {
+						if ( status !== 200 ) {
 							if ( authWindow ) {
 								authWindow.close();
 							}
-						} );
-				} );
+							if ( googleLoginForm?.endLoginFlow ) {
+								googleLoginForm.endLoginFlow( data.message, status );
+							}
+						} else if ( authWindow ) {
+							authWindow.location = data;
+							const interval = setInterval( () => {
+								if ( authWindow.closed ) {
+									checkLoginStatus( metadata );
+									clearInterval( interval );
+								}
+							}, 500 );
+						} else if ( googleLoginForm?.endLoginFlow ) {
+							googleLoginForm.endLoginFlow();
+						}
+					} )
+					.catch( error => {
+						if ( googleLoginForm?.endLoginFlow ) {
+							googleLoginForm.endLoginFlow( error.message );
+						}
+						if ( authWindow ) {
+							authWindow.close();
+						}
+					} );
 			} );
 		} );
 	} );

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -54,302 +54,307 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			return;
 		}
 
-		const container = document.querySelector( '#newspack-reader-auth' );
-		if ( ! container ) {
+		const containers = [ ...document.querySelectorAll( '.newspack-reader-auth' ) ];
+		if ( ! containers.length ) {
 			return;
 		}
 
-		const initialForm = container.querySelector( 'form' );
-		let form;
-		/** Workaround AMP's enforced XHR strategy. */
-		if ( initialForm.getAttribute( 'action-xhr' ) ) {
-			initialForm.removeAttribute( 'action-xhr' );
-			form = initialForm.cloneNode( true );
-			initialForm.replaceWith( form );
-		} else {
-			form = initialForm;
-		}
+		containers.forEach( container => {
+			const isInline = container.classList.contains( 'newspack-reader__auth-form__inline' );
+			const initialForm = container.querySelector( 'form' );
+			let form;
+			/** Workaround AMP's enforced XHR strategy. */
+			if ( initialForm.getAttribute( 'action-xhr' ) ) {
+				initialForm.removeAttribute( 'action-xhr' );
+				form = initialForm.cloneNode( true );
+				initialForm.replaceWith( form );
+			} else {
+				form = initialForm;
+			}
 
-		let currentlyOpenOverlayPrompts = [];
-		const hideCurrentlyOpenOverlayPrompts = () =>
-			currentlyOpenOverlayPrompts.forEach( promptElement =>
-				promptElement.setAttribute( 'amp-access-hide', '' )
-			);
-		const displayCurrentlyOpenOverlayPrompts = () =>
-			currentlyOpenOverlayPrompts.forEach( promptElement =>
-				promptElement.removeAttribute( 'amp-access-hide' )
-			);
+			let currentlyOpenOverlayPrompts = [];
+			const hideCurrentlyOpenOverlayPrompts = () =>
+				currentlyOpenOverlayPrompts.forEach( promptElement =>
+					promptElement.setAttribute( 'amp-access-hide', '' )
+				);
+			const displayCurrentlyOpenOverlayPrompts = () =>
+				currentlyOpenOverlayPrompts.forEach( promptElement =>
+					promptElement.removeAttribute( 'amp-access-hide' )
+				);
 
-		const actionInput = form.querySelector( 'input[name="action"]' );
-		const emailInput = form.querySelector( 'input[name="email"]' );
-		const passwordInput = form.querySelector( 'input[name="password"]' );
-		const redirectInput = form.querySelector( 'input[name="redirect"]' );
-		const submitButtons = form.querySelectorAll( '[type="submit"]' );
-		const closeButton = container.querySelector( 'button[data-close]' );
+			const actionInput = form.querySelector( 'input[name="action"]' );
+			const emailInput = form.querySelector( 'input[name="email"]' );
+			const passwordInput = form.querySelector( 'input[name="password"]' );
+			const redirectInput = form.querySelector( 'input[name="redirect"]' );
+			const submitButtons = form.querySelectorAll( '[type="submit"]' );
+			const closeButton = container.querySelector( 'button[data-close]' );
 
-		if ( closeButton ) {
-			closeButton.addEventListener( 'click', function ( ev ) {
-				ev.preventDefault();
-				container.classList.remove( 'newspack-reader__auth-form__visible' );
-				container.style.display = 'none';
-				displayCurrentlyOpenOverlayPrompts();
-			} );
-		}
-
-		const messageContentElement = container.querySelector(
-			'.newspack-reader__auth-form__response__content'
-		);
-
-		const authLinkMessage = container.querySelector( '[data-has-auth-link]' );
-		authLinkMessage.hidden = true;
-
-		let accountLinks, triggerLinks;
-		const initLinks = function () {
-			accountLinks = document.querySelectorAll( '.newspack-reader__account-link' );
-			triggerLinks = document.querySelectorAll( '[data-newspack-reader-account-link]' );
-			triggerLinks.forEach( link => {
-				link.addEventListener( 'click', handleAccountLinkClick );
-			} );
-		};
-		initLinks();
-		/** Re-initialize links in case the navigation DOM was modified by a third-party. */
-		setTimeout( initLinks, 1000 );
-
-		/**
-		 * Handle reader changes.
-		 */
-		function handleReaderChanges() {
-			const reader = readerActivation.getReader();
-			emailInput.value = reader?.email || '';
-			if ( accountLinks?.length ) {
-				accountLinks.forEach( link => {
-					/** If there's a pre-auth, signing in redirects to the reader account. */
-					if ( reader?.email && ! reader?.authenticated ) {
-						link.setAttribute( 'data-redirect', link.getAttribute( 'href' ) );
-					} else {
-						link.removeAttribute( 'data-redirect' );
-					}
-					try {
-						const labels = JSON.parse( link.getAttribute( 'data-labels' ) );
-						link.querySelector( '.newspack-reader__account-link__label' ).textContent =
-							reader?.email ? labels.signedin : labels.signedout;
-					} catch {}
+			if ( closeButton ) {
+				closeButton.addEventListener( 'click', function ( ev ) {
+					ev.preventDefault();
+					container.classList.remove( 'newspack-reader__auth-form__visible' );
+					container.style.display = 'none';
+					displayCurrentlyOpenOverlayPrompts();
 				} );
 			}
-			if ( reader?.authenticated ) {
-				container.style.display = 'none';
-			}
-		}
-		readerActivation.on( 'reader', handleReaderChanges );
-		handleReaderChanges();
 
-		/**
-		 * Handle account links.
-		 */
-		function handleAccountLinkClick( ev ) {
-			const reader = readerActivation.getReader();
-			/** If logged in, bail and allow page redirection. */
-			if ( reader?.authenticated ) {
-				return;
-			}
-			ev.preventDefault();
-
-			if ( readerActivation.hasAuthLink() ) {
-				authLinkMessage.style.display = 'block';
-			} else {
-				authLinkMessage.style.display = 'none';
-			}
-
-			emailInput.value = reader?.email || '';
-
-			if ( ev.target.getAttribute( 'data-redirect' ) ) {
-				redirectInput.value = ev.target.getAttribute( 'data-redirect' );
-			}
-
-			container.hidden = false;
-			container.style.display = 'flex';
-
-			currentlyOpenOverlayPrompts = document.querySelectorAll(
-				'.newspack-lightbox:not([amp-access-hide])'
+			const messageContentElement = container.querySelector(
+				'.newspack-reader__auth-form__response__content'
 			);
-			hideCurrentlyOpenOverlayPrompts();
 
-			if ( emailInput.value && 'pwd' === actionInput.value ) {
-				passwordInput.focus();
-			} else {
-				emailInput.focus();
-			}
-		}
+			const authLinkMessage = container.querySelector( '[data-has-auth-link]' );
+			authLinkMessage.hidden = true;
 
-		/**
-		 * Handle auth form action selection.
-		 */
-		function setFormAction( action ) {
-			actionInput.value = action;
-			container.removeAttribute( 'data-form-status' );
-			messageContentElement.innerHTML = '';
-			container.querySelectorAll( '[data-action]' ).forEach( item => {
-				if ( 'none' !== item.style.display ) {
-					item.prevDisplay = item.style.display;
-				}
-				item.style.display = 'none';
-			} );
-			container.querySelectorAll( '[data-action~="' + action + '"]' ).forEach( item => {
-				item.style.display = item.prevDisplay;
-			} );
-			try {
-				const labels = JSON.parse( container.getAttribute( 'data-labels' ) );
-				const label = 'register' === action ? labels.register : labels.signin;
-				container.querySelector( 'h2' ).textContent = label;
-			} catch {}
-			if ( action === 'pwd' && emailInput.value ) {
-				passwordInput.focus();
-			} else {
-				emailInput.focus();
-			}
-		}
-		setFormAction( actionInput.value );
-		container.querySelectorAll( '[data-set-action]' ).forEach( item => {
-			item.addEventListener( 'click', function ( ev ) {
-				ev.preventDefault();
-				setFormAction( ev.target.getAttribute( 'data-set-action' ) );
-			} );
-		} );
-
-		form.startLoginFlow = () => {
-			container.removeAttribute( 'data-form-status' );
-			submitButtons.forEach( button => {
-				button.disabled = true;
-			} );
-			messageContentElement.innerHTML = '';
-			form.style.opacity = 0.5;
-		};
-
-		form.endLoginFlow = ( message, status, data, redirect ) => {
-			if ( message ) {
-				const messageNode = document.createElement( 'p' );
-				messageNode.textContent = message;
-				messageContentElement.appendChild( messageNode );
-			}
-			if ( status === 200 && data ) {
-				const authenticated = !! data?.authenticated;
-				readerActivation.setReaderEmail( data.email );
-				readerActivation.setAuthenticated( authenticated );
-				if ( authenticated ) {
-					if ( redirect ) {
-						window.location = redirect;
-					}
-				} else {
-					form.replaceWith( messageContentElement.parentNode );
-				}
-			}
-			form.style.opacity = 1;
-			submitButtons.forEach( button => {
-				button.disabled = false;
-			} );
-		};
-
-		/**
-		 * Handle auth form submission.
-		 */
-		form.addEventListener( 'submit', function ( ev ) {
-			ev.preventDefault();
-			const body = new FormData( ev.target );
-			if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
-				return;
-			}
-			readerActivation.setReaderEmail( body.get( 'email' ) );
-			form.startLoginFlow();
-			fetch( form.getAttribute( 'action' ) || window.location.pathname, {
-				method: 'POST',
-				headers: {
-					Accept: 'application/json',
-				},
-				body,
-			} )
-				.then( res => {
-					container.setAttribute( 'data-form-status', res.status );
-					res
-						.json()
-						.then( ( { message, data } ) => {
-							form.endLoginFlow( message, res.status, data, body.get( 'redirect' ) );
-						} )
-						.catch( () => {
-							form.endLoginFlow();
-						} );
-				} )
-				.catch( () => {
-					form.endLoginFlow();
+			let accountLinks, triggerLinks;
+			const initLinks = function () {
+				accountLinks = document.querySelectorAll( '.newspack-reader__account-link' );
+				triggerLinks = document.querySelectorAll( '[data-newspack-reader-account-link]' );
+				triggerLinks.forEach( link => {
+					link.addEventListener( 'click', handleAccountLinkClick );
 				} );
-		} );
+			};
+			initLinks();
+			/** Re-initialize links in case the navigation DOM was modified by a third-party. */
+			setTimeout( initLinks, 1000 );
 
-		/**
-		 * Third party auth.
-		 */
-		const loginsElements = document.querySelectorAll( '.newspack-reader__logins' );
-		[ ...loginsElements ].forEach( element => {
-			element.classList.remove( 'newspack-reader__logins--disabled' );
-		} );
-		const googleLoginElements = document.querySelectorAll( '.newspack-reader__logins__google' );
-		googleLoginElements.forEach( googleLoginElement => {
-			const googleLoginForm = googleLoginElement.closest( 'form' );
-
-			const checkLoginStatus = metadata => {
-				fetch(
-					`/wp-json/newspack/v1/login/google/register?metadata=${ JSON.stringify( metadata ) }`
-				).then( res => {
-					res.json().then( ( { message, data } ) => {
-						if ( googleLoginForm.endLoginFlow ) {
-							googleLoginForm.endLoginFlow( message, res.status, data );
+			/**
+			 * Handle reader changes.
+			 */
+			function handleReaderChanges() {
+				const reader = readerActivation.getReader();
+				emailInput.value = reader?.email || '';
+				if ( accountLinks?.length ) {
+					accountLinks.forEach( link => {
+						/** If there's a pre-auth, signing in redirects to the reader account. */
+						if ( reader?.email && ! reader?.authenticated ) {
+							link.setAttribute( 'data-redirect', link.getAttribute( 'href' ) );
+						} else {
+							link.removeAttribute( 'data-redirect' );
 						}
+						try {
+							const labels = JSON.parse( link.getAttribute( 'data-labels' ) );
+							link.querySelector( '.newspack-reader__account-link__label' ).textContent =
+								reader?.email ? labels.signedin : labels.signedout;
+						} catch {}
 					} );
+				}
+				if ( reader?.authenticated && ! isInline ) {
+					container.style.display = 'none';
+				}
+			}
+			readerActivation.on( 'reader', handleReaderChanges );
+			handleReaderChanges();
+
+			/**
+			 * Handle account links.
+			 */
+			function handleAccountLinkClick( ev ) {
+				const reader = readerActivation.getReader();
+				/** If logged in, bail and allow page redirection. */
+				if ( reader?.authenticated ) {
+					return;
+				}
+				ev.preventDefault();
+
+				if ( readerActivation.hasAuthLink() ) {
+					authLinkMessage.style.display = 'block';
+				} else {
+					authLinkMessage.style.display = 'none';
+				}
+
+				emailInput.value = reader?.email || '';
+
+				if ( ev.target.getAttribute( 'data-redirect' ) ) {
+					redirectInput.value = ev.target.getAttribute( 'data-redirect' );
+				}
+
+				container.hidden = false;
+				container.style.display = 'flex';
+
+				currentlyOpenOverlayPrompts = document.querySelectorAll(
+					'.newspack-lightbox:not([amp-access-hide])'
+				);
+				hideCurrentlyOpenOverlayPrompts();
+
+				if ( emailInput.value && 'pwd' === actionInput.value ) {
+					passwordInput.focus();
+				} else {
+					emailInput.focus();
+				}
+			}
+
+			/**
+			 * Handle auth form action selection.
+			 */
+			function setFormAction( action ) {
+				actionInput.value = action;
+				container.removeAttribute( 'data-form-status' );
+				messageContentElement.innerHTML = '';
+				container.querySelectorAll( '[data-action]' ).forEach( item => {
+					if ( 'none' !== item.style.display ) {
+						item.prevDisplay = item.style.display;
+					}
+					item.style.display = 'none';
+				} );
+				container.querySelectorAll( '[data-action~="' + action + '"]' ).forEach( item => {
+					item.style.display = item.prevDisplay;
+				} );
+				try {
+					const labels = JSON.parse( container.getAttribute( 'data-labels' ) );
+					const label = 'register' === action ? labels.register : labels.signin;
+					container.querySelector( 'h2' ).textContent = label;
+				} catch {}
+				if ( action === 'pwd' && emailInput.value ) {
+					passwordInput.focus();
+				} else {
+					emailInput.focus();
+				}
+			}
+			setFormAction( actionInput.value );
+			container.querySelectorAll( '[data-set-action]' ).forEach( item => {
+				item.addEventListener( 'click', function ( ev ) {
+					ev.preventDefault();
+					setFormAction( ev.target.getAttribute( 'data-set-action' ) );
+				} );
+			} );
+
+			form.startLoginFlow = () => {
+				container.removeAttribute( 'data-form-status' );
+				submitButtons.forEach( button => {
+					button.disabled = true;
+				} );
+				messageContentElement.innerHTML = '';
+				form.style.opacity = 0.5;
+			};
+
+			form.endLoginFlow = ( message, status, data, redirect ) => {
+				if ( message ) {
+					const messageNode = document.createElement( 'p' );
+					messageNode.textContent = message;
+					messageContentElement.appendChild( messageNode );
+				}
+				if ( status === 200 && data ) {
+					const authenticated = !! data?.authenticated;
+					readerActivation.setReaderEmail( data.email );
+					readerActivation.setAuthenticated( authenticated );
+					if ( authenticated ) {
+						if ( redirect ) {
+							window.location = redirect;
+						}
+					} else {
+						form.replaceWith( messageContentElement.parentNode );
+					}
+				}
+				form.style.opacity = 1;
+				submitButtons.forEach( button => {
+					button.disabled = false;
 				} );
 			};
 
-			googleLoginElement.addEventListener( 'click', () => {
-				if ( googleLoginForm?.startLoginFlow ) {
-					googleLoginForm.startLoginFlow();
+			/**
+			 * Handle auth form submission.
+			 */
+			form.addEventListener( 'submit', function ( ev ) {
+				ev.preventDefault();
+				const body = new FormData( ev.target );
+				if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
+					return;
 				}
+				readerActivation.setReaderEmail( body.get( 'email' ) );
+				form.startLoginFlow();
+				fetch( form.getAttribute( 'action' ) || window.location.pathname, {
+					method: 'POST',
+					headers: {
+						Accept: 'application/json',
+					},
+					body,
+				} )
+					.then( res => {
+						container.setAttribute( 'data-form-status', res.status );
+						res
+							.json()
+							.then( ( { message, data } ) => {
+								form.endLoginFlow( message, res.status, data, body.get( 'redirect' ) );
+							} )
+							.catch( () => {
+								form.endLoginFlow();
+							} );
+					} )
+					.catch( () => {
+						form.endLoginFlow();
+					} );
+			} );
 
-				const metadata = googleLoginForm
-					? convertFormDataToObject( new FormData( googleLoginForm ), [ 'lists[]' ] )
-					: {};
-				metadata.current_page_url = window.location.href;
-				const authWindow = window.open(
-					'about:blank',
-					'newspack_google_login',
-					'width=500,height=600'
-				);
-				fetch( '/wp-json/newspack/v1/login/google' )
-					.then( res => res.json().then( data => Promise.resolve( { data, status: res.status } ) ) )
-					.then( ( { data, status } ) => {
-						if ( status !== 200 ) {
+			/**
+			 * Third party auth.
+			 */
+			const loginsElements = document.querySelectorAll( '.newspack-reader__logins' );
+			[ ...loginsElements ].forEach( element => {
+				element.classList.remove( 'newspack-reader__logins--disabled' );
+			} );
+			const googleLoginElements = document.querySelectorAll( '.newspack-reader__logins__google' );
+			googleLoginElements.forEach( googleLoginElement => {
+				const googleLoginForm = googleLoginElement.closest( 'form' );
+
+				const checkLoginStatus = metadata => {
+					fetch(
+						`/wp-json/newspack/v1/login/google/register?metadata=${ JSON.stringify( metadata ) }`
+					).then( res => {
+						res.json().then( ( { message, data } ) => {
+							if ( googleLoginForm.endLoginFlow ) {
+								googleLoginForm.endLoginFlow( message, res.status, data );
+							}
+						} );
+					} );
+				};
+
+				googleLoginElement.addEventListener( 'click', () => {
+					if ( googleLoginForm?.startLoginFlow ) {
+						googleLoginForm.startLoginFlow();
+					}
+
+					const metadata = googleLoginForm
+						? convertFormDataToObject( new FormData( googleLoginForm ), [ 'lists[]' ] )
+						: {};
+					metadata.current_page_url = window.location.href;
+					const authWindow = window.open(
+						'about:blank',
+						'newspack_google_login',
+						'width=500,height=600'
+					);
+					fetch( '/wp-json/newspack/v1/login/google' )
+						.then( res =>
+							res.json().then( data => Promise.resolve( { data, status: res.status } ) )
+						)
+						.then( ( { data, status } ) => {
+							if ( status !== 200 ) {
+								if ( authWindow ) {
+									authWindow.close();
+								}
+								if ( googleLoginForm?.endLoginFlow ) {
+									googleLoginForm.endLoginFlow( data.message, status );
+								}
+							} else if ( authWindow ) {
+								authWindow.location = data;
+								const interval = setInterval( () => {
+									if ( authWindow.closed ) {
+										checkLoginStatus( metadata );
+										clearInterval( interval );
+									}
+								}, 500 );
+							} else if ( googleLoginForm?.endLoginFlow ) {
+								googleLoginForm.endLoginFlow();
+							}
+						} )
+						.catch( error => {
+							if ( googleLoginForm?.endLoginFlow ) {
+								googleLoginForm.endLoginFlow( error.message );
+							}
 							if ( authWindow ) {
 								authWindow.close();
 							}
-							if ( googleLoginForm?.endLoginFlow ) {
-								googleLoginForm.endLoginFlow( data.message, status );
-							}
-						} else if ( authWindow ) {
-							authWindow.location = data;
-							const interval = setInterval( () => {
-								if ( authWindow.closed ) {
-									checkLoginStatus( metadata );
-									clearInterval( interval );
-								}
-							}, 500 );
-						} else if ( googleLoginForm?.endLoginFlow ) {
-							googleLoginForm.endLoginFlow();
-						}
-					} )
-					.catch( error => {
-						if ( googleLoginForm?.endLoginFlow ) {
-							googleLoginForm.endLoginFlow( error.message );
-						}
-						if ( authWindow ) {
-							authWindow.close();
-						}
-					} );
+						} );
+				} );
 			} );
 		} );
 	} );

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -64,6 +64,14 @@
 			display: flex !important;
 		}
 
+		&__inline {
+			display: block;
+			background: none;
+			position: relative;
+			width: auto;
+			z-index: auto;
+		}
+
 		&[data-form-status='200'] {
 			.newspack-reader__auth-form {
 				&__response {
@@ -136,6 +144,11 @@
 			position: relative;
 			max-height: 100vh;
 			overflow-y: auto;
+
+			.newspack-reader__auth-form__inline & {
+				margin: auto;
+				max-width: 780px;
+			}
 		}
 
 		&__header {

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -363,3 +363,10 @@ li.menu-item .newspack-reader__account-link {
 		color: #fff;
 	}
 }
+
+/**
+ * Hide WooCommerce page title on My Account pages.
+ */
+.woocommerce-account .entry-header .entry-title {
+	display: none;
+}

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -184,6 +184,10 @@
 			[type='submit'] {
 				background-color: var( --newspack-primary-color );
 			}
+
+			.newspack-reader__auth-form__inline & {
+				padding: 0;
+			}
 		}
 
 		&__actions {

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -560,7 +560,7 @@ final class Reader_Activation {
 		// phpcs:enable
 
 		if ( $is_inline ) {
-			$classnames[] = 'newspack-reader__auth-form__inline';
+			$classnames[] = $class( 'inline' );
 		}
 
 		$newsletters_label = self::get_setting( 'newsletters_label' );

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -56,8 +56,8 @@ final class Reader_Activation {
 			\add_action( 'resetpass_form', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'password_reset', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'auth_cookie_expiration', [ __CLASS__, 'auth_cookie_expiration' ], 10, 3 );
-			\add_action( 'init', [ __CLASS__, 'setup_nav_menu' ] );
-			\add_action( 'wp_footer', [ __CLASS__, 'render_auth_form' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'setup_nav_menu' ] );
+			\add_action( 'wc_get_template', [ __CLASS__, 'replace_woocommerce_auth_form' ], 10, 2 );
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
 		}
@@ -386,6 +386,11 @@ final class Reader_Activation {
 	 * Setup nav menu hooks.
 	 */
 	public static function setup_nav_menu() {
+		$account_page = \wc_get_page_id( 'myaccount' );
+		if ( get_the_ID() === $account_page ) {
+			return;
+		}
+
 		if ( ! self::get_setting( 'enabled_account_link' ) ) {
 			return;
 		}
@@ -433,6 +438,9 @@ final class Reader_Activation {
 				<?php
 			}
 		);
+
+		/** Render auth form */
+		\add_action( 'wp_footer', [ __CLASS__, 'render_auth_form' ] );
 	}
 
 	/**
@@ -529,10 +537,14 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Renders reader authentication form
+	 * Renders reader authentication form.
+	 *
+	 * @param boolean $is_inline If true, render the form inline, otherwise render as a modal.
 	 */
-	public static function render_auth_form() {
-		if ( \is_user_logged_in() ) {
+	public static function render_auth_form( $is_inline = false ) {
+		// No need to render auth modal on My Account pages or when logged in.
+		$account_page = \wc_get_page_id( 'myaccount' );
+		if ( \is_user_logged_in() || ( ! $is_inline && get_the_ID() === $account_page ) ) {
 			return;
 		}
 
@@ -555,6 +567,10 @@ final class Reader_Activation {
 		}
 		// phpcs:enable
 
+		if ( $is_inline ) {
+			$classnames[] = 'newspack-reader__auth-form__inline';
+		}
+
 		$newsletters_label = self::get_setting( 'newsletters_label' );
 		if ( method_exists( 'Newspack_Newsletters_Subscription', 'get_lists_config' ) ) {
 			$lists_config = \Newspack_Newsletters_Subscription::get_lists_config();
@@ -564,14 +580,17 @@ final class Reader_Activation {
 		}
 		$terms_text = self::get_setting( 'terms_text' );
 		$terms_url  = self::get_setting( 'terms_url' );
+		$redirect   = $is_inline ? home_url( '/my-account/edit-account/' ) : '';
 		?>
 		<div id="newspack-reader-auth" class="<?php echo \esc_attr( implode( ' ', $classnames ) ); ?>" data-labels="<?php echo \esc_attr( htmlspecialchars( \wp_json_encode( $labels ), ENT_QUOTES, 'UTF-8' ) ); ?>">
 			<div class="<?php echo \esc_attr( $class( 'wrapper' ) ); ?>">
+				<?php if ( ! $is_inline ) : ?>
 				<button class="<?php echo \esc_attr( $class( 'close' ) ); ?>" data-close aria-label="<?php \esc_attr_e( 'Close Authentication Form', 'newspack' ); ?>">
 					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 						<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
 					</svg>
 				</button>
+				<?php endif; ?>
 				<div class="<?php echo \esc_attr( $class( 'content' ) ); ?>">
 					<form method="post" target="_top">
 						<input type="hidden" name="<?php echo \esc_attr( self::AUTH_FORM_ACTION ); ?>" value="1" />
@@ -579,7 +598,7 @@ final class Reader_Activation {
 						<div class="<?php echo \esc_attr( $class( 'header' ) ); ?>">
 							<h2><?php _e( 'Sign In', 'newspack' ); ?></h2>
 							<a href="#" data-action="pwd link" data-set-action="register"><?php \esc_html_e( "I don't have an account", 'newspack' ); ?></a>
-							<a href="#" data-action="register" data-set-action="link"><?php \esc_html_e( 'I already have an account', 'newspack' ); ?></a>
+							<a href="#" data-action="register" data-set-action="pwd"><?php \esc_html_e( 'I already have an account', 'newspack' ); ?></a>
 						</div>
 						<p data-has-auth-link>
 							<?php _e( "We've recently sent you an authentication link. Please, check your inbox!", 'newspack' ); ?>
@@ -587,7 +606,7 @@ final class Reader_Activation {
 						<p data-action="pwd">
 							<?php _e( 'Sign in below to verify your identity.', 'newspack' ); ?>
 						</p>
-						<input type="hidden" name="redirect" value="" />
+						<input type="hidden" name="redirect" value="<?php echo \esc_attr( $redirect ); ?>" />
 						<?php if ( isset( $lists ) && ! empty( $lists ) ) : ?>
 							<div data-action="register">
 								<?php if ( 1 < count( $lists ) ) : ?>
@@ -812,6 +831,24 @@ final class Reader_Activation {
 			</button>
 		</div>
 		<?php
+	}
+
+	/**
+	 * If rendering the WooCommerce login form template, trick it into rendering nothing
+	 * and replace it with our own login form.
+	 *
+	 * @param string $template Full template path.
+	 * @param string $template_name Template name.
+	 *
+	 * @return string Filtered template path.
+	 */
+	public static function replace_woocommerce_auth_form( $template, $template_name ) {
+		if ( 'myaccount/form-login.php' === $template_name ) {
+			$template = dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-activation/login-form.php';
+			self::render_auth_form( true );
+		}
+
+		return $template;
 	}
 
 	/**

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -580,7 +580,7 @@ final class Reader_Activation {
 		}
 		$terms_text = self::get_setting( 'terms_text' );
 		$terms_url  = self::get_setting( 'terms_url' );
-		$redirect   = $is_inline ? home_url( '/my-account/edit-account/' ) : '';
+		$redirect   = $is_inline ? \wc_get_account_endpoint_url( 'dashboard' ) : '';
 		?>
 		<div id="newspack-reader-auth" class="<?php echo \esc_attr( implode( ' ', $classnames ) ); ?>" data-labels="<?php echo \esc_attr( htmlspecialchars( \wp_json_encode( $labels ), ENT_QUOTES, 'UTF-8' ) ); ?>">
 			<div class="<?php echo \esc_attr( $class( 'wrapper' ) ); ?>">

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -845,7 +845,6 @@ final class Reader_Activation {
 	public static function replace_woocommerce_auth_form( $template, $template_name ) {
 		if ( 'myaccount/form-login.php' === $template_name ) {
 			$template = dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-activation/login-form.php';
-			self::render_auth_form( true );
 		}
 
 		return $template;

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -904,7 +904,7 @@ final class Reader_Activation {
 				if ( true !== $sent ) {
 					return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( 'Invalid account.', 'newspack' ) ) );
 				}
-				return self::send_auth_form_response( $payload, __( "We've sent you an authentication link, please check your inbox.", 'newspack' ), $redirect );
+				return self::send_auth_form_response( $payload, __( 'An account was already registered with this email. Please check your inbox for an authentication link.', 'newspack' ), $redirect );
 			case 'register':
 				$metadata = [];
 				if ( ! empty( $lists ) ) {
@@ -912,7 +912,7 @@ final class Reader_Activation {
 				}
 				$user_id = self::register_reader( $email, '', true, $metadata );
 				if ( false === $user_id ) {
-					return self::send_auth_form_response( $payload, __( "We've sent you an authentication link, please check your inbox.", 'newspack' ), $redirect );
+					return self::send_auth_form_response( $payload, __( 'An account was already registered with this email. Please check your inbox for an authentication link.', 'newspack' ), $redirect );
 				}
 				if ( \is_wp_error( $user_id ) ) {
 					return self::send_auth_form_response(

--- a/includes/templates/reader-activation/login-form.php
+++ b/includes/templates/reader-activation/login-form.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Reader Activation login form.
+ * This is an empty file in order to trick WooCommerce's My Account login template
+ * into rendering nothing so that we can replace it with our own login form.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;

--- a/includes/templates/reader-activation/login-form.php
+++ b/includes/templates/reader-activation/login-form.php
@@ -8,3 +8,5 @@
  */
 
 namespace Newspack;
+
+Reader_Activation::render_auth_form( true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Replaces the native WooCommerce login form with our own, utilizing the same markup as we use for the login modal (but with some additional styles to make it render inline).

To do so, ~we rely a bit on a hack to hijack the rendering of the WooCommerce login form template; when this template is about to be rendered, we replace with an empty template file and instead call our `render_auth_form` method to output the form markup. There may be a more elegant way to do this, but I couldn't find one in the short term (cc @claudiulodro if you have any suggestions).~ @miguelpeixe suggested a bit of a less-hacky way to do this by simply calling the `render_auth_form` method in the template itself.

Closes #1850.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. In a new session, while not logged in, visit the My Account page to log in.
3. Confirm that you see our Reader Activation login form here instead of the usual native WC login form.
4. Confirm that all functionality works here as expected, and that once you log in successfully you're redirected to the My Account dashboard in the logged-in state.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->