### PR TITLE
Harden Subscriptions meta box logic

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -660,8 +660,10 @@ class WooCommerce_Connection {
 	private static function is_synchronised_with_stripe( $subscription ) {
 		if ( is_numeric( $subscription ) ) {
 			$stripe_subscription_id = get_post_meta( $subscription, self::SUBSCRIPTION_STRIPE_ID_META_KEY, true );
-		} else {
+		} elseif ( $subscription ) {
 			$stripe_subscription_id = $subscription->get_meta( self::SUBSCRIPTION_STRIPE_ID_META_KEY );
+		} else {
+			$stripe_subscription_id = false;
 		}
 		return boolval( $stripe_subscription_id );
 	}
@@ -669,10 +671,12 @@ class WooCommerce_Connection {
 	/**
 	 * Remove subscription-related meta boxes if the subscription is sync'd with Stripe.
 	 * This is because some subscription variables should not be editable here.
+	 *
+	 * @param string $post_type Post type of current screen.
 	 */
-	public static function remove_subscriptions_schedule_meta_box() {
+	public static function remove_subscriptions_schedule_meta_box( $post_type ) {
 		global $post_ID;
-		if ( self::is_synchronised_with_stripe( $post_ID ) ) {
+		if ( 'shop_subscription' === $post_type && self::is_synchronised_with_stripe( $post_ID ) ) {
 			remove_meta_box( 'woocommerce-subscription-schedule', 'shop_subscription', 'side' );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue where `null` can sometimes be passed into `is_synchronised_with_stripe` and this causes a fatal error. See testing steps.

### How to test the changes in this Pull Request:

1. Set up RAS. Make a comment on a post:

<img width="862" alt="Screenshot 2022-11-21 at 4 42 35 PM" src="https://user-images.githubusercontent.com/7317227/203186747-c462f440-de99-4069-8841-80581c3c2439.png">

2. In WP Admin, edit the comment. Observe a fatal error is thrown:

<img width="842" alt="Screenshot 2022-11-21 at 4 42 14 PM" src="https://user-images.githubusercontent.com/7317227/203186795-d5fb9e8a-0b57-4e8e-944a-e46f27516360.png">

3. Apply this patch. Edit the comment. Observe no fatal error is thrown:

<img width="884" alt="Screenshot 2022-11-21 at 4 39 11 PM" src="https://user-images.githubusercontent.com/7317227/203186844-76c6f0ca-02cc-401c-985c-c3cbc282de65.png">

4. Verify the subscriptions schedule metabox continues to be hidden on SDB subscriptions and shown on Woo-based subscriptions:

<img width="307" alt="Screenshot 2022-11-21 at 4 39 00 PM" src="https://user-images.githubusercontent.com/7317227/203186937-71ab6c6d-ee07-4497-9553-e43d13a968e3.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->