### PR TITLE
feat(plugins-screen): display a plugin review form, if supplied

### DIFF
--- a/assets/plugins-screen/plugins-screen.js
+++ b/assets/plugins-screen/plugins-screen.js
@@ -18,31 +18,33 @@ import './plugins-screen.scss';
 	) {
 		const modalEl = document.createElement( 'div' );
 		const modalContentEl = document.createElement( 'div' );
-		const modalMessageEl = document.createElement( 'div' );
 		const modalHeadingEl = document.createElement( 'h1' );
 		const modalPEl = document.createElement( 'p' );
-		const modalLinkEl = document.createElement( 'a' );
-		const modalCloseWrapperEl = document.createElement( 'div' );
+		const modalButtonsWrapperEl = document.createElement( 'div' );
+		const modalActionEl = document.createElement( 'button' );
 		const modalCloseEl = document.createElement( 'button' );
 
 		modalEl.classList.add( 'newspack-plugin-info-modal' );
-		modalHeadingEl.innerText = wp.i18n.__( 'Before installing a new plugin', 'newspack' );
-		modalPEl.innerText = wp.i18n.__( 'Please fill out this form:', 'newspack' );
-		modalCloseEl.innerText = wp.i18n.__( 'Close', 'newspack' );
+		modalHeadingEl.innerText = wp.i18n.__( 'Plugin review', 'newspack' );
+		modalPEl.innerText = wp.i18n.__(
+			'Please submit a plugin for review by the Newspack Team before installing it on your website.',
+			'newspack'
+		);
+		modalCloseEl.innerHTML =
+			'<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"></path></svg>';
 		modalCloseEl.onclick = () => {
 			modalEl.classList.add( 'newspack-plugin-info-modal--hidden' );
 		};
-		modalLinkEl.setAttribute( 'href', newspack_plugin_info.plugin_review_link );
-		modalLinkEl.setAttribute( 'target', '_blank' );
-		modalLinkEl.innerText = wp.i18n.__( 'Plugin review form', 'newspack' );
+		modalActionEl.setAttribute( 'href', newspack_plugin_info.plugin_review_link );
+		modalActionEl.setAttribute( 'target', '_blank' );
+		modalActionEl.innerText = wp.i18n.__( 'Plugin Review Form', 'newspack' );
 
 		modalEl.appendChild( modalContentEl );
-		modalMessageEl.appendChild( modalHeadingEl );
-		modalMessageEl.appendChild( modalPEl );
-		modalMessageEl.appendChild( modalLinkEl );
-		modalContentEl.appendChild( modalMessageEl );
-		modalCloseWrapperEl.appendChild( modalCloseEl );
-		modalContentEl.appendChild( modalCloseWrapperEl );
+		modalContentEl.appendChild( modalHeadingEl );
+		modalContentEl.appendChild( modalPEl );
+		modalContentEl.appendChild( modalCloseEl );
+		modalButtonsWrapperEl.appendChild( modalActionEl );
+		modalContentEl.appendChild( modalButtonsWrapperEl );
 		document.body.appendChild( modalEl );
 	}
 

