### PR TITLE
fix: override woo subscriptions login requirement on checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.97.1-hotfix.2](https://github.com/Automattic/newspack-plugin/compare/v1.97.1-hotfix.1...v1.97.1-hotfix.2) (2022-11-30)
+
+
+### Bug Fixes
+
+* only do temp login if Woo intends to create an account ([1fbe56c](https://github.com/Automattic/newspack-plugin/commit/1fbe56c33c08c3fae714de152a92aaab881e0f9d))
+
 ## [1.97.1-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.97.0...v1.97.1-hotfix.1) (2022-11-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.97.1-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.97.0...v1.97.1-hotfix.1) (2022-11-30)
+
+
+### Bug Fixes
+
+* allow WC subscription purchase without logging in ([7362c56](https://github.com/Automattic/newspack-plugin/commit/7362c562104e5c410417752e0e7e1502d14b5a9e))
+* update default registration success message ([c971b14](https://github.com/Automattic/newspack-plugin/commit/c971b14bf70d940b091fbc347bc2a6f0c1cbc67b))
+
 # [1.97.0](https://github.com/Automattic/newspack-plugin/compare/v1.96.0...v1.97.0) (2022-11-28)
 
 

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -104,9 +104,15 @@ function render_block( $attrs, $content ) {
 		return '';
 	}
 
-	$registered      = false;
-	$message         = '';
-	$success_message = __( 'Thank you for registering!', 'newspack' ) . '<br />' . __( 'Check your email for a confirmation link.', 'newspack' );
+	$registered       = false;
+	$my_account_url   = \wc_get_account_endpoint_url( 'dashboard' );
+	$message          = '';
+	$success_message  = __( 'Thank you for registering!', 'newspack' ) . '<br />';
+	$success_message .= sprintf(
+		// Translators: %s is a link to My Account.
+		__( 'Please visit %s to verify and manage your account.', 'newspack' ),
+		'<a href="' . esc_url( $my_account_url ) . '">' . __( 'My Account', 'newspack' ) . '</a>'
+	);
 
 	/** Handle default attributes. */
 	$default_attrs = [
@@ -126,7 +132,7 @@ function render_block( $attrs, $content ) {
 
 	$sign_in_url = \wp_login_url();
 	if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
-		$sign_in_url = \wc_get_account_endpoint_url( 'dashboard' );
+		$sign_in_url = $my_account_url;
 	}
 
 	/** Setup list subscription */

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1526,7 +1526,7 @@ final class Reader_Activation {
 		$wc_checkout = new \WC_Checkout();
 		$posted_data = $wc_checkout->get_posted_data();
 
-		if ( empty( $posted_data ) || empty( $posted_data['billing_email'] ) ) {
+		if ( empty( $posted_data ) || empty( $posted_data['billing_email'] || empty( $posted_data['createaccount'] ) ) ) {
 			return;
 		}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -84,6 +84,7 @@ final class Reader_Activation {
 			\add_filter( 'retrieve_password_notification_email', [ __CLASS__, 'password_reset_configuration' ], 10, 4 );
 			\add_action( 'lostpassword_post', [ __CLASS__, 'set_password_reset_mail_content_type' ] );
 			\add_filter( 'lostpassword_errors', [ __CLASS__, 'rate_limit_lost_password' ], 10, 2 );
+			\add_action( 'woocommerce_checkout_process', [ __CLASS__, 'allow_subscription_purchase_without_login' ] );
 		}
 	}
 
@@ -1509,6 +1510,36 @@ final class Reader_Activation {
 			\update_user_meta( $user_data->ID, self::LAST_EMAIL_DATE, time() );
 		}
 		return $errors;
+	}
+
+	/**
+	 * If a reader tries to make a recurring donation with an email address that
+	 * has been previously registered, force Woo to allow the subscription to
+	 * be created and associated with the existing account without requiring the
+	 * reader to log in.
+	 */
+	public static function allow_subscription_purchase_without_login() {
+		if ( ! class_exists( '\WC_Checkout' ) ) {
+			return;
+		}
+
+		$wc_checkout = new \WC_Checkout();
+		$posted_data = $wc_checkout->get_posted_data();
+
+		if ( empty( $posted_data ) || empty( $posted_data['billing_email'] ) ) {
+			return;
+		}
+
+		// If the reader account already exists, and they're not already logged in.
+		$user_id = \email_exists( $posted_data['billing_email'] );
+		if ( $user_id && ! \is_user_logged_in() && self::is_user_reader( \get_user_by( 'id', $user_id ) ) ) {
+
+			// Temporarily log in the user to let the transaction happen.
+			self::set_current_reader( $user_id );
+
+			// Log out the user once the transaction is complete.
+			\add_action( 'woocommerce_checkout_order_processed', '\wp_logout' );
+		}
 	}
 }
 Reader_Activation::init();

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.97.0
+ * Version: 1.97.1-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.97.0' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.97.1-hotfix.1' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.97.1-hotfix.1
+ * Version: 1.97.1-hotfix.2
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.97.1-hotfix.1' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.97.1-hotfix.2' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.97.0",
+  "version": "1.97.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.97.0",
+      "version": "1.97.1-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.19.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.97.1-hotfix.1",
+  "version": "1.97.1-hotfix.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.97.1-hotfix.1",
+      "version": "1.97.1-hotfix.2",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.97.1-hotfix.1",
+  "version": "1.97.1-hotfix.2",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.97.0",
+  "version": "1.97.1-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a UX conflict between RAS and WooCommerce Subscriptions. The latter requires that any subscription transaction be associated with a logged-in account, and will prompt the user to log in if it finds an existing account. But the former may have created an account upon newsletter signup, resulting in a lot of unnecessary friction on the user's part in order to complete the donation.

This fix checks if the inputted email address is an existing but not logged-in RAS reader, checks if the transaction normally require a login, and if so, temporarily logs in the reader account to allow the transaction to succeed without user input. Once the transaction is complete, the user is logged out.

#### Bonus fix

Also updates the default success message upon registration. On `master`, the default message instructs the reader to check their email inbox for a verification email, but no such email is sent upon registration—it's only sent if the user visits My Account and requests it. The new message instructs the reader to visit My Account to verify and manage their account.

### How to test the changes in this Pull Request:

1. On a site using RAS and with Newspack as the Reader Revenue platform, sign up for newsletters via the Subscription Form block, or register via the Register block.
2. In a new session, while still not logged-in, make a recurring donation to get to the checkout form, and fill it in using the same email address you used to register in step 1.
3. On `master`, observe an error message prompting you to log in:

<img width="794" alt="Screen Shot 2022-11-30 at 12 49 55 PM" src="https://user-images.githubusercontent.com/2230142/204900111-987dcfca-9e22-4abf-bf2d-e8b2c7ad9e42.png">

4. Check out this branch, repeat step 2, and confirm that the transaction succeeds without prompting you to log in.
5. Continue navigating around the site in the same session and confirm that you remain logged out.
6. Also confirm in the dashboard that the subscription is associated with the correct user account.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->