### PR TITLE
style: red buttons for auth and register buttons; fix z-index on auth modal

### DIFF
--- a/assets/blocks/reader-registration/editor.scss
+++ b/assets/blocks/reader-registration/editor.scss
@@ -15,8 +15,8 @@
 			border-radius: 0;
 		}
 		[type='submit'] {
-			transition: background 150ms ease-in-out;
-			background: #555;
+			transition: background-color 150ms ease-in-out;
+			background-color: #d33;
 			border: none;
 			border-radius: 5px;
 			box-sizing: border-box;

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -53,6 +53,7 @@
 			flex: 1 1 auto;
 		}
 		[type='submit'] {
+			background-color: #d33;
 			margin-left: 0.4rem;
 		}
 	}

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -50,7 +50,7 @@
 		bottom: 0;
 		justify-content: center;
 		align-items: center;
-		z-index: 999999;
+		z-index: 9999999999;
 		font-size: 0.8888em;
 
 		@media screen and ( min-width: 600px ) {
@@ -150,6 +150,16 @@
 				flex: 1 1 100%;
 				font-size: 1rem;
 				margin: 0;
+
+				button[type='submit'] {
+					background-color: #d33;
+					transition: background-color 150ms ease-in-out;
+
+					&:hover,
+					&:focus {
+						background-color: #111;
+					}
+				}
 			}
 
 			&__help {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some minor style tweaks as discussed internally.

1. Makes the submit buttons for Register and Login forms the same `#d33` red color as default CTA buttons in the Newspack theme.
2. Bumps up the `z-index` for the login form modal so that it appears on top of the sidebar overlay.

### How to test the changes in this Pull Request:

1. Check out this branch.
3. Confirm the button colors (static and hover/focus) for the Register block and login forms.
4. To test the z-index fix, enable the slide-out sidebar in **Customize > Header Settings > Slide-out Sidebar**. Confirm that when clicking the "Sign In" button from within the slide-out sidebar, the login modal appears on top of the slide-out sidebar and is interactive without first closing the slide-out sidebar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->