### PR TITLE
Improved Woo sync to ActiveCampaign

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -120,6 +120,11 @@ class WooCommerce_Connection {
 			return;
 		}
 
+		if ( self::CREATED_VIA_NAME === $order->get_created_via() ) {
+			// Only sync orders not created via the Stripe integration.
+			return;
+		}
+
 		$metadata_keys = Newspack_Newsletters::$metadata_keys;
 		$user_id       = $order->get_customer_id();
 		if ( ! $user_id ) {

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -36,7 +36,7 @@ class WooCommerce_Connection {
 	 *
 	 * @return bool True if enabled. False if not.
 	 */
-	protected function can_sync_customers() {
+	protected static function can_sync_customers() {
 		return Reader_Activation::is_enabled() && class_exists( 'WC_Customer' ) && function_exists( 'wcs_get_users_subscriptions' );
 	}
 

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -24,7 +24,20 @@ class WooCommerce_Connection {
 	 */
 	public static function init() {
 		\add_action( 'admin_init', [ __CLASS__, 'disable_woocommerce_setup' ] );
-		\add_action( 'woocommerce_checkout_order_created', [ __CLASS__, 'register_reader' ] );
+		
+		// WC Subscriptions hooks in and creates subscription at priority 100, so use priority 101.
+		\add_action( 'woocommerce_checkout_order_processed', [ __CLASS__, 'sync_reader_on_order_complete' ], 101 );
+
+		\add_action( 'wp_login', [ __CLASS__, 'sync_reader_on_customer_login' ], 10, 2 );
+	}
+
+	/**
+	 * Check whether everything is set up to enable customer syncinc to ESP.
+	 *
+	 * @return bool True if enabled. False if not.
+	 */
+	protected function can_sync_customers() {
+		return Reader_Activation::is_enabled() && class_exists( 'WC_Customer' ) && function_exists( 'wcs_get_users_subscriptions' );
 	}
 
 	/**
@@ -59,20 +72,135 @@ class WooCommerce_Connection {
 	}
 
 	/**
-	 * Ensure that donors are registered.
+	 * Sync a reader's info to the ESP when they make an order.
+	 *
+	 * @param int $order_id Order post ID.
+	 */
+	public static function sync_reader_on_order_complete( $order_id ) {
+		if ( ! self::can_sync_customers() ) {
+			return;
+		}
+
+		$order = new \WC_Order( $order_id );
+		if ( ! $order->get_customer_id() ) {
+			return;
+		}
+
+		self::sync_reader_from_order( $order );
+	}
+
+	/**
+	 * Sync a reader's info to the ESP when they log in.
+	 *
+	 * @param string  $user_login User's login name.
+	 * @param WP_User $user User object.
+	 */
+	public static function sync_reader_on_customer_login( $user_login, $user ) {
+		if ( ! self::can_sync_customers() ) {
+			return;
+		}
+
+		$customer = new \WC_Customer( $user->ID );
+
+		// If user is not a Woo customer, don't need to sync them.
+		if ( ! $customer->get_order_count() ) {
+			return;
+		}
+
+		self::sync_reader_from_order( $customer->get_last_order() );
+	}
+
+	/**
+	 * Sync a customer to the ESP from an order.
 	 *
 	 * @param WC_Order $order Order object.
 	 */
-	public static function register_reader( $order ) {
-		if ( Reader_Activation::is_enabled() ) {
-			$email_address = $order->get_billing_email();
-			$first_name    = $order->get_billing_first_name();
-			$last_name     = $order->get_billing_last_name();
-			$full_name     = "$first_name $last_name";
-			$metadata      = [ 'registration_method' => 'woocommerce-order' ];
-
-			Reader_Activation::register_reader( $email_address, $full_name, true, $metadata );
+	public static function sync_reader_from_order( $order ) {
+		if ( ! self::can_sync_customers() ) {
+			return;
 		}
+
+		$metadata_keys = Newspack_Newsletters::$metadata_keys;
+		$user_id       = $order->get_customer_id();
+		if ( ! $user_id ) {
+			return;
+		}
+		
+		$customer      = new \WC_Customer( $user_id );
+		$email_address = $order->get_billing_email();
+		$metadata      = [ 
+			'registration_method' => 'woocommerce-order', 
+		];
+
+		$metadata[ $metadata_keys['account'] ]           = $order->get_customer_id();
+		$metadata[ $metadata_keys['registration_date'] ] = $customer->get_date_created()->date( 'Y-m-d' );
+		$metadata[ $metadata_keys['payment_page'] ]      = \wc_get_checkout_url();
+
+		$order_subscriptions = wcs_get_subscriptions_for_order( $order->get_id() );
+
+		// One-time donation.
+		if ( empty( $order_subscriptions ) ) {
+			$metadata[ $metadata_keys['membership_status'] ] = 'Donor';
+			$metadata[ $metadata_keys['total_paid'] ]        = (float) $customer->get_total_spent() ? $customer->get_total_spent() : $order->get_total();
+			$metadata[ $metadata_keys['product_name'] ]      = '';
+			$order_items                                     = $order->get_items();
+			if ( $order_items ) {
+				$metadata[ $metadata_keys['product_name'] ] = reset( $order_items )->get_name();
+			}
+			$metadata[ $metadata_keys['last_payment_amount'] ] = $order->get_total();
+
+			// Subscription donation.
+		} else {
+			$current_subscription = reset( $order_subscriptions );
+
+			$metadata[ $metadata_keys['membership_status'] ] = 'Donor';
+			if ( 'active' === $current_subscription->get_status() || 'pending' === $current_subscription->get_status() ) {
+				if ( 'month' === $current_subscription->get_billing_period() ) {
+					$metadata[ $metadata_keys['membership_status'] ] = 'Monthly Donor';
+				}
+
+				if ( 'year' === $current_subscription->get_billing_period() ) {
+					$metadata[ $metadata_keys['membership_status'] ] = 'Yearly Donor';
+				}
+			} else {
+				if ( 'month' === $current_subscription->get_billing_period() ) {
+					$metadata[ $metadata_keys['membership_status'] ] = 'Ex-Monthly Donor';
+				}
+
+				if ( 'year' === $current_subscription->get_billing_period() ) {
+					$metadata[ $metadata_keys['membership_status'] ] = 'Ex-Yearly Donor';
+				}
+			}
+			
+			$metadata[ $metadata_keys['sub_start_date'] ]      = $current_subscription->get_date( 'start' );
+			$metadata[ $metadata_keys['sub_end_date'] ]        = $current_subscription->get_date( 'end' ) ? $current_subscription->get_date( 'end' ) : '';
+			$metadata[ $metadata_keys['billing_cycle'] ]       = $current_subscription->get_billing_period();
+			$metadata[ $metadata_keys['recurring_payment'] ]   = $current_subscription->get_total();
+			$metadata[ $metadata_keys['last_payment_date'] ]   = $current_subscription->get_date( 'last_order_date_paid' ) ? $current_subscription->get_date( 'last_order_date_paid' ) : gmdate( 'Y-m-d' );
+			$metadata[ $metadata_keys['last_payment_amount'] ] = $current_subscription->get_total();
+			$metadata[ $metadata_keys['next_payment_date'] ]   = $current_subscription->get_date( 'next_payment' );
+			$metadata[ $metadata_keys['total_paid'] ]          = (float) $customer->get_total_spent() ? $customer->get_total_spent() : $current_subscription->get_total();
+			$metadata[ $metadata_keys['product_name'] ]        = '';
+			if ( $current_subscription ) {
+				$subscription_order_items = $current_subscription->get_items();
+				if ( $subscription_order_items ) {
+					$metadata[ $metadata_keys['product_name'] ] = reset( $subscription_order_items )->get_name();
+				}
+			}
+		}
+
+		\update_user_meta( $user_id, Reader_Activation::READER, true );
+
+		/**
+		 * Action after registering and authenticating a reader.
+		 *
+		 * @param string         $email_address Email address.
+		 * @param bool           $authenticate  Whether to authenticate after registering.
+		 * @param false|int      $user_id       The created user id.
+		 * @param false|\WP_User $existing_user The existing user object.
+		 * @param array          $metadata      Metadata.
+		 */
+		\do_action( 'newspack_registered_reader', $email_address, true, $user_id, get_user_by( 'id', $user_id ), $metadata );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR syncs more data from WC customers to ActiveCampaign in an attempt to get parity with the sort of reader revenue data that syncs when using the Simplified Donate Block. It also adds some legacy handling and updating for Woo customers, so whenever they log in it'll sync the latest customer data.

The one bit I haven't been able to figure out from the codebase is how the name fields are synced to ActiveCampaign. I'm sure it's a small tweak, but I haven't got that working yet. Most of the other fields are synchronizing nicely, so the data should look the same in ActiveCampaign no matter what (Newspack-supported) reader revenue platform people are using.

### How to test the changes in this Pull Request:

1. Set up a site with an ActiveCampaign connection and Reader Revenue.
2. In an incognito window, go to `example.com/product/donate` and you should see the Woo Donate products Newspack creates.
3. Purchase a Monthly Donation. After checkout, in ActiveCampaign you should see the customer and synced data:
<img width="281" alt="Screen Shot 2022-09-03 at 3 15 26 PM" src="https://user-images.githubusercontent.com/7317227/188289803-e2d705cf-9d39-4412-be1e-4e02802f7643.png">
4.  Delete the customer's contact in ActiveCampaign (to simulate a legacy Woo customer that hasn't been synced). Log out of the site. Log in as the customer. Verify the customer's data shows up in ActiveCampaign.
5. In separate incognito sessions, test with Yearly Donation and One-Time Donation. The data should sync for those also.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->