### PR TITLE
feat(woocommerce): handle metadata when creating a membership

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -217,8 +217,9 @@ class WooCommerce_Connection {
 	 * @param string $email_address Email address.
 	 * @param string $full_name Full name.
 	 * @param string $frequency Donation frequency.
+	 * @param array  $metadata Donor metadata.
 	 */
-	public static function set_up_membership( $email_address, $full_name, $frequency ) {
+	public static function set_up_membership( $email_address, $full_name, $frequency, $metadata = [] ) {
 		if ( ! class_exists( 'WC_Memberships_Membership_Plans' ) ) {
 			return;
 		}
@@ -236,7 +237,7 @@ class WooCommerce_Connection {
 		}
 		if ( $should_create_account ) {
 			if ( Reader_Activation::is_enabled() ) {
-				$metadata = [ 'registration_method' => 'woocommerce-memberships' ];
+				$metadata = array_merge( $metadata, [ 'registration_method' => 'woocommerce-memberships' ] );
 				$user_id  = Reader_Activation::register_reader( $email_address, $full_name, true, $metadata );
 				return $user_id;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds metadata handling to the method that creates a WC Memberships membership.

### How to test the changes in this Pull Request:

1. Set up the site with Stripe as the Reader Revenue platform and ensure it is reachable for Stripe webhooks
3. Set up the site with Active Campaign as the ESP and enable Reader Activation
4. Install the WooCommerce suite, with WC Memberships 
5. Ensure a membership plan is tied to a donation product created by Newspack
6. On `master`, make a donation (one that would result in a membership) and observe the `NP_Signup Page` field in AC is set to a WP REST API URL
7. Switch `newspack-blocks` to `fix/wc-membership-metadata`
8. Switch to this branch of the plugin 
9. Make a donation again, observe correct URL reported in `NP_Signup Page` field

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->