### PR TITLE
feat(plugins): handle missing organic-profile-block plugin

### DIFF
--- a/assets/other-scripts/organic-profile-block/index.js
+++ b/assets/other-scripts/organic-profile-block/index.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/assets/other-scripts/organic-profile-block/style.scss
+++ b/assets/other-scripts/organic-profile-block/style.scss
@@ -1,0 +1,85 @@
+// Source: https://wordpress.org/plugins/organic-profile-block/
+
+.wp-block-organic-profile-block {
+	display: flex;
+	align-items: stretch;
+	background-color: #fff;
+	margin: 32px 0;
+	ul,
+	li {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+	.organic-profile-image {
+		display: flex;
+		align-items: center;
+		background-size: cover;
+		background-position: center;
+		width: 60%;
+		overflow: hidden;
+	}
+	.organic-profile-image figure {
+		margin: 0;
+	}
+	.organic-profile-image img {
+		opacity: 0;
+		margin: -9999px;
+	}
+	.organic-profile-content {
+		width: 100%;
+		align-self: center;
+		padding: 36px;
+		box-sizing: border-box;
+	}
+	.organic-profile-content h3 {
+		margin: 0;
+		padding: 0;
+	}
+	.organic-profile-content h5 {
+		color: rgba( 0, 0, 0, 0.4 );
+		text-transform: uppercase;
+		margin: 0;
+		padding: 8px 0;
+	}
+	.organic-profile-content p {
+		line-height: 1.6;
+		margin: 0;
+		padding: 8px 0;
+	}
+	.organic-profile-social {
+		padding-top: 12px;
+	}
+	.organic-profile-social:empty {
+		display: none;
+	}
+	.organic-profile-social .social-link {
+		color: rgba( 0, 0, 0, 0.24 );
+		padding: 6px 12px;
+		font-size: 18px;
+		text-decoration: none;
+		border-left: 1px solid rgba( 0, 0, 0, 0.12 );
+		border-bottom: none;
+		box-shadow: none;
+	}
+	.organic-profile-social .social-link:hover {
+		color: rgba( 0, 0, 0, 1 );
+	}
+	.organic-profile-social .social-link:first-child {
+		border: none;
+	}
+}
+
+@media screen and ( max-width: 767px ) {
+	.wp-block-organic-profile-block {
+		flex-direction: column;
+		.organic-profile-image {
+			background: none !important;
+			width: 100%;
+		}
+		.organic-profile-image img {
+			opacity: 1;
+			margin: 0 auto;
+		}
+	}
+}

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -136,6 +136,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-newspack-newsletters.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-mailchimp-for-woocommerce.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
 

--- a/includes/plugins/class-organic-profile-block.php
+++ b/includes/plugins/class-organic-profile-block.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Organic Profile Block integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Organic_Profile_Block {
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
+	}
+
+	/**
+	 * If the post has the Organic Profile Block, but the plugin is not active,
+	 * enqueue the styles to render the block.
+	 */
+	public static function wp_enqueue_scripts() {
+		if (
+			! is_plugin_active( 'organic-profile-block/organic-profile-block.php' )
+			&& has_block( 'organic/profile-block' )
+		) {
+			\wp_enqueue_style(
+				'organic-profile-block',
+				Newspack::plugin_url() . '/dist/other-scripts/organic-profile-block.css',
+				[],
+				NEWSPACK_PLUGIN_VERSION
+			);
+		}
+	}
+}
+Organic_Profile_Block::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds styles of organic-profile-block if it's missing. 

### How to test the changes in this Pull Request:

1. Switch the theme to `fix/organic-profile-block` branch (https://github.com/Automattic/newspack-theme/pull/1926)
1. Install [`organic-profile-block` plugin](https://wordpress.org/plugins/organic-profile-block/)
2. Insert the profile block on a page and fill in the fields
3. Load the page and observe the block rendering 
4. Deactivate the `organic-profile-block` plugin, reload the page
5. Observe the block still rendering nicely

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->