### PR TITLE
Feature: Limit the number of revisions kept in the database

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -96,6 +96,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-fivetran-connection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-google-login.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-blocks.php';
+		include_once NEWSPACK_ABSPATH . 'includes/revisions-control/class-revisions-control.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-rss.php';
 

--- a/includes/revisions-control/README.md
+++ b/includes/revisions-control/README.md
@@ -1,0 +1,46 @@
+# Revisions Control
+
+This feature allows sites to limit the number of revisions kept for each post.
+
+## How it works
+
+Everytime a post is saved, WordPress check the maximum number of revisions should be kept in the database. By default, there's no limit.
+
+When you enable this feature, you will set the max number of revisions you want to preserve in the database. If there are more than the set maximum, older revisions will be deleted.
+
+This feature also takes into consideration the age of the revision. By default, a revisions will be deleted only if it is more than 1 week old. So even if the number of existing revisions exceeds the maximum number set, revisions will not be deleted if they are not old enough.
+
+See bellow how to change these settings.
+
+## Usage
+
+There are two ways to enable it.
+
+### Using a Constant
+
+Add this to your `wp-config.php`:
+
+```php
+define( 'NEWSPACK_LIMIT_REVISIONS_NUMBER', 30 );
+```
+
+Replace `30` with the maximum number of revisions you want to keep.
+
+When using the constant, the minimum age a revision must have to be deleted will default to 1 week.
+
+### Using an option
+
+You can also add an option to control the feature and it will override the value in the constant:
+
+```php
+update_option(
+	'newspack_revisions_control',
+	[
+		'active'  => true,
+		'number'  => 30,
+		'min_age' => '-1 week',
+	]
+);
+```
+
+When setting the option you can define the maximum number of revisions to be kept as well as the minimum age a revision must have to be deleted. Accepted values are string compatible with the PHP DateTime modifiers. Example: '-1 day', '-1 month', '-2 months'.

