### PR TITLE
Stripe webhooks management

### DIFF
--- a/assets/components/src/accordion/index.js
+++ b/assets/components/src/accordion/index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Icon, chevronDown } from '@wordpress/icons';
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const Accordion = ( { children } ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
+	return (
+		<details
+			className={ classNames( 'newspack-accordion', { 'newspack-accordion--is-open': isOpen } ) }
+		>
+			<summary onClick={ () => setIsOpen( ! isOpen ) }>
+				{ __( 'Webhooks not connected to this site.', 'newspack' ) }
+				<Icon className="newspack-accordion__icon" icon={ chevronDown } size={ 24 } />
+			</summary>
+			{ children }
+		</details>
+	);
+};
+
+export default Accordion;

--- a/assets/components/src/accordion/index.js
+++ b/assets/components/src/accordion/index.js
@@ -15,14 +15,14 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
-const Accordion = ( { children } ) => {
+const Accordion = ( { children, title } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	return (
 		<details
 			className={ classNames( 'newspack-accordion', { 'newspack-accordion--is-open': isOpen } ) }
 		>
 			<summary onClick={ () => setIsOpen( ! isOpen ) }>
-				{ __( 'Webhooks not connected to this site.', 'newspack' ) }
+				{ title }
 				<Icon className="newspack-accordion__icon" icon={ chevronDown } size={ 24 } />
 			</summary>
 			{ children }

--- a/assets/components/src/accordion/index.js
+++ b/assets/components/src/accordion/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { Icon, chevronDown } from '@wordpress/icons';
 

--- a/assets/components/src/accordion/style.scss
+++ b/assets/components/src/accordion/style.scss
@@ -15,10 +15,12 @@
 		}
 	}
 	summary {
-		padding: 18px 24px;
+		padding: 16px 32px;
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		cursor: pointer;
+		font-size: 14px;
+		font-weight: bold;
 	}
 }

--- a/assets/components/src/accordion/style.scss
+++ b/assets/components/src/accordion/style.scss
@@ -1,4 +1,8 @@
+@use '~@wordpress/base-styles/colors' as wp-colors;
+
 .newspack-accordion {
+	border: 1px solid wp-colors.$gray-300;
+
 	&__icon {
 		transition: transform 200ms ease-out;
 	}
@@ -11,9 +15,10 @@
 		}
 	}
 	summary {
+		padding: 18px 24px;
 		display: flex;
 		align-items: center;
+		justify-content: space-between;
 		cursor: pointer;
-		font-weight: bold;
 	}
 }

--- a/assets/components/src/accordion/style.scss
+++ b/assets/components/src/accordion/style.scss
@@ -1,0 +1,19 @@
+.newspack-accordion {
+	&__icon {
+		transition: transform 200ms ease-out;
+	}
+
+	&--is-open {
+		.newspack-accordion {
+			&__icon {
+				transform: rotate( -180deg );
+			}
+		}
+	}
+	summary {
+		display: flex;
+		align-items: center;
+		cursor: pointer;
+		font-weight: bold;
+	}
+}

--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -1,3 +1,4 @@
+export { default as Accordion } from './accordion';
 export { default as ActionCard } from './action-card';
 export { default as AutocompleteTokenField } from './autocomplete-tokenfield';
 export { default as AutocompleteWithSuggestions } from './autocomplete-with-suggestions';

