### PR TITLE
fix: handle email sender when not under RAS

### DIFF
--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -358,21 +358,19 @@ class Emails {
 	 * @return string Email address used as the sender for Newspack emails.
 	 */
 	public static function get_from_email() {
-		$from_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'sender_email_address', '' );
-		if ( empty( $from_email ) ) {
-			// Get the site domain and get rid of www.
-			$sitename   = wp_parse_url( network_home_url(), PHP_URL_HOST );
-			$from_email = 'no-reply@';
+		// Get the site domain and get rid of www.
+		$sitename   = wp_parse_url( network_home_url(), PHP_URL_HOST );
+		$from_email = 'no-reply@';
 
-			if ( null !== $sitename ) {
-				if ( 'www.' === substr( $sitename, 0, 4 ) ) {
-					$sitename = substr( $sitename, 4 );
-				}
-
-				$from_email .= $sitename;
+		if ( null !== $sitename ) {
+			if ( 'www.' === substr( $sitename, 0, 4 ) ) {
+				$sitename = substr( $sitename, 4 );
 			}
+			$from_email .= $sitename;
 		}
-
+		if ( Reader_Activation::is_enabled() ) {
+			$from_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'sender_email_address', $from_email );
+		}
 		return apply_filters( 'newspack_from_email', $from_email );
 	}
 
@@ -382,7 +380,10 @@ class Emails {
 	 * @return string
 	 */
 	public static function get_reply_to_email() {
-		$reply_to_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'contact_email_address', self::get_from_email() );
+		$reply_to_email = get_bloginfo( 'admin_email' );
+		if ( Reader_Activation::is_enabled() ) {
+			$reply_to_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'contact_email_address', self::get_from_email() );
+		}
 		return apply_filters( 'newspack_reply_to_email', $reply_to_email );
 	}
 
@@ -394,7 +395,10 @@ class Emails {
 	 * @return string Name used as the sender for Newspack emails.
 	 */
 	public static function get_from_name() {
-		$from_name = get_option( Reader_Activation::OPTIONS_PREFIX . 'sender_name', get_bloginfo( 'name' ) );
+		$from_name = get_bloginfo( 'name' );
+		if ( Reader_Activation::is_enabled() ) {
+			$from_name = get_option( Reader_Activation::OPTIONS_PREFIX . 'sender_name', $from_name );
+		}
 		return apply_filters( 'newspack_from_name', $from_name );
 	}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -282,7 +282,7 @@ final class Reader_Activation {
 		}
 
 		if ( $is_enabled ) {
-			$is_enabled = self::get_setting( 'enabled' );
+			$is_enabled = (bool) \get_option( self::OPTIONS_PREFIX . 'enabled', true );
 		}
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reader revenue email sender configuration currently relies on RAS being active. This PR modifies the defaults so that it checks for RAS before applying RAS values.

It also uses the `admin_email` as the default `Reply-To` since there's currently no other way - outside of RAS - to modify this value.

### How to test the changes in this Pull Request:

1. Confirm the issue by disabling RAS and sending a test donation through Stripe platform
2. You should receive an email from `receipts@` with `Reply-To` header set to `no-reply@`
3. Check out this branch and send another test donation
4. Confirm the email is sent by `receipts@` with `Reply-To` set to the configured admin email

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->