### PR TITLE
ga4 events poc

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -168,6 +168,10 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/author-filter/class-author-filter.php';
 
 		\Newspack\CLI\Initializer::init();
+
+		include_once NEWSPACK_ABSPATH . 'includes/ga4-poc/class-ga4-events.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/consumers/ga-4/class-ga4.php';
+
 	}
 
 	/**

--- a/includes/data-events/consumers/ga-4/class-ga4.php
+++ b/includes/data-events/consumers/ga-4/class-ga4.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Newspack;
+
+class GA_4 {
+
+	public static function init() {
+
+		add_action( 'wp_ajax_ga4_trigger_event', array( __CLASS__, 'ajax_callback' ) );
+		add_action( 'wp_ajax_nopriv_ga4_trigger_event', array( __CLASS__, 'ajax_callback' ) );
+
+		Data_Events::register_handler( [ __CLASS__, 'handle_click_body' ], 'click_body' );
+		Data_Events::register_handler( [ __CLASS__, 'handle_reader_registered' ], 'reader_registered' );
+	}
+
+	public static function ajax_callback() {
+
+		check_ajax_referer( 'newspack_ga4_poc_nonce' );
+
+		Logger::log(
+			'Handling ajax request',
+			'GA4 POC'
+		);
+
+		Data_Events::dispatch( $_POST['params']['event_name'], $_POST['params']['event_params'], true );
+		die;
+	}
+
+	public static function send_event( $name, $params, $user_id = null ) {
+
+		// Go to Analytics > Admin > Data Streams and you will find these values .
+		$api_secret     = get_option( 'ga4_poc_api_secret' );
+		$measurement_id = get_option( 'ga4_poc_measurement_id' );
+
+		$client_id = self::extract_cid_from_cookies();
+
+		$payload = [
+			'client_id' => $client_id,
+			'events'    => [
+				[
+					'name'   => $name,
+					'params' => $params,
+				],
+			],
+		];
+
+		if ( $user_id ) {
+			$payload['user_id'] = $user_id;
+		}
+
+		Logger::log(
+			sprintf( 'Sending event with client "%s" and user "%s".', $client_id, $user_id ),
+			'GA4 POC'
+		);
+
+		$url = add_query_arg(
+			[
+				'api_secret'     => $api_secret,
+				'measurement_id' => $measurement_id,
+			],
+			'https://www.google-analytics.com/mp/collect'
+		);
+
+		$r = wp_remote_post(
+			$url,
+			[
+				'body' => wp_json_encode( $payload ),
+			]
+		);
+
+		Logger::log(
+			'Event sent.',
+			'GA4 POC'
+		);
+
+	}
+
+	public static function extract_cid_from_cookies() {
+
+		if ( isset( $_COOKIE['_ga'] ) ) {
+			$cookie_pieces = explode( '.', $_COOKIE['_ga'], 3 ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( 1 === count( $cookie_pieces ) ) {
+				$cid = reset( $cookie_pieces );
+			} else {
+				list( $version, $domain_depth, $cid ) = $cookie_pieces;
+			}
+		} else {
+			$time = time();
+			// make up a _ga cookie using variables based on what we know about the _ga cookie, advice taken from multiple sources including - http://taylrr.co.uk/blog/server-side-analytics/
+			// will need to check against the js cookies now and then to ensure compatability
+			$cid                 = rand( 1000000000, 2147483647 ) . ".{$time}";
+			$numDomainComponents = count( explode( '.', preg_replace( '/^www\./', '', $_SERVER['HTTP_HOST'] ) ) );
+			$ga                  = "GA1.{$numDomainComponents}.{$cid}";
+			setcookie( '_ga', $ga, $time + 63115200, '/', $_SERVER['HTTP_HOST'], false, false );
+			$_COOKIE['_ga'] = $ga;
+		}
+
+		return $cid;
+	}
+
+	public static function handle_click_body( $timestamp, $data, $user_id ) {
+
+		self::send_event( 'click_body', $data, $user_id );
+
+	}
+
+	public static function handle_reader_registered( $timestamp, $data, $user_id ) {
+
+		$event_name = 'reader_registered';
+		$event_data = [
+			'status'              => 'success',
+			'method'              => $data['metadata']['registration_method'],
+			'include_newsletters' => ! empty( $data['metadata']['lists'] ),
+		];
+		self::send_event( $event_name, $event_data, $user_id );
+	}
+}
+
+GA_4::init();

--- a/includes/ga4-poc/class-ga4-events.php
+++ b/includes/ga4-poc/class-ga4-events.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Newspack;
+
+class GA4_Events {
+
+	public static function init() {
+
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
+		Data_Events::register_action( 'click_body' );
+
+	}
+
+	public static function enqueue_scripts() {
+		wp_enqueue_script(
+			'newspack_ga4_poc',
+			Newspack::plugin_url() . '/includes/ga4-poc/poc.js',
+			[ 'jquery' ],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+		wp_localize_script(
+			'newspack_ga4_poc',
+			'newspack_ga4_poc',
+			[
+				'ajax_url'  => admin_url( 'admin-ajax.php' ),
+				'poc_nonce' => wp_create_nonce( 'newspack_ga4_poc_nonce' ),
+			]
+		);
+	}
+}
+
+GA4_Events::init();

--- a/includes/ga4-poc/poc.js
+++ b/includes/ga4-poc/poc.js
@@ -1,0 +1,15 @@
+( function ( $ ) {
+	$( 'body' ).click( function ( ev ) {
+		$.post( newspack_ga4_poc.ajax_url, {
+			action: 'ga4_trigger_event',
+			_ajax_nonce: newspack_ga4_poc.poc_nonce,
+			params: {
+				event_name: 'click_body',
+				event_params: {
+					position_x: ev.pageX,
+					position_y: ev.pageY,
+				},
+			},
+		} );
+	} );
+} )( jQuery );


### PR DESCRIPTION
See pemhSX-2Q-p2

This is a proof of concept for a GA4 events consumer for our Data Events lib.

The `includes/data-events/consumers/ga-4/` folder holds the prototype. This will:

* register the handler for 2 events that will be sent to GA
* register an ajax callback that can be used to send events from the front-end though the same route

The `includes/ga4-poc/` folder holds a proof of concept of how we could use it. This code is just to see how things could work. It will

* Enqueue a script to every page in the front end
* trigger an event every time `body` is clicked (yes, lots of events)

# How to test it

* First go to your Google Analytics dashboard, to Admin > Data Streams and fetch the "Measurement ID" and create a API Secret.
* Populate each of these values in an option: `ga4_poc_api_secret` and `ga4_poc_measurement_id`
```
wp option set ga4_poc_api_secret XXXX
wp option set ga4_poc_measurement_id YYYY
```

* Visit your Google Analytics Real time dashboard
* `tail -f` your error log
* add `define( 'NEWSPACK_LOG_LEVEL', 2);` to your wp-config
* Visit your site and click the page
* Watch the events being sent in the log
* Watch the events showing up in the Analytics realtime
* Register to your site
* Watch the events
* Inspect the events parameter and see them available in GA