### PR TITLE
style: fix unwanted scrollbar for inline auth wrapper

### DIFF
--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -193,6 +193,7 @@
 			.newspack-reader__auth-form__inline & {
 				margin: auto;
 				max-width: 780px;
+				overflow-y: hidden;
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures that the inline auth wrapper never displays scrollbars.

### How to test the changes in this Pull Request:

1. On `master`, visit the My Account page while not logged in.
2. Observe vertical scrollbars in the auth wrapper:

<img width="834" alt="Screen Shot 2022-09-06 at 3 04 17 PM" src="https://user-images.githubusercontent.com/2230142/188737993-ac2db1c7-c563-4c1a-9191-f976aea2eb7d.png">

3. Check out this branch, refresh, confirm that the scrollbars no longer appear.
4. Trigger some messaging (try to log into an account with the wrong password, or send yourself a magic link). Confirm that the auth wrapper still expands as expected to show all contents, but without showing any scrollbar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->