### PR TITLE
fix(ga): cookie parsing

### DIFF
--- a/includes/oauth/class-google-services-connection.php
+++ b/includes/oauth/class-google-services-connection.php
@@ -98,8 +98,8 @@ class Google_Services_Connection {
 				if ( isset( $event_spec['cid'] ) ) {
 					$analytics_ping_params['cid'] = $event_spec['cid'];
 				} elseif ( isset( $_COOKIE['_ga'] ) ) {
-					list($version, $domain_depth, $cid1, $cid2) = explode( '.', $_COOKIE['_ga'], 4 ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-					$analytics_ping_params['cid']               = $cid1 . '.' . $cid2;
+					list($version, $domain_depth, $cid) = explode( '.', $_COOKIE['_ga'], 3 ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					$analytics_ping_params['cid']       = $cid;
 				} else {
 					$analytics_ping_params['cid'] = '555'; // Anonymous client.
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tiny bug w/ cookie parsing. The `_ga` cookie might have different values than previously expected.

### How to test the changes in this Pull Request:

1. Register on a site with Reader Activation & Site Kit w/ GA configured
2. manually set `_ga` cookie to value of `GA1.2.amp-12345`
3. On `master`, observe a `PHP Notice:  Undefined offset: 3` notice logged
4. Switch to this branch, observe no notice logged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->