### PR TITLE
feat: update woocommerce account message/notice

### DIFF
--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -6,8 +6,9 @@
 	.woocommerce-message,
 	.woocommerce-info,
 	.woocommerce-error {
-		background: none;
-		border: 1px solid var( --newspack-primary-color );
+		background: color.adjust( wp-colors.$alert-green, $lightness: 42% );
+		border: 1px solid wp-colors.$alert-green;
+		color: inherit;
 		display: block;
 		font-family: inherit;
 		font-size: 0.8rem;
@@ -38,10 +39,9 @@
 		margin-top: 8px;
 	}
 
-	.woocommerce-message {
-		background: color.adjust( wp-colors.$alert-green, $lightness: 42% );
-		border-color: wp-colors.$alert-green;
-		color: inherit;
+	.woocommerce-info {
+		background: white;
+		border-color: var( --newspack-primary-color );
 	}
 
 	.edit-account {

--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -1,3 +1,6 @@
+@use 'sass:color';
+@use '~@wordpress/base-styles/colors' as wp-colors;
+
 .woocommerce-account {
 	.newspack-wc-message,
 	.woocommerce-message,
@@ -5,32 +8,20 @@
 	.woocommerce-error {
 		background: none;
 		border: 1px solid var( --newspack-primary-color );
-		border-radius: 5px;
 		display: block;
 		font-family: inherit;
-		font-size: inherit;
-		margin-bottom: 28px;
+		font-size: 0.8rem;
+		line-height: 1.5;
+		margin-bottom: 2rem;
 		margin-top: 0;
-		padding: 28px;
+		padding: 0.6875em;
 		position: relative;
-		&::before {
-			content: '';
-			width: 100%;
-			height: 100%;
-			position: absolute;
-			top: 0;
-			left: 0;
-			background: var( --newspack-primary-color );
-			opacity: 0.1;
-		}
 
 		&--error,
 		&.woocommerce-error {
-			border: 1px solid #ff4364;
+			background: color.adjust( wp-colors.$alert-red, $lightness: 51% );
+			border-color: wp-colors.$alert-red;
 			color: inherit;
-			&::before {
-				background: #ff000038;
-			}
 		}
 
 		p {
@@ -38,7 +29,7 @@
 			margin-top: 0;
 
 			+ p {
-				margin-top: 1rem;
+				margin-top: 0.5em;
 			}
 		}
 	}
@@ -48,13 +39,16 @@
 	}
 
 	.woocommerce-message {
-		padding: 28px;
+		background: color.adjust( wp-colors.$alert-green, $lightness: 42% );
+		border-color: wp-colors.$alert-green;
+		color: inherit;
 	}
 
 	.edit-account {
 		input {
 			&:disabled {
-				background-color: #f5f5f5;
+				background-color: wp-colors.$gray-100;
+				color: wp-colors.$gray-700;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Reduces the padding, font-size
* Standardise the notice to use Gutenberg red/green alert colours
* Removes `before` pseudo-element and use background-colour instead

### How to test the changes in this Pull Request:

1. Navigate to /my-account/
2. Update your account, try to generate an error message as well
3. Switch to this branch
4. Repeat 2

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->