### PR TITLE
Hotfix/perfmatters defaults admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [1.99.0-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.98.0...v1.99.0-hotfix.1) (2022-12-14)
+
+
+### Bug Fixes
+
+* **perfmatters:** display defaults for admin only if URL param is set ([ecca448](https://github.com/Automattic/newspack-plugin/commit/ecca448b9c788d473694960fa890ad023e05ee8c))
+
+
+### Features
+
+* **perfmatters:** add an environment feature flag ([774a710](https://github.com/Automattic/newspack-plugin/commit/774a7109ee750dc22d8812d3ce53a7b2687f0dbd))
+
 # [1.98.0](https://github.com/Automattic/newspack-plugin/compare/v1.97.3...v1.98.0) (2022-12-12)
 
 

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -103,7 +103,7 @@ class Perfmatters {
 	 * @param array $options Perfmatters options.
 	 */
 	public static function set_defaults( $options = [] ) {
-		if ( ! is_admin() && ! isset( $_GET['newspack-perfmatters-defaults'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['newspack-perfmatters-defaults'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return $options;
 		}
 

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -106,6 +106,9 @@ class Perfmatters {
 		if ( ! isset( $_GET['newspack-perfmatters-defaults'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return $options;
 		}
+		if ( defined( 'NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS' ) && NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS ) {
+			return $options;
+		}
 
 		// Basic options.
 		$options['disable_emojis']              = true;

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.98.0
+ * Version: 1.99.0-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.98.0' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.99.0-hotfix.1' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.98.0",
+  "version": "1.99.0-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.98.0",
+      "version": "1.99.0-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.98.0",
+  "version": "1.99.0-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The defaults for the Perfmatters plugin will be applied only if the `newspack-perfmatters-defaults` parameter is present in the URL, but in the admin panel, these will be displayed always. This is misleading, so this PR makes it so the defaults will only be presented in the admin panel if the URL parameter is present too. 

### How to test the changes in this Pull Request:

1. On `master`
1. Install Perfmatters plugin, visit the plugin settings (`/wp-admin/options-general.php?page=perfmatters`)
2. Observe the defaults are presented
3. Switch to this branch, reload
4. Observe the defaults are not presented
5. Add the `newspack-perfmatters-defaults` URL param, reload the page, observe the defaults are reflected
6. Set the `NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS` environment variable to `true`, observe that defaults are reflected even with the URL param

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->