### PR TITLE
feat(stripe-sync-cli): create WC subscriptions

### DIFF
--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -161,29 +161,55 @@ class Stripe_Connection {
 	}
 
 	/**
+	 * Get Stripe charge.
+	 *
+	 * @param string $charge_id Customer ID.
+	 */
+	public static function get_charge_by_id( $charge_id ) {
+		$stripe = self::get_stripe_client();
+		try {
+			return $stripe->charges->retrieve( $charge_id, [] );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error( 'stripe_newspack', __( 'Could not fetch charge.', 'newspack' ), $e->getMessage() );
+		}
+	}
+
+	/**
 	 * Get customer's charges.
 	 *
 	 * @param string $customer_id Customer ID.
 	 * @param int    $page Page of results.
 	 * @param int    $limit Limit of results.
+	 * @param string $type 'charge' or 'invoice'. The latter contains information about a subcription, if applicable.
 	 */
-	public static function get_customer_charges( $customer_id, $page = false, $limit = 10 ) {
+	public static function get_customer_transactions( $customer_id, $page = false, $limit = false, $type = 'charge' ) {
 		$stripe = self::get_stripe_client();
 		try {
-			$all_charges = [];
-			$params      = [
+			$all_transactions = [];
+			$params           = [
 				'query' => 'customer:"' . $customer_id . '"',
-				'limit' => $limit,
 			];
+			if ( $limit ) {
+				$params['limit'] = $limit;
+			}
 			if ( $page ) {
 				$params['page'] = $page;
 			}
-			$response    = $stripe->charges->search( $params );
-			$all_charges = $response['data'];
-			if ( $response['has_more'] ) {
-				$all_charges = array_merge( $all_charges, self::get_customer_charges( $customer_id, $response['next_page'] ) );
+			if ( 'invoice' === $type ) {
+				$response = $stripe->invoices->search( $params );
+			} elseif ( 'charge' === $type ) {
+				$response = $stripe->charges->search( $params );
+			} else {
+				return new \WP_Error( 'stripe_newspack', __( 'Invalid transaction type.', 'newspack' ) );
 			}
-			return $all_charges;
+			$all_transactions = $response['data'];
+			if ( $limit && count( $all_transactions ) >= $limit ) {
+				return $all_transactions;
+			}
+			if ( $response['has_more'] ) {
+				$all_transactions = array_merge( $all_transactions, self::get_customer_transactions( $customer_id, $response['next_page'], $limit, $type ) );
+			}
+			return $all_transactions;
 		} catch ( \Throwable $e ) {
 			return new \WP_Error( 'stripe_newspack', __( 'Could not fetch customer\'s charges.', 'newspack' ), $e->getMessage() );
 		}
@@ -195,7 +221,7 @@ class Stripe_Connection {
 	 * @param string $customer_id Customer ID.
 	 */
 	public static function get_customer_ltv( $customer_id ) {
-		$all_charges = self::get_customer_charges( $customer_id );
+		$all_charges = self::get_customer_transactions( $customer_id );
 		if ( \is_wp_error( $all_charges ) ) {
 			return $all_charges;
 		}
@@ -353,7 +379,7 @@ class Stripe_Connection {
 	 *
 	 * @param string $customer_id Customer ID.
 	 */
-	private static function get_subscriptions_of_customer( $customer_id ) {
+	public static function get_subscriptions_of_customer( $customer_id ) {
 		$stripe = self::get_stripe_client();
 		try {
 			return $stripe->subscriptions->all(
@@ -991,10 +1017,21 @@ class Stripe_Connection {
 			if ( \is_wp_error( $invoice ) ) {
 				return $frequency;
 			}
-			$recurring = $invoice['lines']['data'][0]['price']['recurring'];
-			if ( isset( $recurring['interval'] ) ) {
-				$frequency = $recurring['interval'];
-			}
+			$frequency = self::get_frequency_from_invoice( $invoice );
+		}
+		return $frequency;
+	}
+
+	/**
+	 * Get payment frequency from invoice.
+	 *
+	 * @param array $invoice Stripe invoice.
+	 */
+	public static function get_frequency_from_invoice( $invoice ) {
+		$frequency = 'once';
+		$recurring = $invoice['lines']['data'][0]['price']['recurring'];
+		if ( isset( $recurring['interval'] ) ) {
+			$frequency = $recurring['interval'];
 		}
 		return $frequency;
 	}
@@ -1015,19 +1052,31 @@ class Stripe_Connection {
 	 * @param array $payment Stripe payment.
 	 */
 	public static function create_wc_transaction_payload( $customer, $payment ) {
-		$balance_transaction    = self::get_balance_transaction( $payment['balance_transaction'] );
-		$amount_normalised      = self::normalise_amount( $payment['amount'], $payment['currency'] );
-		$stripe_data            = self::get_stripe_data();
-		$subscription_id        = null;
-		$invoice_billing_reason = null;
-		$invoice                = self::get_invoice( $payment['invoice'] );
-		if ( $invoice && ! \is_wp_error( $invoice ) ) {
-			$invoice_billing_reason = $invoice['billing_reason'];
-			if ( isset( $invoice['subscription'] ) && is_string( $invoice['subscription'] ) ) {
-				$subscription_id = $invoice['subscription'];
+		$balance_transaction = self::get_balance_transaction( $payment['balance_transaction'] );
+		$amount_normalised   = self::normalise_amount( $payment['amount'], $payment['currency'] );
+		$stripe_data         = self::get_stripe_data();
+
+		if ( isset( $payment['billing_reason'], $payment['subscription'] ) ) {
+			$subscription_id        = $payment['subscription'];
+			$invoice_billing_reason = $payment['billing_reason'];
+		} elseif ( $payment['invoice'] ) {
+			$invoice = self::get_invoice( $payment['invoice'] );
+			if ( $invoice && ! \is_wp_error( $invoice ) ) {
+				$invoice_billing_reason = $invoice['billing_reason'];
+				if ( isset( $invoice['subscription'] ) && is_string( $invoice['subscription'] ) ) {
+					$subscription_id = $invoice['subscription'];
+				}
+			} elseif ( \is_wp_error( $invoice ) ) {
+				Logger::log( 'Invoice error: ' . $invoice->get_error_message() );
 			}
-		} elseif ( \is_wp_error( $invoice ) ) {
-			Logger::log( 'Invoice error: ' . $invoice->get_error_message() );
+		} else {
+			$subscription_id        = null;
+			$invoice_billing_reason = null;
+		}
+		if ( isset( $payment['frequency'] ) ) {
+			$frequency = $payment['frequency'];
+		} else {
+			$frequency = self::get_frequency_of_payment( $payment );
 		}
 		return [
 			'email'                         => $customer['email'],
@@ -1040,7 +1089,7 @@ class Stripe_Connection {
 			'stripe_subscription_id'        => $subscription_id,
 			'date'                          => $payment['created'],
 			'amount'                        => $amount_normalised,
-			'frequency'                     => self::get_frequency_of_payment( $payment ),
+			'frequency'                     => $frequency,
 			'currency'                      => $stripe_data['currency'],
 			'client_id'                     => $customer['metadata']['clientId'],
 			'user_id'                       => $customer['metadata']['userId'],

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -68,8 +68,8 @@ class Stripe_Sync {
 			}
 			// Construct the payment object expected by the Stripe_Connection::create_wc_transaction_payload method.
 			$stripe_payment = [
-				'id'      => $invoice->id,
-				'created' => $invoice->created,
+				'id'      => $charge->id,
+				'created' => $charge->created,
 			];
 
 			$processed_charges_ids[] = $invoice->charge;
@@ -134,14 +134,13 @@ class Stripe_Sync {
 		}
 
 		foreach ( $charges as $charge ) {
-			$wc_transaction_payload            = Stripe_Connection::create_wc_transaction_payload( $customer, $charge );
-			$wc_transaction_payload['user_id'] = $user_id;
-			$wc_transaction_payloads[]         = $wc_transaction_payload;
+			$wc_transaction_payloads[] = Stripe_Connection::create_wc_transaction_payload( $customer, $charge );
 			self::$results['wc_stripe_one_time_charges_processed']++;
 		}
 
 		foreach ( $wc_transaction_payloads as $transation_payload ) {
-			$charge_id = $transation_payload['stripe_id'];
+			$charge_id                     = $transation_payload['stripe_id'];
+			$transation_payload['user_id'] = $user_id;
 			// Find the order associated with this charge.
 			$found_order = \WC_Stripe_Helper::get_order_by_charge_id( $charge_id );
 			if ( $found_order ) {

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -20,12 +20,14 @@ class Stripe_Sync {
 	 * @codeCoverageIgnore
 	 */
 	private static $results = [
-		'processed'            => 0,
-		'wc_created'           => 0,
-		'wc_found'             => 0,
-		'wc_orders_updated'    => 0,
-		'wc_orders_created'    => 0,
-		'wc_skipped_customers' => 0,
+		'processed'                                => 0,
+		'wc_created'                               => 0,
+		'wc_found'                                 => 0,
+		'wc_orders_updated'                        => 0,
+		'wc_orders_created'                        => 0,
+		'wc_stripe_subscription_charges_processed' => 0,
+		'wc_stripe_one_time_charges_processed'     => 0,
+		'wc_skipped_customers'                     => 0,
 	];
 
 	/**
@@ -47,16 +49,52 @@ class Stripe_Sync {
 		$email_address = $customer->email;
 		$is_dry_run    = false !== $args['dry-run'];
 
-		$all_charges = Stripe_Connection::get_customer_charges( $customer->id );
+		$all_invoices            = Stripe_Connection::get_customer_transactions( $customer->id, false, false, 'invoice' );
+		$processed_charges_ids   = [];
+		$wc_transaction_payloads = [];
+		foreach ( $all_invoices as $invoice ) {
+			if ( ! $invoice->charge ) {
+				\WP_CLI::warning( __( 'Missing charge ID on invoice ', 'newspack' ) . ' ' . $invoice->id );
+				continue;
+			}
+			$charge = Stripe_Connection::get_charge_by_id( $invoice->charge );
+			if ( \is_wp_error( $charge ) ) {
+				\WP_CLI::warning( __( 'Error retrieving charge of ', 'newspack' ) . ' ' . $email_address . ': ' . $charge->get_error_message() );
+				continue;
+			}
+			// Construct the payment object expected by the Stripe_Connection::create_wc_transaction_payload method.
+			$stripe_payment = [
+				'id'      => $invoice->id,
+				'created' => $invoice->created,
+			];
 
-		// Skip charges created by WC.
+			$processed_charges_ids[] = $invoice->charge;
+
+			$stripe_payment['amount']              = $charge->amount;
+			$stripe_payment['currency']            = $charge->currency;
+			$stripe_payment['balance_transaction'] = $charge->balance_transaction;
+			$stripe_payment['frequency']           = Stripe_Connection::get_frequency_from_invoice( $invoice );
+
+			if ( $invoice->subscription ) {
+				$stripe_payment['billing_reason'] = $invoice->billing_reason;
+				$stripe_payment['subscription']   = $invoice->subscription;
+				self::$results['wc_stripe_subscription_charges_processed']++;
+			} else {
+				self::$results['wc_stripe_one_time_charges_processed']++;
+			}
+			$wc_transaction_payloads[] = Stripe_Connection::create_wc_transaction_payload( $customer, $stripe_payment );
+		}
+
+		$all_charges = Stripe_Connection::get_customer_transactions( $customer->id );
+		// Skip charges created by WC and those already processed from invoices.
 		$charges = array_filter(
 			$all_charges,
-			function( $charge ) {
-				return ! isset( $charge->metadata->order_id );
+			function( $charge ) use ( $processed_charges_ids ) {
+				return ! isset( $charge->metadata->order_id ) && ! in_array( $charge->id, $processed_charges_ids );
 			}
 		);
-		if ( empty( $charges ) ) {
+
+		if ( empty( $charges ) && empty( $wc_transaction_payloads ) ) {
 			self::$results['wc_skipped_customers']++;
 			return;
 		}
@@ -68,58 +106,58 @@ class Stripe_Sync {
 			self::$results['wc_found']++;
 		} else {
 			// Create the WC Customer and update past orders (lookup is done by email).
+			$full_name  = $customer->name;
+			$user_login = \sanitize_title( $full_name );
+			if ( username_exists( $user_login ) ) {
+				$user_login = $user_login . '-' . uniqid();
+			}
 			if ( ! $is_dry_run ) {
-				$full_name  = $customer->name;
-				$user_login = \sanitize_title( $full_name );
-				if ( username_exists( $user_login ) ) {
-					$user_login = $user_login . '-' . uniqid();
-				}
 				$user_id = \wc_create_new_customer( $email_address, $user_login, '', [ 'display_name' => $full_name ] );
 				if ( is_wp_error( $user_id ) ) {
 					\WP_CLI::warning( __( 'Error processing customer', 'newspack' ) . ' ' . $email_address . ': ' . $user_id->get_error_message() );
-					$user_id = false;
-				} else {
-					$linked_orders_count                 = \wc_update_new_customer_past_orders( $user_id );
-					self::$results['wc_orders_updated'] += $linked_orders_count;
-
-					// translators: Customer email, linked orders count.
-					\WP_CLI::success( sprintf( __( 'Created WC Customer with email: %1$s and linked %2$d order(s) to them.', 'newspack' ), $email_address, $linked_orders_count ) );
-					self::$results['wc_created']++;
+					return;
 				}
+				$linked_orders_count                 = \wc_update_new_customer_past_orders( $user_id );
+				self::$results['wc_orders_updated'] += $linked_orders_count;
+				// translators: Customer email, linked orders count.
+				\WP_CLI::success( sprintf( __( 'Created WC Customer with email: %1$s and linked %2$d order(s) to them.', 'newspack' ), $email_address, $linked_orders_count ) );
 			}
+			self::$results['wc_created']++;
 		}
 
-		if ( false !== $user_id ) {
-			foreach ( $charges as $charge ) {
-				// Find the order associated with this charge.
-				$found_order = \WC_Stripe_Helper::get_order_by_charge_id( $charge->id );
-				if ( $found_order ) {
-					$order_customer_id = $found_order->get_customer_id();
-					if ( ! $order_customer_id ) {
-						// The order and the customer exist, but the order is not linked to the customer. Link them.
-						if ( ! $is_dry_run ) {
-							$found_order->set_customer_id( $user_id );
-							$found_order->save();
-							// translators: Order ID.
-							\WP_CLI::success( sprintf( __( 'Updated WC order: %d.', 'newspack' ), $found_order->get_id() ) );
-							self::$results['wc_orders_updated'] ++;
-						}
-					}
-				} else {
-					// This is a charge without an order. Create a new order.
+		foreach ( $charges as $charge ) {
+			$wc_transaction_payload            = Stripe_Connection::create_wc_transaction_payload( $customer, $charge );
+			$wc_transaction_payload['user_id'] = $user_id;
+			$wc_transaction_payloads[]         = $wc_transaction_payload;
+			self::$results['wc_stripe_one_time_charges_processed']++;
+		}
+
+		foreach ( $wc_transaction_payloads as $transation_payload ) {
+			$charge_id = $transation_payload['stripe_id'];
+			// Find the order associated with this charge.
+			$found_order = \WC_Stripe_Helper::get_order_by_charge_id( $charge_id );
+			if ( $found_order ) {
+				$order_customer_id = $found_order->get_customer_id();
+				if ( ! $order_customer_id ) {
+					// The order and the customer exist, but the order is not linked to the customer. Link them.
 					if ( ! $is_dry_run ) {
-						$wc_transaction_payload            = Stripe_Connection::create_wc_transaction_payload( $customer, $charge );
-						$wc_transaction_payload['user_id'] = $user_id;
-						$order_id                          = WooCommerce_Connection::create_transaction( $wc_transaction_payload );
+						$found_order->set_customer_id( $user_id );
+						$found_order->save();
 						// translators: Order ID.
-						\WP_CLI::success( sprintf( __( 'Created WC order: %d.', 'newspack' ), $order_id ) );
-						self::$results['wc_orders_created'] ++;
+						\WP_CLI::success( sprintf( __( 'Updated WC order: %d.', 'newspack' ), $found_order->get_id() ) );
 					}
+					self::$results['wc_orders_updated'] ++;
 				}
+			} else {
+				// This is a charge without an order. Create a new order.
+				if ( ! $is_dry_run ) {
+					$order_id = WooCommerce_Connection::create_transaction( $transation_payload );
+					// translators: Order ID.
+					\WP_CLI::success( sprintf( __( 'Created WC order: %d.', 'newspack' ), $order_id ) );
+				}
+				self::$results['wc_orders_created'] ++;
 			}
 		}
-
-		self::$results['processed']++;
 	}
 
 	/**
@@ -141,7 +179,7 @@ class Stripe_Sync {
 			$metadata_keys['total_paid'] => Stripe_Connection::get_customer_ltv( $customer->id ),
 		];
 
-		$last_payments = Stripe_Connection::get_customer_charges( $customer->id, false, 1 );
+		$last_payments = Stripe_Connection::get_customer_transactions( $customer->id, false, 1 );
 		if ( ! empty( $last_payments ) ) {
 			$payment           = $last_payments[0];
 			$amount_normalised = Stripe_Connection::normalise_amount( $payment['amount'], $payment['currency'] );
@@ -220,6 +258,7 @@ class Stripe_Sync {
 				} elseif ( $args['sync-to-wc'] ) {
 					self::sync_to_wc( $customer, $args );
 				}
+				self::$results['processed']++;
 			}
 
 			if ( $response['has_more'] ) {
@@ -231,6 +270,74 @@ class Stripe_Sync {
 			}
 		} catch ( \Throwable $e ) {
 			return new \WP_Error( 'stripe_newspack', __( 'Could not process all customers:', 'newspack' ) . ' ' . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * CLI command for data backfill from Stripe to either WC or an ESP.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public static function data_backfill( $args, $assoc_args ) {
+		$default_args = [
+			'batch-size'  => 10,
+			'sync-to-wc'  => true, // Sync data to WooCommerce.
+			'sync-to-esp' => false, // Sync data to the ESP.
+			'dry-run'     => false,
+		];
+		$passed_args  = array_merge( $default_args, $assoc_args );
+		if ( false !== $passed_args['dry-run'] ) {
+			\WP_CLI::warning( __( 'This is a dry run, no changes will be made.', 'newspack' ) );
+		}
+
+		if ( $passed_args['sync-to-wc'] ) {
+			if ( ! class_exists( 'WC_Stripe_Helper' ) || ! method_exists( 'WC_Stripe_Helper', 'get_order_by_charge_id' ) ) {
+				\WP_CLI::error( __( 'WC Stripe Gateway plugin has to be active.', 'newspack' ) );
+				return;
+			}
+
+			if ( ! function_exists( 'wc_create_new_customer' ) ) {
+				\WP_CLI::error( __( 'WooCommerce plugin has to be active.', 'newspack' ) );
+				return;
+			}
+			if ( ! Donations::is_platform_stripe() ) {
+				\WP_CLI::error( __( 'Reader Revenue platform has to be set to Stripe.', 'newspack' ) );
+				return;
+			}
+		}
+
+		if ( $passed_args['sync-to-esp'] ) {
+			if ( ! method_exists( '\Newspack_Newsletters_Subscription', 'add_contact' ) ) {
+				\WP_CLI::error( __( 'Newspack Newsletters has to be active.', 'newspack' ) );
+				return;
+			}
+		}
+
+		$result = self::process_all_stripe_customers( $passed_args );
+
+		if ( \is_wp_error( $result ) ) {
+			\WP_CLI::error( $result->get_error_message() );
+		}
+
+		// translators: Number of Stripe customers processed.
+		\WP_CLI::success( sprintf( __( 'Processed %d Stripe customers.', 'newspack' ), self::$results['processed'] ) );
+
+		if ( $passed_args['sync-to-wc'] ) {
+			// translators: Number of customers found.
+			\WP_CLI::success( sprintf( __( 'Found %d WC customers linked to Stripe customers.', 'newspack' ), self::$results['wc_found'] ) );
+			// translators: Number of customers created.
+			\WP_CLI::success( sprintf( __( 'Created %d WC customers from Stripe customers.', 'newspack' ), self::$results['wc_created'] ) );
+			// translators: Number of subscription charges processed.
+			\WP_CLI::success( sprintf( __( 'Processed %d subscription-related Stripe charges.', 'newspack' ), self::$results['wc_stripe_subscription_charges_processed'] ) );
+			// translators: Number of one-time charges processed.
+			\WP_CLI::success( sprintf( __( 'Processed %d one-time Stripe charges.', 'newspack' ), self::$results['wc_stripe_one_time_charges_processed'] ) );
+			// translators: Number of orders updated.
+			\WP_CLI::success( sprintf( __( 'Updated %d WC orders linked to Stripe charges.', 'newspack' ), self::$results['wc_orders_updated'] ) );
+			// translators: Number of orders created.
+			\WP_CLI::success( sprintf( __( 'Created %d WC orders from Stripe charges.', 'newspack' ), self::$results['wc_orders_created'] ) );
+			// translators: Number of Stripe customers skipped.
+			\WP_CLI::success( sprintf( __( 'Skipped %d Stripe customers.', 'newspack' ), self::$results['wc_skipped_customers'] ) );
 		}
 	}
 
@@ -378,63 +485,9 @@ class Stripe_Sync {
 			return;
 		}
 
-		$sync_to_wc = function ( $args, $assoc_args ) {
-			$default_args = [
-				'batch-size'  => 10,
-				'sync-to-wc'  => true, // Sync data to WooCommerce.
-				'sync-to-esp' => false, // Sync data to the ESP.
-				'dry-run'     => false,
-			];
-			$passed_args  = array_merge( $default_args, $assoc_args );
-			if ( false !== $passed_args['dry-run'] ) {
-				\WP_CLI::warning( __( 'This is a dry run, no changes will be made.', 'newspack' ) );
-			}
-
-			if ( $passed_args['sync-to-wc'] ) {
-				if ( ! class_exists( 'WC_Stripe_Helper' ) || ! method_exists( 'WC_Stripe_Helper', 'get_order_by_charge_id' ) ) {
-					\WP_CLI::error( __( 'WC Stripe Gateway plugin has to be active.', 'newspack' ) );
-					return;
-				}
-
-				if ( ! function_exists( 'wc_create_new_customer' ) ) {
-					\WP_CLI::error( __( 'WooCommerce plugin has to be active.', 'newspack' ) );
-					return;
-				}
-			}
-
-			if ( $passed_args['sync-to-esp'] ) {
-				if ( ! method_exists( '\Newspack_Newsletters_Subscription', 'add_contact' ) ) {
-					\WP_CLI::error( __( 'Newspack Newsletters has to be active.', 'newspack' ) );
-					return;
-				}
-			}
-
-			$result = self::process_all_stripe_customers( $passed_args );
-
-			if ( \is_wp_error( $result ) ) {
-				\WP_CLI::error( $result->get_error_message() );
-			}
-
-			// translators: Number of Stripe customers processed.
-			\WP_CLI::success( sprintf( __( 'Processed %d Stripe customers.', 'newspack' ), self::$results['processed'] ) );
-
-			if ( $passed_args['sync-to-wc'] ) {
-				// translators: Number of customers found.
-				\WP_CLI::success( sprintf( __( 'Found %d WC customers linked to Stripe customers.', 'newspack' ), self::$results['wc_found'] ) );
-				// translators: Number of customers created.
-				\WP_CLI::success( sprintf( __( 'Created %d WC customers from Stripe customers.', 'newspack' ), self::$results['wc_created'] ) );
-				// translators: Number of orders updated.
-				\WP_CLI::success( sprintf( __( 'Updated %d WC orders linked to Stripe charges.', 'newspack' ), self::$results['wc_orders_updated'] ) );
-				// translators: Number of orders created.
-				\WP_CLI::success( sprintf( __( 'Created %d WC orders from Stripe charges.', 'newspack' ), self::$results['wc_orders_created'] ) );
-				// translators: Number of Stripe customers skipped.
-				\WP_CLI::success( sprintf( __( 'Skipped %d Stripe customers.', 'newspack' ), self::$results['wc_skipped_customers'] ) );
-			}
-		};
-
 		\WP_CLI::add_command(
 			'newspack stripe sync-customers',
-			$sync_to_wc,
+			[ __CLASS__, 'data_backfill' ],
 			[
 				'shortdesc' => __( 'Backfill WC Customers from Stripe database.', 'newspack' ),
 			]

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -50,8 +50,8 @@ class Stripe_Sync {
 		$is_dry_run    = false !== $args['dry-run'];
 
 		$all_invoices = Stripe_Connection::get_customer_transactions( $customer->id, false, false, 'invoice' );
-		if ( \is_wp_error( $all_charges ) ) {
-			\WP_CLI::warning( __( 'Error fetching customer transactions: ', 'newspack' ) . $all_charges->get_error_message() );
+		if ( \is_wp_error( $all_invoices ) ) {
+			\WP_CLI::warning( __( 'Error fetching customer transactions: ', 'newspack' ) . $all_invoices->get_error_message() );
 			return;
 		}
 		$processed_charges_ids   = [];

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -51,7 +51,7 @@ class Stripe_Sync {
 
 		$all_invoices = Stripe_Connection::get_customer_transactions( $customer->id, false, false, 'invoice' );
 		if ( \is_wp_error( $all_invoices ) ) {
-			\WP_CLI::warning( __( 'Error fetching customer transactions: ', 'newspack' ) . $all_invoices->get_error_message() );
+			\WP_CLI::warning( __( 'Error fetching customer invoices: ', 'newspack' ) . $all_invoices->get_error_message() );
 			return;
 		}
 		$processed_charges_ids   = [];
@@ -90,6 +90,10 @@ class Stripe_Sync {
 		}
 
 		$all_charges = Stripe_Connection::get_customer_transactions( $customer->id );
+		if ( \is_wp_error( $all_charges ) ) {
+			\WP_CLI::warning( __( 'Error fetching customer charges: ', 'newspack' ) . $all_charges->get_error_message() );
+			return;
+		}
 		// Skip charges created by WC and those already processed from invoices.
 		$charges = array_filter(
 			$all_charges,
@@ -184,6 +188,11 @@ class Stripe_Sync {
 		];
 
 		$last_payments = Stripe_Connection::get_customer_transactions( $customer->id, false, 1 );
+		if ( \is_wp_error( $last_payments ) ) {
+			\WP_CLI::warning( __( 'Error fetching customer charges: ', 'newspack' ) . $last_payments->get_error_message() );
+			return;
+		}
+
 		if ( ! empty( $last_payments ) ) {
 			$payment           = $last_payments[0];
 			$amount_normalised = Stripe_Connection::normalise_amount( $payment['amount'], $payment['currency'] );

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -49,7 +49,11 @@ class Stripe_Sync {
 		$email_address = $customer->email;
 		$is_dry_run    = false !== $args['dry-run'];
 
-		$all_invoices            = Stripe_Connection::get_customer_transactions( $customer->id, false, false, 'invoice' );
+		$all_invoices = Stripe_Connection::get_customer_transactions( $customer->id, false, false, 'invoice' );
+		if ( \is_wp_error( $all_charges ) ) {
+			\WP_CLI::warning( __( 'Error fetching customer transactions: ', 'newspack' ) . $all_charges->get_error_message() );
+			return;
+		}
 		$processed_charges_ids   = [];
 		$wc_transaction_payloads = [];
 		foreach ( $all_invoices as $invoice ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When the CLI command for synchronising Stripe data to WC was created (#1981), the Stripe-to-WC-Subscriptions functionality (#1936) was not ready yet. For this reason, the CLI command will not create WC Subscriptions and a series of one-time charges will be created instead.

This PR updates the CLI command, so that WC Subscriptions are created for corresponding Stripe Subscriptions. 

### How to test the changes in this Pull Request:

1. Ensure your Stripe instance has at least:
    1. one one-time donation charge, not synced to WC
    2. one one-time donation charge, synced to WC*
    3. one donation subscription, not synced to WC
    4. one donation subscription, synced to WC
    5. one-time donation made via WC**
    6. recurring donation made via WC**
7. Run `wp newspack stripe sync-customers --sync-to-wc` 
8. Observe that (from pt. 1):
    - 1., 3. were synced to WC
    - 2., 4. were not (there were already there)
    - 5., 6. are still there
    - new customers were created where applicable

\* Made with Stripe as Reader Revenue platform and WC suite active. Ensure webhook is configured and can reach your site. 
\** Set the Reader Revenue platform to Newspack and make a donation via WC checkout using Stripe Gateway (configured to use the same Stripe instance). The important bit is that WC Stripe Gateway will set `order_id` meta on the Stripe charge. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->