### PR TITLE
feat: do not redirect resubscribe requests

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -313,9 +313,13 @@ class WooCommerce_My_Account {
 
 	/**
 	 * Redirect to "Account details" if accessing "My Account" directly.
+	 * Do not redirect if the request is a resubscribe request, as resubscribe
+	 * requests do their own redirect to the cart/checkout page.
 	 */
 	public static function redirect_to_account_details() {
-		if ( \is_user_logged_in() && Reader_Activation::is_enabled() && function_exists( 'wc_get_page_permalink' ) ) {
+		$resubscribe_request = isset( $_REQUEST['resubscribe'] ) ? 'shop_subscription' === get_post_type( absint( $_REQUEST['resubscribe'] ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( \is_user_logged_in() && Reader_Activation::is_enabled() && function_exists( 'wc_get_page_permalink' ) && ! $resubscribe_request ) {
 			global $wp;
 			$current_url               = \home_url( $wp->request );
 			$my_account_page_permalink = \wc_get_page_permalink( 'myaccount' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a RAS-related bug affecting WooCommerce Subscriptions functionality. When executing a "resubscribe" action, the WC Subscriptions plugin redirects to the root "My Account" dashboard URL, but the RAS class hijacks the request by redirecting to Account Details before the action completes. 

### How to test the changes in this Pull Request:

1. On a site without RAS enabled and Newspack set as the Reader Revenue platform, make a recurring donation on the front-end.
2. Switch the platform to Stripe and enable RAS. 
3. In WP admin, go to WooCommerce > Subscriptions and cancel the subscription for the recurring donation you just made.
4. On the front-end, register using the same email address you used to make the legacy donation. Verify the account.
5. In My Account, go to Subscriptions and click "Resubscribe". Observe that you're redirected to the "Account Details" page with seemingly no action taken.
6. Check out this branch, repeat step 5, and confirm that you're redirected to the checkout page to resubscribe to your recurring donation.
7. Try to go to the root `/my-account/` URL and confirm that you're still redirected to the Account Details page when not trying to resubscribe.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->