### PR TITLE
ActiveCampaigns – subscription metadata

### DIFF
--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl, ExternalLink, ToggleControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -109,13 +108,6 @@ const StripeSetup = () => {
 		errors = [],
 	} = Wizard.useWizardData( 'reader-revenue' );
 
-	const resetWebhooks = () => {
-		apiFetch( {
-			path: '/newspack/v1/stripe/reset-webhooks',
-		} ).then( () => {
-			window.location.reload();
-		} );
-	};
 	const displayStripeSettingsOnly = platform_data?.platform === STRIPE;
 
 	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
@@ -138,20 +130,7 @@ const StripeSetup = () => {
 		<>
 			{ errors.length > 0 &&
 				errors.map( ( error, index ) => (
-					<Notice
-						isError
-						key={ index }
-						noticeText={
-							<span>
-								{ error.message }{ ' ' }
-								{ error.code === 'newspack_plugin_stripe_webhooks' && (
-									<Button isLink onClick={ resetWebhooks }>
-										{ __( 'Reset webhooks', 'newspack' ) }
-									</Button>
-								) }
-							</span>
-						}
-					/>
+					<Notice isError key={ index } noticeText={ <span>{ error.message }</span> } />
 				) ) }
 			{ is_ssl === false && (
 				<Notice

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -29,6 +29,7 @@ class Newspack_Newsletters {
 		'payment_page_utm'     => 'NP_Payment UTM: ',
 		'newsletter_selection' => 'NP_Newsletter Selection',
 		'membership_status'    => 'NP_Membership Status',
+		'sub_start_date'       => 'NP_Current Subscription Start Date',
 		'billing_cycle'        => 'NP_Billing Cycle',
 		'recurring_payment'    => 'NP_Recurring Payment',
 		'last_payment_date'    => 'NP_Last Payment Date',

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -30,6 +30,7 @@ class Newspack_Newsletters {
 		'newsletter_selection' => 'NP_Newsletter Selection',
 		'membership_status'    => 'NP_Membership Status',
 		'sub_start_date'       => 'NP_Current Subscription Start Date',
+		'sub_end_date'         => 'NP_Current Subscription End Date',
 		'billing_cycle'        => 'NP_Billing Cycle',
 		'recurring_payment'    => 'NP_Recurring Payment',
 		'last_payment_date'    => 'NP_Last Payment Date',

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -358,7 +358,7 @@ class Stripe_Connection {
 		$metadata[ Newspack_Newsletters::$metadata_keys['next_payment_date'] ] = $next_payment_date;
 		$metadata[ Newspack_Newsletters::$metadata_keys['sub_start_date'] ]    = $payment_date;
 		// In case this was previously set after a previous cancelled subscription, clear it.
-		$metadata[ Newspack_Newsletters::$metadata_keys['sub_end_date'] ] = '-';
+		$metadata[ Newspack_Newsletters::$metadata_keys['sub_end_date'] ] = '';
 		return $metadata;
 	}
 

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -157,7 +157,7 @@ class Stripe_Connection {
 	 * because it has to stay in sync with WP.
 	 */
 	private static function get_billing_portal_configuration_id() {
-		$config_meta_key = 'newspack_config_v1';
+		$config_meta_key = 'newspack_config_v2';
 		$stripe          = self::get_stripe_client();
 		try {
 			$all_configs = $stripe->billingPortal->configurations->all( [ 'active' => true ] );
@@ -192,9 +192,6 @@ class Stripe_Connection {
 								'enabled'             => true,
 								'mode'                => 'at_period_end',
 								'proration_behavior'  => 'none',
-							],
-							'subscription_pause'    => [
-								'enabled' => true,
 							],
 						],
 						'business_profile' => [ 'headline' => '' ],

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -386,11 +386,12 @@ class Stripe_Connection {
 				$stripe_data                        = self::get_stripe_data();
 				$has_opted_in_to_newsletters        = isset( $customer['metadata']['newsletterOptIn'] ) && 'true' === $customer['metadata']['newsletterOptIn'];
 				if ( $has_opted_in_to_newsletters || Reader_Activation::is_enabled() ) {
-					$contact = [
+					$payment_date = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payment['created'] );
+					$contact      = [
 						'email'    => $customer['email'],
 						'name'     => $customer['name'],
 						'metadata' => [
-							Newspack_Newsletters::$metadata_keys['last_payment_date']   => gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payment['created'] ),
+							Newspack_Newsletters::$metadata_keys['last_payment_date']   => $payment_date,
 							Newspack_Newsletters::$metadata_keys['last_payment_amount'] => $amount_normalised,
 						],
 					];
@@ -410,6 +411,7 @@ class Stripe_Connection {
 						}
 						$next_payment_date = date_format( date_add( date_create( 'now' ), date_interval_create_from_date_string( '1 ' . $frequency ) ), Newspack_Newsletters::METADATA_DATE_FORMAT );
 						$contact['metadata'][ Newspack_Newsletters::$metadata_keys['next_payment_date'] ] = $next_payment_date;
+						$contact['metadata'][ Newspack_Newsletters::$metadata_keys['sub_start_date'] ]    = $payment_date;
 					}
 
 					if ( ! empty( $client_id ) ) {

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -451,7 +451,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			$nrh_config            = get_option( NEWSPACK_NRH_CONFIG, [] );
 			$args['platform_data'] = wp_parse_args( $nrh_config, $args['platform_data'] );
 		} elseif ( Donations::is_platform_stripe() ) {
-			$are_webhooks_valid = Stripe_Connection::validate_webhooks();
+			$are_webhooks_valid = Stripe_Connection::validate_or_create_webhooks();
 			if ( is_wp_error( $are_webhooks_valid ) ) {
 				$args['errors'][] = [
 					'code'    => $are_webhooks_valid->get_error_code(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A few related updates to how Stripe & ESP metadata integration work:

- removes explicit Stripe webhook re-creation, with implicit (behind the scenes) webhook creation and reset
- adds handling of subscription update and cancellation events in the Stripe webhook
- adds subscription-related metadata to ESP integration
- removes ability to pause a subscription via the Stripe billing portal

### How to test the changes in this Pull Request:

1. Start with a site with Stripe, ActiveCampaign as ESP, and Reader Activation configured
2. Make a new recurring donation as a reader
3. Observe that the following fields are added in AC:
    - `NP_Current Subscription Start Date`
    - `NP_Current Subscription End Date` (`-` initially or if subscription cancelled)
    - `NP_Membership Status` – `Donor` for one-time donations, `<Montly|Yearly> Donor` for recurring, with `Ex-` suffix if subscription cancelled
4. Visit My Account -> Billing page, and proceed to Stripe customer portal
5. Observe the subscription can be cancelled, but not paused
6. Cancel the subscription (it will be _scheduled_ to be cancelled), observe the `NP_Current Subscription End Date` field updated accordingly
7. In Stripe dashboard, cancel the subscription immediately
8. Observe the `NP_Membership Status` field updated accordingly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->