### PR TITLE
feat(plugin-screen): improve the pre-install prompt

### DIFF
--- a/assets/plugins-screen/plugins-screen.js
+++ b/assets/plugins-screen/plugins-screen.js
@@ -5,6 +5,24 @@
  */
 import './plugins-screen.scss';
 
+const getCreateButton =
+	targetEl =>
+	( text, hrefOrCallback, isPrimary = false ) => {
+		const buttonEl = document.createElement( 'a' );
+		if ( typeof hrefOrCallback === 'string' ) {
+			buttonEl.setAttribute( 'href', hrefOrCallback );
+		} else if ( typeof hrefOrCallback === 'function' ) {
+			buttonEl.onclick = hrefOrCallback;
+		} else {
+			return;
+		}
+		buttonEl.setAttribute( 'target', '_blank' );
+		buttonEl.classList.add( `button-${ isPrimary ? 'primary' : 'secondary' }` );
+		buttonEl.innerText = text;
+		targetEl.appendChild( buttonEl );
+		return buttonEl;
+	};
+
 /**
  * Extra zazz for the WP Admin Plugins page.
  *
@@ -21,30 +39,38 @@ import './plugins-screen.scss';
 		const modalHeadingEl = document.createElement( 'h1' );
 		const modalPEl = document.createElement( 'p' );
 		const modalButtonsWrapperEl = document.createElement( 'div' );
-		const modalActionEl = document.createElement( 'a' );
 		const modalCloseEl = document.createElement( 'button' );
+		const createButton = getCreateButton( modalButtonsWrapperEl );
+
+		const closeModal = () => {
+			modalEl.classList.add( 'newspack-plugin-info-modal--hidden' );
+		};
 
 		modalEl.classList.add( 'newspack-plugin-info-modal' );
 		modalHeadingEl.innerText = wp.i18n.__( 'Plugin review required', 'newspack' );
 		modalPEl.innerText = wp.i18n.__(
-			'Please submit a plugin for review by the Newspack Team before installing it on your website.',
+			'Please submit a plugin for review by the Newspack Team before installing it on your website. If you plan to install an approved plugin, feel free to close this message.',
 			'newspack'
 		);
 		modalCloseEl.innerHTML =
 			'<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"></path></svg>';
-		modalCloseEl.onclick = () => {
-			modalEl.classList.add( 'newspack-plugin-info-modal--hidden' );
-		};
-		modalActionEl.setAttribute( 'href', newspack_plugin_info.plugin_review_link );
-		modalActionEl.setAttribute( 'target', '_blank' );
-		modalActionEl.classList.add( 'button-primary' );
-		modalActionEl.innerText = wp.i18n.__( 'Plugin Review Form', 'newspack' );
+		modalCloseEl.onclick = closeModal;
+
+		createButton(
+			wp.i18n.__( 'Plugin Review Form', 'newspack' ),
+			newspack_plugin_info.plugin_review_link,
+			true
+		);
+		createButton(
+			wp.i18n.__( 'Approved Plugins List', 'newspack' ),
+			newspack_plugin_info.approved_plugins_list_link
+		);
+		createButton( wp.i18n.__( 'Close this message', 'newspack' ), closeModal );
 
 		modalEl.appendChild( modalContentEl );
 		modalContentEl.appendChild( modalHeadingEl );
 		modalContentEl.appendChild( modalPEl );
 		modalContentEl.appendChild( modalCloseEl );
-		modalButtonsWrapperEl.appendChild( modalActionEl );
 		modalContentEl.appendChild( modalButtonsWrapperEl );
 		document.body.appendChild( modalEl );
 	}

--- a/assets/plugins-screen/plugins-screen.scss
+++ b/assets/plugins-screen/plugins-screen.scss
@@ -44,6 +44,10 @@ table.plugins {
 		flex-direction: column;
 		background-color: wp-colors.$white;
 		box-shadow: 0 10px 10px rgb( 0 0 0 / 25% );
+		max-width: 80vw;
+		@media screen and ( min-width: 700px ) {
+			max-width: 570px;
+		}
 		> button {
 			position: absolute;
 			top: 14px;
@@ -57,8 +61,11 @@ table.plugins {
 		}
 		> div:last-child {
 			display: flex;
-			justify-content: flex-end;
-			padding-top: 20px;
+			flex-wrap: wrap;
+			justify-content: space-between;
+			> a {
+				margin-top: 20px;
+			}
 		}
 	}
 }

--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -215,10 +215,11 @@ class Admin_Plugins_Screen {
 		$installed_plugins[] = 'newspack';
 
 		$newspack_plugin_info = [
-			'plugins'            => $plugins,
-			'installed_plugins'  => $installed_plugins,
-			'screen'             => $hook,
-			'plugin_review_link' => defined( 'NEWSPACK_PLUGIN_REVIEW_FORM_URL' ) ? NEWSPACK_PLUGIN_REVIEW_FORM_URL : null,
+			'plugins'                    => $plugins,
+			'installed_plugins'          => $installed_plugins,
+			'screen'                     => $hook,
+			'plugin_review_link'         => defined( 'NEWSPACK_PLUGIN_REVIEW_FORM_URL' ) ? NEWSPACK_PLUGIN_REVIEW_FORM_URL : null,
+			'approved_plugins_list_link' => defined( 'NEWSPACK_APPROVED_PLUGINS_LIST_LINK' ) ? NEWSPACK_APPROVED_PLUGINS_LIST_LINK : null,
 		];
 
 		wp_localize_script( 'newspack_plugins_screen', 'newspack_plugin_info', $newspack_plugin_info );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves the plugin installation prompt.

### How to test the changes in this Pull Request:

1. Define `NEWSPACK_PLUGIN_REVIEW_FORM_URL` as some URL, and `NEWSPACK_PLUGIN_REVIEW_FORM_URL` as another URL
2. Visit the plugins install screen (`/wp-admin/plugin-install.php`)
3. Observe a prompt with three buttons – "Plugin Review Form" should take you to the first URL, "Approved Plugins List" to the second, and "Close this message" should do as it says

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->