### PR TITLE
feat: better welcome email copy for initial verification

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -28,6 +28,8 @@ final class Magic_Link {
 	const AUTH_ACTION_RESULT = 'np_auth_link_result';
 	const COOKIE             = 'np_auth_link';
 
+	const MAGIC_LINK_PLACEHOLDER = '%MAGIC_LINK_URL%';
+
 	/**
 	 * Current session secret.
 	 *
@@ -345,10 +347,16 @@ final class Magic_Link {
 		if ( empty( $message ) ) {
 			/* translators: %s: Site title. */
 			$message  = sprintf( __( 'Welcome back to %s!', 'newspack' ), $blogname ) . "\r\n\r\n";
-			$message .= __( 'Authenticate your account by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
+			$message .= __( 'Log into your account by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
 		}
 
-		$message .= $magic_link_url . "\r\n";
+		// If the message contains a magic link placeholder, populate the magic link there.
+		if ( false !== strpos( $message, self::MAGIC_LINK_PLACEHOLDER ) ) {
+			$message = str_replace( self::MAGIC_LINK_PLACEHOLDER, $magic_link_url, $message );
+		} else {
+			// Otherwise, append it to the end of the message.
+			$message .= $magic_link_url . "\r\n";
+		}
 
 		$email = [
 			'to'      => $user->user_email,

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -363,7 +363,13 @@ final class Magic_Link {
 			/* translators: %s Site title. */
 			'subject' => __( '[%s] ', 'newspack' ) . $subject,
 			'message' => $message,
-			'headers' => '',
+			'headers' => [
+				sprintf(
+					'From: %1$s <%2$s>',
+					Reader_Activation::get_from_name(),
+					Reader_Activation::get_from_email()
+				),
+			],
 		];
 
 		if ( $switched_locale ) {

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -1149,8 +1149,9 @@ final class Reader_Activation {
 
 		$subject = __( 'Please verify your account', 'newspack' );
 
+		$message = __( 'Hi there!', 'newspack' ) . "\r\n\r\n";
 		/* translators: %s: Site title. */
-		$message  = __( 'To manage your account, please verify your email address by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
+		$message .= __( 'To manage your account, please verify your email address by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
 		$message .= Magic_Link::MAGIC_LINK_PLACEHOLDER . "\r\n\r\n";
 
 		if ( $redirect_to ) {
@@ -1195,6 +1196,8 @@ final class Reader_Activation {
 	 * We avoid use of the `wp_mail_from` hook because we only want to
 	 * set the email address for Reader Activation emails, not all emails
 	 * sent via wp_mail.
+	 *
+	 * @return string Email address used as the sender for Reader Activation emails.
 	 */
 	public static function get_from_email() {
 		// Get the site domain and get rid of www.
@@ -1217,6 +1220,8 @@ final class Reader_Activation {
 	 * We avoid use of the `wp_mail_from_name` hook because we only want
 	 * to set the name for Reader Activation emails, not all emails
 	 * sent via wp_mail.
+	 *
+	 * @return string Name used as the sender for Reader Activation emails.
 	 */
 	public static function get_from_name() {
 		return apply_filters( 'newspack_reader_activation_from_name', get_bloginfo( 'name' ) );

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -1150,8 +1150,13 @@ final class Reader_Activation {
 		$subject = __( 'Please verify your account', 'newspack' );
 
 		/* translators: %s: Site title. */
-		$message  = sprintf( __( 'Welcome to %s!', 'newspack' ), $blogname ) . "\r\n\r\n";
 		$message .= __( 'To manage your account, please verify your email address by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
+		$message .= Magic_Link::MAGIC_LINK_PLACEHOLDER . "\r\n\r\n";
+
+		if ( $redirect_to ) {
+			/* translators: %s: My Account URL. */
+			$message .= sprintf( __( 'Once verified, visit %s to edit your profile, set a password for easier access, and manage your newsletter subscriptions and billing information.', 'newspack' ), $redirect_to ) . "\r\n";
+		}
 
 		Logger::log( 'Sending verification email to new user ' . $user->user_email );
 		return Magic_Link::send_email( $user, $redirect_to, $subject, $message );

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -1149,8 +1149,7 @@ final class Reader_Activation {
 
 		$subject = __( 'Please verify your account', 'newspack' );
 
-		$message = __( 'Hi there!', 'newspack' ) . "\r\n\r\n";
-		/* translators: %s: Site title. */
+		$message  = __( 'Hi there!', 'newspack' ) . "\r\n\r\n";
 		$message .= __( 'To manage your account, please verify your email address by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
 		$message .= Magic_Link::MAGIC_LINK_PLACEHOLDER . "\r\n\r\n";
 

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -1189,5 +1189,37 @@ final class Reader_Activation {
 
 		return $emails;
 	}
+
+	/**
+	 * Get the from email address used to send all transactional emails.
+	 * We avoid use of the `wp_mail_from` hook because we only want to
+	 * set the email address for Reader Activation emails, not all emails
+	 * sent via wp_mail.
+	 */
+	public static function get_from_email() {
+		// Get the site domain and get rid of www.
+		$sitename   = wp_parse_url( network_home_url(), PHP_URL_HOST );
+		$from_email = 'no-reply@';
+
+		if ( null !== $sitename ) {
+			if ( 'www.' === substr( $sitename, 0, 4 ) ) {
+				$sitename = substr( $sitename, 4 );
+			}
+
+			$from_email .= $sitename;
+		}
+
+		return apply_filters( 'newspack_reader_activation_from_email', $from_email );
+	}
+
+	/**
+	 * Get the from from name used to send all transactional emails.
+	 * We avoid use of the `wp_mail_from_name` hook because we only want
+	 * to set the name for Reader Activation emails, not all emails
+	 * sent via wp_mail.
+	 */
+	public static function get_from_name() {
+		return apply_filters( 'newspack_reader_activation_from_name', get_bloginfo( 'name' ) );
+	}
 }
 Reader_Activation::init();

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -1150,7 +1150,7 @@ final class Reader_Activation {
 		$subject = __( 'Please verify your account', 'newspack' );
 
 		/* translators: %s: Site title. */
-		$message .= __( 'To manage your account, please verify your email address by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
+		$message  = __( 'To manage your account, please verify your email address by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
 		$message .= Magic_Link::MAGIC_LINK_PLACEHOLDER . "\r\n\r\n";
 
 		if ( $redirect_to ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks the language of the magic link email that's sent to newly registered readers to be slightly more descriptive.

Because of the placement of the magic link URL in the middle of the message, I had to implement some primitive placeholder logic to populate the link where I wanted it to appear.

### How to test the changes in this Pull Request:

1. Check out this branch
2. In a new session, register a new email address
3. Confirm the new language:

```
To manage your account, please verify your email address by visiting the following URL:

[magic link URL]

Once verified, visit [My Account URL] to edit your profile, set a password for easier access, and manage your newsletter subscriptions and billing information.
```

4. Also confirm that the sender name and email is customized to `Site Name <no-reply@sitedomain.com>` from the default `WordPress <wordpress@sitedomain.com>`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->