### PR TITLE
feat: disable woocomerce welcome emails in favor of verification email

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -509,16 +509,6 @@ final class Magic_Link {
 			return false;
 		}
 
-		if ( ! Reader_Activation::is_reader_verified( $user ) ) {
-			Reader_Activation::set_reader_verified( $user );
-
-			if ( function_exists( '\wc_add_notice' ) ) {
-				\wc_add_notice( __( 'Thank you for verifying your account!', 'newspack' ), 'success' );
-			}
-		}
-
-		Reader_Activation::set_current_reader( $user->ID );
-
 		/**
 		 * Fires after a reader has been authenticated via magic link.
 		 *

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -318,6 +318,7 @@ final class Magic_Link {
 	 *   Used to build wp_mail().
 	 *
 	 *   @type string $to      The intended recipient - New user email address.
+	 *   @type string $subject The subject of the email.
 	 *   @type string $message The body of the email.
 	 *   @type string $headers The headers of the email.
 	 * }

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -311,7 +311,7 @@ final class Magic_Link {
 	 *
 	 * @param \WP_User $user        User to generate the magic link for.
 	 * @param string   $redirect_to Which page to redirect the reader after authenticating.
-	 * @param string   $subject The subject of the email.
+	 * @param string   $subject     The subject of the email.
 	 * @param string   $message     Message to show in body of email.
 	 *
 	 * @return array|\WP_Error $email Email arguments or error. {

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -509,6 +509,9 @@ final class Magic_Link {
 			return false;
 		}
 
+		// Authenticate the reader.
+		Reader_Activation::set_current_reader( $user->ID );
+
 		/**
 		 * Fires after a reader has been authenticated via magic link.
 		 *

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -61,6 +61,7 @@ final class Reader_Activation {
 			\add_action( 'wc_get_template', [ __CLASS__, 'replace_woocommerce_auth_form' ], 10, 2 );
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
+			\add_filter( 'woocommerce_email_actions', [ __CLASS__, 'disable_woocommerce_new_user_email' ] );
 		}
 	}
 
@@ -1102,6 +1103,26 @@ final class Reader_Activation {
 	public static function get_client_id() {
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		return isset( $_COOKIE[ NEWSPACK_CLIENT_ID_COOKIE_NAME ] ) ? sanitize_text_field( $_COOKIE[ NEWSPACK_CLIENT_ID_COOKIE_NAME ] ) : false;
+	}
+
+	/**
+	 * Disable the standard WooCommerce "new customer welcome" email.
+	 *
+	 * @param array $emails Types of transactional emails sent by WooCommerce.
+	 *
+	 * @return array Filtered array of transactional email types.
+	 */
+	public static function disable_woocommerce_new_user_email( $emails ) {
+		$emails = array_values(
+			array_filter(
+				$emails,
+				function( $type ) {
+					return 'woocommerce_created_customer' !== $type;
+				}
+			)
+		);
+
+		return $emails;
 	}
 }
 Reader_Activation::init();

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -1083,6 +1083,22 @@ final class Reader_Activation {
 			}
 		}
 
