### PR TITLE
style: update styles of Subscription Totals table in My Account

### DIFF
--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -52,4 +52,36 @@
 			}
 		}
 	}
+
+	/* WooCommerce Subscriptions styles. */
+	&.woocommerce-view-subscription {
+		.order_details {
+			border: none;
+			font-weight: normal;
+
+			thead {
+				background-color: #eee;
+			}
+
+			th {
+				border: none;
+				padding: 10px;
+			}
+
+			tr {
+				border-bottom: 1px solid #515151;
+			}
+
+			td {
+				border: none;
+				padding: 10px;
+			}
+		}
+
+		.wcs-switch-link.button {
+			display: inline-block;
+			margin-left: 0.5rem;
+			vertical-align: middle;
+		}
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks the styles of the Subscription Totals table in My Account to more closely match the My Orders table on the same page. The main subscription info table remains styled as in the default plugin, because this table serves a different purpose and looks more or less okay with the default styles.

cc @thomasguillot in case you wanted to do some further design explorations of this. It's fairly low-priority since it only affects "legacy" WooCommerce subscribers before RAS is rolled out on a wider basis.

Old:

<img width="1224" alt="Screen Shot 2022-09-16 at 11 18 21 AM" src="https://user-images.githubusercontent.com/2230142/190694536-dcf7a9cc-cf39-4934-a78c-10200c73e342.png">

Proposed

<img width="1222" alt="Screen Shot 2022-09-16 at 11 17 18 AM" src="https://user-images.githubusercontent.com/2230142/190694571-160d417d-198e-4ef4-a6c5-dc3d6125fa94.png">


### How to test the changes in this Pull Request:

1. On a site with the Reader Revenue platform set to Newspack, make a recurring donation in a new session.
2. Go to My Account > Subscriptions and compare styles before and after this PR is applied.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->