### PR TITLE
fix: delay receipt sending until Stripe webhook handler succeeds

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -640,9 +640,6 @@ class Stripe_Connection {
 					$label .= ' - ' . $origin;
 				}
 
-				// Send email to the donor.
-				self::send_email_to_customer( $customer, $payment );
-
 				// Send custom event to GA.
 				\Newspack\Google_Services_Connection::send_custom_event(
 					[
@@ -658,6 +655,9 @@ class Stripe_Connection {
 				if ( Donations::is_woocommerce_suite_active() ) {
 					WooCommerce_Connection::create_transaction( self::create_wc_transaction_payload( $customer, $payment ) );
 				}
+
+				// Send email to the donor.
+				self::send_email_to_customer( $customer, $payment );
 
 				break;
 			case 'charge.failed':

--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -541,9 +541,6 @@ class Stripe_Connection {
 					}
 				}
 
-				// Send email to the donor.
-				self::send_email_to_customer( $customer, $payment );
-
 				// Update data in Newsletters provider.
 				$was_customer_added_to_mailing_list = false;
 				$stripe_data                        = self::get_stripe_data();
@@ -642,6 +639,9 @@ class Stripe_Connection {
 				if ( ! empty( $origin ) ) {
 					$label .= ' - ' . $origin;
 				}
+
+				// Send email to the donor.
+				self::send_email_to_customer( $customer, $payment );
 
 				// Send custom event to GA.
 				\Newspack\Google_Services_Connection::send_custom_event(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Related to #2103 and #2094.

Currently, we send the "thank you" receipt email to the customer as part of the Stripe webhook handler, as soon as we get the transaction invoice from Stripe. However, a lot of other code happens in the webhook handler after that. If any error occurs in that other code, the receipt email gets sent anyway, but Stripe will schedule retries for the webhook, which will result in the email getting sent on every retry as well. This fix should avoid that in most cases by delaying the sending of the email until after most of the webhook handler has succeeded. 

### How to test the changes in this Pull Request:

1. On `master`, add a forced error somewhere inside the webhook handler after [this line](https://github.com/Automattic/newspack-plugin/blob/master/includes/reader-revenue/class-stripe-connection.php#L546). e.g. `throw new \Exception( ' an error occurred!' );`
2. Submit a donation via the simplified donate block. Observe that the webhook fails (in the Stripe dashboard) and that the transaction isn't synced to Woo, but that the receipt email is sent anyway. Also observe that Stripe will schedule a retry attempt after each failure, up to three additional times, and that each time the same receipt email is sent.
3. Check out this branch and confirm that the email won't be sent if an error occurs anywhere in the webhook handler.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->