### PR TITLE
feat(registration-block): hidden input for subscription

### DIFF
--- a/assets/blocks/reader-registration/block.json
+++ b/assets/blocks/reader-registration/block.json
@@ -34,6 +34,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"hideSubscriptionInput": {
+			"type": "boolean",
+			"default": false
+		},
 		"newsletterTitle": {
 			"type": "string",
 			"default": "Newsletters"

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -148,7 +148,7 @@ export default function ReaderRegistrationEdit( {
 									}
 								/>
 								<ToggleControl
-									label={ __( 'Hide input and always subscribe', 'newspack' ) }
+									label={ __( 'Hide newsletter selection and always subscribe', 'newspack' ) }
 									checked={ hideSubscriptionInput }
 									disabled={ inFlight || lists.length !== 1 }
 									onChange={ () =>

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -47,6 +47,7 @@ export default function ReaderRegistrationEdit( {
 		privacyLabel,
 		newsletterSubscription,
 		displayListDescription,
+		hideSubscriptionInput,
 		newsletterTitle,
 		newsletterLabel,
 		haveAccountLabel,
@@ -103,6 +104,10 @@ export default function ReaderRegistrationEdit( {
 		}
 	}, [ listConfig ] );
 
+	const shouldHideSubscribeInput = () => {
+		return lists.length === 1 && hideSubscriptionInput;
+	};
+
 	return (
 		<>
 			<InspectorControls>
@@ -140,6 +145,14 @@ export default function ReaderRegistrationEdit( {
 									disabled={ inFlight }
 									onChange={ () =>
 										setAttributes( { displayListDescription: ! displayListDescription } )
+									}
+								/>
+								<ToggleControl
+									label={ __( 'Hide input and always subscribe', 'newspack' ) }
+									checked={ hideSubscriptionInput }
+									disabled={ inFlight || lists.length !== 1 }
+									onChange={ () =>
+										setAttributes( { hideSubscriptionInput: ! hideSubscriptionInput } )
 									}
 								/>
 								{ lists.length < 1 && (
@@ -206,7 +219,7 @@ export default function ReaderRegistrationEdit( {
 								tagName="p"
 							/>
 							<div className="newspack-registration__form-content">
-								{ newsletterSubscription && lists.length ? (
+								{ ! shouldHideSubscribeInput() && newsletterSubscription && lists.length ? (
 									<div className="newspack-reader__lists">
 										{ lists?.length > 1 && (
 											<RichText

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -159,16 +159,22 @@ function render_block( $attrs, $content ) {
 				<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
 				<div class="newspack-registration__form-content">
 					<?php
-					if ( isset( $lists ) ) {
-						Reader_Activation::render_subscription_lists_inputs(
-							$lists,
-							array_keys( $lists ),
-							[
-								'title'            => $attrs['newsletterTitle'],
-								'single_label'     => $attrs['newsletterLabel'],
-								'show_description' => $attrs['displayListDescription'],
-							]
-						);
+					if ( ! empty( $lists ) ) {
+						if ( 1 === count( $lists ) && $attrs['hideSubscriptionInput'] ) {
+							?>
+							<input type="hidden" name="lists[]" value="<?php echo \esc_attr( key( $lists ) ); ?>">
+							<?php
+						} else {
+							Reader_Activation::render_subscription_lists_inputs(
+								$lists,
+								array_keys( $lists ),
+								[
+									'title'            => $attrs['newsletterTitle'],
+									'single_label'     => $attrs['newsletterLabel'],
+									'show_description' => $attrs['displayListDescription'],
+								]
+							);
+						}
 					}
 					?>
 					<div class="newspack-registration__main">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements an option so that the registration block with only 1 newsletter list can have the list input as a hidden field. This allows for the block to have newsletter subscription messaging.

<img width="280" alt="image" src="https://user-images.githubusercontent.com/820752/187302664-1c3ab970-e3b7-4249-b023-242a658519bc.png">

### How to test the changes in this Pull Request:

1. Check out this branch and edit a Reader Registration Block
2. Confirm you see the new "Hide input and always subscribe" option
3. Select only one newsletter and confirm the input is no longer disabled
4. Enable the option
5. Confirm the list is hidden
6. Visit the frontend and confirm the list is hidden and you can register and subscribe to that list
7. Back to the editor, add another list to the block so it has 2
8. Confirm the button is disabled and the block is rendering the 2 lists inputs regardless of the stored option
9. Save and visit the frontend
10. Confirm both lists appear and you can subscribe to them

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->