### PR TITLE
fix(analytics): remove illegal reference on wizard

### DIFF
--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -372,7 +372,7 @@ class Analytics_Wizard extends Wizard {
 		}
 		if ( isset( $custom_dimensions['items'] ) ) {
 			return array_map(
-				function ( &$dimension ) {
+				function ( $dimension ) {
 					// Assign role to custom dimension if it's found as a saved option.
 					foreach ( self::get_custom_dimensions_config() as $config_item ) {
 						$saved_dimension_id = get_option( self::get_custom_dimensions_option_name( $config_item['role'] ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a warning on the Analytics wizard.

### How to test the changes in this Pull Request:

1. While on master, visit the Analytics wizard and confirm you see the warning: `PHP Warning:  Newspack\Analytics_Wizard::Newspack\{closure}(): Argument #1 ($dimension) must be passed by reference, value given in newspack-plugin/includes/wizards/class-analytics-wizard.php on line 386
2. Check out this branch and confirm the warning is gone
3. Visit "Custom Dimensions" and confirm you are still able to view and manage them.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->