### PR TITLE
feat: new option for minimum donation amount

### DIFF
--- a/assets/wizards/readerRevenue/components/money-input/index.js
+++ b/assets/wizards/readerRevenue/components/money-input/index.js
@@ -21,7 +21,7 @@ class MoneyInput extends Component {
 	 * Render.
 	 */
 	render() {
-		const { currencySymbol, label, value, onChange, min } = this.props;
+		const { currencySymbol, error, label, min, value, onChange } = this.props;
 
 		return (
 			<div className="newspack-donations-wizard__money-input-container">
@@ -30,13 +30,14 @@ class MoneyInput extends Component {
 					<div className="currency">{ currencySymbol }</div>
 					<TextControl
 						type="number"
-						min={ min }
-						label={ label }
 						hideLabelFromVision
+						label={ label }
+						min={ min }
 						value={ value }
 						onChange={ onChange }
 					/>
 				</div>
+				{ error && <p className="newspack-donations-wizard__money-input-error">{ error }</p> }
 			</div>
 		);
 	}

--- a/assets/wizards/readerRevenue/components/money-input/index.js
+++ b/assets/wizards/readerRevenue/components/money-input/index.js
@@ -21,7 +21,7 @@ class MoneyInput extends Component {
 	 * Render.
 	 */
 	render() {
-		const { currencySymbol, label, value, onChange } = this.props;
+		const { currencySymbol, label, value, onChange, min } = this.props;
 
 		return (
 			<div className="newspack-donations-wizard__money-input-container">
@@ -30,7 +30,7 @@ class MoneyInput extends Component {
 					<div className="currency">{ currencySymbol }</div>
 					<TextControl
 						type="number"
-						min="0"
+						min={ min }
 						label={ label }
 						hideLabelFromVision
 						value={ value }

--- a/assets/wizards/readerRevenue/components/money-input/style.scss
+++ b/assets/wizards/readerRevenue/components/money-input/style.scss
@@ -48,5 +48,10 @@
 				margin: 0 0 8px;
 			}
 		}
+
+		&-error {
+			color: wp-colors.$alert-red;
+			padding-top: 8px;
+		}
 	}
 }

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -53,7 +53,7 @@ type WizardData = {
 				};
 				currencySymbol: string;
 				tiered: boolean;
-				minimumDonation: number;
+				minimumDonation: string;
 		  };
 	donation_page: {
 		editUrl: string;
@@ -83,6 +83,9 @@ export const DonationAmounts = () => {
 		key: slug,
 		...FREQUENCIES[ slug ],
 	} ) );
