### PR TITLE
fix: verify reader on google authentication

### DIFF
--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -320,7 +320,7 @@ final class Reader_Activation {
 	 * @return bool Whether the email address was verified.
 	 */
 	public static function set_reader_verified( $user_or_user_id ) {
-		if ( $user_or_user_id instanceof WP_User ) {
+		if ( $user_or_user_id instanceof \WP_User ) {
 			$user = $user_or_user_id;
 		} elseif ( absint( $user_or_user_id ) ) {
 			$user = get_user_by( 'id', $user_or_user_id );

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -315,12 +315,18 @@ final class Reader_Activation {
 	/**
 	 * Verify email address of a reader given the user.
 	 *
-	 * @param \WP_User $user User object.
+	 * @param \WP_User|int $user_or_user_id User object.
 	 *
 	 * @return bool Whether the email address was verified.
 	 */
-	public static function set_reader_verified( $user ) {
-		if ( ! $user ) {
+	public static function set_reader_verified( $user_or_user_id ) {
+		if ( $user_or_user_id instanceof WP_User ) {
+			$user = $user_or_user_id;
+		} elseif ( absint( $user_or_user_id ) ) {
+			$user = get_user_by( 'id', $user_or_user_id );
+		}
+
+		if ( ! isset( $user ) || ! $user ) {
 			return false;
 		}
 
@@ -329,12 +335,14 @@ final class Reader_Activation {
 			return false;
 		}
 
-		$verified = \get_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
-		if ( $verified ) {
-			return true;
-		}
-
 		\update_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
+
+		/**
+		 * Fires after a reader's email address is verified.
+		 *
+		 * @param \WP_User $user User object.
+		 */
+		do_action( 'newspack_reader_verified', $user );
 
 		return true;
 	}
@@ -1063,9 +1071,15 @@ final class Reader_Activation {
 			}
 		}
 
+		/** Registration methods that don't require account verification. */
+		$verified_registration_methods = [ 'google' ];
+
 		// Note the user's login method for later use.
 		if ( isset( $metadata['registration_method'] ) ) {
 			\update_user_meta( $user_id, self::REGISTRATION_METHOD, $metadata['registration_method'] );
+			if ( in_array( $metadata['registration_method'], $verified_registration_methods, true ) ) {
+				self::set_reader_verified( $user_id );
+			}
 		}
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Creates a new action hook for reader verification and makes a reader verified if using Google authentication.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-newsletters/pull/922
2. With reader activation, register a new reader through Google
3. Visit "Account -> Newsletters" and confirm you can manage the subscriptions without having to verify your email

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->