### PR TITLE
fix(ads): rename GAM methods

### DIFF
--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -10,7 +10,6 @@ namespace Newspack;
 use \WP_Error;
 
 use Newspack_Ads\Providers\GAM_Model;
-use Newspack_Ads\Providers\GAM_API;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -57,7 +56,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function update_gam_credentials( $credentials ) {
 		return $this->is_configured() ?
-			GAM_API::update_gam_credentials( $credentials ) :
+			GAM_Model::update_service_account_credentials( $credentials ) :
 			$this->unconfigured_error();
 	}
 
@@ -68,7 +67,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function remove_gam_credentials() {
 		return $this->is_configured() ?
-			GAM_API::remove_gam_credentials() :
+			GAM_Model::remove_service_account_credentials() :
 			$this->unconfigured_error();
 	}
 
@@ -139,7 +138,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function is_gam_connected() {
 		return $this->is_configured() ?
-			GAM_Model::is_gam_connected() :
+			GAM_Model::is_api_connected() :
 			$this->unconfigured_error();
 	}
 
@@ -150,7 +149,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_gam_connection_status() {
 		return $this->is_configured() ?
-			GAM_Model::get_gam_connection_status() :
+			GAM_Model::get_connection_status() :
 			$this->unconfigured_error();
 	}
 
@@ -161,7 +160,7 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_gam_available_networks() {
 		return $this->is_configured() ?
-			GAM_Model::get_gam_available_networks() :
+			GAM_Model::get_available_networks() :
 			$this->unconfigured_error();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Rename GAM methods for https://github.com/Automattic/newspack-ads/pull/529

### How to test the changes in this Pull Request:

Details and instructions at https://github.com/Automattic/newspack-ads/pull/529

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->