### PR TITLE
feat: stop auto-email on registration and rate limit unverified accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.91.0-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.90.0...v1.91.0-hotfix.1) (2022-09-15)
+
+
+### Features
+
+* stop auto-email on registration and rate limit unverified accounts ([c6a2566](https://github.com/Automattic/newspack-plugin/commit/c6a256660ffaaeed115a6933377ee768f76e2487))
+
 # [1.90.0](https://github.com/Automattic/newspack-plugin/compare/v1.89.1...v1.90.0) (2022-09-14)
 
 

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -71,10 +71,7 @@ export default function ReaderRegistrationEdit( {
 					'core/paragraph',
 					{
 						align: 'center',
-						content: __(
-							'Thank you for registering!<br />Check your email for a confirmation link.',
-							'newspack'
-						),
+						content: __( 'Thank you for registering!', 'newspack' ),
 					},
 				],
 			],

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -1,4 +1,4 @@
-/* globals newspack_reader_auth_labels */
+/* globals newspack_reader_activation_data newspack_reader_auth_labels */
 
 /**
  * Internal dependencies.
@@ -312,11 +312,13 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 				ev.preventDefault();
 				form.startLoginFlow();
 
+				const action = form.action?.value;
+
 				if ( ! form.npe?.value ) {
 					return form.endLoginFlow( newspack_reader_auth_labels.invalid_email, 400 );
 				}
 
-				if ( 'pwd' === actionInput?.value && ! form.password?.value ) {
+				if ( 'pwd' === action && ! form.password?.value ) {
 					return form.endLoginFlow( newspack_reader_auth_labels.invalid_password, 400 );
 				}
 
@@ -353,10 +355,15 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 						} )
 							.then( res => {
 								container.setAttribute( 'data-form-status', res.status );
+								let redirect = body.get( 'redirect' );
+								/** Redirect every registration to the account page for verification */
+								if ( action === 'register' ) {
+									redirect = newspack_reader_activation_data.account_url;
+								}
 								res
 									.json()
 									.then( ( { message, data } ) => {
-										form.endLoginFlow( message, res.status, data, body.get( 'redirect' ) );
+										form.endLoginFlow( message, res.status, data, redirect );
 									} )
 									.catch( () => {
 										form.endLoginFlow();

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -100,6 +100,7 @@ final class Reader_Activation {
 			'auth_intention_cookie' => self::AUTH_INTENTION_COOKIE,
 			'cid_cookie'            => NEWSPACK_CLIENT_ID_COOKIE_NAME,
 			'authenticated_email'   => $authenticated_email,
+			'account_url'           => function_exists( 'wc_get_account_endpoint_url' ) ? \wc_get_account_endpoint_url( 'dashboard' ) : '',
 		];
 
 		if ( Recaptcha::can_use_captcha() ) {

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1457,7 +1457,7 @@ final class Reader_Activation {
 	 */
 	public static function rate_limit_lost_password( $errors, $user_data ) {
 		if ( $user_data && self::is_reader_email_rate_limited( $user_data ) ) {
-			$errors->add( 'newspack_password_reset_interval', __( 'Please wait before requesting another password reset email.', 'newspack' ) );
+			$errors->add( 'newspack_password_reset_interval', __( 'Please wait a moment before requesting another password reset email.', 'newspack' ) );
 		} else {
 			\update_user_meta( $user_data->ID, self::LAST_EMAIL_DATE, time() );
 		}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -31,6 +31,13 @@ final class Reader_Activation {
 	const WITHOUT_PASSWORD    = 'np_reader_without_password';
 	const REGISTRATION_METHOD = 'np_reader_registration_method';
 
+
+	/**
+	 * Unverified email rate limiting
+	 */
+	const LAST_EMAIL_DATE = 'np_reader_last_email_date';
+	const EMAIL_INTERVAL  = 10; // 10 seconds
+
 	/**
 	 * Auth form.
 	 */
@@ -76,6 +83,7 @@ final class Reader_Activation {
 			\add_filter( 'woocommerce_email_actions', [ __CLASS__, 'disable_woocommerce_new_user_email' ] );
 			\add_filter( 'retrieve_password_notification_email', [ __CLASS__, 'password_reset_configuration' ], 10, 4 );
 			\add_action( 'lostpassword_post', [ __CLASS__, 'set_password_reset_mail_content_type' ] );
+			\add_filter( 'lostpassword_errors', [ __CLASS__, 'rate_limit_lost_password' ], 10, 2 );
 		}
 	}
 
@@ -1303,12 +1311,6 @@ final class Reader_Activation {
 			}
 		}
 
-		// Send a magic link to new, unverified readers to verify their email address.
-		$user = \get_user_by( 'id', $user_id );
-		if ( ! $existing_user && ! self::is_reader_verified( $user ) ) {
-			self::send_verification_email( $user );
-		}
-
 		/**
 		 * Action after registering and authenticating a reader.
 		 *
@@ -1324,12 +1326,33 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Whether the current reader is rate limited.
+	 *
+	 * @param \WP_User $user WP_User object to be verified.
+	 *
+	 * @return bool
+	 */
+	public static function is_reader_email_rate_limited( $user ) {
+		if ( self::is_reader_verified( $user ) ) {
+			return false;
+		}
+		$last_email = get_user_meta( $user->ID, self::LAST_EMAIL_DATE, true );
+		return $last_email && self::EMAIL_INTERVAL > time() - $last_email;
+	}
+
+	/**
 	 * Send a magic link with special messaging to verify the user.
 	 *
 	 * @param WP_User $user WP_User object to be verified.
 	 */
 	public static function send_verification_email( $user ) {
 		$redirect_to = function_exists( '\wc_get_account_endpoint_url' ) ? \wc_get_account_endpoint_url( 'dashboard' ) : '';
+
+		/** Rate limit control */
+		if ( self::is_reader_email_rate_limited( $user ) ) {
+			return new \WP_Error( 'newspack_verification_email_interval', __( 'Please wait before requesting another verification email.', 'newspack' ) );
+		}
+		\update_user_meta( $user->ID, self::LAST_EMAIL_DATE, time() );
 
 		return Emails::send_email(
 			Reader_Activation_Emails::EMAIL_TYPES['VERIFICATION'],
@@ -1420,6 +1443,24 @@ final class Reader_Activation {
 			return 'text/html';
 		};
 		add_filter( 'wp_mail_content_type', $email_content_type );
+	}
+
+	/**
+	 * Rate limit password reset.
+	 *
+	 * @param \WP_Error      $errors    A WP_Error object containing any errors generated
+	 *                                  by using invalid credentials.
+	 * @param \WP_User|false $user_data WP_User object if found, false if the user does not exist.
+	 *
+	 * @return \WP_Error
+	 */
+	public static function rate_limit_lost_password( $errors, $user_data ) {
+		if ( $user_data && self::is_reader_email_rate_limited( $user_data ) ) {
+			$errors->add( 'newspack_password_reset_interval', __( 'Please wait before requesting another password reset email.', 'newspack' ) );
+		} else {
+			\update_user_meta( $user_data->ID, self::LAST_EMAIL_DATE, time() );
+		}
+		return $errors;
 	}
 }
 Reader_Activation::init();

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -142,7 +142,7 @@ class WooCommerce_My_Account {
 			$message = __( 'Please check your email inbox for instructions on how to set a new password.', 'newspack' );
 			if ( \is_wp_error( $result ) ) {
 				Logger::log( 'Error resetting password: ' . $result->get_error_message() );
-				$message  = __( 'Something went wrong.', 'newspack' );
+				$message  = $result->get_error_message();
 				$is_error = true;
 			}
 		} else {
@@ -275,7 +275,7 @@ class WooCommerce_My_Account {
 				$message = __( 'Please check your email inbox for a link to verify your account.', 'newspack' );
 				if ( \is_wp_error( $result ) ) {
 					Logger::log( 'Error sending verification email: ' . $result->get_error_message() );
-					$message  = __( 'Something went wrong.', 'newspack' );
+					$message  = $result->get_error_message();
 					$is_error = true;
 				}
 			} else {

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.90.0
+ * Version: 1.91.0-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.90.0' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.91.0-hotfix.1' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.90.0",
+  "version": "1.91.0-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.90.0",
+      "version": "1.91.0-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.90.0",
+  "version": "1.91.0-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR changes the original behavior of reader registration, which sends an account verification as soon as a reader is registered.

The default phrasing for the reader registration block success message was changed to not look for a verification email:

<img width="867" alt="image" src="https://user-images.githubusercontent.com/820752/190483293-89ec11ce-c8f6-4862-b678-1426a2210db2.png">

Now the account verification email must be requested on the "My Account" page, until then the account will remain unverified. Mind that magic links and password resets also verify an account, so even if that session is lost, the next session will authenticate **and** verify the account.

This PR also introduces some rate limiting for unverified accounts. Password resets and account verifications must be sent within an interval of at least 10 seconds. Should it be more?

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/820752/190490195-23ef4bc6-894c-4378-8a85-6e12eea32768.png">

Registrations coming from the Sign In modal will be redirected to the "My Account" page to suggest account verification.

### How to test the changes in this Pull Request:

1. Check out this branch and create a new Reader Registration block on a page or campaign prompt (if you have a previous one it will have the success message to "check your email")
2. Check out this branch and register a new account through the Registration Block
3. Confirm you didn't receive any email
4. Click on "My Account" and click to send a verification link
5. Quickly click again and confirm the error
6. Do the same thing for password reset and confirm the error
7. Click on the last received email and confirm you're verified
8. On a fresh session, click on the Sign In modal
9. Click "I don't have an account"
10. Register a new email and confirm you're redirected to the My Account page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->