### PR TITLE
feat: cookie reader's preferred auth strategy

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -225,6 +225,9 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			 * Handle auth form action selection.
 			 */
 			function setFormAction( action ) {
+				if ( [ 'link', 'pwd' ].includes( action ) ) {
+					readerActivation.setAuthStrategy( action );
+				}
 				actionInput.value = action;
 				container.removeAttribute( 'data-form-status' );
 				messageContentElement.innerHTML = '';
@@ -248,7 +251,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					emailInput.focus();
 				}
 			}
-			setFormAction( actionInput.value );
+			setFormAction( readerActivation.getAuthStrategy() || 'pwd' );
 			container.querySelectorAll( '[data-set-action]' ).forEach( item => {
 				item.addEventListener( 'click', function ( ev ) {
 					ev.preventDefault();

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -160,6 +160,32 @@ export function hasAuthLink() {
 	return !! ( reader?.email && emailLinkSecret );
 }
 
+const authStrategies = [ 'pwd', 'link' ];
+
+/**
+ * Set the reader preferred authentication strategy.
+ *
+ * @param {string} strategy Authentication strategy.
+ *
+ * @return {string} Reader preferred authentication strategy.
+ */
+export function setAuthStrategy( strategy ) {
+	if ( ! authStrategies.includes( strategy ) ) {
+		throw 'Invalid authentication strategy';
+	}
+	setCookie( 'np_auth_strategy', strategy );
+	return strategy;
+}
+
+/**
+ * Get the reader preferred authentication strategy.
+ *
+ * @return {string} Reader preferred authentication strategy.
+ */
+export function getAuthStrategy() {
+	return getCookie( 'np_auth_strategy' );
+}
+
 /**
  * Initialize store data.
  */
@@ -180,6 +206,8 @@ const readerActivation = {
 	setAuthenticated,
 	getReader,
 	hasAuthLink,
+	setAuthStrategy,
+	getAuthStrategy,
 };
 window.newspackReaderActivation = readerActivation;
 

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -517,7 +517,7 @@ final class Reader_Activation {
 		};
 
 		$labels = [
-			'signedin'  => \__( 'Account', 'newspack' ),
+			'signedin'  => \__( 'My Account', 'newspack' ),
 			'signedout' => \__( 'Sign In', 'newspack' ),
 		];
 		$label  = \is_user_logged_in() ? 'signedin' : 'signedout';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements a cookie to store the reader's preferred auth strategy, which is updated by switching the strategy on the "Sign In" modal.

This management should be later enhanced to change the auth strategy once a reader sets a password for the first time.

It also updates the account link label from "Account" to "My Account" for authenticated and pre-authenticated readers.

### How to test the changes in this Pull Request:

1. Check out this branch, click on Sign In
2. Observe the default method is authentication through a password
3. Switch to authenticate through a link
4. Refresh the page and click on Sign In again
5. Observe the strategy is preserved

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->