### PR TITLE
fix(ac-master-list): handle empty lists

### DIFF
--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -212,7 +212,7 @@ class Newspack_Newsletters {
 	 */
 	public static function get_lists_without_active_campaign_master_list( $list_ids ) {
 		$master_list_id = Reader_Activation::get_setting( 'active_campaign_master_list' );
-		if ( is_int( intval( $master_list_id ) ) ) {
+		if ( is_int( intval( $master_list_id ) ) && is_array( $list_ids ) ) {
 			return array_values( // Reset keys.
 				array_filter(
 					$list_ids,


### PR DESCRIPTION
It may happen that the master list is set, but the Newsletter provider returns an error when getting list IDs. 