### PR TITLE
Feat/use universal from email

### DIFF
--- a/assets/other-scripts/emails/index.js
+++ b/assets/other-scripts/emails/index.js
@@ -4,7 +4,7 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Button, Spinner, TextControl } from '@wordpress/components';
@@ -38,7 +38,7 @@ const ReaderRevenueEmailSidebar = compose( [
 			updatePostTitle: title => editPost( { title } ),
 		};
 	} ),
-] )( ( { postId, savePost, title, postMeta, updatePostTitle, updatePostMeta, createNotice } ) => {
+] )( ( { postId, savePost, title, postMeta, updatePostTitle, createNotice } ) => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ settings, updateSettings ] = hooks.useObjectState( {
 		testRecipient: newspack_emails.current_user_email,
@@ -52,6 +52,18 @@ const ReaderRevenueEmailSidebar = compose( [
 				isDismissible: false,
 			} );
 		}
+		createNotice(
+			'info',
+			sprintf(
+				/* translators: 1: "From" email address 2: "From" email name */
+				__( 'This email will appear as sent from "%1$s" email address, by "%2$s".', 'newspack' ),
+				config.from_email || newspack_emails.from_email,
+				config.from_name || newspack_emails.from_name
+			),
+			{
+				isDismissible: false,
+			}
+		);
 	}, [] );
 
 	const sendTestEmail = async () => {
@@ -103,29 +115,6 @@ const ReaderRevenueEmailSidebar = compose( [
 					label={ __( 'Subject', 'newspack' ) }
 					value={ title }
 					onChange={ updatePostTitle }
-				/>
-				<TextControl
-					label={ __( '"From" name', 'newspack' ) }
-					value={ config.from_name || postMeta.from_name }
-					onChange={ updatePostMeta( 'from_name' ) }
-					disabled={ config.from_name }
-					help={
-						config.from_name
-							? __( '"From" name is not editable because of the email configuration.', 'newspack' )
-							: undefined
-					}
-				/>
-				<TextControl
-					label={ __( '"From" email address', 'newspack' ) }
-					value={ config.from_email || postMeta.from_email }
-					type="email"
-					onChange={ updatePostMeta( 'from_email' ) }
-					disabled={ config.from_email }
-					help={
-						config.from_email
-							? __( '"From" email is not editable because of the email configuration.', 'newspack' )
-							: undefined
-					}
 				/>
 			</PluginDocumentSettingPanel>
 			<PluginDocumentSettingPanel name="email-testing-panel" title={ __( 'Testing', 'newspack' ) }>

--- a/assets/other-scripts/emails/index.js
+++ b/assets/other-scripts/emails/index.js
@@ -56,7 +56,7 @@ const ReaderRevenueEmailSidebar = compose( [
 			'info',
 			sprintf(
 				/* translators: 1: "From" email address 2: "From" email name */
-				__( 'This email will appear as sent from "%1$s" email address, by "%2$s".', 'newspack' ),
+				__( 'This email will be sent from %1$s <%2$s>.', 'newspack' ),
 				config.from_email || newspack_emails.from_email,
 				config.from_name || newspack_emails.from_name
 			),

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -307,85 +307,6 @@ final class Magic_Link {
 	}
 
 	/**
-	 * Get a magic link email arguments given a user.
-	 *
-	 * @param \WP_User $user        User to generate the magic link for.
-	 * @param string   $redirect_to Which page to redirect the reader after authenticating.
-	 * @param string   $subject     The subject of the email.
-	 * @param string   $message     Message to show in body of email.
-	 *
-	 * @return array|\WP_Error $email Email arguments or error. {
-	 *   Used to build wp_mail().
-	 *
-	 *   @type string $to      The intended recipient - New user email address.
-	 *   @type string $subject The subject of the email.
-	 *   @type string $message The body of the email.
-	 *   @type string $headers The headers of the email.
-	 * }
-	 */
-	public static function generate_email( $user, $redirect_to = '', $subject, $message = '' ) {
-		if ( ! self::can_magic_link( $user->ID ) ) {
-			return new \WP_Error( 'newspack_magic_link_invalid_user', __( 'Invalid user.', 'newspack' ) );
-		}
-
-		$magic_link_url = self::generate_url( $user, $redirect_to );
-
-		if ( \is_wp_error( $magic_link_url ) ) {
-			return $magic_link_url;
-		}
-
-		$blogname = \wp_specialchars_decode( \get_option( 'blogname' ), ENT_QUOTES );
-
-		$switched_locale = \switch_to_locale( \get_user_locale( $user ) );
-
-		if ( empty( $subject ) ) {
-			$subject = __( 'Authentication link', 'newspack' );
-		}
-
-		if ( empty( $message ) ) {
-			/* translators: %s: Site title. */
-			$message  = sprintf( __( 'Welcome back to %s!', 'newspack' ), $blogname ) . "\r\n\r\n";
-			$message .= __( 'Log into your account by visiting the following URL:', 'newspack' ) . "\r\n\r\n";
-		}
-
-		$message .= $magic_link_url . "\r\n";
-
-		$email = [
-			'to'      => $user->user_email,
-			/* translators: %s Site title. */
-			'subject' => __( '[%s] ', 'newspack' ) . $subject,
-			'message' => $message,
-			'headers' => [
-				sprintf(
-					'From: %1$s <%2$s>',
-					Emails::get_from_name(),
-					Emails::get_from_email()
-				),
-			],
-		];
-
-		if ( $switched_locale ) {
-			\restore_previous_locale();
-		}
-
-		/**
-		 * Filters the magic link email.
-		 *
-		 * @param array    $email          Email arguments. {
-		 *   Used to build wp_mail().
-		 *
-		 *   @type string $to      The intended recipient - New user email address.
-		 *   @type string $subject The subject of the email.
-		 *   @type string $message The body of the email.
-		 *   @type string $headers The headers of the email.
-		 * }
-		 * @param \WP_User $user           User to send the magic link to.
-		 * @param string   $magic_link_url Magic link url.
-		 */
-		return \apply_filters( 'newspack_magic_link_email', $email, $user, $magic_link_url );
-	}
-
-	/**
 	 * Send magic link email to reader.
 	 *
 	 * @param \WP_User $user        User to send the magic link to.
@@ -396,24 +317,16 @@ final class Magic_Link {
 	 * @return bool|\WP_Error Whether the email was sent or WP_Error if sending failed.
 	 */
 	public static function send_email( $user, $redirect_to = '', $subject = '', $message = '' ) {
-		$email = self::generate_email( $user, $redirect_to, $subject, $message );
-
-		if ( \is_wp_error( $email ) ) {
-			return $email;
-		}
-
-		$blogname = \wp_specialchars_decode( \get_option( 'blogname' ), ENT_QUOTES );
-
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
-		$sent = \wp_mail(
-			$email['to'],
-			\wp_specialchars_decode( sprintf( $email['subject'], $blogname ) ),
-			$email['message'],
-			$email['headers']
+		return Emails::send_email(
+			Reader_Activation_Emails::EMAIL_TYPES['MAGIC_LINK'],
+			$user->user_email,
+			[
+				[
+					'template' => '*MAGIC_LINK_URL*',
+					'value'    => self::generate_url( $user, $redirect_to ),
+				],
+			]
 		);
-		Logger::log( 'Sending magic link to ' . $email['to'] );
-
-		return $sent;
 	}
 
 	/**

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -358,8 +358,8 @@ final class Magic_Link {
 			'headers' => [
 				sprintf(
 					'From: %1$s <%2$s>',
-					Reader_Activation::get_from_name(),
-					Reader_Activation::get_from_email()
+					Emails::get_from_name(),
+					Emails::get_from_email()
 				),
 			],
 		];

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class Emails {
 	const POST_TYPE              = 'newspack_rr_email'; // "Reader Revenue" emails, for legacy reasons.
-	const EMAIL_CONFIG_NAME_META = 'newspack_email_type'; // "ype" for legacy reasons.
+	const EMAIL_CONFIG_NAME_META = 'newspack_email_type'; // "type" for legacy reasons.
 
 	/**
 	 * Initialize.
@@ -162,21 +162,23 @@ class Emails {
 	/**
 	 * Send an HTML email.
 	 *
-	 * @param string|int $type_or_post_id Email type or email post ID.
+	 * @param string|int $config_name_or_post_id Email config name or email post ID.
 	 * @param string     $to Recipient's email addesss.
 	 * @param array      $placeholders Dynamic content substitutions.
 	 */
-	public static function send_email( $type_or_post_id, $to, $placeholders = [] ) {
+	public static function send_email( $config_name_or_post_id, $to, $placeholders = [] ) {
 		if ( ! self::supports_emails() ) {
 			return false;
 		}
 
-		$switched_locale = \switch_to_locale( \get_user_locale( \wp_get_current_user() ) );
+		$switched_locale   = \switch_to_locale( \get_user_locale( \wp_get_current_user() ) );
+		$email_config_name = $config_name_or_post_id;
 
-		if ( 'string' === gettype( $type_or_post_id ) ) {
-			$email_config = self::get_email_config_by_type( $type_or_post_id );
-		} elseif ( 'integer' === gettype( $type_or_post_id ) ) {
-			$email_config = self::serialize_email( null, $type_or_post_id );
+		if ( 'string' === gettype( $config_name_or_post_id ) ) {
+			$email_config = self::get_email_config_by_type( $config_name_or_post_id );
+		} elseif ( 'integer' === gettype( $config_name_or_post_id ) ) {
+			$email_config      = self::serialize_email( null, $config_name_or_post_id );
+			$email_config_name = \get_post_meta( $config_name_or_post_id, self::EMAIL_CONFIG_NAME_META, true );
 		} else {
 			return false;
 		}
@@ -227,6 +229,8 @@ class Emails {
 		if ( $switched_locale ) {
 			\restore_previous_locale();
 		}
+
+		Logger::log( 'Sending "' . $email_config_name . '" email to: ' . $to );
 
 		return $email_send_result;
 	}

--- a/includes/reader-activation/class-reader-activation-emails.php
+++ b/includes/reader-activation/class-reader-activation-emails.php
@@ -34,8 +34,6 @@ class Reader_Activation_Emails {
 	public static function add_email_configs( $configs ) {
 		$configs[ self::EMAIL_TYPES['VERIFICATION'] ] = [
 			'name'                   => self::EMAIL_TYPES['VERIFICATION'],
-			'from_name'              => Reader_Activation::get_from_name(),
-			'from_email'             => Reader_Activation::get_from_email(),
 			'label'                  => __( 'Verification', 'newspack' ),
 			'description'            => __( "Email sent to the reader after they've registered.", 'newspack' ),
 			'template'               => dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-activation-emails/verification.php',

--- a/includes/reader-activation/class-reader-activation-emails.php
+++ b/includes/reader-activation/class-reader-activation-emails.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
 class Reader_Activation_Emails {
 	const EMAIL_TYPES = [
 		'VERIFICATION' => 'reader-activation-verification',
+		'MAGIC_LINK'   => 'reader-activation-magic-link',
 	];
 
 	/**
@@ -42,6 +43,19 @@ class Reader_Activation_Emails {
 				[
 					'label'    => __( 'the verification link', 'newspack' ),
 					'template' => '*VERIFICATION_URL*',
+				],
+			],
+		];
+		$configs[ self::EMAIL_TYPES['MAGIC_LINK'] ]   = [
+			'name'                   => self::EMAIL_TYPES['MAGIC_LINK'],
+			'label'                  => __( 'Login link', 'newspack' ),
+			'description'            => __( 'Email with a login link.', 'newspack' ),
+			'template'               => dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-activation-emails/magic-link.php',
+			'editor_notice'          => __( 'This email will be sent to a reader when they request a login link.', 'newspack' ),
+			'available_placeholders' => [
+				[
+					'label'    => __( 'the login link', 'newspack' ),
+					'template' => '*MAGIC_LINK_URL*',
 				],
 			],
 		];

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -141,7 +141,7 @@ final class Reader_Activation {
 			'sync_esp'                    => true,
 			'sync_esp_delete'             => true,
 			'active_campaign_master_list' => '',
-			'emails'                      => Emails::get_emails( [ Reader_Activation_Emails::EMAIL_TYPES['VERIFICATION'] ], false ),
+			'emails'                      => Emails::get_emails( array_values( Reader_Activation_Emails::EMAIL_TYPES ), false ),
 		];
 
 		/**
@@ -1259,8 +1259,6 @@ final class Reader_Activation {
 	public static function send_verification_email( $user ) {
 		$redirect_to = function_exists( '\wc_get_account_endpoint_url' ) ? \wc_get_account_endpoint_url( 'dashboard' ) : '';
 
-
-		Logger::log( 'Sending verification email to new user ' . $user->user_email );
 		return Emails::send_email(
 			Reader_Activation_Emails::EMAIL_TYPES['VERIFICATION'],
 			$user->user_email,

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1301,41 +1301,6 @@ final class Reader_Activation {
 		return $emails;
 	}
 
-	/**
-	 * Get the from email address used to send all transactional emails.
-	 * We avoid use of the `wp_mail_from` hook because we only want to
-	 * set the email address for Reader Activation emails, not all emails
-	 * sent via wp_mail.
-	 *
-	 * @return string Email address used as the sender for Reader Activation emails.
-	 */
-	public static function get_from_email() {
-		// Get the site domain and get rid of www.
-		$sitename   = wp_parse_url( network_home_url(), PHP_URL_HOST );
-		$from_email = 'no-reply@';
-
-		if ( null !== $sitename ) {
-			if ( 'www.' === substr( $sitename, 0, 4 ) ) {
-				$sitename = substr( $sitename, 4 );
-			}
-
-			$from_email .= $sitename;
-		}
-
-		return apply_filters( 'newspack_reader_activation_from_email', $from_email );
-	}
-
-	/**
-	 * Get the from from name used to send all transactional emails.
-	 * We avoid use of the `wp_mail_from_name` hook because we only want
-	 * to set the name for Reader Activation emails, not all emails
-	 * sent via wp_mail.
-	 *
-	 * @return string Name used as the sender for Reader Activation emails.
-	 */
-	public static function get_from_name() {
-		return apply_filters( 'newspack_reader_activation_from_name', get_bloginfo( 'name' ) );
-	}
 
 	/**
 	 * Filters args sent to wp_mail when a password change email is sent.
@@ -1347,8 +1312,8 @@ final class Reader_Activation {
 	public static function password_reset_email_from( $args ) {
 		$args['headers'] = sprintf(
 			'From: %1$s <%2$s>',
-			self::get_from_name(),
-			self::get_from_email()
+			Emails::get_from_name(),
+			Emails::get_from_email()
 		);
 
 		return $args;

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -209,8 +209,8 @@ class WooCommerce_My_Account {
 			'headers' => [
 				sprintf(
 					'From: %1$s <%2$s>',
-					Reader_Activation::get_from_name(),
-					Reader_Activation::get_from_email()
+					Emails::get_from_name(),
+					Emails::get_from_email()
 				),
 			],
 		];

--- a/includes/templates/reader-activation-emails/magic-link.php
+++ b/includes/templates/reader-activation-emails/magic-link.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Homepage Pattern.
+ *
+ * @package Newspack
+ */
+
+// phpcs:disable WordPressVIPMinimum.Security.Mustache.OutputNotation
+
+return array(
+	'post_title'   => __( 'Authentication link', 'newspack' ),
+	'post_content' => '<!-- wp:site-logo {"align":"center"} /-->
+
+  <!-- wp:heading -->
+  <h2>' . __( 'Welcome back!', 'newspack' ) . '</h2>
+  <!-- /wp:heading -->
+
+  <!-- wp:paragraph -->
+  <p>' . __( 'Log into your account by clicking this button:', 'newspack' ) . '</p>
+  <!-- /wp:paragraph -->
+
+  <!-- wp:buttons -->
+  <div class="wp-block-buttons"><!-- wp:button {"style":{"color":{"background":"#dd3333"}}} -->
+  <div class="wp-block-button"><a class="wp-block-button__link has-background" href="*MAGIC_LINK_URL*" style="background-color:#dd3333">' . __( 'Log in', 'newspack' ) . '</a></div>
+  <!-- /wp:button --></div>
+  <!-- /wp:buttons -->
+
+  <!-- wp:paragraph -->
+  <p>' . __( 'Or copy and paste the link in your browser:', 'newspack' ) . ' <a href="*MAGIC_LINK_URL*" data-type="URL" data-id="*MAGIC_LINK_URL*">*MAGIC_LINK_URL*</a></p>
+  <!-- /wp:paragraph -->',
+	'email_html'   => '<!doctype html><html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head><title>Your verification link</title><!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]--><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style type="text/css">#outlook a { padding:0; }
+  body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+  table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+  img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+  p { display:block;margin:13px 0; }</style><!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+  <o:AllowPNG/>
+  <o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<![endif]--><!--[if lte mso 11]>
+<style type="text/css">
+  .mj-outlook-group-fix { width:100% !important; }
+</style>
+<![endif]--><style type="text/css">@media only screen and (min-width:480px) {
+    .mj-column-per-100 { width:100% !important; max-width: 100%; }
+  }</style><style media="screen and (min-width:480px)">.moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }</style><style type="text/css">@media only screen and (max-width:480px) {
+  table.mj-full-width-mobile { width: 100% !important; }
+  td.mj-full-width-mobile { width: auto !important; }
+}</style><style type="text/css">/* Paragraph */
+p {
+margin-top: 0 !important;
+margin-bottom: 0 !important;
+}
+
+/* Link */
+a {
+color: inherit !important;
+text-decoration: underline;
+}
+a:active, a:focus, a:hover {
+text-decoration: none;
+}
+a:focus {
+outline: thin dotted #000;
+}
+
+/* Button */
+.is-style-outline a {
+background: #fff !important;
+border: 2px solid !important;
+display: block !important;
+}
+
+/* Heading */
+h1, h2, h3, h4, h5, h6 {
+margin-top: 0;
+margin-bottom: 0;
+}
+
+h1 {
+font-size: 2.44em;
+line-height: 1.24;
+}
+
+h2 {
+font-size: 1.95em;
+line-height: 1.36;
+}
+
+h3 {
+font-size: 1.56em;
+line-height: 1.44;
+}
+
+h4 {
+font-size: 1.25em;
+line-height: 1.6;
+}
+
+h5 {
+font-size: 1em;
+line-height: 1.5em;
+}
+
+h6 {
+font-size: 0.8em;
+line-height: 1.56;
+}
+
+/* List */
+ul, ol {
+margin-bottom: 0;
+margin-top: 0;
+padding-left: 1.3em;
+}
+
+/* Quote */
+blockquote,
+.wp-block-quote {
+background: transparent;
+border-left: 0.25em solid;
+margin: 0;
+padding-left: 24px;
+}
+blockquote cite,
+.wp-block-quote cite {
+color: #767676;
+}
+blockquote p,
+.wp-block-quote p {
+padding-bottom: 12px;
+}
+.wp-block-quote.is-style-plain,
+.wp-block-quote.is-style-large {
+border-left: 0;
+padding-left: 0;
+}
+.wp-block-quote.is-style-large p {
+font-size: 24px;
+font-style: italic;
+line-height: 1.6;
+}
+
+/* Image */
+@media all and (max-width: 590px) {
+img {
+height: auto !important;
+}
+}
+
+/* Social links */
+.social-element img {
+border-radius: 0 !important;
+}
+
+/* Has Background */
+.mj-column-has-width .has-background,
+.mj-column-per-50 .has-background {
+padding: 12px;
+}
+
+/* Mailchimp Footer */
+#canspamBarWrapper {
+border: 0 !important;
+}</style></head><body style="word-spacing:normal;background-color:#ffffff;"><div style="background-color:#ffffff;"><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]--><div style="margin:0px auto;max-width:600px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]--><div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="center" style="font-size:0px;padding:0;word-break:break-word;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"><tbody><tr><td style="width:125px;"><a href="*SITE_URL*" target=""><img height="auto" src="*SITE_LOGO*" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="125"></a></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]--><div style="margin:0px auto;max-width:600px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]--><div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><div style="font-family:Arial;font-size:16px;line-height:1.5;text-align:left;color:#000000;"><h2>' . __( 'Welcome back!', 'newspack' ) . '</h2></div></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]--><div style="margin:0px auto;max-width:600px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]--><div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><div style="font-family:Georgia;font-size:16px;line-height:1.5;text-align:left;color:#000000;"><p>' . __( 'Log into your account by clicking this button:', 'newspack' ) . '</p></div></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]--><div style="margin:0px auto;max-width:600px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]--><div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="center" vertical-align="middle" style="font-size:0px;padding:0;word-break:break-word;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"><tbody><tr><td align="center" bgcolor="#dd3333 !important" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:12px 24px;background:#dd3333 !important;" valign="middle"><a href="*MAGIC_LINK_URL*" style="display:inline-block;background:#dd3333 !important;color:#fff !important;font-family:Georgia;font-size:16px;font-weight:bold;line-height:1.5;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:999px;" target="_blank">' . __( 'Log in', 'newspack' ) . '</a></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]--><div style="margin:0px auto;max-width:600px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]--><div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><div style="font-family:Georgia;font-size:16px;line-height:1.5;text-align:left;color:#000000;"><p>' . __( 'Or copy and paste the link in your browser:', 'newspack' ) . ' <a href="*MAGIC_LINK_URL*" data-type="URL" data-id="*MAGIC_LINK_URL*">*MAGIC_LINK_URL*</a></p></div></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></div></body></html>',
+);

--- a/tests/unit-tests/emails.php
+++ b/tests/unit-tests/emails.php
@@ -44,12 +44,6 @@ class Newspack_Test_Emails extends WP_UnitTestCase {
 	 * @param string $type Email type.
 	 */
 	private static function get_test_email( $type ) {
-		$email = Emails::get_emails()[ $type ];
-		// Mitigate a weird issue with PHPUnit – when running the whole test suite (as opposed to a
-		// single run with `--filter` flag), the default values from `register_meta` calls are ignored.
-		update_post_meta( $email['post_id'], 'from_name', get_bloginfo( 'name' ) );
-		update_post_meta( $email['post_id'], 'from_email', get_bloginfo( 'admin_email' ) );
-		// Return the updated version.
 		return Emails::get_emails()[ $type ];
 	}
 

--- a/tests/unit-tests/emails.php
+++ b/tests/unit-tests/emails.php
@@ -137,7 +137,7 @@ class Newspack_Test_Emails extends WP_UnitTestCase {
 			'Sent email has the expected subject'
 		);
 		self::assertContains(
-			'From: Test Blog <admin@example.org>',
+			'From: Test Blog <no-reply@example.org>',
 			$mailer->get_sent()->header,
 			'Sent email has the expected "From" header'
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Removes the ability to set "From" name and email per-email. Instead, this can be overwritten per-email-config (not by the end user, though). 
2. Adds universal "From" name and email handling, for all emails sent by Newspack
3. HTMLifies and adds ability to customise Reader Activation's magic link email 

_Note: after this is merged, https://github.com/Automattic/newspack-newsletters/pull/938 will have to be merged too_

### How to test the changes in this Pull Request:

1. Configure Reader Activation and set Stripe as the Reader Revenue platform
5. Visit Reader Revenue wizard -> Emails, and edit the "Receipt" email 
6. Observe a notice displayed, informing about the "From" name and email address
7. Make a donation, observe an HTML email is sent, from the expected address (`no-reply@site-name.com`)
8. Use the magic link option to log in, observe the email is an HTML email, and that the log in button link works
9. Visit Engagement -> Reader Activation section, and edit the "Login link" email
10. Again use the magic link to sign in, observe the updated email is sent

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->