### PR TITLE
chore: orb version with better cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: adekbadek/newspack@1.4.0
+  newspack: adekbadek/newspack@1.4.1
 
 workflows:
   version: 2


### PR DESCRIPTION
Updates the [CI Orb](https://circleci.com/developer/orbs/orb/adekbadek/newspack) to a version that handles npm package installation failures.

## To test

Just a sanity check, and all CI jobs should pass