### PR TITLE
feat: show unregistered RAS UI to admins

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -137,13 +137,13 @@ function render_block( $attrs, $content ) {
 		}
 	}
 
-	$is_admin_preview = \method_exists( '\Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin();
+	$is_admin_preview = method_exists( 'Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin();
 
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if (
 		! \is_preview() &&
 		! $is_admin_preview &&
-		( ! method_exists( '\Newspack_Popups', 'is_preview_request' ) || ! \Newspack_Popups::is_preview_request() ) &&
+		( ! method_exists( 'Newspack_Popups', 'is_preview_request' ) || ! \Newspack_Popups::is_preview_request() ) &&
 		(
 			\is_user_logged_in() ||
 			( isset( $_GET['newspack_reader'] ) && absint( $_GET['newspack_reader'] ) )

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -140,6 +140,7 @@ function render_block( $attrs, $content ) {
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if (
 		! \is_preview() &&
+		( ! method_exists( '\Newspack_Popups', 'is_user_admin' ) || ! \Newspack_Popups::is_user_admin() ) &&
 		( ! method_exists( '\Newspack_Popups', 'is_preview_request' ) || ! \Newspack_Popups::is_preview_request() ) &&
 		(
 			\is_user_logged_in() ||

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -197,7 +197,16 @@ function render_block( $attrs, $content ) {
 					if ( ! empty( $lists ) ) {
 						if ( 1 === count( $lists ) && $attrs['hideSubscriptionInput'] ) {
 							?>
-							<input type="hidden" name="lists[]" value="<?php echo \esc_attr( key( $lists ) ); ?>">
+							<input
+							<?php
+							if ( \method_exists( '\Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin() ) :
+								?>
+								disabled
+								<?php endif; ?>
+								type="hidden"
+								name="lists[]"
+								value="<?php echo \esc_attr( key( $lists ) ); ?>"
+							/>
 							<?php
 						} else {
 							Reader_Activation::render_subscription_lists_inputs(
@@ -215,9 +224,25 @@ function render_block( $attrs, $content ) {
 					<div class="newspack-registration__main">
 						<div>
 							<div class="newspack-registration__inputs">
-								<input type="email" name="npe" autocomplete="email" placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>" />
+								<input
+								<?php
+								if ( \method_exists( '\Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin() ) :
+									?>
+									disabled
+									<?php endif; ?>
+									type="email" name="npe" autocomplete="email"
+									placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
+								/>
 								<?php Reader_Activation::render_honeypot_field( $attrs['placeholder'] ); ?>
-								<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
+								<input
+								<?php
+								if ( \method_exists( '\Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin() ) :
+									?>
+									disabled
+									<?php endif; ?>
+									type="submit"
+									value="<?php echo \esc_attr( $attrs['label'] ); ?>"
+								/>
 							</div>
 							<?php Reader_Activation::render_third_party_auth(); ?>
 							<div class="newspack-registration__response <?php echo ( empty( $message ) ) ? 'newspack-registration--hidden' : null; ?>">

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -137,10 +137,12 @@ function render_block( $attrs, $content ) {
 		}
 	}
 
+	$is_admin_preview = \method_exists( '\Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin();
+
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if (
 		! \is_preview() &&
-		( ! method_exists( '\Newspack_Popups', 'is_user_admin' ) || ! \Newspack_Popups::is_user_admin() ) &&
+		! $is_admin_preview &&
 		( ! method_exists( '\Newspack_Popups', 'is_preview_request' ) || ! \Newspack_Popups::is_preview_request() ) &&
 		(
 			\is_user_logged_in() ||
@@ -164,8 +166,6 @@ function render_block( $attrs, $content ) {
 	if ( ! empty( \wp_strip_all_tags( $attrs['signedInLabel'] ) ) ) {
 		$success_login_markup = '<p class="has-text-align-center">' . $attrs['signedInLabel'] . '</p>';
 	}
-
-	$is_admin_preview = \method_exists( '\Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin();
 
 	ob_start();
 	?>

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -165,6 +165,8 @@ function render_block( $attrs, $content ) {
 		$success_login_markup = '<p class="has-text-align-center">' . $attrs['signedInLabel'] . '</p>';
 	}
 
+	$is_admin_preview = \method_exists( '\Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin();
+
 	ob_start();
 	?>
 	<div class="newspack-registration <?php echo esc_attr( get_block_classes( $attrs ) ); ?>">
@@ -199,7 +201,7 @@ function render_block( $attrs, $content ) {
 							?>
 							<input
 							<?php
-							if ( \method_exists( '\Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin() ) :
+							if ( $is_admin_preview ) :
 								?>
 								disabled
 								<?php endif; ?>
@@ -226,7 +228,7 @@ function render_block( $attrs, $content ) {
 							<div class="newspack-registration__inputs">
 								<input
 								<?php
-								if ( \method_exists( '\Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin() ) :
+								if ( $is_admin_preview ) :
 									?>
 									disabled
 									<?php endif; ?>
@@ -236,7 +238,7 @@ function render_block( $attrs, $content ) {
 								<?php Reader_Activation::render_honeypot_field( $attrs['placeholder'] ); ?>
 								<input
 								<?php
-								if ( \method_exists( '\Newspack_Popups', 'is_user_admin' ) && \Newspack_Popups::is_user_admin() ) :
+								if ( $is_admin_preview ) :
 									?>
 									disabled
 									<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When viewing RAS components as a logged-in editor or admin user, force the UI to show the "unregistered" state.

### How to test the changes in this Pull Request:

Instructions in https://github.com/Automattic/newspack-popups/pull/979.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->