### PR TITLE
feat(plugins-screen): update button to use primary style

### DIFF
--- a/assets/plugins-screen/plugins-screen.js
+++ b/assets/plugins-screen/plugins-screen.js
@@ -37,6 +37,7 @@ import './plugins-screen.scss';
 		};
 		modalActionEl.setAttribute( 'href', newspack_plugin_info.plugin_review_link );
 		modalActionEl.setAttribute( 'target', '_blank' );
+		modalActionEl.classList.add( 'button-primary' );
 		modalActionEl.innerText = wp.i18n.__( 'Plugin Review Form', 'newspack' );
 
 		modalEl.appendChild( modalContentEl );

--- a/assets/plugins-screen/plugins-screen.scss
+++ b/assets/plugins-screen/plugins-screen.scss
@@ -1,4 +1,3 @@
-@use '../shared/scss/colors';
 @use '~@wordpress/base-styles/colors' as wp-colors;
 
 /**
@@ -60,23 +59,6 @@ table.plugins {
 			display: flex;
 			justify-content: flex-end;
 			padding-top: 20px;
-			a {
-				padding: 11px 19px;
-				border-radius: 2px;
-				border: none;
-				color: wp-colors.$white;
-				background-color: colors.$primary-500;
-				text-decoration: none;
-
-				&:hover,
-				&:active {
-					background: colors.$primary-600;
-				}
-
-				&:focus {
-					box-shadow: inset 0 0 0 1px #fff, 0 0 0 2px colors.$primary-500;
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#2005 introduces a modal prompting the user to fill out a plugin review form before installing a new plugin. In this PR I simplify the custom button to use the `button-primary` class so we don't need any custom CSS.

We should use default wp admin colours here because we're outside of Newspack Plugin

![](https://user-images.githubusercontent.com/177929/192239076-fcd7a5d1-b501-4f12-9f93-1e71198280bf.png)

### How to test the changes in this Pull Request:

1. Load the WP admin plugin install screen (/wp-admin/plugin-install.php) and observe the modal
2. Switch to this branch
3. Reload the install screen and observe the "Plugin Review Form" button

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->