### PR TITLE
feat(reader-auth): improved otp ux

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -438,6 +438,8 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 							if ( prev ) {
 								prev.focus();
 							}
+							values[ i ] = '';
+							otpCodeInput.value = values.join( '' );
 							break;
 						case 'ArrowLeft':
 							ev.preventDefault();

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -414,6 +414,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 				return;
 			}
 			const inputContainer = originalInput.parentNode;
+			inputContainer.removeChild( originalInput );
 			const values = [];
 			const otpCodeInput = document.createElement( 'input' );
 			otpCodeInput.setAttribute( 'type', 'hidden' );
@@ -492,7 +493,6 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 				} );
 				inputContainer.appendChild( digit );
 			}
-			inputContainer.removeChild( originalInput );
 		} );
 
 		/**

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -454,7 +454,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 							}
 							break;
 						default:
-							if ( ev.key.match( /^[0-9]/ ) && ev.key.length === 1 ) {
+							if ( ev.key.match( /^[0-9]$/ ) ) {
 								ev.preventDefault();
 								ev.target.value = ev.key;
 								ev.target.dispatchEvent(
@@ -471,7 +471,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					}
 				} );
 				digit.addEventListener( 'input', ev => {
-					if ( ev.target.value.match( /^[0-9]/ ) && ev.target.value.length === 1 ) {
+					if ( ev.target.value.match( /^[0-9]$/ ) ) {
 						values[ i ] = ev.target.value;
 					} else {
 						ev.target.value = '';
@@ -485,7 +485,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 						return;
 					}
 					for ( let j = 0; j < length; j++ ) {
-						if ( paste[ j ].match( /^[0-9]/ ) ) {
+						if ( paste[ j ].match( /^[0-9]$/ ) ) {
 							const digitInput = inputContainer.querySelector( `[data-index="${ j }"]` );
 							digitInput.value = paste[ j ];
 							values[ j ] = paste[ j ];

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -483,9 +483,11 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					}
 					otpCodeInput.value = paste;
 					for ( let j = 0; j < length; j++ ) {
-						const digitInput = inputContainer.querySelector( `[data-index="${ j }"]` );
-						digitInput.value = paste[ j ];
-						values[ j ] = paste[ j ];
+						if ( paste[ j ].match( /[0-9]/ ) ) {
+							const digitInput = inputContainer.querySelector( `[data-index="${ j }"]` );
+							digitInput.value = paste[ j ];
+							values[ j ] = paste[ j ];
+						}
 					}
 				} );
 				inputContainer.appendChild( digit );

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -408,12 +408,12 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 		 * OTP Input
 		 */
 		const otpInputs = document.querySelectorAll( 'input[name="otp_code"]' );
-		otpInputs.forEach( input => {
-			const length = parseInt( input.getAttribute( 'maxlength' ) );
+		otpInputs.forEach( originalInput => {
+			const length = parseInt( originalInput.getAttribute( 'maxlength' ) );
 			if ( ! length ) {
 				return;
 			}
-			const inputContainer = input.parentNode;
+			const inputContainer = originalInput.parentNode;
 			const values = [];
 			const otpCodeInput = document.createElement( 'input' );
 			otpCodeInput.setAttribute( 'type', 'hidden' );
@@ -492,7 +492,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 				} );
 				inputContainer.appendChild( digit );
 			}
-			inputContainer.removeChild( input );
+			inputContainer.removeChild( originalInput );
 		} );
 
 		/**

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -469,7 +469,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					}
 				} );
 				digit.addEventListener( 'input', ev => {
-					if ( ev.target.value.match( /^[0-9]/ ) && ev.key.length === 1 ) {
+					if ( ev.target.value.match( /^[0-9]/ ) && ev.target.value.length === 1 ) {
 						values[ i ] = ev.target.value;
 					} else {
 						ev.target.value = '';

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -452,7 +452,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 							}
 							break;
 						default:
-							if ( ev.key.match( /[0-9]/ ) ) {
+							if ( ev.key.match( /^[0-9]/ ) && ev.key.length === 1 ) {
 								ev.preventDefault();
 								ev.target.value = ev.key;
 								ev.target.dispatchEvent(
@@ -469,7 +469,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					}
 				} );
 				digit.addEventListener( 'input', ev => {
-					if ( ev.target.value.match( /[0-9]/ ) ) {
+					if ( ev.target.value.match( /^[0-9]/ ) && ev.key.length === 1 ) {
 						values[ i ] = ev.target.value;
 					} else {
 						ev.target.value = '';
@@ -482,14 +482,14 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					if ( paste.length !== length ) {
 						return;
 					}
-					otpCodeInput.value = paste;
 					for ( let j = 0; j < length; j++ ) {
-						if ( paste[ j ].match( /[0-9]/ ) ) {
+						if ( paste[ j ].match( /^[0-9]/ ) ) {
 							const digitInput = inputContainer.querySelector( `[data-index="${ j }"]` );
 							digitInput.value = paste[ j ];
 							values[ j ] = paste[ j ];
 						}
 					}
+					otpCodeInput.value = values.join( '' );
 				} );
 				inputContainer.appendChild( digit );
 			}

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -405,6 +405,95 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 		} );
 
 		/**
+		 * OTP Input
+		 */
+		const otpInputs = document.querySelectorAll( 'input[name="otp_code"]' );
+		otpInputs.forEach( input => {
+			const length = parseInt( input.getAttribute( 'maxlength' ) );
+			if ( ! length ) {
+				return;
+			}
+			const inputContainer = input.parentNode;
+			const values = [];
+			const otpCodeInput = document.createElement( 'input' );
+			otpCodeInput.setAttribute( 'type', 'hidden' );
+			otpCodeInput.setAttribute( 'name', 'otp_code' );
+			inputContainer.appendChild( otpCodeInput );
+			for ( let i = 0; i < length; i++ ) {
+				const digit = document.createElement( 'input' );
+				digit.setAttribute( 'type', 'text' );
+				digit.setAttribute( 'maxlength', '1' );
+				digit.setAttribute( 'pattern', '[0-9]' );
+				digit.setAttribute( 'autocomplete', 'off' );
+				digit.setAttribute( 'inputmode', 'numeric' );
+				digit.setAttribute( 'data-index', i );
+				digit.addEventListener( 'keydown', ev => {
+					const prev = inputContainer.querySelector( `[data-index="${ i - 1 }"]` );
+					const next = inputContainer.querySelector( `[data-index="${ i + 1 }"]` );
+					switch ( ev.key ) {
+						case 'Backspace':
+							ev.preventDefault();
+							ev.target.value = '';
+							if ( prev ) {
+								prev.focus();
+							}
+							break;
+						case 'ArrowLeft':
+							ev.preventDefault();
+							if ( prev ) {
+								prev.focus();
+							}
+							break;
+						case 'ArrowRight':
+							ev.preventDefault();
+							if ( next ) {
+								next.focus();
+							}
+							break;
+						default:
+							if ( ev.key.match( /[0-9]/ ) ) {
+								ev.preventDefault();
+								ev.target.value = ev.key;
+								ev.target.dispatchEvent(
+									new Event( 'input', {
+										bubbles: true,
+										cancelable: true,
+									} )
+								);
+								if ( next ) {
+									next.focus();
+								}
+							}
+							break;
+					}
+				} );
+				digit.addEventListener( 'input', ev => {
+					if ( ev.target.value.match( /[0-9]/ ) ) {
+						values[ i ] = ev.target.value;
+					} else {
+						ev.target.value = '';
+					}
+					otpCodeInput.value = values.join( '' );
+				} );
+				digit.addEventListener( 'paste', ev => {
+					ev.preventDefault();
+					const paste = ( ev.clipboardData || window.clipboardData ).getData( 'text' );
+					if ( paste.length !== length ) {
+						return;
+					}
+					otpCodeInput.value = paste;
+					for ( let j = 0; j < length; j++ ) {
+						const digitInput = inputContainer.querySelector( `[data-index="${ j }"]` );
+						digitInput.value = paste[ j ];
+						values[ j ] = paste[ j ];
+					}
+				} );
+				inputContainer.appendChild( digit );
+			}
+			inputContainer.removeChild( input );
+		} );
+
+		/**
 		 * Third party auth.
 		 */
 		const loginsElements = document.querySelectorAll( '.newspack-reader__logins' );

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -264,6 +264,19 @@
 			input[type='password'] {
 				width: 100%;
 			}
