### PR TITLE
fix: use default terms text in reg block if no text defined

### DIFF
--- a/assets/blocks/reader-registration/block.json
+++ b/assets/blocks/reader-registration/block.json
@@ -24,7 +24,7 @@
 		},
 		"privacyLabel": {
 			"type": "string",
-			"default": "By signing up, you agree to our Terms and Conditions."
+			"default": ""
 		},
 		"newsletterSubscription": {
 			"type": "boolean",

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -59,8 +59,12 @@ export default function ReaderRegistrationEdit( {
 } ) {
 	const blockProps = useBlockProps();
 	const [ editedState, setEditedState ] = useState( editedStateOptions[ 0 ].value );
-	const { reader_activation_terms: defaultTermsText, reader_activation_url: defaultTermsUrl } =
+	let { reader_activation_terms: defaultTermsText, reader_activation_url: defaultTermsUrl } =
 		window.newspack_blocks;
+
+	if ( defaultTermsUrl ) {
+		defaultTermsText = `<a href="${ defaultTermsUrl }">` + defaultTermsText + '</a>';
+	}
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{},
@@ -312,25 +316,12 @@ export default function ReaderRegistrationEdit( {
 										<div className="newspack-registration__response" />
 									</div>
 									<div className="newspack-registration__help-text">
-										<p>
-											{ defaultTermsUrl ? (
-												<a href={ defaultTermsUrl } onClick={ ev => ev.preventDefault() }>
-													<RichText
-														onChange={ value => setAttributes( { privacyLabel: value } ) }
-														placeholder={ __( 'Terms & Conditions statement…', 'newspack' ) }
-														value={ privacyLabel || defaultTermsText }
-														tagName="span"
-													/>
-												</a>
-											) : (
-												<RichText
-													onChange={ value => setAttributes( { privacyLabel: value } ) }
-													placeholder={ __( 'Terms & Conditions statement…', 'newspack' ) }
-													value={ privacyLabel || defaultTermsText }
-													tagName="span"
-												/>
-											) }
-										</p>
+										<RichText
+											onChange={ value => setAttributes( { privacyLabel: value } ) }
+											placeholder={ __( 'Terms & Conditions statement…', 'newspack' ) }
+											value={ privacyLabel || defaultTermsText }
+											tagName="p"
+										/>
 									</div>
 								</div>
 							</div>

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -311,7 +311,13 @@ export default function ReaderRegistrationEdit( {
 										) }
 										<div className="newspack-registration__response" />
 									</div>
-									<div className="newspack-registration__help-text">
+									<div
+										className={
+											defaultTermsUrl
+												? 'newspack-registration__help-text has-terms-link'
+												: 'newspack-registration__help-text'
+										}
+									>
 										<p>
 											{ defaultTermsUrl ? (
 												<a href={ defaultTermsUrl } onClick={ ev => ev.preventDefault() }>
@@ -327,7 +333,7 @@ export default function ReaderRegistrationEdit( {
 													onChange={ value => setAttributes( { privacyLabel: value } ) }
 													placeholder={ __( 'Terms & Conditions statement…', 'newspack' ) }
 													value={ privacyLabel || defaultTermsText }
-													tagName="p"
+													tagName="span"
 												/>
 											) }
 										</p>

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -59,6 +59,7 @@ export default function ReaderRegistrationEdit( {
 } ) {
 	const blockProps = useBlockProps();
 	const [ editedState, setEditedState ] = useState( editedStateOptions[ 0 ].value );
+	const { reader_activation_terms: defaultTermsText } = window.newspack_blocks;
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{},
@@ -313,7 +314,7 @@ export default function ReaderRegistrationEdit( {
 										<RichText
 											onChange={ value => setAttributes( { privacyLabel: value } ) }
 											placeholder={ __( 'Terms & Conditions statement…', 'newspack' ) }
-											value={ privacyLabel }
+											value={ privacyLabel || defaultTermsText }
 											tagName="p"
 										/>
 									</div>

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -312,12 +312,25 @@ export default function ReaderRegistrationEdit( {
 										<div className="newspack-registration__response" />
 									</div>
 									<div className="newspack-registration__help-text">
-										<RichText
-											onChange={ value => setAttributes( { privacyLabel: value } ) }
-											placeholder={ __( 'Terms & Conditions statement…', 'newspack' ) }
-											value={ privacyLabel || defaultTermsText }
-											tagName={ defaultTermsUrl ? 'a' : 'p' }
-										/>
+										<p>
+											{ defaultTermsUrl ? (
+												<a href={ defaultTermsUrl } onClick={ ev => ev.preventDefault() }>
+													<RichText
+														onChange={ value => setAttributes( { privacyLabel: value } ) }
+														placeholder={ __( 'Terms & Conditions statement…', 'newspack' ) }
+														value={ privacyLabel || defaultTermsText }
+														tagName="span"
+													/>
+												</a>
+											) : (
+												<RichText
+													onChange={ value => setAttributes( { privacyLabel: value } ) }
+													placeholder={ __( 'Terms & Conditions statement…', 'newspack' ) }
+													value={ privacyLabel || defaultTermsText }
+													tagName="p"
+												/>
+											) }
+										</p>
 									</div>
 								</div>
 							</div>

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -59,7 +59,8 @@ export default function ReaderRegistrationEdit( {
 } ) {
 	const blockProps = useBlockProps();
 	const [ editedState, setEditedState ] = useState( editedStateOptions[ 0 ].value );
-	const { reader_activation_terms: defaultTermsText } = window.newspack_blocks;
+	const { reader_activation_terms: defaultTermsText, reader_activation_url: defaultTermsUrl } =
+		window.newspack_blocks;
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{},
@@ -315,7 +316,7 @@ export default function ReaderRegistrationEdit( {
 											onChange={ value => setAttributes( { privacyLabel: value } ) }
 											placeholder={ __( 'Terms & Conditions statement…', 'newspack' ) }
 											value={ privacyLabel || defaultTermsText }
-											tagName="p"
+											tagName={ defaultTermsUrl ? 'a' : 'p' }
 										/>
 									</div>
 								</div>

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -311,13 +311,7 @@ export default function ReaderRegistrationEdit( {
 										) }
 										<div className="newspack-registration__response" />
 									</div>
-									<div
-										className={
-											defaultTermsUrl
-												? 'newspack-registration__help-text has-terms-link'
-												: 'newspack-registration__help-text'
-										}
-									>
+									<div className="newspack-registration__help-text">
 										<p>
 											{ defaultTermsUrl ? (
 												<a href={ defaultTermsUrl } onClick={ ev => ev.preventDefault() }>

--- a/assets/blocks/reader-registration/editor.scss
+++ b/assets/blocks/reader-registration/editor.scss
@@ -92,6 +92,7 @@
 	&__help-text {
 		margin-top: 1em;
 
+		a,
 		p {
 			font-size: 0.55em !important;
 			margin: 0;

--- a/assets/blocks/reader-registration/editor.scss
+++ b/assets/blocks/reader-registration/editor.scss
@@ -92,7 +92,6 @@
 	&__help-text {
 		margin-top: 1em;
 
-		a,
 		p {
 			font-size: 0.55em !important;
 			margin: 0;

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -255,9 +255,18 @@ function render_block( $attrs, $content ) {
 						<div class="newspack-registration__help-text">
 							<p>
 								<?php
+								$terms_url = wp_http_validate_url( Reader_Activation::get_setting( 'terms_url' ) );
+								if ( $terms_url ) :
+									?>
+									<a href="<?php echo esc_url( $terms_url ); ?>">
+									<?php
+								endif;
 								$terms_text = empty( $attrs['privacyLabel'] ) ? Reader_Activation::get_setting( 'terms_text' ) : $attrs['privacyLabel'];
 								echo \wp_kses_post( $terms_text );
 								?>
+								<?php if ( $terms_url ) : ?>
+								</a>
+								<?php endif; ?>
 							</p>
 						</div>
 					</div>

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -254,7 +254,10 @@ function render_block( $attrs, $content ) {
 
 						<div class="newspack-registration__help-text">
 							<p>
-								<?php echo \wp_kses_post( $attrs['privacyLabel'] ); ?>
+								<?php
+								$terms_text = empty( $attrs['privacyLabel'] ) ? Reader_Activation::get_setting( 'terms_text' ) : $attrs['privacyLabel'];
+								echo \wp_kses_post( $terms_text );
+								?>
 							</p>
 						</div>
 					</div>

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -38,11 +38,12 @@ final class Blocks {
 			'newspack-blocks',
 			'newspack_blocks',
 			[
-				'has_newsletters'       => method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ),
-				'has_reader_activation' => Reader_Activation::is_enabled( false ),
-				'newsletters_url'       => Wizards::get_wizard( 'engagement' )->newsletters_settings_url(),
-				'has_google_oauth'      => Google_OAuth::is_oauth_configured(),
-				'google_logo_svg'       => file_get_contents( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/blocks/reader-registration/icons/google.svg' ),
+				'has_newsletters'         => method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ),
+				'has_reader_activation'   => Reader_Activation::is_enabled( false ),
+				'newsletters_url'         => Wizards::get_wizard( 'engagement' )->newsletters_settings_url(),
+				'has_google_oauth'        => Google_OAuth::is_oauth_configured(),
+				'google_logo_svg'         => file_get_contents( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/blocks/reader-registration/icons/google.svg' ),
+				'reader_activation_terms' => Reader_Activation::get_setting( 'terms_text' ),
 			]
 		);
 		\wp_enqueue_style(

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -44,6 +44,7 @@ final class Blocks {
 				'has_google_oauth'        => Google_OAuth::is_oauth_configured(),
 				'google_logo_svg'         => file_get_contents( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/blocks/reader-registration/icons/google.svg' ),
 				'reader_activation_terms' => Reader_Activation::get_setting( 'terms_text' ),
+				'reader_activation_url'   => Reader_Activation::get_setting( 'terms_url' ),
 			]
 		);
 		\wp_enqueue_style(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Uses the global "terms & conditions" text as set in the Reader Activation wizard UI as the default text in the registration block.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Visit the Newspack > Engagement > Reader Activation wizard and note or update the terms & conditions text here.
3. Add a Reader Registration block to a post or page. Confirm that the text in the RichText field at the bottom of the block matches the wizard text in step 2.
4. View the block on the front-end and confirm that the text matches here, too.
5. Update the text in the block and update. Confirm that the block now shows the updated text on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->