### PR TITLE
fix: register and auth form tweaks

### DIFF
--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -70,7 +70,14 @@
 		}
 		[type='submit'] {
 			background-color: #d33;
-			margin-left: 0.4rem;
+			margin-top: 0.5rem;
+			width: 100%;
+
+			@media ( min-width: 782px ) {
+				margin-left: 0.4rem;
+				margin-top: 0;
+				width: auto;
+			}
 		}
 	}
 

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -120,7 +120,7 @@ function domReady( callback ) {
 					.finally( () => {
 						const body = new FormData( form );
 						if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
-							return;
+							return form.endFlow( 'Please enter a vaild email address.', 400 );
 						}
 						fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 							method: 'POST',

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -93,6 +93,11 @@ function domReady( callback ) {
 
 			form.addEventListener( 'submit', ev => {
 				ev.preventDefault();
+				form.startLoginFlow();
+
+				if ( ! form.npe?.value ) {
+					return form.endLoginFlow( 'Please enter a vaild email address.', 400 );
+				}
 
 				readerActivation
 					.getCaptchaToken()
@@ -100,11 +105,14 @@ function domReady( callback ) {
 						if ( ! captchaToken ) {
 							return;
 						}
-						const tokenField = document.createElement( 'input' );
-						tokenField.setAttribute( 'type', 'hidden' );
-						tokenField.setAttribute( 'name', 'captcha_token' );
+						let tokenField = form.captcha_token;
+						if ( ! tokenField ) {
+							tokenField = document.createElement( 'input' );
+							tokenField.setAttribute( 'type', 'hidden' );
+							tokenField.setAttribute( 'name', 'captcha_token' );
+							form.appendChild( tokenField );
+						}
 						tokenField.value = captchaToken;
-						form.appendChild( tokenField );
 					} )
 					.catch( e => {
 						form.endLoginFlow( e, 400 );
@@ -114,7 +122,6 @@ function domReady( callback ) {
 						if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 							return;
 						}
-						form.startLoginFlow();
 						fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 							method: 'POST',
 							headers: {

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -308,6 +308,15 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			 */
 			form.addEventListener( 'submit', ev => {
 				ev.preventDefault();
+				form.startLoginFlow();
+
+				if ( ! form.npe?.value ) {
+					return form.endLoginFlow( 'Please enter a vaild email address.', 400 );
+				}
+
+				if ( 'pwd' === actionInput?.value && ! form.password?.value ) {
+					return form.endLoginFlow( 'Please enter a password.', 400 );
+				}
 
 				readerActivation
 					.getCaptchaToken()
@@ -315,11 +324,14 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 						if ( ! captchaToken ) {
 							return;
 						}
-						const tokenField = document.createElement( 'input' );
-						tokenField.setAttribute( 'type', 'hidden' );
-						tokenField.setAttribute( 'name', 'captcha_token' );
+						let tokenField = form.captcha_token;
+						if ( ! tokenField ) {
+							tokenField = document.createElement( 'input' );
+							tokenField.setAttribute( 'type', 'hidden' );
+							tokenField.setAttribute( 'name', 'captcha_token' );
+							form.appendChild( tokenField );
+						}
 						tokenField.value = captchaToken;
-						form.appendChild( tokenField );
 					} )
 					.catch( e => {
 						form.endLoginFlow( e, 400 );
@@ -330,7 +342,6 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 							return;
 						}
 						readerActivation.setReaderEmail( body.get( 'npe' ) );
-						form.startLoginFlow();
 						fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 							method: 'POST',
 							headers: {

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -339,7 +339,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					.finally( () => {
 						const body = new FormData( ev.target );
 						if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
-							return;
+							return form.endFlow( 'Please enter a vaild email address.', 400 );
 						}
 						readerActivation.setReaderEmail( body.get( 'npe' ) );
 						fetch( form.getAttribute( 'action' ) || window.location.pathname, {

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -201,6 +201,15 @@
 			gap: 0.5em;
 			justify-content: space-between;
 			margin: 0 0 1em;
+			padding-right: 40px;
+
+			.newspack-reader__auth-form__inline & {
+				padding-right: 0;
+			}
+
+			@media screen and ( min-width: 600px ) {
+				padding-right: 0;
+			}
 
 			h2 {
 				font-size: 1em;

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -201,11 +201,6 @@
 			gap: 0.5em;
 			justify-content: space-between;
 			margin: 0 0 1em;
-			padding-right: 40px;
-
-			@media screen and ( min-width: 600px ) {
-				padding-right: 0;
-			}
 
 			h2 {
 				font-size: 1em;

--- a/includes/class-reader-activation.php
+++ b/includes/class-reader-activation.php
@@ -1016,7 +1016,7 @@ final class Reader_Activation {
 
 		$user = \get_user_by( 'email', $email );
 		if ( ( ! $user && 'register' !== $action ) || ( $user && ! self::is_user_reader( $user ) ) ) {
-			return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( 'Invalid account.', 'newspack' ) ) );
+			return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( "We couldn't find an account registered to this email address. Please confirm that you entered the correct email, or sign up for a new account.", 'newspack' ) ) );
 		}
 
 		$payload = [
@@ -1039,7 +1039,7 @@ final class Reader_Activation {
 			case 'link':
 				$sent = Magic_Link::send_email( $user );
 				if ( true !== $sent ) {
-					return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( 'Invalid account.', 'newspack' ) ) );
+					return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( 'We encountered an error sending an authentication link. Please try again.', 'newspack' ) ) );
 				}
 				return self::send_auth_form_response( $payload, __( 'Please check your inbox for an authentication link.', 'newspack' ), $redirect );
 			case 'register':

--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -31,6 +31,10 @@
 		}
 	}
 
+	.woocommerce-Button {
+		margin-top: 8px;
+	}
+
 	.woocommerce-message {
 		padding: 28px;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks some mobile form styles and front-end behavior for the Register and Login forms. There's a corresponding [Newsletters PR](https://github.com/Automattic/newspack-newsletters/pull/937) with similar fixes, too. The Blocks repo doesn't need these fixes despite also using reCAPTCHA because it uses a different mechanism to capture the captcha token and send it to the server for verification, and because the Donate block's styles are already mobile-friendly.

### How to test the changes in this Pull Request:

#### Register block mobile styles

1. View a Register block in a mobile viewport. Confirm that the "Sign Up" button appears below the email address field, and that both email address field and Sign Up button appear at full-width:

<img width="351" alt="Screen Shot 2022-08-25 at 5 14 15 PM" src="https://user-images.githubusercontent.com/2230142/186784672-d3de372c-8aca-44eb-95fe-c7c16bd54928.png">

2. View at a desktop viewport and confirm that the styles still look appropriate here too:

<img width="703" alt="Screen Shot 2022-08-25 at 5 14 51 PM" src="https://user-images.githubusercontent.com/2230142/186784709-efd91f60-30bd-44a1-9fe0-93266cbc2836.png">

#### Inline auth form mobile styles

1. Go to the My Account page while not logged in. View at a mobile viewport and confirm that the "I don't have an account" link aligns flush-right with the edge of the content:

<img width="357" alt="Screen Shot 2022-08-25 at 5 16 14 PM" src="https://user-images.githubusercontent.com/2230142/186784825-73b6b16f-fe54-4445-bb81-b5fa9809e167.png">

2. Open the auth modal by clicking on "Sign In" button from the nav header, or by clicking the "Already have an account? Sign in" link from a Register block. Confirm that the "I don't have an account" link is offset slightly, allowing it to be fully visible alongside the X close button:

<img width="366" alt="Screen Shot 2022-08-25 at 5 17 02 PM" src="https://user-images.githubusercontent.com/2230142/186784980-62a519f8-8067-4444-81ac-8e34386781a0.png">

#### Front-end form validation

This helps us avoid hitting the server at all if we're missing the required fields, and gives more helpful reader-facing feedback if they submit without filling out the form.

1. For both the Register and auth forms, try to submit the form without entering an email address and confirm that you get an error message stating "Please enter a vaild email address" no matter how many times you try to submit the empty field.
2. For the auth form, request the magic link with a valid email address and confirm that it still works.
3. For the auth form, try to submit a password form with an email address but no password and confirm that you get an error message stating "Please enter a password".

#### reCAPTCHA token field fix

Currently, we generate a reCAPTCHA token and append it to the form as a hidden field each time the form is submitted. This means if the form submission fails for whatever reason, a new field will be added for each submission attempt. This PR fixes things so that a maximum of one reCAPTCHA token field will be created, and its value simply updated for each submission attempt.

1. On `master`, for both the Register and auth forms, try to submit the form without any fields filled out. Inspect the form in the DOM and observe that for each failed form submission, a new hidden input with name `captcha_token` is appended to the form.
2. Check out this branch and repeat. This time confirm that only one input is created on the first submission attempt, and its value is updated for each attempt thereafter.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->