### PR TITLE
fix: version for cache busting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.89.1-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.89.0...v1.89.1-hotfix.1) (2022-08-18)
+
+
+### Bug Fixes
+
+* version for cache busting ([1db4ee2](https://github.com/Automattic/newspack-plugin/commit/1db4ee255d0131c1713cbae6a37eaed9d9447603))
+
 # [1.89.0](https://github.com/Automattic/newspack-plugin/compare/v1.88.0...v1.89.0) (2022-08-16)
 
 

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.89.0
+ * Version: 1.89.1-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.89.0' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.89.1-hotfix.1' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/newspack.php
+++ b/newspack.php
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.80.0' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.89.0' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.89.0",
+  "version": "1.89.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.89.0",
+      "version": "1.89.1-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.89.0",
+  "version": "1.89.1-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Should fix the issue with `NEWSPACK_PLUGIN_VERSION` being out of sync. When it was introduced in #1612, the initial value was not set accordingly (`1.80.0` instead of `1.80.1`), so it started as out of sync and was not updated by [`semantic-release-version-bump`](https://github.com/automattic/semantic-release-version-bump). 

### How to test the changes in this Pull Request:

Inspect the `newspack.php` file [in the hotfix release ZIP](https://github.com/Automattic/newspack-plugin/releases/tag/v1.89.1-hotfix.1) – it should have the `NEWSPACK_PLUGIN_VERSION` variable updated accordingly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->