### PR TITLE
feat(registration-block): newsletter subscription by default

### DIFF
--- a/assets/blocks/reader-registration/block.json
+++ b/assets/blocks/reader-registration/block.json
@@ -28,7 +28,7 @@
 		},
 		"newsletterSubscription": {
 			"type": "boolean",
-			"default": false
+			"default": true
 		},
 		"displayListDescription": {
 			"type": "boolean",

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -137,54 +137,62 @@ export default function ReaderRegistrationEdit( {
 								{ inFlight && <Spinner /> }
 								{ ! inFlight && ! Object.keys( listConfig ).length && (
 									<div style={ { marginBottom: '1.5rem' } }>
-										<Notice isDismissible={ false } status="error">
-											{ __( 'You must enable lists for subscription.', 'newspack-newsletters' ) }
-										</Notice>
+										{ __(
+											'To enable newsletter subscription, you must enable subscription lists on Newspack Newsletters.',
+											'newspack-newsletters'
+										) }
 									</div>
 								) }
-								<ToggleControl
-									label={ __( 'Display list description', 'newspack-newsletters' ) }
-									checked={ displayListDescription }
-									disabled={ inFlight }
-									onChange={ () =>
-										setAttributes( { displayListDescription: ! displayListDescription } )
-									}
-								/>
-								<ToggleControl
-									label={ __( 'Hide newsletter selection and always subscribe', 'newspack' ) }
-									checked={ hideSubscriptionInput }
-									disabled={ inFlight || lists.length !== 1 }
-									onChange={ () =>
-										setAttributes( { hideSubscriptionInput: ! hideSubscriptionInput } )
-									}
-								/>
-								{ lists.length < 1 && (
-									<div style={ { marginBottom: '1.5rem' } }>
-										<Notice isDismissible={ false } status="error">
-											{ __( 'You must select at least one list.', 'newspack-newsletters' ) }
-										</Notice>
-									</div>
-								) }
-								{ Object.keys( listConfig ).length > 0 && <p>{ __( 'Lists', 'newspack' ) }:</p> }
-								{ Object.keys( listConfig ).map( listId => (
-									<ToggleControl
-										key={ listId }
-										label={ listConfig[ listId ].title }
-										checked={ lists.includes( listId ) }
-										disabled={ inFlight }
-										onChange={ () => {
-											if ( ! lists.includes( listId ) ) {
-												setAttributes( { lists: lists.concat( listId ) } );
-											} else {
-												setAttributes( { lists: lists.filter( id => id !== listId ) } );
+								{ Object.keys( listConfig ).length > 0 && (
+									<>
+										<ToggleControl
+											label={ __( 'Display list description', 'newspack-newsletters' ) }
+											checked={ displayListDescription }
+											disabled={ inFlight }
+											onChange={ () =>
+												setAttributes( { displayListDescription: ! displayListDescription } )
 											}
-										} }
-									/>
-								) ) }
+										/>
+										<ToggleControl
+											label={ __( 'Hide newsletter selection and always subscribe', 'newspack' ) }
+											checked={ hideSubscriptionInput }
+											disabled={ inFlight || lists.length !== 1 }
+											onChange={ () =>
+												setAttributes( { hideSubscriptionInput: ! hideSubscriptionInput } )
+											}
+										/>
+										{ lists.length < 1 && (
+											<div style={ { marginBottom: '1.5rem' } }>
+												<Notice isDismissible={ false } status="error">
+													{ __( 'You must select at least one list.', 'newspack-newsletters' ) }
+												</Notice>
+											</div>
+										) }
+										{ Object.keys( listConfig ).length > 0 && (
+											<p>{ __( 'Lists', 'newspack' ) }:</p>
+										) }
+										{ Object.keys( listConfig ).map( listId => (
+											<ToggleControl
+												key={ listId }
+												label={ listConfig[ listId ].title }
+												checked={ lists.includes( listId ) }
+												disabled={ inFlight }
+												onChange={ () => {
+													if ( ! lists.includes( listId ) ) {
+														setAttributes( { lists: lists.concat( listId ) } );
+													} else {
+														setAttributes( { lists: lists.filter( id => id !== listId ) } );
+													}
+												} }
+											/>
+										) ) }
+									</>
+								) }
 								<p>
 									<a href={ newspack_blocks.newsletters_url }>
 										{ __( 'Manage your subscription lists', 'newspack-newsletters' ) }
 									</a>
+									.
 								</p>
 							</>
 						) }

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -138,7 +138,7 @@ export default function ReaderRegistrationEdit( {
 								{ ! inFlight && ! Object.keys( listConfig ).length && (
 									<div style={ { marginBottom: '1.5rem' } }>
 										{ __(
-											'To enable newsletter subscription, you must enable subscription lists on Newspack Newsletters.',
+											'To enable newsletter subscription, you must configure subscription lists on Newspack Newsletters.',
 											'newspack-newsletters'
 										) }
 									</div>
@@ -190,7 +190,7 @@ export default function ReaderRegistrationEdit( {
 								) }
 								<p>
 									<a href={ newspack_blocks.newsletters_url }>
-										{ __( 'Manage your subscription lists', 'newspack-newsletters' ) }
+										{ __( 'Configure your subscription lists', 'newspack-newsletters' ) }
 									</a>
 									.
 								</p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make "Enable newsletter subscription" toggled on by default and improve the UI for when newsletters is not yet properly configured:

| Before | After |
| --- | --- |
| <img width="278" alt="image" src="https://user-images.githubusercontent.com/820752/208171250-679ebb02-19ae-401a-b12d-2c3a508cfe21.png"> | <img width="278" alt="image" src="https://user-images.githubusercontent.com/820752/208171093-40301ffb-8499-48ad-977f-c318db7a9070.png"> |

There's no need to flood the UI with error messages and settings if the lists are not yet configured.

### How to test the changes in this Pull Request:

1. Make sure you have newsletters installed but no subscription list configured
2. While on master, place a Reader Registration block on a draft page
3. Confirm the "Enable newsletter subscription" is toggled off
4. Toggle it on and confirm the error messages
5. Switch to this branch
6. Start a new draft, place the block and confirm the "Enable newsletter subscription" option is toggled on by default
7. Confirm the new message
8. Enable and configure subscription lists
9. Start a new draft, place the block and confirm you have "Enable newsletter subscription" toggled on with the first list also active by default

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->