### PR TITLE
chore(data-events): switch wp hooks priority

### DIFF
--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -118,7 +118,7 @@ final class Data_Events {
 		 * @param mixed  $data        Data.
 		 * @param string $client_id   Client ID.
 		 */
-		do_action( 'newspack_data_event_' . $action_name, $timestamp, $data, $client_id );
+		do_action( "newspack_data_event_{$action_name}", $timestamp, $data, $client_id );
 
 		/**
 		 * Fires after all global and action-specific handlers have been executed.

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -111,16 +111,6 @@ final class Data_Events {
 		/**
 		 * Fires after all global and action-specific handlers have been executed.
 		 *
-		 * @param string $action_name Action name.
-		 * @param int    $timestamp   Timestamp.
-		 * @param mixed  $data        Data.
-		 * @param string $client_id   Client ID.
-		 */
-		do_action( 'newspack_data_event', $action_name, $timestamp, $data, $client_id );
-
-		/**
-		 * Fires after all global and action-specific handlers have been executed.
-		 *
 		 * The dynamic portion of the hook name, `$action_name`, refers to the name
 		 * of the action being fired.
 		 *
@@ -129,6 +119,16 @@ final class Data_Events {
 		 * @param string $client_id   Client ID.
 		 */
 		do_action( 'newspack_data_event_' . $action_name, $timestamp, $data, $client_id );
+
+		/**
+		 * Fires after all global and action-specific handlers have been executed.
+		 *
+		 * @param string $action_name Action name.
+		 * @param int    $timestamp   Timestamp.
+		 * @param mixed  $data        Data.
+		 * @param string $client_id   Client ID.
+		 */
+		do_action( 'newspack_data_event', $action_name, $timestamp, $data, $client_id );
 	}
 
 	/**
@@ -272,17 +272,6 @@ final class Data_Events {
 		 * Fires when an action is dispatched. This occurs before any handlers are
 		 * executed.
 		 *
-		 * @param string $action_name Action name.
-		 * @param int    $timestamp   Timestamp.
-		 * @param mixed  $data        Data.
-		 * @param string $client_id   Client ID.
-		 */
-		do_action( 'newspack_data_event_dispatch', $action_name, $timestamp, $data, $client_id );
-
-		/**
-		 * Fires when an action is dispatched. This occurs before any handlers are
-		 * executed.
-		 *
 		 * The dynamic portion of the hook name, `$action_name`, refers to the name
 		 * of the action being fired.
 		 *
@@ -292,6 +281,17 @@ final class Data_Events {
 		 * @param string $client_id   Client ID.
 		 */
 		do_action( "newspack_data_event_dispatch_{$action_name}", $timestamp, $data, $client_id );
+
+		/**
+		 * Fires when an action is dispatched. This occurs before any handlers are
+		 * executed.
+		 *
+		 * @param string $action_name Action name.
+		 * @param int    $timestamp   Timestamp.
+		 * @param mixed  $data        Data.
+		 * @param string $client_id   Client ID.
+		 */
+		do_action( 'newspack_data_event_dispatch', $action_name, $timestamp, $data, $client_id );
 
 		$url = \add_query_arg(
 			[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As a WordPress standard, the more specific hook should be called first ([example](https://github.com/WordPress/wordpress-develop/blob/6.1/src/wp-includes/post.php#L4689-L4717)).

This PR switches the data events' WordPress hooks priority.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->