### PR TITLE
feat: custom email sender for reader activation

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -128,6 +128,24 @@ export default withWizardScreen( () => {
 							title={ __( 'Emails', 'newspack' ) }
 							description={ __( 'Customize emails sent to readers.', 'newspack' ) }
 						/>
+						<TextControl
+							label={ __( 'Sender name', 'newspack' ) }
+							{ ...getSharedProps( 'sender_name', 'text' ) }
+						/>
+						<Grid columns={ 2 } gutter={ 16 }>
+							<TextControl
+								label={ __( 'Sender email address', 'newspack' ) }
+								{ ...getSharedProps( 'sender_email_address', 'text' ) }
+							/>
+							<TextControl
+								label={ __( 'Contact email address', 'newspack' ) }
+								help={ __(
+									'This email will be used as "Reply-To" for transactional emails as well.',
+									'newspack'
+								) }
+								{ ...getSharedProps( 'contact_email_address', 'text' ) }
+							/>
+						</Grid>
 						{ emails.map( email => (
 							<ActionCard
 								key={ email.post_id }

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -374,10 +374,7 @@ class Emails {
 	 * @return string
 	 */
 	public static function get_reply_to_email() {
-		$reply_to_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'contact_email_address', '' );
-		if ( empty( $reply_to_email ) ) {
-			$reply_to_email = self::get_from_email();
-		}
+		$reply_to_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'contact_email_address', self::get_from_email() );
 		return apply_filters( 'newspack_reply_to_email', $reply_to_email );
 	}
 
@@ -389,7 +386,8 @@ class Emails {
 	 * @return string Name used as the sender for Newspack emails.
 	 */
 	public static function get_from_name() {
-		return apply_filters( 'newspack_from_name', get_bloginfo( 'name' ) );
+		$from_name = get_option( Reader_Activation::OPTIONS_PREFIX . 'sender_name', get_bloginfo( 'name' ) );
+		return apply_filters( 'newspack_from_name', $from_name );
 	}
 
 	/**

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -126,6 +126,7 @@ class Emails {
 				'email_config_name_meta' => self::EMAIL_CONFIG_NAME_META,
 				'from_name'              => self::get_from_name(),
 				'from_email'             => self::get_from_email(),
+				'reply_to_email'         => self::get_reply_to_email(),
 			]
 		);
 		wp_enqueue_script( $handle );
@@ -166,14 +167,14 @@ class Emails {
 	 * @param array  $placeholders Placeholders to replace in email.
 	 */
 	public static function get_email_payload( $config_name, $placeholders = [] ) {
-		$email_config = self::get_email_config_by_type( $config_name );
-		$html         = $email_config['html_payload'];
-		$from_email   = $email_config['from_email'];
-		$placeholders = array_merge(
+		$email_config   = self::get_email_config_by_type( $config_name );
+		$html           = $email_config['html_payload'];
+		$reply_to_email = $email_config['reply_to_email'];
+		$placeholders   = array_merge(
 			[
 				[
 					'template' => '*CONTACT_EMAIL*',
-					'value'    => sprintf( '<a href="mailto:%s">%s</a>', $from_email, $from_email ),
+					'value'    => sprintf( '<a href="mailto:%s">%s</a>', $reply_to_email, $reply_to_email ),
 				],
 				[
 					'template' => '*SITE_URL*',
@@ -223,14 +224,19 @@ class Emails {
 			return 'text/html';
 		};
 
+		$headers = [
+			sprintf( 'From: %s <%s>', $email_config['from_name'], $email_config['from_email'] ),
+		];
+		if ( $email_config['from_email'] !== $email_config['reply_to_email'] ) {
+			$headers[] = sprintf( 'Reply-To: %s <%s>', $email_config['from_name'], $email_config['reply_to_email'] );
+		}
+
 		add_filter( 'wp_mail_content_type', $email_content_type );
 		$email_send_result = wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
 			$to,
 			$email_config['subject'],
 			self::get_email_payload( $config_name, $placeholders ),
-			[
-				sprintf( 'From: %s <%s>', $email_config['from_name'], $email_config['from_email'] ),
-			]
+			$headers
 		);
 		remove_filter( 'wp_mail_content_type', $email_content_type );
 
@@ -320,16 +326,17 @@ class Emails {
 			return false;
 		}
 		$serialized_email = [
-			'label'        => $email_config['label'],
-			'description'  => $email_config['description'],
-			'post_id'      => $post_id,
+			'label'          => $email_config['label'],
+			'description'    => $email_config['description'],
+			'post_id'        => $post_id,
 			// Make the edit link relative.
-			'edit_link'    => str_replace( site_url(), '', get_edit_post_link( $post_id, '' ) ),
-			'subject'      => get_the_title( $post_id ),
-			'from_name'    => isset( $email_config['from_name'] ) ? $email_config['from_name'] : self::get_from_name(),
-			'from_email'   => isset( $email_config['from_email'] ) ? $email_config['from_email'] : self::get_from_email(),
-			'status'       => get_post_status( $post_id ),
-			'html_payload' => $html_payload,
+			'edit_link'      => str_replace( site_url(), '', get_edit_post_link( $post_id, '' ) ),
+			'subject'        => get_the_title( $post_id ),
+			'from_name'      => isset( $email_config['from_name'] ) ? $email_config['from_name'] : self::get_from_name(),
+			'from_email'     => isset( $email_config['from_email'] ) ? $email_config['from_email'] : self::get_from_email(),
+			'reply_to_email' => isset( $email_config['reply_to_email'] ) ? $email_config['reply_to_email'] : self::get_reply_to_email(),
+			'status'         => get_post_status( $post_id ),
+			'html_payload'   => $html_payload,
 		];
 
 		return $serialized_email;
@@ -343,19 +350,35 @@ class Emails {
 	 * @return string Email address used as the sender for Newspack emails.
 	 */
 	public static function get_from_email() {
-		// Get the site domain and get rid of www.
-		$sitename   = wp_parse_url( network_home_url(), PHP_URL_HOST );
-		$from_email = 'no-reply@';
+		$from_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'sender_email_address', '' );
+		if ( empty( $from_email ) ) {
+			// Get the site domain and get rid of www.
+			$sitename   = wp_parse_url( network_home_url(), PHP_URL_HOST );
+			$from_email = 'no-reply@';
 
-		if ( null !== $sitename ) {
-			if ( 'www.' === substr( $sitename, 0, 4 ) ) {
-				$sitename = substr( $sitename, 4 );
+			if ( null !== $sitename ) {
+				if ( 'www.' === substr( $sitename, 0, 4 ) ) {
+					$sitename = substr( $sitename, 4 );
+				}
+
+				$from_email .= $sitename;
 			}
-
-			$from_email .= $sitename;
 		}
 
 		return apply_filters( 'newspack_from_email', $from_email );
+	}
+
+	/**
+	 * Get the "reply-to" email address used to send all transactional emails.
+	 *
+	 * @return string
+	 */
+	public static function get_reply_to_email() {
+		$reply_to_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'contact_email_address', '' );
+		if ( empty( $reply_to_email ) ) {
+			$reply_to_email = self::get_from_email();
+		}
+		return apply_filters( 'newspack_reply_to_email', $reply_to_email );
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -172,6 +172,9 @@ final class Reader_Activation {
 			'sync_esp_delete'             => true,
 			'active_campaign_master_list' => '',
 			'emails'                      => Emails::get_emails( array_values( Reader_Activation_Emails::EMAIL_TYPES ), false ),
+			'sender_name'                 => Emails::get_from_name(),
+			'sender_email_address'        => Emails::get_from_email(),
+			'contact_email_address'       => Emails::get_reply_to_email(),
 		];
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements a customizable sender for RAS emails. The "Contact email address" will be used as Reply-To but also as the `*CONTACT_EMAIL*` placeholder value.

<img width="1114" alt="image" src="https://user-images.githubusercontent.com/820752/192803189-d1041808-c8a4-4aa8-9c5d-3ca085f6b508.png">

### How to test the changes in this Pull Request:

1. Check out this branch and visit the Engagement wizard
2. Confirm the new form fields as displayed above
3. Edit the values and on a new session authenticate a reader through email
4. Confirm the email sender and "Reply-To" header is updated

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->