### PR TITLE
feat: recaptcha settings in Reader Revenue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.88.0-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.87.0...v1.88.0-hotfix.1) (2022-08-10)
+
+
+### Features
+
+* add UI to manage reCaptcha v3 settings in Reader Revenue wizard ([9b88366](https://github.com/Automattic/newspack-plugin/commit/9b88366303b181c61860c2626811c863663b066b))
+
 # [1.87.0](https://github.com/Automattic/newspack-plugin/compare/v1.86.0...v1.87.0) (2022-07-26)
 
 

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -106,6 +106,74 @@ export const StripeKeysSettings = () => {
 	);
 };
 
+export const StripeCaptchaSettings = () => {
+	const wizardData = Wizard.useWizardData( 'reader-revenue' );
+	const {
+		useCaptcha = false,
+		captchaSiteKey = '',
+		captchaSiteSecret = '',
+	} = wizardData.stripe_data || {};
+
+	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const changeHandler = key => value =>
+		updateWizardSettings( {
+			slug: READER_REVENUE_WIZARD_SLUG,
+			path: [ 'stripe_data', key ],
+			value,
+		} );
+
+	return (
+		<Grid columns={ 1 } gutter={ 16 }>
+			<Grid columns={ 1 } gutter={ 16 }>
+				<p className="newspack-payment-setup-screen__api-keys-instruction">
+					{ __(
+						'Enabling reCaptcha for Stripe checkouts makes your site more secure.',
+						'newspack'
+					) }
+					{ ' – ' }
+					<ExternalLink href="https://www.google.com/recaptcha/admin/create">
+						{ __( 'get started' ) }
+					</ExternalLink>
+				</p>
+				<CheckboxControl
+					label={ __( 'Use reCaptcha v3 to secure Stripe checkout', 'newspack' ) }
+					checked={ useCaptcha }
+					onChange={ changeHandler( 'useCaptcha' ) }
+					help={ __(
+						'Without reCaptcha, your Stripe checkout process may be vulnerable to bot attacks and card testing.',
+						'newspack-blocks'
+					) }
+				/>
+			</Grid>
+			{ useCaptcha && ( ! captchaSiteKey || ! captchaSiteSecret ) && (
+				<Notice
+					noticeText={ __(
+						'You must enter a valid site key and secret to use reCaptcha.',
+						'newspack'
+					) }
+				/>
+			) }
+			<Grid noMargin rowGap={ 16 }>
+				{ useCaptcha && (
+					<>
+						<TextControl
+							value={ captchaSiteKey }
+							label={ __( 'Site Key', 'newspack' ) }
+							onChange={ changeHandler( 'captchaSiteKey' ) }
+						/>
+						<TextControl
+							type="password"
+							value={ captchaSiteSecret }
+							label={ __( 'Site Secret', 'newspack' ) }
+							onChange={ changeHandler( 'captchaSiteSecret' ) }
+						/>
+					</>
+				) }
+			</Grid>
+		</Grid>
+	);
+};
+
 const StripeSetup = () => {
 	const {
 		stripe_data: data = {},
@@ -193,6 +261,23 @@ const StripeSetup = () => {
 								onChange={ changeHandler( 'currency' ) }
 							/>
 						</Grid>
+					</SettingsCard>
+					<SettingsCard
+						title={ __( 'reCaptcha v3 Settings', 'newspack' ) }
+						columns={ 1 }
+						gutter={ 16 }
+						noBorder
+					>
+						{ data.can_use_stripe_platform === false && (
+							<Notice
+								isError
+								noticeText={ __(
+									'The Stripe platform will not work properly on this site.',
+									'newspack'
+								) }
+							/>
+						) }
+						<StripeCaptchaSettings />
 					</SettingsCard>
 					<SettingsCard
 						title={ __( 'Newsletters', 'newspack' ) }

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -110,6 +110,9 @@ class Stripe_Connection {
 			'secretKey'          => '',
 			'testPublishableKey' => '',
 			'testSecretKey'      => '',
+			'useCaptcha'         => false,
+			'captchaSiteKey'     => '',
+			'captchaSiteSecret'  => '',
 			'currency'           => $currency,
 			'location_code'      => $location_code,
 			'newsletter_list_id' => '',
@@ -122,6 +125,20 @@ class Stripe_Connection {
 	public static function get_stripe_data() {
 		$stripe_data = self::get_saved_stripe_data();
 		return $stripe_data;
+	}
+
+	/**
+	 * Check whether reCaptcha is enabled and that we have all required settings.
+	 *
+	 * @return boolean True if we can use reCaptcha to secure checkout requests.
+	 */
+	public static function can_use_captcha() {
+		$settings = self::get_stripe_data();
+		if ( empty( $settings['useCaptcha'] ) || empty( $settings['captchaSiteKey'] ) || empty( $settings['captchaSiteSecret'] ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -150,6 +150,15 @@ class Reader_Revenue_Wizard extends Wizard {
 					'testSecretKey'      => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
+					'useCaptcha'         => [
+						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
+					],
+					'captchaSiteKey'     => [
+						'sanitize_callback' => 'Newspack\newspack_clean',
+					],
+					'captchaSiteSecret'  => [
+						'sanitize_callback' => 'Newspack\newspack_clean',
+					],
 					'newsletter_list_id' => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.87.0
+ * Version: 1.88.0-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.87.0",
+  "version": "1.88.0-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.87.0",
+      "version": "1.88.0-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.87.0",
+  "version": "1.88.0-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements UI in the Reader Revenue wizard to enable reCaptcha v3 to secure Stripe donate forms, and enter reCaptcha v3 credentials if enabled. Also exposes a `can_use_captcha` method which can be used to determine if we have all the necessary credentials to process reCaptcah requests upon form submission.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Visit Newspack > Reader Revenue and set Stripe as your donation platform.
3. Go to Stripe Settings and confirm there's a new section here:

<img width="577" alt="Screen Shot 2022-08-10 at 12 54 28 PM" src="https://user-images.githubusercontent.com/2230142/183999311-74a6b99c-8f70-4e75-ba3e-239095ba4056.png">

4. Check the box to enable reCaptcha, and enter credentials into both inputs (for this test, you don't really need to have valid credentials).
5. Save, refresh the wizard page and confirm that your settings are persisted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->