### PR TITLE
fix(woo): use variable post meta table name

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -323,7 +323,7 @@ class WooCommerce_Connection {
 		}
 		global $wpdb;
 		$query           = $wpdb->prepare(
-			'SELECT post_id FROM `wp_postmeta` WHERE `meta_key` = %s AND `meta_value` = %s',
+			"SELECT post_id FROM $wpdb->postmeta WHERE `meta_key` = %s AND `meta_value` = %s",
 			self::SUBSCRIPTION_STRIPE_ID_META_KEY,
 			$stripe_subscription_id
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The post meta table might be called differently than `wp_postmeta`, depending on the table prefix. 

### How to test the changes in this Pull Request:

Just a sanity check.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->