+		// Send a magic link to new, unverified readers to verify their email address.
+		$user = \get_user_by( 'id', $user_id );
+		if ( ! $existing_user && ! self::is_reader_verified( $user ) ) {
+			$redirect_to = function_exists( '\wc_get_account_endpoint_url' ) ? \wc_get_account_endpoint_url( 'dashboard' ) : '';
+			$blogname    = \wp_specialchars_decode( \get_option( 'blogname' ), ENT_QUOTES );
+
+			$subject = __( 'Please verify your account', 'newspack' );
+
+			/* translators: %s: Site title. */
+			$message  = sprintf( __( 'Welcome to %s!', 'newspack' ), $blogname ) . "\r\n\r\n";
+			$message .= __( 'To manage your account, please verify your email address by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
+
+			Magic_Link::send_email( $user, $redirect_to, $subject, $message );
+			Logger::log( 'Sent verification email to new user ' . $email );
+		}
+
 		/**
 		 * Action after registering and authenticating a reader.
 		 *

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -23,9 +23,12 @@ final class Reader_Activation {
 	/**
 	 * Reader user meta keys.
 	 */
-	const READER              = 'np_reader';
-	const EMAIL_VERIFIED      = 'np_reader_email_verified';
-	const REGISTRATION_METHOD = 'np_reader_registration_method';
+	const READER                 = 'np_reader';
+	const EMAIL_VERIFIED         = 'np_reader_email_verified';
+	const REGISTRATION_METHOD    = 'np_reader_registration_method';
+	const EMAIL_VERIFIED_META    = 'np_reader_emails_verified';
+	const EMAIL_VERIFIED_REQUEST = 'np_reader_email_verification_request';
+	const EMAIL_VERIFIED_CONFIRM = 'np_reader_email_verification';
 
 	/**
 	 * Auth form.
@@ -61,7 +64,15 @@ final class Reader_Activation {
 			\add_action( 'wc_get_template', [ __CLASS__, 'replace_woocommerce_auth_form' ], 10, 2 );
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
+
+			/** User email verification for subscription management. */
 			\add_filter( 'woocommerce_email_actions', [ __CLASS__, 'disable_woocommerce_new_user_email' ] );
+			\add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
+			\add_action( 'password_reset', [ __CLASS__, 'set_current_user_email_verified' ] );
+			\add_action( 'newspack_magic_link_authenticated', [ __CLASS__, 'set_current_user_email_verified' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'process_email_verification_request' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'process_email_verification' ] );
+			\add_action( 'newspack_registered_reader', [ __CLASS__, 'send_verification_email_on_registration' ], 10, 4 );
 		}
 	}
 
@@ -337,13 +348,7 @@ final class Reader_Activation {
 		}
 
 		\update_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
-
-		/**
-		 * Fires after a reader's email address is verified.
-		 *
-		 * @param \WP_User $user User object.
-		 */
-		do_action( 'newspack_reader_verified', $user );
+		self::set_user_email_verified( $user );
 
 		return true;
 	}
@@ -1123,6 +1128,247 @@ final class Reader_Activation {
 		);
 
 		return $emails;
