### PR TITLE
feat(reader-activation): improve password reset flow

### DIFF
--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -497,5 +497,21 @@ class Emails {
 		}
 		return true;
 	}
+
+	/**
+	 * Get a password reset URL.
+	 *
+	 * @param WP_User $user WP user object.
+	 * @param string  $key Reset key.
+	 */
+	public static function get_password_reset_url( $user, $key ) {
+		return add_query_arg(
+			[
+				'key' => $key,
+				'id'  => $user->ID,
+			],
+			wc_get_account_endpoint_url( 'lost-password' )
+		);
+	}
 }
 Emails::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Two changes to password reset flow:

1. For a logged-in reader, the password-reset-request will link to WC's password reset screen (`/my-account/lost-password…`) instead of native WP screen (`/wp-login.php?action=rp&…`)
2. For a non-logged-in reader, the lost-password flow will use Newspack's email instead of WC's email

### How to test the changes in this Pull Request:

1. Start with a site with Reader Activation configured
1. Register or log in and use My Account -> Reset Password option to request a password reset link
3. Follow the link, observe it pointing to WC's password reset screen 
4. Reset the password, log in, and then log out
5. Use the "Lost your password?" flow of RA's Registration block or authentication modal* to request a password reset link
6. Observe the email is a Newspack email (not WC email), and complete the password resetting flow again

\* 
<img width="287" alt="image" src="https://user-images.githubusercontent.com/7383192/188464410-8fab7fa5-3cdb-4307-b751-5723588899d0.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->