### PR TITLE
fix: parse CID from _ga cookie if it only contains CID string

### DIFF
--- a/includes/oauth/class-google-services-connection.php
+++ b/includes/oauth/class-google-services-connection.php
@@ -98,8 +98,13 @@ class Google_Services_Connection {
 				if ( isset( $event_spec['cid'] ) ) {
 					$analytics_ping_params['cid'] = $event_spec['cid'];
 				} elseif ( isset( $_COOKIE['_ga'] ) ) {
-					list($version, $domain_depth, $cid) = explode( '.', $_COOKIE['_ga'], 3 ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-					$analytics_ping_params['cid']       = $cid;
+					$cookie_pieces = explode( '.', $_COOKIE['_ga'], 3 ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					if ( 1 === count( $cookie_pieces ) ) {
+						$cid = reset( $cookie_pieces );
+					} else {
+						list( $version, $domain_depth, $cid ) = $cookie_pieces;
+					}
+					$analytics_ping_params['cid'] = $cid;
 				} else {
 					$analytics_ping_params['cid'] = '555'; // Anonymous client.
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1857 fixed cookie parsing if it only contains the version number, domain depth and CID string parts, but I noticed in some sessions the cookie string contains _only_ the CID, which still causes the parsing to fail. This PR handles that situation.

I'm not sure if the cookie value can contain other combinations of strings, so @adekbadek may have some insight into this.

### How to test the changes in this Pull Request:

1. Register on a site with Reader Activation & Site Kit w/ GA configured
2. manually set `_ga` cookie to value of `amp-12345`
3. On `master`, observe a `PHP Notice:  Undefined offset: 1` notice logged
4. Switch to this branch, observe no notice logged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->