### PR TITLE
Hotfix/remove preset frequency

### DIFF
--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -96,7 +96,6 @@ const frequencyMap = {
 	weekly: __( 'Once a week', 'newspack' ),
 	daily: __( 'Once a day', 'newspack' ),
 	always: __( 'Every pageview', 'newspack' ),
-	preset_1: __( 'Every 4th pageview, up to 5x per month', 'newspack' ),
 	custom: __( 'Custom frequency (edit prompt to manage)', 'newspack' ),
 };
 

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -99,22 +99,8 @@ const frequencyMap = {
 	custom: __( 'Custom frequency (edit prompt to manage)', 'newspack' ),
 };
 
-export const frequenciesForPopup = popup => {
-	const { experimental } = window.newspack_popups_wizard_data;
-	const standardKeys = [ 'once', 'daily', 'always' ];
-	return Object.keys( frequencyMap )
-		.filter( key => {
-			if ( experimental ) {
-				return true;
-			}
-
-			if ( isOverlay( popup ) && 'always' === key ) {
-				return false;
-			}
-
-			return -1 < standardKeys.indexOf( key );
-		} )
-		.map( key => ( { label: frequencyMap[ key ], value: key } ) );
+export const frequenciesForPopup = () => {
+	return Object.keys( frequencyMap ).map( key => ( { label: frequencyMap[ key ], value: key } ) );
 };
 
 export const overlaySizesForPopups = () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note:** This PR contains the same changes as #2000 and supersedes that PR. It rebases the changes against `release` so we can release as a hotfix, since the related [Campaigns PR](https://github.com/Automattic/newspack-popups/pull/963) is already opened as a hotfix so we can roll it out ASAP.

Handles changes in https://github.com/Automattic/newspack-popups/pull/963. Moves the new frequency options implemented in https://github.com/Automattic/newspack-popups/pull/908 out from behind the `NEWSPACK_EXPERIMENTAL_READER_ACTIVATION` feature flag, and temporarily removes the preset option from the dropdown until we have a better idea what the preset(s) should be.

### How to test the changes in this Pull Request:

See instructions in https://github.com/Automattic/newspack-popups/pull/963.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->