### PR TITLE
fix(wizards): rename advertising scripts and API paths to bypass ad blockers

### DIFF
--- a/assets/wizards/advertising/components/onboarding/index.js
+++ b/assets/wizards/advertising/components/onboarding/index.js
@@ -23,7 +23,7 @@ export default function AdsOnboarding( { onUpdate, onSuccess } ) {
 	const updateGAMCredentials = credentials => {
 		setInFlight( true );
 		apiFetch( {
-			path: '/newspack/v1/wizard/advertising/credentials',
+			path: '/newspack/v1/wizard/billboard/credentials',
 			method: 'post',
 			data: { credentials, onboarding: true },
 		} )

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -77,11 +77,11 @@ class AdvertisingWizard extends Component {
 			} );
 
 	fetchAdvertisingData = ( quiet = false ) =>
-		this.updateWithAPI( { path: '/newspack/v1/wizard/advertising', quiet } );
+		this.updateWithAPI( { path: '/newspack/v1/wizard/billboard', quiet } );
 
 	toggleService = ( service, enabled ) =>
 		this.updateWithAPI( {
-			path: '/newspack/v1/wizard/advertising/service/' + service,
+			path: '/newspack/v1/wizard/billboard/service/' + service,
 			method: enabled ? 'POST' : 'DELETE',
 			quiet: true,
 		} );
@@ -97,7 +97,7 @@ class AdvertisingWizard extends Component {
 
 	saveAdUnit = id =>
 		this.updateWithAPI( {
-			path: '/newspack/v1/wizard/advertising/ad_unit/' + ( id || 0 ),
+			path: '/newspack/v1/wizard/billboard/ad_unit/' + ( id || 0 ),
 			method: 'post',
 			data: this.state.advertisingData.adUnits[ id ],
 			quiet: true,
@@ -112,7 +112,7 @@ class AdvertisingWizard extends Component {
 		// eslint-disable-next-line no-alert
 		if ( confirm( __( 'Are you sure you want to archive this ad unit?', 'newspack' ) ) ) {
 			return this.updateWithAPI( {
-				path: '/newspack/v1/wizard/advertising/ad_unit/' + id,
+				path: '/newspack/v1/wizard/billboard/ad_unit/' + id,
 				method: 'delete',
 				quiet: true,
 			} );
@@ -121,7 +121,7 @@ class AdvertisingWizard extends Component {
 
 	updateAdSuppression = suppressionConfig =>
 		this.updateWithAPI( {
-			path: '/newspack/v1/wizard/advertising/suppression',
+			path: '/newspack/v1/wizard/billboard/suppression',
 			method: 'post',
 			data: { config: suppressionConfig },
 			quiet: true,

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -45,7 +45,7 @@ const AdUnits = ( {
 
 	const updateNetworkCode = async ( value, isGam ) => {
 		await wizardApiFetch( {
-			path: '/newspack/v1/wizard/advertising/network_code/',
+			path: '/newspack/v1/wizard/billboard/network_code/',
 			method: 'POST',
 			data: { network_code: value, is_gam: isGam },
 			quiet: true,

--- a/assets/wizards/advertising/views/ad-units/service-account-connection.js
+++ b/assets/wizards/advertising/views/ad-units/service-account-connection.js
@@ -16,14 +16,14 @@ const ServiceAccountConnection = ( { updateWithAPI, isConnected } ) => {
 
 	const updateGAMCredentials = credentials =>
 		updateWithAPI( {
-			path: '/newspack/v1/wizard/advertising/credentials',
+			path: '/newspack/v1/wizard/billboard/credentials',
 			method: 'post',
 			data: { credentials },
 			quiet: true,
 		} );
 	const removeGAMCredentials = () =>
 		updateWithAPI( {
-			path: '/newspack/v1/wizard/advertising/credentials',
+			path: '/newspack/v1/wizard/billboard/credentials',
 			method: 'delete',
 			quiet: true,
 		} );

--- a/assets/wizards/advertising/views/providers/index.js
+++ b/assets/wizards/advertising/views/providers/index.js
@@ -35,7 +35,7 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 	const updateGAMNetworkCode = () => {
 		setInFlight( true );
 		apiFetch( {
-			path: '/newspack/v1/wizard/advertising/network_code/',
+			path: '/newspack/v1/wizard/billboard/network_code/',
 			method: 'POST',
 			data: { network_code: networkCode, is_gam: false },
 			quiet: true,

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -80,7 +80,7 @@ class Advertising_Wizard extends Wizard {
 		// Get all Newspack advertising data.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/',
+			'/wizard/billboard/',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_advertising' ],
@@ -91,7 +91,7 @@ class Advertising_Wizard extends Wizard {
 		// Enable one service.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/service/(?P<service>[\a-z]+)',
+			'/wizard/billboard/service/(?P<service>[\a-z]+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_enable_service' ],
@@ -107,7 +107,7 @@ class Advertising_Wizard extends Wizard {
 		// Disable one service.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/service/(?P<service>[\a-z]+)',
+			'/wizard/billboard/service/(?P<service>[\a-z]+)',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'api_disable_service' ],
@@ -123,7 +123,7 @@ class Advertising_Wizard extends Wizard {
 		// Update GAM credentials.
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/credentials',
+			'/wizard/billboard/credentials',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_gam_credentials' ],
@@ -186,7 +186,7 @@ class Advertising_Wizard extends Wizard {
 		// Remove GAM credentials.
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/credentials',
+			'/wizard/billboard/credentials',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'api_remove_gam_credentials' ],
@@ -197,7 +197,7 @@ class Advertising_Wizard extends Wizard {
 		// Save a ad unit.
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/ad_unit/(?P<id>\d+)',
+			'/wizard/billboard/ad_unit/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_adunit' ],
@@ -225,7 +225,7 @@ class Advertising_Wizard extends Wizard {
 		// Delete a ad unit.
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/ad_unit/(?P<id>\d+)',
+			'/wizard/billboard/ad_unit/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'api_delete_adunit' ],
@@ -241,7 +241,7 @@ class Advertising_Wizard extends Wizard {
 		// Update network code.
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/network_code',
+			'/wizard/billboard/network_code',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_network_code' ],
@@ -276,7 +276,7 @@ class Advertising_Wizard extends Wizard {
 		// Update global ad suppression.
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/advertising/suppression',
+			'/wizard/billboard/suppression',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_ad_suppression' ],
@@ -553,7 +553,7 @@ class Advertising_Wizard extends Wizard {
 
 		\wp_enqueue_script(
 			'newspack-advertising-wizard',
-			Newspack::plugin_url() . '/dist/advertising.js',
+			Newspack::plugin_url() . '/dist/billboard.js',
 			$this->get_script_dependencies(),
 			NEWSPACK_PLUGIN_VERSION,
 			true
@@ -561,7 +561,7 @@ class Advertising_Wizard extends Wizard {
 
 		\wp_register_style(
 			'newspack-advertising-wizard',
-			Newspack::plugin_url() . '/dist/advertising.css',
+			Newspack::plugin_url() . '/dist/billboard.css',
 			$this->get_style_dependencies(),
 			NEWSPACK_PLUGIN_VERSION
 		);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,18 @@ const wizardsScriptFiles = {
 	'plugins-screen': path.join( __dirname, 'assets', 'plugins-screen', 'plugins-screen.js' ),
 };
 wizardsScripts.forEach( function ( wizard ) {
-	wizardsScriptFiles[ wizard ] = path.join( __dirname, 'assets', 'wizards', wizard, 'index.js' );
+	let wizardFileName = wizard;
+	if ( wizard === 'advertising' ) {
+		// "advertising.js" might be blocked by ad-blocking extensions.
+		wizardFileName = 'billboard';
+	}
+	wizardsScriptFiles[ wizardFileName ] = path.join(
+		__dirname,
+		'assets',
+		'wizards',
+		wizard,
+		'index.js'
+	);
 } );
 
 // Get files for other scripts.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a long-standing issue with ad-blockers blocking the ad management UI. The API paths and assets sent to the browser are renamed to innocuous "billboard". 

<img width="497" alt="image" src="https://user-images.githubusercontent.com/7383192/191741622-e33473d9-3131-4d9f-905f-cd5d152fce3d.png">

Open to other suggestions, though. 

### How to test the changes in this Pull Request:

1. On `master`, install AdBlock Plus extension
2. Load the Ad wizard, notice the fatal error
3. Switch to this branch, rebuild, observe the Ad wizard loading correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->