### PR TITLE
fix: tweak arguments for magic link client hash

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -171,22 +171,37 @@ final class Magic_Link {
 
 		$hash_args = [];
 
-		// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
-		if ( isset( $_SERVER['REMOTE_ADDR'] ) && ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
-			// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
-			$hash_args['ip'] = \wp_unslash( $_SERVER['REMOTE_ADDR'] );
+		/**
+		 * Filters whether to use IP as hash argument.
+		 *
+		 * @param bool $use_ip
+		 */
+		if ( true === \apply_filters( 'newspack_magic_link_hash_use_ip', true ) ) {
+			// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+			if ( isset( $_SERVER['REMOTE_ADDR'] ) && ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+				$hash_args['ip'] = \wp_unslash( $_SERVER['REMOTE_ADDR'] );
+			}
 		}
-		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && ! empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-			$hash_args['user_agent'] = \wp_unslash( $_SERVER['HTTP_USER_AGENT'] );
+
+		/**
+		 * Filters whether to use user agent as hash argument.
+		 *
+		 * @param bool $use_user_agent
+		 */
+		if ( true === \apply_filters( 'newspack_magic_link_hash_use_user_agent', false ) ) {
+			if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && ! empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+				$hash_args['user_agent'] = \wp_unslash( $_SERVER['HTTP_USER_AGENT'] );
+			}
 		}
 
 		/**
 		 * Filters whether to use a locally stored secret as a client hash argument.
 		 *
-		 * @param bool $use_secret Whether to use a locally stored secret as a client hash argument.
+		 * @param bool $use_secret
 		 */
-		if ( true === \apply_filters( 'newspack_magic_link_use_secret', true ) ) {
+		if ( true === \apply_filters( 'newspack_magic_link_hash_use_secret', false ) ) {
 			$hash_args['secret'] = self::get_client_secret( $reset_secret );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The first implementation of magic links (more details in #1668) introduces a security layer that restricts the usage of self-served magic links to the person that created them.

This security layer can be inconvenient in some situations, for example, a reader accessed an article through Facebook's mobile in-app browser and requested to sign in through a link. Through their email app, the link will open on the default browser and fail to authenticate due to `user_agent` and `secret` (cookie) hash arguments.

This PR adds more filters to determine the usage of the default arguments and defaults `user_agent` and `secret` to false, leaving only the IP as a standard hash argument.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
### How to test the changes in this Pull Request:

1. Check out this branch and request a magic link to an existing reader account
2. Copy the received link and paste into a different browser/session
3. Confirm you're logged in
4. Log out and request another link
5. This time use a different network (mobile data) and confirm the link is not valid

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->