### PR TITLE
fix(oauth): csrf token lifespan

### DIFF
--- a/includes/oauth/class-oauth.php
+++ b/includes/oauth/class-oauth.php
@@ -48,7 +48,7 @@ class OAuth {
 	public static function generate_csrf_token( $namespace ) {
 		$csrf_token     = sha1( openssl_random_pseudo_bytes( 1024 ) );
 		$transient_name = self::CSRF_TOKEN_TRANSIENT_NAME_BASE . $namespace . self::get_unique_id();
-		set_transient( $transient_name, $csrf_token, 60 );
+		set_transient( $transient_name, $csrf_token, 5 * MINUTE_IN_SECONDS );
 		return $csrf_token;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Although we want this token to be short-lived, 60 seconds may not be enough if the user is not yet authenticated to the service and needs to go through 2FA.

This PR increases the expiration of the transient to 5 minutes.

### How to test the changes in this Pull Request:

1. With reader activation on, click sign in using Google
2. Before resolving the Google popup, wait 3 minutes
3. Resolve the prompt and confirm you are authenticated

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->