### PR TITLE
feat: allow RAS library to load async

### DIFF
--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -25,11 +25,10 @@ function domReady( callback ) {
 	document.addEventListener( 'DOMContentLoaded', callback );
 }
 
-( function ( readerActivation ) {
+window.newspackRAS = window.newspackRAS || [];
+
+window.newspackRAS.push( function ( readerActivation ) {
 	domReady( function () {
-		if ( ! readerActivation ) {
-			return;
-		}
 		document.querySelectorAll( '.newspack-registration' ).forEach( container => {
 			const form = container.querySelector( 'form' );
 			if ( ! form ) {
@@ -141,4 +140,4 @@ function domReady( callback ) {
 			} );
 		} );
 	} );
-} )( window.newspackReaderActivation );
+} );

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -143,7 +143,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 		 * Handle account links.
 		 */
 		function handleAccountLinkClick( ev ) {
-			console.log( ev );
 			const reader = readerActivation.getReader();
 			/** If logged in, bail and allow page redirection. */
 			if ( reader?.authenticated ) {

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -50,12 +50,10 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 		return acc;
 	}, {} );
 
-( function ( readerActivation ) {
-	domReady( function () {
-		if ( ! readerActivation ) {
-			return;
-		}
+window.newspackRAS = window.newspackRAS || [];
 
+window.newspackRAS.push( function ( readerActivation ) {
+	domReady( function () {
 		const containers = [ ...document.querySelectorAll( '.newspack-reader-auth' ) ];
 		const alerts = [ ...document.querySelectorAll( '.woocommerce-message' ) ];
 		if ( ! containers.length ) {
@@ -145,6 +143,7 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 		 * Handle account links.
 		 */
 		function handleAccountLinkClick( ev ) {
+			console.log( ev );
 			const reader = readerActivation.getReader();
 			/** If logged in, bail and allow page redirection. */
 			if ( reader?.authenticated ) {
@@ -592,4 +591,4 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 			} );
 		} );
 	} );
-} )( window.newspackReaderActivation );
+} );

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -322,9 +322,7 @@ if ( ! getCookie( clientIDCookieName ) ) {
 }
 
 window.newspackRAS = window.newspackRAS || [];
-window.newspackRAS.forEach( fn => {
-	fn( readerActivation );
-} );
+window.newspackRAS.forEach( fn => fn( readerActivation ) );
 window.newspackRAS.push = fn => fn( readerActivation );
 
 export default readerActivation;

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -321,4 +321,12 @@ if ( ! getCookie( clientIDCookieName ) ) {
 	setCookie( clientIDCookieName, `${ getShortStringId() }${ getShortStringId() }` );
 }
 
+window.newspackRAS = window.newspackRAS || [];
+window.newspackRAS.forEach( fn => {
+	fn( readerActivation );
+} );
+if ( typeof window.newspackRAS.push === 'function' ) {
+	window.newspackRAS.push = fn => fn( readerActivation );
+}
+
 export default readerActivation;

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -325,8 +325,6 @@ window.newspackRAS = window.newspackRAS || [];
 window.newspackRAS.forEach( fn => {
 	fn( readerActivation );
 } );
-if ( typeof window.newspackRAS.push === 'function' ) {
-	window.newspackRAS.push = fn => fn( readerActivation );
-}
+window.newspackRAS.push = fn => fn( readerActivation );
 
 export default readerActivation;

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -126,6 +126,7 @@ final class Reader_Activation {
 			'newspack_reader_activation_data',
 			$script_data
 		);
+		\wp_script_add_data( self::SCRIPT_HANDLE, 'async', true );
 		\wp_script_add_data( self::SCRIPT_HANDLE, 'amp-plus', true );
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements a RAS callback strategy to allow the `reader-activation.js` library to load asynchronously.

### How to test the changes in this Pull Request:

1. Install Perfmatters and configure so it defers every script by default
2. Make sure you have RAS active
3. While on master, confirm that clicking on "Sign In" redirects you to the My Account page. The event listener that triggers the modal did not run
4. Check out this branch and confirm the modal now renders
5. Place a Reader Registration block and confirm it works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->