### PR TITLE
fix(stripe): handle error if customer LTV is not retrievable

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -494,8 +494,10 @@ class Stripe_Connection {
 					if ( Reader_Activation::is_enabled() ) {
 						$payment_date = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payment['created'] );
 						$customer_ltv = self::get_customer_ltv( $customer['id'] );
-						$total_paid   = $customer_ltv + $amount_normalised;
-						$contact['metadata'][ Newspack_Newsletters::$metadata_keys['total_paid'] ] = $total_paid;
+						if ( ! \is_wp_error( $customer_ltv ) ) {
+							$total_paid = $customer_ltv + $amount_normalised;
+							$contact['metadata'][ Newspack_Newsletters::$metadata_keys['total_paid'] ] = $total_paid;
+						}
 
 						$contact['metadata'] = array_merge(
 							$contact['metadata'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The return value of the `get_customer_ltv` can be an error. This PR ensure it's handled.

Closes https://github.com/Automattic/newspack-blocks/issues/1269

### How to test the changes in this Pull Request:

1. Set up a site with Stripe as the Reader Revenue platform
2. Cause an error to be thrown in `get_customer_charges` method of `Stipe_Connection` class
3. Observe no PHP notices logged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->