### PR TITLE
fix(oauth): change Google's `dfp` scope to `admanager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.95.2-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.95.1...v1.95.2-hotfix.1) (2022-11-03)
+
+
+### Bug Fixes
+
+* **oauth:** change Google's `dfp` scope to `admanager` ([46e5eea](https://github.com/Automattic/newspack-plugin/commit/46e5eea6da738e59c2d56d3d34c2f8c1abe25bc0))
+
 ## [1.95.1](https://github.com/Automattic/newspack-plugin/compare/v1.95.0...v1.95.1) (2022-10-31)
 
 

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -23,7 +23,7 @@ class Google_OAuth {
 
 	const REQUIRED_SCOPES = [
 		'https://www.googleapis.com/auth/userinfo.email', // User's email address.
-		'https://www.googleapis.com/auth/dfp', // Google Ad Manager.
+		'https://www.googleapis.com/auth/admanager',
 		'https://www.googleapis.com/auth/analytics',
 		'https://www.googleapis.com/auth/analytics.edit',
 	];
@@ -336,6 +336,12 @@ class Google_OAuth {
 		if ( 200 === wp_remote_retrieve_response_code( $token_info_response ) ) {
 			$token_info     = json_decode( wp_remote_retrieve_body( $token_info_response ) );
 			$granted_scopes = explode( ' ', $token_info->scope );
+			/** If granted scope is 'dfp', interpret as 'admanager'.  */
+			foreach ( $granted_scopes as &$scope ) {
+				if ( 'https://www.googleapis.com/auth/dfp' === $scope ) {
+					$scope = 'https://www.googleapis.com/auth/admanager';
+				}
+			}
 			$missing_scopes = array_diff( $required_scopes, $granted_scopes );
 			if ( 0 < count( $missing_scopes ) ) {
 				Logger::log( 'OAuth token validation errored with missing scopes: ' . implode( ', ', $missing_scopes ) . '. Granted scopes: ' . $token_info->scope );

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.95.1
+ * Version: 1.95.2-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.95.1' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.95.2-hotfix.1' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.95.1",
+  "version": "1.95.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.95.1",
+      "version": "1.95.2-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.95.1",
+  "version": "1.95.2-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some accounts are experiencing a change in the `dfp` granted scope to `admanager`. This is causing a scope check mismatch.

We can assume that Google is changing the `dfp` scope name to `admanager`.

This PR changes requested scope name and ensures that if the granted scope is `dfp` we can interpret as `admanager` to match.

### How to test the changes in this Pull Request:

1. Make sure your instance is using the `release` branch
2. Connect with Google using OAuth
3. Confirm you are connected (or you might receive the scope mismatch error - not all accounts are experiencing the issue)
4. Switch to this branch and confirm you remain connected (or don't see the error anymore, if you had an error before)
5. Disconnect
6. Connect again and confirm you are connected without issues
7. Visit the Advertising wizard, edit a GAM ad unit
8. Confirm the ad unit is edited, meaning the dfp/admanager granted scope is fully working

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->