### PR TITLE
fix(stripe): handle failed invoice fatal error

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -1334,7 +1334,10 @@ class Stripe_Connection {
 		$frequency = 'once';
 		if ( $payment['invoice'] ) {
 			// A subscription payment will have an invoice.
-			$invoice   = self::get_invoice( $payment['invoice'] );
+			$invoice = self::get_invoice( $payment['invoice'] );
+			if ( \is_wp_error( $invoice ) ) {
+				return $frequency;
+			}
 			$recurring = $invoice['lines']['data'][0]['price']['recurring'];
 			if ( isset( $recurring['interval'] ) ) {
 				$frequency = $recurring['interval'];

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -1365,11 +1365,13 @@ class Stripe_Connection {
 		$subscription_id        = null;
 		$invoice_billing_reason = null;
 		$invoice                = self::get_invoice( $payment['invoice'] );
-		if ( $invoice ) {
+		if ( $invoice && ! \is_wp_error( $invoice ) ) {
 			$invoice_billing_reason = $invoice['billing_reason'];
 			if ( isset( $invoice['subscription'] ) && is_string( $invoice['subscription'] ) ) {
 				$subscription_id = $invoice['subscription'];
 			}
+		} elseif ( \is_wp_error( $invoice ) ) {
+			Logger::error( 'Invoice error: ' . $invoice->get_error_message() );
 		}
 		return [
 			'email'                         => $customer['email'],

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -369,7 +369,7 @@ class Stripe_Connection {
 	public static function get_subscription_from_payment( $payment ) {
 		if ( $payment['invoice'] ) {
 			$invoice = self::get_invoice( $payment['invoice'] );
-			if ( $invoice['subscription'] ) {
+			if ( ! \is_wp_error( $invoice ) && $invoice['subscription'] ) {
 				return self::get_subscription( $invoice['subscription'] );
 			}
 		}
@@ -536,7 +536,7 @@ class Stripe_Connection {
 
 				if ( $payment['invoice'] ) {
 					$invoice = self::get_invoice( $payment['invoice'] );
-					if ( isset( $invoice['metadata']['referer'] ) ) {
+					if ( ! \is_wp_error( $invoice ) && isset( $invoice['metadata']['referer'] ) ) {
 						$referer = $invoice['metadata']['referer'];
 					}
 				}
@@ -1117,7 +1117,7 @@ class Stripe_Connection {
 					'metadata' => $client_metadata,
 				]
 			);
-			if ( is_wp_error( $customer ) ) {
+			if ( \is_wp_error( $customer ) ) {
 				$response['error'] = $customer->get_error_message();
 				return $response;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR handles when `Newspack\Stripe_Connection::get_invoice()` returns `WP_Error` to avoid fatal errors and logs the error message for debugging.

See #2094 for more information.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->