+	}
+
+	/**
+	 * Whether the current user has its email verified in order to manage their
+	 * newletters subscriptions.
+	 *
+	 * @param int    $user_id User ID. Default is the current user ID.
+	 * @param string $email   Email address being verified. Default is the current user email.
+	 *
+	 * @return bool
+	 */
+	public static function is_email_verified( $user_id = 0, $email = '' ) {
+		if ( empty( $user_id ) ) {
+			$user_id = get_current_user_id();
+		}
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$user = get_user_by( 'id', $user_id );
+		if ( ! $user ) {
+			return false;
+		}
+
+		if ( empty( $email ) ) {
+			$email = $user->user_email;
+		}
+
+		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
+		if ( ! is_array( $verified_emails ) ) {
+			$verified_emails = [];
+		}
+
+		$verified = in_array( $email, $verified_emails, true );
+
+		/**
+		 * Filters whether the current user has its email verified.
+		 *
+		 * @param bool    $verified Whether the current user has its email verified.
+		 * @param WP_User $user     User object.
+		 * @param string  $email    Email address being verified.
+		 */
+		return (bool) apply_filters( 'newspack_newsletters_is_email_verified', $verified, $user, $email );
+	}
+
+	/**
+	 * Set email as verified for a user.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $email   Email address being verified. Default is the current user's email.
+	 *
+	 * @return bool Wether the email was marked as verified successfully.
+	 */
+	public static function set_email_verified( $user_id, $email = '' ) {
+		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
+		if ( ! is_array( $verified_emails ) ) {
+			$verified_emails = [];
+		}
+		if ( empty( $email ) ) {
+			$email = get_user_by( 'id', $user_id )->user_email;
+		}
+		if ( ! in_array( $email, $verified_emails, true ) ) {
+			$verified_emails[] = $email;
+			return update_user_meta( $user_id, self::EMAIL_VERIFIED_META, $verified_emails );
+		}
+		return false;
+	}
+
+	/**
+	 * Set the user's email as verified.
+	 *
+	 * @param WP_User $user User.
+	 */
+	public static function set_user_email_verified( $user ) {
+		if ( ! $user instanceof WP_User ) {
+			return;
+		}
+		self::set_email_verified( $user->ID, $user->user_email );
+	}
+
+	/**
+	 * Set current user's email as verified.
+	 */
+	public static function set_current_user_email_verified() {
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+		self::set_user_email_verified( wp_get_current_user() );
+	}
+
+	/**
+	 * Get current user email verification transient key.
+	 *
+	 * @param string $email Email address being verified. Default is the current user's email.
+	 */
+	private static function get_email_verification_transient_key( $email = '' ) {
+		$user_id = get_current_user_id();
+		if ( empty( $email ) ) {
+			$email = get_user_by( 'id', $user_id )->user_email;
+		}
+		return sprintf( 'newspack_newsletters_email_verification_%s_%s', $user_id, wp_hash( $email ) );
+	}
+
+	/**
+	 * Process request to verify a user's email.
+	 *
+	 * @param boolean $direct_request If calling this method directly from the server, no need to verify nonce.
+	 *
+	 * A 1-day transient will hold a token to verify the email.
+	 */
+	public static function process_email_verification_request( $direct_request = false ) {
+		if (
+			! $direct_request &&
+			( ! isset( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ), self::EMAIL_VERIFIED_REQUEST ) )
+		) {
+			return;
+		}
+
+		if ( ! is_user_logged_in() ) {
+			wp_die( esc_html( __( 'Invalid request.', 'newspack' ) ) );
+		}
+
+		$user               = wp_get_current_user();
+		$transient_key      = self::get_email_verification_transient_key();
+		$token              = \wp_generate_password( 43, false, false );
+		$verification_nonce = wp_create_nonce( self::EMAIL_VERIFIED_CONFIRM );
+
+		$url = home_url();
+		if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
+			$url = wc_get_account_endpoint_url( '' );
+		}
+		$url = add_query_arg(
+			[
+				self::EMAIL_VERIFIED_CONFIRM => $verification_nonce,
+				'token'                      => $token,
+			],
+			$url
+		);
+
+		set_transient( $transient_key, $token, DAY_IN_SECONDS );
+
+		$blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+		$switched_locale = switch_to_locale( get_user_locale( $user ) );
+
+		/* translators: %s: User display name. */
+		$message  = sprintf( __( 'Welcome, %s! Thank you for registering an account.', 'newspack' ), $user->display_name ) . "\r\n\r\n";
+		$message .= __( 'To manage your account details, please verify your email address by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
+		$message .= $url . "\r\n";
+
+		$email = [
+			'to'      => $user->user_email,
+			/* translators: %s Site title. */
+			'subject' => __( '[%s] Verify your email', 'newspack' ),
+			'message' => $message,
+			'headers' => '',
+		];
+
+		/**
+		 * Filters the email verification email.
+		 *
+		 * @param array    $email          Email arguments. {
+		 *   Used to build wp_mail().
+		 *
+		 *   @type string $to      The intended recipient - New user email address.
+		 *   @type string $subject The subject of the email.
+		 *   @type string $message The body of the email.
+		 *   @type string $headers The headers of the email.
+		 * }
+		 * @param \WP_User $user           User to send the magic link to.
+		 * @param string   $magic_link_url Magic link url.
+		 */
+		$email = \apply_filters( 'newspack_newsletters_email_verification_email', $email, $user, $url );
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+		$sent = \wp_mail(
+			$email['to'],
+			\wp_specialchars_decode( sprintf( $email['subject'], $blogname ) ),
+			$email['message'],
+			$email['headers']
+		);
+
+		if ( $switched_locale ) {
+			\restore_previous_locale();
+		}
+
+		if ( ! $direct_request ) {
+			if ( function_exists( 'wc_add_notice' ) ) {
+				wc_add_notice( __( 'Check your email address for a verification link.', 'newspack' ), 'success' );
+			}
+			wp_safe_redirect( add_query_arg( [ 'verification_sent' => 1 ], remove_query_arg( self::EMAIL_VERIFIED_REQUEST, wp_get_referer() ) ) );
+			exit;
+		}
+	}
+
+	/**
+	 * Process email verification.
+	 */
+	public static function process_email_verification() {
+		if ( ! isset( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ), self::EMAIL_VERIFIED_CONFIRM ) ) {
+			return;
+		}
+		if ( ! is_user_logged_in() ) {
+			wp_die( esc_html( __( 'You\'re not logged in.', 'newspack' ) ) );
+		}
+		$transient_key = self::get_email_verification_transient_key();
+		$token         = get_transient( $transient_key );
+		if ( ! $token ) {
+			wp_die( esc_html( __( 'Invalid request.', 'newspack' ) ) );
+		}
+		if ( ! isset( $_GET['token'] ) || sanitize_text_field( $_GET['token'] ) !== $token ) {
+			wp_die( esc_html( __( 'Invalid request.', 'newspack' ) ) );
+		}
+
+		self::set_email_verified( get_current_user_id() );
+
+		delete_transient( $transient_key );
+
+		if ( function_exists( 'wc_add_notice' ) ) {
+			wc_add_notice( __( 'Your email has been verified.', 'newspack' ), 'success' );
+		}
+		wp_safe_redirect( remove_query_arg( [ self::EMAIL_VERIFIED_CONFIRM, 'token' ] ) );
+		exit;
+	}
+
+	/**
+	 * Upon new reader registration, send a verification email.
+	 *
+	 * @param string         $email         Email address.
+	 * @param bool           $authenticate  Whether to authenticate after registering.
+	 * @param false|int      $user_id       The created user id.
+	 * @param false|\WP_User $existing_user The existing user object.
+	 */
+	public static function send_verification_email_on_registration( $email, $authenticate, $user_id, $existing_user ) {
+		// Only send for new, unverified users.
+		if ( false !== $existing_user || self::is_email_verified( $user_id, $email ) ) {
+			return;
+		}
+
+		self::process_email_verification_request( true );
+		Logger::log( 'New reader account registered. Sending verification email to ' . $email . '.' );
 	}
 }
 Reader_Activation::init();

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -23,12 +23,9 @@ final class Reader_Activation {
 	/**
 	 * Reader user meta keys.
 	 */
-	const READER                 = 'np_reader';
-	const EMAIL_VERIFIED         = 'np_reader_email_verified';
-	const REGISTRATION_METHOD    = 'np_reader_registration_method';
-	const EMAIL_VERIFIED_META    = 'np_reader_emails_verified';
-	const EMAIL_VERIFIED_REQUEST = 'np_reader_email_verification_request';
-	const EMAIL_VERIFIED_CONFIRM = 'np_reader_email_verification';
+	const READER              = 'np_reader';
+	const EMAIL_VERIFIED      = 'np_reader_email_verified';
+	const REGISTRATION_METHOD = 'np_reader_registration_method';
 
 	/**
 	 * Auth form.
@@ -64,15 +61,7 @@ final class Reader_Activation {
 			\add_action( 'wc_get_template', [ __CLASS__, 'replace_woocommerce_auth_form' ], 10, 2 );
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
-
-			/** User email verification for subscription management. */
 			\add_filter( 'woocommerce_email_actions', [ __CLASS__, 'disable_woocommerce_new_user_email' ] );
-			\add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
-			\add_action( 'password_reset', [ __CLASS__, 'set_current_user_email_verified' ] );
-			\add_action( 'newspack_magic_link_authenticated', [ __CLASS__, 'set_current_user_email_verified' ] );
-			\add_action( 'template_redirect', [ __CLASS__, 'process_email_verification_request' ] );
-			\add_action( 'template_redirect', [ __CLASS__, 'process_email_verification' ] );
-			\add_action( 'newspack_registered_reader', [ __CLASS__, 'send_verification_email_on_registration' ], 10, 4 );
 		}
 	}
 
