### PR TITLE
style: hide logged-out message if submitting login form again

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -57,6 +57,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 		}
 
 		const containers = [ ...document.querySelectorAll( '.newspack-reader-auth' ) ];
+		const alerts = [ ...document.querySelectorAll( '.woocommerce-message' ) ];
 		if ( ! containers.length ) {
 			return;
 		}
@@ -324,6 +325,10 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			form.addEventListener( 'submit', ev => {
 				ev.preventDefault();
 				form.startLoginFlow();
+
+				if ( 0 < alerts.length ) {
+					alerts.forEach( alert => ( alert.style.display = 'none' ) );
+				}
 
 				const action = form.action?.value;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tiny fix to hide the logout success message when trying to log in again.

### How to test the changes in this Pull Request:

1. On `master`, log into My Account with a reader account, then log out. You'll be redirected to the login form with a success message:

<img width="1191" alt="Screen Shot 2022-10-31 at 3 52 09 PM" src="https://user-images.githubusercontent.com/2230142/199117369-8e913268-49fd-4494-9565-eb8ca88ece0e.png">

2. Log in again from this page. Observe that the logout success message remains throughout the login flow.
3. Check out this branch and repeat steps 1-2. Confirm that the logout success message is hidden as soon as you submit the login form.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->