### PR TITLE
fix: prefix WC My Account actions so we can decide which hooks to support

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Recaptcha {
 	const SCRIPT_HANDLE  = 'newspack-recaptcha';
-	const THRESHOLD      = 0.5;
+	const THRESHOLD      = 0.25;
 	const OPTIONS_PREFIX = 'newspack_recaptcha_';
 
 	/**

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Recaptcha {
 	const SCRIPT_HANDLE  = 'newspack-recaptcha';
-	const THRESHOLD      = 0.25;
+	const THRESHOLD      = 0.5;
 	const OPTIONS_PREFIX = 'newspack_recaptcha_';
 
 	/**

--- a/includes/reader-revenue/templates/myaccount-delete-account.php
+++ b/includes/reader-revenue/templates/myaccount-delete-account.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 
 $delete_account_form = WooCommerce_My_Account::DELETE_ACCOUNT_FORM;
 
-\do_action( 'woocommerce_before_edit_account_form' );
+\do_action( 'newspack_woocommerce_before_edit_account_form' );
 
 $nonce_value = isset( $_GET[ $delete_account_form ] ) ? \sanitize_text_field( $_GET[ $delete_account_form ] ) : '';
 if ( ! \wp_verify_nonce( $nonce_value, $delete_account_form ) ) {
@@ -51,4 +51,4 @@ if ( ! $transient_token || $transient_token !== $token ) {
 	</form>
 </div>
 
-<?php \do_action( 'woocommerce_after_edit_account_form' ); ?>
+<?php \do_action( 'newspack_woocommerce_after_edit_account_form' ); ?>

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -12,7 +12,7 @@ use Newspack\WooCommerce_My_Account;
 
 defined( 'ABSPATH' ) || exit;
 
-\do_action( 'woocommerce_before_edit_account_form' );
+\do_action( 'newspack_woocommerce_before_edit_account_form' );
 
 $newspack_reset_password_arg = WooCommerce_My_Account::RESET_PASSWORD_URL_PARAM;
 $newspack_delete_account_arg = WooCommerce_My_Account::DELETE_ACCOUNT_URL_PARAM;
@@ -38,9 +38,9 @@ if ( $message ) :
 endif;
 ?>
 
-<form class="woocommerce-EditAccountForm edit-account" action="" method="post" <?php \do_action( 'woocommerce_edit_account_form_tag' ); ?> >
+<form class="woocommerce-EditAccountForm edit-account" action="" method="post" <?php \do_action( 'newspack_woocommerce_edit_account_form_tag' ); ?> >
 
-	<?php \do_action( 'woocommerce_edit_account_form_start' ); ?>
+	<?php \do_action( 'newspack_woocommerce_edit_account_form_start' ); ?>
 
 	<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">
 		<label for="account_first_name"><?php \esc_html_e( 'First name', 'newspack' ); ?>&nbsp;<span class="required">*</span></label>
@@ -57,7 +57,7 @@ endif;
 		<input type="email" disabled class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
 	</p>
 
-	<?php \do_action( 'woocommerce_edit_account_form' ); ?>
+	<?php \do_action( 'newspack_woocommerce_edit_account_form' ); ?>
 
 	<p>
 		<?php \wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>
@@ -65,7 +65,7 @@ endif;
 		<input type="hidden" name="action" value="save_account_details" />
 	</p>
 
-	<?php \do_action( 'woocommerce_edit_account_form_end' ); ?>
+	<?php \do_action( 'newspack_woocommerce_edit_account_form_end' ); ?>
 </form>
 
 <hr />
@@ -88,4 +88,4 @@ endif;
 	</a>
 </p>
 
-<?php \do_action( 'woocommerce_after_edit_account_form' ); ?>
+<?php \do_action( 'newspack_woocommerce_after_edit_account_form' ); ?>

--- a/includes/reader-revenue/templates/myaccount-verify.php
+++ b/includes/reader-revenue/templates/myaccount-verify.php
@@ -12,7 +12,7 @@ use Newspack\WooCommerce_My_Account;
 
 defined( 'ABSPATH' ) || exit;
 
-\do_action( 'woocommerce_before_edit_account_form' );
+\do_action( 'newspack_woocommerce_before_edit_account_form' );
 
 $newspack_reset_password_arg  = WooCommerce_My_Account::RESET_PASSWORD_URL_PARAM;
 $newspack_send_magic_link_arg = WooCommerce_My_Account::SEND_MAGIC_LINK_PARAM;
@@ -65,4 +65,4 @@ $reset_password_url                                  = \add_query_arg(
 	</p>
 </div>
 
-<?php \do_action( 'woocommerce_after_edit_account_form' ); ?>
+<?php \do_action( 'newspack_woocommerce_after_edit_account_form' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WooCommerce's My Account dashboard contains many action and filter hooks to allow other plugins and themes to extend and modify its UI. Our custom Reader Activation templates call those same hooks, but in most cases the modifications are probably undesired. This PR retains the hooks in place, but prefixes them with `newspack_`. The effect is that most modifications from other plugins won't take effect, but we can selectively allow certain hooks to run if needed by calling the original action hook on our prefixed ones, e.g.

```php
\add_action(
	'newspack_woocommerce_before_edit_account_form,
	function() {
		\do_action( 'woocommerce_before_edit_account_form' );
	}
);
```

### How to test the changes in this Pull Request:

1. Install and set up the [Mailchimp for WooCommerce plugin](https://wordpress.org/plugins/mailchimp-for-woocommerce/). This plugin appends an undesired newsletter opt-in checkbox to the My Account form.
2. Observe in My Account that the checkbox shows up under the account details fields:

<img width="1266" alt="Screen Shot 2022-08-31 at 1 20 41 PM" src="https://user-images.githubusercontent.com/2230142/187764600-8080ab8f-d842-4a57-a9be-e2ed6d10fe46.png">

3. Check out this branch, refresh My Account, and confirm that the extra field no longer appears.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->