### PR TITLE
fix(stripe): WC Subs scheduled actions errors suppression

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -56,7 +56,7 @@ class WooCommerce_Connection {
 
 		// WC Subscriptions hooks in and creates subscription at priority 100, so use priority 101.
 		\add_action( 'woocommerce_checkout_order_processed', [ __CLASS__, 'sync_reader_on_order_complete' ], 101 );
-		\add_action( 'option_woocommerce_subscriptions_failed_scheduled_actions', [ __CLASS__, 'filter_subscription_renewal_errors' ] );
+		\add_action( 'option_woocommerce_subscriptions_failed_scheduled_actions', [ __CLASS__, 'filter_subscription_scheduled_actions_errors' ] );
 
 		\add_action( 'wp_login', [ __CLASS__, 'sync_reader_on_customer_login' ], 10, 2 );
 	}
@@ -754,17 +754,17 @@ class WooCommerce_Connection {
 	}
 
 	/**
-	 * Filter WC Subscriptions' renewal errors. If a subscription is only sync'd,
-	 * it won't be renewed by WC Subscriptions, so we don't want to show an error.
+	 * Filter WC Subscriptions' renewal errors. If a subscription is sync'd,
+	 * it won't be handled by WC Subscriptions, so error can be ignored.
 	 *
 	 * @param array $renewal_errors An associative array of errors.
 	 */
-	public static function filter_subscription_renewal_errors( $renewal_errors ) {
+	public static function filter_subscription_scheduled_actions_errors( $renewal_errors ) {
 		if ( is_array( $renewal_errors ) ) {
 			foreach ( $renewal_errors as $key => $error ) {
 				if ( isset( $error['args'], $error['args']['subscription_id'], $error['type'] ) ) {
 					$subscription_id = $error['args']['subscription_id'];
-					if ( 'subscription payment' === $error['type'] && self::is_synchronised_with_stripe( $subscription_id ) ) {
+					if ( self::is_synchronised_with_stripe( $subscription_id ) ) {
 						unset( $renewal_errors[ $key ] );
 					}
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#2175 introduced ignoring WC Subscriptions' scheduled actions errors. It only handled one kind of error, though, but there may be other ones. For subscriptions synchronised from Stripe ("shadow subscriptions", so to speak), all errors should be ignored. 

### How to test the changes in this Pull Request:

Follow steps in #2175, but in step 4. replace `"subscription payment"` with another error type, e.g. `"subscription expiration"`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->