### PR TITLE
Fix test emails sending

### DIFF
--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -213,6 +213,9 @@ class Emails {
 
 		if ( 'string' === gettype( $config_name ) ) {
 			$email_config = self::get_email_config_by_type( $config_name );
+		} elseif ( 'integer' === gettype( $config_name ) ) {
+			$email_config = self::serialize_email( null, $config_name );
+			$config_name  = \get_post_meta( $config_name, self::EMAIL_CONFIG_NAME_META, true );
 		} else {
 			return false;
 		}
@@ -479,7 +482,7 @@ class Emails {
 		if ( $was_sent ) {
 			return \rest_ensure_response( [] );
 		} else {
-			return new WP_Error(
+			return new \WP_Error(
 				'newspack_test_email_not_sent',
 				__( 'Test email was not sent.', 'newspack' )
 			);

--- a/tests/unit-tests/emails.php
+++ b/tests/unit-tests/emails.php
@@ -149,6 +149,26 @@ class Newspack_Test_Emails extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Sending by email id.
+	 */
+	public function test_emails_send_by_id() {
+		Plugin_Manager::activate( 'newspack-newsletters' );
+		$test_email = self::get_test_email( 'test-email-config' );
+
+		$send_result = Emails::send_email(
+			$test_email['post_id'],
+			'someone@example.com'
+		);
+		self::assertTrue( $send_result, 'Email has been sent.' );
+
+		$send_result = Emails::send_email(
+			9999,
+			'someone@example.com'
+		);
+		self::assertFalse( $send_result, 'Non-existent email is not sent.' );
+	}
+
+	/**
 	 * Email post status handling.
 	 */
 	public function test_emails_status() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with sending test emails.

### How to test the changes in this Pull Request:

1. On `master`, edit an email (e.g. Reader Revenue wizard -> emails -> Receipt)
2. Try sending a test email, observe that it fails and an error notice is displayed in the editor
3. Switch to this branch, test again, observe the test email is sent 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->