### PR TITLE
fix: if logging in from an overlay prompt, dismiss the prompt after login

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -60,14 +60,22 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 		}
 
 		let currentlyOpenOverlayPrompts = [];
+		let overlayPromptOrigin = null;
 		const hideCurrentlyOpenOverlayPrompts = () =>
 			currentlyOpenOverlayPrompts.forEach( promptElement =>
 				promptElement.setAttribute( 'amp-access-hide', '' )
 			);
-		const displayCurrentlyOpenOverlayPrompts = () =>
-			currentlyOpenOverlayPrompts.forEach( promptElement =>
-				promptElement.removeAttribute( 'amp-access-hide' )
-			);
+		const displayCurrentlyOpenOverlayPrompts = () => {
+			const reader = readerActivation.getReader();
+			const authenticatedFromPrompt = reader?.authenticated && overlayPromptOrigin;
+			currentlyOpenOverlayPrompts.forEach( promptElement => {
+				if ( authenticatedFromPrompt && overlayPromptOrigin.isEqualNode( promptElement ) ) {
+					promptElement.setAttribute( 'amp-access-hide', '' );
+				} else {
+					promptElement.removeAttribute( 'amp-access-hide' );
+				}
+			} );
+		};
 
 		let accountLinks, triggerLinks;
 		const initLinks = function () {
@@ -178,6 +186,8 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			currentlyOpenOverlayPrompts = document.querySelectorAll(
 				'.newspack-lightbox:not([amp-access-hide])'
 			);
+			overlayPromptOrigin = ev.currentTarget.closest( '.newspack-lightbox' );
+
 			hideCurrentlyOpenOverlayPrompts();
 
 			if ( passwordInput && emailInput?.value && 'pwd' === actionInput?.value ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The default Reader Activation strategy serves a Registration block inside of an overlay prompt. The Registration block offers readers with existing accounts the option to log in, which opens another login modal on top of the Registration overlay prompt. If you then log in via this login modal and close the modal after successfully authenticating, the overlay prompt becomes visible again, but with the Registration prompt hidden (because the reader is now authenticated).

This PR detects if a login modal has been opened from inside an overlay prompt, and if the reader's status becomes authenticated at the point they close the login modal, will keep the overlay prompt of origin hidden as well.

### How to test the changes in this Pull Request:

1. Check out this branch
2. Publish an overlay prompt containing a Registration block
3. In a new session, click the "Already have an account? Sign in" link from inside the overlay prompt
4. Observe the login modal appearing while hiding the overlay prompt
5. Close the login modal without interacting with it, confirm that the Registration overlay prompt is shown again
6. Click "Already have an account? Sign in" from inside the prompt again
7. Log into an existing account with a password
8. Close the login modal
9. Confirm that the overlay prompt does NOT become visible again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->