### PR TITLE
fix: fatal if no woo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.97.2-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.97.1...v1.97.2-hotfix.1) (2022-12-01)
+
+
+### Bug Fixes
+
+* fatal if no woo ([54fe144](https://github.com/Automattic/newspack-plugin/commit/54fe14461d50d52eb53e8249bddd7e050be7b42e))
+
 ## [1.97.1](https://github.com/Automattic/newspack-plugin/compare/v1.97.0...v1.97.1) (2022-11-30)
 
 

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -104,15 +104,18 @@ function render_block( $attrs, $content ) {
 		return '';
 	}
 
-	$registered       = false;
-	$my_account_url   = \wc_get_account_endpoint_url( 'dashboard' );
-	$message          = '';
-	$success_message  = __( 'Thank you for registering!', 'newspack' ) . '<br />';
-	$success_message .= sprintf(
-		// Translators: %s is a link to My Account.
-		__( 'Please visit %s to verify and manage your account.', 'newspack' ),
-		'<a href="' . esc_url( $my_account_url ) . '">' . __( 'My Account', 'newspack' ) . '</a>'
-	);
+	$registered      = false;
+	$my_account_url  = function_exists( 'wc_get_account_endpoint_url' ) ? \wc_get_account_endpoint_url( 'dashboard' ) : false;
+	$message         = '';
+	$success_message = __( 'Thank you for registering!', 'newspack' ) . '<br />';
+
+	if ( $my_account_url ) {
+		$success_message .= sprintf(
+			// Translators: %s is a link to My Account.
+			__( 'Please visit %s to verify and manage your account.', 'newspack' ),
+			'<a href="' . esc_url( $my_account_url ) . '">' . __( 'My Account', 'newspack' ) . '</a>'
+		);
+	}
 
 	/** Handle default attributes. */
 	$default_attrs = [

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.97.1
+ * Version: 1.97.2-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.97.1' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.97.2-hotfix.1' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.97.1",
+  "version": "1.97.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.97.1",
+      "version": "1.97.2-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.97.1",
+  "version": "1.97.2-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal error introduced by #2158.

### How to test the changes in this Pull Request:

1. On a site with RAS enabled, disable WooCommerce.
2. Visit a page containing a RAS Register block and observe fatal errors.
3. Check out this branch, confirm the fatals are avoided.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->