### PR TITLE
fix(auth): ensure OTP on reader state changes

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -271,9 +271,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					emailInput.focus();
 				}
 			}
-			setFormAction(
-				readerActivation.getOTPHash() ? 'otp' : readerActivation.getAuthStrategy() || 'pwd'
-			);
+			setFormAction( readerActivation.getAuthStrategy() || 'pwd' );
 			readerActivation.on( 'reader', () => {
 				if ( readerActivation.getOTPHash() ) {
 					setFormAction( 'otp' );

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -271,7 +271,14 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 					emailInput.focus();
 				}
 			}
-			setFormAction( readerActivation.getAuthStrategy() || 'pwd' );
+			setFormAction(
+				readerActivation.getOTPHash() ? 'otp' : readerActivation.getAuthStrategy() || 'pwd'
+			);
+			readerActivation.on( 'reader', () => {
+				if ( readerActivation.getOTPHash() ) {
+					setFormAction( 'otp' );
+				}
+			} );
 			container.querySelectorAll( '[data-set-action]' ).forEach( item => {
 				item.addEventListener( 'click', function ( ev ) {
 					ev.preventDefault();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adjusts the Sign In modal to update the auth method when the reader state changes. If an OTP hash becomes available, means a code has been sent and the method should be OTP.

### How to test the changes in this Pull Request:

1. On master and a fresh session, use a registered email on the Reader Registration block
2. Confirm the success message from the block and click "My Account"
3. Confirm you're prompted to put in a password
4. Check out this branch, repeat steps 1 and 2 and confirm you're prompted to put in the OTP code

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->