### PR TITLE
feat: after account deletion message

### DIFF
--- a/includes/reader-revenue/templates/myaccount-after-delete-account.php
+++ b/includes/reader-revenue/templates/myaccount-after-delete-account.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * My Account page for reader account deletion.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+?>
+
+<div>
+	<h1>
+		<?php echo esc_html__( 'Your account has been deleted.', 'newspack' ); ?>
+	</h1>
+	<p>
+		<?php echo esc_html__( "We're sorry to see you go. But hope you'll continue to follow our coverage.", 'newspack' ); ?>
+	</p>
+	<a class="woocommerce-Button button" href="<?php echo esc_url( site_url() ); ?>">
+		<?php echo esc_html__( 'Return to home page', 'newspack' ); ?>
+	</a>
+</div>
+


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a special page for handling after account deletion flow.

### How to test the changes in this Pull Request:

1. With Reader Activation set up, create and then delete an account as a reader
2. Observe that after deletion, this page appears instead of the login screen:

<img width="728" alt="image" src="https://user-images.githubusercontent.com/7383192/187666170-158c529c-3225-4e9a-ac24-c980f479bcb8.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->