### PR TITLE
hotfix: disable author filter for co-authors

### DIFF
--- a/includes/author-filter/class-author-filter.php
+++ b/includes/author-filter/class-author-filter.php
@@ -61,6 +61,11 @@ class Author_Filter {
 	 */
 	public static function author_filters_admin( $post_type ) {
 
+		// Disable this for sites with co authors plus enabled until we fix its issue with large sites.
+		if ( self::is_coauthors_plus_enabled( $post_type ) ) {
+			return;
+		}
+
 		$excluded_post_types = [ 'attachment', 'revision', 'nav_menu_item' ];
 
 		if ( in_array( $post_type, $excluded_post_types, true ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Disable Authors filter if Co-Authos Plus plugin is enabled

### How to test the changes in this Pull Request:

1. Verify Posts page and see the authors filter
2. Activate CAP
3. See the filter is gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->