### PR TITLE
feat(newsletter-contact): disallow overriding membership status field

### DIFF
--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -146,7 +146,7 @@ class Newspack_Newsletters {
 					}
 				}
 
-				// If the membership status it to be switched from recurring to non-recurring, ignore this change.
+				// If the membership status is to be switched from recurring to non-recurring, ignore this change.
 				if ( $contact['existing_contact_data'] && isset( $contact['metadata'][ self::$metadata_keys['membership_status'] ], $existing_metadata[ self::$metadata_keys['membership_status'] ] ) ) {
 					$existing_metadata  = $contact['existing_contact_data']['metadata'];
 					$becomes_once_donor = Stripe_Connection::ESP_METADATA_VALUES['once_donor'] === $contact['metadata'][ self::$metadata_keys['membership_status'] ];

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -23,12 +23,14 @@ class Newspack_Newsletters {
 	public static $metadata_keys = [
 		'account'              => 'NP_Account',
 		'registration_date'    => 'NP_Registration Date',
+		'connected_account'    => 'NP_Connected Account',
 		'signup_page'          => 'NP_Signup Page',
 		'signup_page_utm'      => 'NP_Signup UTM: ',
+		'newsletter_selection' => 'NP_Newsletter Selection',
+		// Payment-related.
+		'membership_status'    => 'NP_Membership Status',
 		'payment_page'         => 'NP_Payment Page',
 		'payment_page_utm'     => 'NP_Payment UTM: ',
-		'newsletter_selection' => 'NP_Newsletter Selection',
-		'membership_status'    => 'NP_Membership Status',
 		'sub_start_date'       => 'NP_Current Subscription Start Date',
 		'sub_end_date'         => 'NP_Current Subscription End Date',
 		'billing_cycle'        => 'NP_Billing Cycle',
@@ -38,7 +40,6 @@ class Newspack_Newsletters {
 		'product_name'         => 'NP_Product Name',
 		'next_payment_date'    => 'NP_Next Payment Date',
 		'total_paid'           => 'NP_Total Paid',
-		'connected_account'    => 'NP_Connected Account',
 	];
 
 	/**
@@ -142,6 +143,22 @@ class Newspack_Newsletters {
 						if ( isset( $current_page_url_params[ $param ] ) ) {
 							$metadata[ self::$metadata_keys['signup_page_utm'] . $value ] = sanitize_text_field( $current_page_url_params[ $param ] );
 						}
+					}
+				}
+
+				// If the membership status it to be switched from recurring to non-recurring, ignore this change.
+				if ( $contact['existing_contact_data'] && isset( $contact['metadata'][ self::$metadata_keys['membership_status'] ], $existing_metadata[ self::$metadata_keys['membership_status'] ] ) ) {
+					$existing_metadata  = $contact['existing_contact_data']['metadata'];
+					$becomes_once_donor = Stripe_Connection::ESP_METADATA_VALUES['once_donor'] === $contact['metadata'][ self::$metadata_keys['membership_status'] ];
+					$is_recurring_donor = in_array(
+						$existing_metadata[ self::$metadata_keys['membership_status'] ],
+						[
+							Stripe_Connection::ESP_METADATA_VALUES['monthly_donor'],
+							Stripe_Connection::ESP_METADATA_VALUES['yearly_donor'],
+						]
+					);
+					if ( $becomes_once_donor && $is_recurring_donor ) {
+						unset( $contact['metadata'][ self::$metadata_keys['membership_status'] ] );
 					}
 				}
 

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -22,6 +22,12 @@ class Stripe_Connection {
 	const STRIPE_DONATION_PRICE_METADATA = 'newspack_donation_price';
 	const STRIPE_CUSTOMER_ID_USER_META   = '_newspack_stripe_customer_id';
 
+	const ESP_METADATA_VALUES = [
+		'once_donor'    => 'Donor',
+		'monthly_donor' => 'Monthly Donor',
+		'yearly_donor'  => 'Yearly Donor',
+	];
+
 	/**
 	 * Ensures the customer ID lookup is run only once per request.
 	 *
@@ -442,11 +448,11 @@ class Stripe_Connection {
 	public static function get_membership_status_field_value( $frequency ) {
 		switch ( $frequency ) {
 			case 'once':
-				return 'Donor';
+				return self::ESP_METADATA_VALUES['once_donor'];
 			case 'year':
-				return 'Yearly Donor';
+				return self::ESP_METADATA_VALUES['yearly_donor'];
 			case 'month':
-				return 'Monthly Donor';
+				return self::ESP_METADATA_VALUES['monthly_donor'];
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents a situation where the `NP_Membership Status` field in ESP data is overridden in an undesirable way. This field should have the value denoting a one-time donor only if the donor has _never_ donated in a recurring manner.  

### How to test the changes in this Pull Request:

1. Set up a site with RAS enabled and ESP set to ActiveCampaign
2. Make a montly donation, observe the `NP_Membership Status` is set to `Monthly Donor`
3. Make a one-time donation, observe the `NP_Membership Status` field is not changed, but the values of `NP_Total Paid` and ``NP_Last Payment Amount` are updated accordingly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->