### PR TITLE
fix: apply ex-donor status only if user has no active subscriptions

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -662,9 +662,10 @@ class Stripe_Connection {
 					return $customer;
 				}
 
+				$active_subs = 0;
 				if ( Donations::is_woocommerce_suite_active() ) {
 					if ( $payload['ended_at'] ) {
-						WooCommerce_Connection::end_subscription(
+						$active_subs = WooCommerce_Connection::end_subscription(
 							$payload['id'],
 							$payload['ended_at']
 						);
@@ -679,7 +680,7 @@ class Stripe_Connection {
 							Newspack_Newsletters::$metadata_keys['sub_end_date']   => $sub_end_date,
 						],
 					];
-					if ( in_array( $payload['plan']['interval'], [ 'month', 'year' ] ) ) {
+					if ( 0 === $active_subs && in_array( $payload['plan']['interval'], [ 'month', 'year' ] ) ) {
 						$membership_status = 'Ex-' . self::get_membership_status_field_value( $payload['plan']['interval'] );
 						$contact['metadata'][ Newspack_Newsletters::$metadata_keys['membership_status'] ] = $membership_status;
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently, if a reader cancels a recurring Stripe subscription, their donor status in the `NP_Membership Status` custom field is updated to "Ex-" donor. However, it's possible for readers to have multiple active recurring subscriptions, so cancelling one while keeping others active should not apply the "ex-donor" status. A contact should be considered an ex-donor only if they've canceled donations and have no currently active donations.

### How to test the changes in this Pull Request:

1. Check out this branch, set up RAS, and connect your site to an ActiveCampaign account.
2. As a reader, make a recurring donation.
3. Verify in the connected Stripe account that a subscription is created, and in the ActiveCampaign account that a contact is create with an `NP_Membership Status` like "Monthly Donor" depending on the frequency of the donation.
4. Make a second recurring donation as the same reader with the same email address.
5. In the Stripe dashboard, cancel one of the donations immediately.
6. Confirm in the ActiveCampaign contact info that the `NP_Current Subscription End Date` is updated with the date of the cancellation, but that the `NP_Membership Status` value is still "Monthly Donor" (or matching the frequency of the most recently created recurring donation).
7. In Stripe, cancel the other donation so that the reader has no remaining active recurring subscriptions.
8. Confirm in the ActiveCampaign contact info that the `NP_Current Subscription End Date` is updated with the date of the latest cancellation, and that the `NP_Membership Status` value is now "Ex-Monthly Donor", since the contact has cancelled all known subscriptions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->