### PR TITLE
Stripe-to-Stripe Migrator

### DIFF
--- a/includes/reader-revenue/class-stripe-sync.php
+++ b/includes/reader-revenue/class-stripe-sync.php
@@ -156,6 +156,141 @@ class Stripe_Sync {
 	}
 
 	/**
+	 * CLI command for migrating Stripe Subscriptions from Stripe Connect to a regular Stripe account.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public static function sync_stripe_connect_to_stripe( $args, $assoc_args ) {
+		$is_dry_run     = ! empty( $assoc_args['dry-run'] );
+		$force_override = ! empty( $assoc_args['force'] );
+		$batch_size     = ! empty( $assoc_args['batch-size'] ) ? intval( $assoc_args['batch-size'] ) : 10;
+
+		$customers = self::get_batch_of_customers_for_stripe_connect_to_stripe( $batch_size );
+		while ( $customers ) {
+			$customer = array_shift( $customers );
+
+			self::process_customer_for_stripe_connect_to_stripe(
+				$customer,
+				[
+					'dry_run'                     => $is_dry_run,
+					'force_subscription_override' => $force_override,
+				] 
+			);
+
+			// Get the next batch.
+			if ( empty( $customers ) ) {
+				$customers = self::get_batch_of_customers_for_stripe_connect_to_stripe( $batch_size, $customer->id );
+			}
+		}
+
+		\WP_CLI::success( 'Finished processing.' );
+	}
+
+	/**
+	 * Get a batch of customers for the Stripe-Connect-to-Stripe CLI tool.
+	 *
+	 * @param int    $limit Number of customers to fetch.
+	 * @param string $last_customer_id Stripe ID of customer to get results after, essentially the offset.
+	 * @return array Array of Stripe customers.
+	 */
+	protected function get_batch_of_customers_for_stripe_connect_to_stripe( $limit, $last_customer_id = false ) {
+		$stripe = Stripe_Connection::get_stripe_client();
+		try {
+			$params = [ 
+				'limit'  => $limit,
+				'expand' => [
+					'data.subscriptions',
+				],
+			];
+
+			if ( $last_customer_id ) {
+				$params['starting_after'] = $last_customer_id;
+			}
+
+			return $stripe->customers->all( $params )['data'];
+		} catch ( \Throwable $e ) {
+			\WP_CLI::error( sprintf( 'Could not process all customers: %s', $e->getMessage() ) );
+		}
+	}
+
+	/**
+	 * Process one customer's Stripe subscriptions and migrate them to Newspack Stripe subscriptions.
+	 *
+	 * @param Stripe_Customer $customer Stripe customer object.
+	 * @param array           $args Params to control migration behavior.
+	 */
+	protected function process_customer_for_stripe_connect_to_stripe( $customer, $args ) {
+		$dry_run                     = ! empty( $args['dry_run'] );
+		$force_subscription_override = ! empty( $args['force_subscription_override'] );
+
+		$stripe        = Stripe_Connection::get_stripe_client();
+		$stripe_prices = Stripe_Connection::get_donation_prices();
+
+		\WP_CLI::log( sprintf( 'Processing customer: %s', $customer->email ) );
+		if ( empty( $customer->subscriptions ) || empty( $customer->subscriptions->data ) ) {
+			\WP_CLI::log( '  - No subscriptions found for customer. Skipping. A future version of this tool will handle the case where we want to turn one-time Stripe payments into Stripe subscriptions.' );
+			return;
+		}
+
+		foreach ( $customer->subscriptions['data'] as $existing_subscription ) {
+			\WP_CLI::log( sprintf( '  - Processing subscription: %s', $existing_subscription->id ) );
+
+			// Skip subscription if it's already migrated.
+			if ( ! empty( $existing_subscription->metadata['subscription_migrated_to_newspack'] && ! $force_subscription_override ) ) {
+				\WP_CLI::log( sprintf( '  - Subscription already migrated to Newspack on %s. Skipping.', $existing_subscription->metadata['subscription_migrated_to_newspack'] ) );
+				continue;
+			}
+
+			$new_subscription_items = [];
+
+			foreach ( $existing_subscription->items->data as $existing_subscription_item ) {
+				// Quantity is used here as a fallback because Simplified Donate Block uses quantity * 1 cent to do a variable price subscription.
+				$existing_subscription_item_price = ! empty( $existing_subscription_item->price->unit_amount ) ? $existing_subscription_item->price->unit_amount : $existing_subscription_item->quantity;
+				
+				$frequency                = $existing_subscription_item->price->recurring->interval;
+				$new_subscription_items[] = [
+					'price'    => $stripe_prices[ $frequency ]['id'],
+					'quantity' => $existing_subscription_item_price,
+				];
+
+				\WP_CLI::log( sprintf( '    * Found subscription item: $%s/%s', $existing_subscription_item_price / 100, $frequency ) );
+			}
+
+			if ( $dry_run ) {
+				\WP_CLI::log( sprintf( '    * Would have created subscription with next renewal at %s', gmdate( 'Y-m-d', $existing_subscription->current_period_end ) ) );
+				return;
+
+			}
+
+			// Create new subscriptions.
+			try {
+				$subscription = $stripe->subscriptions->create(
+					[
+						'customer'             => $customer->id,
+						'items'                => $new_subscription_items,
+						'payment_behavior'     => 'allow_incomplete',
+						'billing_cycle_anchor' => $existing_subscription->current_period_end,
+						'metadata'             => [
+							'subscription_migrated_to_newspack' => gmdate( 'c' ),
+						],
+					]
+				);
+				\WP_CLI::log( sprintf( '    * Created subscription: %s with next renewal at %s', $subscription->id, gmdate( 'Y-m-d', $existing_subscription->current_period_end ) ) );
+			} catch ( \Throwable $e ) {
+				\WP_CLI::error( sprintf( 'Failed to create subscription: %s', $e->getMessage() ) );
+			}
+
+			try {
+				$stripe->subscriptions->cancel( $existing_subscription->id );
+				\WP_CLI::log( sprintf( '    * Cancelled old subscription: %s', $existing_subscription->id ) );
+			} catch ( \Throwable $e ) {
+				\WP_CLI::error( sprintf( 'Failed to cancel subscription: %s', $e->getMessage() ) );
+			}
+		}
+	}
+
+	/**
 	 * Add CLI commands.
 	 */
 	public static function wp_cli() {
@@ -208,6 +343,32 @@ class Stripe_Sync {
 			$sync_to_wc,
 			[
 				'shortdesc' => __( 'Backfill WC Customers from Stripe database.', 'newspack' ),
+			]
+		);
+
+		\WP_CLI::add_command(
+			'newspack stripe sync-stripe-connect-to-stripe',
+			[ __CLASS__, 'sync_stripe_connect_to_stripe' ],
+			[
+				'shortdesc' => __( 'Migrate customers from Stripe Connect to Stripe', 'newspack' ),
+				'synopsis'  => [
+					[
+						'type'     => 'flag',
+						'name'     => 'dry-run',
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'force',
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'batch-size',
+						'default'  => 10,
+						'optional' => true,
+					],
+				],
 			]
 		);
 	}

