### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -134,7 +134,7 @@ class Admin_Plugins_Screen {
 			wp_die( esc_html__( 'Sorry, you are not allowed to install plugins.', 'newspack' ) );
 		}
 
-		$plugin = filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_STRING );
+		$plugin = filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! $plugin ) {
 			wp_die( esc_html__( 'Invalid plugin.', 'newspack' ) );
 		}
@@ -175,10 +175,10 @@ class Admin_Plugins_Screen {
 				</button>
 			</div>
 			<?php
-		} elseif ( filter_input( INPUT_GET, 'newspack_install_error', FILTER_VALIDATE_BOOLEAN ) && filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_STRING ) && filter_input( INPUT_GET, 'message', FILTER_SANITIZE_STRING ) ) {
-			$plugin = filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_STRING );
+		} elseif ( filter_input( INPUT_GET, 'newspack_install_error', FILTER_VALIDATE_BOOLEAN ) && filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) && filter_input( INPUT_GET, 'message', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) {
+			$plugin = filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			check_admin_referer( 'newspack-install-error_' . $plugin, '_error_nonce' );
-			$message = filter_input( INPUT_GET, 'message', FILTER_SANITIZE_STRING );
+			$message = filter_input( INPUT_GET, 'message', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			?>
 			<div class="notice notice-error is-dismissible">
 				<p><strong><?php echo esc_html__( 'Failed to install plugin:', 'newspack' ); ?></strong> <?php echo esc_html( $message ); ?></p>

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -532,20 +532,20 @@ class Donations {
 		}
 
 		// Parse values from the form.
-		$donation_frequency = filter_input( INPUT_GET, 'donation_frequency', FILTER_SANITIZE_STRING );
+		$donation_frequency = filter_input( INPUT_GET, 'donation_frequency', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! $donation_frequency ) {
 			return;
 		}
-		$donation_value = filter_input( INPUT_GET, 'donation_value_' . $donation_frequency, FILTER_SANITIZE_STRING );
+		$donation_value = filter_input( INPUT_GET, 'donation_value_' . $donation_frequency, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! $donation_value ) {
-			$donation_value = filter_input( INPUT_GET, 'donation_value_' . $donation_frequency . '_untiered', FILTER_SANITIZE_STRING );
+			$donation_value = filter_input( INPUT_GET, 'donation_value_' . $donation_frequency . '_untiered', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 			if ( ! $donation_value ) {
 				return;
 			}
 		}
 		if ( 'other' === $donation_value ) {
-			$donation_value = filter_input( INPUT_GET, 'donation_value_' . $donation_frequency . '_other', FILTER_SANITIZE_STRING );
+			$donation_value = filter_input( INPUT_GET, 'donation_value_' . $donation_frequency . '_other', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! $donation_value ) {
 				return;
 			}
@@ -764,7 +764,7 @@ class Donations {
 	 * @param Array $form_fields WC form fields.
 	 */
 	public static function woocommerce_billing_fields( $form_fields ) {
-		$params = filter_input_array( INPUT_GET, FILTER_SANITIZE_STRING );
+		$params = filter_input_array( INPUT_GET, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( is_array( $params ) ) {
 			foreach ( $params as $param => $value ) {
@@ -803,7 +803,7 @@ class Donations {
 	 * @param String $order_id WC order id.
 	 */
 	public static function woocommerce_checkout_update_order_meta( $order_id ) {
-		$params = filter_input_array( INPUT_POST, FILTER_SANITIZE_STRING );
+		$params = filter_input_array( INPUT_POST, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( is_array( $params ) ) {
 			foreach ( $params as $param => $value ) {

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -184,7 +184,7 @@ final class Newspack {
 	 */
 	public function handle_resets() {
 		$redirect_url   = admin_url( 'admin.php?page=newspack' );
-		$newspack_reset = filter_input( INPUT_GET, 'newspack_reset', FILTER_SANITIZE_STRING );
+		$newspack_reset = filter_input( INPUT_GET, 'newspack_reset', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( 'starter-content' === $newspack_reset ) {
 			Starter_Content::remove_starter_content();
 			$redirect_url = add_query_arg( 'newspack-notice', __( 'Starter content removed.', 'newspack' ), $redirect_url );

--- a/includes/class-nrh.php
+++ b/includes/class-nrh.php
@@ -45,7 +45,7 @@ class NRH {
 		if ( isset( $nrh_config['nrh_salesforce_campaign_id'] ) ) {
 			$salesforce_id = wp_strip_all_tags( $nrh_config['nrh_salesforce_campaign_id'] );
 		}
-		$custom_campaign = filter_input( INPUT_GET, 'campaign', FILTER_SANITIZE_STRING );
+		$custom_campaign = filter_input( INPUT_GET, 'campaign', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( $custom_campaign ) {
 			$salesforce_id = wp_strip_all_tags( $custom_campaign );
 		}
@@ -86,7 +86,7 @@ class NRH {
 			return $html;
 		}
 
-		$custom_campaign = filter_input( INPUT_GET, 'campaign', FILTER_SANITIZE_STRING );
+		$custom_campaign = filter_input( INPUT_GET, 'campaign', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! $custom_campaign ) {
 			return $html;
 		}

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -325,12 +325,17 @@ class Emails {
 		if ( ! $html_payload || empty( $html_payload ) ) {
 			return false;
 		}
+		$edit_link = '';
+		$post_link = get_edit_post_link( $post_id, '' );
+		if ( $post_link ) {
+			// Make the edit link relative.
+			$edit_link = str_replace( site_url(), '', $post_link );
+		}
 		$serialized_email = [
 			'label'          => $email_config['label'],
 			'description'    => $email_config['description'],
 			'post_id'        => $post_id,
-			// Make the edit link relative.
-			'edit_link'      => str_replace( site_url(), '', get_edit_post_link( $post_id, '' ) ),
+			'edit_link'      => $edit_link,
 			'subject'        => get_the_title( $post_id ),
 			'from_name'      => isset( $email_config['from_name'] ) ? $email_config['from_name'] : self::get_from_name(),
 			'from_email'     => isset( $email_config['from_email'] ) ? $email_config['from_email'] : self::get_from_email(),

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -94,7 +94,7 @@ class RSS {
 		];
 
 		if ( ! $feed_post ) {
-			$query_feed = filter_input( INPUT_GET, self::FEED_QUERY_ARG, FILTER_SANITIZE_STRING );
+			$query_feed = filter_input( INPUT_GET, self::FEED_QUERY_ARG, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! $query_feed ) {
 				return false;
 			}
@@ -417,7 +417,7 @@ class RSS {
 	 * @param int $feed_post_id The post ID of feed.
 	 */
 	public static function save_settings( $feed_post_id ) {
-		$nonce = filter_input( INPUT_POST, 'newspack_rss_enhancements_nonce', FILTER_SANITIZE_STRING );
+		$nonce = filter_input( INPUT_POST, 'newspack_rss_enhancements_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'newspack_rss_enhancements_nonce' ) ) {
 			return;
 		}
@@ -508,7 +508,7 @@ class RSS {
 		}
 
 		$query->set( 'posts_per_rss', absint( $settings['num_items_in_feed'] ) );
-		
+
 		$query->set( 'offset', absint( $settings['offset'] ) );
 
 		if ( ! empty( $settings['timeframe'] ) ) {

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -160,7 +160,7 @@ class WooCommerce_My_Account {
 			return;
 		}
 
-		$nonce = filter_input( INPUT_GET, self::RESET_PASSWORD_URL_PARAM, FILTER_SANITIZE_STRING );
+		$nonce = filter_input( INPUT_GET, self::RESET_PASSWORD_URL_PARAM, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! $nonce ) {
 			return;
 		}
@@ -205,7 +205,7 @@ class WooCommerce_My_Account {
 			return;
 		}
 
-		$nonce = filter_input( INPUT_GET, self::DELETE_ACCOUNT_URL_PARAM, FILTER_SANITIZE_STRING );
+		$nonce = filter_input( INPUT_GET, self::DELETE_ACCOUNT_URL_PARAM, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! $nonce || ! \wp_verify_nonce( $nonce, self::DELETE_ACCOUNT_URL_PARAM ) ) {
 			return;
 		}
@@ -295,7 +295,7 @@ class WooCommerce_My_Account {
 		if ( ! \is_user_logged_in() ) {
 			return;
 		}
-		$nonce = filter_input( INPUT_GET, self::SEND_MAGIC_LINK_PARAM, FILTER_SANITIZE_STRING );
+		$nonce = filter_input( INPUT_GET, self::SEND_MAGIC_LINK_PARAM, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( $nonce ) {
 			$is_error = false;

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -478,7 +478,7 @@ class Advertising_Wizard extends Wizard {
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -202,7 +202,7 @@ class Analytics_Wizard extends Wizard {
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -60,7 +60,7 @@ class Components_Demo extends Wizard {
 		parent::enqueue_scripts_and_styles();
 		wp_enqueue_media();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-connections-wizard.php
+++ b/includes/wizards/class-connections-wizard.php
@@ -47,7 +47,7 @@ class Connections_Wizard extends Wizard {
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -159,7 +159,7 @@ class Dashboard extends Wizard {
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -298,7 +298,7 @@ class Engagement_Wizard extends Wizard {
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-health-check-wizard.php
+++ b/includes/wizards/class-health-check-wizard.php
@@ -150,7 +150,7 @@ class Health_Check_Wizard extends Wizard {
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -430,7 +430,7 @@ class Popups_Wizard extends Wizard {
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -510,7 +510,7 @@ class Reader_Revenue_Wizard extends Wizard {
 	 */
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 		\wp_enqueue_media();

--- a/includes/wizards/class-seo-wizard.php
+++ b/includes/wizards/class-seo-wizard.php
@@ -178,7 +178,7 @@ class SEO_Wizard extends Wizard {
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -587,7 +587,7 @@ class Setup_Wizard extends Wizard {
 	 */
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 		wp_enqueue_script(

--- a/includes/wizards/class-site-design-wizard.php
+++ b/includes/wizards/class-site-design-wizard.php
@@ -47,7 +47,7 @@ class Site_Design_Wizard extends Wizard {
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-syndication-wizard.php
+++ b/includes/wizards/class-syndication-wizard.php
@@ -60,7 +60,7 @@ class Syndication_Wizard extends Wizard {
 	public function enqueue_scripts_and_styles() {
 		parent::enqueue_scripts_and_styles();
 
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -81,7 +81,7 @@ abstract class Wizard {
 	 * Load up common JS/CSS for wizards.
 	 */
 	public function enqueue_scripts_and_styles() {
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $this->slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A few tweaks needed for this plugin to run on PHP 8.1. It may be a bit too early for that, but won't hurt to be proactive:

- `FILTER_SANITIZE_STRING` is deprecated (updated to use `FILTER_SANITIZE_FULL_SPECIAL_CHARS`)
- `Emails::serialize_email` needed some refactoring, as it caused `str_replace` to be called with `null` as the third argument, which is also deprecated

### How to test the changes in this Pull Request:

1. On `master`, set PHP to 8.1 and observe a flurry of deprecation warnings. You might have to deactivate other plugins to get a clearer picture of which errors stem from this plugin.
2. Switch to this branch, observe errors gone and site functioning properly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->