### PR TITLE
fix: show My Account messages using custom messaging instead of WC messaging

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -244,8 +244,8 @@ class WooCommerce_My_Account {
 		\wp_safe_redirect(
 			add_query_arg(
 				[
-					'message'  => $is_error ? __( 'Please check your email inbox for instructions on how to delete your account.', 'newspack' ) : __( 'Something went wrong.', 'newspack' ),
-					'is_error' => $is_error,
+					'message'  => $sent ? __( 'Please check your email inbox for instructions on how to delete your account.', 'newspack' ) : __( 'Something went wrong.', 'newspack' ),
+					'is_error' => ! $sent,
 				],
 				remove_query_arg( self::DELETE_ACCOUNT_URL_PARAM )
 			)

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -147,12 +147,15 @@ class WooCommerce_My_Account {
 			$is_error = true;
 		}
 
-		if ( $is_error ) {
-			\wc_add_notice( $message, 'error' );
-		} else {
-			\wc_add_notice( $message, 'success' );
-		}
-		wp_safe_redirect( remove_query_arg( self::RESET_PASSWORD_URL_PARAM ) );
+		\wp_safe_redirect(
+			add_query_arg(
+				[
+					'message'  => $message,
+					'is_error' => $is_error,
+				],
+				remove_query_arg( self::RESET_PASSWORD_URL_PARAM )
+			)
+		);
 		exit;
 	}
 
@@ -238,13 +241,15 @@ class WooCommerce_My_Account {
 			\restore_previous_locale();
 		}
 
-		if ( $sent ) {
-			wc_add_notice( __( 'Please check your email inbox for instructions on how to delete your account.', 'newspack' ), 'success' );
-		} else {
-			wc_add_notice( __( 'Something went wrong.', 'newspack' ), 'error' );
-		}
-
-		\wp_safe_redirect( \remove_query_arg( self::DELETE_ACCOUNT_URL_PARAM ) );
+		\wp_safe_redirect(
+			add_query_arg(
+				[
+					'message'  => $is_error ? __( 'Please check your email inbox for instructions on how to delete your account.', 'newspack' ) : __( 'Something went wrong.', 'newspack' ),
+					'is_error' => $is_error,
+				],
+				remove_query_arg( self::DELETE_ACCOUNT_URL_PARAM )
+			)
+		);
 		exit;
 	}
 

--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -1,32 +1,45 @@
-.newspack-wc-message {
-	border: 1px solid var( --newspack-primary-color );
-	border-radius: 5px;
-	margin-bottom: 28px;
-	padding: 1px 28px;
-	position: relative;
-	&::before {
-		content: '';
-		width: 100%;
-		height: 100%;
-		position: absolute;
-		top: 0;
-		left: 0;
-		background: var( --newspack-primary-color );
-		opacity: 0.1;
-	}
-
-	&--error {
-		border: 1px solid #ff4364;
+.woocommerce-account {
+	.newspack-wc-message,
+	.woocommerce-message,
+	.woocommerce-info,
+	.woocommerce-error {
+		background: none;
+		border: 1px solid var( --newspack-primary-color );
+		border-radius: 5px;
+		font-family: inherit;
+		font-size: inherit;
+		margin-bottom: 28px;
+		padding: 1px 28px;
+		position: relative;
 		&::before {
-			background: #ff000038;
+			content: '';
+			width: 100%;
+			height: 100%;
+			position: absolute;
+			top: 0;
+			left: 0;
+			background: var( --newspack-primary-color );
+			opacity: 0.1;
+		}
+
+		&--error,
+		&.woocommerce-error {
+			border: 1px solid #ff4364;
+			&::before {
+				background: #ff000038;
+			}
 		}
 	}
-}
 
-.edit-account {
-	input {
-		&:disabled {
-			background-color: #f5f5f5;
+	.woocommerce-message {
+		padding: 28px;
+	}
+
+	.edit-account {
+		input {
+			&:disabled {
+				background-color: #f5f5f5;
+			}
 		}
 	}
 }

--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -1,8 +1,9 @@
 .newspack-wc-message {
-	position: relative;
-	padding: 1px 28px;
-	border-radius: 5px;
 	border: 1px solid var( --newspack-primary-color );
+	border-radius: 5px;
+	margin-bottom: 28px;
+	padding: 1px 28px;
+	position: relative;
 	&::before {
 		content: '';
 		width: 100%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug in some My Account-related flows which should be using our custom My Account templates' messaging UI instead of WooCommerce's default. Also consolidates the styling for WooCommerce's messages so they look the same as ours.

### How to test the changes in this Pull Request:

1. On `master`, register a new email address and go to My Account before verifying. Click the "Set a new password" button and observe that the page seems to reload but no message is shown to indicate anything has happened. Repeat several times.
2. Click the "Send me a link" button and observe that a message is shown instructing you to check your email inbox for a link to verify.
3. Follow the link from the verification email to verify your account, and observe that you see several instances of the "Please check your email inbox for instructions on how to set a new password" message (it queues up the messages for each time you click the button and shows them all at once). Also observe that the styling of these messages differs visually from the "Send me a link" message.
4. Check out this branch, repeat steps 1–3. Confirm that you see a single message when appropriate at each step, and that all messages match visually.
5. Also follow the full "Request account deletion" flow and confirm that messages are shown when appropriate, and that all messages match visually.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->