### PR TITLE
fix: logic to update existing contact on subscription cancellation or deletion

### DIFF
--- a/includes/reader-revenue/stripe/class-stripe-webhooks.php
+++ b/includes/reader-revenue/stripe/class-stripe-webhooks.php
@@ -245,7 +245,7 @@ class Stripe_Webhooks {
 				if ( Reader_Activation::is_enabled() && method_exists( '\Newspack_Newsletters_Subscription', 'add_contact' ) ) {
 					$contact_exists = ! \is_wp_error( \Newspack_Newsletters_Subscription::get_contact_data( $customer['email'] ) );
 					// Only handle subscription deletion of an existing contact.
-					if ( ! $contact_exists ) {
+					if ( $contact_exists ) {
 						$sub_end_date = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payload['ended_at'] );
 						$contact      = [
 							'email'    => $customer['email'],
@@ -306,7 +306,7 @@ class Stripe_Webhooks {
 					}
 					$contact_exists = ! \is_wp_error( \Newspack_Newsletters_Subscription::get_contact_data( $customer['email'] ) );
 					// Only handle subscription update of an existing contact.
-					if ( ! $contact_exists ) {
+					if ( $contact_exists ) {
 						$sub_end_date = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payload['ended_at'] );
 						$contact      = [
 							'email'    => $customer['email'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The Stripe webhook handler has logic to update a contact's metadata in the ESP when a subscription is canceled or deleted, but the condition in the code to do so seems to only attempt to make such updates when the contact doesn't already exist, which both doesn't make logical sense in the context of the action, and is the opposite of what the code commenting seems to describe.

Closes `1200550061930446/1203469622245017`.

### How to test the changes in this Pull Request:

1. On a site using Stripe + RAS + ActiveCampaign, make a recurring donation as a new reader.
2. Go to My Account, verify your account, go to Billing and open the Stripe billing portal. Cancel your subscription.
3. On `master`, observe in the ActiveCampaign contact info that the contact metadata is not updated with the cancellation date (`NP_Current Subscription End Date` field).
4. Check out this branch, repeat steps 1-2, and confirm that the contact metadata is now updated with the anticipated cancellation date as soon as the reader cancels the subscription.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->