### PR TITLE
feat(analytics): prevent Site Kit's false positive notice

### DIFF
--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -475,6 +475,13 @@ class Analytics {
 	 * More: https://github.com/ampproject/amphtml/issues/32911.
 	 */
 	public static function insert_gtag_amp_analytics() {
+		// If this is a request to verify the tag (from Site Kit), don't insert the amp-analytics tag.
+		// Site Kit will only check if the tag is present, not if the send_page_view parameter is true.
+		// In this case, the tag won't send page views – but only events. Thus it is not duplicating Site Kit's tag.
+		if ( isset( $_GET['tagverify'] ) && $_GET['tagverify'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			return;
+		}
+
 		$analytics = Google_Services_Connection::get_site_kit_analytics_module();
 		if ( ! $analytics || ! $analytics->is_connected() ) {
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As remarked [here](https://github.com/Automattic/newspack-plugin/issues/2085#issuecomment-1346894948), Site Kit will display a notice about tag duplication if any custom events are reported. This notice is a false positive, because the custom events code does not report page views, so there is no duplication. 

This PR will make it so the notice is not displayed by hiding the custom events code when Site Kit is asking.  

### How to test the changes in this Pull Request:

1. On `master`
1. Configure Site Kit Analytics module and turn on "News Tagging Guide custom events" in the Analytics wizard
2. Load Site Kit Analytics module (`/wp-admin/admin.php?page=googlesitekit-settings#/connected-services/analytics/edit`) and observe the following notice being displayed:

<img width="673" alt="image" src="https://user-images.githubusercontent.com/7383192/207312276-e004c52e-678f-413f-99ad-220da97c6862.png">

4. Switch to this branch, reload the Site Kit page, observe no notice displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->