### PR TITLE
fix: check Woo plugins status before enabling RAS

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -14,6 +14,7 @@ import {
 	Card,
 	Grid,
 	Notice,
+	PluginInstaller,
 	SectionHeader,
 	TextControl,
 	withWizardScreen,
@@ -81,6 +82,25 @@ export default withWizardScreen( () => {
 	};
 
 	const emails = Object.values( config.emails || {} );
+
+	if ( ! inFlight && false === config.plugins_configured ) {
+		return (
+			<>
+				<Notice isError>
+					{ __(
+						'Please activate WooCommerce and WooCommerce Subscriptions plugins to use Reader Activation features.',
+						'newspack'
+					) }
+				</Notice>
+				<PluginInstaller
+					isWaiting={ inFlight }
+					plugins={ [ 'woocommerce', 'woocommerce-subscriptions' ] }
+					onStatus={ ( { complete } ) => complete && fetchConfig() }
+					withoutFooterButton={ true }
+				/>
+			</>
+		);
+	}
 
 	return (
 		<>

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -251,7 +251,7 @@ class Plugin_Manager {
 			],
 			'woocommerce-subscriptions'     => [
 				'Name'        => esc_html__( 'WooCommerce Subscriptions', 'newspack' ),
-				'Description' => esc_html__( 'An eCommerce toolkit that helps you sell anything. Beautifully.', 'newspack' ),
+				'Description' => esc_html__( 'Sell products and services with recurring payments in your WooCommerce Store.', 'newspack' ),
 				'Author'      => esc_html__( 'WooCommerce', 'newspack' ),
 				'PluginURI'   => esc_url( 'https://woocommerce.com/products/woocommerce-subscriptions/' ),
 				'AuthorURI'   => esc_url( 'https://woocommerce.com/' ),

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -259,6 +259,10 @@ final class Reader_Activation {
 	 * @return bool True if reader activation is enabled.
 	 */
 	public static function is_enabled( $strict = true ) {
+		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
+			return true;
+		}
+
 		$is_enabled = defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) && NEWSPACK_EXPERIMENTAL_READER_ACTIVATION;
 
 		if ( ! $strict ) {

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -175,6 +175,7 @@ final class Reader_Activation {
 			'sender_name'                 => Emails::get_from_name(),
 			'sender_email_address'        => Emails::get_from_email(),
 			'contact_email_address'       => Emails::get_reply_to_email(),
+			'plugins_configured'          => self::is_woocommerce_active(),
 		];
 
 		/**
@@ -241,6 +242,15 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Check if the required Woo plugins are active.
+	 *
+	 * @return boolean True if all required plugins are active, otherwise false.
+	 */
+	public static function is_woocommerce_active() {
+		return class_exists( 'WooCommerce' ) && class_exists( 'WC_Subscriptions' );
+	}
+
+	/**
 	 * Whether reader activation is enabled.
 	 *
 	 * @param bool $strict If true, check both the environment constant and the setting.
@@ -257,6 +267,10 @@ final class Reader_Activation {
 
 		if ( $is_enabled ) {
 			$is_enabled = self::get_setting( 'enabled' );
+		}
+
+		if ( $is_enabled ) {
+			$is_enabled = self::is_woocommerce_active();
 		}
 
 		/**

--- a/tests/class-newspack-unit-tests-bootstrap.php
+++ b/tests/class-newspack-unit-tests-bootstrap.php
@@ -68,6 +68,8 @@ class Newspack_Unit_Tests_Bootstrap {
 
 		// Load the WP testing environment.
 		require_once $_tests_dir . '/includes/bootstrap.php';
+
+		define( 'IS_TEST_ENV', 1 );
 	}
 
 	/**

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -26,15 +26,6 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	private static $reader_name = 'Reader Test';
 
 	/**
-	 * Setup for the tests.
-	 */
-	public function set_up() {
-		if ( ! defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) ) {
-			define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );
-		}
-	}
-
-	/**
 	 * Helper function to register sample reader
 	 */
 	private static function register_sample_reader() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

RAS features will behave unpredictably if WooCommerce or WooCommerce Subscriptions plugins are not active. This PR adds a check for these required plugins before considering RAS enabled  Also adds a plugin installer component to the RAS wizard if either plugin is missing for ease of setup.

Also updates the description for WooCommerce Subscriptions with the correct plugin description from the WP.org repository.

### How to test the changes in this Pull Request:

1. On a site with RAS already enabled and configured, check out this branch and deactivate WooCommerce and/or WooCommerce Subscriptions.
2. Confirm on the front-end that no reader-facing RAS features are enabled (no My Account link, no registration block).
3. In the dashboard > Newspack > Engagement Reader Activation, confirm that you see a plugin installer prompt:

<img width="1561" alt="Screen Shot 2022-10-11 at 3 30 14 PM" src="https://user-images.githubusercontent.com/2230142/195202261-d3ed5a28-d887-46d8-bd70-36b660c41b02.png">

4. Install/activate both plugins and confirm that the RAS wizard reappears after both plugins are confirmed active.
5. Revisit the front-end and confirm that reader-facing RAS features are available again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->