### PR TITLE
fix: overzealous woo check for RAS front-end

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -273,10 +273,6 @@ final class Reader_Activation {
 			$is_enabled = self::get_setting( 'enabled' );
 		}
 
-		if ( $is_enabled ) {
-			$is_enabled = self::is_woocommerce_active();
-		}
-
 		/**
 		 * Filters whether reader activation is enabled.
 		 *
@@ -561,7 +557,7 @@ final class Reader_Activation {
 	 * Setup nav menu hooks.
 	 */
 	public static function setup_nav_menu() {
-		if ( ! self::get_setting( 'enabled_account_link' ) ) {
+		if ( ! self::get_setting( 'enabled_account_link' ) || ! self::is_woocommerce_active() ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#2076 implemented a check for required Woo plugins before considering RAS "enabled", but this is an overzealous requirement for reader-facing features, because the check that happens in the `init` hook to enqueue front-end scripts happens before the `WooCommerce` or `WooCommerce_Subscriptions` classes are instantiated. This means RAS front-end scripts are never enqueued!

This PR allows RAS front-end features to function if Woo or Woo Subscriptions is missing, but the My Account link won't appear in nav since the UI won't work. 

### How to test the changes in this Pull Request:

1. On `master`, enable RAS, WooCommerce, and WooCommerce Subscriptions plugins.
2. On the front-end, observe that RAS features are partially broken—registration blocks render without styles, magic links don't work, etc.
3. Check out this branch and confirm the issues are fixed.
4. Disable the WooCommerce plugin. Confirm that RAS features still work, partially—you should be able to subscribe via the Subscribe block and register via the Registration block without errors, but the My Account link won't appear in nav. This is an edge case scenario which should only occur if a site has previously enabled RAS but then disabled one of the required plugins.
5. In the dashboard > Newspack > Engagement > Reader Activation, confirm that you're prompted to activate the required Woo plugins.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->