### PR TITLE
feat(analytics): prevent sending NTG newsletter event if subscribing to master list

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -944,6 +944,12 @@ class Analytics {
 			return;
 		}
 
+		// If the user is only being subscribed to the master list, they did not sign up for the newsletter explicitly.
+		$lists = Newspack_Newsletters::get_lists_without_active_campaign_master_list( $lists );
+		if ( empty( $lists ) ) {
+			return;
+		}
+
 		\Newspack\Google_Services_Connection::send_custom_event(
 			[
 				'category' => __( 'NTG newsletter', 'newspack' ),

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -202,11 +202,16 @@ class Newspack_Newsletters {
 	public static function get_lists_without_active_campaign_master_list( $list_ids ) {
 		$master_list_id = Reader_Activation::get_setting( 'active_campaign_master_list' );
 		if ( is_int( intval( $master_list_id ) ) ) {
-			if ( ( $key = array_search( $master_list_id, $list_ids ) ) !== false ) { // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure
-				unset( $list_ids[ $key ] );
-			}
+			return array_values( // Reset keys.
+				array_filter(
+					$list_ids,
+					function( $id ) use ( $master_list_id ) {
+						return $id !== $master_list_id;
+					}
+				)
+			);
 		}
-		return array_values( $list_ids ); // Reset keys.
+		return $list_ids;
 	}
 
 	/**

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -206,7 +206,7 @@ class Newspack_Newsletters {
 				unset( $list_ids[ $key ] );
 			}
 		}
-		return $list_ids;
+		return array_values( $list_ids ); // Reset keys.
 	}
 
 	/**

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -195,8 +195,22 @@ class Newspack_Newsletters {
 	}
 
 	/**
-	 * Ensure the contact is always added to ActiveCampaign's selected master
-	 * list.
+	 * Get lists without the master list, if set.
+	 *
+	 * @param int[] $list_ids List IDs to filter.
+	 */
+	public static function get_lists_without_active_campaign_master_list( $list_ids ) {
+		$master_list_id = Reader_Activation::get_setting( 'active_campaign_master_list' );
+		if ( is_int( intval( $master_list_id ) ) ) {
+			if ( ( $key = array_search( $master_list_id, $list_ids ) ) !== false ) { // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure
+				unset( $list_ids[ $key ] );
+			}
+		}
+		return $list_ids;
+	}
+
+	/**
+	 * Ensure the contact is always added to ActiveCampaign's selected master list.
 	 *
 	 * @param string[]|false $lists    Array of list IDs the contact will be subscribed to, or false.
 	 * @param array          $contact  {

--- a/tests/unit-tests/newsletters.php
+++ b/tests/unit-tests/newsletters.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests the Newsletters integration.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Newspack_Newsletters;
+use Newspack\Reader_Activation;
+
+/**
+ * Tests the Newsletters integration.
+ */
+class Newspack_Test_Newspack_Newsletters extends WP_UnitTestCase {
+	/**
+	 * Test the "master list" feature.
+	 */
+	public function test_newsletters_master_list_feature() {
+		$list_ids = [ 1, 2, 3 ];
+		self::assertEquals(
+			$list_ids,
+			Newspack_Newsletters::add_activecampaign_master_list( $list_ids, '', 'active_campaign' ),
+			'Expected to get the same lists back when no master list is set.'
+		);
+
+		self::assertEquals(
+			$list_ids,
+			Newspack_Newsletters::add_activecampaign_master_list( $list_ids, '', 'other_provider' ),
+			'Expected to get the same lists back when other provider is set.'
+		);
+
+		self::assertEquals(
+			$list_ids,
+			Newspack_Newsletters::get_lists_without_active_campaign_master_list( $list_ids ),
+			'Expected to get the same lists back when no master list is set.'
+		);
+
+		// Set the master list.
+		$master_list_id = 2;
+		Reader_Activation::update_setting( 'active_campaign_master_list', $master_list_id );
+
+		self::assertEquals(
+			[ $master_list_id ],
+			Newspack_Newsletters::add_activecampaign_master_list( [], '', 'active_campaign' ),
+			'Expected to get the master list id if empty lists are passed.'
+		);
+
+		self::assertEquals(
+			[ 4, 5, $master_list_id ],
+			Newspack_Newsletters::add_activecampaign_master_list( [ 4, 5 ], '', 'active_campaign' ),
+			'Master list id is appended.'
+		);
+
+		self::assertEquals(
+			[ 1, 3 ],
+			Newspack_Newsletters::get_lists_without_active_campaign_master_list( $list_ids ),
+			'Expected to get the same lists back when no master list is set.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small issue.

### How to test the changes in this Pull Request:

1. Configure a site w/ ActiveCampagin and set a "Master List" in the Engagement wizard
1. On `master`, register w/out subscribing to any newsletter
2. Observe an "NTG newsletter" event is sent anyway*
3. Switch to this branch, observe the event is not sent

\* This will be logged if `NEWSPACK_LOG_LEVEL` is set to `>= 2`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->