### PR TITLE
fix(stripe): validate webhook existence on donation

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -695,17 +695,28 @@ class Stripe_Connection {
 
 	/**
 	 * Create Stripe webhooks if they are missing. Otherwise, validate the webhhooks.
+	 *
+	 * @param bool $validate_existence_only If true, only validate the existence of the webhooks.
 	 */
-	public static function validate_or_create_webhooks() {
+	public static function validate_or_create_webhooks( $validate_existence_only = false ) {
 		$is_valid        = true;
-		$webhook_events  = [
+		$created_webhook = get_option( self::STRIPE_WEBHOOK_OPTION_NAME );
+
+		if ( $validate_existence_only ) {
+			if ( false === $created_webhook ) {
+				// If the webhook does not exist, do the full validation & creation.
+				self::validate_or_create_webhooks();
+			}
+			return;
+		}
+
+		$webhook_events = [
 			'charge.failed',
 			'charge.succeeded',
 			'customer.subscription.deleted',
 			'customer.subscription.updated',
 		];
-		$stripe          = self::get_stripe_client();
-		$created_webhook = get_option( self::STRIPE_WEBHOOK_OPTION_NAME );
+		$stripe         = self::get_stripe_client();
 		if ( ! $created_webhook ) {
 			Logger::log( 'Creating Stripe webhooks…' );
 			try {
@@ -974,6 +985,8 @@ class Stripe_Connection {
 	 * @param object $config Data about the donation.
 	 */
 	public static function handle_donation( $config ) {
+		self::validate_or_create_webhooks( true );
+
 		$response = [
 			'error'  => null,
 			'status' => null,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The Stripe integration relies on webhooks, which are currently validated on loading the Reader Revenue wizard. It might happen though that the integration was set up way back when the webhook creation was manual, and since then the user did not visit the RR wizard. This PR ensures that the webhook is partially* validated on every donation. 

\* only checked if the webhook-identifying WP option was created, we don't want to hit the Stripe API excessively

### How to test the changes in this Pull Request:

1. Set up a site with Stripe as the Reader Revenue platform
2. Remove the webhook-bearing option (`wp option delete newspack_stripe_webhook`)
3. Make a donation, observe the webhook has been recreated 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->