### PR TITLE
feat(data-events): use WC's Action Scheduler if available

### DIFF
--- a/assets/wizards/connections/views/main/webhooks.js
+++ b/assets/wizards/connections/views/main/webhooks.js
@@ -377,14 +377,12 @@ const Webhooks = () => {
 											? sprintf(
 													// translators: %s is a human-readable time difference.
 													__( 'sending in %s', 'newspack' ),
-													moment( request.scheduled.date + request.scheduled.timezone ).fromNow(
-														true
-													)
+													moment( parseInt( request.scheduled ) * 1000 ).fromNow( true )
 											  )
 											: sprintf(
 													// translators: %s is a human-readable time difference.
 													__( 'processed %s', 'newspack' ),
-													moment( request.scheduled.date + request.scheduled.timezone ).fromNow()
+													moment( parseInt( request.scheduled ) * 1000 ).fromNow()
 											  ) }
 									</td>
 									{ hasEndpointErrors( viewing ) && (

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -48,6 +48,8 @@ final class Data_Events {
 
 	/**
 	 * Whether to use Action Scheduler if available.
+	 *
+	 * @return bool
 	 */
 	public static function use_action_scheduler() {
 		$use_action_scheduler = false;
@@ -59,7 +61,7 @@ final class Data_Events {
 		 *
 		 * @param bool $use_action_scheduler
 		 */
-		return apply_filters( 'newspack_data_events_use_action_scheduler', $use_action_scheduler );
+		return \apply_filters( 'newspack_data_events_use_action_scheduler', $use_action_scheduler );
 	}
 
 	/**
@@ -70,12 +72,12 @@ final class Data_Events {
 		session_write_close(); // phpcs:ignore
 
 		if ( ! isset( $_REQUEST['nonce'] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST['nonce'] ), self::ACTION ) ) {
-			wp_die();
+			\wp_die();
 		}
 
 		$action_name = isset( $_POST['action_name'] ) ? \sanitize_text_field( \wp_unslash( $_POST['action_name'] ) ) : null;
 		if ( empty( $action_name ) || ! isset( self::$actions[ $action_name ] ) ) {
-			wp_die();
+			\wp_die();
 		}
 
 		$timestamp = isset( $_POST['timestamp'] ) ? \sanitize_text_field( \wp_unslash( $_POST['timestamp'] ) ) : null;
@@ -84,7 +86,7 @@ final class Data_Events {
 
 		self::handle( $action_name, $timestamp, $data, $client_id );
 
-		wp_die();
+		\wp_die();
 	}
 
 	/**
@@ -135,7 +137,7 @@ final class Data_Events {
 		 * @param array  $data        Data.
 		 * @param string $client_id   Client ID.
 		 */
-		do_action( "newspack_data_event_{$action_name}", $timestamp, $data, $client_id );
+		\do_action( "newspack_data_event_{$action_name}", $timestamp, $data, $client_id );
 
 		/**
 		 * Fires after all global and action-specific handlers have been executed.
@@ -145,7 +147,7 @@ final class Data_Events {
 		 * @param array  $data        Data.
 		 * @param string $client_id   Client ID.
 		 */
-		do_action( 'newspack_data_event', $action_name, $timestamp, $data, $client_id );
+		\do_action( 'newspack_data_event', $action_name, $timestamp, $data, $client_id );
 	}
 
 	/**
@@ -292,7 +294,7 @@ final class Data_Events {
 		 * @param array  $data        Data.
 		 * @param string $client_id   Client ID.
 		 */
-		do_action( "newspack_data_event_dispatch_{$action_name}", $timestamp, $data, $client_id );
+		\do_action( "newspack_data_event_dispatch_{$action_name}", $timestamp, $data, $client_id );
 
 		/**
 		 * Fires when an action is dispatched. This occurs before any handlers are
@@ -303,7 +305,7 @@ final class Data_Events {
 		 * @param array  $data        Data.
 		 * @param string $client_id   Client ID.
 		 */
-		do_action( 'newspack_data_event_dispatch', $action_name, $timestamp, $data, $client_id );
+		\do_action( 'newspack_data_event_dispatch', $action_name, $timestamp, $data, $client_id );
 
 		$body = [
 			'action_name' => $action_name,

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -318,8 +318,7 @@ final class Data_Events {
 		];
 
 		/**
-		 * Filters the body of the request that is sent to the server to dispatch an
-		 * action.
+		 * Filters the body of the action dispatch request.
 		 *
 		 * @param array  $body        Body.
 		 * @param string $action_name The action name.

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -54,7 +54,7 @@ final class Data_Events {
 	public static function use_action_scheduler() {
 		$use_action_scheduler = false;
 		if ( function_exists( 'as_enqueue_async_action' ) ) {
-			$use_action_schedueler = true;
+			$use_action_scheduler = true;
 		}
 		/**
 		 * Filters whether to use the Action Scheduler if available.

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -332,28 +332,30 @@ final class Data_Events {
 				sprintf( 'Dispatching action "%s" via Action Scheduler.', $action_name ),
 				self::LOGGER_HEADER
 			);
+
 			\as_enqueue_async_action( 'newspack_data_events_as_dispatch', array_values( $body ), 'newspack-data-events' );
-			return;
-		}
 
-		$url = \add_query_arg(
-			[
-				'action' => self::ACTION,
-				'nonce'  => \wp_create_nonce( self::ACTION ),
-			],
-			\admin_url( 'admin-ajax.php' )
-		);
+		} else {
 
-		return \wp_remote_post(
-			$url,
-			[
-				'timeout'   => 0.01,
-				'blocking'  => false,
-				'body'      => $body,
+			$url = \add_query_arg(
+				[
+					'action' => self::ACTION,
+					'nonce'  => \wp_create_nonce( self::ACTION ),
+				],
+				\admin_url( 'admin-ajax.php' )
+			);
+
+			return \wp_remote_post(
+				$url,
+				[
+					'timeout'  => 0.01,
+					'blocking' => false,
+					'body'     => $body,
 				'cookies'   => $_COOKIE, // phpcs:ignore
-				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
-			]
-		);
+				'sslverify'    => apply_filters( 'https_local_ssl_verify', false ),
+				]
+			);
+		}
 	}
 }
 Data_Events::init();

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -280,11 +280,6 @@ final class Data_Events {
 			$client_id = Reader_Activation::get_client_id();
 		}
 
-		Logger::log(
-			sprintf( 'Dispatching action "%s".', $action_name ),
-			self::LOGGER_HEADER
-		);
-
 		/**
 		 * Fires when an action is dispatched. This occurs before any handlers are
 		 * executed.
@@ -325,7 +320,6 @@ final class Data_Events {
 		 */
 		$body = apply_filters( 'newspack_data_events_dispatch_body', $body, $action_name );
 
-		/** Prioritize the Action Scheduler tool if available. */
 		if ( self::use_action_scheduler() ) {
 			Logger::log(
 				sprintf( 'Dispatching action "%s" via Action Scheduler.', $action_name ),
@@ -335,6 +329,10 @@ final class Data_Events {
 			\as_enqueue_async_action( 'newspack_data_events_as_dispatch', array_values( $body ), 'newspack-data-events' );
 
 		} else {
+			Logger::log(
+				sprintf( 'Dispatching action "%s" via HTTP request.', $action_name ),
+				self::LOGGER_HEADER
+			);
 
 			$url = \add_query_arg(
 				[

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -522,7 +522,7 @@ final class Webhooks {
 		$time     = strtotime( sprintf( '+%d minutes', \absint( $delay ) ) );
 		$date     = date( 'Y-m-d H:i:s', $time ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 		$date_gmt = gmdate( 'Y-m-d H:i:s', strtotime( $date ) );
-		update_post_meta( $request_id, 'scheduled', $time );
+		\update_post_meta( $request_id, 'scheduled', $time );
 		if ( Data_Events::use_action_scheduler() ) {
 			Logger::log( "Scheduling request {$request_id} for {$date_gmt} via Action Scheduler.", self::LOGGER_HEADER );
 			\as_schedule_single_action( $time, 'newspack_webhooks_as_process_request', [ $request_id ], 'newspack-data-events' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the dispatch of data events and processing of webhook requests to use WooCommerce's Action Scheduler tool if available.

This allows for more sophisticated async handling that won't rely on WP Cron or the non-blocking HTTP request.

### How to test the changes in this Pull Request:

1. Make sure you have the following flags on your instance:
```php
define( 'NEWSPACK_AMP_PLUS_ENABLED', true );
define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );
define( 'NEWSPACK_EXPERIMENTAL_WEBHOOKS', true );
define( 'NEWSPACK_LOG_LEVEL', 2 );
```
2. Confirm WooCommerce is installed and active
3. Configure a valid global webhook endpoint at the Connections wizard (see #2182 and #2197 for reference)
4. Register a new reader in another session (incognito window)
5. Confirm the logs show:
```
[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::dispatch]: Dispatching action "reader_registered" via Action Scheduler.
```
6. Wait a few minutes and confirm the webhook request is also processed successfully and the logs show:
```
[NEWSPACK-WEBHOOKS][Newspack\Data_Events\Webhooks::transition_post_status]: Processing request XX via Action Scheduler.
```
7. Deactivate WooCommerce, authenticate the new reader in another session and confirm the logs:
```
[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::dispatch]: Dispatching action "reader_logged_in" via HTTP request.
```
8. Wait a few minutes and confirm the webhook request is also processed without issues

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->