### PR TITLE
feat: disable jetpacks google analytics

### DIFF
--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -33,6 +33,7 @@ class Jetpack {
 		add_filter( 'newspack_amp_plus_sanitized', [ __CLASS__, 'jetpack_modules_amp_plus' ], 10, 2 );
 		add_action( 'wp_head', [ __CLASS__, 'fix_instant_search_sidebar_display' ], 10 );
 		add_filter( 'jetpack_lazy_images_skip_image_with_attributes', [ __CLASS__, 'skip_lazy_loading_on_feeds' ], 10 );
+		add_filter( 'jetpack_active_modules', array( __CLASS__, 'disable_google_analytics' ), 10, 2 );
 	}
 
 	/**
@@ -112,6 +113,16 @@ class Jetpack {
 			}
 		</style>
 		<?php
+	}
+
+	/**
+	 * Disables Google Analytics module. Users will not be able to activate it.
+	 *
+	 * @param array $modules Array with modules slugs.
+	 * @return array
+	 */
+	public static function disable_google_analytics( $modules ) {
+		return array_diff( $modules, array( 'google-analytics' ) );
 	}
 }
 Jetpack::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using Newspack, we want users to use Sitekit in order to connect with Google Analytics. Many sites have configured GA also with Jetpack resulting in duplicate counts.

This PR forces Jetpack's google analytics module to always be disabled.

### How to test the changes in this Pull Request:

1. on a regular site, go to Jetpack Settings > Traffic
2. Confirm you see Google Analytics section
3. Checkout this branch
4. Confirm the setting is gone
5. Go to Calypso > Tools > Marketing 'https://wordpress.com/marketing/traffic/YOUR_SITE?site=YOUR-SITE#analytics'
6. Activate google analytics there and enter a fake Measurement ID. Save it
7. You'll need to buy a plan for that
8. Back to your site, confirm the code is not added
9. Confirm that if you refresh the page, Google Analytics is disabled again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->