### PR TITLE
fix(wc-to-ac-metadata): add last payment date field for one-time donors

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -137,7 +137,7 @@ class WooCommerce_Connection {
 		];
 
 		$metadata[ $metadata_keys['account'] ]           = $order->get_customer_id();
-		$metadata[ $metadata_keys['registration_date'] ] = $customer->get_date_created()->date( 'Y-m-d' );
+		$metadata[ $metadata_keys['registration_date'] ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
 		$metadata[ $metadata_keys['payment_page'] ]      = \wc_get_checkout_url();
 
 		$order_subscriptions = wcs_get_subscriptions_for_order( $order->get_id() );
@@ -152,6 +152,7 @@ class WooCommerce_Connection {
 				$metadata[ $metadata_keys['product_name'] ] = reset( $order_items )->get_name();
 			}
 			$metadata[ $metadata_keys['last_payment_amount'] ] = $order->get_total();
+			$metadata[ $metadata_keys['last_payment_date'] ]   = $order->get_date_paid()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
 
 			// Subscription donation.
 		} else {
@@ -180,7 +181,7 @@ class WooCommerce_Connection {
 			$metadata[ $metadata_keys['sub_end_date'] ]        = $current_subscription->get_date( 'end' ) ? $current_subscription->get_date( 'end' ) : '';
 			$metadata[ $metadata_keys['billing_cycle'] ]       = $current_subscription->get_billing_period();
 			$metadata[ $metadata_keys['recurring_payment'] ]   = $current_subscription->get_total();
-			$metadata[ $metadata_keys['last_payment_date'] ]   = $current_subscription->get_date( 'last_order_date_paid' ) ? $current_subscription->get_date( 'last_order_date_paid' ) : gmdate( 'Y-m-d' );
+			$metadata[ $metadata_keys['last_payment_date'] ]   = $current_subscription->get_date( 'last_order_date_paid' ) ? $current_subscription->get_date( 'last_order_date_paid' ) : gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT );
 			$metadata[ $metadata_keys['last_payment_amount'] ] = $current_subscription->get_total();
 
 			// When a WC Subscription is terminated, the next payment date is set to 0. We don't want to sync that – the next payment date should remain as it was


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds last payment date field to WC-to-ESP sync.

### How to test the changes in this Pull Request:

1. Set Newspack (WooCommerce) as the Reader Revenue platform
2. Set up ActiveCampaign as the ESP in the Newsletters plugin
3. Make a one-time donation
4. Observe the data sent to AC contains the `NP_Last Payment Date` field, with the appropriate value

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->