### PR TITLE
feat: set from details for password reset emails

### DIFF
--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -65,6 +65,7 @@ final class Reader_Activation {
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
 			\add_filter( 'woocommerce_email_actions', [ __CLASS__, 'disable_woocommerce_new_user_email' ] );
+			\add_filter( 'retrieve_password_notification_email', [ __CLASS__, 'password_reset_email_from' ] );
 		}
 	}
 
@@ -1299,6 +1300,23 @@ final class Reader_Activation {
 	 */
 	public static function get_from_name() {
 		return apply_filters( 'newspack_reader_activation_from_name', get_bloginfo( 'name' ) );
+	}
+
+	/**
+	 * Filters args sent to wp_mail when a password change email is sent.
+	 *
+	 * @param array $args The default notification email arguments. Used to build wp_mail().
+	 *
+	 * @return array The filtered $args.
+	 */
+	public static function password_reset_email_from( $args ) {
+		$args['headers'] = sprintf(
+			'From: %1$s <%2$s>',
+			self::get_from_name(),
+			self::get_from_email()
+		);
+
+		return $args;
 	}
 }
 Reader_Activation::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Sets the from name and email to the Reader Activation from name/email (default: `Site Name <no-reply@sitedomain.com>`).

### How to test the changes in this Pull Request:

1. Check out this branch, log in or register as a reader.
2. From My Account, click the "Email me a password reset link" button.
3. Confirm that the resulting Password Reset email is sent from the Reader Activation defaults (`Site Name <no-reply@sitedomain.com>`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->