### PR TITLE
fix(pixel): proper usage of action hooks

### DIFF
--- a/includes/tracking/class-meta-pixel.php
+++ b/includes/tracking/class-meta-pixel.php
@@ -56,21 +56,17 @@ class Meta_Pixel extends Pixel {
 	}
 
 	/**
-	 * Gets the template for the img tag snippet
-	 *
-	 * @return string
+	 * Prints the template for the img tag snippet
 	 */
 	public function print_footer_snippet() {
 		$event_params = self::get_event_params();
 		$url_params   = http_build_query( [ 'cd' => $event_params ] );
 		$snippet      = '<img height="1" width="1" style="display: none;" src="https://www.facebook.com/tr?id=__PIXEL_ID__&ev=PageView&noscript=1&' . $url_params . '">';
-		return $this->create_noscript_snippet( $snippet );
+		$this->create_noscript_snippet( $snippet );
 	}
 
 	/**
-	 * Gets the template for the script tag snippet
-	 *
-	 * @return string
+	 * Prints the template for the script tag snippet
 	 */
 	public function print_head_snippet() {
 		$snippet = sprintf(
@@ -88,7 +84,7 @@ class Meta_Pixel extends Pixel {
 		</script>",
 			wp_json_encode( self::get_event_params() )
 		);
-		return $this->create_js_snippet( $snippet );
+		$this->create_js_snippet( $snippet );
 	}
 
 	/**

--- a/includes/tracking/class-twitter-pixel.php
+++ b/includes/tracking/class-twitter-pixel.php
@@ -31,17 +31,13 @@ class Twitter_Pixel extends Pixel {
 
 	/**
 	 * Gets the template for the img tag snippet
-	 *
-	 * @return string
 	 */
 	public function print_footer_snippet() {
-		return parent::create_noscript_snippet( '<img height="1" width="1" style="display: none;" src="//t.co/i/adsct?txn_id=__PIXEL_ID__&amp;p_id=Twitter">' );
+		parent::create_noscript_snippet( '<img height="1" width="1" style="display: none;" src="//t.co/i/adsct?txn_id=__PIXEL_ID__&amp;p_id=Twitter">' );
 	}
 
 	/**
-	 * Gets the template for the script tag snippet
-	 *
-	 * @return string
+	 * Prints the template for the script tag snippet
 	 */
 	public function print_head_snippet() {
 		$snippet = "<!-- Twitter conversion tracking base code -->
@@ -52,7 +48,7 @@ class Twitter_Pixel extends Pixel {
 			twq('config','__PIXEL_ID__');
 			</script>
 			<!-- End Twitter conversion tracking base code -->";
-		return parent::create_js_snippet( $snippet );
+		parent::create_js_snippet( $snippet );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Proper usage of action hooks for printing the pixels.

### How to test the changes in this Pull Request:

Configuring Twitter and Meta pixels through "Engagement -> Social" wizard should continue to work as expected (#2144).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->