### PR TITLE
feat(reader-revenue): add "other" reader revenue platform

### DIFF
--- a/assets/wizards/readerRevenue/constants.js
+++ b/assets/wizards/readerRevenue/constants.js
@@ -5,5 +5,6 @@
 export const NRH = 'nrh';
 export const NEWSPACK = 'wc';
 export const STRIPE = 'stripe';
+export const OTHER = 'other';
 
 export const READER_REVENUE_WIZARD_SLUG = 'newspack-reader-revenue-wizard';

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -16,7 +16,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { Wizard, Notice } from '../../components/src';
 import * as Views from './views';
-import { READER_REVENUE_WIZARD_SLUG, NEWSPACK, NRH, STRIPE } from './constants';
+import { READER_REVENUE_WIZARD_SLUG, NEWSPACK, NRH, STRIPE, OTHER } from './constants';
 
 const ReaderRevenueWizard = () => {
 	const { platform_data, plugin_status, donation_data } = Wizard.useWizardData( 'reader-revenue' );
@@ -31,6 +31,7 @@ const ReaderRevenueWizard = () => {
 			label: __( 'Donations', 'newspack' ),
 			path: '/donations',
 			render: Views.Donation,
+			isHidden: usedPlatform === OTHER,
 		},
 		{
 			label:

--- a/assets/wizards/readerRevenue/views/platform/index.js
+++ b/assets/wizards/readerRevenue/views/platform/index.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { Card, PluginInstaller, SelectControl, Wizard } from '../../../../components/src';
-import { NEWSPACK, NRH, STRIPE } from '../../constants';
+import { NEWSPACK, NRH, STRIPE, OTHER } from '../../constants';
 
 /**
  * Platform Selection  Screen Component
@@ -24,6 +24,10 @@ const Platform = () => {
 					label={ __( 'Select Reader Revenue Platform', 'newspack' ) }
 					value={ wizardData.platform_data?.platform }
 					options={ [
+						{
+							label: __( 'Other', 'newspack' ),
+							value: OTHER,
+						},
 						{
 							label: __( 'Newspack', 'newspack' ),
 							value: NEWSPACK,

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -521,6 +521,13 @@ class Donations {
 	}
 
 	/**
+	 * Is the donation platform set to 'other'?
+	 */
+	public static function is_platform_other() {
+		return 'other' === self::get_platform_slug();
+	}
+
+	/**
 	 * Handle submission of the donation form.
 	 */
 	public static function process_donation_form() {

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -350,6 +350,8 @@ class Donations {
 			self::update_donation_product( [ 'minimumDonation' => $settings['minimumDonation'] ] );
 		}
 
+		$parsed_settings['platform'] = self::get_platform_slug();
+
 		return $parsed_settings;
 	}
 

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -46,6 +46,24 @@ class Reader_Revenue_Wizard extends Wizard {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+		add_filter( 'render_block', [ $this, 'prevent_rendering_donate_block' ], 10, 2 );
+	}
+
+	/**
+	 * Prevent rendering of Donate block if Reader Revenue platform is set to 'other.
+	 *
+	 * @param string $block_content The block content about to be rendered.
+	 * @param array  $block The data of the block about to be rendered.
+	 */
+	public static function prevent_rendering_donate_block( $block_content, $block ) {
+		if (
+			isset( $block['blockName'] )
+			&& 'newspack-blocks/donate' === $block['blockName']
+			&& Donations::is_platform_other()
+		) {
+			return '';
+		}
+		return $block_content;
 	}
 
 	/**

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -541,6 +541,6 @@ class Reader_Revenue_Wizard extends Wizard {
 	 * @return bool
 	 */
 	public function api_validate_platform( $value ) {
-		return in_array( $value, [ 'nrh', 'wc', 'stripe' ] );
+		return in_array( $value, [ 'nrh', 'wc', 'stripe', 'other' ] );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #2059.

### How to test the changes in this Pull Request:

1. Visit the Reader Revenue wizard, observe a new option in the platform selection – "Other" 
2. Select it, observe the only available tab is the "Platform" tab
3. Observe any Donate block added will no be rendered on the front-end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->