### PR TITLE
fix(google-auth): catch and display errors

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -328,13 +328,26 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			const checkLoginStatus = metadata => {
 				fetch(
 					`/wp-json/newspack/v1/login/google/register?metadata=${ JSON.stringify( metadata ) }`
-				).then( res => {
-					res.json().then( ( { message, data } ) => {
-						if ( googleLoginForm.endLoginFlow ) {
-							googleLoginForm.endLoginFlow( message, res.status, data );
+				)
+					.then( res => {
+						res
+							.json()
+							.then( ( { message, data } ) => {
+								if ( googleLoginForm?.endLoginFlow ) {
+									googleLoginForm.endLoginFlow( message, res.status, data );
+								}
+							} )
+							.catch( error => {
+								if ( googleLoginForm?.endLoginFlow ) {
+									googleLoginForm.endLoginFlow( error?.message );
+								}
+							} );
+					} )
+					.catch( error => {
+						if ( googleLoginForm?.endLoginFlow ) {
+							googleLoginForm.endLoginFlow( error?.message );
 						}
 					} );
-				} );
 			};
 
 			googleLoginElement.addEventListener( 'click', () => {
@@ -375,7 +388,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					} )
 					.catch( error => {
 						if ( googleLoginForm?.endLoginFlow ) {
-							googleLoginForm.endLoginFlow( error.message );
+							googleLoginForm.endLoginFlow( error?.message );
 						}
 						if ( authWindow ) {
 							authWindow.close();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make sure to catch and display OAuth potential errors for different steps of the flow.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Signing in with Google should continue to work as expected
2. Change line 330 of `assets/reader-activation/auth.js` to a 404 URL and recompile
3. Try to sign in again and confirm JS doesn't break and you see an error message

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->