--- a/assets/components/src/tabbed-navigation/index.js
+++ b/assets/components/src/tabbed-navigation/index.js
@@ -13,12 +13,13 @@ import './style.scss';
 const { NavLink, useHistory } = Router;
 
 const TabbedNavigation = ( { items, className, disableUpcoming, children = null } ) => {
+	const displayedItems = items.filter( item => ! item.isHiddenInTabbedNavigation );
 	const { location } = useHistory();
-	const currentIndex = findIndex( items, [ 'path', location.pathname ] );
+	const currentIndex = findIndex( displayedItems, [ 'path', location.pathname ] );
 	return (
 		<div className={ classnames( 'newspack-tabbed-navigation', className ) }>
 			<ul>
-				{ items.map( ( item, index ) => (
+				{ displayedItems.map( ( item, index ) => (
 					<li key={ index }>
 						<NavLink
 							to={ item.path }

--- a/assets/components/src/tabbed-navigation/index.js
+++ b/assets/components/src/tabbed-navigation/index.js
@@ -23,6 +23,12 @@ const TabbedNavigation = ( { items, className, disableUpcoming, children = null 
 					<li key={ index }>
 						<NavLink
 							to={ item.path }
+							isActive={ ( match, { pathname } ) => {
+								if ( item.activeTabPaths ) {
+									return item.activeTabPaths.includes( pathname );
+								}
+								return match;
+							} }
 							exact
 							activeClassName={ 'selected' }
 							className={ classnames( {

--- a/assets/components/src/utils/index.js
+++ b/assets/components/src/utils/index.js
@@ -13,6 +13,15 @@ const InteractiveDiv = ( { style = {}, ...props } ) => (
 	/>
 );
 
+const confirmAction = message => {
+	// eslint-disable-next-line no-alert
+	if ( confirm( message ) ) {
+		return true;
+	}
+	return false;
+};
+
 export default {
 	InteractiveDiv,
+	confirmAction,
 };

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { withWizard } from '../../components/src';
+import { withWizard, utils } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
 import { AdUnit, AdUnits, Providers, Settings, Placements, Suppression, AddOns } from './views';
 import { getSizes } from './components/ad-unit-size-control';
@@ -109,8 +109,9 @@ class AdvertisingWizard extends Component {
 	 * @param {number} id Ad Unit ID.
 	 */
 	deleteAdUnit = id => {
-		// eslint-disable-next-line no-alert
-		if ( confirm( __( 'Are you sure you want to archive this ad unit?', 'newspack' ) ) ) {
+		if (
+			utils.confirmAction( __( 'Are you sure you want to archive this ad unit?', 'newspack' ) )
+		) {
 			return this.updateWithAPI( {
 				path: '/newspack/v1/wizard/billboard/ad_unit/' + id,
 				method: 'delete',

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -38,6 +38,7 @@ const ReaderRevenueWizard = () => {
 					? __( 'Stripe Gateway', 'newspack' )
 					: __( 'Stripe Settings', 'newspack' ),
 			path: '/stripe-setup',
+			activeTabPaths: [ '/stripe-setup', '/stripe-webhooks' ],
 			render: Views.StripeSetup,
 			isHidden: usedPlatform !== NEWSPACK && usedPlatform !== STRIPE,
 		},

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -42,6 +42,13 @@ const ReaderRevenueWizard = () => {
 			isHidden: usedPlatform !== NEWSPACK && usedPlatform !== STRIPE,
 		},
 		{
+			label: __( 'Stripe Webhooks', 'newspack' ),
+			path: '/stripe-webhooks',
+			render: Views.StripeWebhooksSettings,
+			isHidden: usedPlatform !== STRIPE,
+			isHiddenInTabbedNavigation: true,
+		},
+		{
 			label: __( 'Emails', 'newspack' ),
 			path: '/emails',
 			render: Views.Emails,

--- a/assets/wizards/readerRevenue/views/index.js
+++ b/assets/wizards/readerRevenue/views/index.js
@@ -3,5 +3,6 @@ export { default as LocationSetup } from './location-setup';
 export { default as NRHSettings } from './nrh-settings';
 export { default as Platform } from './platform';
 export { default as StripeSetup } from './stripe-setup';
+export { default as StripeWebhooksSettings } from './stripe-setup/webhooks-settings';
 export { default as Emails } from './emails';
 export { default as Salesforce } from './salesforce';

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl, ExternalLink, ToggleControl } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { trash } from '@wordpress/icons';
 
 /**
  * External dependencies
@@ -21,6 +22,7 @@ import {
 	SelectControl,
 	TextControl,
 	Wizard,
+	Accordion,
 } from '../../../../components/src';
 import NewsletterSettings from './newsletter-settings';
 import { STRIPE, READER_REVENUE_WIZARD_SLUG } from '../../constants';
@@ -100,6 +102,115 @@ export const StripeKeysSettings = () => {
 				) }
 			</Grid>
 		</Grid>
+	);
+};
+
+const WebhooksList = ( { webhooks, onUpdate } ) => {
+	const { wizardApiFetch } = useDispatch( Wizard.STORE_NAMESPACE );
+	const isLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isQuietLoading() );
+
+	const handleChange = ( webhook, method, payload ) => {
+		const args = {
+			path: `/newspack/v1/stripe/webhook/${ webhook.id }`,
+			method,
+			data: payload,
+			isQuietFetch: true,
+		};
+		if ( payload ) {
+			args.data = payload;
+		}
+		wizardApiFetch( args ).then( onUpdate( method ) );
+	};
+
+	return (
+		<ul>
+			{ webhooks.map( webhook => {
+				return (
+					<li key={ webhook.id }>
+						<span>
+							<ToggleControl
+								checked={ webhook.status === 'enabled' }
+								disabled={ isLoading }
+								onChange={ () =>
+									handleChange( webhook, 'POST', {
+										status: webhook.status === 'enabled' ? 'disabled' : 'enabled',
+									} )
+								}
+							/>
+							<code>{ webhook.url }</code>
+						</span>
+
+						<Button
+							isDestructive
+							icon={ trash }
+							disabled={ isLoading }
+							onClick={ () => handleChange( webhook, 'DELETE' ) }
+						/>
+					</li>
+				);
+			} ) }
+		</ul>
+	);
+};
+
+const StripeWebhooksSettings = () => {
+	const { stripe_data: data = {} } = Wizard.useWizardData( 'reader-revenue' );
+	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const webhooksList = data.webhooks_list || [];
+
+	const [ thisSiteWebhooks, otherWebhooks ] = webhooksList.reduce(
+		( acc, webhook ) => {
+			if ( webhook.matches_url ) {
+				acc[ 0 ].push( webhook );
+			} else {
+				acc[ 1 ].push( webhook );
+			}
+			return acc;
+		},
+		[ [], [] ]
+	);
+	const activeThisSiteWebhooks = thisSiteWebhooks.filter( webhook => webhook.status === 'enabled' );
+
+	const handleWebhooksListUpdate = method => payload => {
+		let newList = webhooksList;
+		switch ( method ) {
+			case 'POST':
+				newList = webhooksList.map( webhook => ( payload.id === webhook.id ? payload : webhook ) );
+				break;
+			case 'DELETE':
+				newList = webhooksList.filter( webhook => payload.id !== webhook.id );
+				break;
+		}
+		updateWizardSettings( {
+			slug: READER_REVENUE_WIZARD_SLUG,
+			path: [ 'stripe_data', 'webhooks_list' ],
+			value: newList,
+		} );
+	};
+	return (
+		<div className="newspack-payment-setup-screen__webhooks">
+			{ activeThisSiteWebhooks.length > 1 && (
+				<Notice
+					isError
+					noticeText={ __(
+						'There are too many webhoooks for this site. Please delete or disable the extra ones.',
+						'newspack'
+					) }
+				/>
+			) }
+			{ activeThisSiteWebhooks.length === 0 && (
+				<Notice
+					isError
+					noticeText={ __( 'There are no active webhoooks for this site.', 'newspack' ) }
+				/>
+			) }
+			<WebhooksList webhooks={ thisSiteWebhooks } onUpdate={ handleWebhooksListUpdate } />
+			{ otherWebhooks.length ? (
+				<Accordion title={ __( 'Webhooks not connected to this site.', 'newspack' ) }>
+					<WebhooksList webhooks={ otherWebhooks } onUpdate={ handleWebhooksListUpdate } />
+				</Accordion>
+			) : null }
+		</div>
 	);
 };
 
@@ -221,6 +332,17 @@ const StripeSetup = () => {
 								onChange={ changeHandler( 'fee_static' ) }
 							/>
 						</Grid>
+					</SettingsCard>
+					<SettingsCard
+						title={ __( 'Webhooks', 'newspack' ) }
+						description={ __(
+							'Manage the webhooks Stripe uses to communicate with your site.',
+							'newspack'
+						) }
+						columns={ 1 }
+						noBorder
+					>
+						<StripeWebhooksSettings />
 					</SettingsCard>
 				</>
 			) : (

--- a/assets/wizards/readerRevenue/views/stripe-setup/style.scss
+++ b/assets/wizards/readerRevenue/views/stripe-setup/style.scss
@@ -6,3 +6,43 @@
 		margin-top: -8px !important;
 	}
 }
+
+.newspack-payment-setup-screen {
+	&__webhooks {
+		.newspack-notice {
+			margin-top: 0;
+		}
+		li {
+			margin: 0;
+			padding: 18px 24px;
+			border: 1px solid wp-colors.$gray-300;
+			+ li {
+				border-top: 0;
+			}
+			&:first-child {
+				border-top-left-radius: 2px;
+				border-top-right-radius: 2px;
+			}
+			&:last-child {
+				border-bottom-left-radius: 2px;
+				border-bottom-right-radius: 2px;
+			}
+			&,
+			> span {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+			}
+			code {
+				margin-left: 10px;
+			}
+		}
+		.components-toggle-control {
+			margin: 0;
+			display: inline-block;
+		}
+		.components-button {
+			box-shadow: none;
+		}
+	}
+}

--- a/assets/wizards/readerRevenue/views/stripe-setup/style.scss
+++ b/assets/wizards/readerRevenue/views/stripe-setup/style.scss
@@ -36,13 +36,19 @@
 			code {
 				margin-left: 10px;
 			}
+			.components-button {
+				box-shadow: none;
+			}
 		}
 		.components-toggle-control {
 			margin: 0;
 			display: inline-block;
 		}
-		.components-button {
-			box-shadow: none;
+		.newspack-buttons-card {
+			margin: 20px 0 30px;
+		}
+		.newspack-settings__no-border {
+			margin-bottom: 0;
 		}
 	}
 }

--- a/assets/wizards/readerRevenue/views/stripe-setup/style.scss
+++ b/assets/wizards/readerRevenue/views/stripe-setup/style.scss
@@ -7,26 +7,27 @@
 	}
 }
 
+.newspack-webhooks-list {
+	&__title {
+		padding: 16px 24px;
+	}
+	&--border {
+		border: 1px solid wp-colors.$gray-300;
+	}
+}
+
 .newspack-payment-setup-screen {
 	&__webhooks {
 		.newspack-notice {
 			margin-top: 0;
 		}
+		ul {
+			margin: 0;
+		}
 		li {
 			margin: 0;
-			padding: 18px 24px;
-			border: 1px solid wp-colors.$gray-300;
-			+ li {
-				border-top: 0;
-			}
-			&:first-child {
-				border-top-left-radius: 2px;
-				border-top-right-radius: 2px;
-			}
-			&:last-child {
-				border-bottom-left-radius: 2px;
-				border-bottom-right-radius: 2px;
-			}
+			padding: 24px;
+			border-top: 1px solid wp-colors.$gray-300;
 			&,
 			> span {
 				display: flex;
@@ -35,9 +36,6 @@
 			}
 			code {
 				margin-left: 10px;
-			}
-			.components-button {
-				box-shadow: none;
 			}
 		}
 		.components-toggle-control {

--- a/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
@@ -159,7 +159,10 @@ const WebhooksSettings = () => {
 							onClick={ () => {
 								if (
 									utils.confirmAction(
-										__( 'Are you sure you want to reset all webhooks connected to this site?', 'newspack' )
+										__(
+											'Are you sure you want to reset all webhooks connected to this site?',
+											'newspack'
+										)
 									)
 								) {
 									resetWebhooks();

--- a/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
@@ -1,0 +1,171 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { trash } from '@wordpress/icons';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { ToggleControl } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Wizard, Accordion, ActionCard, Notice, utils } from '../../../../components/src';
+
+const WebhooksList = ( { title, webhooks, onUpdate } ) => {
+	const { wizardApiFetch } = useDispatch( Wizard.STORE_NAMESPACE );
+	const isLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isQuietLoading() );
+
+	const handleChange = ( webhook, method, payload ) => {
+		const args = {
+			path: `/newspack/v1/stripe/webhook/${ webhook.id }`,
+			method,
+			data: payload,
+			isQuietFetch: true,
+		};
+		if ( payload ) {
+			args.data = payload;
+		}
+		wizardApiFetch( args ).then( onUpdate( method ) );
+	};
+
+	return (
+		<div>
+			<h4>{ title }</h4>
+			<ul>
+				{ webhooks.map( webhook => {
+					return (
+						<li key={ webhook.id }>
+							<span>
+								<ToggleControl
+									checked={ webhook.status === 'enabled' }
+									disabled={ isLoading }
+									onChange={ () =>
+										handleChange( webhook, 'POST', {
+											status: webhook.status === 'enabled' ? 'disabled' : 'enabled',
+										} )
+									}
+								/>
+								<code>{ webhook.url }</code>
+							</span>
+							<Button
+								isDestructive
+								icon={ trash }
+								disabled={ isLoading }
+								onClick={ () => {
+									if (
+										utils.confirmAction(
+											__( 'Are you sure you want to remove this webhook?', 'newspack' )
+										)
+									) {
+										handleChange( webhook, 'DELETE' );
+									}
+								} }
+							/>
+						</li>
+					);
+				} ) }
+			</ul>
+		</div>
+	);
+};
+
+const WebhooksSettings = () => {
+	const [ webhooksList, setWebhooksList ] = useState( [] );
+	const { wizardApiFetch } = useDispatch( Wizard.STORE_NAMESPACE );
+	useEffect( () => {
+		wizardApiFetch( {
+			path: `/newspack/v1/stripe/webhooks`,
+		} ).then( setWebhooksList );
+	}, [] );
+
+	const [ thisSiteWebhooks, otherWebhooks ] = webhooksList.reduce(
+		( acc, webhook ) => {
+			if ( webhook.matches_url ) {
+				acc[ 0 ].push( webhook );
+			} else {
+				acc[ 1 ].push( webhook );
+			}
+			return acc;
+		},
+		[ [], [] ]
+	);
+	const activeThisSiteWebhooks = thisSiteWebhooks.filter( webhook => webhook.status === 'enabled' );
+
+	const handleWebhooksListUpdate = method => payload => {
+		let newList = webhooksList;
+		switch ( method ) {
+			case 'POST':
+				newList = webhooksList.map( webhook => ( payload.id === webhook.id ? payload : webhook ) );
+				break;
+			case 'DELETE':
+				newList = webhooksList.filter( webhook => payload.id !== webhook.id );
+				break;
+		}
+		setWebhooksList( newList );
+	};
+	const resetWebhooks = () => {
+		const args = {
+			path: `/newspack/v1/stripe/reset-webhook`,
+			method: 'DELETE',
+			isQuietFetch: true,
+		};
+		wizardApiFetch( args ).then( setWebhooksList );
+	};
+	return (
+		<div className="newspack-payment-setup-screen__webhooks">
+			{ activeThisSiteWebhooks.length > 1 && (
+				<Notice
+					isError
+					noticeText={ __(
+						'There are too many webhoooks for this site. Please delete or disable the extra ones.',
+						'newspack'
+					) }
+				/>
+			) }
+			{ activeThisSiteWebhooks.length === 0 && (
+				<Notice
+					isError
+					noticeText={ __( 'There are no active webhoooks for this site.', 'newspack' ) }
+				/>
+			) }
+			<ActionCard
+				title={ __( 'Webhooks', 'newspack' ) }
+				className="newspack-settings__no-border"
+				description={ __(
+					'Manage the webhooks Stripe uses to communicate with your site.',
+					'newspack'
+				) }
+			/>
+			<WebhooksList
+				title={ __( 'Webhooks connected to this site', 'newspack' ) }
+				webhooks={ thisSiteWebhooks }
+				onUpdate={ handleWebhooksListUpdate }
+			/>
+			<div className="newspack-buttons-card">
+				<Button
+					variant="secondary"
+					isDestructive
+					onClick={ () => {
+						if (
+							utils.confirmAction(
+								__( 'Are you sure you want to reset all webhooks?', 'newspack' )
+							)
+						) {
+							resetWebhooks();
+						}
+					} }
+				>
+					{ __( 'Reset Webhooks', 'newspack' ) }
+				</Button>
+			</div>
+			{ otherWebhooks.length ? (
+				<Accordion title={ __( 'Webhooks not connected to this site.', 'newspack' ) }>
+					<WebhooksList webhooks={ otherWebhooks } onUpdate={ handleWebhooksListUpdate } />
+				</Accordion>
+			) : null }
+		</div>
+	);
+};
+
+export default WebhooksSettings;

--- a/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
@@ -159,7 +159,7 @@ const WebhooksSettings = () => {
 							onClick={ () => {
 								if (
 									utils.confirmAction(
-										__( 'Are you sure you want to reset all webhooks?', 'newspack' )
+										__( 'Are you sure you want to reset all webhooks connected to this site?', 'newspack' )
 									)
 								) {
 									resetWebhooks();
@@ -174,7 +174,7 @@ const WebhooksSettings = () => {
 				onUpdate={ handleWebhooksListUpdate }
 			/>
 			{ otherWebhooks.length ? (
-				<Accordion title={ __( 'Webhooks not connected to this site.', 'newspack' ) }>
+				<Accordion title={ __( 'Webhooks not connected to this site', 'newspack' ) }>
 					<WebhooksList webhooks={ otherWebhooks } onUpdate={ handleWebhooksListUpdate } />
 				</Accordion>
 			) : null }

--- a/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
@@ -2,17 +2,21 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { trash } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { ToggleControl } from '@wordpress/components';
+import { ToggleControl, ExternalLink } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { Button, Wizard, Accordion, ActionCard, Notice, utils } from '../../../../components/src';
 
-const WebhooksList = ( { title, webhooks, onUpdate } ) => {
+const WebhooksList = ( { title, webhooks, onUpdate, withBorder, className } ) => {
 	const { wizardApiFetch } = useDispatch( Wizard.STORE_NAMESPACE );
 	const isLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isQuietLoading() );
 
@@ -30,41 +34,47 @@ const WebhooksList = ( { title, webhooks, onUpdate } ) => {
 	};
 
 	return (
-		<div>
-			<h4>{ title }</h4>
+		<div
+			className={ classNames( className, 'newspack-webhooks-list', {
+				'newspack-webhooks-list--border': withBorder,
+			} ) }
+		>
+			{ 'function' === typeof title && (
+				<div className="newspack-webhooks-list__title">{ title() }</div>
+			) }
 			<ul>
-				{ webhooks.map( webhook => {
-					return (
-						<li key={ webhook.id }>
-							<span>
-								<ToggleControl
-									checked={ webhook.status === 'enabled' }
-									disabled={ isLoading }
-									onChange={ () =>
-										handleChange( webhook, 'POST', {
-											status: webhook.status === 'enabled' ? 'disabled' : 'enabled',
-										} )
-									}
-								/>
-								<code>{ webhook.url }</code>
-							</span>
-							<Button
-								isDestructive
-								icon={ trash }
+				{ webhooks.map( webhook => (
+					<li key={ webhook.id }>
+						<span>
+							<ToggleControl
+								checked={ webhook.status === 'enabled' }
 								disabled={ isLoading }
-								onClick={ () => {
-									if (
-										utils.confirmAction(
-											__( 'Are you sure you want to remove this webhook?', 'newspack' )
-										)
-									) {
-										handleChange( webhook, 'DELETE' );
-									}
-								} }
+								onChange={ () =>
+									handleChange( webhook, 'POST', {
+										status: webhook.status === 'enabled' ? 'disabled' : 'enabled',
+									} )
+								}
 							/>
-						</li>
-					);
-				} ) }
+							<code className="mr3">{ webhook.url }</code>
+						</span>
+						<Button
+							isDestructive
+							isLink
+							disabled={ isLoading }
+							onClick={ () => {
+								if (
+									utils.confirmAction(
+										__( 'Are you sure you want to remove this webhook?', 'newspack' )
+									)
+								) {
+									handleChange( webhook, 'DELETE' );
+								}
+							} }
+						>
+							{ __( 'Delete', 'newspack' ) }
+						</Button>
+					</li>
+				) ) }
 			</ul>
 		</div>
 	);
@@ -138,32 +148,44 @@ const WebhooksSettings = () => {
 				) }
 			/>
 			<WebhooksList
-				title={ __( 'Webhooks connected to this site', 'newspack' ) }
+				withBorder
+				className="mb4"
+				title={ () => (
+					<div className="flex justify-between items-center">
+						<h4 className="b f6 ma0">{ __( 'Webhooks connected to this site', 'newspack' ) }</h4>
+						<Button
+							variant="secondary"
+							isSmall
+							onClick={ () => {
+								if (
+									utils.confirmAction(
+										__( 'Are you sure you want to reset all webhooks?', 'newspack' )
+									)
+								) {
+									resetWebhooks();
+								}
+							} }
+						>
+							{ __( 'Reset', 'newspack' ) }
+						</Button>
+					</div>
+				) }
 				webhooks={ thisSiteWebhooks }
 				onUpdate={ handleWebhooksListUpdate }
 			/>
-			<div className="newspack-buttons-card">
-				<Button
-					variant="secondary"
-					isDestructive
-					onClick={ () => {
-						if (
-							utils.confirmAction(
-								__( 'Are you sure you want to reset all webhooks?', 'newspack' )
-							)
-						) {
-							resetWebhooks();
-						}
-					} }
-				>
-					{ __( 'Reset Webhooks', 'newspack' ) }
-				</Button>
-			</div>
 			{ otherWebhooks.length ? (
 				<Accordion title={ __( 'Webhooks not connected to this site.', 'newspack' ) }>
 					<WebhooksList webhooks={ otherWebhooks } onUpdate={ handleWebhooksListUpdate } />
 				</Accordion>
 			) : null }
+			<div className="newspack-buttons-card">
+				<Button href="#/stripe-setup" isPrimary>
+					{ __( 'Back to Stripe Settings', 'newspack' ) }
+				</Button>
+				<ExternalLink href="https://dashboard.stripe.com/webhooks">
+					{ __( 'Stripe Dashboard', 'newspack' ) }
+				</ExternalLink>
+			</div>
 		</div>
 	);
 };

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -58,26 +58,6 @@ class Stripe_Connection {
 	}
 
 	/**
-	 * Check capabilities for using API.
-	 *
-	 * @codeCoverageIgnore
-	 * @param WP_REST_Request $request API request object.
-	 * @return bool|WP_Error
-	 */
-	public static function api_permissions_check( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new \WP_Error(
-				'newspack_rest_forbidden',
-				esc_html__( 'You cannot use this resource.', 'newspack' ),
-				[
-					'status' => 403,
-				]
-			);
-		}
-		return true;
-	}
-
-	/**
 	 * Get Stripe data blueprint.
 	 */
 	public static function get_default_stripe_data() {

--- a/includes/reader-revenue/stripe/class-stripe-webhooks.php
+++ b/includes/reader-revenue/stripe/class-stripe-webhooks.php
@@ -577,7 +577,12 @@ class Stripe_Webhooks {
 					$is_valid = false;
 				}
 			} catch ( \Throwable $e ) {
-				return self::get_error( __( 'Webhook validation failed: ', 'newspack' ) . $e->getMessage(), 'newspack_plugin_stripe_webhooks' );
+				$message = $e->getMessage();
+				if ( strpos( $message, 'No such webhook endpoint' ) !== false ) {
+					$is_valid = false;
+				} else {
+					return self::get_error( __( 'Webhook validation failed: ', 'newspack' ) . $message, 'newspack_plugin_stripe_webhooks' );
+				}
 			}
 		} else {
 			$is_valid = false;

--- a/includes/reader-revenue/stripe/class-stripe-webhooks.php
+++ b/includes/reader-revenue/stripe/class-stripe-webhooks.php
@@ -98,6 +98,16 @@ class Stripe_Webhooks {
 				'permission_callback' => '__return_true',
 			]
 		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/stripe/webhooks',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_all_webhooks' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+			]
+		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/stripe/webhook/(?P<id>[\w_]+)',
@@ -127,6 +137,15 @@ class Stripe_Webhooks {
 						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
+			]
+		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/stripe/reset-webhook',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ __CLASS__, 'api_reset_webhoooks' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
 			]
 		);
 	}
@@ -509,6 +528,25 @@ class Stripe_Webhooks {
 		} catch ( \Throwable $th ) {
 			Logger::log( 'Could not reset Stripe webhooks: ' . $th->getMessage() );
 			return false;
+		}
+	}
+
+	/**
+	 * Get all webhooks.
+	 */
+	public static function api_get_all_webhooks() {
+		return rest_ensure_response( self::get_all_webhooks() );
+	}
+
+	/**
+	 * Handle webhook reset API request.
+	 */
+	public static function api_reset_webhoooks() {
+		$result = self::reset_webhooks();
+		if ( true === $result ) {
+			return self::api_get_all_webhooks();
+		} else {
+			return self::get_error( __( 'Webhook reset failed ', 'newspack' ) );
 		}
 	}
 

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -467,7 +467,6 @@ class Reader_Revenue_Wizard extends Wizard {
 			if ( Stripe_Connection::is_configured() ) {
 				$args['stripe_data']['connection_error'] = Stripe_Connection::get_connection_error();
 			}
-			$args['stripe_data']['webhooks_list'] = Stripe_Webhooks::get_all_webhooks();
 		}
 		return $args;
 	}

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -467,6 +467,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			if ( Stripe_Connection::is_configured() ) {
 				$args['stripe_data']['connection_error'] = Stripe_Connection::get_connection_error();
 			}
+			$args['stripe_data']['webhooks_list'] = Stripe_Webhooks::get_all_webhooks();
 		}
 		return $args;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds webhook management UI for Stripe Reader Revenue platform. 

Closes 1203451787793554-as-1203362361069776

### How to test the changes in this Pull Request:

1. Visit Stripe Settings tab in Reader Revenue wizard (set Stripe as the platform first)
2. If Stripe is connected, observe the webhooks list
3. Test that the webhooks can be disabled/enabled and deleted using this UI

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->