### PR TITLE
update newspack-scripts and CI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: adekbadek/newspack@1.4.1
+  newspack: adekbadek/newspack@1.4.2
 
 workflows:
   version: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@wordpress/browserslist-config": "^5.3.0",
         "eslint": "^7.32.0",
         "lint-staged": "^13.0.3",
-        "newspack-scripts": "^4.3.7",
+        "newspack-scripts": "^4.3.8",
         "postcss-scss": "^4.0.5",
         "prettier": "npm:wp-prettier@^2.6.2-beta-1",
         "stylelint": "^14.9.1"
@@ -177,6 +177,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.16.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
@@ -205,6 +206,7 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.0",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -535,6 +537,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.16.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.16.7",
@@ -8119,26 +8122,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array.prototype.filter": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.2.tgz",
-      "integrity": "sha512-us+UrmGOilqttSOgoWZTpOvHu68vZT2YCjc/H4vhu56vzZpaDFBhB+Se2UwqWzMKbDv7Myq5M5pcZLAtUvTQdQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array.prototype.find": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.1.tgz",
@@ -8997,188 +8980,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio-select/node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio-select/node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio-select/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select/node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "peer": true
-    },
-    "node_modules/cheerio-select/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select/node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/cheerio/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/cheerio/node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "peer": true
-    },
-    "node_modules/cheerio/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/cheerio/node_modules/parse5": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.5.2",
       "dev": true,
@@ -9854,6 +9655,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.1"
@@ -10836,13 +10638,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "dev": true,
@@ -10928,35 +10723,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domhandler/node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "peer": true
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -11108,19 +10874,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/env-ci": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
@@ -11144,40 +10897,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/enzyme": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-      "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array.prototype.flat": "^1.2.3",
-        "cheerio": "^1.0.0-rc.3",
-        "enzyme-shallow-equal": "^1.0.1",
-        "function.prototype.name": "^1.1.2",
-        "has": "^1.0.3",
-        "html-element-map": "^1.2.0",
-        "is-boolean-object": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-number-object": "^1.0.4",
-        "is-regex": "^1.0.5",
-        "is-string": "^1.0.5",
-        "is-subset": "^0.1.1",
-        "lodash.escape": "^4.0.1",
-        "lodash.isequal": "^4.5.0",
-        "object-inspect": "^1.7.0",
-        "object-is": "^1.0.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.1",
-        "object.values": "^1.1.1",
-        "raf": "^3.4.1",
-        "rst-selector-parser": "^2.2.3",
-        "string.prototype.trim": "^1.2.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/enzyme-matchers": {
@@ -11224,13 +10943,6 @@
       "version": "16.13.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/enzyme/node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/equivalent-key-map": {
       "version": "0.2.2",
@@ -11293,13 +11005,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
@@ -12761,6 +12466,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -13356,20 +13062,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/html-element-map": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-      "integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array.prototype.filter": "^1.0.0",
-        "call-bind": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "dev": true,
@@ -13395,69 +13087,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "entities": "^4.3.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "peer": true
-    },
-    "node_modules/htmlparser2/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -14157,13 +13786,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -17161,6 +16783,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5"
@@ -17731,25 +17354,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "node_modules/lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true
-    },
-    "node_modules/lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
@@ -18531,13 +18140,6 @@
         "node": "*"
       }
     },
-    "node_modules/moo": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/mousetrap": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -18596,36 +18198,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nearley": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      },
-      "bin": {
-        "nearley-railroad": "bin/nearley-railroad.js",
-        "nearley-test": "bin/nearley-test.js",
-        "nearley-unparse": "bin/nearley-unparse.js",
-        "nearleyc": "bin/nearleyc.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://nearley.js.org/#give-to-nearley"
-      }
-    },
-    "node_modules/nearley/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "dev": true,
@@ -18638,9 +18210,9 @@
       "dev": true
     },
     "node_modules/newspack-scripts": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.7.tgz",
