### PR TITLE
Hotfix(stripe): force sync'd subscriptions to manual renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.97.3-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.97.2...v1.97.3-hotfix.1) (2022-12-07)
+
+
+### Bug Fixes
+
+* **stripe:** force sync'd subscriptions to manual renewal ([7151986](https://github.com/Automattic/newspack-plugin/commit/715198610d0139fa74181cc2b8cb54c7ad64c085))
+
 ## [1.97.2](https://github.com/Automattic/newspack-plugin/compare/v1.97.1...v1.97.2) (2022-12-02)
 
 

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.97.2
+ * Version: 1.97.3-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.pub/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.97.2' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.97.3-hotfix.1' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.97.2",
+  "version": "1.97.3-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.97.2",
+      "version": "1.97.3-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.97.2",
+  "version": "1.97.3-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with Stripe to WC Subscriptions sychronization. 

### How to test the changes in this Pull Request:

1. On `master`
1. Enable RAS, set the Reader Revenue platform to Stripe
2. Make a recurring donation as user A
3. Switch the Reader Revenue platform to Newspack 
4. Log in to `/my-account` as user A
5. Go to "Payment Methods" and add a credit card
6. Check "Update the payment method used for all of my active subscriptions"
7. Now WC Subs will update the payment method on the WC Subscription to the new payment method, because there were no payment methods for this customer before
8. Switch to this branch and repeat the test steps – observe the payment method is not updated on the WC Subscription

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->