### PR TITLE
feat: allow non-readers to log in via RAS and send them to WP admin

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -368,7 +368,11 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 							readerActivation
 								.authenticateOTP( body.get( 'otp_code' ) )
 								.then( data => {
-									form.endLoginFlow( data.message, 200, data, body.get( 'redirect' ) );
+									let redirect = body.get( 'redirect' );
+									if ( data.redirect_to ) {
+										redirect = data.redirect_to;
+									}
+									form.endLoginFlow( data.message, 200, data, redirect );
 								} )
 								.catch( data => {
 									if ( data.expired ) {
@@ -398,6 +402,9 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 												/** Redirect every registration to the account page for verification */
 												if ( action === 'register' ) {
 													redirect = newspack_reader_activation_data.account_url;
+												}
+												if ( action !== 'register' && data.redirect_to ) {
+													redirect = data.redirect_to;
 												}
 												form.endLoginFlow( message, res.status, data, redirect );
 											} )

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -77,10 +77,6 @@ final class Magic_Link {
 			return false;
 		}
 
-		if ( ! Reader_Activation::is_user_reader( $user ) ) {
-			return false;
-		}
-
 		$can_magic_link = ! (bool) \get_user_meta( $user_id, self::DISABLED_META, true );
 
 		/**
@@ -788,7 +784,12 @@ final class Magic_Link {
 			return self::send_otp_request_response( __( 'Unable to authenticated. Please try again.', 'newspack' ), false, [ 'expired' => true ] );
 		}
 
-		return self::send_otp_request_response( __( 'Login successful!', 'newspack' ), true );
+		$data = [];
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			$data['redirect_to'] = \get_admin_url();
+		}
+
+		return self::send_otp_request_response( __( 'Login successful!', 'newspack' ), true, $data );
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1158,7 +1158,7 @@ final class Reader_Activation {
 		self::set_auth_intention_cookie( $email );
 
 		$user = \get_user_by( 'email', $email );
-		if ( ( ! $user && 'register' !== $action ) || ( $user && ! self::is_user_reader( $user ) ) ) {
+		if ( ! $user && 'register' !== $action ) {
 			return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( "We couldn't find an account registered to this email address. Please confirm that you entered the correct email, or sign up for a new account.", 'newspack' ) ) );
 		}
 
@@ -1166,6 +1166,11 @@ final class Reader_Activation {
 			'email'         => $email,
 			'authenticated' => 0,
 		];
+
+		if ( $user && 'register' !== $action && ! self::is_user_reader( $user ) ) {
+			$redirect               = \get_admin_url();
+			$payload['redirect_to'] = $redirect;
+		}
 
 		switch ( $action ) {
 			case 'pwd':
@@ -1204,7 +1209,6 @@ final class Reader_Activation {
 		}
 	}
 
-
 	/**
 	 * Check if current reader has its email verified.
 	 *
@@ -1242,7 +1246,7 @@ final class Reader_Activation {
 			$user = get_user_by( 'id', $user_or_user_id );
 		}
 
-		if ( ! $user || \is_wp_error( $user ) || ! self::is_user_reader( $user ) ) {
+		if ( ! $user || \is_wp_error( $user ) ) {
 			return new \WP_Error( 'newspack_authenticate_invalid_user', __( 'Invalid user.', 'newspack' ) );
 		}
 

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -124,15 +124,6 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that generating a token for an admin returns an error.
-	 */
-	public function test_generate_token_for_admin() {
-		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$admin_id ) );
-		$this->assertTrue( is_wp_error( $token_data ) );
-		$this->assertEquals( 'newspack_magic_link_invalid_user', $token_data->get_error_code() );
-	}
-
-	/**
 	 * Test that generating a token for a user with disabled magic links returns
 	 * an error.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There have been reports from confused publishers about not being able to log into their sites. Turns out, some of them were trying to log into admin/editor accounts using the RAS login forms.

Current behavior: If a non-reader tries to log in via the RAS registration or auth form, the form returns an unhelpful error: `We couldn't find an account registered to this email address. Please confirm that you entered the correct email, or sign up for a new account.`

Proposed behavior: If a non-reader tries to log in via RAS, allow the login to occur, but redirect them to WP admin instead of My Account.

Closes /0/1203349230040139/1203185882657586

### How to test the changes in this Pull Request:

Confirm that all magic link and password login flows work for non-reader users, including admins/editors/authors/subscribers, but that you're redirected to WP admin instead of My Account after being authenticated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->