### PR TITLE
feat(data-events): webhooks

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -79,6 +79,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-data-events.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-webhooks.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/listeners.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-analytics.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -49,6 +49,7 @@ final class Newspack {
 		add_action( 'network_admin_notices', [ $this, 'remove_notifications' ], -9999 );
 		add_action( 'all_admin_notices', [ $this, 'remove_notifications' ], -9999 );
 		register_activation_hook( NEWSPACK_PLUGIN_FILE, [ $this, 'activation_hook' ] );
+		register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ $this, 'deactivation_hook' ] );
 	}
 
 	/**
@@ -235,6 +236,14 @@ final class Newspack {
 	 */
 	public function activation_hook() {
 		set_transient( NEWSPACK_ACTIVATION_TRANSIENT, 1, 30 );
+		do_action( 'newspack_activation' );
+	}
+
+	/**
+	 * Deactivation Hook
+	 */
+	public function deactivation_hook() {
+		do_action( 'newspack_deactivation' );
 	}
 
 	/**

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -246,6 +246,9 @@ final class Newspack {
 	 * Deactivation Hook
 	 */
 	public function deactivation_hook() {
+		/**
+		 * Fires on the newspack plugin deactivation hook
+		 */
 		do_action( 'newspack_deactivation' );
 	}
 

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -78,6 +78,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-theme-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-data-events.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-webhooks.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-analytics.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -236,6 +236,9 @@ final class Newspack {
 	 */
 	public function activation_hook() {
 		set_transient( NEWSPACK_ACTIVATION_TRANSIENT, 1, 30 );
+		/**
+		 * Fires on the newspack plugin activation hook
+		 */
 		do_action( 'newspack_activation' );
 	}
 

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -172,11 +172,14 @@ final class Data_Events {
 	}
 
 	/**
-	 * Register a listener so it dispatches an action when a WordPress hook is fired.
+	 * Register a listener so it dispatches an action when a WordPress hook is
+	 * fired.
 	 *
-	 * @param string   $hook_name   WordPress hook name.
-	 * @param string   $action_name Action name.
-	 * @param callable $callable    Optional callable to filter the data passed to dispatch.
+	 * @param string         $hook_name   WordPress hook name.
+	 * @param string         $action_name Action name.
+	 * @param callable|array $callable    Optional callable to filter the data
+	 *                                    passed to dispatch or an array of
+	 *                                    strings to map argument names.
 	 */
 	public static function register_listener( $hook_name, $action_name, $callable = null ) {
 		self::register_action( $action_name );
@@ -186,6 +189,13 @@ final class Data_Events {
 				$args = func_get_args();
 				if ( is_callable( $callable ) ) {
 					$data = call_user_func_array( $callable, $args );
+				} elseif ( is_array( $callable ) ) {
+					$data = [];
+					foreach ( $callable as $i => $key ) {
+						if ( isset( $args[ $i ] ) ) {
+							$data[ $key ] = $args[ $i ];
+						}
+					}
 				} else {
 					$data = $args;
 				}

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -189,7 +189,9 @@ final class Data_Events {
 				} else {
 					$data = $args;
 				}
-				self::dispatch( $action_name, $data );
+				if ( ! empty( $data ) ) {
+					self::dispatch( $action_name, $data );
+				}
 			},
 			PHP_INT_MAX, // We want dispatches to be executed last so that any modified data is available.
 			PHP_INT_MAX // The handler should receive all arguments of a hook.

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -192,6 +192,7 @@ final class Data_Events {
 				if ( ! empty( $data ) ) {
 					self::dispatch( $action_name, $data );
 				}
+				return $args[0];
 			},
 			PHP_INT_MAX, // We want dispatches to be executed last so that any modified data is available.
 			PHP_INT_MAX // The handler should receive all arguments of a hook.

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * Newspack Data Events Webhooks.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Data_Events;
+
+use Newspack\Logger;
+
+/**
+ * Main class.
+ */
+final class Webhooks {
+
+	const REQUEST_POST_TYPE = 'np_webhook_request';
+	const ENDPOINT_TAXONOMY = 'np_webhook_endpoint';
+	const MAX_RETRIES       = 12;
+	const LOGGER_HEADER     = 'NEWSPACK-WEBHOOKS';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		\add_action( 'init', [ __CLASS__, 'register_request_post_type' ] );
+		\add_action( 'init', [ __CLASS__, 'register_endpoint_taxonomy' ] );
+		\add_action( 'newspack_data_event_dispatch', [ __CLASS__, 'handle_dispatch' ], 10, 4 );
+		\add_action( 'transition_post_status', [ __CLASS__, 'transition_post_status' ], 10, 3 );
+	}
+
+	/**
+	 * Register custom post type for webhook requests
+	 */
+	public static function register_request_post_type() {
+		\register_post_type(
+			self::REQUEST_POST_TYPE,
+			[
+				'labels'       => [
+					'name'          => __( 'Webhook Requests', 'newspack' ),
+					'singular_name' => __( 'Webhook Request', 'newspack' ),
+				],
+				'public'       => false,
+				'show_ui'      => false,
+				'show_in_menu' => false,
+				'show_in_rest' => false,
+				'supports'     => [
+					'title',
+					'custom-fields',
+				],
+				'taxonomies'   => [
+					self::ENDPOINT_TAXONOMY,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Register taxonomy for webhook endpoints
+	 */
+	public static function register_endpoint_taxonomy() {
+		\register_taxonomy(
+			self::ENDPOINT_TAXONOMY,
+			self::REQUEST_POST_TYPE,
+			[
+				'labels'       => [
+					'name'          => __( 'Webhook Endpoints', 'newspack' ),
+					'singular_name' => __( 'Webhook Endpoint', 'newspack' ),
+				],
+				'public'       => false,
+				'show_ui'      => false,
+				'show_in_menu' => false,
+				'show_in_rest' => false,
+			]
+		);
+	}
+
+	/**
+	 * Update a webhook endpoint.
+	 *
+	 * @param string $url     Endpoint URL.
+	 * @param array  $actions Array of action names.
+	 * @param bool   $global  Whether the endpoint should be triggered for all actions.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public static function update_endpoint( $url, $actions = [], $global = false ) {
+		$endpoint = get_term_by( 'name', $url, self::ENDPOINT_TAXONOMY, ARRAY_A );
+		if ( ! $endpoint ) {
+			$endpoint = \wp_insert_term(
+				$url,
+				self::ENDPOINT_TAXONOMY,
+				[
+					'description' => $url,
+				]
+			);
+		}
+		\update_term_meta( $endpoint['term_id'], 'actions', $actions );
+		\update_term_meta( $endpoint['term_id'], 'global', $global );
+		return $endpoint;
+	}
+
+	/**
+	 * Delete a webhook endpoint.
+	 *
+	 * @param string $url Endpoint URL.
+	 *
+	 * @return void|\WP_Error Error if endpoint not found.
+	 */
+	public static function delete_endpoint( $url ) {
+		$endpoint = get_term_by( 'name', $url, self::ENDPOINT_TAXONOMY );
+		if ( ! $endpoint ) {
+			return new \WP_Error( 'newspack_webhook_endpoint_not_found', __( 'Webhook endpoint not found.', 'newspack' ) );
+		}
+		$endpoint_id = $endpoint->term_id;
+		\wp_delete_term( $endpoint_id, self::ENDPOINT_TAXONOMY );
+	}
+
+	/**
+	 * Get all webhook endpoints.
+	 *
+	 * @return array Array of endpoints.
+	 */
+	public static function get_endpoints() {
+		$endpoints = get_terms( self::ENDPOINT_TAXONOMY, [ 'hide_empty' => false ] );
+		return array_map(
+			function( $endpoint ) {
+				return [
+					'id'      => $endpoint->term_id,
+					'url'     => $endpoint->name,
+					'actions' => get_term_meta( $endpoint->term_id, 'actions', true ),
+					'global'  => get_term_meta( $endpoint->term_id, 'global', true ),
+				];
+			},
+			$endpoints
+		);
+	}
+
+	/**
+	 * Get endpoints for actions.
+	 *
+	 * @param string $action_name Action name.
+	 *
+	 * @return array Array of endpoints.
+	 */
+	private static function get_endpoints_for_action( $action_name ) {
+		$endpoints = self::get_endpoints();
+		return array_values(
+			array_filter(
+				$endpoints,
+				function( $endpoint ) use ( $action_name ) {
+					return $endpoint['global'] || in_array( $action_name, $endpoint['actions'], true );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Create webhook request.
+	 *
+	 * @param int    $endpoint_id Endpoint ID.
+	 * @param string $action_name Action name.
+	 * @param int    $timestamp   Timestamp.
+	 * @param array  $data        Data.
+	 * @param string $client_id   Client ID.
+	 *
+	 * @return int|\WP_Error.
+	 */
+	private static function create_request( $endpoint_id, $action_name, $timestamp, $data, $client_id ) {
+		$request_id = \wp_insert_post(
+			[
+				'post_type'  => self::REQUEST_POST_TYPE,
+				'post_title' => $action_name,
+			],
+			true
+		);
+
+		if ( is_wp_error( $request_id ) ) {
+			return $request_id;
+		}
+
+		\wp_set_object_terms( $request_id, $endpoint_id, self::ENDPOINT_TAXONOMY );
+
+		$body = [
+			'timestamp' => $timestamp,
+			'action'    => $action_name,
+			'data'      => $data,
+			'client_id' => $client_id,
+		];
+		\update_post_meta( $request_id, 'body', wp_json_encode( $body ) );
+		\update_post_meta( $request_id, 'action_name', $action_name );
+		\update_post_meta( $request_id, 'client_id', $action_name );
+
+		\update_post_meta( $request_id, 'status', 'pending' );
+
+		self::schedule_request( $request_id );
+
+		return $request_id;
+	}
+
+	/**
+	 * Get webhook request errors.
+	 *
+	 * @param int $request_id Request ID.
+	 */
+	private static function get_request_errors( $request_id ) {
+		$errors = \get_post_meta( $request_id, 'errors', true );
+		return $errors ? $errors : [];
+	}
+
+	/**
+	 * Get webhook request endpoint.
+	 *
+	 * @param int $request_id Request ID.
+	 *
+	 * @return array|null
+	 */
+	private static function get_request_endpoint( $request_id ) {
+		$endpoint_id = \wp_get_object_terms( $request_id, self::ENDPOINT_TAXONOMY, [ 'fields' => 'ids' ] );
+		$endpoint_id = $endpoint_id ? $endpoint_id[0] : null;
+		if ( ! $endpoint_id ) {
+			return null;
+		}
+		$endpoints = self::get_endpoints();
+		$endpoint  = array_filter(
+			$endpoints,
+			function( $endpoint ) use ( $endpoint_id ) {
+				return $endpoint['id'] === $endpoint_id;
+			}
+		);
+		return $endpoint ? array_values( $endpoint )[0] : null;
+	}
+
+	/**
+	 * Add webhook request error.
+	 *
+	 * @param int    $request_id Request ID.
+	 * @param string $error      Error message.
+	 */
+	private static function add_request_error( $request_id, $error ) {
+		Logger::error( $error, self::LOGGER_HEADER );
+		$errors = self::get_request_errors( $request_id );
+		$errors = array_merge( $errors, [ $error ] );
+		\update_post_meta( $request_id, 'errors', $errors );
+	}
+
+	/**
+	 * Handle post status transition for scheduled requests.
+	 *
+	 * This is executed after the post is updated.
+	 *
+	 * Scheduling a post (future -> publish) does not trigger the
+	 * `pre_post_update` action hook because it uses the `wp_publish_post()`
+	 * function. Unfortunately, this function does not fire any action hook prior
+	 * to updating the post, so we need to handle it after the post is published.
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post object.
+	 */
+	public static function transition_post_status( $new_status, $old_status, $post ) {
+		if ( self::REQUEST_POST_TYPE !== $post->post_type ) {
+			return;
+		}
+		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
+			self::process_request( $post->ID );
+		}
+	}
+
+	/**
+	 * Kill and trash a webhook request.
+	 *
+	 * @param int $request_id Request ID.
+	 */
+	private static function kill_request( $request_id ) {
+		\wp_update_post(
+			[
+				'ID'          => $request_id,
+				'post_status' => 'trash',
+			]
+		);
+	}
+
+	/**
+	 * Schedule a webhook request.
+	 *
+	 * @param int $request_id Request ID.
+	 * @param int $delay      Delay in minutes. Default is 1 minute.
+	 */
+	private static function schedule_request( $request_id, $delay = 1 ) {
+		$date     = date( 'Y-m-d H:i:s', strtotime( "+{$delay} minutes" ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+		$date_gmt = gmdate( 'Y-m-d H:i:s', strtotime( $date ) );
+		Logger::log( "Scheduling request {$request_id} for {$date}.", self::LOGGER_HEADER );
+		\wp_update_post(
+			[
+				'ID'            => $request_id,
+				'post_status'   => 'future',
+				'post_date'     => $date,
+				'post_date_gmt' => $date_gmt,
+				'edit_date'     => true,
+			]
+		);
+	}
+
+	/**
+	 * Finish a webhook request.
+	 *
+	 * @param int $request_id Request ID.
+	 */
+	public static function finish_request( $request_id ) {
+		Logger::log( "Finishing request {$request_id}.", self::LOGGER_HEADER );
+		\update_post_meta( $request_id, 'status', 'finished' );
+	}
+
+	/**
+	 * Process a webhook request
+	 *
+	 * @param int $request_id Request ID.
+	 */
+	private static function process_request( $request_id ) {
+		$endpoint = self::get_request_endpoint( $request_id );
+		if ( ! $endpoint ) {
+			self::kill_request( $request_id );
+		}
+
+		$errors = self::get_request_errors( $request_id );
+
+		$response = self::send_request( $request_id );
+
+		if ( is_wp_error( $response ) ) {
+
+			if ( count( $errors ) >= self::MAX_RETRIES ) {
+				self::kill_request( $request_id );
+				self::disable_endpoint( $endpoint['id'] );
+				return;
+			}
+
+			self::add_request_error( $request_id, $response->get_error_message() );
+
+			$delay = pow( 2, count( $errors ) );
+			self::schedule_request( $request_id, $delay );
+		} else {
+			self::finish_request( $request_id );
+		}
+	}
+
+	/**
+	 * Send a webhook request.
+	 *
+	 * @param int $request_id Request ID.
+	 *
+	 * @return array|WP_Error
+	 */
+	private static function send_request( $request_id ) {
+		Logger::log( "Sending request {$request_id}", self::LOGGER_HEADER );
+		$endpoint = self::get_request_endpoint( $request_id );
+		if ( ! $endpoint ) {
+			return new \WP_Error( 'endpoint_not_found', __( 'Endpoint not registered', 'newspack' ) );
+		}
+
+		$url  = $endpoint['url'];
+		$body = \get_post_meta( $request_id, 'body', true );
+
+		$args = [
+			'method'  => 'POST',
+			'headers' => [
+				'Content-Type' => 'application/json',
+			],
+			'timeout' => apply_filters( 'newspack_webhook_request_timeout', 10 ),
+			'body'    => $body,
+		];
+
+		$response = \wp_safe_remote_request( $url, $args );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( ! $response['response']['code'] || $response['response']['code'] < 200 || $response['response']['code'] >= 300 ) {
+			return new \WP_Error( 'request_failed', __( 'Client did not respond with 2xx code.', 'newspack' ) );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Create a webhook request on data event dispatch.
+	 *
+	 * @param string $action_name Action name.
+	 * @param int    $timestamp   Event timestamp.
+	 * @param array  $data        Event data.
+	 * @param string $client_id   Optional user session's client ID.
+	 */
+	public static function handle_dispatch( $action_name, $timestamp, $data, $client_id ) {
+		$endpoints = self::get_endpoints_for_action( $action_name );
+		if ( empty( $endpoints ) ) {
+			return;
+		}
+
+		$requests = [];
+		foreach ( $endpoints as $endpoint ) {
+			$requests[] = self::create_request( $endpoint['id'], $action_name, $timestamp, $data, $client_id );
+		}
+
+		\do_action( 'newspack_data_events_webhook_requests_created', $requests );
+	}
+}
+Webhooks::init();

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -274,22 +274,6 @@ final class Webhooks {
 	}
 
 	/**
-	 * Whether an endpoint is disabled.
-	 *
-	 * @param string $url Endpoint URL.
-	 *
-	 * @return bool
-	 */
-	public static function is_endpoint_disabled( $url ) {
-		$endpoint = \get_term_by( 'name', $url, self::ENDPOINT_TAXONOMY );
-		if ( ! $endpoint ) {
-			return false;
-		}
-		$endpoint_id = $endpoint->term_id;
-		return (bool) \get_term_meta( $endpoint_id, 'disabled', true );
-	}
-
-	/**
 	 * Get a webhook endpoint array.
 	 *
 	 * @param int|WP_Term $endpoint Endpoint ID or term object.

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -105,7 +105,7 @@ final class Webhooks {
 	 *
 	 * "send_late_requests": Hourly will send webhook requests that are late.
 	 *
-	 * @return array
+	 * @return array Schedules keyed by the class method that should be called.
 	 */
 	private static function get_cron_config() {
 		return [
@@ -146,10 +146,10 @@ final class Webhooks {
 	public static function clear_finished() {
 		$requests = \get_posts(
 			[
+				'fields'         => 'ids',
 				'post_type'      => self::REQUEST_POST_TYPE,
 				'post_status'    => 'publish',
 				'posts_per_page' => 100,
-				'fields'         => 'ids',
 				'date_query'     => [
 					[
 						'column' => 'post_date_gmt',
@@ -323,6 +323,32 @@ final class Webhooks {
 				return self::get_endpoint( $endpoint );
 			},
 			$endpoints
+		);
+	}
+
+	/**
+	 * Get all webhook requests for an endpoint.
+	 *
+	 * This executes a potentially slow query, use with caution.
+	 *
+	 * @param int $endpoint_id Endpoint ID.
+	 *
+	 * @return WP_Post[] Array of request posts.
+	 */
+	public static function get_endpoint_requests( $endpoint_id ) {
+		return \get_posts(
+			[
+				'post_type'      => self::REQUEST_POST_TYPE,
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+					[
+						'taxonomy' => self::ENDPOINT_TAXONOMY,
+						'field'    => 'term_id',
+						'terms'    => $endpoint_id,
+					],
+				],
+			]
 		);
 	}
 

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -303,12 +303,7 @@ final class Webhooks {
 	 */
 	public static function get_endpoints() {
 		$endpoints = \get_terms( self::ENDPOINT_TAXONOMY, [ 'hide_empty' => false ] );
-		return array_map(
-			function( $endpoint ) {
-				return self::get_endpoint( $endpoint );
-			},
-			$endpoints
-		);
+		return array_map( [ __CLASS__, 'get_endpoint' ], $endpoints );
 	}
 
 	/**

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -121,9 +121,10 @@ final class Webhooks {
 		\register_deactivation_hook( __FILE__, [ __CLASS__, 'clear_cron_events' ] );
 		$config = self::get_cron_config();
 		foreach ( $config as $event => $schedule ) {
-			\add_action( "newspack_webhooks_cron_{$event}", [ __CLASS__, $event ] );
-			if ( ! \wp_next_scheduled( "newspack_webhooks_cron_{$event}" ) ) {
-				\wp_schedule_event( time(), $schedule, "newspack_webhooks_cron_{$event}" );
+			$hook = "newspack_webhooks_cron_{$event}";
+			\add_action( $hook, [ __CLASS__, $event ] );
+			if ( ! \wp_next_scheduled( $hook ) ) {
+				\wp_schedule_event( time(), $schedule, $hook );
 			}
 		}
 	}
@@ -478,6 +479,7 @@ final class Webhooks {
 	 * @param int $request_id Request ID.
 	 */
 	private static function kill_request( $request_id ) {
+		\update_post_meta( $request_id, 'status', 'killed' );
 		\wp_update_post(
 			[
 				'ID'          => $request_id,

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -413,9 +413,10 @@ final class Webhooks {
 	 * @param int $delay      Delay in minutes. Default is 1 minute.
 	 */
 	private static function schedule_request( $request_id, $delay = 1 ) {
-		$date     = date( 'Y-m-d H:i:s', strtotime( "+{$delay} minutes" ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+		$time     = strtotime( sprintf( '+%d minutes', \absint( $delay ) ) );
+		$date     = date( 'Y-m-d H:i:s', $time ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 		$date_gmt = gmdate( 'Y-m-d H:i:s', strtotime( $date ) );
-		Logger::log( "Scheduling request {$request_id} for {$date}.", self::LOGGER_HEADER );
+		Logger::log( "Scheduling request {$request_id} for {$date_gmt}.", self::LOGGER_HEADER );
 		\wp_update_post(
 			[
 				'ID'            => $request_id,

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -47,6 +47,7 @@ final class Webhooks {
 		\add_action( 'init', [ __CLASS__, 'register_request_post_type' ] );
 		\add_action( 'init', [ __CLASS__, 'register_endpoint_taxonomy' ] );
 		\add_action( 'init', [ __CLASS__, 'register_cron_events' ] );
+		\add_action( 'newspack_deactivation', [ __CLASS__, 'clear_cron_events' ] );
 		\add_action( 'newspack_data_event_dispatch', [ __CLASS__, 'handle_dispatch' ], 10, 4 );
 		\add_action( 'transition_post_status', [ __CLASS__, 'transition_post_status' ], 10, 3 );
 	}
@@ -118,7 +119,6 @@ final class Webhooks {
 	 * Register webhook cron events.
 	 */
 	public static function register_cron_events() {
-		\register_deactivation_hook( __FILE__, [ __CLASS__, 'clear_cron_events' ] );
 		$config = self::get_cron_config();
 		foreach ( $config as $event => $schedule ) {
 			$hook = "newspack_webhooks_cron_{$event}";

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -28,7 +28,7 @@ final class Webhooks {
 	/**
 	 * Maximum number of request retries before disabling the endpoint.
 	 */
-	const MAX_RETRIES = 12;
+	const MAX_RETRIES = 15;
 
 	/**
 	 * Time to retain finished requests.
@@ -530,7 +530,8 @@ final class Webhooks {
 
 			self::add_request_error( $request_id, $response->get_error_message() );
 
-			$delay = pow( 2, count( $errors ) );
+			// Schedule a retry with exponential backoff maxed to 12 hours.
+			$delay = min( 720, pow( 2, count( $errors ) ) );
 			self::schedule_request( $request_id, $delay );
 		} else {
 			self::finish_request( $request_id );

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -557,9 +557,11 @@ final class Webhooks {
 		/**
 		 * Filters the timeout for webhook requests.
 		 *
-		 * @param int $request_timeout Timeout in seconds. Default is 10.
+		 * @param int   $request_timeout Timeout in seconds. Default is 10.
+		 * @param int   $request_id      Request ID.
+		 * @param array $endpoint        Endpoint data.
 		 */
-		$timeout = apply_filters( 'newspack_webhook_request_timeout', 10 );
+		$timeout = apply_filters( 'newspack_webhooks_request_timeout', 10, $request_id, $endpoint );
 
 		$args = [
 			'method'  => 'POST',

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -105,9 +105,9 @@ final class Webhooks {
 	 */
 	public static function register_cron_events() {
 		\register_deactivation_hook( __FILE__, [ __CLASS__, 'clear_cron_events' ] );
-		\add_action( 'newspack_data_events_webhooks_clear_finished', [ __CLASS__, 'clear_finished' ] );
-		if ( ! \wp_next_scheduled( 'newspack_data_events_webhooks_clear_finished' ) ) {
-			\wp_schedule_event( time(), 'twicedaily', 'newspack_data_events_webhooks_clear_finished' );
+		\add_action( 'newspack_webhooks_clear_finished', [ __CLASS__, 'clear_finished' ] );
+		if ( ! \wp_next_scheduled( 'newspack_webhooks_clear_finished' ) ) {
+			\wp_schedule_event( time(), 'twicedaily', 'newspack_webhooks_clear_finished' );
 		}
 	}
 
@@ -115,8 +115,8 @@ final class Webhooks {
 	 * Clear cron events.
 	 */
 	public static function clear_cron_events() {
-		$timestamp = \wp_next_scheduled( 'newspack_data_events_webhooks_clear_finished' );
-		\wp_unschedule_event( $timestamp, 'newspack_data_events_webhooks_clear_finished' );
+		$timestamp = \wp_next_scheduled( 'newspack_webhooks_clear_finished' );
+		\wp_unschedule_event( $timestamp, 'newspack_webhooks_clear_finished' );
 	}
 
 	/**
@@ -184,7 +184,7 @@ final class Webhooks {
 	public static function update_endpoint( $id, $url, $actions = [], $global = false, $disabled = false ) {
 		$endpoint = \get_term( $id, self::ENDPOINT_TAXONOMY, ARRAY_A );
 		if ( ! $endpoint ) {
-			return new WP_Error( 'newspack_webhook_endpoint_not_found', __( 'Webhook endpoint not found.', 'newspack' ) );
+			return new WP_Error( 'newspack_webhooks_endpoint_not_found', __( 'Webhook endpoint not found.', 'newspack' ) );
 		}
 		$endpoint = \wp_update_term(
 			$id,
@@ -210,7 +210,7 @@ final class Webhooks {
 	public static function delete_endpoint( $id ) {
 		$endpoint = get_term( $id, self::ENDPOINT_TAXONOMY );
 		if ( ! $endpoint ) {
-			return new WP_Error( 'newspack_webhook_endpoint_not_found', __( 'Webhook endpoint not found.', 'newspack' ) );
+			return new WP_Error( 'newspack_webhooks_endpoint_not_found', __( 'Webhook endpoint not found.', 'newspack' ) );
 		}
 		\wp_delete_term( $id, self::ENDPOINT_TAXONOMY );
 	}
@@ -482,7 +482,7 @@ final class Webhooks {
 		Logger::log( "Sending request {$request_id}", self::LOGGER_HEADER );
 		$endpoint = self::get_request_endpoint( $request_id );
 		if ( ! $endpoint ) {
-			return new WP_Error( 'endpoint_not_found', __( 'Endpoint not registered', 'newspack' ) );
+			return new WP_Error( 'newspack_webhooks_endpoint_not_found', __( 'Endpoint not registered', 'newspack' ) );
 		}
 
 		$url  = $endpoint['url'];
@@ -510,7 +510,7 @@ final class Webhooks {
 		}
 
 		if ( ! $response['response']['code'] || $response['response']['code'] < 200 || $response['response']['code'] >= 300 ) {
-			return new WP_Error( 'request_failed', __( 'Client did not respond with 2xx code.', 'newspack' ) );
+			return new WP_Error( 'newspack_webhooks_request_failed', __( 'Client did not respond with 2xx code.', 'newspack' ) );
 		}
 
 		return true;
@@ -540,7 +540,7 @@ final class Webhooks {
 		 *
 		 * @param int|WP_Error[] $requests Array of request IDs.
 		 */
-		\do_action( 'newspack_data_events_webhook_requests_created', $requests );
+		\do_action( 'newspack_webhooks_requests_created', $requests );
 	}
 }
 Webhooks::init();

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -131,8 +131,10 @@ final class Webhooks {
 				'posts_per_page' => 100,
 				'fields'         => 'ids',
 				'date_query'     => [
-					'column' => 'post_date_gmt',
-					'before' => self::DELETE_REQUESTS_BEFORE,
+					[
+						'column' => 'post_date_gmt',
+						'before' => self::DELETE_REQUESTS_BEFORE,
+					],
 				],
 			]
 		);

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -479,6 +479,7 @@ final class Webhooks {
 	 * @param int $request_id Request ID.
 	 */
 	private static function kill_request( $request_id ) {
+		Logger::log( "Killing request {$request_id}.", self::LOGGER_HEADER );
 		\update_post_meta( $request_id, 'status', 'killed' );
 		\wp_update_post(
 			[
@@ -529,6 +530,10 @@ final class Webhooks {
 		$endpoint = self::get_request_endpoint( $request_id );
 		if ( ! $endpoint ) {
 			self::add_request_error( $request_id, __( 'Endpoint not found.', 'newspack' ) );
+			self::kill_request( $request_id );
+		}
+		if ( $endpoint['disabled'] ) {
+			self::add_request_error( $request_id, __( 'Endpoint is disabled.', 'newspack' ) );
 			self::kill_request( $request_id );
 		}
 

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -100,6 +100,11 @@ final class Webhooks {
 	/**
 	 * Get cron configuration.
 	 *
+	 * "clear_finished": Twice a day will permanently delete finished webhook
+	 * requests older than 7 days.
+	 *
+	 * "send_late_requests": Hourly will send webhook requests that are late.
+	 *
 	 * @return array
 	 */
 	private static function get_cron_config() {
@@ -111,11 +116,6 @@ final class Webhooks {
 
 	/**
 	 * Register webhook cron events.
-	 *
-	 * "clear_finished": Twice a day will permanently delete finished webhook
-	 * requests older than 7 days.
-	 *
-	 * "send_late_requests": Hourly will send webhook requests that are late.
 	 */
 	public static function register_cron_events() {
 		\register_deactivation_hook( __FILE__, [ __CLASS__, 'clear_cron_events' ] );

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Newspack data events listeners.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Data_Events;
+
+use Newspack\Data_Events;
+use Newspack\Reader_Activation;
+
+/**
+ * For when a reader registers.
+ */
+Data_Events::register_listener(
+	'newspack_registered_reader',
+	'reader_registered',
+	function( $email, $authenticate, $user_id, $existing_user, $metadata ) {
+		if ( $existing_user ) {
+			return null;
+		}
+		return [
+			'user_id'  => $user_id,
+			'email'    => $email,
+			'metadata' => $metadata,
+		];
+	}
+);
+
+/**
+ * For when a reader logs in.
+ */
+Data_Events::register_listener(
+	'wp_login',
+	'reader_logged_in',
+	function( $user_login, $user ) {
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			return;
+		}
+		return [
+			'user_id' => $user->ID,
+			'email'   => $user->user_email,
+		];
+	}
+);
+
+/**
+ * For when a reader is marked as verified.
+ */
+Data_Events::register_listener(
+	'newspack_reader_verified',
+	'reader_verified',
+	function( $user ) {
+		return [
+			'user_id' => $user->ID,
+		];
+	}
+);
+
+/**
+ * For when a contact is added to newsletter lists.
+ */
+Data_Events::register_listener(
+	'newspack_newsletters_add_contact',
+	'newsletter_subscribed',
+	function( $provider, $contact, $lists ) {
+		if ( empty( $lists ) ) {
+			return;
+		}
+		return [
+			'provider' => $provider,
+			'email'    => $contact['email'],
+			'lists'    => $lists,
+		];
+	}
+);
+
+/**
+ * For when a contact newsletter subscription is updated.
+ */
+Data_Events::register_listener(
+	'newspack_newsletters_update_contact_lists',
+	'newsletter_updated',
+	[ 'provider', 'email', 'lists_added', 'lists_removed' ]
+);

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -70,7 +70,7 @@ Data_Events::register_listener(
 		}
 		return [
 			'provider' => $provider,
-			'email'    => $contact['email'],
+			'contact'  => $contact,
 			'lists'    => $lists,
 		];
 	}

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -64,8 +64,11 @@ Data_Events::register_listener(
 Data_Events::register_listener(
 	'newspack_newsletters_add_contact',
 	'newsletter_subscribed',
-	function( $provider, $contact, $lists ) {
+	function( $provider, $contact, $lists, $result ) {
 		if ( empty( $lists ) ) {
+			return;
+		}
+		if ( true !== $result ) {
 			return;
 		}
 		return [
@@ -82,5 +85,18 @@ Data_Events::register_listener(
 Data_Events::register_listener(
 	'newspack_newsletters_update_contact_lists',
 	'newsletter_updated',
-	[ 'provider', 'email', 'lists_added', 'lists_removed' ]
+	function( $provider, $email, $lists_added, $lists_removed, $result ) {
+		if ( empty( $lists_added ) && empty( $lists_removed ) ) {
+			return;
+		}
+		if ( true !== $result ) {
+			return;
+		}
+		return [
+			'provider'      => $provider,
+			'email'         => $email,
+			'lists_added'   => $lists_added,
+			'lists_removed' => $lists_removed,
+		];
+	}
 );

--- a/includes/scheduled-post-checker/scheduled-post-checker.php
+++ b/includes/scheduled-post-checker/scheduled-post-checker.php
@@ -15,7 +15,7 @@ define( 'NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK', 'newspack_scheduled_post_ch
  * Set up the checking.
  */
 function nspc_init() {
-	register_deactivation_hook( __FILE__, 'nspc_deactivate' );
+	add_action( 'newspack_deactivation', 'nspc_deactivate' );
 	if ( ! wp_next_scheduled( NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK ) ) {
 		wp_schedule_event( time(), 'fivemins', NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK );
 	}

--- a/includes/scheduled-post-checker/scheduled-post-checker.php
+++ b/includes/scheduled-post-checker/scheduled-post-checker.php
@@ -15,7 +15,7 @@ define( 'NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK', 'newspack_scheduled_post_ch
  * Set up the checking.
  */
 function nspc_init() {
-	add_action( 'newspack_deactivation', 'nspc_deactivate' );
+	add_action( 'newspack_deactivation', '\Newspack\Scheduled_Post_Checker\nspc_deactivate' );
 	if ( ! wp_next_scheduled( NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK ) ) {
 		wp_schedule_event( time(), 'fivemins', NEWSPACK_SCHEDULED_POST_CHECKER_CRON_HOOK );
 	}

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -189,9 +189,9 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test registering a listener with a filter.
+	 * Test registering a listener with a callable.
 	 */
-	public function test_register_listener_with_filter() {
+	public function test_register_listener_with_callable() {
 		$action_name = 'test_action';
 		Data_Events::register_listener(
 			'some_actionable_thing',
@@ -214,5 +214,37 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		do_action( 'some_actionable_thing', 'data' );
 
 		$this->assertEquals( 'data was parsed', $parsed_data );
+	}
+
+	/**
+	 * Test registering a listener with an argument map.
+	 */
+	public function test_register_listener_with_map() {
+		$action_name = 'test_action';
+		Data_Events::register_listener(
+			'some_actionable_thing',
+			$action_name,
+			[ 'key1', 'key2' ]
+		);
+
+		$parsed_data = [];
+		add_action(
+			"newspack_data_event_dispatch_$action_name",
+			function( $timestamp, $data, $client_id ) use ( &$parsed_data ) {
+				$parsed_data = $data;
+			},
+			10,
+			3
+		);
+
+		do_action( 'some_actionable_thing', 'value1', 'value2' );
+
+		$this->assertEquals(
+			[
+				'key1' => 'value1',
+				'key2' => 'value2',
+			],
+			$parsed_data
+		);
 	}
 }

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * Tests the Webhooks functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Data_Events;
+
+/**
+ * Tests the Webhooks functionality.
+ */
+class Newspack_Test_Webhooks extends WP_UnitTestCase {
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		// Delete all lingering endpoints and requests before starting tests.
+		$endpoints = Data_Events\Webhooks::get_endpoints();
+		foreach ( $endpoints as $endpoint ) {
+			Data_Events\Webhooks::delete_endpoint( $endpoint['id'] );
+		}
+		$requests = get_posts(
+			[
+				'post_type'      => Data_Events\Webhooks::REQUEST_POST_TYPE,
+				'posts_per_page' => -1,
+			]
+		);
+		foreach ( $requests as $request ) {
+			wp_delete_post( $request->ID, true );
+		}
+	}
+
+	/**
+	 * Dispatch a sample data event.
+	 */
+	private function dispatch_event() {
+		$action_name = 'test_action';
+		$data        = [ 'test' => 'data' ];
+		Data_Events::register_action( $action_name );
+		Data_Events::dispatch( $action_name, $data );
+	}
+
+	/**
+	 * Test creating an endpoint.
+	 */
+	public function test_create_endpoint() {
+		$url       = 'https://example.com/webhook';
+		$actions   = [];
+		$global    = true;
+		$id        = Data_Events\Webhooks::create_endpoint( $url, $actions, $global );
+		$endpoints = Data_Events\Webhooks::get_endpoints();
+		$this->assertEquals( 1, count( $endpoints ) );
+		$this->assertEquals( $id, $endpoints[0]['id'] );
+		$this->assertEquals( $url, $endpoints[0]['url'] );
+		$this->assertEquals( $actions, $endpoints[0]['actions'] );
+		$this->assertEquals( $global, $endpoints[0]['global'] );
+		$this->assertEquals( false, $endpoints[0]['disabled'] );
+		return $id;
+	}
+
+	/**
+	 * Test deleting an endpoint.
+	 */
+	public function test_delete_endpoint() {
+		// Create an endpoint.
+		$endpoint_id = $this->test_create_endpoint();
+
+		// Delete the endpoint.
+		Data_Events\Webhooks::delete_endpoint( $endpoint_id );
+
+		// Assert that the endpoint was deleted.
+		$endpoints = Data_Events\Webhooks::get_endpoints();
+		$this->assertEquals( 0, count( $endpoints ) );
+	}
+
+	/**
+	 * Test disabling an endpoint.
+	 */
+	public function test_disable_endpoint() {
+		$endpoint_id = $this->test_create_endpoint();
+
+		// Disable the endpoint.
+		Data_Events\Webhooks::disable_endpoint( $endpoint_id );
+
+		// Assert that the endpoint was disabled.
+		$endpoints = Data_Events\Webhooks::get_endpoints();
+		$this->assertEquals( 1, count( $endpoints ) );
+		$this->assertEquals( true, $endpoints[0]['disabled'] );
+	}
+
+	/**
+	 * Test that dispatching an action creates webhook requests.
+	 */
+	public function test_dispatch_create_request() {
+		$endpoint_id = $this->test_create_endpoint();
+
+		// Hook into webhook's handler to assert that the request was created.
+		$requests = [];
+		add_action(
+			'newspack_data_events_webhook_requests_created',
+			function() use ( &$requests ) {
+				$requests = func_get_args()[0];
+			}
+		);
+
+		$this->dispatch_event();
+
+		$this->assertEquals( 1, count( $requests ) );
+	}
+
+	/**
+	 * Test that a disabled endpoint doesn't create webhook requests.
+	 */
+	public function test_disabled_endpoints() {
+		// Create an endpoint.
+		$endpoint_id = $this->test_create_endpoint();
+
+		// Disable the endpoint.
+		Data_Events\Webhooks::disable_endpoint( $endpoint_id );
+
+		// Hook into webhook's handler to assert that the request was created.
+		$requests = [];
+		add_action(
+			'newspack_data_events_webhook_requests_created',
+			function() use ( &$requests ) {
+				$requests = func_get_args()[0];
+			}
+		);
+
+		$this->dispatch_event();
+
+		$this->assertEquals( 0, count( $requests ) );
+	}
+
+	/**
+	 * Test request scheduling.
+	 */
+	public function test_request_scheduling() {
+		// Create an endpoint.
+		$endpoint_id = $this->test_create_endpoint();
+
+		// Hook into webhook's handler to fetch the created request ID.
+		$requests = [];
+		add_action(
+			'newspack_data_events_webhook_requests_created',
+			function() use ( &$requests ) {
+				$requests = func_get_args()[0];
+			}
+		);
+
+		$this->dispatch_event();
+
+		$post = get_post( $requests[0] );
+		$this->assertEquals( 'future', $post->post_status );
+		$this->assertGreaterThan( time(), strtotime( $post->post_date ) );
+	}
+
+	/**
+	 * Test that publishing a request processes it.
+	 */
+	public function test_request_publish() {
+		// Create an endpoint.
+		$endpoint_id = $this->test_create_endpoint();
+
+		// Hook into webhook's handler to fetch the created request ID.
+		$requests = [];
+		add_action(
+			'newspack_data_events_webhook_requests_created',
+			function() use ( &$requests ) {
+				$requests = func_get_args()[0];
+			}
+		);
+
+		$this->dispatch_event();
+
+		$http_args = [];
+		$http_url  = '';
+		add_filter(
+			'pre_http_request',
+			function( $preempt, $args, $url ) use ( &$http_args, &$http_url ) {
+				$http_args = $args;
+				$http_url  = $url;
+				return [
+					'response' => [
+						'code' => 200,
+					],
+				];
+			},
+			10,
+			3
+		);
+
+		// Manually publish the request.
+		wp_update_post(
+			[
+				'ID'            => $requests[0],
+				'post_status'   => 'publish',
+				'post_date'     => gmdate( 'Y-m-d H:i:s' ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s' ),
+				'edit_date'     => true,
+			]
+		);
+
+		$this->assertEquals( 'https://example.com/webhook', $http_url );
+		$this->assertEquals( 'POST', $http_args['method'] );
+		$this->assertEquals( 'application/json', $http_args['headers']['Content-Type'] );
+		$this->assertEquals( get_post_meta( $requests[0], 'body', true ), $http_args['body'] );
+	}
+
+	/**
+	 * Test that a failed send re-schedules the request.
+	 */
+	public function test_request_error_handling() {
+		// Create an endpoint.
+		$endpoint_id = $this->test_create_endpoint();
+
+		// Hook into webhook's handler to fetch the created request ID.
+		$requests = [];
+		add_action(
+			'newspack_data_events_webhook_requests_created',
+			function() use ( &$requests ) {
+				$requests = func_get_args()[0];
+			}
+		);
+
+		$this->dispatch_event();
+
+		add_filter(
+			'pre_http_request',
+			function() {
+				return [
+					'response' => [
+						'code' => 500,
+					],
+				];
+			}
+		);
+
+		// Manually publish the request.
+		wp_update_post(
+			[
+				'ID'            => $requests[0],
+				'post_status'   => 'publish',
+				'post_date'     => gmdate( 'Y-m-d H:i:s' ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s' ),
+				'edit_date'     => true,
+			]
+		);
+
+		$this->assertEquals( 'future', get_post_status( $requests[0] ) );
+		$this->assertGreaterThan( time(), strtotime( get_post( $requests[0] )->post_date ) );
+	}
+
+	/**
+	 * Test reaching max retries should kill the request and disable the endpoint.
+	 */
+	public function test_request_max_retries() {
+		// Create an endpoint.
+		$endpoint_id = $this->test_create_endpoint();
+
+		// Hook into webhook's handler to fetch the created request ID.
+		$requests = [];
+		add_action(
+			'newspack_data_events_webhook_requests_created',
+			function() use ( &$requests ) {
+				$requests = func_get_args()[0];
+			}
+		);
+
+		$this->dispatch_event();
+
+		$max_retries = Data_Events\Webhooks::MAX_RETRIES;
+		$retries     = 0;
+
+		add_filter(
+			'pre_http_request',
+			function() use ( &$retries ) {
+				$retries++;
+				return [
+					'response' => [
+						'code' => 500,
+					],
+				];
+			}
+		);
+
+		while ( $retries <= $max_retries ) {
+			wp_update_post(
+				[
+					'ID'            => $requests[0],
+					'post_status'   => 'publish',
+					'post_date'     => gmdate( 'Y-m-d H:i:s' ),
+					'post_date_gmt' => gmdate( 'Y-m-d H:i:s' ),
+					'edit_date'     => true,
+				]
+			);
+		}
+
+		$this->assertEquals( 'trash', get_post_status( $requests[0] ) );
+
+		$endpoints = Data_Events\Webhooks::get_endpoints();
+		$this->assertTrue( $endpoints[0]['disabled'] );
+	}
+}

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -277,8 +277,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 
 		add_filter(
 			'pre_http_request',
-			function() use ( &$retries ) {
-				$retries++;
+			function() {
 				return [
 					'response' => [
 						'code' => 500,
@@ -297,9 +296,13 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 					'edit_date'     => true,
 				]
 			);
+			$status = 'future';
+			if ( $max_retries === $retries ) {
+				$status = 'trash';
+			}
+			$this->assertEquals( $status, get_post_status( $requests[0] ) );
+			$retries++;
 		}
-
-		$this->assertEquals( 'trash', get_post_status( $requests[0] ) );
 
 		$endpoints = Data_Events\Webhooks::get_endpoints();
 		$this->assertTrue( $endpoints[0]['disabled'] );

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -340,14 +340,15 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 
 		$this->assertEquals( 10, count( $requests ) );
 
-		// Manually publish each request and pretend it happened 10 days ago.
-		foreach ( $requests as $request ) {
+		// Manually publish each request and pretend half happened 10 days ago.
+		foreach ( $requests as $i => $request ) {
+			$date = gmdate( 'Y-m-d H:i:s', $i % 2 ? strtotime( '10 days ago' ) : time() );
 			wp_update_post(
 				[
 					'ID'            => $request->ID,
 					'post_status'   => 'publish',
-					'post_date'     => gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) ),
-					'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) ),
+					'post_date'     => $date, // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+					'post_date_gmt' => $date,
 					'edit_date'     => true,
 				]
 			);
@@ -363,6 +364,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertEquals( 0, count( $requests ) );
+		// Half should've been deleted.
+		$this->assertEquals( 5, count( $requests ) );
 	}
 }

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -100,7 +100,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 		// Hook into webhook's handler to assert that the request was created.
 		$requests = [];
 		add_action(
-			'newspack_data_events_webhook_requests_created',
+			'newspack_webhooks_requests_created',
 			function() use ( &$requests ) {
 				$requests = func_get_args()[0];
 			}
@@ -124,7 +124,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 		// Hook into webhook's handler to assert that the request was created.
 		$requests = [];
 		add_action(
-			'newspack_data_events_webhook_requests_created',
+			'newspack_webhooks_requests_created',
 			function() use ( &$requests ) {
 				$requests = func_get_args()[0];
 			}
@@ -145,7 +145,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 		// Hook into webhook's handler to fetch the created request ID.
 		$requests = [];
 		add_action(
-			'newspack_data_events_webhook_requests_created',
+			'newspack_webhooks_requests_created',
 			function() use ( &$requests ) {
 				$requests = func_get_args()[0];
 			}
@@ -168,7 +168,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 		// Hook into webhook's handler to fetch the created request ID.
 		$requests = [];
 		add_action(
-			'newspack_data_events_webhook_requests_created',
+			'newspack_webhooks_requests_created',
 			function() use ( &$requests ) {
 				$requests = func_get_args()[0];
 			}
@@ -220,7 +220,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 		// Hook into webhook's handler to fetch the created request ID.
 		$requests = [];
 		add_action(
-			'newspack_data_events_webhook_requests_created',
+			'newspack_webhooks_requests_created',
 			function() use ( &$requests ) {
 				$requests = func_get_args()[0];
 			}
@@ -264,7 +264,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 		// Hook into webhook's handler to fetch the created request ID.
 		$requests = [];
 		add_action(
-			'newspack_data_events_webhook_requests_created',
+			'newspack_webhooks_requests_created',
 			function() use ( &$requests ) {
 				$requests = func_get_args()[0];
 			}

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -347,7 +347,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 				[
 					'ID'            => $request->ID,
 					'post_status'   => 'publish',
-					'post_date'     => $date, // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+					'post_date'     => $date,
 					'post_date_gmt' => $date,
 					'edit_date'     => true,
 				]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

As part of the core Data Events system (#2173), webhooks are responsible for integrating the data events to any API that is capable of interpreting the payload.

### Requests

The webhook requests are registered as a custom post type. This allows flexibility to log, query, and more efficiently manage the relationship with registered endpoints.

Once a data event is dispatched, webhook requests may be created if there are endpoints registered to receive that type of data.

Requests make use of WP's post scheduling in order to send a request. Once a request is created, its send is scheduled for 1 minute from now. Every webhook request is expected to have a slight delay but the original timestamp is preserved in the payload.

### Endpoints

A custom taxonomy for registering the webhook URLs and their configuration.

In the next PR, the publisher will be able to register new webhook URLs through the “Connections” wizard. A section at the bottom of the wizard will allow the entire user-facing management:

- List existing endpoints
- Display the latest request response code (endpoint health)
- Enable/disable endpoints
- Add and edit endpoints with their URL, whether it's global or select the data events actions it's supposed to listen to

If we wish to, it’s also possible to display the log of the most recent requests per endpoint.

### Handling request response codes

The registered endpoints are prone to unexpected errors and we should allow the client to fix them while preserving data integrity.

Until the server receives a 2xx response from the client, it attempts using an exponential backoff (2<sup>n</sup> minutes intervals) maxed to 12 hours. On the 15th attempt, an error will kill the request and deactivate the endpoint.

### Cron events

- Twice a day every finished request older than 7 days is permanently deleted
- Every hour ensure to send any request that should've been sent according to its scheduling but it was not

### Tweaks to the data events API

The 3rd argument of `register_listener()` can now be a `callable` **or an `array`**. The array should be a list of strings to be mapped with the hook's arguments, e.g.:

https://github.com/Automattic/newspack-plugin/blob/87b628be7463ddaff2e15d873a779bfdc8ade462/includes/data-events/listeners.php#L79-L86

A listener also no longer dispatches an action if the resulting data is empty.

### Inaugurating listeners

This PR introduces common listeners to be registered at [`includes/data-events/listeners.php`](https://github.com/Automattic/newspack-plugin/blob/feat/data-events-webhooks/includes/data-events/listeners.php). They create the following actions:

 - reader_registered
 - reader_logged_in
 - newsletter_subscribed
 - newsletter_updated

### How to test the changes in this Pull Request:

Confirm all written tests are passing.

1. Visit this site to mock a webhook receiver: https://webhook.site/ and leave this page open
2. Open your site shell with `$ wp shell`:
   1. Copy the endpoint URL and place it in a variable: `$url = 'https://webhook.site/{some-id-here}';`
   2. Create a global endpoint with: `Newspack\Data_Events\Webhooks::create_endpoint( $url, [], true );`
   3. Confirm the endpoint is created by the return of an `int`, which is the endpoint ID
3. Confirm you have RAS active, AMP Plus and newspack log enabled:
```php
define( 'NEWSPACK_AMP_PLUS_ENABLED', true );
define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );
define( 'NEWSPACK_LOG_LEVEL', 2 );
```
4. Visit your site in incognito and go through the reader registration flow
5. Confirm the `NEWSPACK-DATA-EVENTS` and `NEWSPACK-WEBHOOKS` logs:
```
[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::dispatch]: Dispatching action "reader_logged_in".
[NEWSPACK-WEBHOOKS][Newspack\Data_Events\Webhooks::schedule_request]: Scheduling request 346 for 2022-12-14 13:24:23.
[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::handle]: Executing global action handlers for "reader_logged_in".
[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::handle]: Executing action handlers for "reader_logged_in".
```
6. Wait one minute until the scheduled request is sent and confirm you than see the following log:
```
[NEWSPACK-WEBHOOKS][Newspack\Data_Events\Webhooks::send_request]: Sending request 346
[NEWSPACK-WEBHOOKS][Newspack\Data_Events\Webhooks::finish_request]: Finishing request 346.
```
7. The https://webhook.site page should be updated with this:
<img width="1017" alt="Captura de Tela 2022-12-14 às 10 26 30" src="https://user-images.githubusercontent.com/820752/207609391-751307a2-48e8-4e26-b532-1d6cc30c71b1.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->