### PR TITLE
chore: error handling in reader registration

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -323,19 +323,21 @@ function send_form_response( $data, $message = '' ) {
 		\wp_send_json( compact( 'message', 'data' ), \is_wp_error( $data ) ? 400 : 200 );
 		exit;
 	} elseif ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) {
-		$args_to_remove = [
+		$args_to_remove   = [
 			'_wp_http_referer',
 			FORM_ACTION,
 		];
+		$is_existing_user = 0;
 		if ( ! $is_error ) {
-			$args_to_remove = array_merge( $args_to_remove, [ 'email', 'lists' ] );
+			$args_to_remove   = array_merge( $args_to_remove, [ 'email', 'lists' ] );
+			$is_existing_user = isset( $data['existing_user'] ) && boolval( $data['existing_user'] ) ? 1 : 0;
 		}
 		\wp_safe_redirect(
 			\add_query_arg(
 				[
 					'newspack_reader' => $is_error ? '0' : '1',
 					'message'         => $message,
-					'existing_user'   => isset( $data['existing_user'] ) && boolval( $data['existing_user'] ) ? 1 : 0,
+					'existing_user'   => $is_existing_user,
 				],
 				\remove_query_arg( $args_to_remove )
 			)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves error handling in RAS's `send_form_response` function. 

### How to test the changes in this Pull Request:

Not sure how to reproduce, but I've noticed `PHP Fatal error:  Uncaught Error: Cannot use object of type WP_Error as array` on a live site. The changes should be self-explanatory, though – the `$data` argument might be an error, and it's not handled as such in all cases. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->