--- a/includes/revisions-control/class-revisions-control.php
+++ b/includes/revisions-control/class-revisions-control.php
@@ -39,7 +39,7 @@ class Revisions_Control {
 	 *
 	 * @return array
 	 */
-	public static function get_option() {
+	private static function get_option() {
 		$option = get_option( 'newspack_revisions_control' );
 		// If option does not exist or is invalid, fallback to defaults.
 		if ( empty( $option ) || ! is_array( $option ) || empty( $option['active'] ) || empty( $option['number'] ) || empty( $option['min_age'] ) ) {
@@ -53,7 +53,7 @@ class Revisions_Control {
 	 *
 	 * @return array
 	 */
-	public static function get_status() {
+	private static function get_status() {
 		$option = self::get_option();
 		if ( ! empty( $option ) ) {
 			return $option;
@@ -73,7 +73,7 @@ class Revisions_Control {
 	 *
 	 * @return boolean
 	 */
-	public static function is_active() {
+	private static function is_active() {
 		return self::get_status()['active'];
 	}
 
@@ -82,7 +82,7 @@ class Revisions_Control {
 	 *
 	 * @return ?int
 	 */
-	public static function get_number() {
+	private static function get_number() {
 		if ( self::get_status()['active'] ) {
 			return self::get_status()['number'];
 		}
@@ -93,7 +93,7 @@ class Revisions_Control {
 	 *
 	 * @return ?string
 	 */
-	public static function get_min_age() {
+	private static function get_min_age() {
 		if ( self::get_status()['active'] ) {
 			$min_age = self::get_status()['min_age'];
 			$date    = ( new DateTime() )->modify( $min_age );

--- a/includes/revisions-control/class-revisions-control.php
+++ b/includes/revisions-control/class-revisions-control.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Handles the revisions control for Newspack, managing how many revisions should be kept in the database
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+/**
+ * Revisions Control class
+ */
+class Revisions_Control {
+
+	/**
+	 * Flag to make sure hooks are initialized only once
+	 *
+	 * @var boolean
+	 */
+	private static $initiated = false;
+
+	/**
+	 * Initializes the hook
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( ! self::$initiated ) {
+			add_filter( 'wp_revisions_to_keep', [ __CLASS__, 'filter_revisions_to_keep' ] );
+			add_filter( 'pre_delete_post', [ __CLASS__, 'pre_delete_revision' ], 10, 2 );
+			self::$initiated = true;
+		}
+	}
+
+	/**
+	 * Gets the option stored in the database with the feature configuration
+	 *
+	 * @return array
+	 */
+	public static function get_option() {
+		$option = get_option( 'newspack_revisions_control' );
+		// If option does not exist or is invalid, fallback to defaults.
+		if ( empty( $option ) || ! is_array( $option ) || empty( $option['active'] ) || empty( $option['number'] ) || empty( $option['min_age'] ) ) {
+			return [];
+		}
+		return $option;
+	}
+
+	/**
+	 * Gets the current status of the feature configuration
+	 *
+	 * @return array
+	 */
+	public static function get_status() {
+		$option = self::get_option();
+		if ( ! empty( $option ) ) {
+			return $option;
+		}
+		if ( defined( 'NEWSPACK_LIMIT_REVISIONS_NUMBER' ) && is_int( NEWSPACK_LIMIT_REVISIONS_NUMBER ) ) {
+			return [
+				'active'  => true,
+				'number'  => NEWSPACK_LIMIT_REVISIONS_NUMBER,
+				'min_age' => '-1 week',
+			];
+		}
+		return [ 'active' => false ];
+	}
+
+	/**
+	 * Checks if the feature is active
+	 *
+	 * @return boolean
+	 */
+	public static function is_active() {
+		return self::get_status()['active'];
+	}
+
+	/**
+	 * Checks the number of revisions that should be kept, if feature is active
+	 *
+	 * @return ?int
+	 */
+	public static function get_number() {
+		if ( self::get_status()['active'] ) {
+			return self::get_status()['number'];
+		}
+	}
+
+	/**
+	 * Gets the maximum date a revision must have to be deleted, if the feature is active
+	 *
+	 * @return ?string
+	 */
+	public static function get_min_age() {
+		if ( self::get_status()['active'] ) {
+			$min_age = self::get_status()['min_age'];
+			$date    = ( new DateTime() )->modify( $min_age );
+			return $date->format( 'Y-m-d H:i:s' );
+		}
+	}
+
+	/**
+	 * Filters the number of revisions to keep
+	 *
+	 * @param int $number Number of revisions to store.
+	 * @return int
+	 */
+	public static function filter_revisions_to_keep( $number ) {
+		if ( ! self::is_active() ) {
+			return $number;
+		}
+		return (int) self::get_number();
+	}
+
+	/**
+	 * Keep revisions that are not old enough from being deleted
+	 *
+	 * @param mixed    $check Whether to go forward with deletion.
+	 * @param \WP_Post $post Post object.
+	 * @return mixed
+	 */
+	public static function pre_delete_revision( $check, \WP_Post $post ) {
+		if ( ! self::is_active() || 'revision' !== $post->post_type ) {
+			return $check;
+		}
+		if ( $post->post_date > self::get_min_age() ) {
+			return true; // do not delete.
+		}
+		return $check;
+	}
+
+}
+
+Revisions_Control::init();

--- a/includes/revisions-control/class-revisions-control.php
+++ b/includes/revisions-control/class-revisions-control.php
@@ -7,6 +7,8 @@
 
 namespace Newspack;
 
+use DateTime;
+use WP_Post;
 /**
  * Revisions Control class
  */
@@ -119,7 +121,7 @@ class Revisions_Control {
 	 * @param \WP_Post $post Post object.
 	 * @return mixed
 	 */
-	public static function pre_delete_revision( $check, \WP_Post $post ) {
+	public static function pre_delete_revision( $check, WP_Post $post ) {
 		if ( ! self::is_active() || 'revision' !== $post->post_type ) {
 			return $check;
 		}

--- a/tests/unit-tests/revisions-control.php
+++ b/tests/unit-tests/revisions-control.php
@@ -22,6 +22,22 @@ class Newspack_Test_Revisions_Control extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Sets the option to a valid value
+	 *
+	 * @return void
+	 */
+	public function set_option() {
+		update_option(
+			'newspack_revisions_control',
+			[
+				'active'  => true,
+				'number'  => 3,
+				'min_age' => '-1 week',
+			]
+		);
+	}
+
+	/**
 	 * Data provider for test_get_option
 	 *
 	 * @return array
@@ -65,5 +81,164 @@ class Newspack_Test_Revisions_Control extends WP_UnitTestCase {
 	public function test_get_option( $option_value, $expected ) {
 		update_option( 'newspack_revisions_control', $option_value );
 		$this->assertSame( $expected, Revisions_Control::get_option() );
+	}
+
+	/**
+	 * Data provider for test_get_status
+	 *
+	 * @return array
+	 */
+	public function get_status_data() {
+		$valid_value    = [
+			'active'  => true,
+			'number'  => 3,
+			'min_age' => '-1 week',
+		];
+		$invalid_return = [ 'active' => false ];
+		return [
+			'no option'            => [
+				null,
+				$invalid_return,
+				false,
+				null,
+				null,
+			],
+			'invalid option'       => [
+				'asdsad',
+				$invalid_return,
+				false,
+				null,
+				null,
+			],
+			'invalid array option' => [
+				[
+					'active'  => 123,
+					'invalid' => true,
+				],
+				$invalid_return,
+				false,
+				null,
+				null,
+			],
+			'valid'                => [
+				$valid_value,
+				$valid_value,
+				true,
+				3,
+				'-1 week',
+			],
+		];
+	}
+	/**
+	 * Tests the get_status and other get_methods
+	 *
+	 * @param mixed $option_value The value to be present in the database.
+	 * @param array $expected The expected value of get_status.
+	 * @param bool  $active The expected value of is_active.
+	 * @param mixed $number The expected value of get_number.
+	 * @param mixed $min_age The expected value of get_min_age.
+	 * @return void
+	 * @dataProvider get_status_data
+	 */
+	public function test_get_status( $option_value, $expected, $active, $number, $min_age ) {
+		update_option( 'newspack_revisions_control', $option_value );
+		$this->assertSame( $expected, Revisions_Control::get_status() );
+		$this->assertSame( $active, Revisions_Control::is_active() );
+		$this->assertSame( $number, Revisions_Control::get_number() );
+		$_min_age = Revisions_Control::get_min_age();
+		if ( ! is_null( $min_age ) ) {
+			$diff = date_diff( new DateTime(), new DateTime( $_min_age ) );
+			$this->assertSame( 7, $diff->d );
+		} else {
+			$this->assertSame( $min_age, $_min_age );
+		}
+	}
+
+	/**
+	 * Tests filter_revisions_to_keep when feature is inactive
+	 *
+	 * @return void
+	 */
+	public function test_filter_revisions_to_keep_inactive() {
+		$this->assertSame( 10, Revisions_Control::filter_revisions_to_keep( 10 ) );
+		$this->assertSame( 20, Revisions_Control::filter_revisions_to_keep( 20 ) );
+		$this->assertSame( false, Revisions_Control::filter_revisions_to_keep( false ) );
+	}
+
+	/**
+	 * Tests filter_revisions_to_keep when feature is active
+	 *
+	 * @return void
+	 */
+	public function test_filter_revisions_to_keep_active() {
+		$this->set_option();
+		$this->assertSame( 3, Revisions_Control::filter_revisions_to_keep( 10 ) );
+		$this->assertSame( 3, Revisions_Control::filter_revisions_to_keep( 20 ) );
+		$this->assertSame( 3, Revisions_Control::filter_revisions_to_keep( false ) );
+	}
+
+	/**
+	 * Data source for testing pre_delete_revision
+	 *
+	 * @return array
+	 */
+	public function pre_delete_revision_data() {
+		return [
+			'other old post type' => [
+				new WP_Post(
+					(object) [
+						'post_type' => 'post',
+						'post_date' => ( new DateTime( '-1 month' ) )->format( 'Y-m-d H:i:s' ),
+					]
+				),
+				null,
+			],
+			'new revision'        => [
+				new WP_Post(
+					(object) [
+						'post_type' => 'revision',
+						'post_date' => ( new DateTime( '-1 day' ) )->format( 'Y-m-d H:i:s' ),
+					]
+				),
+				true,
+			],
+			'old revision'        => [
+				new WP_Post(
+					(object) [
+						'post_type' => 'revision',
+						'post_date' => ( new DateTime( '-1 month' ) )->format( 'Y-m-d H:i:s' ),
+					]
+				),
+				null,
+			],
+		];
+	}
+
+
+	/**
+	 * Undocumented function
+	 *
+	 * @param WP_Post $post The Post object.
+	 * @param mixed   $expected The expected result.
+	 *
+	 * @return void
+	 * @dataProvider pre_delete_revision_data
+	 */
+	public function test_pre_delete_revision_active( $post, $expected ) {
+		$this->set_option();
+		$this->assertSame( $expected, Revisions_Control::pre_delete_revision( null, $post ) );
+	}
+
+
+	/**
+	 * Undocumented function
+	 *
+	 * @param WP_Post $post The Post object.
+	 *
+	 * @return void
+	 * @dataProvider pre_delete_revision_data
+	 */
+	public function test_pre_delete_revision_inactive( $post ) {
+		$this->assertSame( null, Revisions_Control::pre_delete_revision( null, $post ) );
 	}
 }

--- a/tests/unit-tests/revisions-control.php
+++ b/tests/unit-tests/revisions-control.php
@@ -37,6 +37,12 @@ class Newspack_Test_Revisions_Control extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Gets a ReflecionMethod from one of our private methods so we can test them
+	 *
+	 * @param string $method_name The name of the private method.
+	 * @return ReflectionMethod
+	 */
 	public function get_private_method( $method_name ) {
 		$class  = new ReflectionClass( 'Newspack\Revisions_Control' );
 		$method = $class->getMethod( $method_name );

--- a/tests/unit-tests/revisions-control.php
+++ b/tests/unit-tests/revisions-control.php
@@ -37,6 +37,13 @@ class Newspack_Test_Revisions_Control extends WP_UnitTestCase {
 		);
 	}
 
+	public function get_private_method( $method_name ) {
+		$class  = new ReflectionClass( 'Newspack\Revisions_Control' );
+		$method = $class->getMethod( $method_name );
+		$method->setAccessible( true );
+		return $method;
+	}
+
 	/**
 	 * Data provider for test_get_option
 	 *
@@ -80,7 +87,8 @@ class Newspack_Test_Revisions_Control extends WP_UnitTestCase {
 	 */
 	public function test_get_option( $option_value, $expected ) {
 		update_option( 'newspack_revisions_control', $option_value );
-		$this->assertSame( $expected, Revisions_Control::get_option() );
+		$method = $this->get_private_method( 'get_option' );
+		$this->assertSame( $expected, $method->invoke( null ) );
 	}
 
 	/**
@@ -142,10 +150,19 @@ class Newspack_Test_Revisions_Control extends WP_UnitTestCase {
 	 */
 	public function test_get_status( $option_value, $expected, $active, $number, $min_age ) {
 		update_option( 'newspack_revisions_control', $option_value );
-		$this->assertSame( $expected, Revisions_Control::get_status() );
-		$this->assertSame( $active, Revisions_Control::is_active() );
-		$this->assertSame( $number, Revisions_Control::get_number() );
-		$_min_age = Revisions_Control::get_min_age();
+
+		$get_status = $this->get_private_method( 'get_status' );
+		$this->assertSame( $expected, $get_status->invoke( null ) );
+
+		$is_active = $this->get_private_method( 'is_active' );
+		$this->assertSame( $active, $is_active->invoke( null ) );
+
+		$get_number = $this->get_private_method( 'get_number' );
+		$this->assertSame( $number, $get_number->invoke( null ) );
+
+		$get_min_age = $this->get_private_method( 'get_min_age' );
+		$_min_age    = $get_min_age->invoke( null );
+
 		if ( ! is_null( $min_age ) ) {
 			$diff = date_diff( new DateTime(), new DateTime( $_min_age ) );
 			$this->assertSame( 7, $diff->d );
@@ -216,7 +233,7 @@ class Newspack_Test_Revisions_Control extends WP_UnitTestCase {
 
 
 	/**
-	 * Undocumented function
+	 * Tests the pre_delete_revision hook when the feature is active
 	 *
 	 * @param WP_Post $post The Post object.
 	 * @param mixed   $expected The expected result.
@@ -231,7 +248,7 @@ class Newspack_Test_Revisions_Control extends WP_UnitTestCase {
 
 
 	/**
-	 * Undocumented function
+	 * Tests the pre_delete_revision hook when the feature is active
 	 *
 	 * @param WP_Post $post The Post object.
 	 *

--- a/tests/unit-tests/revisions-control.php
+++ b/tests/unit-tests/revisions-control.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests the Revisions Control Newspack functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Revisions_Control;
+
+/**
+ * Test Revisions Control functionality.
+ */
+class Newspack_Test_Revisions_Control extends WP_UnitTestCase {
+
+	/**
+	 * Clean up
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		delete_option( 'newspack_revisions_control' );
+	}
+
+	/**
+	 * Data provider for test_get_option
+	 *
+	 * @return array
+	 */
+	public function get_option_data() {
+		$valid_value = [
+			'active'  => true,
+			'number'  => 3,
+			'min_age' => '-1 week',
+		];
+		return [
+			'no option'            => [
+				null,
+				[],
+			],
+			'invalid option'       => [
+				'asdsad',
+				[],
+			],
+			'invalid array option' => [
+				[
+					'active'  => 123,
+					'invalid' => true,
+				],
+				[],
+			],
+			'valid'                => [
+				$valid_value,
+				$valid_value,
+			],
+		];
+	}
+	/**
+	 * Tests the get_option method
+	 *
+	 * @param mixed $option_value The value to be present in the database.
+	 * @param array $expected The expected value.
+	 * @return void
+	 * @dataProvider get_option_data
+	 */
+	public function test_get_option( $option_value, $expected ) {
+		update_option( 'newspack_revisions_control', $option_value );
+		$this->assertSame( $expected, Revisions_Control::get_option() );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a feature to limit the number of revisions kept in the database.

See https://app.asana.com/0/1200550061930446/1200839903666391

Fixes #1731

### How to test the changes in this Pull Request:

It's easier to test this if you have a post with many revisions across a period of time. Thankfully I made a little script to set it up for you :) 

* Download this file: [create-revisions.txt](https://github.com/Automattic/newspack-plugin/files/9628347/create-revisions.txt)
* rename it to `create-revisions.php` and save it on the root of your site
* run `wp eval-file create-revisions.php` to run the script
* You should see something like this:
```
Created post with ID 506
Creating revisions .................................................
See revisions at http://localhost/wp-admin/revision.php?revision=555&gutenberg=true
```
OK, now you have a post with 50 revisions that goes back 50 days in the past. Now let's do some testing

1. Go to the edit page of the post you created (See the script output. The post is 50 days old so it might not show up at the top of your list in the admin)
2. Confirm it has 50 revisions
3. Click to see the revisions
4. There's one revision per day and each of them add one line to the content
5. Edit your wp-config file and add `define( 'NEWSPACK_LIMIT_REVISIONS_NUMBER', 30 );`
6. Edit your post, add a new line or make any change. Save it.
7. Verify that now you only have 30 revisions
8. Confirm the revisions look good and make sense
9. Edit your `wp-config.php` again and lower the number to only `3`
10. Make some changes to your post and save it again
11. Confirm that you only have 7 revisions now
12. Confirm that the revisions kept are the ones within one week from now
13. Read the README file, check for typos. Confirm it's clear and has all the information needed
14. Play with different values for the constant and also with the option described in the README file

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->