### PR TITLE
feat: give each registration form a unique ID

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -74,6 +74,15 @@ function enqueue_scripts() {
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 
 /**
+ * Generate a unique ID for each registration form.
+ *
+ * @return string A unique ID string to identify the form.
+ */
+function get_form_id() {
+	return \wp_unique_id( 'newspack-register-' );
+}
+
+/**
  * Render Registration Block.
  *
  * @param array[] $attrs Block attributes.
@@ -149,7 +158,7 @@ function render_block( $attrs, $content ) {
 				<?php echo \wp_kses_post( $success_registration_markup ); ?>
 			</div>
 		<?php else : ?>
-			<form>
+			<form id="<?php echo esc_attr( get_form_id() ); ?>">
 				<?php if ( ! empty( $attrs['title'] ) ) : ?>
 					<h2 class="newspack-registration__title"><?php echo \wp_kses_post( $attrs['title'] ); ?></h2>
 				<?php endif; ?>

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -76,6 +76,11 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 /**
  * Generate a unique ID for each registration form.
  *
+ * The ID for each form instance is unique only for each page render.
+ * The main intent is to be able to pass this ID to analytics so we
+ * can identify what type of form it is, so the ID doesn't need to be
+ * predictable nor consistent across page renders.
+ *
  * @return string A unique ID string to identify the form.
  */
 function get_form_id() {

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -736,18 +736,20 @@ class Analytics {
 								var fields = eventLabel.match( /\${formFields\[(.*?)\]}/g )
 								fields.forEach( function( field ) {
 									var fieldName = field.match( /\${formFields\[(.*?)\]}/ )[1];
-									var fieldValues = [];
-									if ( form[ fieldName ].length ) {
-										for ( var j = 0; j < form[ fieldName ].length; j++ ) {
-											if ( form[ fieldName ][ j ].checked ) {
-												fieldValues.push( form[ fieldName ][ j ].value );
+									if ( form[ fieldName ] ) {
+										var fieldValues = [];
+										if ( form[ fieldName ].length ) {
+											for ( var j = 0; j < form[ fieldName ].length; j++ ) {
+												if ( form[ fieldName ][ j ].checked ) {
+													fieldValues.push( form[ fieldName ][ j ].value );
+												}
 											}
+										} else {
+											fieldValues.push( form[ fieldName ].value );
 										}
-									} else {
-										fieldValues.push( form[ fieldName ].value );
-									}
 
-									eventLabel = eventLabel.replace( field, fieldValues.join( ',' ) );
+										eventLabel = eventLabel.replace( field, fieldValues.join( ',' ) );
+									}
 								} );
 							<?php endif; ?>
 							eventInfo.event_label = eventLabel;

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -724,16 +724,39 @@ class Analytics {
 				var elements        = Array.prototype.slice.call( document.querySelectorAll( elementSelector ) );
 
 				for ( var i = 0; i < elements.length; ++i ) {
-					elements[i].addEventListener( 'submit', function() {
+					elements[i].addEventListener( 'submit', function(e) {
+						var eventInfo = {
+								event_category: '<?php echo esc_attr( $event['event_category'] ); ?>'
+						};
+						<?php if ( isset( $event['event_label'] ) ) : ?>
+							var form = e.currentTarget;
+							var eventLabel = '<?php echo isset( $event['event_label'] ) ? esc_attr( $event['event_label'] ) : ''; ?>';
+							<?php if ( preg_match( '/(\${formId}|\${formFields\[(.*?)\]})/', $event['event_label'] ) ) : ?>
+								eventLabel = eventLabel.replace( '${formId}', form.id );
+								var fields = eventLabel.match( /\${formFields\[(.*?)\]}/g )
+								fields.forEach( function( field ) {
+									var fieldName = field.match( /\${formFields\[(.*?)\]}/ )[1];
+									var fieldValues = [];
+									if ( form[ fieldName ].length ) {
+										for ( var j = 0; j < form[ fieldName ].length; j++ ) {
+											if ( form[ fieldName ][ j ].checked ) {
+												fieldValues.push( form[ fieldName ][ j ].value );
+											}
+										}
+									} else {
+										fieldValues.push( form[ fieldName ].value );
+									}
+
+									eventLabel = eventLabel.replace( field, fieldValues.join( ',' ) );
+								} );
+							<?php endif; ?>
+							eventInfo.event_label = eventLabel;
+						<?php endif; ?>
+
 						gtag(
 							'event',
 							'<?php echo esc_attr( $event['event_name'] ); ?>',
-							{
-								event_category: '<?php echo esc_attr( $event['event_category'] ); ?>',
-								<?php if ( isset( $event['event_label'] ) ) : ?>
-									event_label: '<?php echo esc_attr( $event['event_label'] ); ?>',
-								<?php endif; ?>
-							}
+							eventInfo
 						);
 					} );
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This gives each registration form a unique ID that can be picked up by Google Analytics to identify the form while firing submission events. Required for https://github.com/Automattic/newspack-popups/pull/951.

### How to test the changes in this Pull Request:

Instructions in https://github.com/Automattic/newspack-popups/pull/951.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->