### PR TITLE
fix(emails): don't create post if pluggable functions are not available

### DIFF
--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -295,6 +295,8 @@ class Emails {
 	 *
 	 * @param string $type Type of the email.
 	 * @param int    $post_id Email post id.
+	 *
+	 * @return array|false The serialized email config or false if not available or supported.
 	 */
 	private static function serialize_email( $type = null, $post_id = 0 ) {
 		if ( ! self::supports_emails() ) {
@@ -372,6 +374,8 @@ class Emails {
 	 * If the email does not exist, it will be created based on default template.
 	 *
 	 * @param string $type Type of the email.
+	 *
+	 * @return array|false The serialized email config or false if not available or supported.
 	 */
 	public static function get_email_config_by_type( $type ) {
 		$emails_query = new \WP_Query(
@@ -385,6 +389,9 @@ class Emails {
 		);
 		if ( $emails_query->post ) {
 			return self::serialize_email( $type, $emails_query->post->ID );
+		} elseif ( ! function_exists( 'is_user_logged_in' ) ) {
+			/** Only attempt to create the email post if wp-includes/pluggable.php is loaded. */
+			return false;
 		} else {
 			$email_post_data = self::load_email_template( $type );
 			if ( ! $email_post_data ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `Emails::get_email_config_by_type( $type )` method creates the email post on demand if it's called and the email is not found. This can be problematic if the method is called before `wp-includes/pluggable.php` has not yet been loaded.

This PR prevents the method from creating the post if `is_user_logged_in()` is not defined, which means pluggable functions are not yet loaded.

This change shouldn't prevent the posts from being created because the method is called multiple times and the post should be created as soon as pluggable functions are available.

### How to test the changes in this Pull Request:

1. While on master, remove posts from the `newspack_rr_email` post type directly from the database
2. Refresh your dashboard page and confirm the error
3. Check out this branch, remove the posts from the database again
4. Refresh the dashboard and confirm there's no error and the email posts are created

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->