### PR TITLE
fix: apply My Account template changes only when RAS is active

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -37,25 +37,25 @@ class WooCommerce_My_Account {
 	 * @codeCoverageIgnore
 	 */
 	public static function init() {
-		if ( ! Reader_Activation::is_enabled() ) {
-			return;
-		}
-
-		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
-		\add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'my_account_menu_items' ], 1000 );
-		\add_action( 'woocommerce_account_' . self::BILLING_ENDPOINT . '_endpoint', [ __CLASS__, 'render_billing_template' ] );
-		\add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 5 );
 		\add_action( 'init', [ __CLASS__, 'add_rewrite_endpoints' ] );
-		\add_action( 'template_redirect', [ __CLASS__, 'handle_password_reset_request' ] );
-		\add_action( 'template_redirect', [ __CLASS__, 'handle_delete_account_request' ] );
-		\add_action( 'template_redirect', [ __CLASS__, 'handle_delete_account' ] );
-		\add_action( 'template_redirect', [ __CLASS__, 'handle_magic_link_request' ] );
-		\add_action( 'template_redirect', [ __CLASS__, 'redirect_to_account_details' ] );
-		\add_action( 'template_redirect', [ __CLASS__, 'edit_account_prevent_email_update' ] );
-		\add_action( 'init', [ __CLASS__, 'restrict_account_content' ], 100 );
-		\add_filter( 'woocommerce_save_account_details_required_fields', [ __CLASS__, 'remove_required_fields' ] );
-		\add_action( 'logout_redirect', [ __CLASS__, 'add_param_after_logout' ] );
-		\add_action( 'template_redirect', [ __CLASS__, 'show_message_after_logout' ] );
+		\add_action( 'woocommerce_account_' . self::BILLING_ENDPOINT . '_endpoint', [ __CLASS__, 'render_billing_template' ] );
+		\add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'my_account_menu_items' ], 1000 );
+
+		// Reader Activation mods.
+		if ( Reader_Activation::is_enabled() ) {
+			\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
+			\add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 5 );
+			\add_action( 'template_redirect', [ __CLASS__, 'handle_password_reset_request' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'handle_delete_account_request' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'handle_delete_account' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'handle_magic_link_request' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'redirect_to_account_details' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'edit_account_prevent_email_update' ] );
+			\add_action( 'init', [ __CLASS__, 'restrict_account_content' ], 100 );
+			\add_filter( 'woocommerce_save_account_details_required_fields', [ __CLASS__, 'remove_required_fields' ] );
+			\add_action( 'logout_redirect', [ __CLASS__, 'add_param_after_logout' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'show_message_after_logout' ] );
+		}
 	}
 
 	/**
@@ -81,64 +81,69 @@ class WooCommerce_My_Account {
 			return $items;
 		}
 
+		$default_disabled_items = [];
+
 		// Rename 'Logout' action to 'Log out', for grammatical reasons.
 		if ( isset( $items['customer-logout'] ) ) {
 			$items['customer-logout'] = __( 'Log out', 'newspack' );
 		}
 
-		// If the reader hasn't verified their account, only show options to verify or log out.
-		if ( ! self::is_user_verified() ) {
-			$minimum_items = [ 'edit-account', 'customer-logout' ];
-			foreach ( $items as $key => $label ) {
-				if ( ! in_array( $key, $minimum_items, true ) ) {
+		if ( Reader_Activation::is_enabled() ) {
+			// If the reader hasn't verified their account, only show options to verify or log out.
+			if ( ! self::is_user_verified() ) {
+				$minimum_items = [ 'edit-account', 'customer-logout' ];
+				foreach ( $items as $key => $label ) {
+					if ( ! in_array( $key, $minimum_items, true ) ) {
+						unset( $items[ $key ] );
+					}
+				}
+				return $items;
+			}
+
+			$default_disabled_items = array_merge( $default_disabled_items, [ 'dashboard', 'members-area', 'edit-address' ] );
+			$customer_id            = \get_current_user_id();
+			if ( function_exists( 'wcs_user_has_subscription' ) && function_exists( 'wcs_get_subscriptions' ) ) {
+				$user_subscriptions             = wcs_get_subscriptions( [ 'customer_id' => $customer_id ] );
+				$has_non_newspack_subscriptions = false;
+				foreach ( $user_subscriptions as $subscription ) {
+					if ( ! $subscription->get_meta( WooCommerce_Connection::SUBSCRIPTION_STRIPE_ID_META_KEY ) ) {
+						$has_non_newspack_subscriptions = true;
+						break;
+					}
+				}
+				// Unless user has any subscriptions that aren't tied to a Stripe subscription by Newspack, hide the subscriptions link.
+				// The Stripe-tied subscriptions will be available for management in the "Billing" section.
+				if ( ! $has_non_newspack_subscriptions ) {
+					$default_disabled_items[] = 'subscriptions';
+				}
+			}
+			if ( function_exists( 'wc_get_orders' ) ) {
+				$wc_non_newspack_orders = array_filter(
+					\wc_get_orders( [ 'customer' => $customer_id ] ),
+					function ( $order ) {
+						return WooCommerce_Connection::CREATED_VIA_NAME !== $order->get_created_via();
+					}
+				);
+				if ( empty( $wc_non_newspack_orders ) ) {
+					$default_disabled_items = array_merge( $default_disabled_items, [ 'orders', 'payment-methods' ] );
+				}
+			}
+			if ( function_exists( 'wc_get_customer_available_downloads' ) ) {
+				$wc_customer_downloads = \wc_get_customer_available_downloads( $customer_id );
+
+				if ( empty( $wc_customer_downloads ) ) {
+					$default_disabled_items[] = 'downloads';
+				}
+			}
+			$disabled_wc_menu_items = \apply_filters( 'newspack_my_account_disabled_pages', $default_disabled_items );
+			foreach ( $disabled_wc_menu_items as $key ) {
+				if ( isset( $items[ $key ] ) ) {
 					unset( $items[ $key ] );
 				}
 			}
-			return $items;
 		}
 
-		$default_disabled_items = [ 'dashboard', 'members-area', 'edit-address' ];
-		$customer_id            = \get_current_user_id();
-		if ( function_exists( 'wcs_user_has_subscription' ) && function_exists( 'wcs_get_subscriptions' ) ) {
-			$user_subscriptions             = wcs_get_subscriptions( [ 'customer_id' => $customer_id ] );
-			$has_non_newspack_subscriptions = false;
-			foreach ( $user_subscriptions as $subscription ) {
-				if ( ! $subscription->get_meta( WooCommerce_Connection::SUBSCRIPTION_STRIPE_ID_META_KEY ) ) {
-					$has_non_newspack_subscriptions = true;
-					break;
-				}
-			}
-			// Unless user has any subscriptions that aren't tied to a Stripe subscription by Newspack, hide the subscriptions link.
-			// The Stripe-tied subscriptions will be available for management in the "Billing" section.
-			if ( ! $has_non_newspack_subscriptions ) {
-				$default_disabled_items[] = 'subscriptions';
-			}
-		}
-		if ( function_exists( 'wc_get_orders' ) ) {
-			$wc_non_newspack_orders = array_filter(
-				\wc_get_orders( [ 'customer' => $customer_id ] ),
-				function ( $order ) {
-					return WooCommerce_Connection::CREATED_VIA_NAME !== $order->get_created_via();
-				}
-			);
-			if ( empty( $wc_non_newspack_orders ) ) {
-				$default_disabled_items = array_merge( $default_disabled_items, [ 'orders', 'payment-methods' ] );
-			}
-		}
-		if ( function_exists( 'wc_get_customer_available_downloads' ) ) {
-			$wc_customer_downloads = \wc_get_customer_available_downloads( $customer_id );
-
-			if ( empty( $wc_customer_downloads ) ) {
-				$default_disabled_items[] = 'downloads';
-			}
-		}
-		$disabled_wc_menu_items = \apply_filters( 'newspack_my_account_disabled_pages', $default_disabled_items );
-		foreach ( $disabled_wc_menu_items as $key ) {
-			if ( isset( $items[ $key ] ) ) {
-				unset( $items[ $key ] );
-			}
-		}
-
+		// Add a nav item for Stripe's billing portal.
 		$stripe_customer_id = self::get_current_user_stripe_id();
 		if ( false === $stripe_customer_id ) {
 			return $items;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Conditionally applies RAS template changes and logic to the WC My Account UI only when RAS is active. Non-RAS sites are reporting that customers are confused by UI changes that shouldn't apply to their account pages.

Also checks whether logged-in customers have any available downloads before hiding the "Downloads" item from the menu.

### How to test the changes in this Pull Request:

#### My Account UI

1. Disable RAS.
2. Log into My Account as a WC customer, or set your Reader Revenue platform to Newspack and make a recurring donation via WC.
3. Visit the My Account page. On `master`, observe that the RAS UI is applied (links to send a reset password email, delete account, etc. which will only work if RAS is active).
4. Apply this patch and refresh. Confirm that the My Account page now shows the standard WooCommere UI with all nav menu items, and RAS-specific UI not shown. Note that the custom theme styles still apply, e.g. the nav menu is still a sidebar, but these styles should be cosmetic only.

#### Downloads

1. In the Products dashboard, edit the product used to test the donation above and add a downloadable file. Hint: look for a panel like this:

<img width="784" alt="Screen Shot 2022-10-20 at 5 08 15 PM" src="https://user-images.githubusercontent.com/2230142/197075778-61aa36c0-0268-4cf2-aabd-a07b31f8d0b4.png">

2. Enable RAS.
3. Log into My Account as a WC customer, or make a donation using this product via the simplified Donate block.\
4. On `master`, observe that there is no "Downloads" link in the My Account nav menu.
5. Apply the patch and refresh. Confirm that the Downloads link reappears.
6. In a new session, make a donation using a different product without any downloadable files.
7. In My Account, confirm that the Downloads link does not appear, since this customer doesn't have access to any downloadable files.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->