### PR TITLE
feat: use privacy policy URL as default terms URL

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -217,6 +217,15 @@ final class Reader_Activation {
 			return null;
 		}
 		$value = \get_option( self::OPTIONS_PREFIX . $name, $config[ $name ] );
+
+		// If fetching terms URL, set the default here as \get_permalink and \get_post_status aren't available on the init hook.
+		if ( 'terms_url' === $name && empty( $value ) ) {
+			$privacy_policy_page_id = \get_option( 'wp_page_for_privacy_policy' );
+			if ( ! empty( $privacy_policy_page_id ) && 'publish' === \get_post_status( $privacy_policy_page_id ) ) {
+				$value = \get_permalink( $privacy_policy_page_id );
+			}
+		}
+
 		// Use default value type for casting bool option value.
 		if ( is_bool( $config[ $name ] ) ) {
 			$value = (bool) $value;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Many sites don't have a specific terms & conditions page, and we aren't in a position to require one or to suggest language for such a page. However, almost all Newspack sites should have a privacy policy page, and while not a perfect replacement for terms & conditions, it can serve as a fallback for readers who want to know about how their data is used when registering for an account.

If the site has a published privacy policy page, this patch will use it as a default value.

Closes `1203366842368217/1202728371980722`.

### How to test the changes in this Pull Request:

1. Install this branch on a fresh RAS test site, or delete all options prefixed with `newspack_reader_activation_` to reset RAS options to their defaults.
2. Add a Register block to a post or page.
3. Confirm that the default terms text links to the privacy policy page without making any changes to the block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->