--- a/assets/plugins-screen/plugins-screen.js
+++ b/assets/plugins-screen/plugins-screen.js
@@ -11,15 +11,52 @@ import './plugins-screen.scss';
  * @see Admin_Plugins_Screen::enqueue_scripts_and_styles().
  */
 ( function ( $ ) {
-	// Add a 'newspack_plugin' class to managed plugins.
-	newspack_plugin_info.plugins.forEach( function ( plugin_slug ) {
-		const $row = $( 'tr[data-slug="' + plugin_slug + '"]' );
-		if ( $row.length ) {
-			$row.addClass( 'newspack-plugin' );
-		}
+	// Display a modal when adding a new plugin.
+	if (
+		newspack_plugin_info.screen === 'plugin-install.php' &&
+		newspack_plugin_info.plugin_review_link
+	) {
+		const modalEl = document.createElement( 'div' );
+		const modalContentEl = document.createElement( 'div' );
+		const modalMessageEl = document.createElement( 'div' );
+		const modalHeadingEl = document.createElement( 'h1' );
+		const modalPEl = document.createElement( 'p' );
+		const modalLinkEl = document.createElement( 'a' );
+		const modalCloseWrapperEl = document.createElement( 'div' );
+		const modalCloseEl = document.createElement( 'button' );
 
-		if ( ! newspack_plugin_info.installed_plugins.includes( plugin_slug ) ) {
-			$row.addClass( 'uninstalled' );
-		}
-	} );
+		modalEl.classList.add( 'newspack-plugin-info-modal' );
+		modalHeadingEl.innerText = wp.i18n.__( 'Before installing a new plugin', 'newspack' );
+		modalPEl.innerText = wp.i18n.__( 'Please fill out this form:', 'newspack' );
+		modalCloseEl.innerText = wp.i18n.__( 'Close', 'newspack' );
+		modalCloseEl.onclick = () => {
+			modalEl.classList.add( 'newspack-plugin-info-modal--hidden' );
+		};
+		modalLinkEl.setAttribute( 'href', newspack_plugin_info.plugin_review_link );
+		modalLinkEl.setAttribute( 'target', '_blank' );
+		modalLinkEl.innerText = wp.i18n.__( 'Plugin review form', 'newspack' );
+
+		modalEl.appendChild( modalContentEl );
+		modalMessageEl.appendChild( modalHeadingEl );
+		modalMessageEl.appendChild( modalPEl );
+		modalMessageEl.appendChild( modalLinkEl );
+		modalContentEl.appendChild( modalMessageEl );
+		modalCloseWrapperEl.appendChild( modalCloseEl );
+		modalContentEl.appendChild( modalCloseWrapperEl );
+		document.body.appendChild( modalEl );
+	}
+
+	// Add a 'newspack_plugin' class to managed plugins.
+	if ( newspack_plugin_info.screen === 'plugins.php' ) {
+		newspack_plugin_info.plugins.forEach( function ( plugin_slug ) {
+			const $row = $( 'tr[data-slug="' + plugin_slug + '"]' );
+			if ( $row.length ) {
+				$row.addClass( 'newspack-plugin' );
+			}
+
+			if ( ! newspack_plugin_info.installed_plugins.includes( plugin_slug ) ) {
+				$row.addClass( 'uninstalled' );
+			}
+		} );
+	}
 } )( jQuery );

--- a/assets/plugins-screen/plugins-screen.js
+++ b/assets/plugins-screen/plugins-screen.js
@@ -21,7 +21,7 @@ import './plugins-screen.scss';
 		const modalHeadingEl = document.createElement( 'h1' );
 		const modalPEl = document.createElement( 'p' );
 		const modalButtonsWrapperEl = document.createElement( 'div' );
-		const modalActionEl = document.createElement( 'button' );
+		const modalActionEl = document.createElement( 'a' );
 		const modalCloseEl = document.createElement( 'button' );
 
 		modalEl.classList.add( 'newspack-plugin-info-modal' );

--- a/assets/plugins-screen/plugins-screen.js
+++ b/assets/plugins-screen/plugins-screen.js
@@ -25,7 +25,7 @@ import './plugins-screen.scss';
 		const modalCloseEl = document.createElement( 'button' );
 
 		modalEl.classList.add( 'newspack-plugin-info-modal' );
