### PR TITLE
Site Kit: prevent excluding logged-in users from GA if RA is enabled

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -23,6 +23,22 @@ class GoogleSiteKit {
 	public static function init() {
 		add_action( 'admin_init', [ __CLASS__, 'setup_sitekit_ga4' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'insert_ga4_analytics' ] );
+		add_filter( 'option_googlesitekit_analytics_settings', [ __CLASS__, 'filter_ga_settings' ] );
+	}
+
+	/**
+	 * Filter GA settings.
+	 *
+	 * @param array $googlesitekit_analytics_settings GA settings.
+	 */
+	public static function filter_ga_settings( $googlesitekit_analytics_settings ) {
+		if ( Reader_Activation::is_enabled() ) {
+			// If RA is enabled, readers will become logged in users. They should still be tracked in GA.
+			if ( in_array( 'loggedinUsers', $googlesitekit_analytics_settings['trackingDisabled'] ) ) {
+				$googlesitekit_analytics_settings['trackingDisabled'] = [ 'contentCreators' ];
+			}
+		}
+		return $googlesitekit_analytics_settings;
 	}
 
 	/**
@@ -85,11 +101,11 @@ class GoogleSiteKit {
 	 * Get Site Kit's GA4 settings.
 	 */
 	private static function get_sitekit_ga4_settings() {
-		$option_name = self::get_sitekit_ga4_settings_option_name();
-		if ( false === $option_name ) {
+		$googlesitekit_analytics_settingsion_name = self::get_sitekit_ga4_settings_option_name();
+		if ( false === $googlesitekit_analytics_settingsion_name ) {
 			return false;
 		}
-		return get_option( $option_name, false );
+		return get_option( $googlesitekit_analytics_settingsion_name, false );
 	}
 
 	/**

--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -101,11 +101,11 @@ class GoogleSiteKit {
 	 * Get Site Kit's GA4 settings.
 	 */
 	private static function get_sitekit_ga4_settings() {
-		$googlesitekit_analytics_settingsion_name = self::get_sitekit_ga4_settings_option_name();
-		if ( false === $googlesitekit_analytics_settingsion_name ) {
+		$option_name = self::get_sitekit_ga4_settings_option_name();
+		if ( false === $option_name ) {
 			return false;
 		}
-		return get_option( $googlesitekit_analytics_settingsion_name, false );
+		return get_option( $option_name, false );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

With Reader Activation, we don't wanna risk preventing GA from reporting data for registered readers.

### How to test the changes in this Pull Request:

1. Start with a site with Site Kit (w/ Analytics module) configured
2. Ensure Reader Activation is enabled
1. On `master`, visit the Site Kit settings -> Analytics and set (unless it's already set) "Excluded from Analytics" to "All logged-in users" 
3. Switch to this branch, reload, observe the setting is forced to "Users that can write posts"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->