### PR TITLE
fix: "Sign In" page styles

### DIFF
--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -232,7 +232,8 @@
 		display: none;
 	}
 
-	.nphp {
+	.nphp,
+	input[type='email'].nphp {
 		@include mixins.visuallyHidden;
 	}
 }

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -2,6 +2,7 @@
 @use '~@wordpress/base-styles/colors' as wp-colors;
 @use '../shared/scss/mixins';
 
+.entry-content .newspack-reader,
 .newspack-reader {
 	/**
 	 * Account Link
@@ -83,7 +84,8 @@
 			z-index: auto;
 		}
 
-		.nphp {
+		.nphp,
+		input[type='email'].nphp {
 			@include mixins.visuallyHidden;
 		}
 
@@ -221,7 +223,7 @@
 			}
 			&,
 			a {
-				color: #fff !important;
+				color: #fff;
 			}
 			a:active,
 			a:hover {

--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -221,7 +221,7 @@
 			}
 			&,
 			a {
-				color: #fff;
+				color: #fff !important;
 			}
 			a:active,
 			a:hover {

--- a/assets/shared/scss/_mixins.scss
+++ b/assets/shared/scss/_mixins.scss
@@ -2,11 +2,11 @@
 	border: 0;
 	clip: rect( 1px, 1px, 1px, 1px );
 	clip-path: inset( 50% );
-	height: 1px;
+	width: 1px !important;
+	height: 1px !important;
 	margin: -1px;
 	overflow: hidden;
 	padding: 0;
 	position: absolute !important;
-	width: 1px;
 	word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
 }

--- a/assets/shared/scss/_mixins.scss
+++ b/assets/shared/scss/_mixins.scss
@@ -2,8 +2,8 @@
 	border: 0;
 	clip: rect( 1px, 1px, 1px, 1px );
 	clip-path: inset( 50% );
-	width: 1px !important;
-	height: 1px !important;
+	width: 1px;
+	height: 1px;
 	margin: -1px;
 	overflow: hidden;
 	padding: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#2025 introduced a few issues to the Sign In form styles while accessing through the "My Account" page. This PR fixes those issues:

 - Dark text color for "I don't have an account" link
 - Horizontal scrolling

| Master | This branch |
| --- | --- |
| <img width="836" alt="image" src="https://user-images.githubusercontent.com/820752/195156436-f1ba9cef-f1eb-4d07-9e90-bdf17cc806b9.png"> | <img width="842" alt="image" src="https://user-images.githubusercontent.com/820752/195156323-53a8a13c-1eaa-4ac8-904d-9504a63fc09d.png"> |

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->