### PR TITLE
feat: reader account deletion and ESP sync options

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -131,7 +131,7 @@ export default withWizardScreen( () => {
 						<CheckboxControl
 							label={ __( 'Delete contact on reader deletion', 'newspack' ) }
 							help={ __(
-								"If the reader's email is verified, permanently delete contact from ESP on reader deletion. ESP synchronization must be enabled.",
+								"If the reader's email is verified, delete contact from ESP on reader deletion. ESP synchronization must be enabled.",
 								'newspack'
 							) }
 							checked={ !! config.sync_esp_delete }

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -89,15 +89,6 @@ export default withWizardScreen( () => {
 					checked={ !! config.enabled_account_link }
 					onChange={ value => updateConfig( 'enabled_account_link', value ) }
 				/>
-				<TextControl
-					label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
-					help={ __(
-						'The text to display while subscribing to newsletters on the registration modal.',
-						'newspack'
-					) }
-					value={ config.newsletters_label }
-					onChange={ value => updateConfig( 'newsletters_label', value ) }
-				/>
 				<Grid columns={ 2 } gutter={ 16 }>
 					<TextControl
 						label={ __( 'Terms & Conditions Text', 'newspack' ) }
@@ -112,17 +103,53 @@ export default withWizardScreen( () => {
 						onChange={ value => updateConfig( 'terms_url', value ) }
 					/>
 				</Grid>
-			</Card>
-			{ isActiveCampaign && (
-				<ActiveCampaign
-					value={ { masterList: config.active_campaign_master_list } }
-					onChange={ ( key, value ) => {
-						if ( key === 'masterList' ) {
-							updateConfig( 'active_campaign_master_list', value );
-						}
-					} }
+				<hr />
+				<SectionHeader
+					title={ __( 'Email Service Provider and Newsletters Integration', 'newspack' ) }
+					description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
 				/>
-			) }
+				<TextControl
+					label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
+					help={ __(
+						'The text to display while subscribing to newsletters on the registration modal.',
+						'newspack'
+					) }
+					value={ config.newsletters_label }
+					onChange={ value => updateConfig( 'newsletters_label', value ) }
+				/>
+				<CheckboxControl
+					label={ __( 'Synchronize reader to ESP', 'newspack' ) }
+					help={ __(
+						'Whether to synchronize reader data to the ESP. A contact will be created on reader registration if the ESP supports contacts without a list subscription.',
+						'newspack'
+					) }
+					checked={ !! config.sync_esp }
+					onChange={ value => updateConfig( 'sync_esp', value ) }
+				/>
+				{ config.sync_esp && (
+					<>
+						<CheckboxControl
+							label={ __( 'Delete contact on reader deletion', 'newspack' ) }
+							help={ __(
+								"If the reader's email is verified, permanently delete contact from ESP on reader deletion. ESP synchronization must be enabled.",
+								'newspack'
+							) }
+							checked={ !! config.sync_esp_delete }
+							onChange={ value => updateConfig( 'sync_esp_delete', value ) }
+						/>
+						{ isActiveCampaign && (
+							<ActiveCampaign
+								value={ { masterList: config.active_campaign_master_list } }
+								onChange={ ( key, value ) => {
+									if ( key === 'masterList' ) {
+										updateConfig( 'active_campaign_master_list', value );
+									}
+								} }
+							/>
+						) }
+					</>
+				) }
+			</Card>
 			<div className="newspack-buttons-card">
 				<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
 					{ __( 'Save Changes', 'newspack' ) }

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -105,7 +105,7 @@ export default withWizardScreen( () => {
 				</Grid>
 				<hr />
 				<SectionHeader
-					title={ __( 'Email Service Provider and Newsletters Integration', 'newspack' ) }
+					title={ __( 'Email Service Provider Settings', 'newspack' ) }
 					description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
 				/>
 				<TextControl

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -127,6 +127,8 @@ final class Reader_Activation {
 			'newsletters_label'           => __( 'Subscribe to our newsletters:', 'newspack' ),
 			'terms_text'                  => __( 'By signing up, you agree to our Terms and Conditions.', 'newspack' ),
 			'terms_url'                   => '',
+			'sync_esp'                    => true,
+			'sync_esp_delete'             => true,
 			'active_campaign_master_list' => '',
 		];
 
@@ -148,7 +150,7 @@ final class Reader_Activation {
 
 		$settings = [];
 		foreach ( $config as $key => $default_value ) {
-			$settings[ $key ] = \get_option( self::OPTIONS_PREFIX . $key, $default_value );
+			$settings[ $key ] = self::get_setting( $key );
 		}
 		return $settings;
 	}
@@ -1081,6 +1083,8 @@ final class Reader_Activation {
 		 * @param \WP_User $user    User object.
 		 */
 		do_action( 'newspack_reader_before_delete', $user_id, $user );
+
+		Logger::log( 'Deleting reader with ID ' . $user->ID . ' (' . $user->user_email . ')' );
 
 		$result = \wp_delete_user( $user_id );
 

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -1067,47 +1067,6 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Delete a reader.
-	 *
-	 * @param int $user_id User ID.
-	 *
-	 * @return bool|\WP_Error Whether the user was deleted or error.
-	 */
-	public static function delete_reader( $user_id ) {
-
-		/** Make sure `wp_delete_user()` is available. */
-		require_once ABSPATH . 'wp-admin/includes/user.php';
-
-		$user = get_user_by( 'id', $user_id );
-
-		if ( ! $user || ! self::is_user_reader( $user ) ) {
-			return new \WP_Error( 'newspack_delete_reader_invalid_user', __( 'Invalid user.', 'newspack' ) );
-		}
-
-		/**
-		 * Fires before a reader is deleted.
-		 *
-		 * @param int      $user_id User ID.
-		 * @param \WP_User $user    User object.
-		 */
-		do_action( 'newspack_reader_before_delete', $user_id, $user );
-
-		Logger::log( 'Deleting reader with ID ' . $user->ID . ' (' . $user->user_email . ')' );
-
-		$result = \wp_delete_user( $user_id );
-
-		/**
-		 * Fires after a reader is deleted.
-		 *
-		 * @param int      $user_id User ID.
-		 * @param \WP_User $user    User object.
-		 */
-		do_action( 'newspack_reader_after_delete', $user_id, $user );
-
-		return $result;
-	}
-
-	/**
 	 * Register a reader given its email.
 	 *
 	 * Due to authentication or auth intention, this method should be used

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -167,7 +167,12 @@ final class Reader_Activation {
 		if ( ! isset( $config[ $name ] ) ) {
 			return null;
 		}
-		return \get_option( self::OPTIONS_PREFIX . $name, $config[ $name ] );
+		$value = \get_option( self::OPTIONS_PREFIX . $name, $config[ $name ] );
+		// Use default value type for casting bool option value.
+		if ( is_bool( $config[ $name ] ) ) {
+			$value = (bool) $value;
+		}
+		return $value;
 	}
 
 	/**
@@ -182,6 +187,9 @@ final class Reader_Activation {
 		$config = self::get_settings_config();
 		if ( ! isset( $config[ $key ] ) ) {
 			return false;
+		}
+		if ( is_bool( $value ) ) {
+			$value = intval( $value );
 		}
 		return \update_option( self::OPTIONS_PREFIX . $key, $value );
 	}

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -1057,6 +1057,45 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Delete a reader.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return bool|\WP_Error Whether the user was deleted or error.
+	 */
+	public static function delete_reader( $user_id ) {
+
+		/** Make sure `wp_delete_user()` is available. */
+		require_once ABSPATH . 'wp-admin/includes/user.php';
+
+		$user = get_user_by( 'id', $user_id );
+
+		if ( ! $user || ! self::is_user_reader( $user ) ) {
+			return new \WP_Error( 'newspack_delete_reader_invalid_user', __( 'Invalid user.', 'newspack' ) );
+		}
+
+		/**
+		 * Fires before a reader is deleted.
+		 *
+		 * @param int      $user_id User ID.
+		 * @param \WP_User $user    User object.
+		 */
+		do_action( 'newspack_reader_before_delete', $user_id, $user );
+
+		$result = \wp_delete_user( $user_id );
+
+		/**
+		 * Fires after a reader is deleted.
+		 *
+		 * @param int      $user_id User ID.
+		 * @param \WP_User $user    User object.
+		 */
+		do_action( 'newspack_reader_after_delete', $user_id, $user );
+
+		return $result;
+	}
+
+	/**
 	 * Register a reader given its email.
 	 *
 	 * Due to authentication or auth intention, this method should be used

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -41,7 +41,7 @@ class Newspack_Newsletters {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		if ( Reader_Activation::is_enabled() ) {
+		if ( Reader_Activation::is_enabled() && Reader_Activation::get_setting( 'sync_esp' ) ) {
 			\add_action( 'newspack_newsletters_update_contact_lists', [ __CLASS__, 'update_contact_lists' ], 10, 5 );
 			\add_filter( 'newspack_newsletters_contact_data', [ __CLASS__, 'contact_data' ], 10, 3 );
 			\add_filter( 'newspack_newsletters_contact_lists', [ __CLASS__, 'add_activecampaign_master_list' ], 10, 3 );

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -256,6 +256,10 @@ class WooCommerce_My_Account {
 		/** Make sure `wp_delete_user()` is available. */
 		require_once ABSPATH . 'wp-admin/includes/user.php';
 
+		if ( isset( $_GET['account_deleted'] ) && function_exists( 'wc_add_notice' ) ) {
+			\wc_add_notice( __( 'Your account has been deleted.', 'newspack' ), 'success' );
+		}
+
 		if ( ! isset( $_POST[ self::DELETE_ACCOUNT_FORM ] ) ) {
 			return;
 		}
@@ -287,9 +291,7 @@ class WooCommerce_My_Account {
 		\delete_transient( 'np_reader_account_delete_' . $user_id );
 
 		\wp_delete_user( $user_id );
-
-		\wc_add_notice( __( 'Your account has been deleted.', 'newspack' ), 'success' );
-		\wp_safe_redirect( \wc_get_account_endpoint_url( 'edit-account' ) );
+		\wp_safe_redirect( add_query_arg( 'account_deleted', 1, \wc_get_account_endpoint_url( 'edit-account' ) ) );
 		exit;
 	}
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -252,6 +252,10 @@ class WooCommerce_My_Account {
 	 * Handle delete account confirmation.
 	 */
 	public static function handle_delete_account() {
+
+		/** Make sure `wp_delete_user()` is available. */
+		require_once ABSPATH . 'wp-admin/includes/user.php';
+
 		if ( ! isset( $_POST[ self::DELETE_ACCOUNT_FORM ] ) ) {
 			return;
 		}

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -7,6 +7,7 @@
 
 namespace Newspack;
 
+use Newspack\Reader_Activation;
 use \WP_Error;
 
 defined( 'ABSPATH' ) || exit;
@@ -18,6 +19,8 @@ class WooCommerce_My_Account {
 	const BILLING_ENDPOINT             = 'billing';
 	const STRIPE_CUSTOMER_ID_USER_META = '_newspack_stripe_customer_id';
 	const RESET_PASSWORD_URL_PARAM     = 'reset-password';
+	const DELETE_ACCOUNT_URL_PARAM     = 'delete-account';
+	const DELETE_ACCOUNT_FORM          = 'delete-account-form';
 	const SEND_MAGIC_LINK_PARAM        = 'magic-link';
 
 	/**
@@ -36,9 +39,11 @@ class WooCommerce_My_Account {
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'my_account_menu_items' ], 1000 );
 		add_action( 'woocommerce_account_' . self::BILLING_ENDPOINT . '_endpoint', [ __CLASS__, 'render_billing_template' ] );
-		add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 100, 5 );
+		add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 5 );
 		add_action( 'init', [ __CLASS__, 'add_rewrite_endpoints' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'handle_password_reset_request' ] );
+		add_action( 'template_redirect', [ __CLASS__, 'handle_delete_account_request' ] );
+		add_action( 'template_redirect', [ __CLASS__, 'handle_delete_account' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'handle_magic_link_request' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'redirect_to_account_details' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'edit_account_prevent_email_update' ] );
@@ -122,33 +127,170 @@ class WooCommerce_My_Account {
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
-		$nonce = filter_input( INPUT_GET, self::RESET_PASSWORD_URL_PARAM, FILTER_SANITIZE_STRING );
 
-		if ( $nonce ) {
-			$is_error = false;
-			if ( wp_verify_nonce( $nonce, self::RESET_PASSWORD_URL_PARAM ) ) {
-				$result  = retrieve_password( wp_get_current_user()->user_email );
-				$message = __( 'Please check your email inbox for instructions on how to set a new password.', 'newspack' );
-				if ( is_wp_error( $result ) ) {
-					Logger::log( 'Error resetting password: ' . $result->get_error_message() );
-					$message  = __( 'Something went wrong.', 'newspack' );
-					$is_error = true;
-				}
-			} else {
+		$nonce = filter_input( INPUT_GET, self::RESET_PASSWORD_URL_PARAM, FILTER_SANITIZE_STRING );
+		if ( ! $nonce ) {
+			return;
+		}
+
+		$is_error = false;
+		if ( wp_verify_nonce( $nonce, self::RESET_PASSWORD_URL_PARAM ) ) {
+			$result  = retrieve_password( wp_get_current_user()->user_email );
+			$message = __( 'Please check your email inbox for instructions on how to set a new password.', 'newspack' );
+			if ( is_wp_error( $result ) ) {
+				Logger::log( 'Error resetting password: ' . $result->get_error_message() );
 				$message  = __( 'Something went wrong.', 'newspack' );
 				$is_error = true;
 			}
-			wp_safe_redirect(
-				add_query_arg(
-					[
-						'message'  => $message,
-						'is_error' => $is_error,
-					],
-					remove_query_arg( self::RESET_PASSWORD_URL_PARAM )
-				)
-			);
-			exit;
+		} else {
+			$message  = __( 'Something went wrong.', 'newspack' );
+			$is_error = true;
 		}
+
+		if ( $is_error ) {
+			\wc_add_notice( $message, 'error' );
+		} else {
+			\wc_add_notice( $message, 'success' );
+		}
+		wp_safe_redirect( remove_query_arg( self::RESET_PASSWORD_URL_PARAM ) );
+		exit;
+	}
+
+	/**
+	 * Handle delete account request.
+	 */
+	public static function handle_delete_account_request() {
+		if ( ! \is_user_logged_in() ) {
+			return;
+		}
+
+		$user_id = \get_current_user_id();
+		$user    = \wp_get_current_user();
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			return;
+		}
+
+		$nonce = filter_input( INPUT_GET, self::DELETE_ACCOUNT_URL_PARAM, FILTER_SANITIZE_STRING );
+		if ( ! $nonce || ! \wp_verify_nonce( $nonce, self::DELETE_ACCOUNT_URL_PARAM ) ) {
+			return;
+		}
+
+		$token      = \wp_generate_password( 43, false, false );
+		$form_nonce = \wp_create_nonce( self::DELETE_ACCOUNT_FORM );
+
+		$url = \add_query_arg(
+			[
+				self::DELETE_ACCOUNT_FORM => $form_nonce,
+				'token'                   => $token,
+			],
+			\wc_get_account_endpoint_url( 'edit-account' )
+		);
+		\set_transient( 'np_reader_account_delete_' . $user_id, $token, DAY_IN_SECONDS );
+
+		/* translators: %s User display name. */
+		$message  = sprintf( __( 'Hello, %s!', 'newspack' ), $user->display_name ) . "\r\n\r\n";
+		$message .= __( 'To delete your account, follow the instructions in the following address:', 'newspack' ) . "\r\n\r\n";
+		$message .= $url . "\r\n";
+
+		$blogname = \wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+		$switched_locale = \switch_to_locale( get_user_locale( $user ) );
+
+		$email = [
+			'to'      => $user->user_email,
+			/* translators: %s Site title. */
+			'subject' => __( '[%s] Account deletion request', 'newspack' ),
+			'message' => $message,
+			'headers' => [
+				sprintf(
+					'From: %1$s <%2$s>',
+					Reader_Activation::get_from_name(),
+					Reader_Activation::get_from_email()
+				),
+			],
+		];
+
+		/**
+		 * Filters the account deletion email.
+		 *
+		 * @param array    $email Email arguments. {
+		 *   Used to build wp_mail().
+		 *
+		 *   @type string $to      The intended recipient - New user email address.
+		 *   @type string $subject The subject of the email.
+		 *   @type string $message The body of the email.
+		 *   @type string $headers The headers of the email.
+		 * }
+		 * @param \WP_User $user  User to send the magic link to.
+		 * @param string   $url   Account deletion form url.
+		 */
+		$email = \apply_filters( 'newspack_reader_account_delete_email', $email, $user, $url );
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+		$sent = \wp_mail(
+			$email['to'],
+			\wp_specialchars_decode( sprintf( $email['subject'], $blogname ) ),
+			$email['message'],
+			$email['headers']
+		);
+
+		if ( $switched_locale ) {
+			\restore_previous_locale();
+		}
+
+		if ( $sent ) {
+			wc_add_notice( __( 'Please check your email inbox for instructions on how to delete your account.', 'newspack' ), 'success' );
+		} else {
+			wc_add_notice( __( 'Something went wrong.', 'newspack' ), 'error' );
+		}
+
+		\wp_safe_redirect( \remove_query_arg( self::DELETE_ACCOUNT_URL_PARAM ) );
+		exit;
+	}
+
+	/**
+	 * Handle delete account confirmation.
+	 */
+	public static function handle_delete_account() {
+		if ( ! isset( $_POST[ self::DELETE_ACCOUNT_FORM ] ) ) {
+			return;
+		}
+
+		$form_nonce = \sanitize_text_field( $_POST[ self::DELETE_ACCOUNT_FORM ] );
+		if ( ! $form_nonce || ! \wp_verify_nonce( $form_nonce, self::DELETE_ACCOUNT_FORM ) ) {
+			\wp_die( \esc_html__( 'Invalid request.', 'newspack' ) );
+		}
+
+		if ( ! isset( $_POST['confirm_delete'] ) ) {
+			return;
+		}
+
+		if ( ! \is_user_logged_in() ) {
+			return;
+		}
+
+		$user_id = \get_current_user_id();
+		$user    = \wp_get_current_user();
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			return;
+		}
+
+		$token           = isset( $_POST['token'] ) ? \sanitize_text_field( $_POST['token'] ) : '';
+		$transient_token = \get_transient( 'np_reader_account_delete_' . $user_id );
+		if ( ! $token || ! $transient_token || $token !== $transient_token ) {
+			wp_die( \esc_html__( 'Invalid request.', 'newspack' ) );
+		}
+		\delete_transient( 'np_reader_account_delete_' . $user_id );
+
+		$result = Reader_Activation::delete_reader( $user_id );
+
+		if ( \is_wp_error( $result ) ) {
+			\wc_add_notice( $result->get_error_message(), 'error' );
+		} else {
+			\wc_add_notice( __( 'Your account has been deleted.', 'newspack' ), 'success' );
+		}
+		\wp_safe_redirect( \wc_get_account_endpoint_url( 'edit-account' ) );
+		exit;
 	}
 
 	/**
@@ -306,6 +448,9 @@ class WooCommerce_My_Account {
 	 */
 	public static function wc_get_template( $template, $template_name ) {
 		if ( 'myaccount/form-edit-account.php' === $template_name ) {
+			if ( isset( $_GET[ self::DELETE_ACCOUNT_FORM ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				return dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/reader-revenue/templates/myaccount-delete-account.php';
+			}
 			return dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/reader-revenue/templates/myaccount-edit-account.php';
 		}
 		return $template;

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -282,13 +282,9 @@ class WooCommerce_My_Account {
 		}
 		\delete_transient( 'np_reader_account_delete_' . $user_id );
 
-		$result = Reader_Activation::delete_reader( $user_id );
+		\wp_delete_user( $user_id );
 
-		if ( \is_wp_error( $result ) ) {
-			\wc_add_notice( $result->get_error_message(), 'error' );
-		} else {
-			\wc_add_notice( __( 'Your account has been deleted.', 'newspack' ), 'success' );
-		}
+		\wc_add_notice( __( 'Your account has been deleted.', 'newspack' ), 'success' );
 		\wp_safe_redirect( \wc_get_account_endpoint_url( 'edit-account' ) );
 		exit;
 	}

--- a/includes/reader-revenue/templates/myaccount-delete-account.php
+++ b/includes/reader-revenue/templates/myaccount-delete-account.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * My Account page before account has been verified.
+ * The user will be asked to verify before they can manage account settings.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Newspack\WooCommerce_My_Account;
+
+defined( 'ABSPATH' ) || exit;
+
+$delete_account_form = WooCommerce_My_Account::DELETE_ACCOUNT_FORM;
+
+\do_action( 'woocommerce_before_edit_account_form' );
+
+$nonce_value = isset( $_GET[ $delete_account_form ] ) ? \sanitize_text_field( $_GET[ $delete_account_form ] ) : '';
+if ( ! \wp_verify_nonce( $nonce_value, $delete_account_form ) ) {
+	\wc_add_notice( __( 'Invalid nonce.', 'newspack' ), 'error' );
+	return;
+}
+
+if ( ! isset( $_GET['token'] ) ) {
+	\wc_add_notice( __( 'Invalid token', 'newspack' ), 'error' );
+	return;
+}
+
+$token           = \sanitize_text_field( $_GET['token'] );
+$transient_token = get_transient( 'np_reader_account_delete_' . \get_current_user_id() );
+if ( ! $transient_token || $transient_token !== $token ) {
+	\wc_add_notice( __( 'Invalid token', 'newspack' ), 'error' );
+	return;
+}
+?>
+
+<div class="newspack-verify-account-message">
+	<p>
+		<?php esc_html_e( 'Confirm to delete your account permanently.', 'newspack' ); ?>
+	</p>
+	<p>
+		<strong><?php esc_html_e( 'Caution, this action is irreversible!', 'newspack' ); ?></strong>
+	</p>
+	<form method="POST">
+		<input type="hidden" name="<?php echo \esc_attr( $delete_account_form ); ?>" value="<?php echo \esc_attr( $nonce_value ); ?>">
+		<input type="hidden" name="token" value="<?php echo \esc_attr( $token ); ?>">
+		<input type="hidden" name="confirm_delete" value="1" />
+		<button type="submit" class="woocommerce-Button button">
+			<?php esc_html_e( 'Delete Account', 'newspack' ); ?>
+		</button>
+	</form>
+</div>
+
+<?php \do_action( 'woocommerce_after_edit_account_form' ); ?>

--- a/includes/reader-revenue/templates/myaccount-delete-account.php
+++ b/includes/reader-revenue/templates/myaccount-delete-account.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * My Account page before account has been verified.
- * The user will be asked to verify before they can manage account settings.
+ * My Account page for reader account deletion.
  *
  * @package Newspack
  */

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
 \do_action( 'woocommerce_before_edit_account_form' );
 
 $newspack_reset_password_arg = WooCommerce_My_Account::RESET_PASSWORD_URL_PARAM;
+$newspack_delete_account_arg = WooCommerce_My_Account::DELETE_ACCOUNT_URL_PARAM;
 
 $message = false;
 if ( isset( $_GET['message'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -67,10 +68,26 @@ endif;
 	<?php \do_action( 'woocommerce_edit_account_form_end' ); ?>
 </form>
 
+<hr />
+
+<h3><?php \esc_html_e( 'Reset Password', 'newspack' ); ?></h3>
+
 <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
 	<a href="<?php echo '?' . \esc_attr( $newspack_reset_password_arg ) . '=' . \esc_attr( \wp_create_nonce( $newspack_reset_password_arg ) ); ?>">
 		<?php \esc_html_e( 'Email me a password reset link', 'newspack' ); ?>
 	</a>
 </p>
+
+<hr />
+
+<h3><?php \esc_html_e( 'Delete Account', 'newspack' ); ?></h3>
+
+<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+	<a href="<?php echo '?' . \esc_attr( $newspack_delete_account_arg ) . '=' . \esc_attr( \wp_create_nonce( $newspack_delete_account_arg ) ); ?>">
+		<?php \esc_html_e( 'Email me a link for account deletion', 'newspack' ); ?>
+	</a>
+</p>
+
+<?php \do_action( 'woocommerce_delete_account_form' ); ?>
 
 <?php \do_action( 'woocommerce_after_edit_account_form' ); ?>

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -84,7 +84,7 @@ endif;
 
 <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
 	<a href="<?php echo '?' . \esc_attr( $newspack_delete_account_arg ) . '=' . \esc_attr( \wp_create_nonce( $newspack_delete_account_arg ) ); ?>">
-		<?php \esc_html_e( 'Email me a link for account deletion', 'newspack' ); ?>
+		<?php \esc_html_e( 'Request account deletion', 'newspack' ); ?>
 	</a>
 </p>
 

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -88,6 +88,4 @@ endif;
 	</a>
 </p>
 
-<?php \do_action( 'woocommerce_delete_account_form' ); ?>
-
 <?php \do_action( 'woocommerce_after_edit_account_form' ); ?>

--- a/includes/templates/reader-activation/login-form.php
+++ b/includes/templates/reader-activation/login-form.php
@@ -9,4 +9,12 @@
 
 namespace Newspack;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+\do_action( 'woocommerce_before_customer_login_form' );
+
 Reader_Activation::render_auth_form( true );
+
+\do_action( 'woocommerce_after_customer_login_form' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allow the reader to delete their own account through email confirmation.

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/820752/184413526-be817ae6-35fd-4ef0-8d12-579e75f15436.png">

<img width="694" alt="image" src="https://user-images.githubusercontent.com/820752/184413612-1f073d16-a139-4318-b590-d821ad97cf36.png">

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/820752/184413717-0776efa1-5721-481a-9628-e81e612a9233.png">

This PR also implements ESP synchronization options:

 - Reader metadata synchronization
 - Delete from ESP on reader deletion

<img width="1130" alt="image" src="https://user-images.githubusercontent.com/820752/184721454-0ad7b145-1887-4f16-bf8a-067cfe5bc8a0.png">

Question for @Automattic/newspack-product: the ESP synced deletion only occurs when readers self-delete their account (which triggers `Reader_Activation::delete_reader()`). The regular `wp_delete_user()`, which is used by admins on the WP dashboard, does not. Should we reconsider this?

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-newsletters/pull/929
2. Make sure you have RAS activated and Newsletters setup with ActiveCampaign
3. Visit the Engagement wizard and confirm the default options are set (sync and delete enabled)
4. Using a Registration Block, register a new account subscribed to the lists
5. Confirm the account is created on the ESP with RAS metadata
6. Access the "My Account" page, confirm the email, and scroll down to request account deletion
7. Click on the received email and confirm you access a confirmation page
8. Click to delete and confirm you're redirected to the sign-in form
9. Confirm on the ESP dashboard that the contact has been deleted as well
10. Disable synchronization and repeat steps 4-9, this time confirm the contact is subscribed to the list but:
    1. without RAS metadata
    2. preserved after reader deletion
12. Re-enable sync, change your ESP to Mailchimp, update your block to use Mailchimp's lists, and repeat steps 4-9

Closes #1892
Closes #1893

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->