### PR TITLE
Hotfix: donations sync errors

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -485,7 +485,7 @@ class Stripe_Connection {
 		// Verify the webhook signature (https://stripe.com/docs/webhooks/signatures).
 		$webhook = get_option( self::STRIPE_WEBHOOK_OPTION_NAME, false );
 		if ( false === $webhook || ! isset( $webhook['secret'], $_SERVER['HTTP_STRIPE_SIGNATURE'] ) ) {
-			return new \WP_Error( 'newspack_webhook_missing_data' );
+			return new \WP_Error( 'newspack_webhook_missing_verification_data' );
 		}
 		try {
 			$sig_header = sanitize_text_field( $_SERVER['HTTP_STRIPE_SIGNATURE'] );
@@ -496,7 +496,7 @@ class Stripe_Connection {
 				$webhook['secret']
 			);
 		} catch ( \Throwable $e ) {
-			return new \WP_Error( 'newspack_webhook_error' );
+			return new \WP_Error( 'newspack_webhook_verification_error' );
 		}
 
 		$payload = $request['data']['object'];

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -511,9 +511,12 @@ class Stripe_Connection {
 
 		switch ( $request['type'] ) {
 			case 'charge.succeeded':
-				$payment           = $payload;
-				$metadata          = $payment['metadata'];
-				$customer          = self::get_customer_by_id( $payment['customer'] );
+				$payment  = $payload;
+				$metadata = $payment['metadata'];
+				$customer = self::get_customer_by_id( $payment['customer'] );
+				if ( \is_wp_error( $customer ) ) {
+					return $customer;
+				}
 				$amount_normalised = self::normalise_amount( $payment['amount'], $payment['currency'] );
 				$client_id         = isset( $customer['metadata']['clientId'] ) ? $customer['metadata']['clientId'] : null;
 				$origin            = isset( $customer['metadata']['origin'] ) ? $customer['metadata']['origin'] : null;
@@ -655,6 +658,9 @@ class Stripe_Connection {
 				break;
 			case 'customer.subscription.deleted':
 				$customer = self::get_customer_by_id( $payload['customer'] );
+				if ( \is_wp_error( $customer ) ) {
+					return $customer;
+				}
 
 				if ( Reader_Activation::is_enabled() && method_exists( '\Newspack_Newsletters_Subscription', 'add_contact' ) ) {
 					$sub_end_date = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payload['ended_at'] );
@@ -695,7 +701,11 @@ class Stripe_Connection {
 				break;
 			case 'customer.subscription.updated':
 				if ( Reader_Activation::is_enabled() && method_exists( '\Newspack_Newsletters_Subscription', 'add_contact' ) ) {
-					$customer     = self::get_customer_by_id( $payload['customer'] );
+					$customer = self::get_customer_by_id( $payload['customer'] );
+					if ( \is_wp_error( $customer ) ) {
+						return $customer;
+					}
+
 					$sub_end_date = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payload['ended_at'] );
 					$contact      = [
 						'email'    => $customer['email'],

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -263,12 +263,33 @@ class WooCommerce_Connection {
 	}
 
 	/**
+	 * Find order by Stripe transaction ID.
+	 *
+	 * @param string $transaction_id Transaction ID.
+	 */
+	private static function find_order_by_transaction_id( $transaction_id ) {
+		global $wpdb;
+		return $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key=%s AND meta_value=%s;", '_transaction_id', $transaction_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			ARRAY_A
+		);
+	}
+
+	/**
 	 * Add a donation transaction to WooCommerce.
 	 *
 	 * @param object $order_data Order data.
 	 */
 	public static function create_transaction( $order_data ) {
-		Logger::log( 'Creating an order' );
+		$transaction_id = $order_data['stripe_id'];
+
+		$found_order = self::find_order_by_transaction_id( $transaction_id );
+		if ( ! empty( $found_order ) ) {
+			Logger::log( 'NOT creating an order, it was already synced.' );
+			return;
+		}
+
+		Logger::log( 'Creating an order.' );
 
 		$frequency = $order_data['frequency'];
 
@@ -299,7 +320,7 @@ class WooCommerce_Connection {
 		// Metadata for woocommerce-gateway-stripe plugin.
 		$order->set_payment_method( 'stripe' );
 		$order->set_payment_method_title( __( 'Stripe via Newspack', 'newspack' ) );
-		$order->set_transaction_id( $order_data['stripe_id'] );
+		$order->set_transaction_id( $transaction_id );
 		$order->add_meta_data( '_stripe_customer_id', $order_data['stripe_customer_id'] );
 		$order->add_meta_data( '_stripe_charge_captured', 'yes' );
 		$order->add_meta_data( '_stripe_fee', $order_data['stripe_fee'] );

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -152,7 +152,10 @@ class WooCommerce_Connection {
 				$metadata[ $metadata_keys['product_name'] ] = reset( $order_items )->get_name();
 			}
 			$metadata[ $metadata_keys['last_payment_amount'] ] = $order->get_total();
-			$metadata[ $metadata_keys['last_payment_date'] ]   = $order->get_date_paid()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
+			$order_date_paid                                   = $order->get_date_paid();
+			if ( null !== $order_date_paid ) {
+				$metadata[ $metadata_keys['last_payment_date'] ] = $order_date_paid->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
+			}
 
 			// Subscription donation.
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Adds handling of two potential error situations:
    1. The result of `Stripe_Connection::get_customer_by_id` may be an error
    2. The result of `$order->get_date_paid()` may be `null` 
2. Prevents duplicate WC order creation. This can happen when the Stripe webhook is retired after a failure, but the failure was unrelated to WC order creation. 

### How to test the changes in this Pull Request:

Hard to test item 1, so it's more about a sanity check. These situations have been seen in the wild, maybe as results of race conditions.

Testing item 2:

1. Configure a site to use Stripe as the Reader Revenue platform, and make sure it's reachable for webhooks
3. Activate WooCommerce plugins, so transactions are synced to WC
4. On `master`, make a donation and then resend the successful webhook via Stripe dashboard
5. Observe a duplicate WC order is created
6. Repeat on this branch, observe no duplicate order is created

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->