### PR TITLE
feat: move already have account message above content

### DIFF
--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -206,33 +206,35 @@ export default function ReaderRegistrationEdit( {
 				{ editedState === 'initial' && (
 					<div className={ `newspack-registration ${ className }` }>
 						<form onSubmit={ ev => ev.preventDefault() }>
-							<div className="newspack-registration__have-account">
-								<p>
-									<RichText
-										onChange={ value => setAttributes( { haveAccountLabel: value } ) }
-										placeholder={ __( 'Already have an account?', 'newspack' ) }
-										value={ haveAccountLabel }
-										tagName="span"
-									/>{ ' ' }
-									<a href="/my-account" onClick={ ev => ev.preventDefault() }>
+							<div className="newspack-registration__header">
+								<RichText
+									onChange={ value => setAttributes( { title: value } ) }
+									placeholder={ __( 'Write title…', 'newspack' ) }
+									value={ title }
+									tagName="h2"
+								/>
+								<div className="newspack-registration__have-account">
+									<p>
 										<RichText
-											onChange={ value => setAttributes( { signInLabel: value } ) }
-											placeholder={ __( 'Sign In', 'newspack' ) }
-											value={ signInLabel }
+											onChange={ value => setAttributes( { haveAccountLabel: value } ) }
+											placeholder={ __( 'Already have an account?', 'newspack' ) }
+											value={ haveAccountLabel }
 											tagName="span"
-										/>
-									</a>
-								</p>
+										/>{ ' ' }
+										<a href="/my-account" onClick={ ev => ev.preventDefault() }>
+											<RichText
+												onChange={ value => setAttributes( { signInLabel: value } ) }
+												placeholder={ __( 'Sign In', 'newspack' ) }
+												value={ signInLabel }
+												tagName="span"
+											/>
+										</a>
+									</p>
+								</div>
 							</div>
 							<RichText
-								onChange={ value => setAttributes( { title: value } ) }
-								placeholder={ __( 'Block title…', 'newspack' ) }
-								value={ title }
-								tagName="h2"
-							/>
-							<RichText
 								onChange={ value => setAttributes( { description: value } ) }
-								placeholder={ __( 'Block description…', 'newspack' ) }
+								placeholder={ __( 'Write description…', 'newspack' ) }
 								value={ description }
 								tagName="p"
 							/>

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -206,6 +206,24 @@ export default function ReaderRegistrationEdit( {
 				{ editedState === 'initial' && (
 					<div className={ `newspack-registration ${ className }` }>
 						<form onSubmit={ ev => ev.preventDefault() }>
+							<div className="newspack-registration__have-account">
+								<p>
+									<RichText
+										onChange={ value => setAttributes( { haveAccountLabel: value } ) }
+										placeholder={ __( 'Already have an account?', 'newspack' ) }
+										value={ haveAccountLabel }
+										tagName="span"
+									/>{ ' ' }
+									<a href="/my-account" onClick={ ev => ev.preventDefault() }>
+										<RichText
+											onChange={ value => setAttributes( { signInLabel: value } ) }
+											placeholder={ __( 'Sign In', 'newspack' ) }
+											value={ signInLabel }
+											tagName="span"
+										/>
+									</a>
+								</p>
+							</div>
 							<RichText
 								onChange={ value => setAttributes( { title: value } ) }
 								placeholder={ __( 'Block title…', 'newspack' ) }
@@ -293,24 +311,6 @@ export default function ReaderRegistrationEdit( {
 											</div>
 										) }
 										<div className="newspack-registration__response" />
-										<div className="newspack-registration__have-account">
-											<p>
-												<RichText
-													onChange={ value => setAttributes( { haveAccountLabel: value } ) }
-													placeholder={ __( 'Already have an account?', 'newspack' ) }
-													value={ haveAccountLabel }
-													tagName="span"
-												/>{ ' ' }
-												<a href="/my-account" onClick={ ev => ev.preventDefault() }>
-													<RichText
-														onChange={ value => setAttributes( { signInLabel: value } ) }
-														placeholder={ __( 'Sign In', 'newspack' ) }
-														value={ signInLabel }
-														tagName="span"
-													/>
-												</a>
-											</p>
-										</div>
 									</div>
 									<div className="newspack-registration__help-text">
 										<RichText

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -209,7 +209,7 @@ export default function ReaderRegistrationEdit( {
 							<div className="newspack-registration__header">
 								<RichText
 									onChange={ value => setAttributes( { title: value } ) }
-									placeholder={ __( 'Write title…', 'newspack' ) }
+									placeholder={ __( 'Add title', 'newspack' ) }
 									value={ title }
 									tagName="h2"
 								/>
@@ -234,7 +234,7 @@ export default function ReaderRegistrationEdit( {
 							</div>
 							<RichText
 								onChange={ value => setAttributes( { description: value } ) }
-								placeholder={ __( 'Write description…', 'newspack' ) }
+								placeholder={ __( 'Add description', 'newspack' ) }
 								value={ description }
 								tagName="p"
 							/>

--- a/assets/blocks/reader-registration/editor.scss
+++ b/assets/blocks/reader-registration/editor.scss
@@ -6,6 +6,8 @@
 	font-size: inherit;
 
 	form {
+		padding-top: 0;
+
 		input[type='email'] {
 			background: #fff;
 			border: solid 1px #ccc;
@@ -71,15 +73,21 @@
 		}
 	}
 	& &__have-account {
-		font-size: 0.65em;
+		background: var( --wp--preset--color--secondary );
+		font-size: 0.8em;
+		margin-bottom: 32px;
+		position: relative;
 
 		p {
 			font-size: 1em;
 		}
 	}
 	&__help-text {
+		margin-top: 1em;
+
 		p {
 			font-size: 0.55em !important;
+			margin: 0;
 		}
 	}
 	&__response {
@@ -129,6 +137,12 @@
 					color: inherit;
 					text-decoration: none;
 				}
+			}
+		}
+
+		form {
+			> p {
+				font-size: 0.8em;
 			}
 		}
 	}

--- a/assets/blocks/reader-registration/editor.scss
+++ b/assets/blocks/reader-registration/editor.scss
@@ -72,11 +72,18 @@
 			gap: 4px;
 		}
 	}
-	& &__have-account {
-		background: var( --wp--preset--color--secondary );
+	& &__header {
 		font-size: 0.8em;
-		margin-bottom: 32px;
-		position: relative;
+
+		h2 {
+			font-size: 1rem;
+			line-height: 1.3333333333;
+
+			@media screen and ( min-width: 600px ) {
+				font-size: 1.3125em;
+				line-height: 1.523809;
+			}
+		}
 
 		p {
 			font-size: 1em;

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -160,6 +160,14 @@ function render_block( $attrs, $content ) {
 			</div>
 		<?php else : ?>
 			<form>
+				<div class="newspack-registration__have-account">
+					<p>
+						<?php echo \wp_kses_post( $attrs['haveAccountLabel'] ); ?>
+						<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link>
+							<?php echo \wp_kses_post( $attrs['signInLabel'] ); ?>
+						</a>
+					</p>
+				</div>
 				<?php if ( ! empty( $attrs['title'] ) ) : ?>
 					<h2 class="newspack-registration__title"><?php echo \wp_kses_post( $attrs['title'] ); ?></h2>
 				<?php endif; ?>
@@ -199,14 +207,6 @@ function render_block( $attrs, $content ) {
 								<?php if ( ! empty( $message ) ) : ?>
 									<p><?php echo \esc_html( $message ); ?></p>
 								<?php endif; ?>
-							</div>
-							<div class="newspack-registration__have-account">
-								<p>
-									<?php echo \wp_kses_post( $attrs['haveAccountLabel'] ); ?>
-									<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link>
-										<?php echo \wp_kses_post( $attrs['signInLabel'] ); ?>
-									</a>
-								</p>
 							</div>
 						</div>
 

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -160,17 +160,19 @@ function render_block( $attrs, $content ) {
 			</div>
 		<?php else : ?>
 			<form>
-				<div class="newspack-registration__have-account">
-					<p>
-						<?php echo \wp_kses_post( $attrs['haveAccountLabel'] ); ?>
-						<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link>
-							<?php echo \wp_kses_post( $attrs['signInLabel'] ); ?>
-						</a>
-					</p>
+				<div class="newspack-registration__header">
+					<?php if ( ! empty( $attrs['title'] ) ) : ?>
+						<h2 class="newspack-registration__title"><?php echo \wp_kses_post( $attrs['title'] ); ?></h2>
+					<?php endif; ?>
+					<div class="newspack-registration__have-account">
+						<p>
+							<?php echo \wp_kses_post( $attrs['haveAccountLabel'] ); ?>
+							<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link>
+								<?php echo \wp_kses_post( $attrs['signInLabel'] ); ?>
+							</a>
+						</p>
+					</div>
 				</div>
-				<?php if ( ! empty( $attrs['title'] ) ) : ?>
-					<h2 class="newspack-registration__title"><?php echo \wp_kses_post( $attrs['title'] ); ?></h2>
-				<?php endif; ?>
 				<?php if ( ! empty( $attrs['description'] ) ) : ?>
 					<p class="newspack-registration__description"><?php echo \wp_kses_post( $attrs['description'] ); ?></p>
 				<?php endif; ?>

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -16,19 +16,13 @@
 		}
 	}
 
-	h2 {
-		margin-top: 0;
-	}
-
 	form {
-		padding-top: 36px;
-
 		> p {
 			margin: 1em 0;
 		}
 	}
 
-	@media ( min-width: 782px ) {
+	@media only screen and ( min-width: 782px ) {
 		&.is-style-columns {
 			.newspack-registration__main {
 				flex: 1 1 63.4146%;
@@ -86,7 +80,7 @@
 			margin-top: 0.5rem;
 			width: 100%;
 
-			@media ( min-width: 782px ) {
+			@media only screen and ( min-width: 782px ) {
 				margin-left: 0.4rem;
 				margin-top: 0;
 				width: auto;
@@ -94,38 +88,44 @@
 		}
 	}
 
-	&__have-account {
-		align-items: center;
-		background: var( --newspack-secondary-color );
-		color: var( --newspack-secondary-contrast-color );
+	&__header {
+		align-items: baseline;
+		column-gap: 2em;
 		display: flex;
-		font-size: 1em;
-		justify-content: center;
-		left: 0;
-		line-height: 1.5;
-		min-height: 36px;
-		padding: 0 16px;
-		position: absolute;
-		right: 0;
-		top: 0;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		margin-bottom: 1em;
+		row-gap: 0.5em;
 
-		@media only screen and ( min-width: 600px ) {
-			padding-left: 32px;
-			padding-right: 32px;
-		}
-
+		h2,
 		p {
 			margin: 0;
-			padding: 0.375em 0;
 		}
+
+		h2 {
+			font-size: 1rem;
+			line-height: 1.3333333333;
+
+			@media screen and ( min-width: 600px ) {
+				font-size: 1.3125em;
+				line-height: 1.523809;
+			}
+		}
+	}
+
+	&__have-account {
+		color: wp-colors.$gray-700;
+		font-size: 0.8125em;
+		justify-self: flex-end;
+		line-height: 1.2307692308;
 	}
 
 	&__help-text {
 		p {
 			color: wp-colors.$gray-700;
+			font-size: 0.8125em !important;
+			line-height: 1.2307692308;
 			margin: 0.8rem 0 0;
-			font-size: 0.6875em !important;
-			line-height: 1.45454545;
 		}
 	}
 
@@ -225,23 +225,13 @@
 	}
 }
 
-/* Sepcific styles to apply to .newspack-popup when Reader Registration is displayed */
-.newspack-popup {
-	&__content {
-		position: relative;
-	}
+/* Sepcific styles to apply to Reader Registration when part of a Prompt */
+.newspack-popup__content {
+	.newspack-registration__header {
+		padding-right: 36px;
 
-	&.newspack-lightbox {
-		.newspack-lightbox__close {
-			top: 36px;
-		}
-	}
-
-	&.newspack-lightbox-featured-image {
-		.newspack-lightbox__close {
-			@media only screen and ( min-width: 782px ) {
-				top: 0;
-			}
+		@media screen and ( min-width: 600px ) {
+			padding-right: 0;
 		}
 	}
 }

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -16,6 +16,18 @@
 		}
 	}
 
+	h2 {
+		margin-top: 0;
+	}
+
+	form {
+		padding-top: 36px;
+
+		> p {
+			margin: 1em 0;
+		}
+	}
+
 	@media ( min-width: 782px ) {
 		&.is-style-columns {
 			.newspack-registration__main {
@@ -69,7 +81,8 @@
 			flex: 1 1 auto;
 		}
 		[type='submit'] {
-			background-color: #d33;
+			background-color: var( --newspack-cta-color );
+			color: var( --newspack-cta-contrast-color );
 			margin-top: 0.5rem;
 			width: 100%;
 
@@ -82,19 +95,35 @@
 	}
 
 	&__have-account {
-		font-size: 0.8125em;
-		line-height: 1.2307692308;
-		margin: 0.8rem 0;
+		align-items: center;
+		background: var( --newspack-secondary-color );
+		color: var( --newspack-secondary-contrast-color );
+		display: flex;
+		font-size: 1em;
+		justify-content: center;
+		left: 0;
+		line-height: 1.5;
+		min-height: 36px;
+		padding: 0 16px;
+		position: absolute;
+		right: 0;
+		top: 0;
+
+		@media only screen and ( min-width: 600px ) {
+			padding-left: 32px;
+			padding-right: 32px;
+		}
 
 		p {
 			margin: 0;
+			padding: 0.375em 0;
 		}
 	}
 
 	&__help-text {
 		p {
 			color: wp-colors.$gray-700;
-			margin: 0;
+			margin: 0.8rem 0 0;
 			font-size: 0.6875em !important;
 			line-height: 1.45454545;
 		}
@@ -103,6 +132,12 @@
 	&__response {
 		margin-top: 0.5rem;
 		font-size: 0.8em;
+	}
+
+	&__registration-success {
+		> *:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	&--error {
@@ -187,6 +222,27 @@
 
 	.nphp {
 		@include mixins.visuallyHidden;
+	}
+}
+
+/* Sepcific styles to apply to .newspack-popup when Reader Registration is displayed */
+.newspack-popup {
+	&__content {
+		position: relative;
+	}
+
+	&.newspack-lightbox {
+		.newspack-lightbox__close {
+			top: 36px;
+		}
+	}
+
+	&.newspack-lightbox-featured-image {
+		.newspack-lightbox__close {
+			@media only screen and ( min-width: 782px ) {
+				top: 0;
+			}
+		}
 	}
 }
 

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -152,12 +152,14 @@
 				margin: 0;
 
 				button[type='submit'] {
-					background-color: #d33;
+					background-color: var( --newspack-cta-color );
+					color: var( --newspack-cta-contrast-color );
 					transition: background-color 150ms ease-in-out;
 
 					&:hover,
 					&:focus {
 						background-color: #111;
+						color: white;
 					}
 				}
 			}
@@ -212,18 +214,28 @@
 			}
 
 			h2 {
-				font-size: 1em;
-				line-height: 1.5;
+				font-size: 1rem;
+				line-height: 1.3333333333;
 				margin: 0;
 
-				@media screen and ( min-width: 782px ) {
+				@media screen and ( min-width: 600px ) {
 					font-size: 1.3125em;
 					line-height: 1.523809;
 				}
 			}
+		}
+
+		& &__header {
 			a {
+				color: wp-colors.$gray-700;
 				font-size: 0.8125em;
 				line-height: 1.2307692308;
+
+				&:active,
+				&:focus,
+				&:hover {
+					text-decoration: none;
+				}
 			}
 		}
 
@@ -320,9 +332,9 @@
 		}
 
 		&__terms-text {
-			font-size: 0.6875em;
-			line-height: 1.45454545 !important;
 			color: wp-colors.$gray-700;
+			font-size: 0.8125em;
+			line-height: 1.2307692308 !important;
 			a {
 				color: inherit;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR moves the "Already have an account? Sign in" message next to the Title. It makes it more visible for existing users where to sign in.

__After__

![after](https://user-images.githubusercontent.com/177929/188587229-7ff7f6fe-c371-426d-b41a-b7775fc862b6.png)

__Before__

![before](https://user-images.githubusercontent.com/177929/188587721-60434709-c002-448a-baf0-48c8d9f5f41e.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Test in the editor
3. Check front-end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->