### PR TITLE
feat(data-events): agnostic data integration tool

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -77,6 +77,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-plugin-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-theme-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-data-events.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-analytics.php';

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -95,6 +95,8 @@ final class Data_Events {
 	public static function register_action( $action_name ) {
 		if ( ! isset( self::$actions[ $action_name ] ) ) {
 			self::$actions[ $action_name ] = [];
+		} else {
+			return new WP_Error( 'action_already_registered', __( 'Action already registered.', 'newspack' ) );
 		}
 	}
 
@@ -104,11 +106,17 @@ final class Data_Events {
 	 * @param string   $action_name Action name.
 	 * @param callable $handler     Action handler.
 	 *
-	 * @return void|WP_Error Error if action not registered.
+	 * @return void|WP_Error Error if action not registered, handler already reigstered or is not callable.
 	 */
-	public static function register_action_handler( $action_name, $handler ) {
+	public static function register_handler( $action_name, $handler ) {
 		if ( ! isset( self::$actions[ $action_name ] ) ) {
 			return new WP_Error( 'action_not_registered', __( 'Action not registered.', 'newspack' ) );
+		}
+		if ( ! is_callable( $handler ) ) {
+			return new WP_Error( 'handler_not_callable', __( 'Handler is not callable.', 'newspack' ) );
+		}
+		if ( in_array( $handler, self::$actions[ $action_name ], true ) ) {
+			return new WP_Error( 'handler_already_registered', __( 'Handler already registered.', 'newspack' ) );
 		}
 		self::$actions[ $action_name ][] = $handler;
 	}

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -97,9 +97,27 @@ final class Data_Events {
 			}
 		}
 
-		// Execute WP hooks.
-		do_action( self::ACTION, $action_name, $timestamp, $data, $client_id );
-		do_action( self::ACTION . '_' . $action_name, $timestamp, $data, $client_id );
+		/**
+		 * Fires after all global and action-specific handlers have been executed.
+		 *
+		 * @param string $action_name Action name.
+		 * @param int    $timestamp   Timestamp.
+		 * @param mixed  $data        Data.
+		 * @param string $client_id   Client ID.
+		 */
+		do_action( 'newspack_data_event', $action_name, $timestamp, $data, $client_id );
+
+		/**
+		 * Fires after all global and action-specific handlers have been executed.
+		 *
+		 * The dynamic portion of the hook name, `$action_name`, refers to th name
+		 * of the action being fired.
+		 *
+		 * @param int    $timestamp   Timestamp.
+		 * @param mixed  $data        Data.
+		 * @param string $client_id   Client ID.
+		 */
+		do_action( 'newspack_data_event_' . $action_name, $timestamp, $data, $client_id );
 	}
 
 	/**
@@ -196,8 +214,29 @@ final class Data_Events {
 			$client_id = Reader_Activation::get_client_id();
 		}
 
+		/**
+		 * Fires when and action is dispatched. This occurs before any handlers are
+		 * executed.
+		 *
+		 * @param string $action_name Action name.
+		 * @param int    $timestamp   Timestamp.
+		 * @param mixed  $data        Data.
+		 * @param string $client_id   Client ID.
+		 */
 		do_action( 'newspack_data_event_dispatch', $action_name, $timestamp, $data, $client_id );
 
+		/**
+		 * Fires when and action is dispatched. This occurs before any handlers are
+		 * executed.
+		 *
+		 * The dynamic portion of the hook name, `$action_name`, refers to th name
+		 * of the action being fired.
+		 *
+		 * @param string $action_name Action name.
+		 * @param int    $timestamp   Timestamp.
+		 * @param mixed  $data        Data.
+		 * @param string $client_id   Client ID.
+		 */
 		do_action( "newspack_data_event_dispatch_{$action_name}", $timestamp, $data, $client_id );
 
 		$url = \add_query_arg(

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -19,6 +19,11 @@ final class Data_Events {
 	const ACTION = 'newspack_data_event';
 
 	/**
+	 * Header to be used while logging.
+	 */
+	const LOGGER_HEADER = 'NEWSPACK-DATA-EVENTS';
+
+	/**
 	 * Registered callable handlers, keyed by their action name.
 	 *
 	 * @var callable[]
@@ -75,25 +80,31 @@ final class Data_Events {
 	 */
 	public static function handle( $action_name, $timestamp, $data, $client_id ) {
 		// Execute global handlers.
-		Logger::log( 'Executing global action handlers.' );
+		Logger::log(
+			sprintf( 'Executing global action handlers for %s.', $action_name ),
+			self::LOGGER_HEADER
+		);
 		foreach ( self::$global_handlers as $handler ) {
 			try {
 				call_user_func( $handler, $action_name, $timestamp, $data, $client_id );
 			} catch ( \Throwable $e ) {
 				// Catch fatal errors so it doesn't disrupt other handlers.
-				Logger::error( $e->getMessage() );
+				Logger::error( $e->getMessage(), self::LOGGER_HEADER );
 			}
 		}
 
 		// Execute action handlers.
-		Logger::log( 'Executing action handler: ' . $action_name );
+		Logger::log(
+			sprintf( 'Executing action handlers for %s.', $action_name ),
+			self::LOGGER_HEADER
+		);
 		$handlers = self::get_action_handlers( $action_name );
 		foreach ( $handlers as $handler ) {
 			try {
 				call_user_func( $handler, $timestamp, $data, $client_id );
 			} catch ( \Throwable $e ) {
 				// Catch fatal errors so it doesn't disrupt other handlers.
-				Logger::error( $e->getMessage() );
+				Logger::error( $e->getMessage(), self::LOGGER_HEADER );
 			}
 		}
 
@@ -238,6 +249,11 @@ final class Data_Events {
 		if ( $use_client_id ) {
 			$client_id = Reader_Activation::get_client_id();
 		}
+
+		Logger::log(
+			sprintf( 'Dispatching action %s ', $action_name ),
+			self::LOGGER_HEADER
+		);
 
 		/**
 		 * Fires when an action is dispatched. This occurs before any handlers are

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -161,6 +161,31 @@ final class Data_Events {
 	}
 
 	/**
+	 * Register a listener so it dispatches an action when a WordPress hook is fired.
+	 *
+	 * @param string   $hook_name   WordPress hook name.
+	 * @param string   $action_name Action name.
+	 * @param callable $callable    Optional callable to filter the data passed to dispatch.
+	 */
+	public static function register_listener( $hook_name, $action_name, $callable = null ) {
+		self::register_action( $action_name );
+		\add_action(
+			$hook_name,
+			function() use ( $action_name, $callable ) {
+				$args = func_get_args();
+				if ( is_callable( $callable ) ) {
+					$data = call_user_func_array( $callable, $args );
+				} else {
+					$data = $args;
+				}
+				self::dispatch( $action_name, $data );
+			},
+			10,
+			PHP_INT_MAX
+		);
+	}
+
+	/**
 	 * Get a list of all registered actions.
 	 *
 	 * @return string[] Registered actions.

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -119,15 +119,15 @@ final class Data_Events {
 	/**
 	 * Register a handler for a triggerable action.
 	 *
-	 * @param string   $action_name Action name.
 	 * @param callable $handler     Action handler.
+	 * @param string   $action_name Action name.
 	 *
 	 * @return void|WP_Error Error if action not registered, handler already registered or is not callable.
 	 */
-	public static function register_handler( $action_name, $handler = null ) {
+	public static function register_handler( $handler, $action_name = null ) {
 		/** If first argument is callable, treat as global handler. */
-		if ( is_callable( $action_name ) ) {
-			self::$global_handlers[] = $action_name;
+		if ( empty( $action_name ) ) {
+			self::$global_handlers[] = $handler;
 			return;
 		}
 		if ( ! isset( self::$actions[ $action_name ] ) ) {

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -110,7 +110,7 @@ final class Data_Events {
 		/**
 		 * Fires after all global and action-specific handlers have been executed.
 		 *
-		 * The dynamic portion of the hook name, `$action_name`, refers to th name
+		 * The dynamic portion of the hook name, `$action_name`, refers to the name
 		 * of the action being fired.
 		 *
 		 * @param int    $timestamp   Timestamp.
@@ -215,7 +215,7 @@ final class Data_Events {
 		}
 
 		/**
-		 * Fires when and action is dispatched. This occurs before any handlers are
+		 * Fires when an action is dispatched. This occurs before any handlers are
 		 * executed.
 		 *
 		 * @param string $action_name Action name.
@@ -226,10 +226,10 @@ final class Data_Events {
 		do_action( 'newspack_data_event_dispatch', $action_name, $timestamp, $data, $client_id );
 
 		/**
-		 * Fires when and action is dispatched. This occurs before any handlers are
+		 * Fires when an action is dispatched. This occurs before any handlers are
 		 * executed.
 		 *
-		 * The dynamic portion of the hook name, `$action_name`, refers to th name
+		 * The dynamic portion of the hook name, `$action_name`, refers to the name
 		 * of the action being fired.
 		 *
 		 * @param string $action_name Action name.

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -70,7 +70,8 @@ final class Data_Events {
 
 		// Execute registered handlers.
 		Logger::log( 'Executing action handler: ' . $action_name );
-		foreach ( self::$actions[ $action_name ] as $handler ) {
+		$handlers = self::get_action_handlers( $action_name );
+		foreach ( $handlers as $handler ) {
 			try {
 				call_user_func( $handler, $timestamp, $data, $client_id );
 			} catch ( \Throwable $e ) {

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -14,13 +14,16 @@ use WP_Error;
  */
 final class Data_Events {
 	/**
-	 * Registered triggerable actions.
+	 * Asynchronous action name.
+	 */
+	const ACTION = 'newspack_data_event';
+
+	/**
+	 * Registered callable handlers, keyed by their action name.
 	 *
-	 * @var string[]
+	 * @var callable[]
 	 */
 	private static $actions = [];
-
-	const ACTION = 'newspack_data_event';
 
 	/**
 	 * Initialize hooks.
@@ -44,24 +47,26 @@ final class Data_Events {
 			wp_die();
 		}
 
-		self::handle();
+		self::handle( $action_name );
 
 		wp_die();
 	}
 
 	/**
 	 * Handle an event.
+	 *
+	 * @param string $action_name Action name.
 	 */
-	private static function handle() {
+	private static function handle( $action_name ) {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce already verified.
-		$action_name = isset( $_POST['action_name'] ) ? sanitize_text_field( wp_unslash( $_POST['action_name'] ) ) : null;
-		$timestamp   = isset( $_POST['timestamp'] ) ? sanitize_text_field( wp_unslash( $_POST['timestamp'] ) ) : null;
-		$client_id   = isset( $_POST['client_id'] ) ? sanitize_text_field( wp_unslash( $_POST['client_id'] ) ) : null;
-		$data        = isset( $_POST['data'] ) ? $_POST['data'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$timestamp = isset( $_POST['timestamp'] ) ? sanitize_text_field( wp_unslash( $_POST['timestamp'] ) ) : null;
+		$client_id = isset( $_POST['client_id'] ) ? sanitize_text_field( wp_unslash( $_POST['client_id'] ) ) : null;
+		$data      = isset( $_POST['data'] ) ? $_POST['data'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		// phpcs:enable
 
 		// Execute registered handlers.
+		Logger::log( 'Executing action handler: ' . $action_name );
 		foreach ( self::$actions[ $action_name ] as $action ) {
 			try {
 				call_user_func( $action, $timestamp, $data, $client_id );

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -261,7 +261,7 @@ final class Data_Events {
 				'blocking'  => false,
 				'body'      => $body,
 				'cookies'   => $_COOKIE, // phpcs:ignore
-				'sslverify' => false,
+				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
 			]
 		);
 	}

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -93,11 +93,10 @@ final class Data_Events {
 	 * @return void|WP_Error Error if action already registered.
 	 */
 	public static function register_action( $action_name ) {
-		if ( ! isset( self::$actions[ $action_name ] ) ) {
-			self::$actions[ $action_name ] = [];
-		} else {
+		if ( isset( self::$actions[ $action_name ] ) ) {
 			return new WP_Error( 'action_already_registered', __( 'Action already registered.', 'newspack' ) );
 		}
+		self::$actions[ $action_name ] = [];
 	}
 
 	/**
@@ -156,18 +155,6 @@ final class Data_Events {
 	}
 
 	/**
-	 * Get dispatch request url.
-	 */
-	private static function get_dispatch_url() {
-		$url  = \admin_url( 'admin-ajax.php' );
-		$args = [
-			'action' => self::ACTION,
-			'nonce'  => \wp_create_nonce( self::ACTION ),
-		];
-		return \add_query_arg( $args, $url );
-	}
-
-	/**
 	 * Dispatch an action event.
 	 *
 	 * @param string  $action_name   Action name.
@@ -191,7 +178,13 @@ final class Data_Events {
 
 		do_action( "newspack_data_event_dispatch_{$action_name}", $timestamp, $data, $client_id );
 
-		$url = self::get_dispatch_url();
+		$url = \add_query_arg(
+			[
+				'action' => self::ACTION,
+				'nonce'  => \wp_create_nonce( self::ACTION ),
+			],
+			\admin_url( 'admin-ajax.php' )
+		);
 
 		$body = [
 			'action_name' => $action_name,

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -81,7 +81,7 @@ final class Data_Events {
 	public static function handle( $action_name, $timestamp, $data, $client_id ) {
 		// Execute global handlers.
 		Logger::log(
-			sprintf( 'Executing global action handlers for %s.', $action_name ),
+			sprintf( 'Executing global action handlers for "%s".', $action_name ),
 			self::LOGGER_HEADER
 		);
 		foreach ( self::$global_handlers as $handler ) {
@@ -95,7 +95,7 @@ final class Data_Events {
 
 		// Execute action handlers.
 		Logger::log(
-			sprintf( 'Executing action handlers for %s.', $action_name ),
+			sprintf( 'Executing action handlers for "%s".', $action_name ),
 			self::LOGGER_HEADER
 		);
 		$handlers = self::get_action_handlers( $action_name );
@@ -191,8 +191,8 @@ final class Data_Events {
 				}
 				self::dispatch( $action_name, $data );
 			},
-			10,
-			PHP_INT_MAX
+			PHP_INT_MAX, // We want dispatches to be executed last so that any modified data is available.
+			PHP_INT_MAX // The handler should receive all arguments of a hook.
 		);
 	}
 
@@ -251,7 +251,7 @@ final class Data_Events {
 		}
 
 		Logger::log(
-			sprintf( 'Dispatching action %s ', $action_name ),
+			sprintf( 'Dispatching action "%s".', $action_name ),
 			self::LOGGER_HEADER
 		);
 

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Newspack Data Events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use WP_Error;
+
+/**
+ * Main class.
+ */
+final class Data_Events {
+	/**
+	 * Registered triggerable actions.
+	 *
+	 * @var string[]
+	 */
+	private static $actions = [];
+
+	const ACTION = 'newspack_data_event';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		\add_action( 'wp_ajax_' . self::ACTION, [ __CLASS__, 'maybe_handle' ] );
+		\add_action( 'wp_ajax_nopriv_' . self::ACTION, [ __CLASS__, 'maybe_handle' ] );
+	}
+
+	/**
+	 * Maybe handle an event.
+	 */
+	public static function maybe_handle() {
+		// Don't lock up other requests while processing.
+		session_write_close(); // phpcs:ignore
+
+		check_ajax_referer( self::ACTION, 'nonce' );
+
+		$action_name = isset( $_POST['action_name'] ) ? sanitize_text_field( wp_unslash( $_POST['action_name'] ) ) : null;
+		if ( ! $action_name || ! isset( self::$actions[ $action_name ] ) ) {
+			wp_die();
+		}
+
+		self::handle();
+
+		wp_die();
+	}
+
+	/**
+	 * Handle an event.
+	 */
+	public static function handle() {
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce already verified.
+		$action_name = isset( $_POST['action_name'] ) ? sanitize_text_field( wp_unslash( $_POST['action_name'] ) ) : null;
+		$timestamp   = isset( $_POST['timestamp'] ) ? sanitize_text_field( wp_unslash( $_POST['timestamp'] ) ) : null;
+		$client_id   = isset( $_POST['client_id'] ) ? sanitize_text_field( wp_unslash( $_POST['client_id'] ) ) : null;
+		$data        = isset( $_POST['data'] ) ? $_POST['data'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:enable
+
+		do_action( self::ACTION, $action_name, $timestamp, $data, $client_id );
+
+		do_action( self::ACTION . '_' . $action_name, $timestamp, $data, $client_id );
+
+		foreach ( self::$actions[ $action_name ] as $action ) {
+			call_user_func( $action, $timestamp, $data, $client_id );
+		}
+	}
+
+	/**
+	 * Register a triggerable action.
+	 *
+	 * @param string $action_name Action name.
+	 *
+	 * @return void|WP_Error Error if action already registered.
+	 */
+	public static function register_action( $action_name ) {
+		if ( ! isset( self::$actions[ $action_name ] ) ) {
+			self::$actions[ $action_name ] = [];
+		}
+	}
+
+	/**
+	 * Register a handler for a triggerable action.
+	 *
+	 * @param string   $action_name Action name.
+	 * @param callable $handler     Action handler.
+	 *
+	 * @return void|WP_Error Error if action not registered.
+	 */
+	public static function register_action_handler( $action_name, $handler ) {
+		if ( ! isset( self::$actions[ $action_name ] ) ) {
+			return new WP_Error( 'action_not_registered', __( 'Action not registered.', 'newspack' ) );
+		}
+		self::$actions[ $action_name ][] = $handler;
+	}
+
+	/**
+	 * Get a list of all registered actions.
+	 *
+	 * @return string[] Registered actions.
+	 */
+	public static function get_actions() {
+		return array_keys( $actions );
+	}
+
+	/**
+	 * Whether an action is registered.
+	 *
+	 * @param string $action_name The action name.
+	 *
+	 * @return bool
+	 */
+	public static function is_action_registered( $action_name ) {
+		return isset( self::$actions[ $action_name ] );
+	}
+
+	/**
+	 * Get dispatch request url.
+	 */
+	public static function get_dispatch_url() {
+		$url  = \admin_url( 'admin-ajax.php' );
+		$args = [
+			'action' => self::ACTION,
+			'nonce'  => \wp_create_nonce( self::ACTION ),
+		];
+		return \add_query_arg( $args, $url );
+	}
+
+	/**
+	 * Dispatch an action event.
+	 *
+	 * @param string  $action_name   Action name.
+	 * @param array   $data          Data to pass to the action.
+	 * @param boolean $use_client_id Whether to use the session's client ID. Default is true.
+	 *
+	 * @return void|WP_Error Error if action not registered.
+	 */
+	public static function dispatch( $action_name, $data, $use_client_id = true ) {
+		if ( ! self::is_action_registered( $action_name ) ) {
+			return new WP_Error( 'newspack_data_events_action_not_registered', __( 'Action not registered.', 'newspack' ) );
+		}
+
+		$timestamp = time();
+		$client_id = null;
+		if ( $use_client_id ) {
+			$client_id = Reader_Activation::get_client_id();
+		}
+
+		do_action( 'newspack_data_event_dispatch', $action_name, $timestamp, $data, $client_id );
+
+		do_action( "newspack_data_event_dispatch_{$action_name}", $timestamp, $data, $client_id );
+
+		$url = self::get_dispatch_url();
+
+		$body = [
+			'action_name' => $action_name,
+			'timestamp'   => $timestamp,
+			'data'        => $data,
+			'client_id'   => $client_id,
+		];
+
+		\wp_remote_post(
+			$url,
+			[
+				'timeout'   => 0.01,
+				'blocking'  => false,
+				'body'      => $body,
+				'cookies'   => $_COOKIE, // phpcs:ignore
+				'sslverify' => false,
+			]
+		);
+	}
+}
+Data_Events::init();

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -147,4 +147,36 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		// Should have been called twice.
 		$this->assertEquals( 2, $handler_called );
 	}
+
+	/**
+	 * Test global handler execution.
+	 */
+	public function test_global_handler() {
+		$action_name = 'test_action';
+
+		Data_Events::register_action( $action_name );
+
+		$handler_data = [
+			'called' => 0,
+			'args'   => [],
+		];
+		$handler      = function( ...$handler_args ) use ( &$handler_data ) {
+			$handler_data['called']++;
+			$handler_data['args'] = $handler_args;
+		};
+		Data_Events::register_handler( $handler );
+
+		// Manual trigger.
+		$timestamp = time();
+		$data      = [ 'test' => 'data' ];
+		$client_id = 'test-client-id';
+		Data_Events::handle( $action_name, $timestamp, $data, $client_id );
+
+		// Should have been called twice.
+		$this->assertEquals( 1, $handler_data['called'] );
+		$this->assertEquals( $action_name, $handler_data['args'][0] );
+		$this->assertEquals( $timestamp, $handler_data['args'][1] );
+		$this->assertEquals( $data, $handler_data['args'][2] );
+		$this->assertEquals( $client_id, $handler_data['args'][3] );
+	}
 }

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -27,7 +27,7 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 	 */
 	public function test_register_missing_action_handler() {
 		$handler = function() {};
-		$result  = Data_Events::register_handler( 'missing_action', $handler );
+		$result  = Data_Events::register_handler( $handler, 'missing_action' );
 		$this->assertInstanceOf( WP_Error::class, $result );
 	}
 
@@ -48,7 +48,7 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		$action_name = 'test_action';
 		$handler     = function () {};
 		Data_Events::register_action( $action_name );
-		$result = Data_Events::register_handler( $action_name, $handler );
+		$result = Data_Events::register_handler( $handler, $action_name );
 		$this->assertEquals( null, $result );
 		$action_handlers = Data_Events::get_action_handlers( $action_name );
 		$this->assertContains( $handler, $action_handlers );
@@ -97,7 +97,7 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 			$handler_data['args'] = $handler_args;
 		};
 		// Attach the handler through the Data_Events API.
-		Data_Events::register_handler( $action_name, $handler );
+		Data_Events::register_handler( $handler, $action_name );
 		// Attach the handler through a WP action.
 		add_action( 'newspack_data_event_test_action', $handler, 10, 3 );
 
@@ -135,8 +135,8 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		};
 
 		// Attach the handlers through the Data_Events API.
-		Data_Events::register_handler( $action_name, $handler1 );
-		Data_Events::register_handler( $action_name, $handler2 );
+		Data_Events::register_handler( $handler1, $action_name );
+		Data_Events::register_handler( $handler2, $action_name );
 
 		// Manual trigger.
 		$timestamp = time();

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -166,13 +166,11 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		};
 		Data_Events::register_handler( $handler );
 
-		// Manual trigger.
 		$timestamp = time();
 		$data      = [ 'test' => 'data' ];
 		$client_id = 'test-client-id';
 		Data_Events::handle( $action_name, $timestamp, $data, $client_id );
 
-		// Should have been called twice.
 		$this->assertEquals( 1, $handler_data['called'] );
 		$this->assertEquals( $action_name, $handler_data['args'][0] );
 		$this->assertEquals( $timestamp, $handler_data['args'][1] );

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -27,7 +27,7 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 	 */
 	public function test_register_missing_action_handler() {
 		$handler = function() {};
-		$result  = Data_Events::register_action_handler( 'missing_action', $handler );
+		$result  = Data_Events::register_handler( 'missing_action', $handler );
 		$this->assertInstanceOf( WP_Error::class, $result );
 	}
 
@@ -48,7 +48,7 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		$action_name = 'test_action';
 		$handler     = function () {};
 		Data_Events::register_action( $action_name );
-		$result = Data_Events::register_action_handler( $action_name, $handler );
+		$result = Data_Events::register_handler( $action_name, $handler );
 		$this->assertEquals( null, $result );
 		$action_handlers = Data_Events::get_action_handlers( $action_name );
 		$this->assertContains( $handler, $action_handlers );
@@ -97,7 +97,7 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 			$handler_data['args'] = $handler_args;
 		};
 		// Attach the handler through the Data_Events API.
-		Data_Events::register_action_handler( $action_name, $handler );
+		Data_Events::register_handler( $action_name, $handler );
 		// Attach the handler through a WP action.
 		add_action( 'newspack_data_event_test_action', $handler, 10, 3 );
 
@@ -135,8 +135,8 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		};
 
 		// Attach the handlers through the Data_Events API.
-		Data_Events::register_action_handler( $action_name, $handler1 );
-		Data_Events::register_action_handler( $action_name, $handler2 );
+		Data_Events::register_handler( $action_name, $handler1 );
+		Data_Events::register_handler( $action_name, $handler2 );
 
 		// Manual trigger.
 		$timestamp = time();

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Tests the Data Events functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Data_Events;
+
+/**
+ * Tests the Data Events functionality.
+ */
+class Newspack_Test_Data_Events extends WP_UnitTestCase {
+	/**
+	 * Test registering an action.
+	 */
+	public function test_register_action() {
+		$action_name = 'test_action';
+		Data_Events::register_action( $action_name );
+		$registered_actions = Data_Events::get_actions();
+		$this->assertContains( $action_name, $registered_actions );
+	}
+
+	/**
+	 * Test that registering an action handler without registering an action fails
+	 * with WP_Error.
+	 */
+	public function test_register_missing_action_handler() {
+		$handler = function() {};
+		$result  = Data_Events::register_action_handler( 'missing_action', $handler );
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+
+	/**
+	 * Test "is_action_registered" method.
+	 */
+	public function test_is_action_registered() {
+		$action_name = 'test_action';
+		Data_Events::register_action( $action_name );
+		$this->assertTrue( Data_Events::is_action_registered( $action_name ) );
+		$this->assertFalse( Data_Events::is_action_registered( 'missing_action' ) );
+	}
+
+	/**
+	 * Test register action handler.
+	 */
+	public function test_register_action_handler() {
+		$action_name = 'test_action';
+		$handler     = function () {};
+		Data_Events::register_action( $action_name );
+		$result = Data_Events::register_action_handler( $action_name, $handler );
+		$this->assertEquals( null, $result );
+		$action_handlers = Data_Events::get_action_handlers( $action_name );
+		$this->assertContains( $handler, $action_handlers );
+	}
+
+	/**
+	 * Test that dispatching an action returns a WP_Http response and triggers a
+	 * WP action.
+	 */
+	public function test_dispatch() {
+		$action_name = 'test_action';
+		$data        = [ 'test' => 'data' ];
+
+		// Hook into dispatch.
+		$call_count = 0;
+		$hook       = function() use ( &$call_count ) {
+			$call_count++;
+		};
+		add_action( 'newspack_data_event_dispatch', $hook, 10, 3 );
+
+		Data_Events::register_action( $action_name );
+		$result = Data_Events::dispatch( $action_name, $data );
+
+		// Assert the hook was called once.
+		$this->assertEquals( 1, $call_count );
+
+		// Assert it returns a WP_Http response.
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'http_response', $result );
+	}
+
+	/**
+	 * Test triggering the handler.
+	 */
+	public function test_handler() {
+		$action_name = 'test_action';
+		$timestamp   = time();
+		$data        = [ 'test' => 'data' ];
+		$client_id   = 'test-client-id';
+
+		Data_Events::register_action( $action_name );
+
+		$handler_data = [
+			'called' => 0,
+			'args'   => [],
+		];
+		$handler      = function( ...$handler_args ) use ( &$handler_data ) {
+			$handler_data['called']++;
+			$handler_data['args'] = $handler_args;
+		};
+		// Attach the handler through the Data_Events API.
+		Data_Events::register_action_handler( $action_name, $handler );
+		// Attach the handler through a WP action.
+		add_action( 'newspack_data_event_test_action', $handler, 10, 3 );
+
+		// Manual trigger.
+		Data_Events::handle( $action_name, $timestamp, $data, $client_id );
+
+		// Should have been called twice.
+		$this->assertEquals( 2, $handler_data['called'] );
+
+		// Assert args sent to handler.
+		$this->assertEquals( $timestamp, $handler_data['args'][0] );
+		$this->assertEquals( $data, $handler_data['args'][1] );
+		$this->assertEquals( $client_id, $handler_data['args'][2] );
+	}
+}

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -177,4 +177,42 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		$this->assertEquals( $data, $handler_data['args'][2] );
 		$this->assertEquals( $client_id, $handler_data['args'][3] );
 	}
+
+	/**
+	 * Test registering a listener.
+	 */
+	public function test_register_listener() {
+		$action_name = 'test_action';
+		Data_Events::register_listener( 'some_actionable_thing', $action_name );
+		do_action( 'some_actionable_thing', 'data' );
+		$this->assertEquals( 1, did_action( "newspack_data_event_dispatch_$action_name" ) );
+	}
+
+	/**
+	 * Test registering a listener with a filter.
+	 */
+	public function test_register_listener_with_filter() {
+		$action_name = 'test_action';
+		Data_Events::register_listener(
+			'some_actionable_thing',
+			$action_name,
+			function( $data ) {
+				return $data . ' was parsed';
+			}
+		);
+
+		$parsed_data = '';
+		add_action(
+			"newspack_data_event_dispatch_$action_name",
+			function( $timestamp, $data, $client_id ) use ( &$parsed_data ) {
+				$parsed_data = $data;
+			},
+			10,
+			3
+		);
+
+		do_action( 'some_actionable_thing', 'data' );
+
+		$this->assertEquals( 'data was parsed', $parsed_data );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements a `Data_Events` class for non-blocking dispatch of data events to registered handlers.

The non-blocking strategy is inspired by [TechCrunch's `wp-async-task`](https://github.com/techcrunch/wp-async-task) and uses an HTTP request to trigger the handlers.

#### Registering an action

To dispatch an event an action must first be registered with the following:

```php
Newspack\Data_Events::register_action( 'action_name' );
```

#### Dispatching

Once registered, an array with arbitrary payload can be dispatched:

```php
$data = [ "test" => "data" ];
$use_client_id = true;
Newspack\Data_Events::dispatch( 'action_name', $data, $use_client_id );
```

The use of client ID, which is `true` by default, will send the `Reader_Activation::get_client_id();` as part of the data event payload. This client ID is pulled from the session's `newspack-cid` cookie. Most data events are expected to be user actions and third parties might make use of having an ID that groups anonymous sessions.

#### Registering handlers vs. WP hooks

There are 2 ways of attaching handlers to events. The primary one, which I'm currently favoring, is through the `::register_handler()` API:

```php
// Action handler
function my_action_handler( $timestamp, $data, $client_id ) {
	// Send data to a third-party.
}
Newspack::register_handler( 'my_action_handler', 'my_action' );

// Global handler, to be called on every data event
function my_global_handler( $action_name, $timestamp, $data, $client_id ) {
	// Do some global analytics.
}
Newspack::register_handler( 'my_global_handler' );
```

They don't have a `priority` argument because they are supposed to be independent. Each relates to its own data integration and is contained in a `try...catch` block so it never disrupts another handler.

A WP action hook can also be used and will be executed after the registered handlers:

```php
add_action( 'newspack_data_event_my_action', 'my_action_handler', 10, 3 );
add_action( 'newspack_data_event', 'my_global_handler', 10, 4 );
```

The advantage of using WP hooks is API familiarity. It's a common API that should be easy enough to use.

The disadvantage is that we might need to adapt how these hooks work in order to make them behave as a data event handler, which may grow in requirements as we start implementing it for our integrations. That's why I'm currently leaning toward our own API but would love some opinion and suggestions on it as well.

**UPDATE**

#### Listeners

After discussing with @leogermani, we decided to also add **listeners**. Listeners serve as a shortcut to dispatch an action once a WP hook is fired. Example:

```php
$action_name = 'wc_new_purchase';
$hook_name   = 'woocommerce_checkout_order_processed';
\Newspack\Data_Events::register_listener( $action_name, $hook_name );
```

With this listener, every registered handler will receive the `wc_new_purchase` data event.

You can also pass a `callable` as the 3rd argument to process/filter the data from the WP hook:

```php
\Newspack\Data_Events::register_listener(
	'wc_new_purchase',
	'woocommerce_checkout_order_processed',
	function ( $data ) {
		// Parse data
		return $data;
	}

);
```

### How to test the changes in this Pull Request:

All written tests must pass.

You can also use this small piece of code the test the entire non-blocking flow:

```php
add_action(
	'init',
	function () {
		$action_name = 'my_test_action';
		\Newspack\Data_Events::register_action( $action_name );
		$handler = function ( $timestamp ) {
			sleep( 10 );
			error_log( date( 'Y/m/d H:i:s', $timestamp ) );
		};
		\Newspack\Data_Events::register_handler( $handler, $action_name );
		\Newspack\Data_Events::dispatch( $action_name, [ 'foo' => 'bar' ] );
	}
);
```

The handler's `error_log()` should run 10 seconds after the `init` without blocking the page execution. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->