### PR TITLE
feat: authenticated reader cookie

### DIFF
--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -148,6 +148,8 @@ export function refreshAuthentication() {
 	if ( email ) {
 		setReaderEmail( email );
 		setAuthenticated( true );
+	} else {
+		setReaderEmail( getCookie( 'np_auth_intention' ) );
 	}
 }
 

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -141,6 +141,17 @@ export function setAuthenticated( authenticated = true ) {
 }
 
 /**
+ * Detect whether the current reader is authenticated.
+ */
+export function refreshAuthentication() {
+	const email = getCookie( 'np_auth_reader' );
+	if ( email ) {
+		setReaderEmail( email );
+		setAuthenticated( true );
+	}
+}
+
+/**
  * Get the current reader.
  *
  * @return {Object} Reader data.
@@ -204,6 +215,7 @@ const readerActivation = {
 	off,
 	setReaderEmail,
 	setAuthenticated,
+	refreshAuthentication,
 	getReader,
 	hasAuthLink,
 	setAuthStrategy,

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -269,10 +269,12 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Set cookie to indicate the reader is authenticated.
+	 * Set cookie to indicate the reader has been authenticated.
 	 *
-	 * This cookie expiration doesn't matter, as it's intended to be reader right
+	 * This cookie expiration doesn't matter, as it's intended to be read right
 	 * after a frontend action that might have registered/authenticated a reader.
+	 *
+	 * Do not use this cookie for validation.
 	 *
 	 * @param \WP_User $user User object.
 	 */

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -16,6 +16,7 @@ final class Reader_Activation {
 
 	const OPTIONS_PREFIX = 'newspack_reader_activation_';
 
+	const AUTH_READER_COOKIE    = 'np_auth_reader';
 	const AUTH_INTENTION_COOKIE = 'np_auth_intention';
 	const SCRIPT_HANDLE         = 'newspack-reader-activation';
 	const AUTH_SCRIPT_HANDLE    = 'newspack-reader-auth';
@@ -51,6 +52,7 @@ final class Reader_Activation {
 		if ( self::is_enabled() ) {
 			\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 			\add_action( 'clear_auth_cookie', [ __CLASS__, 'clear_auth_intention_cookie' ] );
+			\add_action( 'clear_auth_cookie', [ __CLASS__, 'clear_auth_reader_cookie' ] );
 			\add_action( 'set_auth_cookie', [ __CLASS__, 'clear_auth_intention_cookie' ] );
 			\add_filter( 'login_form_defaults', [ __CLASS__, 'add_auth_intention_to_login_form' ], 20 );
 			\add_action( 'resetpass_form', [ __CLASS__, 'set_reader_verified' ] );
@@ -251,6 +253,37 @@ final class Reader_Activation {
 		$expire = time() + \apply_filters( 'newspack_auth_intention_expiration', 30 * DAY_IN_SECONDS, $email );
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
 		setcookie( self::AUTH_INTENTION_COOKIE, $email, $expire, COOKIEPATH, COOKIE_DOMAIN, true );
+	}
+
+	/**
+	 * Clear cookie that indicates the reader is authenticated.
+	 */
+	public static function clear_auth_reader_cookie() {
+		/** This filter is documented in wp-includes/pluggable.php */
+		if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+		setcookie( self::AUTH_READER_COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+	}
+
+	/**
+	 * Set cookie to indicate the reader is authenticated.
+	 *
+	 * This cookie expiration doesn't matter, as it's intended to be reader right
+	 * after a frontend action that might have registered/authenticated a reader.
+	 *
+	 * @param \WP_User $user User object.
+	 */
+	public static function set_auth_reader_cookie( $user ) {
+		/** This filter is documented in wp-includes/pluggable.php */
+		if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+		setcookie( self::AUTH_READER_COOKIE, $user->user_email, time() + HOUR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, true );
 	}
 
 	/**
@@ -1014,6 +1047,7 @@ final class Reader_Activation {
 		\wp_clear_auth_cookie();
 		\wp_set_current_user( $user->ID );
 		\wp_set_auth_cookie( $user->ID, true );
+		self::set_auth_reader_cookie( $user );
 		\do_action( 'wp_login', $user->user_login, $user );
 		Logger::log( 'Logged in user ' . $user->ID );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements the `refreshAuthentication()` method for the RAS front-end library. This method reads a cookie so that third-party backend actions (XHR) that might register/authenticate a reader can more easily refresh the UI.

### How to test the changes in this Pull Request:

Instructions at https://github.com/Automattic/newspack-blocks/pull/1236

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->