### PR TITLE
feat: replace recommended cookie plugin

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -394,7 +394,6 @@ class Plugin_Manager {
 			'web-stories',
 			'ads-txt',
 			'woocommerce-memberships',
-			'complianz-gdpr',
 		];
 	}
 

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -391,7 +391,10 @@ class Plugin_Manager {
 			'gravityformsstripe',
 			'perfmatters',
 			'onesignal-free-web-push-notifications',
-			'wp-gdpr-cookie-notice',
+			'web-stories',
+			'ads-txt',
+			'woocommerce-memberships',
+			'complianz-gdpr',
 		];
 	}
 

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -254,7 +254,7 @@ class Plugin_Manager {
 			],
 			'complianz-gdpr'                => [
 				'Name'        => esc_html__( 'Complianz - GDPR/CCPA Cookie Consent', 'newspack' ),
-				'Description' => esc_html__( 'Configure your Cookie Banner, Cookie Consent and Cookie Policy with our Wizard and Cookie Scan. Supports GDPR, DSGVO, TTDSG, LGPD, POPIA, RGPD, CCPA/CPRA and PIPEDA.', 'newspack' ),
+				'Description' => esc_html__( 'Complianz is a GDPR/CCPA Cookie Consent plugin that supports GDPR, ePrivacy, DSGVO, TTDSG, LGPD, POPIA, APA, RGPD, CCPA/CPRA and PIPEDA with a conditional Cookie Notice and customized Cookie Policy based on the results of the built-in Cookie Scan.', 'newspack' ),
 				'Author'      => esc_html__( 'Really Simple Plugins', 'newspack' ),
 				'AuthorURI'   => esc_url( 'https://www.complianz.io/' ),
 				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/complianz-gdpr/' ),

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -252,12 +252,12 @@ class Plugin_Manager {
 				'WPCore'   => true,
 				'EditPath' => 'options-discussion.php',
 			],
-			'wp-gdpr-cookie-notice'         => [
-				'Name'        => esc_html__( 'WP GDPR Cookie Notice', 'newspack' ),
-				'Description' => esc_html__( 'Simple performant cookie consent notice that supports AMP, granular cookie control and live preview customization.', 'newspack' ),
-				'Author'      => esc_html__( 'Felix Arntz', 'newspack' ),
-				'AuthorURI'   => esc_url( 'https://felix-arntz.me/' ),
-				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/wp-gdpr-cookie-notice/' ),
+			'complianz-gdpr'                => [
+				'Name'        => esc_html__( 'Complianz - GDPR/CCPA Cookie Consent', 'newspack' ),
+				'Description' => esc_html__( 'Configure your Cookie Banner, Cookie Consent and Cookie Policy with our Wizard and Cookie Scan. Supports GDPR, DSGVO, TTDSG, LGPD, POPIA, RGPD, CCPA/CPRA and PIPEDA.', 'newspack' ),
+				'Author'      => esc_html__( 'Really Simple Plugins', 'newspack' ),
+				'AuthorURI'   => esc_url( 'https://www.complianz.io/' ),
+				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/complianz-gdpr/' ),
 				'Download'    => 'wporg',
 			],
 			'simple-local-avatars'          => [
@@ -391,9 +391,7 @@ class Plugin_Manager {
 			'gravityformsstripe',
 			'perfmatters',
 			'onesignal-free-web-push-notifications',
-			'web-stories',
-			'ads-txt',
-			'woocommerce-memberships',
+			'wp-gdpr-cookie-notice',
 		];
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For when we're ready to switch from recommending [WP GDPR Cookie Notice](https://wordpress.org/plugins/wp-gdpr-cookie-notice/) to [Complianz](https://wordpress.org/plugins/complianz-gdpr/).

Context: pamTN9-4wk-p2

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->