### PR TITLE
fix(analytics): improve the condition for using Site Kit's Analytics module

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -579,11 +579,12 @@ class Analytics {
 	 * Can we rely on Site Kit's Analytics module?
 	 */
 	private static function can_use_site_kits_analytics() {
-		$sitekit_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'google-site-kit' );
-		return $sitekit_manager->is_module_active( 'analytics' )
-		// If Google Tag Manager module is active, it supersedes the Analytics module.
-		// This means that effectively GTM module being active equals Analytics module being inactive.
-		&& false === $sitekit_manager->is_module_active( 'tagmanager' );
+		if ( ! class_exists( '\Google\Site_Kit\Modules\Analytics\Settings' ) ) {
+			return false;
+		}
+		$sitekit_manager     = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'google-site-kit' );
+		$sitekit_ga_settings = get_option( \Google\Site_Kit\Modules\Analytics\Settings::OPTION, false );
+		return (bool) $sitekit_manager->is_module_active( 'analytics' ) && $sitekit_ga_settings['canUseSnippet'];
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-plugin/pull/1216 added a guard against unavailable `gtag` object by checking if the GTM module of Site Kit was active. It was assumed that if the GTM module is active, the Analytics module won't be – but as @yogeshbeniwal pointed out [here](https://github.com/Automattic/newspack-popups/pull/657#issuecomment-970275131), this is the case [only if the GTM module contains a GA tag](https://github.com/google/site-kit-wp/blob/8df049f73589fea2ef5de13b711d23bef1ec70fe/includes/Modules/Tag_Manager.php#L654-L658). 

This PR changes the condition so that Newspack's Analytics integration will be conditioned on whether Site Kit's Analytics module inserts its code snippet:

<img width="247" alt="image" src="https://user-images.githubusercontent.com/7383192/203350624-cce21c12-8c4b-48fa-91e4-1ca251adffb1.png">

### How to test the changes in this Pull Request:

Same steps as in https://github.com/Automattic/newspack-plugin/pull/1216

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->