### PR TITLE
fix(reader-activation): send payment contact metadata only if RA is enabled

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -438,55 +438,66 @@ class Stripe_Connection {
 				$was_customer_added_to_mailing_list = false;
 				$stripe_data                        = self::get_stripe_data();
 				$has_opted_in_to_newsletters        = isset( $customer['metadata']['newsletterOptIn'] ) && 'true' === $customer['metadata']['newsletterOptIn'];
-				if ( $has_opted_in_to_newsletters || Reader_Activation::is_enabled() ) {
-					$payment_date = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payment['created'] );
-					$contact      = [
+				if (
+					method_exists( '\Newspack_Newsletters_Subscription', 'add_contact' )
+					&& (
+						$has_opted_in_to_newsletters
+						|| Reader_Activation::is_enabled()
+					)
+				) {
+					$contact = [
 						'email'    => $customer['email'],
 						'name'     => $customer['name'],
-						'metadata' => [
-							Newspack_Newsletters::$metadata_keys['last_payment_date']   => $payment_date,
-							Newspack_Newsletters::$metadata_keys['last_payment_amount'] => $amount_normalised,
-						],
+						'metadata' => [],
 					];
 
-					if ( 'once' === $frequency ) {
-						$contact['metadata'][ Newspack_Newsletters::$metadata_keys['membership_status'] ] = 'Donor';
-					} else {
+					if ( Reader_Activation::is_enabled() ) {
+						$payment_date        = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payment['created'] );
 						$contact['metadata'] = array_merge(
-							self::create_recurring_payment_metadata( $frequency, $payment['amount'], $payment['currency'], $payment['created'] ),
-							$contact['metadata']
+							$contact['metadata'],
+							[
+								Newspack_Newsletters::$metadata_keys['last_payment_date']   => $payment_date,
+								Newspack_Newsletters::$metadata_keys['last_payment_amount'] => $amount_normalised,
+							]
 						);
+
+						if ( 'once' === $frequency ) {
+							$contact['metadata'][ Newspack_Newsletters::$metadata_keys['membership_status'] ] = 'Donor';
+						} else {
+							$contact['metadata'] = array_merge(
+								self::create_recurring_payment_metadata( $frequency, $payment['amount'], $payment['currency'], $payment['created'] ),
+								$contact['metadata']
+							);
+						}
+						if ( isset( $customer['metadata']['userId'] ) ) {
+							$contact['metadata'][ Newspack_Newsletters::$metadata_keys['account'] ] = $customer['metadata']['userId'];
+						}
+						if ( isset( $customer['metadata']['current_page_url'] ) ) {
+							$contact['metadata']['current_page_url'] = $customer['metadata']['current_page_url'];
+						}
+
+						if ( Donations::is_woocommerce_suite_active() ) {
+							$wc_product_id = Donations::get_donation_product( $frequency );
+							try {
+								$wc_product = \wc_get_product( $wc_product_id );
+								$contact['metadata'][ Newspack_Newsletters::$metadata_keys['product_name'] ] = $wc_product->get_name();
+							} catch ( \Throwable $th ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+								// Fail silently.
+							}
+						}
 					}
 
 					if ( ! empty( $client_id ) ) {
 						$contact['client_id'] = $client_id;
 					}
-					if ( isset( $customer['metadata']['userId'] ) ) {
-						$contact['metadata'][ Newspack_Newsletters::$metadata_keys['account'] ] = $customer['metadata']['userId'];
-					}
-					if ( isset( $customer['metadata']['current_page_url'] ) ) {
-						$contact['metadata']['current_page_url'] = $customer['metadata']['current_page_url'];
-					}
 
-					if ( Donations::is_woocommerce_suite_active() ) {
-						$wc_product_id = Donations::get_donation_product( $frequency );
-						try {
-							$wc_product = \wc_get_product( $wc_product_id );
-							$contact['metadata'][ Newspack_Newsletters::$metadata_keys['product_name'] ] = $wc_product->get_name();
-						} catch ( \Throwable $th ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-							// Fail silently.
-						}
+					// Note: With Mailchimp, this is adding the contact as 'pending' - the subscriber has to confirm.
+					if ( ! empty( $stripe_data['newsletter_list_id'] ) && $has_opted_in_to_newsletters ) {
+						\Newspack_Newsletters_Subscription::add_contact( $contact, $stripe_data['newsletter_list_id'] );
+					} else {
+						\Newspack_Newsletters_Subscription::add_contact( $contact );
 					}
-
-					if ( method_exists( '\Newspack_Newsletters_Subscription', 'add_contact' ) ) {
-						// Note: With Mailchimp, this is adding the contact as 'pending' - the subscriber has to confirm.
-						if ( ! empty( $stripe_data['newsletter_list_id'] ) && $has_opted_in_to_newsletters ) {
-							\Newspack_Newsletters_Subscription::add_contact( $contact, $stripe_data['newsletter_list_id'] );
-						} else {
-							\Newspack_Newsletters_Subscription::add_contact( $contact );
-						}
-						$was_customer_added_to_mailing_list = true;
-					}
+					$was_customer_added_to_mailing_list = true;
 				}
 
 				// Update data in Campaigns plugin.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small data integrity issue. Metadata for AC contacts was added when Reader Activation is enabled, but not in the case when reader donates _and_ signs up for the newsletter. 

### How to test the changes in this Pull Request:

1. Set up a site with Reader Activation, Active Campaign as ESP, and Stripe as payment platform
2. Ensure a newsletter list is chosen for in the "Allow donors to sign up to your newsletter when donating." setting in Reader Revenue wizard, Stripe Settings section
3. Make a donation and sign up for a newsletter in the Donate block, observe payment-related metadata fields are added to the contact on AC
4. Disable Reader Activation, again make a donation and sign up, observe the payment-related metadata is not added

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->