### PR TITLE
fix: revert non reader login

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -368,11 +368,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 							readerActivation
 								.authenticateOTP( body.get( 'otp_code' ) )
 								.then( data => {
-									let redirect = body.get( 'redirect' );
-									if ( data.redirect_to ) {
-										redirect = data.redirect_to;
-									}
-									form.endLoginFlow( data.message, 200, data, redirect );
+									form.endLoginFlow( data.message, 200, data, body.get( 'redirect' ) );
 								} )
 								.catch( data => {
 									if ( data.expired ) {
@@ -402,9 +398,6 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 												/** Redirect every registration to the account page for verification */
 												if ( action === 'register' ) {
 													redirect = newspack_reader_activation_data.account_url;
-												}
-												if ( action !== 'register' && data.redirect_to ) {
-													redirect = data.redirect_to;
 												}
 												form.endLoginFlow( message, res.status, data, redirect );
 											} )

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -77,6 +77,10 @@ final class Magic_Link {
 			return false;
 		}
 
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			return false;
+		}
+
 		$can_magic_link = ! (bool) \get_user_meta( $user_id, self::DISABLED_META, true );
 
 		/**
@@ -784,12 +788,7 @@ final class Magic_Link {
 			return self::send_otp_request_response( __( 'Unable to authenticated. Please try again.', 'newspack' ), false, [ 'expired' => true ] );
 		}
 
-		$data = [];
-		if ( ! Reader_Activation::is_user_reader( $user ) ) {
-			$data['redirect_to'] = \get_admin_url();
-		}
-
-		return self::send_otp_request_response( __( 'Login successful!', 'newspack' ), true, $data );
+		return self::send_otp_request_response( __( 'Login successful!', 'newspack' ), true );
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1158,7 +1158,7 @@ final class Reader_Activation {
 		self::set_auth_intention_cookie( $email );
 
 		$user = \get_user_by( 'email', $email );
-		if ( ! $user && 'register' !== $action ) {
+		if ( ( ! $user && 'register' !== $action ) || ( $user && ! self::is_user_reader( $user ) ) ) {
 			return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( "We couldn't find an account registered to this email address. Please confirm that you entered the correct email, or sign up for a new account.", 'newspack' ) ) );
 		}
 
@@ -1166,11 +1166,6 @@ final class Reader_Activation {
 			'email'         => $email,
 			'authenticated' => 0,
 		];
-
-		if ( $user && 'register' !== $action && ! self::is_user_reader( $user ) ) {
-			$redirect               = \get_admin_url();
-			$payload['redirect_to'] = $redirect;
-		}
 
 		switch ( $action ) {
 			case 'pwd':
@@ -1209,6 +1204,7 @@ final class Reader_Activation {
 		}
 	}
 
+
 	/**
 	 * Check if current reader has its email verified.
 	 *
@@ -1246,7 +1242,7 @@ final class Reader_Activation {
 			$user = get_user_by( 'id', $user_or_user_id );
 		}
 
-		if ( ! $user || \is_wp_error( $user ) ) {
+		if ( ! $user || \is_wp_error( $user ) || ! self::is_user_reader( $user ) ) {
 			return new \WP_Error( 'newspack_authenticate_invalid_user', __( 'Invalid user.', 'newspack' ) );
 		}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1159,7 +1159,7 @@ final class Reader_Activation {
 
 		$user = \get_user_by( 'email', $email );
 		if ( ( ! $user && 'register' !== $action ) || ( $user && ! self::is_user_reader( $user ) ) ) {
-			return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( "We couldn't find a reader account registered to this email address. Please confirm that you entered the correct email.", 'newspack' ) ) );
+			return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( "We couldn't find a reader account registered to this email address. Please confirm that you entered the correct email, or sign up for a new account.", 'newspack' ) ) );
 		}
 
 		$payload = [

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1159,7 +1159,7 @@ final class Reader_Activation {
 
 		$user = \get_user_by( 'email', $email );
 		if ( ( ! $user && 'register' !== $action ) || ( $user && ! self::is_user_reader( $user ) ) ) {
-			return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( "We couldn't find an account registered to this email address. Please confirm that you entered the correct email, or sign up for a new account.", 'newspack' ) ) );
+			return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( "We couldn't find a reader account registered to this email address. Please confirm that you entered the correct email.", 'newspack' ) ) );
 		}
 
 		$payload = [

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -124,6 +124,15 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that generating a token for an admin returns an error.
+	 */
+	public function test_generate_token_for_admin() {
+		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$admin_id ) );
+		$this->assertTrue( is_wp_error( $token_data ) );
+		$this->assertEquals( 'newspack_magic_link_invalid_user', $token_data->get_error_code() );
+	}
+
+	/**
 	 * Test that generating a token for a user with disabled magic links returns
 	 * an error.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We had some minor security concerns around #2131, so reverting. Also slightly tweaks the error message in a way that will hopefully hint to confused publishers that this login form is for **reader** accounts only.

<img width="787" alt="Screen Shot 2022-11-16 at 4 30 02 PM" src="https://user-images.githubusercontent.com/2230142/202317180-4790e132-2800-4dcc-a820-b3fe9a2ddf21.png">

### How to test the changes in this Pull Request:

Test that you once again can't log in via the RAS auth forms with a non-reader account.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->