### PR TITLE
Adds meta pixel settings section

### DIFF
--- a/assets/wizards/engagement/views/social/index.js
+++ b/assets/wizards/engagement/views/social/index.js
@@ -6,13 +6,14 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { ActionCard, withWizardScreen } from '../../../../components/src';
-
+import MetaPixel from './meta-pixel';
 /**
  * Social Screen
  */
@@ -22,16 +23,19 @@ class Social extends Component {
 	 */
 	render() {
 		return (
-			<ActionCard
-				title={ __( 'Publicize' ) }
-				badge="Jetpack"
-				description={ __(
-					'Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.'
-				) }
-				actionText={ __( 'Configure' ) }
-				handoff="jetpack"
-				editLink="admin.php?page=jetpack#/sharing"
-			/>
+			<>
+				<ActionCard
+					title={ __( 'Publicize' ) }
+					badge="Jetpack"
+					description={ __(
+						'Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.'
+					) }
+					actionText={ __( 'Configure' ) }
+					handoff="jetpack"
+					editLink="admin.php?page=jetpack#/sharing"
+				/>
+				<MetaPixel />
+			</>
 		);
 	}
 }

--- a/assets/wizards/engagement/views/social/index.js
+++ b/assets/wizards/engagement/views/social/index.js
@@ -6,7 +6,6 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/assets/wizards/engagement/views/social/meta-pixel.js
+++ b/assets/wizards/engagement/views/social/meta-pixel.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useState } from '@wordpress/element';
+import { createInterpolateElement, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -53,23 +53,27 @@ export default function MetaPixel() {
 		setInFlight( false );
 	};
 
+	if ( ! settings ) {
+		return null;
+	}
+
 	const fields = [
 		{
 			key: 'pixel_id',
 			type: 'integer',
 			description: __( 'Pixel ID', 'newspack' ),
-			help: __(
-				'The Meta Pixel ID of your account. You can take this information in XXXXXXXX. EXAMPLE.',
-				'newspack'
+			help: createInterpolateElement(
+				__(
+					'The Meta Pixel ID. You only need to add the number, not the full code. Example: 123456789123456789. You can get this information <linkToFb>here</linkToFb>.',
+					'newspack'
+				),
+				{
+					linkToFb: <a href="https://www.facebook.com/ads/manager/pixel/facebook_pixel" target="_blank" />,
+				}
 			),
+			value: settings.pixel_id,
 		},
 	];
-
-	if ( ! settings ) {
-		return null;
-	}
-
-	fields[0].value = settings.pixel_id;
 
 	return (
 		<PluginSettings.Section

--- a/assets/wizards/engagement/views/social/meta-pixel.js
+++ b/assets/wizards/engagement/views/social/meta-pixel.js
@@ -11,7 +11,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { PluginSettings } from '../../../../components/src';
 
 export default function MetaPixel() {
-	const apiEndpoint = '/wp/v2/settings';
+	const apiEndpoint = '/newspack/v1/wizard/newspack-engagement-wizard/social/meta_pixel';
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ error, setError ] = useState( null );
 	const [ settings, setSettings ] = useState( null );
@@ -20,7 +20,7 @@ export default function MetaPixel() {
 		setInFlight( true );
 		try {
 			const response = await apiFetch( { path: apiEndpoint } );
-			setSettings( response.newspack_meta_pixel );
+			setSettings( response );
 		} catch ( err ) {
 			setSettings( null );
 		}
@@ -42,13 +42,11 @@ export default function MetaPixel() {
 				path: apiEndpoint,
 				method: 'POST',
 				data: {
-					newspack_meta_pixel: {
-						...settings,
-						...data,
-					},
+					...settings,
+					...data,
 				},
 			} );
-			setSettings( result.newspack_meta_pixel );
+			setSettings( result );
 		} catch ( err ) {
 			setError( err );
 		}
@@ -58,7 +56,7 @@ export default function MetaPixel() {
 	const fields = [
 		{
 			key: 'pixel_id',
-			type: 'string',
+			type: 'integer',
 			description: __( 'Pixel ID', 'newspack' ),
 			help: __(
 				'The Meta Pixel ID of your account. You can take this information in XXXXXXXX. EXAMPLE.',
@@ -66,6 +64,12 @@ export default function MetaPixel() {
 			),
 		},
 	];
+
+	if ( ! settings ) {
+		return null;
+	}
+
+	fields[0].value = settings.pixel_id;
 
 	return (
 		<PluginSettings.Section

--- a/assets/wizards/engagement/views/social/meta-pixel.js
+++ b/assets/wizards/engagement/views/social/meta-pixel.js
@@ -44,7 +44,7 @@ export default function MetaPixel() {
 				data: {
 					newspack_meta_pixel: {
 						...settings,
-						...data
+						...data,
 					},
 				},
 			} );
@@ -61,7 +61,7 @@ export default function MetaPixel() {
 			type: 'string',
 			description: __( 'Pixel ID', 'newspack' ),
 			help: __(
-				"The Meta Pixel ID of your account. You can take this information in XXXXXXXX. EXAMPLE....",
+				'The Meta Pixel ID of your account. You can take this information in XXXXXXXX. EXAMPLE.',
 				'newspack'
 			),
 		},

--- a/assets/wizards/engagement/views/social/meta-pixel.js
+++ b/assets/wizards/engagement/views/social/meta-pixel.js
@@ -68,7 +68,13 @@ export default function MetaPixel() {
 					'newspack'
 				),
 				{
-					linkToFb: <a href="https://www.facebook.com/ads/manager/pixel/facebook_pixel" target="_blank" />,
+					linkToFb: (
+						<a
+							href="https://www.facebook.com/ads/manager/pixel/facebook_pixel"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
 				}
 			),
 			value: settings.pixel_id,

--- a/assets/wizards/engagement/views/social/meta-pixel.js
+++ b/assets/wizards/engagement/views/social/meta-pixel.js
@@ -1,0 +1,86 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { PluginSettings } from '../../../../components/src';
+
+export default function MetaPixel() {
+	const apiEndpoint = '/wp/v2/settings';
+	const [ inFlight, setInFlight ] = useState( false );
+	const [ error, setError ] = useState( null );
+	const [ settings, setSettings ] = useState( null );
+
+	useEffect( async () => {
+		setInFlight( true );
+		try {
+			const response = await apiFetch( { path: apiEndpoint } );
+			setSettings( response.newspack_meta_pixel );
+		} catch ( err ) {
+			setSettings( null );
+		}
+		setInFlight( false );
+	}, [] );
+
+	const handleChange = ( key, value ) => {
+		setSettings( {
+			...settings,
+			[ key ]: value,
+		} );
+	};
+
+	const handleUpdate = async data => {
+		setError( null );
+		setInFlight( true );
+		try {
+			const result = await apiFetch( {
+				path: apiEndpoint,
+				method: 'POST',
+				data: {
+					newspack_meta_pixel: {
+						...settings,
+						...data
+					},
+				},
+			} );
+			setSettings( result.newspack_meta_pixel );
+		} catch ( err ) {
+			setError( err );
+		}
+		setInFlight( false );
+	};
+
+	const fields = [
+		{
+			key: 'pixel_id',
+			type: 'string',
+			description: __( 'Pixel ID', 'newspack' ),
+			help: __(
+				"The Meta Pixel ID of your account. You can take this information in XXXXXXXX. EXAMPLE....",
+				'newspack'
+			),
+		},
+	];
+
+	return (
+		<PluginSettings.Section
+			error={ error }
+			disabled={ inFlight }
+			sectionKey="ad-refresh-control"
+			title={ __( 'Meta Pixel', 'newspack' ) }
+			description={ __(
+				'Add the Meta pixel (formely known as Facebook pixel) to your site.',
+				'newspack'
+			) }
+			active={ settings.active }
+			fields={ fields }
+			onUpdate={ handleUpdate }
+			onChange={ handleChange }
+		/>
+	);
+}

--- a/assets/wizards/engagement/views/social/meta-pixel.js
+++ b/assets/wizards/engagement/views/social/meta-pixel.js
@@ -68,6 +68,7 @@ export default function MetaPixel() {
 					'newspack'
 				),
 				{
+					/* eslint-disable jsx-a11y/anchor-has-content */
 					linkToFb: (
 						<a
 							href="https://www.facebook.com/ads/manager/pixel/facebook_pixel"

--- a/includes/class-meta-pixel.php
+++ b/includes/class-meta-pixel.php
@@ -154,7 +154,7 @@ class Meta_Pixel {
 	 * @return string
 	 */
 	public static function get_img_snippet() {
-		return '<img height="1" width="1" style="display: none;" src="https://www.facebook.com/tr?id=$PIXEL_ID$&ev=PageView&noscript=1&cd%5Bpage_title%5D=Homepage&cd%5Bpost_type%5D=page&cd%5Bpost_id%5D=125&cd%5Bplugin%5D=PixelYourSite&cd%5Buser_role%5D=guest&cd%5Bevent_url%5D=leogermani.jurassic.tube%2F" alt="">';
+		return '<img height="1" width="1" style="display: none;" src="https://www.facebook.com/tr?id=__PIXEL_ID__&ev=PageView&noscript=1&cd%5Bpage_title%5D=Homepage&cd%5Bpost_type%5D=page&cd%5Bpost_id%5D=125&cd%5Bplugin%5D=PixelYourSite&cd%5Buser_role%5D=guest&cd%5Bevent_url%5D=leogermani.jurassic.tube%2F" alt="">';
 	}
 
 	/**
@@ -164,11 +164,20 @@ class Meta_Pixel {
 	 */
 	public static function get_script_snippet() {
 		// phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation
-		return '<script type="text/javascript" id="pys-js-extra">
-		/* <![CDATA[ */
-		var pysOptions = {"staticEvents":{"facebook":{"init_event":[{"delay":0,"type":"static","name":"PageView","pixelIds":["$PIXEL_ID$"],"eventID":"b69f94f7-5424-467e-a856-124844a132e9","params":{"page_title":"Homepage","post_type":"page","post_id":125,"plugin":"PixelYourSite","user_role":"guest","event_url":"leogermani.jurassic.tube\/"},"e_id":"init_event","ids":[],"hasTimeWindow":false,"timeWindow":0,"woo_order":"","edd_order":""}]}},"dynamicEvents":{"woo_add_to_cart_on_button_click":{"facebook":{"delay":0,"type":"dyn","name":"AddToCart","pixelIds":["$PIXEL_ID$"],"eventID":"78439eb7-a9fc-43cd-926e-670d06c4c8f2","params":{"page_title":"Homepage","post_type":"page","post_id":125,"plugin":"PixelYourSite","user_role":"guest","event_url":"leogermani.jurassic.tube\/"},"e_id":"woo_add_to_cart_on_button_click","ids":[],"hasTimeWindow":false,"timeWindow":0,"woo_order":"","edd_order":""}}},"triggerEvents":[],"triggerEventTypes":[],"facebook":{"pixelIds":["$PIXEL_ID$"],"advancedMatching":[],"removeMetadata":false,"contentParams":{"post_type":"page","post_id":125,"content_name":"Homepage"},"commentEventEnabled":true,"wooVariableAsSimple":false,"downloadEnabled":true,"formEventEnabled":true,"ajaxForServerEvent":true,"serverApiEnabled":false,"wooCRSendFromServer":false},"debug":"","siteUrl":"https:\/\/leogermani.jurassic.tube","ajaxUrl":"https:\/\/leogermani.jurassic.tube\/wp-admin\/admin-ajax.php","enable_remove_download_url_param":"1","cookie_duration":"7","last_visit_duration":"60","gdpr":{"ajax_enabled":false,"all_disabled_by_api":false,"facebook_disabled_by_api":false,"analytics_disabled_by_api":false,"google_ads_disabled_by_api":false,"pinterest_disabled_by_api":false,"bing_disabled_by_api":false,"facebook_prior_consent_enabled":true,"analytics_prior_consent_enabled":true,"google_ads_prior_consent_enabled":null,"pinterest_prior_consent_enabled":true,"bing_prior_consent_enabled":true,"cookiebot_integration_enabled":false,"cookiebot_facebook_consent_category":"marketing","cookiebot_analytics_consent_category":"statistics","cookiebot_google_ads_consent_category":null,"cookiebot_pinterest_consent_category":"marketing","cookiebot_bing_consent_category":"marketing","consent_magic_integration_enabled":false,"real_cookie_banner_integration_enabled":false,"cookie_notice_integration_enabled":false,"cookie_law_info_integration_enabled":false},"woo":{"enabled":true,"addToCartOnButtonEnabled":true,"addToCartOnButtonValueEnabled":true,"addToCartOnButtonValueOption":"price","singleProductId":null,"removeFromCartSelector":"form.woocommerce-cart-form .remove","addToCartCatchMethod":"add_cart_js"},"edd":{"enabled":false}};
-		/* ]]> */
-		</script>';
+		return "
+		<script>
+		!function(f,b,e,v,n,t,s)
+		{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+		n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+		if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+		n.queue=[];t=b.createElement(e);t.async=!0;
+		t.src=v;s=b.getElementsByTagName(e)[0];
+		s.parentNode.insertBefore(t,s)}(window, document,'script',
+		'https://connect.facebook.net/en_US/fbevents.js');
+		fbq('init', '__PIXEL_ID__');
+		fbq('track', 'PageView');
+		</script>
+		";
 	}
 
 	/**
@@ -184,7 +193,7 @@ class Meta_Pixel {
 		if ( empty( $pixel_id ) ) {
 			return;
 		}
-		echo str_replace( '$PIXEL_ID$', intval( $pixel_id ), self::get_script_snippet() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo str_replace( '__PIXEL_ID__', intval( $pixel_id ), self::get_script_snippet() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -198,7 +207,7 @@ class Meta_Pixel {
 			return;
 		}
 		// If AMP plugin is enabled, it will convert the image into a <amp-pixel> tag.
-		echo '<noscript>' . str_replace( '$PIXEL_ID$', intval( $pixel_id ), self::get_img_snippet() ) . '</noscript>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<noscript>' . str_replace( '__PIXEL_ID__', intval( $pixel_id ), self::get_img_snippet() ) . '</noscript>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 

--- a/includes/class-meta-pixel.php
+++ b/includes/class-meta-pixel.php
@@ -195,7 +195,7 @@ class Meta_Pixel {
 	}
 
 	/**
-	 * Prints sinppets in the header
+	 * Prints snippets in the header
 	 *
 	 * @return void
 	 */

--- a/includes/class-meta-pixel.php
+++ b/includes/class-meta-pixel.php
@@ -19,6 +19,11 @@ class Meta_Pixel {
 	 */
 	const OPTION_NAME = 'newspack_meta_pixel';
 
+	/**
+	 * Initialize hooks
+	 *
+	 * @return void
+	 */
 	public static function init() {
 		add_action( 'wp_head', [ __CLASS__, 'print_head_snippet' ], 100 );
 		add_action( 'wp_footer', [ __CLASS__, 'print_footer_snippet' ] );
@@ -158,6 +163,7 @@ class Meta_Pixel {
 	 * @return string
 	 */
 	public static function get_script_snippet() {
+		// phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation
 		return '<script type="text/javascript" id="pys-js-extra">
 		/* <![CDATA[ */
 		var pysOptions = {"staticEvents":{"facebook":{"init_event":[{"delay":0,"type":"static","name":"PageView","pixelIds":["$PIXEL_ID$"],"eventID":"b69f94f7-5424-467e-a856-124844a132e9","params":{"page_title":"Homepage","post_type":"page","post_id":125,"plugin":"PixelYourSite","user_role":"guest","event_url":"leogermani.jurassic.tube\/"},"e_id":"init_event","ids":[],"hasTimeWindow":false,"timeWindow":0,"woo_order":"","edd_order":""}]}},"dynamicEvents":{"woo_add_to_cart_on_button_click":{"facebook":{"delay":0,"type":"dyn","name":"AddToCart","pixelIds":["$PIXEL_ID$"],"eventID":"78439eb7-a9fc-43cd-926e-670d06c4c8f2","params":{"page_title":"Homepage","post_type":"page","post_id":125,"plugin":"PixelYourSite","user_role":"guest","event_url":"leogermani.jurassic.tube\/"},"e_id":"woo_add_to_cart_on_button_click","ids":[],"hasTimeWindow":false,"timeWindow":0,"woo_order":"","edd_order":""}}},"triggerEvents":[],"triggerEventTypes":[],"facebook":{"pixelIds":["$PIXEL_ID$"],"advancedMatching":[],"removeMetadata":false,"contentParams":{"post_type":"page","post_id":125,"content_name":"Homepage"},"commentEventEnabled":true,"wooVariableAsSimple":false,"downloadEnabled":true,"formEventEnabled":true,"ajaxForServerEvent":true,"serverApiEnabled":false,"wooCRSendFromServer":false},"debug":"","siteUrl":"https:\/\/leogermani.jurassic.tube","ajaxUrl":"https:\/\/leogermani.jurassic.tube\/wp-admin\/admin-ajax.php","enable_remove_download_url_param":"1","cookie_duration":"7","last_visit_duration":"60","gdpr":{"ajax_enabled":false,"all_disabled_by_api":false,"facebook_disabled_by_api":false,"analytics_disabled_by_api":false,"google_ads_disabled_by_api":false,"pinterest_disabled_by_api":false,"bing_disabled_by_api":false,"facebook_prior_consent_enabled":true,"analytics_prior_consent_enabled":true,"google_ads_prior_consent_enabled":null,"pinterest_prior_consent_enabled":true,"bing_prior_consent_enabled":true,"cookiebot_integration_enabled":false,"cookiebot_facebook_consent_category":"marketing","cookiebot_analytics_consent_category":"statistics","cookiebot_google_ads_consent_category":null,"cookiebot_pinterest_consent_category":"marketing","cookiebot_bing_consent_category":"marketing","consent_magic_integration_enabled":false,"real_cookie_banner_integration_enabled":false,"cookie_notice_integration_enabled":false,"cookie_law_info_integration_enabled":false},"woo":{"enabled":true,"addToCartOnButtonEnabled":true,"addToCartOnButtonValueEnabled":true,"addToCartOnButtonValueOption":"price","singleProductId":null,"removeFromCartSelector":"form.woocommerce-cart-form .remove","addToCartCatchMethod":"add_cart_js"},"edd":{"enabled":false}};

--- a/includes/class-meta-pixel.php
+++ b/includes/class-meta-pixel.php
@@ -46,7 +46,7 @@ class Meta_Pixel {
 	 * @return boolean
 	 */
 	public static function validate_pixel_id( $value ) {
-		return ctype_digit( $value ) || is_int( $value );
+		return '' === $value || ctype_digit( $value ) || is_int( $value );
 	}
 
 	/**

--- a/includes/class-meta-pixel.php
+++ b/includes/class-meta-pixel.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Newspack Magic Links functionality.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The Meta Pixel class
+ */
+class Meta_Pixel {
+
+	/**
+	 * The option name
+	 */
+	const OPTION_NAME = 'newspack_meta_pixel';
+
+	/**
+	 * Initializes the hooks
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'admin_init', [ __CLASS__, 'register_setting' ] );
+		add_action( 'rest_api_init', [ __CLASS__, 'register_setting' ] );
+	}
+
+	/**
+	 * Register the settings
+	 *
+	 * @return void
+	 */
+	public static function register_setting() {
+		register_setting(
+			'newspack_plugin',
+			self::OPTION_NAME,
+			array(
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'active'   => array(
+								'type' => 'boolean',
+							),
+							'pixel_id' => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+				'type'              => 'object',
+				'sanitize_callback' => [ __CLASS__, 'sanitize_option' ],
+				'default'           => self::get_default_values(),
+			)
+		);
+	}
+
+	/**
+	 * Get settings default values
+	 *
+	 * @return array
+	 */
+	public static function get_default_values() {
+		return [
+			'active'   => false,
+			'pixel_id' => '',
+		];
+	}
+
+	/**
+	 * Sanitizes settings
+	 *
+	 * @param array $value The settings value.
+	 * @return array
+	 */
+	public static function sanitize_option( $value ) {
+		$defaults  = self::get_default_values();
+		$sanitized = [];
+		if ( ! is_array( $value ) ) {
+			return $defaults;
+		}
+		if ( isset( $value['active'] ) ) {
+			$sanitized['active'] = (bool) $value['active'];
+		} else {
+			$sanitized['active'] = $defaults['active'];
+		}
+		if ( isset( $value['pixel_id'] ) ) {
+			$sanitized['pixel_id'] = (string) $value['pixel_id'];
+		} else {
+			$sanitized['pixel_id'] = $defaults['pixel_id'];
+		}
+		return $sanitized;
+	}
+}
+
+Meta_Pixel::init();

--- a/includes/class-meta-pixel.php
+++ b/includes/class-meta-pixel.php
@@ -19,6 +19,11 @@ class Meta_Pixel {
 	 */
 	const OPTION_NAME = 'newspack_meta_pixel';
 
+	public static function init() {
+		add_action( 'wp_head', [ __CLASS__, 'print_head_snippet' ], 1000 );
+		add_action( 'wp_footer', [ __CLASS__, 'print_footer_snippet' ] );
+	}
+
 	/**
 	 * Validates the active argument
 	 *
@@ -72,6 +77,27 @@ class Meta_Pixel {
 	}
 
 	/**
+	 * Checks if Meta pixel option is active
+	 *
+	 * @return boolean
+	 */
+	public static function is_active() {
+		return self::get_option()['active'];
+	}
+
+	/**
+	 * Gets the stored pixel ID. If Meta Pixel option is not active, ignore the saved option
+	 *
+	 * @return string
+	 */
+	public static function get_pixel_id() {
+		if ( ! self::is_active() ) {
+			return '';
+		}
+		return self::get_option()['pixel_id'];
+	}
+
+	/**
 	 * Get settings default values
 	 *
 	 * @return array
@@ -107,4 +133,69 @@ class Meta_Pixel {
 		}
 		return $sanitized;
 	}
+
+	/**
+	 * Checks if AMP plugin is enabled and if the current response is being server as AMP
+	 *
+	 * @return boolean
+	 */
+	public static function is_amp() {
+		return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+	}
+
+	/**
+	 * Gets the template for the img tag snippet
+	 *
+	 * @return string
+	 */
+	public static function get_img_snippet() {
+		return '<img height="1" width="1" style="display: none;" src="https://www.facebook.com/tr?id=$PIXEL_ID$&ev=PageView&noscript=1&cd%5Bpage_title%5D=Homepage&cd%5Bpost_type%5D=page&cd%5Bpost_id%5D=125&cd%5Bplugin%5D=PixelYourSite&cd%5Buser_role%5D=guest&cd%5Bevent_url%5D=leogermani.jurassic.tube%2F" alt="">';
+	}
+
+	/**
+	 * Gets the template for the script tag snippet
+	 *
+	 * @return string
+	 */
+	public static function get_script_snippet() {
+		return '<script type="text/javascript" id="pys-js-extra">
+		/* <![CDATA[ */
+		var pysOptions = {"staticEvents":{"facebook":{"init_event":[{"delay":0,"type":"static","name":"PageView","pixelIds":["$PIXEL_ID$"],"eventID":"b69f94f7-5424-467e-a856-124844a132e9","params":{"page_title":"Homepage","post_type":"page","post_id":125,"plugin":"PixelYourSite","user_role":"guest","event_url":"leogermani.jurassic.tube\/"},"e_id":"init_event","ids":[],"hasTimeWindow":false,"timeWindow":0,"woo_order":"","edd_order":""}]}},"dynamicEvents":{"woo_add_to_cart_on_button_click":{"facebook":{"delay":0,"type":"dyn","name":"AddToCart","pixelIds":["$PIXEL_ID$"],"eventID":"78439eb7-a9fc-43cd-926e-670d06c4c8f2","params":{"page_title":"Homepage","post_type":"page","post_id":125,"plugin":"PixelYourSite","user_role":"guest","event_url":"leogermani.jurassic.tube\/"},"e_id":"woo_add_to_cart_on_button_click","ids":[],"hasTimeWindow":false,"timeWindow":0,"woo_order":"","edd_order":""}}},"triggerEvents":[],"triggerEventTypes":[],"facebook":{"pixelIds":["$PIXEL_ID$"],"advancedMatching":[],"removeMetadata":false,"contentParams":{"post_type":"page","post_id":125,"content_name":"Homepage"},"commentEventEnabled":true,"wooVariableAsSimple":false,"downloadEnabled":true,"formEventEnabled":true,"ajaxForServerEvent":true,"serverApiEnabled":false,"wooCRSendFromServer":false},"debug":"","siteUrl":"https:\/\/leogermani.jurassic.tube","ajaxUrl":"https:\/\/leogermani.jurassic.tube\/wp-admin\/admin-ajax.php","enable_remove_download_url_param":"1","cookie_duration":"7","last_visit_duration":"60","gdpr":{"ajax_enabled":false,"all_disabled_by_api":false,"facebook_disabled_by_api":false,"analytics_disabled_by_api":false,"google_ads_disabled_by_api":false,"pinterest_disabled_by_api":false,"bing_disabled_by_api":false,"facebook_prior_consent_enabled":true,"analytics_prior_consent_enabled":true,"google_ads_prior_consent_enabled":null,"pinterest_prior_consent_enabled":true,"bing_prior_consent_enabled":true,"cookiebot_integration_enabled":false,"cookiebot_facebook_consent_category":"marketing","cookiebot_analytics_consent_category":"statistics","cookiebot_google_ads_consent_category":null,"cookiebot_pinterest_consent_category":"marketing","cookiebot_bing_consent_category":"marketing","consent_magic_integration_enabled":false,"real_cookie_banner_integration_enabled":false,"cookie_notice_integration_enabled":false,"cookie_law_info_integration_enabled":false},"woo":{"enabled":true,"addToCartOnButtonEnabled":true,"addToCartOnButtonValueEnabled":true,"addToCartOnButtonValueOption":"price","singleProductId":null,"removeFromCartSelector":"form.woocommerce-cart-form .remove","addToCartCatchMethod":"add_cart_js"},"edd":{"enabled":false}};
+		/* ]]> */
+		</script>';
+	}
+
+	/**
+	 * Prints sinppets in the header
+	 *
+	 * @return void
+	 */
+	public static function print_head_snippet() {
+		$pixel_id = self::get_pixel_id();
+		if ( empty( $pixel_id ) ) {
+			return;
+		}
+		if ( ! self::is_amp() ) {
+			echo str_replace( '$PIXEL_ID$', intval( $pixel_id ), self::get_script_snippet() );
+		}
+	}
+
+	/**
+	 * Prints snippets in the footer
+	 *
+	 * @return void
+	 */
+	public static function print_footer_snippet() {
+		if ( self::is_amp() ) {
+			return;
+		}
+		$pixel_id = self::get_pixel_id();
+
+		if ( empty( $pixel_id ) ) {
+			return;
+		}
+		echo '<noscript>' . str_replace( '$PIXEL_ID$', intval( $pixel_id ), self::get_img_snippet() ) . '</noscript>';
+	}
 }
+
+Meta_Pixel::init();

--- a/includes/class-meta-pixel.php
+++ b/includes/class-meta-pixel.php
@@ -20,7 +20,7 @@ class Meta_Pixel {
 	const OPTION_NAME = 'newspack_meta_pixel';
 
 	public static function init() {
-		add_action( 'wp_head', [ __CLASS__, 'print_head_snippet' ], 1000 );
+		add_action( 'wp_head', [ __CLASS__, 'print_head_snippet' ], 100 );
 		add_action( 'wp_footer', [ __CLASS__, 'print_footer_snippet' ] );
 	}
 
@@ -171,13 +171,14 @@ class Meta_Pixel {
 	 * @return void
 	 */
 	public static function print_head_snippet() {
+		if ( self::is_amp() ) {
+			return;
+		}
 		$pixel_id = self::get_pixel_id();
 		if ( empty( $pixel_id ) ) {
 			return;
 		}
-		if ( ! self::is_amp() ) {
-			echo str_replace( '$PIXEL_ID$', intval( $pixel_id ), self::get_script_snippet() );
-		}
+		echo str_replace( '$PIXEL_ID$', intval( $pixel_id ), self::get_script_snippet() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -186,15 +187,12 @@ class Meta_Pixel {
 	 * @return void
 	 */
 	public static function print_footer_snippet() {
-		if ( self::is_amp() ) {
-			return;
-		}
 		$pixel_id = self::get_pixel_id();
-
 		if ( empty( $pixel_id ) ) {
 			return;
 		}
-		echo '<noscript>' . str_replace( '$PIXEL_ID$', intval( $pixel_id ), self::get_img_snippet() ) . '</noscript>';
+		// If AMP plugin is enabled, it will convert the image into a <amp-pixel> tag.
+		echo '<noscript>' . str_replace( '$PIXEL_ID$', intval( $pixel_id ), self::get_img_snippet() ) . '</noscript>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 

--- a/includes/class-meta-pixel.php
+++ b/includes/class-meta-pixel.php
@@ -154,7 +154,22 @@ class Meta_Pixel {
 	 * @return string
 	 */
 	public static function get_img_snippet() {
-		return '<img height="1" width="1" style="display: none;" src="https://www.facebook.com/tr?id=__PIXEL_ID__&ev=PageView&noscript=1&cd%5Bpage_title%5D=Homepage&cd%5Bpost_type%5D=page&cd%5Bpost_id%5D=125&cd%5Bplugin%5D=PixelYourSite&cd%5Buser_role%5D=guest&cd%5Bevent_url%5D=leogermani.jurassic.tube%2F" alt="">';
+		global $wp;
+		$current_user = wp_get_current_user();
+		$event_params = [
+			'page_title' => get_the_title(),
+			'user_role'  => empty( $current_user->roles ) ? 'guest' : $current_user->roles[0],
+			'event_url'  => home_url( $wp->request ),
+		];
+
+		if ( is_single() ) {
+			$event_params['post_type'] = get_post_type();
+			$event_params['post_id']   = get_the_ID();
+		}
+
+		$url_params = http_build_query( [ 'cd' => $event_params ] );
+
+		return '<img height="1" width="1" style="display: none;" src="https://www.facebook.com/tr?id=__PIXEL_ID__&ev=PageView&noscript=1&' . $url_params . '">';
 	}
 
 	/**

--- a/includes/class-meta-pixel.php
+++ b/includes/class-meta-pixel.php
@@ -163,7 +163,6 @@ class Meta_Pixel {
 	 * @return string
 	 */
 	public static function get_script_snippet() {
-		// phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation
 		return "
 		<script>
 		!function(f,b,e,v,n,t,s)

--- a/includes/class-meta-pixel.php
+++ b/includes/class-meta-pixel.php
@@ -162,7 +162,7 @@ class Meta_Pixel {
 			'event_url'  => home_url( $wp->request ),
 		];
 
-		if ( is_single() ) {
+		if ( is_singular() ) {
 			$event_params['post_type'] = get_post_type();
 			$event_params['post_id']   = get_the_ID();
 		}

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -95,6 +95,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-fivetran-connection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-google-login.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-blocks.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-meta-pixel.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-rss.php';
 

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -146,7 +146,7 @@ class Engagement_Wizard extends Wizard {
 							'validate_callback' => [ 'Newspack\Meta_Pixel', 'validate_active' ],
 						],
 						'pixel_id' => [
-							'type'              => 'string',
+							'type'              => [ 'integer', 'string' ],
 							'required'          => true,
 							'validate_callback' => [ 'Newspack\Meta_Pixel', 'validate_pixel_id' ],
 						],

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -126,6 +126,34 @@ class Engagement_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/social/meta_pixel',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ 'Newspack\Meta_Pixel', 'api_get' ],
+					'permission_callback' => [ $this, 'api_permissions_check' ],
+				],
+				[
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => [ 'Newspack\Meta_Pixel', 'api_save' ],
+					'permission_callback' => [ $this, 'api_permissions_check' ],
+					'args'                => [
+						'active'   => [
+							'type'              => 'boolean',
+							'required'          => true,
+							'validate_callback' => [ 'Newspack\Meta_Pixel', 'validate_active' ],
+						],
+						'pixel_id' => [
+							'type'              => 'string',
+							'required'          => true,
+							'validate_callback' => [ 'Newspack\Meta_Pixel', 'validate_pixel_id' ],
+						],
+					],
+				],
+			]
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1554 .

Relevant discussion: https://wp.me/pamTN9-3ZQ

Adds an option to the Engagement > Social settings page to allow users to configure Meta (Facebook) pixel.

### How to test the changes in this Pull Request:

1. Go to Newspack > Engagement > Social
2. Activate "Meta Pixel"
3. Add a pixel ID
4. Save
5. Test invalid formats
6. Test enabling and disabling the option
7. Check the copy and the link
8. Visit the site and confirm the pixel was added to the page. You can use a browser extension to help you with that if you want: https://href.li/?https://chrome.google.com/webstore/detail/facebook-pixel-helper/fdgfkebogiimcoedlicjlajpkdmockpc?hl=en
9. Visit the site with AMP enabled and confirm the pixel is also there
10. I've only tested this with random IDs. It would be awesome if someone could test it with a real pixel ID in a real site

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->