@@ -348,7 +337,13 @@ final class Reader_Activation {
 		}
 
 		\update_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
-		self::set_user_email_verified( $user );
+
+		/**
+		 * Fires after a reader's email address is verified.
+		 *
+		 * @param \WP_User $user User object.
+		 */
+		do_action( 'newspack_reader_verified', $user );
 
 		return true;
 	}
@@ -1128,247 +1123,6 @@ final class Reader_Activation {
 		);
 
 		return $emails;
-	}
-
-	/**
-	 * Whether the current user has its email verified in order to manage their
-	 * newletters subscriptions.
-	 *
-	 * @param int    $user_id User ID. Default is the current user ID.
-	 * @param string $email   Email address being verified. Default is the current user email.
-	 *
-	 * @return bool
-	 */
-	public static function is_email_verified( $user_id = 0, $email = '' ) {
-		if ( empty( $user_id ) ) {
-			$user_id = get_current_user_id();
-		}
-		if ( ! $user_id ) {
-			return false;
-		}
-
-		$user = get_user_by( 'id', $user_id );
-		if ( ! $user ) {
-			return false;
-		}
-
-		if ( empty( $email ) ) {
-			$email = $user->user_email;
-		}
-
-		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
-		if ( ! is_array( $verified_emails ) ) {
-			$verified_emails = [];
-		}
-
-		$verified = in_array( $email, $verified_emails, true );
-
-		/**
-		 * Filters whether the current user has its email verified.
-		 *
-		 * @param bool    $verified Whether the current user has its email verified.
-		 * @param WP_User $user     User object.
-		 * @param string  $email    Email address being verified.
-		 */
-		return (bool) apply_filters( 'newspack_newsletters_is_email_verified', $verified, $user, $email );
-	}
-
-	/**
-	 * Set email as verified for a user.
-	 *
-	 * @param int    $user_id User ID.
-	 * @param string $email   Email address being verified. Default is the current user's email.
-	 *
-	 * @return bool Wether the email was marked as verified successfully.
-	 */
-	public static function set_email_verified( $user_id, $email = '' ) {
-		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
-		if ( ! is_array( $verified_emails ) ) {
-			$verified_emails = [];
-		}
-		if ( empty( $email ) ) {
-			$email = get_user_by( 'id', $user_id )->user_email;
-		}
-		if ( ! in_array( $email, $verified_emails, true ) ) {
-			$verified_emails[] = $email;
-			return update_user_meta( $user_id, self::EMAIL_VERIFIED_META, $verified_emails );
-		}
-		return false;
-	}
-
-	/**
-	 * Set the user's email as verified.
-	 *
-	 * @param WP_User $user User.
-	 */
-	public static function set_user_email_verified( $user ) {
-		if ( ! $user instanceof WP_User ) {
-			return;
-		}
-		self::set_email_verified( $user->ID, $user->user_email );
-	}
-
-	/**
-	 * Set current user's email as verified.
-	 */
-	public static function set_current_user_email_verified() {
-		if ( ! is_user_logged_in() ) {
-			return;
-		}
-		self::set_user_email_verified( wp_get_current_user() );
-	}
-
-	/**
-	 * Get current user email verification transient key.
-	 *
-	 * @param string $email Email address being verified. Default is the current user's email.
-	 */
-	private static function get_email_verification_transient_key( $email = '' ) {
-		$user_id = get_current_user_id();
-		if ( empty( $email ) ) {
-			$email = get_user_by( 'id', $user_id )->user_email;
-		}
-		return sprintf( 'newspack_newsletters_email_verification_%s_%s', $user_id, wp_hash( $email ) );
-	}
-
-	/**
-	 * Process request to verify a user's email.
-	 *
-	 * @param boolean $direct_request If calling this method directly from the server, no need to verify nonce.
-	 *
-	 * A 1-day transient will hold a token to verify the email.
-	 */
-	public static function process_email_verification_request( $direct_request = false ) {
-		if (
-			! $direct_request &&
-			( ! isset( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ), self::EMAIL_VERIFIED_REQUEST ) )
-		) {
-			return;
-		}
-
-		if ( ! is_user_logged_in() ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack' ) ) );
-		}
-
-		$user               = wp_get_current_user();
-		$transient_key      = self::get_email_verification_transient_key();
-		$token              = \wp_generate_password( 43, false, false );
-		$verification_nonce = wp_create_nonce( self::EMAIL_VERIFIED_CONFIRM );
-
-		$url = home_url();
-		if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
-			$url = wc_get_account_endpoint_url( '' );
-		}
-		$url = add_query_arg(
-			[
-				self::EMAIL_VERIFIED_CONFIRM => $verification_nonce,
-				'token'                      => $token,
-			],
-			$url
-		);
-
-		set_transient( $transient_key, $token, DAY_IN_SECONDS );
-
-		$blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-
-		$switched_locale = switch_to_locale( get_user_locale( $user ) );
-
-		/* translators: %s: User display name. */
-		$message  = sprintf( __( 'Welcome, %s! Thank you for registering an account.', 'newspack' ), $user->display_name ) . "\r\n\r\n";
-		$message .= __( 'To manage your account details, please verify your email address by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
-		$message .= $url . "\r\n";
-
-		$email = [
-			'to'      => $user->user_email,
-			/* translators: %s Site title. */
-			'subject' => __( '[%s] Verify your email', 'newspack' ),
-			'message' => $message,
-			'headers' => '',
-		];
-
-		/**
-		 * Filters the email verification email.
-		 *
-		 * @param array    $email          Email arguments. {
-		 *   Used to build wp_mail().
-		 *
-		 *   @type string $to      The intended recipient - New user email address.
-		 *   @type string $subject The subject of the email.
-		 *   @type string $message The body of the email.
-		 *   @type string $headers The headers of the email.
-		 * }
-		 * @param \WP_User $user           User to send the magic link to.
-		 * @param string   $magic_link_url Magic link url.
-		 */
-		$email = \apply_filters( 'newspack_newsletters_email_verification_email', $email, $user, $url );
-
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
-		$sent = \wp_mail(
-			$email['to'],
-			\wp_specialchars_decode( sprintf( $email['subject'], $blogname ) ),
-			$email['message'],
-			$email['headers']
-		);
-
-		if ( $switched_locale ) {
-			\restore_previous_locale();
-		}
-
-		if ( ! $direct_request ) {
-			if ( function_exists( 'wc_add_notice' ) ) {
-				wc_add_notice( __( 'Check your email address for a verification link.', 'newspack' ), 'success' );
-			}
-			wp_safe_redirect( add_query_arg( [ 'verification_sent' => 1 ], remove_query_arg( self::EMAIL_VERIFIED_REQUEST, wp_get_referer() ) ) );
-			exit;
-		}
-	}
-
-	/**
-	 * Process email verification.
-	 */
-	public static function process_email_verification() {
-		if ( ! isset( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ), self::EMAIL_VERIFIED_CONFIRM ) ) {
-			return;
-		}
-		if ( ! is_user_logged_in() ) {
-			wp_die( esc_html( __( 'You\'re not logged in.', 'newspack' ) ) );
-		}
-		$transient_key = self::get_email_verification_transient_key();
-		$token         = get_transient( $transient_key );
-		if ( ! $token ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack' ) ) );
-		}
-		if ( ! isset( $_GET['token'] ) || sanitize_text_field( $_GET['token'] ) !== $token ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack' ) ) );
-		}
-
-		self::set_email_verified( get_current_user_id() );
-
-		delete_transient( $transient_key );
-
-		if ( function_exists( 'wc_add_notice' ) ) {
-			wc_add_notice( __( 'Your email has been verified.', 'newspack' ), 'success' );
-		}
-		wp_safe_redirect( remove_query_arg( [ self::EMAIL_VERIFIED_CONFIRM, 'token' ] ) );
-		exit;
-	}
-
-	/**
-	 * Upon new reader registration, send a verification email.
-	 *
-	 * @param string         $email         Email address.
-	 * @param bool           $authenticate  Whether to authenticate after registering.
-	 * @param false|int      $user_id       The created user id.
-	 * @param false|\WP_User $existing_user The existing user object.
-	 */
-	public static function send_verification_email_on_registration( $email, $authenticate, $user_id, $existing_user ) {
-		// Only send for new, unverified users.
-		if ( false !== $existing_user || self::is_email_verified( $user_id, $email ) ) {
-			return;
-		}
-
-		self::process_email_verification_request( true );
-		Logger::log( 'New reader account registered. Sending verification email to ' . $email . '.' );
 	}
 }
 Reader_Activation::init();

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -55,6 +55,7 @@ final class Reader_Activation {
 			\add_filter( 'login_form_defaults', [ __CLASS__, 'add_auth_intention_to_login_form' ], 20 );
 			\add_action( 'resetpass_form', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'password_reset', [ __CLASS__, 'set_reader_verified' ] );
+			\add_action( 'newspack_magic_link_authenticated', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'auth_cookie_expiration', [ __CLASS__, 'auth_cookie_expiration' ], 10, 3 );
 			\add_action( 'init', [ __CLASS__, 'setup_nav_menu' ] );
 			\add_action( 'wp_footer', [ __CLASS__, 'render_auth_form' ] );
@@ -62,8 +63,6 @@ final class Reader_Activation {
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
 			\add_filter( 'woocommerce_email_actions', [ __CLASS__, 'disable_woocommerce_new_user_email' ] );
-			\add_action( 'newspack_magic_link_authenticated', [ __CLASS__, 'set_reader_verified' ] );
-			\add_action( 'newspack_magic_link_authenticated', [ __CLASS__, 'set_current_reader' ] );
 		}
 	}
 
@@ -982,9 +981,6 @@ final class Reader_Activation {
 		}
 
 		$user_id = \absint( $user->ID );
-		if ( empty( $user_id ) ) {
-			return new \WP_Error( 'newspack_authenticate_invalid_user_id', __( 'Invalid user id.', 'newspack' ) );
-		}
 
 		\wp_clear_auth_cookie();
 		\wp_set_current_user( $user->ID );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Disables WooCommerce's standard, WC-branded welcome emails that are normally sent to new customers, so that we can send our own verification email instead.

Will not send a verification email to readers who register via SSO, which is considered a secure login method and doesn't require verification.

Closes #1872.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Register a new email address via the Register block (via direct email input, not SSO) and confirm that you receive a magic link email with a special subject line and message instead of WooCommerce's "Your Newspack account has been created!" email.
3. Visit the magic link URL in the same session where you registered the email address and confirm that you're redirected to the main My Account dashboard page with a message that your email has been verified. Also confirm that you're able to manage newsletter subscriptions at this point.
4. In a new session, register a new account via SSO and confirm that you do not receive a magic link email, and that you're immediately able to manage newsletter subscriptions in My Account > Newsletters.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->