### PR TITLE
fix(Stripe): improve handling of invoice error

### DIFF
--- a/includes/reader-revenue/class-stripe-connection.php
+++ b/includes/reader-revenue/class-stripe-connection.php
@@ -329,6 +329,9 @@ class Stripe_Connection {
 	 * @param string $invoice_id Invoice ID.
 	 */
 	public static function get_invoice( $invoice_id ) {
+		if ( empty( $invoice_id ) ) {
+			return new \WP_Error( 'stripe_newspack', __( 'Invoice ID is missing.', 'newspack' ) );
+		}
 		if ( isset( self::$cache['invoices'][ $invoice_id ] ) ) {
 			return self::$cache['invoices'][ $invoice_id ];
 		}
@@ -1375,7 +1378,7 @@ class Stripe_Connection {
 				$subscription_id = $invoice['subscription'];
 			}
 		} elseif ( \is_wp_error( $invoice ) ) {
-			Logger::error( 'Invoice error: ' . $invoice->get_error_message() );
+			Logger::log( 'Invoice error: ' . $invoice->get_error_message() );
 		}
 		return [
 			'email'                         => $customer['email'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Improve handling of invoice errors for Stripe webhooks.

I've noticed that some transactions might not include the `invoice` ID within the webhook payload. This PR fixes the usage of the `Newspack\Logger`class (there's no `error()` method) and returns an error when the invoice ID is missing, for improved debugging.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->