### PR TITLE
Feat/perfmatters defaults

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -142,6 +142,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-mailchimp-for-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
 

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -46,6 +46,7 @@ class Perfmatters {
 			"ga( '",
 			"ga('",
 			'google-analytics.com/analytics.js',
+			'googletag.pubads',
 			// Google Tag Manager.
 			'/gtm.js',
 			'/gtag/js',

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Perfmatters integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Perfmatters {
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_filter( 'default_option_perfmatters_options', [ __CLASS__, 'set_defaults' ] );
+		add_filter( 'option_perfmatters_options', [ __CLASS__, 'set_defaults' ] );
+	}
+
+	/**
+	 * Scripts to delay spec.
+	 */
+	private static function scripts_to_delay() {
+		return [
+			// Newspack.
+			'newspack-plugin',
+			'newspack-popups',
+			'newspack-blocks',
+			'newspack-newsletters',
+			'newspack-sponsors',
+			'newspack-listings',
+			'newspack-theme',
+			// WordPress.
+			'videopress',
+			'related-posts',
+			'jp-search.js',
+			'jetpack-comment',
+			'photon.min.js',
+			'comment-reply',
+			'stats.wp.com',
+			// Google Analytics.
+			"ga( '",
+			"ga('",
+			'google-analytics.com/analytics.js',
+			// Google Tag Manager.
+			'/gtm.js',
+			'/gtag/js',
+			'gtag(',
+			'/gtm-',
+			'/gtm.',
+			// Advertising.
+			'adsbygoogle.js',
+			'ai_insert_code',
+			'doubleclick.net',
+			// Facebook.
+			'fbevents.js',
+			'fbq(',
+			'/busting/facebook-tracking/',
+			// Twitter.
+			'ads-twitter.com',
+			// Etc.
+			'disqus',
+			'stripe.com',
+		];
+	}
+
+	/**
+	 * Stylesheets to exclude from the "Unused CSS" feature.
+	 */
+	private static function unused_css_excluded_stylesheets() {
+		return [
+			'donateStreamlined.css',
+		];
+	}
+
+	/**
+	 * URLs to preconnect to.
+	 *
+	 * @param array $existing_urls Existing URLs to filter out.
+	 */
+	private static function preconnect_urls( $existing_urls = [] ) {
+		return array_filter(
+			[
+				[
+					'url'         => 'https://i0.wp.com',
+					'crossorigin' => false,
+				],
+			],
+			function( $url ) use ( $existing_urls ) {
+				return ! in_array( $url['url'], $existing_urls );
+			}
+		);
+	}
+
+	/**
+	 * Set default options for Perfmatters.
+	 *
+	 * @param array $options Perfmatters options.
+	 */
+	public static function set_defaults( $options = [] ) {
+		// Basic options.
+		$options['disable_emojis']              = true;
+		$options['disable_dashicons']           = true;
+		$options['remove_global_styles']        = true;
+		$options['disable_woocommerce_scripts'] = true;
+		// "The cart fragments feature and or AJAX request in WooCommerce is used to update the cart
+		// total without refreshing the page."
+		// https://perfmatters.io/docs/disable-woocommerce-cart-fragments-ajax/
+		$options['disable_woocommerce_cart_fragmentation'] = true;
+
+		// JS deferral.
+		if ( ! isset( $options['assets'] ) ) {
+			$options['assets'] = [];
+		}
+		$defer_js_exclusions           = [ 'wp-includes' ];
+		$options['assets']['defer_js'] = true;
+		if ( isset( $options['assets']['js_exclusions'] ) && is_array( $options['assets']['js_exclusions'] ) ) {
+			$options['assets']['js_exclusions'] = array_unique(
+				array_merge(
+					$options['assets']['js_exclusions'],
+					$defer_js_exclusions
+				)
+			);
+		} else {
+			$options['assets']['js_exclusions'] = $defer_js_exclusions;
+		}
+		$options['assets']['defer_jquery'] = true;
+
+		// JS delay.
+		$options['assets']['delay_js'] = true;
+		if ( isset( $options['assets']['delay_js_inclusions'] ) && is_array( $options['assets']['delay_js_inclusions'] ) ) {
+			$options['assets']['delay_js_inclusions'] = array_unique(
+				array_merge(
+					$options['assets']['delay_js_inclusions'],
+					self::scripts_to_delay()
+				)
+			);
+		} else {
+			$options['assets']['delay_js_inclusions'] = self::scripts_to_delay();
+		}
+		$options['assets']['delay_timeout'] = true;
+
+		// Unused CSS.
+		$options['assets']['remove_unused_css'] = true;
+		if ( isset( $options['assets']['rucss_excluded_stylesheets'] ) && is_array( $options['assets']['rucss_excluded_stylesheets'] ) ) {
+			$options['assets']['rucss_excluded_stylesheets'] = array_unique(
+				array_merge(
+					$options['assets']['rucss_excluded_stylesheets'],
+					self::unused_css_excluded_stylesheets()
+				)
+			);
+		} else {
+			$options['assets']['rucss_excluded_stylesheets'] = self::unused_css_excluded_stylesheets();
+		}
+
+		// Preload.
+		if ( ! isset( $options['preload'] ) ) {
+			$options['preload'] = [];
+		}
+		$options['preload']['critical_images'] = '2';
+		if ( isset( $options['preload']['preconnect'] ) && is_array( $options['preload']['preconnect'] ) ) {
+			$options['preload']['preconnect'] = array_merge(
+				$options['preload']['preconnect'],
+				self::preconnect_urls( array_column( $options['preload']['preconnect'], 'url' ) )
+			);
+		} else {
+			$options['preload']['preconnect'] = self::preconnect_urls();
+		}
+
+		// Lazyload.
+		if ( ! isset( $options['lazyload'] ) ) {
+			$options['lazyload'] = [];
+		}
+		$options['lazyload']['lazy_loading_iframes']       = true;
+		$options['lazyload']['youtube_preview_thumbnails'] = true;
+		$options['lazyload']['image_dimensions']           = true;
+
+		return $options;
+	}
+}
+Perfmatters::init();

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -102,6 +102,10 @@ class Perfmatters {
 	 * @param array $options Perfmatters options.
 	 */
 	public static function set_defaults( $options = [] ) {
+		if ( ! is_admin() && ! isset( $_GET['newspack-perfmatters-defaults'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return $options;
+		}
+
 		// Basic options.
 		$options['disable_emojis']              = true;
 		$options['disable_dashicons']           = true;

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -62,14 +62,15 @@ class WooCommerce_My_Account {
 	 * Enqueue front-end scripts.
 	 */
 	public static function enqueue_scripts() {
-		\wp_enqueue_style(
-			'my-account',
-			\Newspack\Newspack::plugin_url() . '/dist/my-account.css',
-			[],
-			NEWSPACK_PLUGIN_VERSION
-		);
+		if ( function_exists( 'is_account_page' ) && is_account_page() ) {
+			\wp_enqueue_style(
+				'my-account',
+				\Newspack\Newspack::plugin_url() . '/dist/my-account.css',
+				[],
+				NEWSPACK_PLUGIN_VERSION
+			);
+		}
 	}
-
 
 	/**
 	 * Filter "My Account" items, if Stripe is the donations platform.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds default setup for the Perfmatters plugin, behind a URL-param feature flag. 

Closes 1202855962089497-as-1203286553017184

### How to test the changes in this Pull Request:

1. Install Perfmatters plugin
2. Visit the plugin settings, observe some things configured by default
3. Visit the front-end, observe no optimisations are at play (e.g. all JS & CSS is loaded on page load)
4. Visit the front-end with `?newspack-perfmatters-defaults` param, observe the optimisations visible in the plugin settings are applied

And a small bonus:

1. On `master`, visit homepage, observe the `my-account.css` file is being loaded 
2. Switch to this branch and with RAS enabled, observe the file is not loaded on the homepage (or anywhere besides `/my-account` page)
3. Visit the `/my-account` page – observe the aforementioned CSS file is loaded 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->