-		modalHeadingEl.innerText = wp.i18n.__( 'Plugin review', 'newspack' );
+		modalHeadingEl.innerText = wp.i18n.__( 'Plugin review required', 'newspack' );
 		modalPEl.innerText = wp.i18n.__(
 			'Please submit a plugin for review by the Newspack Team before installing it on your website.',
 			'newspack'

--- a/assets/plugins-screen/plugins-screen.scss
+++ b/assets/plugins-screen/plugins-screen.scss
@@ -26,29 +26,47 @@ table.plugins {
 	&--hidden {
 		display: none;
 	}
-	h1 {
-		margin-top: 0;
+	h1,
+	p,
+	> div > div {
+		padding-left: 32px;
+		padding-right: 32px;
 	}
-	button {
-		padding: 8px 12px;
-		border-radius: 3px;
-		border: none;
-		color: wp-colors.$white;
-		background-color: colors.$primary-500;
+	h1 {
+		margin-top: 21px;
+		font-size: 16px;
+		padding-bottom: 20px;
+		border-bottom: 1px solid #ddd;
 	}
 	> div {
+		position: relative;
 		display: flex;
+		padding-bottom: 32px;
 		flex-direction: column;
-		min-width: 30vw;
-		min-height: 20vw;
-		padding: 46px 50px;
 		background-color: wp-colors.$white;
-		> div:first-child {
+		box-shadow: 0 10px 10px rgb( 0 0 0 / 25% );
+		> button {
+			position: absolute;
+			top: 14px;
+			right: 27px;
+			padding: 0.5em;
+			background: none;
+			border: none;
+		}
+		> p {
 			flex: 1;
 		}
 		> div:last-child {
 			display: flex;
 			justify-content: flex-end;
+			padding-top: 20px;
+			button {
+				padding: 11px 19px;
+				border-radius: 2px;
+				border: none;
+				color: wp-colors.$white;
+				background-color: colors.$primary-500;
+			}
 		}
 	}
 }

--- a/assets/plugins-screen/plugins-screen.scss
+++ b/assets/plugins-screen/plugins-screen.scss
@@ -67,7 +67,7 @@ table.plugins {
 				color: wp-colors.$white;
 				background-color: colors.$primary-500;
 				text-decoration: none;
-				
+
 				&:hover,
 				&:active {
 					background: colors.$primary-600;

--- a/assets/plugins-screen/plugins-screen.scss
+++ b/assets/plugins-screen/plugins-screen.scss
@@ -1,6 +1,5 @@
-/**
- * Styles for the WP Admin Plugins screen.
- */
+@use '../shared/scss/colors';
+@use '~@wordpress/base-styles/colors' as wp-colors;
 
 /**
  * Plugins table.
@@ -9,6 +8,47 @@ table.plugins {
 	.newspack-plugin {
 		&.uninstalled .check-column input[type='checkbox'] {
 			display: none;
+		}
+	}
+}
+
+.newspack-plugin-info-modal {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100vw;
+	height: 100vh;
+	z-index: 9;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	background: rgba( 0, 0, 0, 0.5 );
+	&--hidden {
+		display: none;
+	}
+	h1 {
+		margin-top: 0;
+	}
+	button {
+		padding: 8px 12px;
+		border-radius: 3px;
+		border: none;
+		color: wp-colors.$white;
+		background-color: colors.$primary-500;
+	}
+	> div {
+		display: flex;
+		flex-direction: column;
+		min-width: 30vw;
+		min-height: 20vw;
+		padding: 46px 50px;
+		background-color: wp-colors.$white;
+		> div:first-child {
+			flex: 1;
+		}
+		> div:last-child {
+			display: flex;
+			justify-content: flex-end;
 		}
 	}
 }

--- a/assets/plugins-screen/plugins-screen.scss
+++ b/assets/plugins-screen/plugins-screen.scss
@@ -60,12 +60,13 @@ table.plugins {
 			display: flex;
 			justify-content: flex-end;
 			padding-top: 20px;
-			button {
+			a {
 				padding: 11px 19px;
 				border-radius: 2px;
 				border: none;
 				color: wp-colors.$white;
 				background-color: colors.$primary-500;
+				text-decoration: none;
 			}
 		}
 	}

--- a/assets/plugins-screen/plugins-screen.scss
+++ b/assets/plugins-screen/plugins-screen.scss
@@ -67,6 +67,15 @@ table.plugins {
 				color: wp-colors.$white;
 				background-color: colors.$primary-500;
 				text-decoration: none;
+				
+				&:hover,
+				&:active {
+					background: colors.$primary-600;
+				}
+
+				&:focus {
+					box-shadow: inset 0 0 0 1px #fff, 0 0 0 2px colors.$primary-500;
+				}
 			}
 		}
 	}

--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -196,7 +196,7 @@ class Admin_Plugins_Screen {
 	 * @param string $hook The current screen.
 	 */
 	public function enqueue_scripts_and_styles( $hook ) {
-		if ( 'plugins.php' !== $hook ) {
+		if ( ! in_array( $hook, array( 'plugins.php', 'plugin-install.php' ) ) ) {
 			return;
 		}
 
@@ -215,8 +215,10 @@ class Admin_Plugins_Screen {
 		$installed_plugins[] = 'newspack';
 
 		$newspack_plugin_info = [
-			'plugins'           => $plugins,
-			'installed_plugins' => $installed_plugins,
+			'plugins'            => $plugins,
+			'installed_plugins'  => $installed_plugins,
+			'screen'             => $hook,
+			'plugin_review_link' => defined( 'NEWSPACK_PLUGIN_REVIEW_FORM_URL' ) ? NEWSPACK_PLUGIN_REVIEW_FORM_URL : null,
 		];
 
 		wp_localize_script( 'newspack_plugins_screen', 'newspack_plugin_info', $newspack_plugin_info );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a modal prompting the user to fill out a plugin review form before installing a new plugin.

<img width="508" alt="image" src="https://user-images.githubusercontent.com/7383192/190679421-7abb9d88-af61-42fb-a8b3-37ed1f0bf16c.png">

Closes #532

### How to test the changes in this Pull Request:

1. Load the WP admin plugin install screen (`/wp-admin/plugin-install.php`) and observe nothing new
2. Define the `NEWSPACK_PLUGIN_REVIEW_FORM_URL` constant (e.g. `wp config set NEWSPACK_PLUGIN_REVIEW_FORM_URL 'https://forms.gle/ofFmGKqoaPWJm2bm8'`)
3. Reload the plugin install screen and observe the modal
4. Click the link in the modal, observe it links to the site under `NEWSPACK_PLUGIN_REVIEW_FORM_URL`
5. Click the "Close" button and observe the modal is closed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->