### PR TITLE
fix: webpack build issue

### DIFF
--- a/assets/components/src/accordion/index.js
+++ b/assets/components/src/accordion/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { Icon, chevronDown } from '@wordpress/icons';
+import { Icon, chevronRight } from '@wordpress/icons';
 
 /**
  * External dependencies
@@ -22,7 +22,7 @@ const Accordion = ( { children, title } ) => {
 		>
 			<summary onClick={ () => setIsOpen( ! isOpen ) }>
 				{ title }
-				<Icon className="newspack-accordion__icon" icon={ chevronDown } size={ 24 } />
+				<Icon className="newspack-accordion__icon" icon={ chevronRight } size={ 24 } />
 			</summary>
 			{ children }
 		</details>

--- a/assets/components/src/accordion/style.scss
+++ b/assets/components/src/accordion/style.scss
@@ -5,12 +5,13 @@
 
 	&__icon {
 		transition: transform 200ms ease-out;
+		transform: rotate( 90deg );
 	}
 
 	&--is-open {
 		.newspack-accordion {
 			&__icon {
-				transform: rotate( -180deg );
+				transform: rotate( -90deg );
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a very weird build issue. For some reason, importing `chevronDown` borks the compiled JS files. When I've inspected the JS file, it turned out that the error in the Design wizard is thrown in the `GroupedSelectControl` component (exactly [here](https://github.com/Automattic/newspack-plugin/blob/39a247459b4151901799093e8bcd311d4f97abe7/assets/components/src/select-control/GroupedSelectControl.js#L70)). Removing the `Icon` component there _or_ in the `Accordion` component fixed the issue. This PR changes the icon used in the `Accordion` to a different chevron and rotates it so it's down 🤷‍♀️. 

### How to test the changes in this Pull Request:

1. On `master`, run `npm run build` and visit the design step of the Setup wizard (`wp-admin/admin.php?page=newspack-setup-wizard#/design`)
2. Observe that it does not load!
3. Switch to this branch, rebuild, reload the wizard, observe that it loads

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->