-      "integrity": "sha512-twxZz9tRnxCIAUlfdppxaFiClt7WJIOoQv57+d4GU5sPQk6zOdXNtqZkWXoptRICWbgzsLzDxoSilKCvV7Ivtw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.8.tgz",
+      "integrity": "sha512-3nK3HKSLUjjkC+wP83DGfc9DKf7uLSN5zYhn6138oL0KEmwn8roP+DUY+ePuywV9MocT8X8sBP7hxvMqInlDHA==",
       "dev": true,
       "dependencies": {
         "@automattic/calypso-build": "^10.0.0",
@@ -19563,43 +19135,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/newspack-scripts/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/newspack-scripts/node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/newspack-scripts/node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/newspack-scripts/node_modules/semver": {
@@ -22814,33 +22349,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "domhandler": "^5.0.2",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/pascal-case": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -24760,27 +24268,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "node_modules/railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "dev": true,
@@ -24919,6 +24406,7 @@
     },
     "node_modules/react-dom": {
       "version": "17.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -25976,17 +25464,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/rst-selector-parser": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-      "integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "lodash.flattendeep": "^4.4.0",
-        "nearley": "^2.7.10"
-      }
-    },
     "node_modules/rsvp": {
       "version": "4.8.5",
       "dev": true,
@@ -26074,6 +25551,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-regex": {
@@ -26450,6 +25928,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.20.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -27242,6 +26721,7 @@
     },
     "node_modules/source-map": {
       "version": "0.5.7",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -27623,24 +27103,6 @@
         "internal-slot": "^1.0.3",
         "regexp.prototype.flags": "^1.3.1",
         "side-channel": "^1.0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trim": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
-      "integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -29970,6 +29432,7 @@
     },
     "@babel/core": {
       "version": "7.16.7",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
         "@babel/generator": "^7.16.7",
@@ -29989,7 +29452,8 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "dev": true
         }
       }
     },
@@ -30228,6 +29692,7 @@
     },
     "@babel/helpers": {
       "version": "7.16.7",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.16.7",
@@ -31463,8 +30928,7 @@
     },
     "@csstools/selector-specificity": {
       "version": "2.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.5",
@@ -31636,8 +31100,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
       "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@emotion/utils": {
       "version": "1.0.0",
@@ -32431,8 +31894,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "6.7.0",
@@ -33547,8 +33009,7 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.4.0",
@@ -33559,8 +33020,7 @@
     },
     "@webpack-cli/serve": {
       "version": "1.6.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@wojtekmaj/enzyme-adapter-react-17": {
       "version": "0.6.5",
@@ -33620,8 +33080,7 @@
     },
     "@wordpress/babel-plugin-import-jsx-pragma": {
       "version": "3.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@wordpress/babel-preset-default": {
       "version": "6.5.0",
@@ -35641,13 +35100,11 @@
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -35705,8 +35162,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -35823,20 +35279,6 @@
     "array-unique": {
       "version": "0.3.2",
       "dev": true
-    },
-    "array.prototype.filter": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.2.tgz",
-      "integrity": "sha512-us+UrmGOilqttSOgoWZTpOvHu68vZT2YCjc/H4vhu56vzZpaDFBhB+Se2UwqWzMKbDv7Myq5M5pcZLAtUvTQdQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.7"
-      }
     },
     "array.prototype.find": {
       "version": "2.2.1",
@@ -36423,144 +35865,6 @@
       "version": "0.7.0",
       "dev": true
     },
-    "cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
-      },
-      "dependencies": {
-        "dom-serializer": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
-            "entities": "^4.2.0"
-          }
-        },
-        "domelementtype": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-          "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-          "dev": true,
-          "peer": true
-        },
-        "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "dom-serializer": "^2.0.0",
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
-          }
-        },
-        "parse5": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-          "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "entities": "^4.4.0"
-          }
-        }
-      }
-    },
-    "cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "dependencies": {
-        "css-select": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-          "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "boolbase": "^1.0.0",
-            "css-what": "^6.1.0",
-            "domhandler": "^5.0.2",
-            "domutils": "^3.0.1",
-            "nth-check": "^2.0.1"
-          }
-        },
-        "css-what": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-          "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-          "dev": true,
-          "peer": true
-        },
-        "dom-serializer": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
-            "entities": "^4.2.0"
-          }
-        },
-        "domelementtype": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-          "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-          "dev": true,
-          "peer": true
-        },
-        "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "dom-serializer": "^2.0.0",
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
-          }
-        },
-        "nth-check": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-          "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "boolbase": "^1.0.0"
-          }
-        }
-      }
-    },
     "chokidar": {
       "version": "3.5.2",
       "dev": true,
@@ -37068,6 +36372,7 @@
     },
     "convert-source-map": {
       "version": "1.8.0",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -37112,8 +36417,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
       "integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "create-react-class": {
       "version": "15.6.3",
@@ -37712,13 +37016,6 @@
       "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
       "dev": true
     },
