### PR TITLE
fix(reader-activation-auth): header link color

### DIFF
--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -7,6 +7,7 @@
 	 * Account Link
 	 */
 	&__account-link {
+		color: inherit;
 		span {
 			display: inline-block;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the color of the Reader Activation auth trigger:

<img width="104" alt="image" src="https://user-images.githubusercontent.com/7383192/191233972-89f3958c-8911-4e7c-b9b5-a6580b7ad631.png">

### How to test the changes in this Pull Request:

1. On `master`
1. Enable Reader Activation w/ the header link
2. Set the site header background color to a dark color
3. Observe that on a smaller viewport, the auth link has grey color and thus is hard to see:

<img width="104" alt="image" src="https://user-images.githubusercontent.com/7383192/191234288-4c2f00e5-230c-4680-8634-6f4d5942474f.png">

4. Apply this PR and rebuild, observe the color is now as the other links' in the header:

<img width="93" alt="image" src="https://user-images.githubusercontent.com/7383192/191234452-067acfa0-ee7b-4ba0-894b-1da5e4bebb97.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->