### PR TITLE
fix(WooCommerce): error notice text color

### DIFF
--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -25,6 +25,7 @@
 		&--error,
 		&.woocommerce-error {
 			border: 1px solid #ff4364;
+			color: inherit;
 			&::before {
 				background: #ff000038;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR ensures that WC error notices get the inherited text color instead of the color applied by WC (white).

### How to test the changes in this Pull Request:

1. On the master branch, sign in to a reader account and update the Newsletters preferences without making any change
2. Confirm the error message appears but the text is not visible (select the text to confirm you see "You must select newsletters to update.")
3. Check out this branch and confirm the text is now visible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->