### PR TITLE
fix(registration-block): column layout in editor

### DIFF
--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -334,6 +334,7 @@
 		border: 1px solid wp-colors.$gray-200;
 		border-radius: 2px;
 		padding: 0.5em;
+		box-sizing: border-box;
 		h3 {
 			display: none;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix the column layout rendering on the editor. The lack of the `box-sizing: border-box;` rule, which is applied to the front end, doesn't allow for the flex sizing to render in the desired column layout.

### How to test the changes in this Pull Request:

1. On the master branch, edit a page with the Reader Registration block
2. Make sure the block has newsletters and the column layout is selected
3. Confirm it's not rendered as column
4. Check out this branch, refresh and confirm the layout is rendered as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->