### PR TITLE
fix: typo in setup command

### DIFF
--- a/includes/cli/class-setup.php
+++ b/includes/cli/class-setup.php
@@ -139,7 +139,7 @@ class Setup {
 	 */
 	private function campaigns_config() {
 		global $table_prefix;
-		$filename = WP_CONTENT_DIR . '/newspack-popups.config.php';
+		$filename = WP_CONTENT_DIR . '/newspack-popups-config.php';
 		if ( ! file_exists( $filename ) ) {
 			$content  = "<?php \n";
 			$content .= sprintf( "define( 'DB_NAME', '%s' );\n", DB_NAME );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a typo in the setup command

### How to test the changes in this Pull Request:

1. Verify that the fix corrects the file name
2. Run setup command and confirm the file is created with the correct name

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->