### PR TITLE
redirect to site home page from my account

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -76,6 +76,7 @@ final class Reader_Activation {
 			\add_filter( 'woocommerce_email_actions', [ __CLASS__, 'disable_woocommerce_new_user_email' ] );
 			\add_filter( 'retrieve_password_notification_email', [ __CLASS__, 'password_reset_configuration' ] );
 			\add_action( 'lostpassword_post', [ __CLASS__, 'set_password_reset_mail_content_type' ] );
+			\add_filter( 'logout_redirect', [ __CLASS__, 'get_logout_redirect_url' ], 10, 2 );
 		}
 	}
 
@@ -1420,6 +1421,20 @@ final class Reader_Activation {
 			return 'text/html';
 		};
 		add_filter( 'wp_mail_content_type', $email_content_type );
+	}
+
+	/**
+	 * Gets the URL to redirect the user after logging out from the My Account page
+	 *
+	 * @param string  $redirect_to           The redirect destination URL.
+	 * @param string  $requested_redirect_to The requested redirect destination URL passed as a parameter.
+	 * @return string
+	 */
+	public static function get_logout_redirect_url( $redirect_to, $requested_redirect_to ) {
+		if ( function_exists( 'wc_get_page_permalink') && wc_get_page_permalink( 'myaccount' ) === $requested_redirect_to ) {
+			return site_url();
+		}
+		return $redirect_to;
 	}
 }
 Reader_Activation::init();

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1426,12 +1426,12 @@ final class Reader_Activation {
 	/**
 	 * Gets the URL to redirect the user after logging out from the My Account page
 	 *
-	 * @param string  $redirect_to           The redirect destination URL.
-	 * @param string  $requested_redirect_to The requested redirect destination URL passed as a parameter.
+	 * @param string $redirect_to           The redirect destination URL.
+	 * @param string $requested_redirect_to The requested redirect destination URL passed as a parameter.
 	 * @return string
 	 */
 	public static function get_logout_redirect_url( $redirect_to, $requested_redirect_to ) {
-		if ( function_exists( 'wc_get_page_permalink') && wc_get_page_permalink( 'myaccount' ) === $requested_redirect_to ) {
+		if ( function_exists( 'wc_get_page_permalink' ) && wc_get_page_permalink( 'myaccount' ) === $requested_redirect_to ) {
 			return site_url();
 		}
 		return $redirect_to;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

It redirects the user to the site home page after they logout from the My Account page.

This could be a one line thing if it wasn't for a small bug in woocommerce.

The `woocommerce_logout_default_redirect_url` should be used to define the url to be redirected after Logout, but it was mistakenly used and it is also interfering with the Logout URL that is built for the `customer-logout` endpoint. So the Logout link breaks. Apparently there's an open issue about this here: https://github.com/woocommerce/woocommerce/issues/24243

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1830 .

### How to test the changes in this Pull Request:

1. Log in to your site
2. Make sure RAS is enabled
3. Go to the My Account page
4. Click Logout
5. Confirm you are redirected to the site home page
6. Log in again and log out from other place (i.e. the wp-admin dashboard)
7. Confirm that the logout redirect was not modified there.

