### PR TITLE
fix: sql error with starter content queries

### DIFF
--- a/includes/starter_content/class-starter-content-provider.php
+++ b/includes/starter_content/class-starter-content-provider.php
@@ -59,7 +59,13 @@ abstract class Starter_Content_Provider {
 	 */
 	public static function has_created_starter_content() {
 		global $wpdb;
-		$post_ids = $wpdb->get_results( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE %s;", self::$starter_post_meta_prefix ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQueryWithPlaceholder
+		$post_ids = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQueryWithPlaceholder
+			$wpdb->prepare(
+				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE %s;",
+				'%' . self::$starter_post_meta_prefix . '%'
+			),
+			ARRAY_A
+		);
 		return ! empty( $post_ids );
 	}
 
@@ -69,7 +75,13 @@ abstract class Starter_Content_Provider {
 	public static function remove_starter_content() {
 		global $wpdb;
 
-		$post_ids = $wpdb->get_results( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE %s;", self::$starter_post_meta_prefix ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQueryWithPlaceholder
+		$post_ids = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQueryWithPlaceholder
+			$wpdb->prepare(
+				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE %s;",
+				'%' . self::$starter_post_meta_prefix . '%'
+			),
+			ARRAY_A
+		);
 
 		if ( ! empty( $post_ids ) ) {
 			foreach ( $post_ids as $post_id ) {

--- a/includes/starter_content/class-starter-content-provider.php
+++ b/includes/starter_content/class-starter-content-provider.php
@@ -59,7 +59,7 @@ abstract class Starter_Content_Provider {
 	 */
 	public static function has_created_starter_content() {
 		global $wpdb;
-		$post_ids = $wpdb->get_results( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE '%%%s%%';", self::$starter_post_meta_prefix ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQueryWithPlaceholder
+		$post_ids = $wpdb->get_results( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE %s;", self::$starter_post_meta_prefix ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQueryWithPlaceholder
 		return ! empty( $post_ids );
 	}
 
@@ -69,7 +69,7 @@ abstract class Starter_Content_Provider {
 	public static function remove_starter_content() {
 		global $wpdb;
 
-		$post_ids = $wpdb->get_results( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE '%%%s%%';", self::$starter_post_meta_prefix ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQueryWithPlaceholder
+		$post_ids = $wpdb->get_results( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE %s;", self::$starter_post_meta_prefix ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQueryWithPlaceholder
 
 		if ( ! empty( $post_ids ) ) {
 			foreach ( $post_ids as $post_id ) {
@@ -130,4 +130,3 @@ abstract class Starter_Content_Provider {
 		return false;
 	}
 }
-

--- a/includes/starter_content/class-starter-content-provider.php
+++ b/includes/starter_content/class-starter-content-provider.php
@@ -61,8 +61,8 @@ abstract class Starter_Content_Provider {
 		global $wpdb;
 		$post_ids = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQueryWithPlaceholder
 			$wpdb->prepare(
-				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE %s;",
-				'%' . self::$starter_post_meta_prefix . '%'
+				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE %s",
+				self::$starter_post_meta_prefix . '%'
 			),
 			ARRAY_A
 		);
@@ -77,8 +77,8 @@ abstract class Starter_Content_Provider {
 
 		$post_ids = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQueryWithPlaceholder
 			$wpdb->prepare(
-				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE %s;",
-				'%' . self::$starter_post_meta_prefix . '%'
+				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key LIKE %s",
+				self::$starter_post_meta_prefix . '%'
 			),
 			ARRAY_A
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I'm not sure when this started or what changed, but I've started seeing an SQL syntax error in the WP dashboard in my local test site. I think this is due to a malformed SQL query due to improper placeholders in a `$wpdb->prepare` statement. There's no need to print `'` single quotes as any strings replacing a placeholder are automatically wrapped in quotes by `$wpdb->prepare`.

### How to test the changes in this Pull Request:

Visit the Newspack dashboard and confirm that you don't see any errors like this:

> WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '_newspack_starter_content_post_'%'' at line 1 for query SELECT post_id FROM wp_postmeta WHERE meta_key LIKE '%'_newspack_starter_content_post_'%'; made by require_once('wp-admin/admin-header.php'), do_action('admin_enqueue_scripts'), WP_Hook->do_action, WP_Hook->apply_filters, Newspack\Engagement_Wizard->enqueue_scripts_and_styles, Newspack\Wizard->enqueue_scripts_and_styles, Newspack\Starter_Content::has_created_starter_content, Newspack\Starter_Content_Provider::has_created_starter_content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->