+			.otp-field {
+				display: flex;
+				gap: 0.4rem;
+				justify-content: space-between;
+				margin: 0.8rem 0;
+				input[type='text'] {
+					flex: 1 1 100%;
+					font-size: 1.2rem;
+					text-align: center;
+					font-family: monospace;
+					caret-color: transparent;
+				}
+			}
 			input[name='otp_code'] {
 				font-size: 1.2rem;
 				text-align: center;

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -267,14 +267,14 @@
 			.otp-field {
 				display: flex;
 				gap: 0.4rem;
-				justify-content: space-between;
+				justify-content: center;
 				margin: 0.8rem 0;
 				input[type='text'] {
 					flex: 1 1 100%;
-					font-size: 1.2rem;
-					text-align: center;
 					font-family: monospace;
-					caret-color: transparent;
+					font-size: 1.2rem;
+					max-width: 2.4rem;
+					text-align: center;
 				}
 			}
 			input[name='otp_code'] {

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -837,8 +837,8 @@ final class Reader_Activation {
 							<input name="npe" type="email" placeholder="<?php \esc_attr_e( 'Enter your email address', 'newspack' ); ?>" />
 							<?php self::render_honeypot_field(); ?>
 						</div>
-						<div class="components-form__field" data-action="otp">
-							<input name="otp_code" type="text" placeholder="<?php \esc_attr_e( '6-digit code', 'newspack' ); ?>" />
+						<div class="components-form__field otp-field" data-action="otp">
+							<input name="otp_code" type="text" maxlength="<?php echo \esc_attr( Magic_Link::OTP_LENGTH ); ?>" placeholder="<?php \esc_attr_e( '6-digit code', 'newspack' ); ?>" />
 						</div>
 						<div class="components-form__field" data-action="pwd">
 							<input name="password" type="password" placeholder="<?php \esc_attr_e( 'Enter your password', 'newspack' ); ?>" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements enhancements to the OTP input UX.

<img width="638" alt="image" src="https://user-images.githubusercontent.com/820752/192562400-160d684a-656b-47ca-af99-90be0a7f55cc.png">

Each digit for the code is treated as a single input. Once a valid number is entered, the next input is focused. It also supports navigating through arrow keys and pasting from the clipboard from any position of the OTP input.

### How to test the changes in this Pull Request:

1. Check out this branch and with reader activation enabled, send an authorization code to a reader account
2. Confirm you see the new UI for entering the code
3. Attempt to enter a non-numeric value into any digit
4. Navigate between the OTP code using arrows and confirm it works as expected
5. Navigate between the OTP code using tab and shift+tab and confirm it works as expected
6. Enter numeric values and confirm the values are applied smoothly
7. Use backspace to clear the values
8. Copy the valid OTP code received, paste it into any digit, and confirm it's applied correctly
9. Sign in and confirm the pasted value is sent
10. Log out, send another authorization code
11. Attempt to copy and paste a random text and confirm it doesn't apply
12. Manually enter the valid code, submit, and confirm you're signed in

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->