### PR TITLE
refactor: add namespace to author filters

### DIFF
--- a/includes/author-filter/class-author-filter.php
+++ b/includes/author-filter/class-author-filter.php
@@ -5,6 +5,11 @@
  * @package Newspack
  */
 
+namespace Newspack;
+
+use WP_Post_Type;
+use WP_User_Query;
+
 /**
  * Author Filter class
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a namespace to the new Author_Filter class.

Reported in https://github.com/Automattic/newspack-plugin/pull/1985/files#r971009134

### How to test the changes in this Pull Request:

1. Check that the author filter still work in the Posts page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->