-    "discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-      "dev": true,
-      "peer": true
-    },
     "doctrine": {
       "version": "3.0.0",
       "dev": true,
@@ -37777,25 +37074,6 @@
         "webidl-conversions": {
           "version": "5.0.0",
           "dev": true
-        }
-      }
-    },
-    "domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "domelementtype": "^2.3.0"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-          "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-          "dev": true,
-          "peer": true
         }
       }
     },
@@ -37915,13 +37193,6 @@
         "ansi-colors": "^4.1.1"
       }
     },
-    "entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-      "dev": true,
-      "peer": true
-    },
     "env-ci": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
@@ -37936,46 +37207,6 @@
     "envinfo": {
       "version": "7.8.1",
       "dev": true
-    },
-    "enzyme": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-      "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "array.prototype.flat": "^1.2.3",
-        "cheerio": "^1.0.0-rc.3",
-        "enzyme-shallow-equal": "^1.0.1",
-        "function.prototype.name": "^1.1.2",
-        "has": "^1.0.3",
-        "html-element-map": "^1.2.0",
-        "is-boolean-object": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-number-object": "^1.0.4",
-        "is-regex": "^1.0.5",
-        "is-string": "^1.0.5",
-        "is-subset": "^0.1.1",
-        "lodash.escape": "^4.0.1",
-        "lodash.isequal": "^4.5.0",
-        "object-inspect": "^1.7.0",
-        "object-is": "^1.0.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.1",
-        "object.values": "^1.1.1",
-        "raf": "^3.4.1",
-        "rst-selector-parser": "^2.2.3",
-        "string.prototype.trim": "^1.2.1"
-      },
-      "dependencies": {
-        "lodash.isequal": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-          "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-          "dev": true,
-          "peer": true
-        }
-      }
     },
     "enzyme-matchers": {
       "version": "7.1.2",
@@ -38058,13 +37289,6 @@
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
       }
-    },
-    "es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true,
-      "peer": true
     },
     "es-module-lexer": {
       "version": "0.9.3",
@@ -38308,8 +37532,7 @@
     },
     "eslint-config-prettier": {
       "version": "8.3.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -39039,7 +38262,8 @@
       "dev": true
     },
     "gensync": {
-      "version": "1.0.0-beta.2"
+      "version": "1.0.0-beta.2",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -39463,17 +38687,6 @@
       "version": "1.0.0",
       "dev": true
     },
-    "html-element-map": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-      "integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "array.prototype.filter": "^1.0.0",
-        "call-bind": "^1.0.2"
-      }
-    },
     "html-encoding-sniffer": {
       "version": "2.0.1",
       "dev": true,
@@ -39488,52 +38701,6 @@
     "html-tags": {
       "version": "3.2.0",
       "dev": true
-    },
-    "htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "entities": "^4.3.0"
-      },
-      "dependencies": {
-        "dom-serializer": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
-            "entities": "^4.2.0"
-          }
-        },
-        "domelementtype": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-          "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-          "dev": true,
-          "peer": true
-        },
-        "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "dom-serializer": "^2.0.0",
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
-          }
-        }
-      }
     },
     "http-proxy-agent": {
       "version": "4.0.1",
@@ -39581,8 +38748,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ignore": {
       "version": "5.2.0",
@@ -39967,13 +39133,6 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-      "dev": true,
-      "peer": true
     },
     "is-symbol": {
       "version": "1.0.4",
@@ -41366,8 +40525,7 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.4.0",
@@ -41987,6 +41145,7 @@
     },
     "json5": {
       "version": "2.2.0",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -42331,25 +41490,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-      "dev": true,
-      "peer": true
-    },
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true
-    },
-    "lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-      "dev": true,
-      "peer": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -42864,13 +42009,6 @@
         "moment": ">= 2.9.0"
       }
     },
-    "moo": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-      "dev": true,
-      "peer": true
-    },
     "mousetrap": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -42914,28 +42052,6 @@
       "version": "1.4.0",
       "dev": true
     },
-    "nearley": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
     "neo-async": {
       "version": "2.6.2",
       "dev": true
@@ -42947,9 +42063,9 @@
       "dev": true
     },
     "newspack-scripts": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.7.tgz",
