### PR TITLE
fix: fire ini-load analytics events on DOMContentLoaded, not load

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -888,7 +888,7 @@ class Analytics {
 						observer.observe(elements[i], { attributes: true });
 					}
 				} else {
-					window.addEventListener('load', handleEvent)
+					window.addEventListener('DOMContentLoaded', handleEvent)
 				}
 			} )();
 		</script>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For non-AMP sites, `ini-load` AMP Analytics events are triggered on the [window `load` event](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event). This event only fires after all of the page's resources have been fully loaded, including HTML content, images, and JS (first and third-party). On live non-AMP pages, it seems that this event is sometimes never fired if any resources fail to fully load for whatever reason, which is more often than might be expected. This PR sidesteps the issue by triggering `ini-load` events on the [`DOMContentLoaded` event](https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event) instead, which fires as soon as the document's HTML is fully loaded. This makes these events much less likely to be blocked by external resources failing to load.

Closes https://github.com/Automattic/newspack-popups/issues/981.

### How to test the changes in this Pull Request:

1. Turn off AMP or turn on AMP Transitional mode on your test site.
2. In your browser's Dev Tools > Network tab, load a page that will display at least one prompt and filter requests by type: JS. Pick any JS file and temporarily block the request. This will prevent the window `load` event handler from ever firing.
3. On `master`, refresh the page and filter network requests by "Newspack Announcement." Observe that the "Load" events don't fire, but "Seen" events do if you scroll the prompt into the viewport.
4. Check out this branch and repeat step 3. Confirm that "Load" events do fire once the page is loaded.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->