### PR TITLE
fix(my-account): hide account deletion for non-reader users

### DIFF
--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -29,6 +29,7 @@ if ( isset( $_GET['is_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVeri
 }
 
 $without_password = true === Reader_Activation::is_reader_without_password( $user );
+$is_reader        = true === Reader_Activation::is_user_reader( $user );
 ?>
 
 <?php
@@ -94,6 +95,10 @@ endif;
 	</a>
 </div>
 
+<?php
+if ( $is_reader ) :
+	?>
+
 <div class="woocommerce-card woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
 	<a href="<?php echo '?' . \esc_attr( $newspack_delete_account_arg ) . '=' . \esc_attr( \wp_create_nonce( $newspack_delete_account_arg ) ); ?>" class="is-destructive">
 		<span class="woocommerce-card__content">
@@ -109,5 +114,7 @@ endif;
 		<?php \esc_html_e( 'Deleting your account will also cancel any newsletter subscriptions and recurring payments.', 'newspack' ); ?>
 	</p>
 </div>
+
+<?php endif; ?>
 
 <?php \do_action( 'newspack_woocommerce_after_edit_account_form' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small issue.

### How to test the changes in this Pull Request:

1. On `master`, log in to the site as a non-reader user (e.g. an admin)
2. Visit the `/my-account` page and observe the account deletion request button is there. It [won't work](https://github.com/Automattic/newspack-plugin/blob/b6e22cdbc021a475cf2c347513fd9d80b6759082/includes/reader-revenue/my-account/class-woocommerce-my-account.php#L204-L206), and should not.
3. Switch to this branch, reload, observe the account deletion request link is not there anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->