### PR TITLE
Site Design: add check to only change theme if not empty

### DIFF
--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -475,7 +475,9 @@ class Setup_Wizard extends Wizard {
 		// If the theme has to be installed, the set_theme_mod calls below will – for some reason – have no effect
 		// If there's a switch_theme call here, even though it's already called in Theme_Manager::install_activate_theme,
 		// correct mods will be saved.
-		switch_theme( $theme );
+		if ( ! empty( $theme ) ) {
+			switch_theme( $theme );
+		}
 
 		// Set homepage pattern.
 		if ( isset( $request['theme_mods']['homepage_pattern_index'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Best I can tell, [this `switch_theme()` function](https://github.com/Automattic/newspack-plugin/pull/1500/files#diff-b68d58272a59cbafbe7aae011ee40fb05e17f57faa5bf55a84836cb073898e0cR493) can pass an empty string as the theme value, causing a site's theme to get set to nothing. This happens when any setting is changed on the Dashboard > Newspack > Site Design > Settings tab, but does not cause issues on the Design tab. 

This PR adds an `! empty()` check on the theme, to make sure it's not empty before running `switch_theme()`. While this _seems_ to work in my testing, I'm not sure if it would be better to revisit the original approach in #1500 since there was some question around why it worked in the first place 🙂 

Closes #1976

### How to test the changes in this Pull Request:

To recreate the original issue:

1. Start on a site that's already been set up. 
2. Navigate to WP Admin > Newspack > Site Design > Settings.
3. Change any of the settings and Save.
4. View the front-end of the site and see that the CSS is basically not loading; if you navigate to WP Admin > Appearance > Themes, no theme will be applied. 

To test this fix:

1. Reset your site's theme if you haven't already. 
2. Apply this PR. 
3. Navigate to WP Admin > Newspack > Site Design > Settings.
4. Change any of the settings and Save.
5. View the front end and confirm that the site looks okay. 
6. Repeat the testing steps [here](https://github.com/Automattic/newspack-plugin/pull/1500) with this PR, and confirm that this change doesn't introduce any regressions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->