### PR TITLE
feat: for donations via a prompt, add prompt ID to event label

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -403,6 +403,7 @@ class Stripe_Connection {
 				$customer          = self::get_customer_by_id( $payment['customer'] );
 				$amount_normalised = self::normalise_amount( $payment['amount'], $payment['currency'] );
 				$client_id         = isset( $customer['metadata']['clientId'] ) ? $customer['metadata']['clientId'] : null;
+				$origin            = isset( $customer['metadata']['origin'] ) ? $customer['metadata']['origin'] : null;
 
 				$referer = '';
 				if ( isset( $metadata['referer'] ) ) {
@@ -501,12 +502,17 @@ class Stripe_Connection {
 					do_action( 'newspack_new_donation_stripe', $client_id, $donation_data, $was_customer_added_to_mailing_list ? $customer['email'] : null );
 				}
 
+				$label = $frequency;
+				if ( ! empty( $origin ) ) {
+					$label .= ' - ' . $origin;
+				}
+
 				// Send custom event to GA.
 				\Newspack\Google_Services_Connection::send_custom_event(
 					[
 						'category' => __( 'Newspack Donation', 'newspack' ),
 						'action'   => __( 'Stripe', 'newspack' ),
-						'label'    => $frequency,
+						'label'    => $label,
 						'value'    => $amount_normalised,
 						'referer'  => $referer,
 					]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Requires https://github.com/Automattic/newspack-blocks/pull/1253.

For better reporting purposes, we should be able to know when a donation happens via a Newspack Campaigns prompt and the details of that prompt. https://github.com/Automattic/newspack-blocks/pull/1253 appends the prompt's unique ID to the payment metadata if a Stripe donation happens from inside a prompt, and this PR picks up that metadata and appends it to the event label sent to GA, for easy reporting.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/1253.
2. On a test site that's connected to Google Analytics (optional—you can also just `error_log` the `\Newspack\Google_Services_Connection::send_custom_event` payload on [this line](https://github.com/Automattic/newspack-plugin/pull/1928/files#diff-801bd383c9c38a05b4ae27e9aad0ac07aeea35d15498abec76f1c9db6c114260R511)) and with Stripe as the Reader Revenue platform, publish a Newspack Campaigns prompt containing a Streamlined Donate block.
3. On the front-end, make a test donation via the prompt.
4. Confirm that the payment is successful and that the `Newspack Donation` GA event label looks like `month - popups.id_656`. This can be confirmed either by monitoring the realtime events in the GA dashboard, or by `error_log`ging the line specified in step 2.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->