### PR TITLE
fix(stripe): webhooks list edge-cases

### DIFF
--- a/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
@@ -152,7 +152,9 @@ const WebhooksSettings = () => {
 				className="mb4"
 				title={ () => (
 					<div className="flex justify-between items-center">
-						<h4 className="b f6 ma0">{ __( 'Webhooks connected to this site', 'newspack' ) }</h4>
+						<h4 className="b f6 ma0">
+							{ __( 'Webhooks connected to Newspack on this site', 'newspack' ) }
+						</h4>
 						<Button
 							variant="secondary"
 							isSmall
@@ -177,7 +179,7 @@ const WebhooksSettings = () => {
 				onUpdate={ handleWebhooksListUpdate }
 			/>
 			{ otherWebhooks.length ? (
-				<Accordion title={ __( 'Webhooks not connected to this site', 'newspack' ) }>
+				<Accordion title={ __( 'Webhooks not connected to Newspack on this site', 'newspack' ) }>
 					<WebhooksList webhooks={ otherWebhooks } onUpdate={ handleWebhooksListUpdate } />
 				</Accordion>
 			) : null }

--- a/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js
@@ -152,9 +152,7 @@ const WebhooksSettings = () => {
 				className="mb4"
 				title={ () => (
 					<div className="flex justify-between items-center">
-						<h4 className="b f6 ma0">
-							{ __( 'Webhooks connected to Newspack on this site', 'newspack' ) }
-						</h4>
+						<h4 className="b f6 ma0">{ __( 'Webhooks connected to this site', 'newspack' ) }</h4>
 						<Button
 							variant="secondary"
 							isSmall
@@ -179,7 +177,7 @@ const WebhooksSettings = () => {
 				onUpdate={ handleWebhooksListUpdate }
 			/>
 			{ otherWebhooks.length ? (
-				<Accordion title={ __( 'Webhooks not connected to Newspack on this site', 'newspack' ) }>
+				<Accordion title={ __( 'Webhooks not connected to this site', 'newspack' ) }>
 					<WebhooksList webhooks={ otherWebhooks } onUpdate={ handleWebhooksListUpdate } />
 				</Accordion>
 			) : null }

--- a/includes/reader-revenue/stripe/class-stripe-webhooks.php
+++ b/includes/reader-revenue/stripe/class-stripe-webhooks.php
@@ -53,7 +53,7 @@ class Stripe_Webhooks {
 			'url'         => $webhook->url,
 			'status'      => $webhook->status,
 			'livemode'    => $webhook->livemode,
-			'matches_url' => self::get_webhook_url() === $webhook->url,
+			'matches_url' => str_replace( [ 'http://', 'https://' ], '', self::get_webhook_url() ) === str_replace( [ 'http://', 'https://' ], '', $webhook->url ),
 		];
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a webhook configuration edge case and updates the UI text to reflect the fact that a webhook might be connected to the site, but is used for a different integration. 

### How to test the changes in this Pull Request:

1. Create a new webhook via Stripe dashboard – same as the existing Newspack webhook, but with different protocol (`https` -> `http` or the other way around)
2. On `master`, observe that the duplicated webhook is not listed in `/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/stripe-webhooks` as connected to this site
3. Switch to this branch, observe the webhook is listed and the warning about duplicate webhook is displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->