--- a/includes/reader-revenue/class-stripe-sync.php
+++ b/includes/reader-revenue/class-stripe-sync.php
@@ -175,7 +175,7 @@ class Stripe_Sync {
 				[
 					'dry_run'                     => $is_dry_run,
 					'force_subscription_override' => $force_override,
-				] 
+				]
 			);
 
 			// Get the next batch.
@@ -194,10 +194,10 @@ class Stripe_Sync {
 	 * @param string $last_customer_id Stripe ID of customer to get results after, essentially the offset.
 	 * @return array Array of Stripe customers.
 	 */
-	protected function get_batch_of_customers_for_stripe_connect_to_stripe( $limit, $last_customer_id = false ) {
+	protected static function get_batch_of_customers_for_stripe_connect_to_stripe( $limit, $last_customer_id = false ) {
 		$stripe = Stripe_Connection::get_stripe_client();
 		try {
-			$params = [ 
+			$params = [
 				'limit'  => $limit,
 				'expand' => [
 					'data.subscriptions',
@@ -220,7 +220,7 @@ class Stripe_Sync {
 	 * @param Stripe_Customer $customer Stripe customer object.
 	 * @param array           $args Params to control migration behavior.
 	 */
-	protected function process_customer_for_stripe_connect_to_stripe( $customer, $args ) {
+	protected static function process_customer_for_stripe_connect_to_stripe( $customer, $args ) {
 		$dry_run                     = ! empty( $args['dry_run'] );
 		$force_subscription_override = ! empty( $args['force_subscription_override'] );
 
@@ -247,7 +247,7 @@ class Stripe_Sync {
 			foreach ( $existing_subscription->items->data as $existing_subscription_item ) {
 				// Quantity is used here as a fallback because Simplified Donate Block uses quantity * 1 cent to do a variable price subscription.
 				$existing_subscription_item_price = ! empty( $existing_subscription_item->price->unit_amount ) ? $existing_subscription_item->price->unit_amount : $existing_subscription_item->quantity;
-				
+
 				$frequency                = $existing_subscription_item->price->recurring->interval;
 				$new_subscription_items[] = [
 					'price'    => $stripe_prices[ $frequency ]['id'],

--- a/includes/reader-revenue/class-stripe-sync.php
+++ b/includes/reader-revenue/class-stripe-sync.php
@@ -271,6 +271,7 @@ class Stripe_Sync {
 						'items'                => $new_subscription_items,
 						'payment_behavior'     => 'allow_incomplete',
 						'billing_cycle_anchor' => $existing_subscription->current_period_end,
+						'trial_end'            => $existing_subscription->current_period_end,
 						'metadata'             => [
 							'subscription_migrated_to_newspack' => gmdate( 'c' ),
 						],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a Stripe-to-Stripe migrator which can migrate Stripe subscriptions (even Connect ones) to Newspack Simplified Donate Block Stripe subscriptions. We'll want to figure out how to merge this and https://github.com/Automattic/newspack-plugin/pull/1984, because merge conflicts are gonna happen as soon as one of these is merged.

### How to test the changes in this Pull Request:

1. Generate some Stripe Connect orders using this PR: https://github.com/Automattic/newspack-plugin/pull/2031 Make sure after you're done and this branch is checked out, you reset the Stripe keys in the Reader Revenue settings to use the child connected account keys, not the parent account which would be e.g. Pico's Stripe keys.
2. Run `wp newspack stripe sync-stripe-connect-to-stripe --dry-run`. You should see output similar to the following:
```
Processing customer: typescripting@example.com
  - Processing subscription: [redacted subscription id]
    * Found subscription item: $15/month
    * Would have created subscription with next renewal at 2022-10-22
Processing customer: refactorconnect1@example.com
  - Processing subscription: [redacted subscription id]
    * Found subscription item: $41.5/month
    * Would have created subscription with next renewal at 2022-10-22
Processing customer: testconnectedacc@example.com
  - Processing subscription: [redacted subscription id]
    * Found subscription item: $20.91/month
    * Would have created subscription with next renewal at 2022-10-22
...
```
4. Run `wp newspack stripe sync-stripe-connect-to-stripe`. You should see output similar to the following:
```
Processing customer: typescripting@example.com
  - Processing subscription: [redacted existing subscription id]
    * Found subscription item: $15/month
    * Created subscription: [redacted new subscription id] with next renewal at 2022-10-22
    * Cancelled old subscription: [redacted existing subscription id]
Processing customer: refactorconnect1@example.com
  - Processing subscription: [redacted existing subscription id]
    * Found subscription item: $41.5/month
    * Created subscription: [redacted new subscription id] with next renewal at 2022-10-22
    * Cancelled old subscription: [redacted existing subscription id]
Processing customer: testconnectedacc@example.com
  - Processing subscription: [redacted existing subscription id]
    * Found subscription item: $20.91/month
    * Created subscription: [redacted new subscription id] with next renewal at 2022-10-22
    * Cancelled old subscription: [redacted existing subscription id]
...
```

In Stripe, you should see the new subscriptions created with correct next renewal date:

<img width="1288" alt="Screen Shot 2022-09-22 at 1 13 12 PM" src="https://user-images.githubusercontent.com/7317227/191842383-37f84f16-f693-44da-944c-ffa17f919c7d.png">

In the cancelled subscriptions section, you should see the old ones cancelled:

<img width="1273" alt="Screen Shot 2022-09-22 at 1 13 30 PM" src="https://user-images.githubusercontent.com/7317227/191842397-5fb1c469-0084-427a-a527-369bdf04e02e.png">

5. Run `wp newspack stripe sync-stripe-connect-to-stripe` again. You should see output similar to the following:
```
Processing customer: typescripting@example.com
  - Processing subscription: [redacted new subscription id]
  - Subscription already migrated to Newspack on 2022-09-22T19:43:15+00:00. Skipping.
Processing customer: refactorconnect1@example.com
  - Processing subscription: [redacted new subscription id]
  - Subscription already migrated to Newspack on 2022-09-22T19:43:19+00:00. Skipping.
Processing customer: testconnectedacc@example.com
  - Processing subscription: [redacted new subscription id]
  - Subscription already migrated to Newspack on 2022-09-22T19:43:23+00:00. Skipping.
...
```
6. Run `wp newspack stripe sync-stripe-connect-to-stripe --force`. This will re-build all subscriptions, even migrated ones. You should see output similar to the following:
```
Processing customer: typescripting@example.com
  - Processing subscription:  [redacted existing subscription id]
    * Found subscription item: $15/month
    * Created subscription: [redacted new subscription id] with next renewal at 2022-10-22
    * Cancelled old subscription:  [redacted existing subscription id]
Processing customer: refactorconnect1@example.com
  - Processing subscription:  [redacted existing subscription id]
    * Found subscription item: $41.5/month
    * Created subscription: [redacted new subscription id] with next renewal at 2022-10-22
    * Cancelled old subscription: [redacted existing subscription id]
Processing customer: testconnectedacc@example.com
  - Processing subscription:  [redacted existing subscription id]
    * Found subscription item: $20.91/month
    * Created subscription: [redacted new subscription id] with next renewal at 2022-10-22
    * Cancelled old subscription:  [redacted existing subscription id]
...
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->