### PR TITLE
feat: use reCAPTCHA to secure all Reader Activation-related forms

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -279,6 +279,15 @@ function process_form() {
 		);
 	}
 
+	// reCAPTCHA test.
+	if ( ! empty( $_REQUEST['captcha_token'] ) ) {
+		$captcha_token  = \sanitize_text_field( $_REQUEST['captcha_token'] );
+		$captcha_result = Reader_Activation::verify_captcha( $captcha_token );
+		if ( \is_wp_error( $captcha_result ) ) {
+			return send_form_response( $captcha_result );
+		}
+	}
+
 	// Note that that the "true" email address field is called `npe` due to the honeypot strategy.
 	// The honeypot field is called `email` to hopefully capture bots that might be looking for such a field.
 	$email = isset( $_REQUEST['npe'] ) ? \sanitize_email( $_REQUEST['npe'] ) : '';

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -9,6 +9,7 @@ namespace Newspack\Blocks\ReaderRegistration;
 
 use Newspack;
 use Newspack\Reader_Activation;
+use Newspack\Recaptcha;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -280,9 +281,9 @@ function process_form() {
 	}
 
 	// reCAPTCHA test.
-	if ( ! empty( $_REQUEST['captcha_token'] ) ) {
-		$captcha_token  = \sanitize_text_field( $_REQUEST['captcha_token'] );
-		$captcha_result = Reader_Activation::verify_captcha( $captcha_token );
+	if ( Recaptcha::can_use_captcha() ) {
+		$captcha_token  = isset( $_REQUEST['captcha_token'] ) ? \sanitize_text_field( $_REQUEST['captcha_token'] ) : '';
+		$captcha_result = Recaptcha::verify_captcha( $captcha_token );
 		if ( \is_wp_error( $captcha_result ) ) {
 			return send_form_response( $captcha_result );
 		}

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -89,8 +89,22 @@ function domReady( callback ) {
 				container.classList.remove( 'newspack-registration--in-progress' );
 			};
 
-			form.addEventListener( 'submit', ev => {
+			form.addEventListener( 'submit', async ev => {
 				ev.preventDefault();
+
+				try {
+					const captchaToken = await readerActivation.getCaptchaToken();
+					if ( captchaToken ) {
+						const tokenField = document.createElement( 'input' );
+						tokenField.setAttribute( 'type', 'hidden' );
+						tokenField.setAttribute( 'name', 'captcha_token' );
+						tokenField.value = captchaToken;
+						form.appendChild( tokenField );
+					}
+				} catch ( e ) {
+					form.endLoginFlow( e, 400 );
+				}
+
 				const body = new FormData( form );
 				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 					return;

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -296,8 +296,22 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			/**
 			 * Handle auth form submission.
 			 */
-			form.addEventListener( 'submit', function ( ev ) {
+			form.addEventListener( 'submit', async ev => {
 				ev.preventDefault();
+
+				try {
+					const captchaToken = await readerActivation.getCaptchaToken();
+					if ( captchaToken ) {
+						const tokenField = document.createElement( 'input' );
+						tokenField.setAttribute( 'type', 'hidden' );
+						tokenField.setAttribute( 'name', 'captcha_token' );
+						tokenField.value = captchaToken;
+						form.appendChild( tokenField );
+					}
+				} catch ( e ) {
+					form.endLoginFlow( e, 400 );
+				}
+
 				const body = new FormData( ev.target );
 				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 					return;

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -313,34 +313,35 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					} )
 					.catch( e => {
 						form.endLoginFlow( e, 400 );
-					} );
-
-				const body = new FormData( ev.target );
-				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
-					return;
-				}
-				readerActivation.setReaderEmail( body.get( 'npe' ) );
-				form.startLoginFlow();
-				fetch( form.getAttribute( 'action' ) || window.location.pathname, {
-					method: 'POST',
-					headers: {
-						Accept: 'application/json',
-					},
-					body,
-				} )
-					.then( res => {
-						container.setAttribute( 'data-form-status', res.status );
-						res
-							.json()
-							.then( ( { message, data } ) => {
-								form.endLoginFlow( message, res.status, data, body.get( 'redirect' ) );
+					} )
+					.finally( () => {
+						const body = new FormData( ev.target );
+						if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
+							return;
+						}
+						readerActivation.setReaderEmail( body.get( 'npe' ) );
+						form.startLoginFlow();
+						fetch( form.getAttribute( 'action' ) || window.location.pathname, {
+							method: 'POST',
+							headers: {
+								Accept: 'application/json',
+							},
+							body,
+						} )
+							.then( res => {
+								container.setAttribute( 'data-form-status', res.status );
+								res
+									.json()
+									.then( ( { message, data } ) => {
+										form.endLoginFlow( message, res.status, data, body.get( 'redirect' ) );
+									} )
+									.catch( () => {
+										form.endLoginFlow();
+									} );
 							} )
 							.catch( () => {
 								form.endLoginFlow();
 							} );
-					} )
-					.catch( () => {
-						form.endLoginFlow();
 					} );
 			} );
 		} );

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -296,21 +296,24 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			/**
 			 * Handle auth form submission.
 			 */
-			form.addEventListener( 'submit', async ev => {
+			form.addEventListener( 'submit', ev => {
 				ev.preventDefault();
 
-				try {
-					const captchaToken = await readerActivation.getCaptchaToken();
-					if ( captchaToken ) {
+				readerActivation
+					.getCaptchaToken()
+					.then( captchaToken => {
+						if ( ! captchaToken ) {
+							return;
+						}
 						const tokenField = document.createElement( 'input' );
 						tokenField.setAttribute( 'type', 'hidden' );
 						tokenField.setAttribute( 'name', 'captcha_token' );
 						tokenField.value = captchaToken;
 						form.appendChild( tokenField );
-					}
-				} catch ( e ) {
-					form.endLoginFlow( e, 400 );
-				}
+					} )
+					.catch( e => {
+						form.endLoginFlow( e, 400 );
+					} );
 
 				const body = new FormData( ev.target );
 				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -200,6 +200,32 @@ export function getAuthStrategy() {
 }
 
 /**
+ * Get a captcha token based on user input
+ */
+export async function getCaptchaToken( action = 'submit' ) {
+	return new Promise( ( res, rej ) => {
+		const { grecaptcha, newspack_reader_activation_data } = window;
+		if ( ! grecaptcha || ! newspack_reader_activation_data ) {
+			return res( '' );
+		}
+
+		const { captcha_site_key: captchaSiteKey } = newspack_reader_activation_data;
+		if ( ! grecaptcha?.ready || ! captchaSiteKey ) {
+			rej( 'Error loading the reCaptcha library.' );
+		}
+
+		grecaptcha.ready( async () => {
+			try {
+				const token = await grecaptcha.execute( captchaSiteKey, { action } );
+				return res( token );
+			} catch ( e ) {
+				rej( e );
+			}
+		} );
+	} );
+}
+
+/**
  * Initialize store data.
  */
 function init() {
@@ -222,6 +248,7 @@ const readerActivation = {
 	hasAuthLink,
 	setAuthStrategy,
 	getAuthStrategy,
+	getCaptchaToken,
 };
 window.newspackReaderActivation = readerActivation;
 

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -202,7 +202,7 @@ export function getAuthStrategy() {
 /**
  * Get a captcha token based on user input
  */
-export async function getCaptchaToken( action = 'submit' ) {
+export function getCaptchaToken( action = 'submit' ) {
 	return new Promise( ( res, rej ) => {
 		const { grecaptcha, newspack_reader_activation_data } = window;
 		if ( ! grecaptcha || ! newspack_reader_activation_data ) {
@@ -214,13 +214,11 @@ export async function getCaptchaToken( action = 'submit' ) {
 			rej( 'Error loading the reCaptcha library.' );
 		}
 
-		grecaptcha.ready( async () => {
-			try {
-				const token = await grecaptcha.execute( captchaSiteKey, { action } );
-				return res( token );
-			} catch ( e ) {
-				rej( e );
-			}
+		grecaptcha.ready( () => {
+			grecaptcha
+				.execute( captchaSiteKey, { action } )
+				.then( token => res( token ) )
+				.catch( e => rej( e ) );
 		} );
 	} );
 }

--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -14,6 +14,7 @@ import Plugins from './plugins';
 import GoogleAuth from './google';
 import Mailchimp from './mailchimp';
 import FivetranConnection from './fivetran';
+import Recaptcha from './recaptcha';
 
 const Main = () => {
 	const [ error, setError ] = useState();
@@ -32,6 +33,7 @@ const Main = () => {
 					<FivetranConnection setError={ setError } />
 				</>
 			) }
+			<Recaptcha setError={ setError } />
 		</>
 	);
 };

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl, ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -10,10 +10,11 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import {
-	Notice,
-	Grid,
-	Card,
+	ActionCard,
 	Button,
+	Card,
+	Grid,
+	Notice,
 	SectionHeader,
 	TextControl,
 	withWizardScreen,
@@ -150,6 +151,54 @@ export default withWizardScreen( () => {
 					</>
 				) }
 			</Card>
+
+			<hr />
+
+			<ActionCard
+				isMedium
+				title={ __( 'reCAPTCHA v3 Settings', 'newspack' ) }
+				description={ () => (
+					<p>
+						{ __(
+							'Enabling reCAPTCHA can help protect your site against bot attacks and credit card testing.',
+							'newspack'
+						) }{ ' ' }
+						<ExternalLink href="https://www.google.com/recaptcha/admin/create">
+							{ __( 'Get started' ) }
+						</ExternalLink>
+					</p>
+				) }
+				hasGreyHeader={ !! config.useCaptcha }
+				toggleChecked={ !! config.useCaptcha }
+				toggleOnChange={ value => updateConfig( 'useCaptcha', value ) }
+				disabled={ inFlight }
+			>
+				{ config.useCaptcha && (
+					<>
+						{ config.useCaptcha && ( ! config.captchaSiteKey || ! config.captchaSiteSecret ) && (
+							<Notice
+								noticeText={ __(
+									'You must enter a valid site key and secret to use reCAPTCHA.',
+									'newspack'
+								) }
+							/>
+						) }
+						<Grid noMargin rowGap={ 16 }>
+							<TextControl
+								value={ config.captchaSiteKey }
+								label={ __( 'Site Key', 'newspack' ) }
+								onChange={ value => updateConfig( 'captchaSiteKey', value ) }
+							/>
+							<TextControl
+								type="password"
+								value={ config.captchaSiteSecret }
+								label={ __( 'Site Secret', 'newspack' ) }
+								onChange={ value => updateConfig( 'captchaSiteSecret', value ) }
+							/>
+						</Grid>
+					</>
+				) }
+			</ActionCard>
 			<div className="newspack-buttons-card">
 				<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
 					{ __( 'Save Changes', 'newspack' ) }

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, ExternalLink } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -10,7 +10,6 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import {
-	ActionCard,
 	Button,
 	Card,
 	Grid,
@@ -151,54 +150,6 @@ export default withWizardScreen( () => {
 					</>
 				) }
 			</Card>
-
-			<hr />
-
-			<ActionCard
-				isMedium
-				title={ __( 'reCAPTCHA v3 Settings', 'newspack' ) }
-				description={ () => (
-					<p>
-						{ __(
-							'Enabling reCAPTCHA can help protect your site against bot attacks and credit card testing.',
-							'newspack'
-						) }{ ' ' }
-						<ExternalLink href="https://www.google.com/recaptcha/admin/create">
-							{ __( 'Get started' ) }
-						</ExternalLink>
-					</p>
-				) }
-				hasGreyHeader={ !! config.useCaptcha }
-				toggleChecked={ !! config.useCaptcha }
-				toggleOnChange={ value => updateConfig( 'useCaptcha', value ) }
-				disabled={ inFlight }
-			>
-				{ config.useCaptcha && (
-					<>
-						{ config.useCaptcha && ( ! config.captchaSiteKey || ! config.captchaSiteSecret ) && (
-							<Notice
-								noticeText={ __(
-									'You must enter a valid site key and secret to use reCAPTCHA.',
-									'newspack'
-								) }
-							/>
-						) }
-						<Grid noMargin rowGap={ 16 }>
-							<TextControl
-								value={ config.captchaSiteKey }
-								label={ __( 'Site Key', 'newspack' ) }
-								onChange={ value => updateConfig( 'captchaSiteKey', value ) }
-							/>
-							<TextControl
-								type="password"
-								value={ config.captchaSiteSecret }
-								label={ __( 'Site Secret', 'newspack' ) }
-								onChange={ value => updateConfig( 'captchaSiteSecret', value ) }
-							/>
-						</Grid>
-					</>
-				) }
-			</ActionCard>
 			<div className="newspack-buttons-card">
 				<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
 					{ __( 'Save Changes', 'newspack' ) }

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -98,74 +98,6 @@ export const StripeKeysSettings = () => {
 	);
 };
 
-export const StripeCaptchaSettings = () => {
-	const wizardData = Wizard.useWizardData( 'reader-revenue' );
-	const {
-		useCaptcha = false,
-		captchaSiteKey = '',
-		captchaSiteSecret = '',
-	} = wizardData.stripe_data || {};
-
-	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
-	const changeHandler = key => value =>
-		updateWizardSettings( {
-			slug: READER_REVENUE_WIZARD_SLUG,
-			path: [ 'stripe_data', key ],
-			value,
-		} );
-
-	return (
-		<Grid columns={ 1 } gutter={ 16 }>
-			<Grid columns={ 1 } gutter={ 16 }>
-				<p className="newspack-payment-setup-screen__api-keys-instruction">
-					{ __(
-						'Enabling reCaptcha for Stripe checkouts makes your site more secure.',
-						'newspack'
-					) }
-					{ ' – ' }
-					<ExternalLink href="https://www.google.com/recaptcha/admin/create">
-						{ __( 'get started' ) }
-					</ExternalLink>
-				</p>
-				<CheckboxControl
-					label={ __( 'Use reCaptcha v3 to secure Stripe checkout', 'newspack' ) }
-					checked={ useCaptcha }
-					onChange={ changeHandler( 'useCaptcha' ) }
-					help={ __(
-						'Without reCaptcha, your Stripe checkout process may be vulnerable to bot attacks and card testing.',
-						'newspack-blocks'
-					) }
-				/>
-			</Grid>
-			{ useCaptcha && ( ! captchaSiteKey || ! captchaSiteSecret ) && (
-				<Notice
-					noticeText={ __(
-						'You must enter a valid site key and secret to use reCaptcha.',
-						'newspack'
-					) }
-				/>
-			) }
-			<Grid noMargin rowGap={ 16 }>
-				{ useCaptcha && (
-					<>
-						<TextControl
-							value={ captchaSiteKey }
-							label={ __( 'Site Key', 'newspack' ) }
-							onChange={ changeHandler( 'captchaSiteKey' ) }
-						/>
-						<TextControl
-							type="password"
-							value={ captchaSiteSecret }
-							label={ __( 'Site Secret', 'newspack' ) }
-							onChange={ changeHandler( 'captchaSiteSecret' ) }
-						/>
-					</>
-				) }
-			</Grid>
-		</Grid>
-	);
-};
-
 const StripeSetup = () => {
 	const {
 		stripe_data: data = {},
@@ -243,23 +175,6 @@ const StripeSetup = () => {
 								onChange={ changeHandler( 'currency' ) }
 							/>
 						</Grid>
-					</SettingsCard>
-					<SettingsCard
-						title={ __( 'reCaptcha v3 Settings', 'newspack' ) }
-						columns={ 1 }
-						gutter={ 16 }
-						noBorder
-					>
-						{ data.can_use_stripe_platform === false && (
-							<Notice
-								isError
-								noticeText={ __(
-									'The Stripe platform will not work properly on this site.',
-									'newspack'
-								) }
-							/>
-						) }
-						<StripeCaptchaSettings />
 					</SettingsCard>
 					<SettingsCard
 						title={ __( 'Newsletters', 'newspack' ) }

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -80,6 +80,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-analytics.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-reader-activation.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-recaptcha.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-magic-link.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-stripe-connection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-woocommerce-connection.php';

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -16,10 +16,12 @@ final class Reader_Activation {
 
 	const OPTIONS_PREFIX = 'newspack_reader_activation_';
 
-	const AUTH_READER_COOKIE    = 'np_auth_reader';
-	const AUTH_INTENTION_COOKIE = 'np_auth_intention';
-	const SCRIPT_HANDLE         = 'newspack-reader-activation';
-	const AUTH_SCRIPT_HANDLE    = 'newspack-reader-auth';
+	const AUTH_READER_COOKIE      = 'np_auth_reader';
+	const AUTH_INTENTION_COOKIE   = 'np_auth_intention';
+	const SCRIPT_HANDLE           = 'newspack-reader-activation';
+	const AUTH_SCRIPT_HANDLE      = 'newspack-reader-auth';
+	const RECAPTCHA_SCRIPT_HANDLE = 'newspack-recaptcha';
+	const RECAPTCHA_THRESHOLD     = 0.5;
 
 	/**
 	 * Reader user meta keys.
@@ -49,6 +51,8 @@ final class Reader_Activation {
 	 * Initialize hooks.
 	 */
 	public static function init() {
+		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'register_recaptcha' ] );
+
 		if ( self::is_enabled() ) {
 			\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 			\add_action( 'clear_auth_cookie', [ __CLASS__, 'clear_auth_intention_cookie' ] );
@@ -69,28 +73,56 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Register the reCAPTCHA v3 script.
+	 * Does not require Reader Activation features to be active.
+	 */
+	public static function register_recaptcha() {
+		if ( self::can_use_captcha() ) {
+			$captcha_site_key = self::get_setting( 'captchaSiteKey' );
+
+			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+			wp_register_script(
+				self::RECAPTCHA_SCRIPT_HANDLE,
+				esc_url( 'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key ),
+				null,
+				null,
+				true
+			);
+			\wp_script_add_data( self::RECAPTCHA_SCRIPT_HANDLE, 'amp-plus', true );
+		}
+	}
+
+	/**
 	 * Enqueue front-end scripts.
 	 */
 	public static function enqueue_scripts() {
-		\wp_register_script(
-			self::SCRIPT_HANDLE,
-			Newspack::plugin_url() . '/dist/reader-activation.js',
-			[],
-			NEWSPACK_PLUGIN_VERSION,
-			true
-		);
 		$authenticated_email = '';
 		if ( \is_user_logged_in() && self::is_user_reader( \wp_get_current_user() ) ) {
 			$authenticated_email = \wp_get_current_user()->user_email;
 		}
+		$script_dependencies = [];
+		$script_data         = [
+			'auth_intention_cookie' => self::AUTH_INTENTION_COOKIE,
+			'cid_cookie'            => NEWSPACK_CLIENT_ID_COOKIE_NAME,
+			'authenticated_email'   => $authenticated_email,
+		];
+
+		if ( self::can_use_captcha() ) {
+			$script_dependencies[]           = self::RECAPTCHA_SCRIPT_HANDLE;
+			$script_data['captcha_site_key'] = self::get_setting( 'captchaSiteKey' );
+		}
+
+		\wp_register_script(
+			self::SCRIPT_HANDLE,
+			Newspack::plugin_url() . '/dist/reader-activation.js',
+			$script_dependencies,
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
 		\wp_localize_script(
 			self::SCRIPT_HANDLE,
 			'newspack_reader_activation_data',
-			[
-				'auth_intention_cookie' => self::AUTH_INTENTION_COOKIE,
-				'cid_cookie'            => NEWSPACK_CLIENT_ID_COOKIE_NAME,
-				'authenticated_email'   => $authenticated_email,
-			]
+			$script_data
 		);
 		\wp_script_add_data( self::SCRIPT_HANDLE, 'amp-plus', true );
 
@@ -130,6 +162,9 @@ final class Reader_Activation {
 			'sync_esp'                    => true,
 			'sync_esp_delete'             => true,
 			'active_campaign_master_list' => '',
+			'useCaptcha'                  => false,
+			'captchaSiteKey'              => '',
+			'captchaSiteSecret'           => '',
 		];
 
 		/**
@@ -152,6 +187,28 @@ final class Reader_Activation {
 		foreach ( $config as $key => $default_value ) {
 			$settings[ $key ] = self::get_setting( $key );
 		}
+
+		// Migrate reCAPTCHA settings from Stripe wizard to Reader Activation, for more generalized usage.
+		if ( ! $settings['useCaptcha'] && empty( $stripe_settings['captchaSiteKey'] ) && empty( $stripe_settings['captchaSiteSecret'] ) ) {
+			$stripe_settings = Stripe_Connection::get_stripe_data();
+			if ( ! empty( $stripe_settings['useCaptcha'] ) && ! empty( $stripe_settings['captchaSiteKey'] ) && ! empty( $stripe_settings['captchaSiteSecret'] ) ) {
+				// If we have all of the required settings in Stripe settings, migrate them here.
+				self::update_setting( 'useCaptcha', $stripe_settings['useCaptcha'] );
+				self::update_setting( 'captchaSiteKey', $stripe_settings['captchaSiteKey'] );
+				self::update_setting( 'captchaSiteSecret', $stripe_settings['captchaSiteSecret'] );
+
+				// Delete the legacy settings from Stripe settings and apply the settings to the return value.
+				unset( $stripe_settings['useCaptcha'] );
+				unset( $stripe_settings['captchaSiteKey'] );
+				unset( $stripe_settings['captchaSiteSecret'] );
+				Stripe_Connection::update_stripe_data( $stripe_settings );
+
+				$settings['useCaptcha']        = $stripe_settings['useCaptcha'];
+				$settings['captchaSiteKey']    = $stripe_settings['captchaSiteKey'];
+				$settings['captchaSiteSecret'] = $stripe_settings['captchaSiteSecret'];
+			}
+		}
+
 		return $settings;
 	}
 
@@ -961,12 +1018,13 @@ final class Reader_Activation {
 		if ( ! isset( $_POST[ self::AUTH_FORM_ACTION ] ) ) {
 			return;
 		}
-		$action   = isset( $_POST['action'] ) ? \sanitize_text_field( $_POST['action'] ) : '';
-		$email    = isset( $_POST['npe'] ) ? \sanitize_email( $_POST['npe'] ) : '';
-		$password = isset( $_POST['password'] ) ? \sanitize_text_field( $_POST['password'] ) : '';
-		$redirect = isset( $_POST['redirect'] ) ? \esc_url_raw( $_POST['redirect'] ) : '';
-		$lists    = isset( $_POST['lists'] ) ? array_map( 'sanitize_text_field', $_POST['lists'] ) : [];
-		$honeypot = isset( $_POST['email'] ) ? \sanitize_text_field( $_POST['email'] ) : '';
+		$action        = isset( $_POST['action'] ) ? \sanitize_text_field( $_POST['action'] ) : '';
+		$email         = isset( $_POST['npe'] ) ? \sanitize_email( $_POST['npe'] ) : '';
+		$password      = isset( $_POST['password'] ) ? \sanitize_text_field( $_POST['password'] ) : '';
+		$redirect      = isset( $_POST['redirect'] ) ? \esc_url_raw( $_POST['redirect'] ) : '';
+		$lists         = isset( $_POST['lists'] ) ? array_map( 'sanitize_text_field', $_POST['lists'] ) : [];
+		$honeypot      = isset( $_POST['email'] ) ? \sanitize_text_field( $_POST['email'] ) : '';
+		$captcha_token = isset( $_POST['captcha_token'] ) ? \sanitize_text_field( $_POST['captcha_token'] ) : '';
 		// phpcs:enable
 
 		// Honeypot trap.
@@ -977,6 +1035,14 @@ final class Reader_Activation {
 					'authenticated' => 1,
 				]
 			);
+		}
+
+		// reCAPTCHA test.
+		if ( ! empty( $captcha_token ) ) {
+			$captcha_result = self::verify_captcha( $captcha_token );
+			if ( \is_wp_error( $captcha_result ) ) {
+				return self::send_auth_form_response( $captcha_result );
+			}
 		}
 
 		if ( ! in_array( $action, self::AUTH_FORM_OPTIONS, true ) ) {
@@ -1299,6 +1365,81 @@ final class Reader_Activation {
 	 */
 	public static function get_from_name() {
 		return apply_filters( 'newspack_reader_activation_from_name', get_bloginfo( 'name' ) );
+	}
+
+	/**
+	 * Check whether reCaptcha is enabled and that we have all required settings.
+	 *
+	 * @return boolean True if we can use reCaptcha to secure checkout requests.
+	 */
+	public static function can_use_captcha() {
+		$settings = self::get_settings();
+		if ( empty( $settings['useCaptcha'] ) || empty( $settings['captchaSiteKey'] ) || empty( $settings['captchaSiteSecret'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Verify a REST API request using reCAPTCHA v3.
+	 *
+	 * @param string $captcha_token Token to verify.
+	 *
+	 * @return boolean|WP_Error True if the request passes the CAPTCHA test, or WP_Error.
+	 */
+	public static function verify_captcha( $captcha_token ) {
+		if ( ! self::can_use_captcha() ) {
+			return true;
+		}
+
+		if ( ! $captcha_token ) {
+			return new \WP_Error(
+				'newspack_recaptcha_invalid_token',
+				__( 'Missing or invalid captcha token.', 'newspack' )
+			);
+		}
+
+		$captcha_secret = self::get_setting( 'captchaSiteSecret' );
+		$captcha_verify = wp_safe_remote_post(
+			add_query_arg(
+				[
+					'secret'   => $captcha_secret,
+					'response' => $captcha_token,
+				],
+				'https://www.google.com/recaptcha/api/siteverify'
+			)
+		);
+
+		// If the reCaptcha verification request fails.
+		if ( is_wp_error( $captcha_verify ) ) {
+			return $captcha_verify;
+		}
+
+		$captcha_verify = json_decode( $captcha_verify['body'], true );
+
+		// If the reCaptcha verification request succeeds, but with error.
+		if ( ! boolval( $captcha_verify['success'] ) ) {
+			$error = isset( $captcha_verify['error-codes'] ) ? reset( $captcha_verify['error-codes'] ) : __( 'Error validating captcha.', 'newspack' );
+			return new \WP_Error(
+				'newspack_recaptcha_error',
+				// Translators: error message for reCaptcha.
+				sprintf( __( 'reCaptcha error: %s', 'newspack' ), $error )
+			);
+		}
+
+		// If the reCaptcha verification score is below our threshold for valid user input.
+		if (
+			isset( $captcha_verify['score'] ) &&
+			self::RECAPTCHA_THRESHOLD > floatval( $captcha_verify['score'] )
+		) {
+			return new \WP_Error(
+				'newspack_recaptcha_failure',
+				__( 'User action failed captcha challenge.', 'newspack' )
+			);
+		}
+
+		return true;
 	}
 }
 Reader_Activation::init();

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -86,7 +86,7 @@ final class Reader_Activation {
 		];
 
 		if ( Recaptcha::can_use_captcha() ) {
-			$script_dependencies[]           = Recaptcha::RECAPTCHA_SCRIPT_HANDLE;
+			$script_dependencies[]           = Recaptcha::SCRIPT_HANDLE;
 			$script_data['captcha_site_key'] = Recaptcha::get_setting( 'site_key' );
 		}
 

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -87,7 +87,7 @@ final class Reader_Activation {
 
 		if ( Recaptcha::can_use_captcha() ) {
 			$script_dependencies[]           = Recaptcha::RECAPTCHA_SCRIPT_HANDLE;
-			$script_data['captcha_site_key'] = Recaptcha::get_setting( 'captchaSiteKey' );
+			$script_data['captcha_site_key'] = Recaptcha::get_setting( 'site_key' );
 		}
 
 		\wp_register_script(

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -274,8 +274,8 @@ final class Recaptcha {
 		}
 
 		$captcha_secret = self::get_setting( 'captchaSiteSecret' );
-		$captcha_verify = wp_safe_remote_post(
-			add_query_arg(
+		$captcha_verify = \wp_safe_remote_post(
+			\add_query_arg(
 				[
 					'secret'   => $captcha_secret,
 					'response' => $captcha_token,
@@ -285,7 +285,7 @@ final class Recaptcha {
 		);
 
 		// If the reCaptcha verification request fails.
-		if ( is_wp_error( $captcha_verify ) ) {
+		if ( \is_wp_error( $captcha_verify ) ) {
 			return $captcha_verify;
 		}
 

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -1,0 +1,319 @@
+<?php
+/**
+ * Class for reCAPTCHA integration.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class for reCAPTCHA integration.
+ */
+final class Recaptcha {
+	const RECAPTCHA_SCRIPT_HANDLE = 'newspack-recaptcha';
+	const RECAPTCHA_THRESHOLD     = 0.5;
+	const RECAPTCHA_API_NAMESPACE = 'newspack/v1';
+	const OPTIONS_PREFIX          = 'newspack_recaptcha_';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		\add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
+		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'register_script' ] );
+	}
+
+	/**
+	 * Register API endpoints.
+	 */
+	public static function register_api_endpoints() {
+		\register_rest_route(
+			self::RECAPTCHA_API_NAMESPACE,
+			'/recaptcha',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_settings' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+			]
+		);
+
+		\register_rest_route(
+			self::RECAPTCHA_API_NAMESPACE,
+			'/recaptcha',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ __CLASS__, 'api_update_setting' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+				'args'                => [
+					'key'   => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'value' => [
+						'sanitize_callback' => [ __CLASS__, 'sanitize_text_or_boolean' ],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Register the reCAPTCHA v3 script.
+	 */
+	public static function register_script() {
+		if ( self::can_use_captcha() ) {
+			$captcha_site_key = self::get_setting( 'captchaSiteKey' );
+
+			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+			\wp_register_script(
+				self::RECAPTCHA_SCRIPT_HANDLE,
+				esc_url( 'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key ),
+				null,
+				null,
+				true
+			);
+			\wp_script_add_data( self::RECAPTCHA_SCRIPT_HANDLE, 'async', true );
+			\wp_script_add_data( self::RECAPTCHA_SCRIPT_HANDLE, 'amp-plus', true );
+		}
+	}
+
+	/**
+	 * Check capabilities for using API.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function api_permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				[
+					'status' => 403,
+				]
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Sanitize a text string or boolean value.
+	 *
+	 * @param string|boolean $value String or boolean value.
+	 *
+	 * @return string|boolean Sanitized value.
+	 */
+	public static function sanitize_text_or_boolean( $value ) {
+		if ( is_numeric( $value ) || is_bool( $value ) ) {
+			return boolval( $value );
+		}
+
+		return \sanitize_text_field( $value );
+	}
+
+	/**
+	 * Get global reCAPTCHA settings and default values.
+	 *
+	 * @return mixed[] Global reCAPTCHA default values keyed by option name.
+	 */
+	public static function get_settings_config() {
+		return [
+			'useCaptcha'        => false,
+			'captchaSiteKey'    => '',
+			'captchaSiteSecret' => '',
+		];
+	}
+
+	/**
+	 * Get settings via REST API.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public static function api_get_settings() {
+		return \rest_ensure_response( self::get_settings() );
+	}
+
+	/**
+	 * Update settings via API.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response containing the settings list.
+	 */
+	public static function api_update_setting( $request ) {
+		$key   = $request->get_param( 'key' );
+		$value = $request->get_param( 'value' );
+
+		$setting_to_update         = [];
+		$setting_to_update[ $key ] = $value;
+
+		return \rest_ensure_response( self::update_settings( $setting_to_update ) );
+	}
+
+	/**
+	 * Get all reCAPTCHA settings.
+	 *
+	 * @return mixed[] Global reCAPTCHA settings keyed by option name.
+	 */
+	public static function get_settings() {
+		$config   = self::get_settings_config();
+		$settings = [];
+		foreach ( $config as $key => $default_value ) {
+			$settings[ $key ] = self::get_setting( $key );
+		}
+
+		// Migrate reCAPTCHA settings from Stripe wizard, for more generalized usage.
+		if ( ! $settings['useCaptcha'] && empty( $settings['captchaSiteKey'] ) && empty( $settings['captchaSiteSecret'] ) ) {
+			$stripe_settings = Stripe_Connection::get_stripe_data();
+			if ( ! empty( $stripe_settings['useCaptcha'] ) && ! empty( $stripe_settings['captchaSiteKey'] ) && ! empty( $stripe_settings['captchaSiteSecret'] ) ) {
+				// If we have all of the required settings in Stripe settings, migrate them here.
+				self::update_settings(
+					[
+						'useCaptcha'        => $stripe_settings['useCaptcha'],
+						'captchaSiteKey'    => $stripe_settings['captchaSiteKey'],
+						'captchaSiteSecret' => $stripe_settings['captchaSiteSecret'],
+					]
+				);
+
+				$settings['useCaptcha']        = $stripe_settings['useCaptcha'];
+				$settings['captchaSiteKey']    = $stripe_settings['captchaSiteKey'];
+				$settings['captchaSiteSecret'] = $stripe_settings['captchaSiteSecret'];
+
+				// Delete the legacy settings from Stripe settings and apply the settings to the return value.
+				unset( $stripe_settings['useCaptcha'] );
+				unset( $stripe_settings['captchaSiteKey'] );
+				unset( $stripe_settings['captchaSiteSecret'] );
+				Stripe_Connection::update_stripe_data( $stripe_settings );
+			}
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Get the value for a given setting key.
+	 *
+	 * @param string $key Setting key.
+	 *
+	 * @return mixed Setting value.
+	 */
+	public static function get_setting( $key ) {
+		$config = self::get_settings_config();
+		if ( ! isset( $config[ $key ] ) ) {
+			return null;
+		}
+		$value = \get_option( self::OPTIONS_PREFIX . $key, $config[ $key ] );
+		// Use default value type for casting bool option value.
+		if ( is_bool( $config[ $key ] ) ) {
+			$value = (bool) $value;
+		}
+		return $value;
+	}
+
+	/**
+	 * Update settings values.
+	 *
+	 * @param mixed[] $settings Setting values to update, keyed by option name.
+	 *
+	 * @return mixed[] Updated settings, or WP_Error.
+	 */
+	public static function update_settings( $settings ) {
+		$config = self::get_settings_config();
+		foreach ( $settings as $key => $value ) {
+			if ( ! isset( $config[ $key ] ) ) {
+				return new \WP_Error(
+					'newspack_recaptcha_update_settings_error',
+					__( 'Invalid settings key: ', 'newspack' ) . $key
+				);
+			}
+
+			$updated = \update_option( self::OPTIONS_PREFIX . $key, $value );
+			if ( ! $updated ) {
+				return new \WP_Error(
+					'newspack_recaptcha_update_settings_error',
+					__( 'Error updating setting: ', 'newspack' ) . $key
+				);
+			}
+		}
+
+		return self::get_settings();
+	}
+
+	/**
+	 * Check whether reCaptcha is enabled and that we have all required settings.
+	 *
+	 * @return boolean True if we can use reCaptcha to secure checkout requests.
+	 */
+	public static function can_use_captcha() {
+		$settings = self::get_settings();
+		if ( empty( $settings['useCaptcha'] ) || empty( $settings['captchaSiteKey'] ) || empty( $settings['captchaSiteSecret'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Verify a REST API request using reCAPTCHA v3.
+	 *
+	 * @param string $captcha_token Token to verify.
+	 *
+	 * @return boolean|WP_Error True if the request passes the CAPTCHA test, or WP_Error.
+	 */
+	public static function verify_captcha( $captcha_token ) {
+		if ( ! self::can_use_captcha() ) {
+			return true;
+		}
+
+		if ( empty( $captcha_token ) ) {
+			return new \WP_Error(
+				'newspack_recaptcha_invalid_token',
+				__( 'Missing or invalid captcha token.', 'newspack' )
+			);
+		}
+
+		$captcha_secret = self::get_setting( 'captchaSiteSecret' );
+		$captcha_verify = wp_safe_remote_post(
+			add_query_arg(
+				[
+					'secret'   => $captcha_secret,
+					'response' => $captcha_token,
+				],
+				'https://www.google.com/recaptcha/api/siteverify'
+			)
+		);
+
+		// If the reCaptcha verification request fails.
+		if ( is_wp_error( $captcha_verify ) ) {
+			return $captcha_verify;
+		}
+
+		$captcha_verify = json_decode( $captcha_verify['body'], true );
+
+		// If the reCaptcha verification request succeeds, but with error.
+		if ( ! boolval( $captcha_verify['success'] ) ) {
+			$error = isset( $captcha_verify['error-codes'] ) ? reset( $captcha_verify['error-codes'] ) : __( 'Error validating captcha.', 'newspack' );
+			return new \WP_Error(
+				'newspack_recaptcha_error',
+				// Translators: error message for reCaptcha.
+				sprintf( __( 'reCaptcha error: %s', 'newspack' ), $error )
+			);
+		}
+
+		// If the reCaptcha verification score is below our threshold for valid user input.
+		if (
+			isset( $captcha_verify['score'] ) &&
+			self::RECAPTCHA_THRESHOLD > floatval( $captcha_verify['score'] )
+		) {
+			return new \WP_Error(
+				'newspack_recaptcha_failure',
+				__( 'User action failed captcha challenge.', 'newspack' )
+			);
+		}
+
+		return true;
+	}
+}
+
+Recaptcha::init();

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -13,10 +13,9 @@ defined( 'ABSPATH' ) || exit;
  * Class for reCAPTCHA integration.
  */
 final class Recaptcha {
-	const SCRIPT_HANDLE           = 'newspack-recaptcha';
-	const THRESHOLD               = 0.5;
-	const RECAPTCHA_API_NAMESPACE = 'newspack/v1';
-	const OPTIONS_PREFIX          = 'newspack_recaptcha_';
+	const SCRIPT_HANDLE  = 'newspack-recaptcha';
+	const THRESHOLD      = 0.5;
+	const OPTIONS_PREFIX = 'newspack_recaptcha_';
 
 	/**
 	 * Initialize hooks.
@@ -31,7 +30,7 @@ final class Recaptcha {
 	 */
 	public static function register_api_endpoints() {
 		\register_rest_route(
-			self::RECAPTCHA_API_NAMESPACE,
+			NEWSPACK_API_NAMESPACE,
 			'/recaptcha',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
@@ -41,7 +40,7 @@ final class Recaptcha {
 		);
 
 		\register_rest_route(
-			self::RECAPTCHA_API_NAMESPACE,
+			NEWSPACK_API_NAMESPACE,
 			'/recaptcha',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -75,7 +75,7 @@ final class Recaptcha {
 			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			\wp_register_script(
 				self::RECAPTCHA_SCRIPT_HANDLE,
-				esc_url( 'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key ),
+				\esc_url( 'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key ),
 				null,
 				null,
 				true
@@ -91,38 +91,16 @@ final class Recaptcha {
 	 * @return bool|WP_Error
 	 */
 	public static function api_permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! \current_user_can( 'manage_options' ) ) {
 			return new \WP_Error(
 				'newspack_rest_forbidden',
-				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				\esc_html__( 'You cannot use this resource.', 'newspack' ),
 				[
 					'status' => 403,
 				]
 			);
 		}
 		return true;
-	}
-
-	/**
-	 * Sanitize an array of text or number values.
-	 *
-	 * @param array $array Array of text or boolean values to be sanitized.
-	 * @return array Sanitized array.
-	 */
-	public static function sanitize_array( $array ) {
-		foreach ( $array as $value ) {
-			if ( is_array( $value ) ) {
-				$value = self::sanitize_array( $value );
-			} else {
-				if ( is_string( $value ) ) {
-					$value = sanitize_text_field( $value );
-				} else {
-					$value = boolval( $value );
-				}
-			}
-		}
-
-		return $array;
 	}
 
 	/**

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -13,8 +13,8 @@ defined( 'ABSPATH' ) || exit;
  * Class for reCAPTCHA integration.
  */
 final class Recaptcha {
-	const RECAPTCHA_SCRIPT_HANDLE = 'newspack-recaptcha';
-	const RECAPTCHA_THRESHOLD     = 0.5;
+	const SCRIPT_HANDLE           = 'newspack-recaptcha';
+	const THRESHOLD               = 0.5;
 	const RECAPTCHA_API_NAMESPACE = 'newspack/v1';
 	const OPTIONS_PREFIX          = 'newspack_recaptcha_';
 
@@ -74,14 +74,14 @@ final class Recaptcha {
 
 			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			\wp_register_script(
-				self::RECAPTCHA_SCRIPT_HANDLE,
+				self::SCRIPT_HANDLE,
 				\esc_url( 'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key ),
 				null,
 				null,
 				true
 			);
-			\wp_script_add_data( self::RECAPTCHA_SCRIPT_HANDLE, 'async', true );
-			\wp_script_add_data( self::RECAPTCHA_SCRIPT_HANDLE, 'amp-plus', true );
+			\wp_script_add_data( self::SCRIPT_HANDLE, 'async', true );
+			\wp_script_add_data( self::SCRIPT_HANDLE, 'amp-plus', true );
 		}
 	}
 
@@ -277,7 +277,7 @@ final class Recaptcha {
 		// If the reCaptcha verification score is below our threshold for valid user input.
 		if (
 			isset( $captcha_verify['score'] ) &&
-			self::RECAPTCHA_THRESHOLD > floatval( $captcha_verify['score'] )
+			self::THRESHOLD > floatval( $captcha_verify['score'] )
 		) {
 			return new \WP_Error(
 				'newspack_recaptcha_failure',

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -109,9 +109,6 @@ class Stripe_Connection {
 			'secretKey'          => '',
 			'testPublishableKey' => '',
 			'testSecretKey'      => '',
-			'useCaptcha'         => false,
-			'captchaSiteKey'     => '',
-			'captchaSiteSecret'  => '',
 			'currency'           => $currency,
 			'location_code'      => $location_code,
 			'newsletter_list_id' => '',
@@ -124,20 +121,6 @@ class Stripe_Connection {
 	public static function get_stripe_data() {
 		$stripe_data = self::get_saved_stripe_data();
 		return $stripe_data;
-	}
-
-	/**
-	 * Check whether reCaptcha is enabled and that we have all required settings.
-	 *
-	 * @return boolean True if we can use reCaptcha to secure checkout requests.
-	 */
-	public static function can_use_captcha() {
-		$settings = self::get_stripe_data();
-		if ( empty( $settings['useCaptcha'] ) || empty( $settings['captchaSiteKey'] ) || empty( $settings['captchaSiteSecret'] ) ) {
-			return false;
-		}
-
-		return true;
 	}
 
 	/**

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -150,15 +150,6 @@ class Reader_Revenue_Wizard extends Wizard {
 					'testSecretKey'      => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
-					'useCaptcha'         => [
-						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
-					],
-					'captchaSiteKey'     => [
-						'sanitize_callback' => 'Newspack\newspack_clean',
-					],
-					'captchaSiteSecret'  => [
-						'sanitize_callback' => 'Newspack\newspack_clean',
-					],
 					'newsletter_list_id' => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements reCAPTCHA v3 verification for all Reader Activation-related forms: registration, auth, subscribe (requires https://github.com/Automattic/newspack-newsletters/pull/935), and donation (requires https://github.com/Automattic/newspack-blocks/pull/1244).

As part of this PR, the wizard UI to enable reCAPTCHA and enter credentials have been moved from the **Reader Revenue > Stripe Settings** wizard to the **Engagement > Reader Activation** wizard. However, because reCAPTCHA is also used by the subscribe and streamlined donation blocks whether or not Reader Activation is enabled on the site, the reCAPTCHA script and methods can be enqueued and used even if Reader Activation features are not enabled.

<img width="1046" alt="Screen Shot 2022-08-16 at 6 46 28 PM" src="https://user-images.githubusercontent.com/2230142/185010642-c191dcc3-999c-48f9-9c33-4fb08119ce3e.png">

Also note that the UI for the reCAPTCHA settings may look out of place right now, but are styled to fit in with [this pending PR](https://github.com/Automattic/newspack-plugin/pull/1852).

Also implements the correct capitalization of reCAPTCHA in all UI.

### How to test the changes in this Pull Request:

1. On `master` for this plugin, Newsletters, and Blocks, confirm that reCAPTCHA is set up and working on your test site by following testing steps 3–7 from [this PR](https://github.com/Automattic/newspack-blocks/pull/1234).
2. Check out this branch, (https://github.com/Automattic/newspack-newsletters/pull/935) and https://github.com/Automattic/newspack-blocks/pull/1244. Confirm that the UI to enable reCAPTCHA and enter creds and all related values are automatically migrated from **Reader Revenue > Stripe Settings** to **Engagement > Reader Activation**.
3. Confirm that reCAPTCHA still works on streamlined donate blocks by setting the reCAPTCHA threshold (now on [this line](https://github.com/Automattic/newspack-plugin/compare/feat/recaptcha-for-all-forms?expand=1#diff-3ce140c40dae980330bca82b55eaf67a4f7abbbcc4f6609368fcf55ea696a7a7R24)) to `1.0` and trying to submit a donation. You should see an error message stating `User action failed captcha challenge`.
4. With the threshold still at `1.0`, confirm that reCAPTCHA now also works on login, subscribe, and register blocks.
5. Disable Reader Activation (either via the wizard option or by removing the environment variable from `wp-config.php`) and confirm that reCAPTCHA still works for streamlined donate and subscribe blocks, both of which don't require Reader Activation in order to function.
6. Re-enable Reader Activation, but disable reCAPTCHA via the wizard UI. Confirm that donation, login, subscribe, and register forms all work again without reCAPTCHA.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->