### PR TITLE
refactor: "My Account" lock for unverified readers

### DIFF
--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -275,15 +275,16 @@ final class Reader_Activation {
 	/**
 	 * Whether the user is a reader.
 	 *
-	 * @param \WP_User $user User object.
+	 * @param \WP_User $user   User object.
+	 * @param bool     $strict Whether to check if the user was created through reader registration. Default false.
 	 *
 	 * @return bool Whether the user is a reader.
 	 */
-	public static function is_user_reader( $user ) {
+	public static function is_user_reader( $user, $strict = false ) {
 		$is_reader = (bool) \get_user_meta( $user->ID, self::READER, true );
 		$user_data = \get_userdata( $user->ID );
 
-		if ( false === $is_reader ) {
+		if ( false === $is_reader && false === $strict ) {
 			/**
 			 * Filters the roles that can determine if a user is a reader.
 			 *

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -6,7 +6,9 @@
  * @package Newspack
  */
 
-use \Newspack\WooCommerce_My_Account;
+namespace Newspack;
+
+use Newspack\WooCommerce_My_Account;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/reader-revenue/templates/myaccount-verify.php
+++ b/includes/reader-revenue/templates/myaccount-verify.php
@@ -6,7 +6,9 @@
  * @package Newspack
  */
 
-use \Newspack\WooCommerce_My_Account;
+namespace Newspack;
+
+use Newspack\WooCommerce_My_Account;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -115,6 +115,25 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test strict argument on method that validates if user is a reader.
+	 */
+	public function test_strict_reader() {
+		$reader_id = self::register_sample_reader();
+		$this->assertTrue( Reader_Activation::is_user_reader( get_user_by( 'id', $reader_id ), true ) );
+		wp_delete_user( $reader_id ); // Clean up.
+
+		$subscriber_id = wp_insert_user(
+			[
+				'user_login' => 'sample-subscriber',
+				'user_pass'  => wp_generate_password(),
+				'user_email' => 'subscriber@test.com',
+			]
+		);
+		$this->assertFalse( Reader_Activation::is_user_reader( get_user_by( 'id', $subscriber_id ), true ) );
+		wp_delete_user( $subscriber_id ); // Clean up.
+	}
+
+	/**
 	 * Test restricted roles for reader.
 	 */
 	public function test_restricted_roles() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR refactors the approach for locking "My Account" access to unverified readers. The approach was changed to hook into the `woocommerce_account_content` instead of the combination of `wc_get_template` hook and URL redirection.

Fixes:
 - Log out URL should now work for unverified readers accessing the page
 - Strict reader check now allows for a non-RAS customer/subscriber to be interpreted as verified

### How to test the changes in this Pull Request:

The new test for the strict reader should pass.

### Non-RAS Subscriber

1. Create a regular subscriber and set a password
2. On a new session, authenticate with the subscriber
3. Confirm you can navigate the account page
4. Visit the Newsletters section and confirm you still have to verify for newsletters management

### RAS Reader

1. Create a new account through RAS (registration block)
2. Access My Account and confirm you have to verify your account
3. Try to access another endpoint ( `/my-account/newsletters` or `/my-account/orders/`)
4. Confirm you're still prompted to verify
5. Log out
6. Confirm you are successfully logged out

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->