### PR TITLE
feat: title and description for registration block

### DIFF
--- a/assets/blocks/reader-registration/block.json
+++ b/assets/blocks/reader-registration/block.json
@@ -7,6 +7,12 @@
 	"description": "Register a reader with their email.",
 	"textdomain": "newspack",
 	"attributes": {
+		"title": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
 		"placeholder": {
 			"type": "string",
 			"default": "Email Address"

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -40,6 +40,8 @@ const editedStateOptions = [
 export default function ReaderRegistrationEdit( {
 	setAttributes,
 	attributes: {
+		title,
+		description,
 		placeholder,
 		label,
 		privacyLabel,
@@ -191,6 +193,18 @@ export default function ReaderRegistrationEdit( {
 				{ editedState === 'initial' && (
 					<div className={ `newspack-registration ${ className }` }>
 						<form onSubmit={ ev => ev.preventDefault() }>
+							<RichText
+								onChange={ value => setAttributes( { title: value } ) }
+								placeholder={ __( 'Block title…', 'newspack' ) }
+								value={ title }
+								tagName="h2"
+							/>
+							<RichText
+								onChange={ value => setAttributes( { description: value } ) }
+								placeholder={ __( 'Block description…', 'newspack' ) }
+								value={ description }
+								tagName="p"
+							/>
 							<div className="newspack-registration__form-content">
 								{ newsletterSubscription && lists.length ? (
 									<div className="newspack-reader__lists">

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -127,23 +127,34 @@ function render_block( $attrs, $content ) {
 	if ( isset( $_GET['newspack_reader'] ) && isset( $_GET['message'] ) ) {
 		$message = \sanitize_text_field( $_GET['message'] );
 	}
-
-	$success_markup = $content;
-	if ( empty( wp_strip_all_tags( $content ) ) ) {
-		$success_markup = '<p class="has-text-align-center">' . $success_message . '</p>';
-	}
 	// phpcs:enable
+
+	$success_registration_markup = $content;
+	if ( ! empty( \wp_strip_all_tags( $content ) ) ) {
+		$success_registration_markup = '<p class="has-text-align-center">' . $success_message . '</p>';
+	}
+
+	$success_login_markup = $attrs['signedInLabel'];
+	if ( ! empty( \wp_strip_all_tags( $attrs['signedInLabel'] ) ) ) {
+		$success_login_markup = '<p class="has-text-align-center">' . $attrs['signedInLabel'] . '</p>';
+	}
 
 	ob_start();
 	?>
 	<div class="newspack-registration <?php echo esc_attr( get_block_classes( $attrs ) ); ?>">
 		<?php if ( $registered ) : ?>
-			<div class="newspack-registration__success">
+			<div class="newspack-registration__registration-success">
 				<div class="newspack-registration__icon"></div>
-				<?php echo \wp_kses_post( $success_markup ); ?>
+				<?php echo \wp_kses_post( $success_registration_markup ); ?>
 			</div>
 		<?php else : ?>
 			<form>
+				<?php if ( ! empty( $attrs['title'] ) ) : ?>
+					<h2 class="newspack-registration__title"><?php echo \wp_kses_post( $attrs['title'] ); ?></h2>
+				<?php endif; ?>
+				<?php if ( ! empty( $attrs['description'] ) ) : ?>
+					<p class="newspack-registration__description"><?php echo \wp_kses_post( $attrs['description'] ); ?></p>
+				<?php endif; ?>
 				<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
 				<div class="newspack-registration__form-content">
 					<?php
@@ -190,13 +201,13 @@ function render_block( $attrs, $content ) {
 					</div>
 				</div>
 			</form>
-			<div class="newspack-registration__success newspack-registration--hidden">
+			<div class="newspack-registration__registration-success newspack-registration--hidden">
 				<div class="newspack-registration__icon"></div>
-				<?php echo \wp_kses_post( $success_markup ); ?>
+				<?php echo \wp_kses_post( $success_registration_markup ); ?>
 			</div>
-			<div class="newspack-login__success newspack-registration--hidden">
+			<div class="newspack-registration__login-success newspack-registration--hidden">
 				<div class="newspack-registration__icon"></div>
-				<p class="has-text-align-center"><?php echo \wp_kses_post( $attrs['signedInLabel'] ); ?></p>
+				<?php echo \wp_kses_post( $success_login_markup ); ?>
 			</div>
 		<?php endif; ?>
 	</div>

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -38,7 +38,9 @@ function domReady( callback ) {
 
 			const messageElement = container.querySelector( '.newspack-registration__response' );
 			const submitElement = form.querySelector( 'input[type="submit"]' );
-			let successElement = container.querySelector( '.newspack-registration__success' );
+			let successElement = container.querySelector(
+				'.newspack-registration__registration-success'
+			);
 
 			readerActivation.on( 'reader', ( { detail: { authenticated } } ) => {
 				if ( authenticated ) {
@@ -57,7 +59,7 @@ function domReady( callback ) {
 				let messageNode;
 
 				if ( data?.existing_user ) {
-					successElement = document.querySelector( '.newspack-login__success' );
+					successElement = container.querySelector( '.newspack-registration__login-success' );
 				}
 
 				if ( message ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces an optional title and description for the registration block. This allows for the success state of the form to not include this content.

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/820752/185956163-ab20f9cb-0bd7-40e4-866c-51f1e9b71965.png">

There's also a small bug fix to the logged-in success message. It was selecting the node from `document.`, which will select the first from the entire DOM. The correct selector should be `container.`.

### How to test the changes in this Pull Request:

1. Check out this branch
2. Place the registration block on a page with title and description configured
3. Register a new email and confirm the success message displays as expected and the title/description is cleared
4. Register an existing email and confirm the above also behaves as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->