### PR TITLE
Disable local lists in the newsletters wizard

### DIFF
--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -9,12 +9,7 @@ import { values, mapValues, property, isEmpty } from 'lodash';
 import { useEffect, useState, Fragment } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
-import {
-	CheckboxControl,
-	ToggleControl,
-	TextareaControl,
-	ExternalLink,
-} from '@wordpress/components';
+import { CheckboxControl, TextareaControl, ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -22,6 +17,7 @@ import {
 import {
 	Button,
 	Card,
+	ActionCard,
 	Grid,
 	Notice,
 	PluginInstaller,
@@ -178,14 +174,22 @@ export const SubscriptionLists = ( { onUpdate } ) => {
 				/>
 			) }
 			{ lists.map( ( list, index ) => (
-				<Card key={ list.id } isSmall>
-					<ToggleControl
-						label={ list?.type_label ? `${ list.name } (${ list.type_label })` : list.name }
-						checked={ list.active }
-						disabled={ inFlight }
-						onChange={ handleChange( index, 'active' ) }
-					/>
-					{ list.active && (
+				<ActionCard
+					key={ list.id }
+					title={ list.name }
+					description={ list?.type_label ? list.type_label : null }
+					disabled={ inFlight }
+					toggleOnChange={ handleChange( index, 'active' ) }
+					toggleChecked={ list.active }
+					actionText={
+						list?.edit_link ? (
+							<ExternalLink href={ list.edit_link }>
+								{ __( 'Edit', 'newspack_newsletters' ) }
+							</ExternalLink>
+						) : null
+					}
+				>
+					{ list.active && 'local' !== list?.type && (
 						<>
 							<TextControl
 								label={ __( 'List title', 'newspack' ) }
@@ -199,16 +203,9 @@ export const SubscriptionLists = ( { onUpdate } ) => {
 								disabled={ inFlight || 'local' === list?.type }
 								onChange={ handleChange( index, 'description' ) }
 							/>
-							{ list?.edit_link && (
-								<p>
-									<ExternalLink href={ list.edit_link }>
-										{ __( 'Edit', 'newspack_newsletters' ) }
-									</ExternalLink>
-								</p>
-							) }
 						</>
 					) }
-				</Card>
+				</ActionCard>
 			) ) }
 			<div className="newspack-buttons-card">
 				<Button isPrimary onClick={ saveLists } disabled={ inFlight }>

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -180,7 +180,7 @@ export const SubscriptionLists = ( { onUpdate } ) => {
 			{ lists.map( ( list, index ) => (
 				<Card key={ list.id } isSmall>
 					<ToggleControl
-						label={ list.name }
+						label={ list?.type_label ? `${ list.name } (${ list.type_label })` : list.name }
 						checked={ list.active }
 						disabled={ inFlight }
 						onChange={ handleChange( index, 'active' ) }
@@ -190,15 +190,22 @@ export const SubscriptionLists = ( { onUpdate } ) => {
 							<TextControl
 								label={ __( 'List title', 'newspack' ) }
 								value={ list.title }
-								disabled={ inFlight }
+								disabled={ inFlight || 'local' === list?.type }
 								onChange={ handleChange( index, 'title' ) }
 							/>
 							<TextareaControl
 								label={ __( 'List description', 'newspack' ) }
 								value={ list.description }
-								disabled={ inFlight }
+								disabled={ inFlight || 'local' === list?.type }
 								onChange={ handleChange( index, 'description' ) }
 							/>
+							{ list?.edit_link && (
+								<p>
+									<ExternalLink href={ list.edit_link }>
+										{ __( 'Edit', 'newspack_newsletters' ) }
+									</ExternalLink>
+								</p>
+							) }
 						</>
 					) }
 				</Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Disables the edit of title and description from the list where we select the active Subscription Lists.

Since they are created locally, there is no need to edit the title and description again. Instead of allowing edits, link to the edit page.

### How to test the changes in this Pull Request:

1. Go to Newsletters > Engagement > Newsletters
2. Make sure there are no changes in the UI and no warnings in the terminal
3. Checkout [this PR](https://github.com/Automattic/newspack-newsletters/pull/1035) in the Newsletter plugin
1.Set up Mailchimp or AC as provider
4. Go to Newsletters > Lists and create a couple of lists
5. Go to Newsletters > Engagement > Newsletters
6. Go to the "Subscription Lists" section
7. Make sure the Local lists are marked as such and you can't edit their title and description
8. Make sure the edit links points to the righ place
9. Make sure you are still able to enable/disable them
10. And make sure they are still working in the rest of the application (registration form, etc)

![Captura de tela de 2022-11-28 11-52-38](https://user-images.githubusercontent.com/971483/204315183-a2115aad-b38a-4df0-a7bd-baa9b2806af6.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
