### PR TITLE
fix(analytics): improve reliability of custom events reporting in AMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.91.2-hotfix.2](https://github.com/Automattic/newspack-plugin/compare/v1.91.2-hotfix.1...v1.91.2-hotfix.2) (2022-09-23)
+
+
+### Bug Fixes
+
+* remove filter priority ([92ad712](https://github.com/Automattic/newspack-plugin/commit/92ad71276e78da40ad96486f0036c3101e00a494))
+
 ## [1.91.2-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.91.1...v1.91.2-hotfix.1) (2022-09-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.91.2-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.91.1...v1.91.2-hotfix.1) (2022-09-23)
+
+
+### Bug Fixes
+
+* **analytics:** improve reliability of custom events reporting in AMP ([a3d5982](https://github.com/Automattic/newspack-plugin/commit/a3d59829ed9c53e81f5ca89899b87e68cb19b43e))
+
 ## [1.91.1](https://github.com/Automattic/newspack-plugin/compare/v1.91.0...v1.91.1) (2022-09-21)
 
 

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -33,7 +33,7 @@ class Analytics {
 	 */
 	public function __construct() {
 		add_filter( 'googlesitekit_gtag_opt', [ __CLASS__, 'set_extra_analytics_config_options' ] );
-		add_action( 'wp_footer', [ __CLASS__, 'insert_gtag_amp_analytics' ], 99 ); // This has to be run after the filter above steals the analytics config.
+		add_action( 'wp_footer', [ __CLASS__, 'insert_gtag_amp_analytics' ] );
 
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'handle_custom_dimensions_reporting' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'inject_non_amp_events' ] );
@@ -472,7 +472,7 @@ class Analytics {
 	 * More: https://github.com/ampproject/amphtml/issues/32911.
 	 */
 	public static function insert_gtag_amp_analytics() {
-		$analytics = \Newspack\Google_Services_Connection::get_site_kit_analytics_module();
+		$analytics = Google_Services_Connection::get_site_kit_analytics_module();
 		if ( ! $analytics || ! $analytics->is_connected() ) {
 			return;
 		}

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -29,17 +29,9 @@ class Analytics {
 	public static $block_render_context = 3;
 
 	/**
-	 * Config for the injected amp-analytics tag.
-	 *
-	 * @var array
-	 */
-	public static $amp_analytics_config_base = [];
-
-	/**
 	 * Constructor
 	 */
 	public function __construct() {
-		add_filter( 'googlesitekit_amp_gtag_opt', [ __CLASS__, 'read_amp_analytics_config' ] );
 		add_filter( 'googlesitekit_gtag_opt', [ __CLASS__, 'set_extra_analytics_config_options' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'insert_gtag_amp_analytics' ], 99 ); // This has to be run after the filter above steals the analytics config.
 
@@ -450,22 +442,6 @@ class Analytics {
 	}
 
 	/**
-	 * Read the amp-analytics config that Site Kit will insert on the page.
-	 * Site Kit will place its amp-analytics tag on the page, and this
-	 * plugin will place other amp-analytics tags.
-	 *
-	 * @param array $config AMP Analytics config from Site Kit.
-	 * @return array Modified $config.
-	 */
-	public static function read_amp_analytics_config( $config ) {
-		if ( is_user_logged_in() ) {
-			$config['vars']['user_id'] = get_current_user_id();
-		}
-		self::$amp_analytics_config_base = $config;
-		return $config;
-	}
-
-	/**
 	 * Filter the Google Analytics config options via Site Kit.
 	 * Allows us to update or set additional config options for GA.
 	 *
@@ -496,10 +472,36 @@ class Analytics {
 	 * More: https://github.com/ampproject/amphtml/issues/32911.
 	 */
 	public static function insert_gtag_amp_analytics() {
-		$config = self::$amp_analytics_config_base;
-		if ( empty( $config ) ) {
-			// Apparently not a page-rendering request - the Site Kit filter (googlesitekit_amp_gtag_opt) was not executed.
+		$analytics = \Newspack\Google_Services_Connection::get_site_kit_analytics_module();
+		if ( ! $analytics || ! $analytics->is_connected() ) {
 			return;
+		}
+		$analytics_settings = $analytics->get_settings()->get();
+		if ( ! isset( $analytics_settings['propertyID'] ) ) {
+			return;
+		}
+		$tracking_id = $analytics_settings['propertyID'];
+
+		// Config for amp-analytics.
+		$config = [
+			'optoutElementId' => '__gaOptOutExtension',
+			'vars'            => [
+				'gtag_id' => $tracking_id,
+				'config'  => [
+					$tracking_id => [
+						'groups' => 'default',
+						'linker' => [
+							'domains' => [ wp_parse_url( home_url(), PHP_URL_HOST ) ],
+						],
+					],
+				],
+			],
+		];
+
+		// The Google Analytics User ID is used to associate multiple user sessions and activities with a unique ID.
+		// See https://support.google.com/tagmanager/answer/4565987.
+		if ( is_user_logged_in() ) {
+			$config['vars']['user_id'] = get_current_user_id();
 		}
 
 		// Gather all custom events.

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.91.2-hotfix.1
+ * Version: 1.91.2-hotfix.2
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.91.2-hotfix.1' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.91.2-hotfix.2' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.91.1
+ * Version: 1.91.2-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.91.1' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.91.2-hotfix.1' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.91.1",
+  "version": "1.91.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.91.1",
+      "version": "1.91.2-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.18.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.91.2-hotfix.1",
+  "version": "1.91.2-hotfix.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.91.2-hotfix.1",
+      "version": "1.91.2-hotfix.2",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.91.2-hotfix.1",
+  "version": "1.91.2-hotfix.2",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.91.1",
+  "version": "1.91.2-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removed dependence on `googlesitekit_amp_gtag_opt` Site Kit hook firing for reporting custom events on AMP pages. Before, the code depended on this hook firing in order to glean the default config for `amp-analytics`. Now, the config will be created based on settings read from the Site Kit settings.

### How to test the changes in this Pull Request:

1. Connect Site Kit & Analytics module
2. Ensure AMP is on and the NTG events enabled in Newspack Analytics wizard 
3. Load a page, observe the NTG events are sent*

\* look for requests with `collect` query and inspect the payload

This can also be tested with Campaigns' custom events, too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->