### PR TITLE
fix(wc-to-ac-metadata): disregard `0` next payment date

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -182,9 +182,16 @@ class WooCommerce_Connection {
 			$metadata[ $metadata_keys['recurring_payment'] ]   = $current_subscription->get_total();
 			$metadata[ $metadata_keys['last_payment_date'] ]   = $current_subscription->get_date( 'last_order_date_paid' ) ? $current_subscription->get_date( 'last_order_date_paid' ) : gmdate( 'Y-m-d' );
 			$metadata[ $metadata_keys['last_payment_amount'] ] = $current_subscription->get_total();
-			$metadata[ $metadata_keys['next_payment_date'] ]   = $current_subscription->get_date( 'next_payment' );
-			$metadata[ $metadata_keys['total_paid'] ]          = (float) $customer->get_total_spent() ? $customer->get_total_spent() : $current_subscription->get_total();
-			$metadata[ $metadata_keys['product_name'] ]        = '';
+
+			// When a WC Subscription is terminated, the next payment date is set to 0. We don't want to sync that – the next payment date should remain as it was
+			// in the event of cancellation.
+			$next_payment_date = $current_subscription->get_date( 'next_payment' );
+			if ( $next_payment_date ) {
+				$metadata[ $metadata_keys['next_payment_date'] ] = $next_payment_date;
+			}
+
+			$metadata[ $metadata_keys['total_paid'] ]   = (float) $customer->get_total_spent() ? $customer->get_total_spent() : $current_subscription->get_total();
+			$metadata[ $metadata_keys['product_name'] ] = '';
 			if ( $current_subscription ) {
 				$subscription_order_items = $current_subscription->get_items();
 				if ( $subscription_order_items ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When a WC Subscription is terminated, the next payment date is set to 0. We don't want to sync that – the next payment date should remain as it was in the event of cancellation.

### How to test the changes in this Pull Request:

1. Set up a site with WC Subscription, add and then terminate a subscription
2. On `master`, observe the `NP_Next Payment Date` metadata field is set to `0` in AC
3. Repeat on this branch, observe the `0` value is not sent

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->