### PR TITLE
feat: honeypot trap for auth and registration forms

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -166,12 +166,12 @@ function render_block( $attrs, $content ) {
 								<?php Reader_Activation::render_honeypot_field( $attrs['placeholder'] ); ?>
 								<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
 							</div>
+							<?php Reader_Activation::render_third_party_auth(); ?>
 							<div class="newspack-registration__response <?php echo ( empty( $message ) ) ? 'newspack-registration--hidden' : null; ?>">
 								<?php if ( ! empty( $message ) ) : ?>
 									<p><?php echo \esc_html( $message ); ?></p>
 								<?php endif; ?>
 							</div>
-							<?php Reader_Activation::render_third_party_auth(); ?>
 						</div>
 
 						<div class="newspack-registration__help-text">

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -163,7 +163,7 @@ function render_block( $attrs, $content ) {
 						<div>
 							<div class="newspack-registration__inputs">
 								<input type="email" name="npe" autocomplete="email" placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>" />
-								<input class="nphp" tabindex="-1" aria-hidden="true" type="email" name="email" autocomplete="email" placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>" />
+								<?php Reader_Activation::render_honeypot_field( $attrs['placeholder'] ); ?>
 								<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
 							</div>
 							<div class="newspack-registration__response <?php echo ( empty( $message ) ) ? 'newspack-registration--hidden' : null; ?>">

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -279,7 +279,10 @@ function process_form() {
 		);
 	}
 
-	if ( ! isset( $_REQUEST['npe'] ) || empty( $_REQUEST['npe'] ) ) {
+	// Note that that the "true" email address field is called `npe` due to the honeypot strategy.
+	// The honeypot field is called `email` to hopefully capture bots that might be looking for such a field.
+	$email = isset( $_REQUEST['npe'] ) ? \sanitize_email( $_REQUEST['npe'] ) : '';
+	if ( empty( $email ) ) {
 		return send_form_response( new \WP_Error( 'invalid_email', __( 'You must enter a valid email address.', 'newspack' ) ) );
 	}
 
@@ -290,7 +293,6 @@ function process_form() {
 	}
 	$metadata['current_page_url']    = home_url( add_query_arg( array(), \wp_get_referer() ) );
 	$metadata['registration_method'] = 'registration-block';
-	$email                           = \sanitize_email( $_REQUEST['npe'] );
 
 	$user_id = Reader_Activation::register_reader( $email, '', true, $metadata );
 

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -162,15 +162,16 @@ function render_block( $attrs, $content ) {
 					<div class="newspack-registration__main">
 						<div>
 							<div class="newspack-registration__inputs">
-								<input type="email" name="email" autocomplete="email" placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>" />
+								<input type="email" name="npe" autocomplete="email" placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>" />
+								<input class="nphp" tabindex="-1" aria-hidden="true" type="email" name="email" autocomplete="email" placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>" />
 								<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
 							</div>
-							<?php Reader_Activation::render_third_party_auth(); ?>
 							<div class="newspack-registration__response <?php echo ( empty( $message ) ) ? 'newspack-registration--hidden' : null; ?>">
 								<?php if ( ! empty( $message ) ) : ?>
 									<p><?php echo \esc_html( $message ); ?></p>
 								<?php endif; ?>
 							</div>
+							<?php Reader_Activation::render_third_party_auth(); ?>
 						</div>
 
 						<div class="newspack-registration__help-text">
@@ -267,7 +268,12 @@ function process_form() {
 		return;
 	}
 
-	if ( ! isset( $_REQUEST['email'] ) || empty( $_REQUEST['email'] ) ) {
+	// Honeypot trap.
+	if ( ! empty( $_REQUEST['email'] ) ) {
+		return send_form_response( new \WP_Error( 'invalid_request', __( 'Invalid request.', 'newspack' ) ) );
+	}
+
+	if ( ! isset( $_REQUEST['npe'] ) || empty( $_REQUEST['npe'] ) ) {
 		return send_form_response( new \WP_Error( 'invalid_email', __( 'You must enter a valid email address.', 'newspack' ) ) );
 	}
 
@@ -278,7 +284,7 @@ function process_form() {
 	}
 	$metadata['current_page_url']    = home_url( add_query_arg( array(), \wp_get_referer() ) );
 	$metadata['registration_method'] = 'registration-block';
-	$email                           = \sanitize_email( $_REQUEST['email'] );
+	$email                           = \sanitize_email( $_REQUEST['npe'] );
 
 	$user_id = Reader_Activation::register_reader( $email, '', true, $metadata );
 

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -270,7 +270,13 @@ function process_form() {
 
 	// Honeypot trap.
 	if ( ! empty( $_REQUEST['email'] ) ) {
-		return send_form_response( new \WP_Error( 'invalid_request', __( 'Invalid request.', 'newspack' ) ) );
+		return send_form_response(
+			[
+				'email'         => \sanitize_email( $_REQUEST['email'] ),
+				'authenticated' => true,
+				'existing_user' => false,
+			]
+		);
 	}
 
 	if ( ! isset( $_REQUEST['npe'] ) || empty( $_REQUEST['npe'] ) ) {

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -1,4 +1,5 @@
 @use '~@wordpress/base-styles/colors' as wp-colors;
+@use '../../shared/scss/mixins';
 
 .newspack-registration {
 	@media ( min-width: 782px ) {
@@ -151,6 +152,10 @@
 
 	+ div:empty {
 		display: none;
+	}
+
+	.nphp {
+		@include mixins.visuallyHidden;
 	}
 }
 

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -47,12 +47,14 @@ function domReady( callback ) {
 			} );
 
 			form.startLoginFlow = () => {
+				messageElement.classList.add( 'newspack-registration--hidden' );
 				messageElement.innerHTML = '';
 				submitElement.disabled = true;
 				container.classList.add( 'newspack-registration--in-progress' );
 			};
 
-			form.endLoginFlow = ( message, status, data ) => {
+			form.endLoginFlow = ( message = null, status = 500, data = null ) => {
+				console.log( message, status );
 				let messageNode;
 
 				if ( data?.existing_user ) {
@@ -82,6 +84,7 @@ function domReady( callback ) {
 					}
 				} else if ( messageNode ) {
 					messageElement.appendChild( messageNode );
+					messageElement.classList.remove( 'newspack-registration--hidden' );
 				}
 				submitElement.disabled = false;
 				container.classList.remove( 'newspack-registration--in-progress' );
@@ -90,7 +93,7 @@ function domReady( callback ) {
 			form.addEventListener( 'submit', ev => {
 				ev.preventDefault();
 				const body = new FormData( form );
-				if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
+				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 					return;
 				}
 				form.startLoginFlow();
@@ -106,7 +109,10 @@ function domReady( callback ) {
 							.json()
 							.then( ( { message, data } ) => form.endLoginFlow( message, res.status, data ) );
 					} )
-					.finally( form.endLoginFlow );
+					.catch( e => {
+						console.log( e );
+						form.endLoginFlow( e, 400 );
+					} );
 			} );
 		} );
 	} );

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -110,7 +110,6 @@ function domReady( callback ) {
 							.then( ( { message, data } ) => form.endLoginFlow( message, res.status, data ) );
 					} )
 					.catch( e => {
-						console.log( e );
 						form.endLoginFlow( e, 400 );
 					} );
 			} );

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -54,7 +54,6 @@ function domReady( callback ) {
 			};
 
 			form.endLoginFlow = ( message = null, status = 500, data = null ) => {
-				console.log( message, status );
 				let messageNode;
 
 				if ( data?.existing_user ) {

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -93,7 +93,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 
 			allContainers.forEach( container => {
 				const form = container.querySelector( 'form' );
-				const emailInput = container.querySelector( 'input[name="email"]' );
+				const emailInput = container.querySelector( 'input[name="npe"]' );
 				const redirectInput = container.querySelector( 'input[name="redirect"]' );
 				const reader = readerActivation.getReader();
 
@@ -151,7 +151,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			ev.preventDefault();
 
 			const authLinkMessage = container.querySelector( '[data-has-auth-link]' );
-			const emailInput = container.querySelector( 'input[name="email"]' );
+			const emailInput = container.querySelector( 'input[name="npe"]' );
 			const redirectInput = container.querySelector( 'input[name="redirect"]' );
 			const passwordInput = container.querySelector( 'input[name="password"]' );
 			const actionInput = container.querySelector( 'input[name="action"]' );
@@ -200,7 +200,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			}
 
 			const actionInput = form.querySelector( 'input[name="action"]' );
-			const emailInput = form.querySelector( 'input[name="email"]' );
+			const emailInput = form.querySelector( 'input[name="npe"]' );
 			const passwordInput = form.querySelector( 'input[name="password"]' );
 			const submitButtons = form.querySelectorAll( '[type="submit"]' );
 			const closeButton = container.querySelector( 'button[data-close]' );
@@ -299,10 +299,10 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			form.addEventListener( 'submit', function ( ev ) {
 				ev.preventDefault();
 				const body = new FormData( ev.target );
-				if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
+				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 					return;
 				}
-				readerActivation.setReaderEmail( body.get( 'email' ) );
+				readerActivation.setReaderEmail( body.get( 'npe' ) );
 				form.startLoginFlow();
 				fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 					method: 'POST',

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -1,5 +1,6 @@
 @use 'sass:color';
 @use '~@wordpress/base-styles/colors' as wp-colors;
+@use '../shared/scss/mixins';
 
 .newspack-reader {
 	/**
@@ -30,16 +31,7 @@
 		&__label {
 			margin-left: 0.2rem;
 			@media screen and ( max-width: 959px ) {
-				border: 0;
-				clip: rect( 1px, 1px, 1px, 1px );
-				clip-path: inset( 50% );
-				height: 1px;
-				margin: -1px;
-				overflow: hidden;
-				padding: 0;
-				position: absolute !important;
-				width: 1px;
-				word-wrap: normal !important;
+				@include mixins.visuallyHidden;
 			}
 		}
 	}
@@ -75,6 +67,10 @@
 			position: relative;
 			width: auto;
 			z-index: auto;
+		}
+
+		.nphp {
+			@include mixins.visuallyHidden;
 		}
 
 		&[data-form-status='200'] {

--- a/assets/shared/scss/_mixins.scss
+++ b/assets/shared/scss/_mixins.scss
@@ -1,0 +1,12 @@
+@mixin visuallyHidden {
+	border: 0;
+	clip: rect( 1px, 1px, 1px, 1px );
+	clip-path: inset( 50% );
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
+	word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+}

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -964,7 +964,7 @@ final class Reader_Activation {
 			return self::send_auth_form_response(
 				[
 					'email'         => $honeypot,
-					'authenticated' => \wp_rand( 1000000, PHP_INT_MAX ),
+					'authenticated' => 1,
 				]
 			);
 		}

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -945,7 +945,12 @@ final class Reader_Activation {
 
 		// Honeypot trap.
 		if ( ! empty( $honeypot ) ) {
-			return self::send_auth_form_response( new \WP_Error( 'invalid_request', __( 'Invalid request.', 'newspack' ) ) );
+			return self::send_auth_form_response(
+				[
+					'email'         => $honeypot,
+					'authenticated' => \wp_rand( 1000000 ),
+				]
+			);
 		}
 
 		if ( ! in_array( $action, self::AUTH_FORM_OPTIONS, true ) ) {

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -956,7 +956,7 @@ final class Reader_Activation {
 		$password = isset( $_POST['password'] ) ? \sanitize_text_field( $_POST['password'] ) : '';
 		$redirect = isset( $_POST['redirect'] ) ? \esc_url_raw( $_POST['redirect'] ) : '';
 		$lists    = isset( $_POST['lists'] ) ? array_map( 'sanitize_text_field', $_POST['lists'] ) : [];
-		$honeypot = isset( $_POST['email'] ) ? \sanitize_email( $_POST['email'] ) : '';
+		$honeypot = isset( $_POST['email'] ) ? \sanitize_text_field( $_POST['email'] ) : '';
 		// phpcs:enable
 
 		// Honeypot trap.

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -652,7 +652,8 @@ final class Reader_Activation {
 							</div>
 						<?php endif; ?>
 						<div class="components-form__field">
-							<input name="email" type="email" placeholder="<?php \esc_attr_e( 'Enter your email address', 'newspack' ); ?>" />
+							<input name="npe" type="email" placeholder="<?php \esc_attr_e( 'Enter your email address', 'newspack' ); ?>" />
+							<input class="nphp" tabindex="-1" aria-hidden="true" name="email" type="email" placeholder="<?php \esc_attr_e( 'Enter your email address', 'newspack' ); ?>" />
 						</div>
 						<div class="components-form__field" data-action="pwd">
 							<input name="password" type="password" placeholder="<?php \esc_attr_e( 'Enter your password', 'newspack' ); ?>" />
@@ -899,11 +900,17 @@ final class Reader_Activation {
 			return;
 		}
 		$action   = isset( $_POST['action'] ) ? \sanitize_text_field( $_POST['action'] ) : '';
-		$email    = isset( $_POST['email'] ) ? \sanitize_email( $_POST['email'] ) : '';
+		$email    = isset( $_POST['npe'] ) ? \sanitize_email( $_POST['npe'] ) : '';
 		$password = isset( $_POST['password'] ) ? \sanitize_text_field( $_POST['password'] ) : '';
 		$redirect = isset( $_POST['redirect'] ) ? \esc_url_raw( $_POST['redirect'] ) : '';
 		$lists    = isset( $_POST['lists'] ) ? array_map( 'sanitize_text_field', $_POST['lists'] ) : [];
+		$honeypot = isset( $_POST['email'] ) ? \sanitize_email( $_POST['email'] ) : '';
 		// phpcs:enable
+
+		// Honeypot trap.
+		if ( ! empty( $honeypot ) ) {
+			return self::send_auth_form_response( new \WP_Error( 'invalid_request', __( 'Invalid request.', 'newspack' ) ) );
+		}
 
 		if ( ! in_array( $action, self::AUTH_FORM_OPTIONS, true ) ) {
 			return self::send_auth_form_response( new \WP_Error( 'invalid_request', __( 'Invalid request.', 'newspack' ) ) );

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -598,6 +598,22 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Render a honeypot field to guard against bot form submissions. Note that
+	 * this field is named `email` to hopefully catch more bots who might be
+	 * looking for such fields, where as the "real" field is named "npe".
+	 *
+	 * @param string $placeholder Placeholder text to render in the field.
+	 */
+	public static function render_honeypot_field( $placeholder = '' ) {
+		if ( empty( $placeholder ) ) {
+			$placeholder = __( 'Enter your email address', 'newspack' );
+		}
+		?>
+		<input class="nphp" tabindex="-1" aria-hidden="true" name="email" type="email" placeholder="<?php echo \esc_attr( $placeholder ); ?>" />
+		<?php
+	}
+
+	/**
 	 * Renders reader authentication form.
 	 *
 	 * @param boolean $is_inline If true, render the form inline, otherwise render as a modal.
@@ -689,7 +705,7 @@ final class Reader_Activation {
 						<?php endif; ?>
 						<div class="components-form__field">
 							<input name="npe" type="email" placeholder="<?php \esc_attr_e( 'Enter your email address', 'newspack' ); ?>" />
-							<input class="nphp" tabindex="-1" aria-hidden="true" name="email" type="email" placeholder="<?php \esc_attr_e( 'Enter your email address', 'newspack' ); ?>" />
+							<?php self::render_honeypot_field(); ?>
 						</div>
 						<div class="components-form__field" data-action="pwd">
 							<input name="password" type="password" placeholder="<?php \esc_attr_e( 'Enter your password', 'newspack' ); ?>" />

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -948,7 +948,7 @@ final class Reader_Activation {
 			return self::send_auth_form_response(
 				[
 					'email'         => $honeypot,
-					'authenticated' => \wp_rand( 1000000 ),
+					'authenticated' => \wp_rand( 1000000, PHP_INT_MAX ),
 				]
 			);
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements honeypot fields for Reader Activation auth and registration forms. If one of these visually hidden fields is filled out, the form will respond with a success message/state (hopefully satisfying any bots' conditions for success), but the auth/registration actions will not occur on the back-end and any data inputted will be silently discarded.

### How to test the changes in this Pull Request:

1. Check out this branch. Confirm that registration and login forms look and function as normal.
2. Temporarily comment out [this SCSS line](https://github.com/Automattic/newspack-plugin/pull/1896/files#diff-ad8f105e75602587030464b8bc3c60d5f456d371d43c43f76f48e9c21d50886dR158) and [this one](https://github.com/Automattic/newspack-plugin/pull/1896/files#diff-b97350f2168c727d03377092125570004f9fecf32bd45a8ac3433040ab230f4dR34) to unhide the honeypot fields.
3. Note a new email input field rendered alongside the usual email inputs in both registration and auth forms.
4. Test the forms, making sure to fill out both email fields, and confirm that the forms resolve and give a success message, but confirm that after navigating to a new page, you are not authenticated or preauthenticated.
5. Confirm that no new user is registered after submitting the registration form in step 4.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->