### PR TITLE
fix(registration-block): fix empty success state

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -131,7 +131,7 @@ function render_block( $attrs, $content ) {
 	// phpcs:enable
 
 	$success_registration_markup = $content;
-	if ( ! empty( \wp_strip_all_tags( $content ) ) ) {
+	if ( empty( \wp_strip_all_tags( $content ) ) ) {
 		$success_registration_markup = '<p class="has-text-align-center">' . $success_message . '</p>';
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug introduced in https://github.com/Automattic/newspack-plugin/pull/1924

### How to test the changes in this Pull Request:

1. On `master`, insert a Registration block and publish the post
2. Register as a new reader, observe the success state contains only the icon
3. Switch to this branch, repeat the test, observe the success state has the default "thank you" copy

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->