### PR TITLE
feat(reader-activation): check lists in auth modal by default

### DIFF
--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -717,7 +717,7 @@ final class Reader_Activation {
 								<?php
 								self::render_subscription_lists_inputs(
 									$lists,
-									[],
+									array_keys( $lists ),
 									[
 										'single_label' => $newsletters_label,
 									]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Small tweak.

### How to test the changes in this Pull Request:

1. Configure Reader Activation
1. Visit site as an anonymous user
3. Click "Sign In" in the header
4. Click "I don't have an account" in the modal
5. Observe the newsletters are checked by default

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->