-      "integrity": "sha512-twxZz9tRnxCIAUlfdppxaFiClt7WJIOoQv57+d4GU5sPQk6zOdXNtqZkWXoptRICWbgzsLzDxoSilKCvV7Ivtw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.8.tgz",
+      "integrity": "sha512-3nK3HKSLUjjkC+wP83DGfc9DKf7uLSN5zYhn6138oL0KEmwn8roP+DUY+ePuywV9MocT8X8sBP7hxvMqInlDHA==",
       "dev": true,
       "requires": {
         "@automattic/calypso-build": "^10.0.0",
@@ -43452,8 +42568,7 @@
         },
         "eslint-plugin-react-hooks": {
           "version": "4.3.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "espree": {
           "version": "9.3.0",
@@ -43573,37 +42688,6 @@
           "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
           "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
           "dev": true
-        },
-        "react": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-          "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0"
-          }
-        },
-        "react-dom": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-          "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "scheduler": "^0.23.0"
-          }
-        },
-        "scheduler": {
-          "version": "0.23.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-          "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0"
-          }
         },
         "semver": {
           "version": "6.3.0",
@@ -45813,29 +44897,6 @@
       "version": "6.0.1",
       "dev": true
     },
-    "parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "domhandler": "^5.0.2",
-        "parse5": "^7.0.0"
-      },
-      "dependencies": {
-        "parse5": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-          "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "entities": "^4.4.0"
-          }
-        }
-      }
-    },
     "pascal-case": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -46424,8 +45485,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -46822,15 +45882,13 @@
     },
     "postcss-safe-parser": {
       "version": "6.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-scss": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.5.tgz",
       "integrity": "sha512-F7xpB6TrXyqUh3GKdyB4Gkp3QL3DDW1+uI+gxx/oJnUt/qXI4trj5OGlp9rOKdoABGULuqtqeG+3HEVQk4DjmA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-selector-parser": {
       "version": "6.0.10",
@@ -47070,24 +46128,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-      "dev": true,
-      "peer": true
-    },
-    "randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "dev": true,
@@ -47119,8 +46159,7 @@
       "version": "6.9.9",
       "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
       "integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react": {
       "version": "17.0.2",
@@ -47150,8 +46189,7 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
       "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-daterange-picker": {
       "version": "2.0.1",
@@ -47189,6 +46227,7 @@
     },
     "react-dom": {
       "version": "17.0.2",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -47214,8 +46253,7 @@
       }
     },
     "react-google-charts": {
-      "version": "4.0.0",
-      "requires": {}
+      "version": "4.0.0"
     },
     "react-is": {
       "version": "17.0.2",
@@ -47528,8 +46566,7 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
       "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "reakit-warning": {
       "version": "0.6.2",
@@ -47939,17 +46976,6 @@
     "round-to": {
       "version": "5.0.0"
     },
-    "rst-selector-parser": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-      "integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash.flattendeep": "^4.4.0",
-        "nearley": "^2.7.10"
-      }
-    },
     "rsvp": {
       "version": "4.8.5",
       "dev": true
@@ -48001,7 +47027,8 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2"
+      "version": "5.1.2",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -48255,6 +47282,7 @@
     },
     "scheduler": {
       "version": "0.20.2",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -48860,7 +47888,8 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.5.7"
+      "version": "0.5.7",
+      "dev": true
     },
     "source-map-js": {
       "version": "1.0.2",
@@ -49145,18 +48174,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "string.prototype.trim": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
-      "integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      }
-    },
     "string.prototype.trimend": {
       "version": "1.0.5",
       "dev": true,
@@ -49375,13 +48392,11 @@
     },
     "stylelint-config-prettier": {
       "version": "9.0.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-recommended": {
       "version": "6.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-recommended-scss": {
       "version": "5.0.2",
@@ -50177,8 +49192,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-lilius": {
       "version": "2.0.3",
@@ -50193,15 +49207,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
       "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -50541,8 +49553,7 @@
     },
     "ws": {
       "version": "7.5.5",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@wordpress/browserslist-config": "^5.3.0",
     "eslint": "^7.32.0",
     "lint-staged": "^13.0.3",
-    "newspack-scripts": "^4.3.7",
+    "newspack-scripts": "^4.3.8",
     "postcss-scss": "^4.0.5",
     "prettier": "npm:wp-prettier@^2.6.2-beta-1",
     "stylelint": "^14.9.1"


### PR DESCRIPTION
Update `newspack-scripts` and CI orb. The latest version combo will handle building JS files on CI better:

- version `1.4.2` of the orb adds setting node version according to the project's `.nvmrc` file prior to installing npm modules and building the JS files
- version `4.3.8` of `newspack-scripts` removes a hacky partial fix for issues caused by node version mismatch