### PR TITLE
fix(woo): disable new order email on subscription renewals

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -479,8 +479,11 @@ class WooCommerce_Connection {
 				$order->save();
 				Logger::log( 'Updated WC subscription with id: ' . $subscription->get_id() . ' with a new order of id: ' . $order->get_id() );
 			} else {
-				// Linked subscription not found, just create an order.
+				// Linked subscription not found, just create an order. Temporarily disable the
+				// "New Order" email, since this is a renewal.
+				\add_filter( 'woocommerce_email_enabled_new_order', '__return_false' );
 				$order = self::create_order( $order_data, $item );
+				\remove_filter( 'woocommerce_email_enabled_new_order', '__return_false' );
 			}
 		} else {
 			/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Before #1936, Stripe Subscriptions were not resulting in Woo Subscriptions. For any recurring donations created before this change, there will be no Woo Subscription tied. This means that each renewal will be a new Woo order, triggering a "New Order" email. This PR disables the "New Order" email in that situation. 

### How to test the changes in this Pull Request:

For a full-fledged test, follow the instructions in #1936, but after pt. 7 unlink the subscriptions by removing the `newspack-stripe-subscription-id` meta from the Woo Subscription post. Then proceed, and observe the "New Order" email is not sent. 

For a small-scale test, just wrap the `create_order` call on line 492, make a one-time donation, observe the "New Order" email is not sent. Just to confirm that the filter works.   

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->