### PR TITLE
fix: allow Register block to be edited even if RAS is not enabled

### DIFF
--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -1,5 +1,3 @@
-/* globals newspack_blocks */
-
 /**
  * WordPress dependencies
  */
@@ -11,8 +9,6 @@ import { registerBlockType } from '@wordpress/blocks';
 import * as readerRegistration from './reader-registration';
 
 export const blocks = [ readerRegistration ];
-
-const readerActivationBlocks = [ 'newspack/reader-registration' ];
 
 /**
  * Function to register an individual block.
@@ -26,12 +22,6 @@ const registerBlock = block => {
 	}
 
 	const { metadata, settings, name } = block;
-
-	/** Do not register reader activation blocks if it's disabled. */
-	if ( readerActivationBlocks.includes( name ) && ! newspack_blocks.has_reader_activation ) {
-		return;
-	}
-
 	registerBlockType( { name, ...metadata }, settings );
 };
 

--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -1,3 +1,5 @@
+/* globals newspack_blocks */
+
 /**
  * WordPress dependencies
  */
@@ -9,6 +11,8 @@ import { registerBlockType } from '@wordpress/blocks';
 import * as readerRegistration from './reader-registration';
 
 export const blocks = [ readerRegistration ];
+
+const readerActivationBlocks = [ 'newspack/reader-registration' ];
 
 /**
  * Function to register an individual block.
@@ -22,6 +26,12 @@ const registerBlock = block => {
 	}
 
 	const { metadata, settings, name } = block;
+
+	/** Do not register reader activation blocks if it's disabled. */
+	if ( readerActivationBlocks.includes( name ) && ! newspack_blocks.has_reader_activation ) {
+		return;
+	}
+
 	registerBlockType( { name, ...metadata }, settings );
 };
 

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -294,7 +294,7 @@ function send_form_response( $data, $message = '' ) {
  * Process registration form.
  */
 function process_form() {
-	if ( ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
+	if ( ! Reader_Activation::is_enabled() || ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
 		return;
 	}
 

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -16,22 +16,22 @@ defined( 'ABSPATH' ) || exit;
 const FORM_ACTION = 'newspack_reader_registration';
 
 /**
- * Do not register block hooks if Reader Activation is not enabled.
- */
-if ( ! Reader_Activation::is_enabled() ) {
-	return;
-}
-
-/**
  * Register block from metadata.
  */
 function register_block() {
+	// Allow render_block callback to run so we can ensure it renders nothing.
 	\register_block_type_from_metadata(
 		__DIR__ . '/block.json',
 		array(
 			'render_callback' => __NAMESPACE__ . '\\render_block',
 		)
 	);
+
+	// No need to register block styles if Reader Activation is disabled.
+	if ( ! Reader_Activation::is_enabled() ) {
+		return '';
+	}
+
 	\register_block_style(
 		'newspack/reader-registration',
 		[
@@ -54,6 +54,11 @@ add_action( 'init', __NAMESPACE__ . '\\register_block' );
  * Enqueue front-end scripts.
  */
 function enqueue_scripts() {
+	// No need to enqueue scripts if Reader Activation is disabled.
+	if ( ! Reader_Activation::is_enabled() ) {
+		return;
+	}
+
 	$handle = 'newspack-reader-registration-block';
 	\wp_enqueue_style(
 		$handle,
@@ -80,6 +85,11 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
  * @param string  $content Block content (inner blocks) – success state in this case.
  */
 function render_block( $attrs, $content ) {
+	// Render nothing if Reader Activation is disabled.
+	if ( ! Reader_Activation::is_enabled() ) {
+		return '';
+	}
+
 	$registered      = false;
 	$message         = '';
 	$success_message = __( 'Thank you for registering!', 'newspack' ) . '<br />' . __( 'Check your email for a confirmation link.', 'newspack' );

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -294,7 +294,13 @@ function send_form_response( $data, $message = '' ) {
  * Process registration form.
  */
 function process_form() {
-	if ( ! Reader_Activation::is_enabled() || ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
+	// No need to process form values if Reader Activation is disabled.
+	if ( ! Reader_Activation::is_enabled() ) {
+		return;
+	}
+
+	// No need to proceed if we don't have the required params.
+	if ( ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
 		return;
 	}
 

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -29,7 +29,7 @@ function register_block() {
 
 	// No need to register block styles if Reader Activation is disabled.
 	if ( ! Reader_Activation::is_enabled() ) {
-		return '';
+		return;
 	}
 
 	\register_block_style(

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -38,10 +38,11 @@ final class Blocks {
 			'newspack-blocks',
 			'newspack_blocks',
 			[
-				'has_newsletters'  => method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ),
-				'newsletters_url'  => Wizards::get_wizard( 'engagement' )->newsletters_settings_url(),
-				'has_google_oauth' => Google_OAuth::is_oauth_configured(),
-				'google_logo_svg'  => file_get_contents( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/blocks/reader-registration/icons/google.svg' ),
+				'has_newsletters'       => method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ),
+				'has_reader_activation' => Reader_Activation::is_enabled( false ),
+				'newsletters_url'       => Wizards::get_wizard( 'engagement' )->newsletters_settings_url(),
+				'has_google_oauth'      => Google_OAuth::is_oauth_configured(),
+				'google_logo_svg'       => file_get_contents( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/blocks/reader-registration/icons/google.svg' ),
 			]
 		);
 		\wp_enqueue_style(

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -38,11 +38,10 @@ final class Blocks {
 			'newspack-blocks',
 			'newspack_blocks',
 			[
-				'has_newsletters'       => method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ),
-				'has_reader_activation' => Reader_Activation::is_enabled(),
-				'newsletters_url'       => Wizards::get_wizard( 'engagement' )->newsletters_settings_url(),
-				'has_google_oauth'      => Google_OAuth::is_oauth_configured(),
-				'google_logo_svg'       => file_get_contents( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/blocks/reader-registration/icons/google.svg' ),
+				'has_newsletters'  => method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ),
+				'newsletters_url'  => Wizards::get_wizard( 'engagement' )->newsletters_settings_url(),
+				'has_google_oauth' => Google_OAuth::is_oauth_configured(),
+				'google_logo_svg'  => file_get_contents( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/blocks/reader-registration/icons/google.svg' ),
 			]
 		);
 		\wp_enqueue_style(

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -222,10 +222,17 @@ final class Reader_Activation {
 	/**
 	 * Whether reader activation is enabled.
 	 *
+	 * @param bool $strict If true, check both the environment constant and the setting.
+	 *                     If false, only check for the constant.
+	 *
 	 * @return bool True if reader activation is enabled.
 	 */
-	public static function is_enabled() {
+	public static function is_enabled( $strict = true ) {
 		$is_enabled = defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) && NEWSPACK_EXPERIMENTAL_READER_ACTIVATION;
+
+		if ( ! $strict ) {
+			return $is_enabled;
+		}
 
 		if ( $is_enabled ) {
 			$is_enabled = self::get_setting( 'enabled' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently, the Register block is only available in the editor if experimental Reader Activation features are enabled via both an environment constant and a Newspack dashboard setting. However, for transitioning live publisher sites to a Reader Activation model, we need to be able to set up registration prompts and flows prior to activating the features. This PR makes the block available and editable in the editor, but ensures that the block is not rendered and its assets not enqueued on the front-end unless the features are enabled.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. In Newspack > Engagement > Reader Activation, turn off Reader Activation with the checkbox and save.
3. Edit a post, page, or prompt and confirm that you can still add a Reader Registration block, update it, save, etc.
4. View the block on the front-end and confirm that it renders nothing, and that its CSS and JS files are not enqueued.
5. Re-enable Reader Activation, view the block on the front-end, and confirm that it now renders as expected with all changes you made in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->