+
+	// Minimum donation is returned by the REST API as a string.
+	const minimumDonationFloat = parseFloat( minimumDonation );
 
 	return (
 		<>
@@ -132,34 +135,46 @@ export const DonationAmounts = () => {
 											<MoneyInput
 												currencySymbol={ currencySymbol }
 												label={ __( 'Low-tier' ) }
-												value={
-													amounts[ section.key ][ 0 ] >= minimumDonation
-														? amounts[ section.key ][ 0 ]
-														: minimumDonation
+												error={
+													amounts[ section.key ][ 0 ] < minimumDonationFloat
+														? __(
+																'Warning: suggested donations should be at least the minimum donation amount.',
+																'newspack'
+														  )
+														: null
 												}
-												min={ minimumDonation }
+												value={ amounts[ section.key ][ 0 ] }
+												min={ minimumDonationFloat }
 												onChange={ changeHandler( [ 'amounts', section.key, 0 ] ) }
 											/>
 											<MoneyInput
 												currencySymbol={ currencySymbol }
 												label={ __( 'Mid-tier' ) }
-												value={
-													amounts[ section.key ][ 1 ] >= minimumDonation
-														? amounts[ section.key ][ 1 ]
-														: minimumDonation
+												error={
+													amounts[ section.key ][ 1 ] < minimumDonationFloat
+														? __(
+																'Warning: suggested donations should be at least the minimum donation amount.',
+																'newspack'
+														  )
+														: null
 												}
-												min={ minimumDonation }
+												value={ amounts[ section.key ][ 1 ] }
+												min={ minimumDonationFloat }
 												onChange={ changeHandler( [ 'amounts', section.key, 1 ] ) }
 											/>
 											<MoneyInput
 												currencySymbol={ currencySymbol }
 												label={ __( 'High-tier' ) }
-												value={
-													amounts[ section.key ][ 2 ] >= minimumDonation
-														? amounts[ section.key ][ 2 ]
-														: minimumDonation
+												error={
+													amounts[ section.key ][ 2 ] < minimumDonationFloat
+														? __(
+																'Warning: suggested donations should be at least the minimum donation amount.',
+																'newspack'
+														  )
+														: null
 												}
-												min={ minimumDonation }
+												value={ amounts[ section.key ][ 2 ] }
+												min={ minimumDonationFloat }
 												onChange={ changeHandler( [ 'amounts', section.key, 2 ] ) }
 											/>
 										</Grid>
@@ -178,9 +193,9 @@ export const DonationAmounts = () => {
 								label={ section.staticLabel }
 								value={ amounts[ section.key ][ 3 ] }
 								min={
-									amounts[ section.key ][ 3 ] >= minimumDonation
+									amounts[ section.key ][ 3 ] >= minimumDonationFloat
 										? amounts[ section.key ][ 3 ]
-										: minimumDonation
+										: minimumDonationFloat
 								}
 								onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
 								key={ section.key }
@@ -202,7 +217,7 @@ export const DonationAmounts = () => {
 					label={ __( 'Minimum donation', 'newspack' ) }
 					type="number"
 					min={ 1 }
-					value={ minimumDonation }
+					value={ minimumDonationFloat }
 					onChange={ value => changeHandler( [ 'minimumDonation' ] )( value ) }
 				/>
 			</Card>

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -192,10 +192,14 @@ export const DonationAmounts = () => {
 								currencySymbol={ currencySymbol }
 								label={ section.staticLabel }
 								value={ amounts[ section.key ][ 3 ] }
-								min={
-									amounts[ section.key ][ 3 ] >= minimumDonationFloat
-										? amounts[ section.key ][ 3 ]
-										: minimumDonationFloat
+								min={ minimumDonationFloat }
+								error={
+									amounts[ section.key ][ 3 ] < minimumDonationFloat
+										? __(
+												'Warning: suggested donations should be at least the minimum donation amount.',
+												'newspack'
+										  )
+										: null
 								}
 								onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
 								key={ section.key }

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -132,21 +132,33 @@ export const DonationAmounts = () => {
 											<MoneyInput
 												currencySymbol={ currencySymbol }
 												label={ __( 'Low-tier' ) }
-												value={ amounts[ section.key ][ 0 ] }
+												value={
+													amounts[ section.key ][ 0 ] >= minimumDonation
+														? amounts[ section.key ][ 0 ]
+														: minimumDonation
+												}
 												min={ minimumDonation }
 												onChange={ changeHandler( [ 'amounts', section.key, 0 ] ) }
 											/>
 											<MoneyInput
 												currencySymbol={ currencySymbol }
 												label={ __( 'Mid-tier' ) }
-												value={ amounts[ section.key ][ 1 ] }
+												value={
+													amounts[ section.key ][ 1 ] >= minimumDonation
+														? amounts[ section.key ][ 1 ]
+														: minimumDonation
+												}
 												min={ minimumDonation }
 												onChange={ changeHandler( [ 'amounts', section.key, 1 ] ) }
 											/>
 											<MoneyInput
 												currencySymbol={ currencySymbol }
 												label={ __( 'High-tier' ) }
-												value={ amounts[ section.key ][ 2 ] }
+												value={
+													amounts[ section.key ][ 2 ] >= minimumDonation
+														? amounts[ section.key ][ 2 ]
+														: minimumDonation
+												}
 												min={ minimumDonation }
 												onChange={ changeHandler( [ 'amounts', section.key, 2 ] ) }
 											/>
@@ -165,7 +177,11 @@ export const DonationAmounts = () => {
 								currencySymbol={ currencySymbol }
 								label={ section.staticLabel }
 								value={ amounts[ section.key ][ 3 ] }
-								min={ minimumDonation }
+								min={
+									amounts[ section.key ][ 3 ] >= minimumDonation
+										? amounts[ section.key ][ 3 ]
+										: minimumDonation
+								}
 								onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
 								key={ section.key }
 							/>

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -16,6 +16,7 @@ import {
 	Notice,
 	SectionHeader,
 	SelectControl,
+	TextControl,
 	Wizard,
 } from '../../../../components/src';
 import { READER_REVENUE_WIZARD_SLUG } from '../../constants';
@@ -52,6 +53,7 @@ type WizardData = {
 				};
 				currencySymbol: string;
 				tiered: boolean;
+				minimumDonation: number;
 		  };
 	donation_page: {
 		editUrl: string;
@@ -67,7 +69,8 @@ export const DonationAmounts = () => {
 		return null;
 	}
 
-	const { amounts, currencySymbol, tiered, disabledFrequencies } = wizardData.donation_data;
+	const { amounts, currencySymbol, tiered, disabledFrequencies, minimumDonation } =
+		wizardData.donation_data;
 
 	const changeHandler = path => value =>
 		updateWizardSettings( {
@@ -166,6 +169,23 @@ export const DonationAmounts = () => {
 					</Grid>
 				</Card>
 			) }
+			<Card headerActions noBorder>
+				<SectionHeader
+					title={ __( 'Minimum Donation', 'newspack' ) }
+					description={ __(
+						'Set minimum donation amount. Setting a reasonable minimum donation amount can help protect your site from bot attacks.',
+						'newspack'
+					) }
+					noMargin
+				/>
+				<TextControl
+					label={ __( 'Minimum donation', 'newspack' ) }
+					type="number"
+					min={ 1 }
+					value={ minimumDonation }
+					onChange={ value => changeHandler( [ 'minimumDonation' ] )( value ) }
+				/>
+			</Card>
 		</>
 	);
 };

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -133,18 +133,21 @@ export const DonationAmounts = () => {
 												currencySymbol={ currencySymbol }
 												label={ __( 'Low-tier' ) }
 												value={ amounts[ section.key ][ 0 ] }
+												min={ minimumDonation }
 												onChange={ changeHandler( [ 'amounts', section.key, 0 ] ) }
 											/>
 											<MoneyInput
 												currencySymbol={ currencySymbol }
 												label={ __( 'Mid-tier' ) }
 												value={ amounts[ section.key ][ 1 ] }
+												min={ minimumDonation }
 												onChange={ changeHandler( [ 'amounts', section.key, 1 ] ) }
 											/>
 											<MoneyInput
 												currencySymbol={ currencySymbol }
 												label={ __( 'High-tier' ) }
 												value={ amounts[ section.key ][ 2 ] }
+												min={ minimumDonation }
 												onChange={ changeHandler( [ 'amounts', section.key, 2 ] ) }
 											/>
 										</Grid>
@@ -162,6 +165,7 @@ export const DonationAmounts = () => {
 								currencySymbol={ currencySymbol }
 								label={ section.staticLabel }
 								value={ amounts[ section.key ][ 3 ] }
+								min={ minimumDonation }
 								onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
 								key={ section.key }
 							/>

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -135,6 +135,7 @@ class Donations {
 				'year'  => false,
 			],
 			'platform'            => self::get_platform_slug(),
+			'minimumDonation'     => 5.0,
 		];
 	}
 
@@ -344,6 +345,11 @@ class Donations {
 			$parsed_settings['amounts'][ $frequency ] = array_map( 'floatval', $amounts );
 		}
 
+		// Ensure a minimum donation amount is set.
+		if ( ! isset( $saved_settings['minimumDonation'] ) && self::is_platform_wc() ) {
+			self::update_donation_product( [ 'minimumDonation' => $settings['minimumDonation'] ] );
+		}
+
 		return $parsed_settings;
 	}
 
@@ -376,7 +382,7 @@ class Donations {
 	 *
 	 * @param array $args Info that will be used to create the products.
 	 */
-	private static function update_donation_product( $args = [] ) {
+	public static function update_donation_product( $args = [] ) {
 		$defaults      = self::get_donation_default_settings();
 		$configuration = wp_parse_args( $args, $defaults );
 
@@ -426,7 +432,7 @@ class Donations {
 			$child_product->set_name( $product_name );
 			$child_product->set_regular_price( $price );
 			$child_product->update_meta_data( '_suggested_price', $price );
-			$child_product->update_meta_data( '_min_price', wc_format_decimal( 1.0 ) );
+			$child_product->update_meta_data( '_min_price', wc_format_decimal( $configuration['minimumDonation'] ) );
 			$child_product->update_meta_data( '_hide_nyp_minimum', 'yes' );
 			$child_product->update_meta_data( '_nyp', 'yes' );
 			$child_product->set_virtual( true );

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -275,6 +275,12 @@ class Reader_Revenue_Wizard extends Wizard {
 			}
 			update_option( NEWSPACK_NRH_CONFIG, $nrh_config );
 		}
+
+		// Ensure that any Reader Revenue settings changed while the platform wasn't WC are persisted to WC products.
+		if ( 'wc' === $platform ) {
+			Donations::update_donation_product( Donations::get_donation_settings() );
+		}
+
 		return \rest_ensure_response( $this->fetch_all_data() );
 	}
 

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -277,7 +277,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		}
 
 		// Ensure that any Reader Revenue settings changed while the platform wasn't WC are persisted to WC products.
-		if ( 'wc' === $platform ) {
+		if ( Donations::is_platform_wc() ) {
 			Donations::update_donation_product( Donations::get_donation_settings() );
 		}
 

--- a/tests/unit-tests/donations.php
+++ b/tests/unit-tests/donations.php
@@ -41,6 +41,7 @@ class Newspack_Test_Donations extends WP_UnitTestCase {
 				'tiered',
 				'disabledFrequencies',
 				'platform',
+				'minimumDonation',
 				'currencySymbol',
 			],
 			array_keys( $donation_settings ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Establishes a new donation setting in the Reader Revenue wizard for "minimum donation", with a default value of `5`. This setting applies to both WC and Stripe platforms and fails donate block form submissions if the donation amount submitted is less than this minimum. Also ensures that the minimum value is updated to `5` automatically for all sites, so that no publisher input will be required for the new default to take effect.

Closes #1886 and https://github.com/Automattic/newspack-blocks/issues/1211.

### How to test the changes in this Pull Request:

1. On `master` on a site with Reader Revenue platform set to Stripe, publish a page with a Donate block.
2. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/1239.
3. In the Newspack dashboard, visit **Reader Revenue > Donations**. Confirm there's a new setting for minimum donation toward the bottom of this page with a default value of `5`. Don't update the setting yet.

<img width="780" alt="Screen Shot 2022-08-15 at 12 36 31 PM" src="https://user-images.githubusercontent.com/2230142/184695245-1470a115-94ad-4cd8-9cde-1d4bb7c14a42.png">

4. On the page with your Donate block, try to submit a donation with an amount less than $5. (You may have to use the "other" option and input the value yourself.) Confirm that the donation fails with an error message.
5. In the Donations settings page, change the minimum donation amount to another value. Confirm that:
  a. The values for other amounts (tiered and untiered) can't be set below the minimum amount.
  b. If increasing the minimum amount to a value above any other amounts, those amounts are updated to match the minimum value. (This is to ensure that you can't create a Donate block with suggested amounts that would be below the minimum donation, and trigger an error message.)
6. Save settings and repeat step 4. Confirm that the block now errors out at your new minimum value.
7. Edit the page with the block and toggle on the "Configure manually" option.
8. Confirm that there's a new block attribute setting for "Minimum donation" and that it behaves identically to the option in the Reader Revenue wizard (e.g. repeat step 5 in block settings).
9. Save the block and repeat step 4. Confirm that the block now errors out at the minimum value set in block attributes, instead of the value set in the Reader Revenue wizard.
10. Switch your Reader Revenue platform to "Newspack" (WooCommerce) and repeat steps 3–9. On a site using WC, the Donate block should error out before you get to the checkout page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->