### PR TITLE
Ignore payment error notifications for sync'd subscriptions

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -54,6 +54,7 @@ class WooCommerce_Connection {
 
 		// WC Subscriptions hooks in and creates subscription at priority 100, so use priority 101.
 		\add_action( 'woocommerce_checkout_order_processed', [ __CLASS__, 'sync_reader_on_order_complete' ], 101 );
+		\add_action( 'option_woocommerce_subscriptions_failed_scheduled_actions', [ __CLASS__, 'filter_subscription_renewal_errors' ] );
 
 		\add_action( 'wp_login', [ __CLASS__, 'sync_reader_on_customer_login' ], 10, 2 );
 	}
@@ -722,6 +723,26 @@ class WooCommerce_Connection {
 			return false;
 		}
 		return $can_update;
+	}
+
+	/**
+	 * Filter WC Subscriptions' renewal errors. If a subscription is only sync'd,
+	 * it won't be renewed by WC Subscriptions, so we don't want to show an error.
+	 *
+	 * @param array $renewal_errors An associative array of errors.
+	 */
+	public static function filter_subscription_renewal_errors( $renewal_errors ) {
+		if ( is_array( $renewal_errors ) ) {
+			foreach ( $renewal_errors as $key => $error ) {
+				if ( isset( $error['args'], $error['args']['subscription_id'], $error['type'] ) ) {
+					$subscription_id = $error['args']['subscription_id'];
+					if ( 'subscription payment' === $error['type'] && self::is_synchronised_with_stripe( $subscription_id ) ) {
+						unset( $renewal_errors[ $key ] );
+					}
+				}
+			}
+		}
+		return $renewal_errors;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When a WC Subscriptions fails to be paid, a notice will be displayed in the admin panel:

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/7383192/205708893-633a0d46-672a-4fe6-89dd-0acfcc6a4933.png">

The Stripe Subscriptions which [are sync'd to WC Subscriptions](https://github.com/Automattic/newspack-plugin/pull/1936) (as read-only) will be processed by Stripe, not by WC Subscriptions (these are "manual renewal" in WCS terms). This error is a false negative, because in reality everything went fine. 

Closes 1203366842368217-as-1203469622245025

### How to test the changes in this Pull Request:

1. On a site with WC suite installed, set Stripe as the Reader Revenue platform and make a recurring donation
2. Notice a WC Subscription has been created, note its ID
3. Now create a subscription manually from the admin panel, note its ID
4. Instead of waiting for a month, just add the WP option of name `woocommerce_subscriptions_failed_scheduled_actions` and value:

```
a:1:{i:<some-id>;a:2:{s:4:"args";a:1:{s:15:"subscription_id";i:<subscription-id>;}s:4:"type";s:20:"subscription payment";}}
```

but replace `<some-id>` with any integer, and `<subscription-id>` with the subscription ID from step 2 

5. On `master`, observe the admin error notice being displayed
6. Switch to this branch, observe no notice displayed
7. Now update the option with the ID of the manually-created subscription and observe that the admin error notice is displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->