### PR TITLE
fix: fatal due to different class property

### DIFF
--- a/includes/analytics/class-analytics-events.php
+++ b/includes/analytics/class-analytics-events.php
@@ -250,7 +250,7 @@ class Analytics_Events {
 			'id'              => self::get_uniqid(),
 			'on'              => 'visible',
 			'element'         => '#' . $block_unique_id,
-			'event_name'      => 'newsletter modal impression ' . self::$block_render_context,
+			'event_name'      => 'newsletter modal impression ' . Analytics::$block_render_context,
 			'event_label'     => get_the_title(),
 			'event_category'  => 'NTG newsletter',
 			'non_interaction' => true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal error introduced in #2157 due to a reference to a class property that has been moved to a different class.

### How to test the changes in this Pull Request:

1. On a site with Analytics set up, publish a Newspack Campaigns prompt.
2. Visit a post front-end that will render the prompt. Observe a fatal error:

```
PHP Fatal error:  Uncaught Error: Access to undeclared static property: Newspack\Analytics_Events::$block_render_context in /wp-content/plugins/newspack-plugin/includes/analytics/class-analytics-events.php:253
```

3. Check out this branch, refresh, confirm no fatal error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->