### PR TITLE
feat(reader-activation): handle global auth success in registration block

### DIFF
--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -42,12 +42,6 @@ function domReady( callback ) {
 				'.newspack-registration__registration-success'
 			);
 
-			readerActivation.on( 'reader', ( { detail: { authenticated } } ) => {
-				if ( authenticated ) {
-					form.style.display = 'none';
-				}
-			} );
-
 			form.startLoginFlow = () => {
 				messageElement.classList.add( 'newspack-registration--hidden' );
 				messageElement.innerHTML = '';
@@ -138,6 +132,12 @@ function domReady( callback ) {
 								form.endLoginFlow( e, 400 );
 							} );
 					} );
+			} );
+
+			readerActivation.on( 'reader', ( { detail: { authenticated } } ) => {
+				if ( authenticated ) {
+					form.endLoginFlow( null, 200 );
+				}
 			} );
 		} );
 	} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small UX issue.

### How to test the changes in this Pull Request:

1. On `master`,
2. Start with a site with Reader Activation configured
3. Insert a Reader Registration block on a page
4. Visit the page and use the header auth UI ("Sign In" link) to register
5. Observe the Registration block disappearing on registration
6. Switch to this branch
7. In a fresh session, redo previous steps and observe the Registration block changes to success state 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->