### PR TITLE
Remove Stripe subs. on WP account deletion

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -56,6 +56,7 @@ class Stripe_Connection {
 		add_action( 'init', [ __CLASS__, 'register_apple_pay_domain' ] );
 		add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'is_wc_complete_order_email_enabled' ] );
 		add_action( 'newspack_reader_verified', [ __CLASS__, 'newspack_reader_verified' ] );
+		add_action( 'delete_user', [ __CLASS__, 'cancel_user_subscriptions' ] );
 	}
 
 	/**
@@ -365,6 +366,25 @@ class Stripe_Connection {
 	}
 
 	/**
+	 * Get Stripe customer's subscriptions.
+	 *
+	 * @param string $customer_id Customer ID.
+	 */
+	private static function get_subscriptions_of_customer( $customer_id ) {
+		$stripe = self::get_stripe_client();
+		try {
+			return $stripe->subscriptions->all(
+				[
+					'customer' => $customer_id,
+					'limit'    => 100,
+				]
+			);
+		} catch ( \Throwable $e ) {
+			return new \WP_Error( 'stripe_newspack', __( 'Could not fetch subscriptions.', 'newspack' ), $e->getMessage() );
+		}
+	}
+
+	/**
 	 * Get Subscription from payment, if one exists.
 	 *
 	 * @param array $payment Payment object.
@@ -375,6 +395,21 @@ class Stripe_Connection {
 			if ( ! \is_wp_error( $invoice ) && $invoice['subscription'] ) {
 				return self::get_subscription( $invoice['subscription'] );
 			}
+		}
+	}
+
+	/**
+	 * Cancel a Stripe subscription.
+	 *
+	 * @param string $subscription_id Subscription ID.
+	 */
+	private static function cancel_subscription( $subscription_id ) {
+		$stripe = self::get_stripe_client();
+		Logger::log( 'Cancelling Stripe subscription with id: ' . $subscription_id );
+		try {
+			return $stripe->subscriptions->cancel( $subscription_id, [] );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error( 'stripe_newspack', __( 'Could not cancel subscription.', 'newspack' ), $e->getMessage() );
 		}
 	}
 
@@ -1397,6 +1432,24 @@ class Stripe_Connection {
 			'user_id'                       => $customer['metadata']['userId'],
 			'subscribed'                    => self::has_customer_opted_in_to_newsletters( $customer ),
 		];
+	}
+
+	/**
+	 * If a WP user is deleted, cancel their Stripe subscriptions.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public static function cancel_user_subscriptions( $user_id ) {
+		$customer_id = get_user_meta( $user_id, self::STRIPE_CUSTOMER_ID_USER_META, true );
+		if ( $customer_id ) {
+			$subscriptions = self::get_subscriptions_of_customer( $customer_id );
+			if ( \is_wp_error( $subscriptions ) ) {
+				return $subscriptions;
+			}
+			foreach ( $subscriptions as $subscription ) {
+				self::cancel_subscription( $subscription['id'] );
+			}
+		}
 	}
 }
 

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -1442,7 +1442,7 @@ class Stripe_Connection {
 	}
 
 	/**
-	 * If a WP user is deleted, cancel their Stripe subscriptions.
+	 * Cancel all Stripe subscriptions of a WP user.
 	 *
 	 * @param int $user_id User ID.
 	 */

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -56,7 +56,7 @@ class Stripe_Connection {
 		add_action( 'init', [ __CLASS__, 'register_apple_pay_domain' ] );
 		add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'is_wc_complete_order_email_enabled' ] );
 		add_action( 'newspack_reader_verified', [ __CLASS__, 'newspack_reader_verified' ] );
-		add_action( 'delete_user', [ __CLASS__, 'cancel_user_subscriptions' ] );
+		add_action( 'delete_user', [ __CLASS__, 'cancel_user_subscriptions' ], 90 ); // Priority 90 to run after Newsletters deletes the contact in ESP.
 	}
 
 	/**

--- a/includes/reader-revenue/templates/myaccount-delete-account.php
+++ b/includes/reader-revenue/templates/myaccount-delete-account.php
@@ -39,6 +39,9 @@ if ( ! $transient_token || $transient_token !== $token ) {
 		<?php esc_html_e( 'Confirm to delete your account permanently.', 'newspack' ); ?>
 	</p>
 	<p>
+		<?php \esc_html_e( 'Deleting your account will also cancel any newsletter subscriptions and recurring payments.', 'newspack' ); ?>
+	</p>
+	<p>
 		<strong><?php esc_html_e( 'Caution, this action is irreversible!', 'newspack' ); ?></strong>
 	</p>
 	<form method="POST">

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -100,14 +100,14 @@ endif;
 			<h4 class="woocommerce-card__title">
 				<?php \esc_html_e( 'Delete Account', 'newspack' ); ?>
 			</h4>
-			<p>
-				<?php \esc_html_e( 'Deleting your account will also cancel any newsletter subscriptions and recurring payments.', 'newspack' ); ?>
-			</p>
 			<span class="woocommerce-card__description">
 				<?php \esc_html_e( 'Request account deletion', 'newspack' ); ?>
 			</span>
 		</span>
 	</a>
+	<p>
+		<?php \esc_html_e( 'Deleting your account will also cancel any newsletter subscriptions and recurring payments.', 'newspack' ); ?>
+	</p>
 </div>
 
 <?php \do_action( 'newspack_woocommerce_after_edit_account_form' ); ?>

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -100,6 +100,9 @@ endif;
 			<h4 class="woocommerce-card__title">
 				<?php \esc_html_e( 'Delete Account', 'newspack' ); ?>
 			</h4>
+			<p>
+				<?php \esc_html_e( 'Deleting your account will also cancel any newsletter subscriptions and recurring payments.', 'newspack' ); ?>
+			</p>
 			<span class="woocommerce-card__description">
 				<?php \esc_html_e( 'Request account deletion', 'newspack' ); ?>
 			</span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds Stripe and newsletter subscriptions cancellation on account deletion.

### How to test the changes in this Pull Request:

1. Set up a site with Stripe as the Reader Revenue platform and RAS enabled
3. Donate and subscribe to a newsletter as a new reader  
4. Verify in Stripe and ESP that the reader has a Stripe subscription and is subscribed to the newsletter
5. Complete the account deletion flow, starting on My Account page
6. After the account is deleted, verify that the Stripe subscription has been cancelled and the reader unsubscribed from the newsletters

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->