### PR TITLE
update CI orb, hopefully finally 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: adekbadek/newspack@1.4.2
+  newspack: adekbadek/newspack@1.4.3
 
 workflows:
   version: 2


### PR DESCRIPTION
Last update to the CI orb for now – the new version ensures that the proper node version is used before all node-related jobs