### PR TITLE
fix(stripe): handle WC-originating Stripe transactions

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -396,6 +396,14 @@ class Stripe_Connection {
 
 		$payload = $request['data']['object'];
 
+		// If order_id is set in the metadata, this was not created by this integration.
+		// This can happen when WC Subscriptions w/ Stripe Gateway was active before using this integration.
+		// In such a situation, WCS continues to charge subscribers, but since the platform is set to this integration,
+		// the webhook will still be exectuted for these payments, resulting in duplicate WC orders.
+		if ( isset( $payload['metadata']['order_id'] ) ) {
+			return;
+		}
+
 		switch ( $request['type'] ) {
 			case 'charge.succeeded':
 				$payment           = $payload;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Handles the situation when Stripe is set as the RR platform, but WC continues to charge customers via Stripe. 

Closes https://app.asana.com/0/1202719992789620/1202851460071001

### How to test the changes in this Pull Request:

1. Set up donations with Newspack (WooCommerce) set as the Reader Revenue platform, using Stripe Gateway for payments
2. Make a recurring donation, which will result in a WC subscription being created
3. Switch the platform to Stripe
4. Edit the subscription, so that the next charge happens ASAP (WC allows a min. of hour from now)
5. Come back after the next charge is made, observe that there is just one order for this charge in WC UI

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->