### PR TITLE
fix: x scrollbar on "Sign In" modal

### DIFF
--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -184,6 +184,7 @@
 			position: relative;
 			max-height: 100vh;
 			overflow-y: auto;
+			overflow-x: hidden;
 
 			transition: height 125ms ease-in-out;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix horizontal scroll being rendered on the Sign In modal.

<img width="578" alt="image" src="https://user-images.githubusercontent.com/820752/185440296-d0b0b301-c314-4347-b806-3dad7933b338.png">

### How to test the changes in this Pull Request:

1. On master, open the Sign In modal and observe the horizontal scroll as displayed above
2. Check out this branch and confirm the scrollbar is no longer there

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->