### PR TITLE
Remove donation products from cart if WC is not the donations platform

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -69,6 +69,7 @@ class Donations {
 			add_action( 'woocommerce_checkout_update_order_meta', [ __CLASS__, 'woocommerce_checkout_update_order_meta' ] );
 			add_filter( 'woocommerce_billing_fields', [ __CLASS__, 'woocommerce_billing_fields' ] );
 			add_filter( 'pre_option_woocommerce_enable_guest_checkout', [ __CLASS__, 'disable_guest_checkout' ] );
+			add_action( 'template_redirect', [ __CLASS__, 'handle_cart' ] );
 			add_filter( 'amp_skip_post', [ __CLASS__, 'should_skip_amp' ], 10, 2 );
 		}
 	}
@@ -847,6 +848,27 @@ class Donations {
 			return $has_stripe_keys;
 		}
 		return false;
+	}
+
+	/**
+	 * Manipulate WC's cart, if needed.
+	 * If WC is not the donations platform, the donation products should not be buyable.
+	 */
+	public static function handle_cart() {
+		if ( ! self::is_woocommerce_suite_active() ) {
+			return;
+		}
+		if ( self::is_platform_wc() ) {
+			return;
+		}
+		if ( \is_cart() || \is_checkout() ) {
+			$donation_products_ids = array_values( self::get_donation_product_child_products_ids() );
+			foreach ( WC()->cart->cart_contents as $prod_in_cart ) {
+				if ( isset( $prod_in_cart['product_id'] ) && in_array( $prod_in_cart['product_id'], $donation_products_ids ) ) {
+					WC()->cart->remove_cart_item( $prod_in_cart['key'] );
+				}
+			}
+		}
 	}
 }
 Donations::init();

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -69,7 +69,7 @@ class Donations {
 			add_action( 'woocommerce_checkout_update_order_meta', [ __CLASS__, 'woocommerce_checkout_update_order_meta' ] );
 			add_filter( 'woocommerce_billing_fields', [ __CLASS__, 'woocommerce_billing_fields' ] );
 			add_filter( 'pre_option_woocommerce_enable_guest_checkout', [ __CLASS__, 'disable_guest_checkout' ] );
-			add_action( 'woocommerce_before_cart', [ __CLASS__, 'handle_cart' ] );
+			add_action( 'woocommerce_check_cart_items', [ __CLASS__, 'handle_cart' ] );
 			add_filter( 'amp_skip_post', [ __CLASS__, 'should_skip_amp' ], 10, 2 );
 		}
 	}

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -69,7 +69,7 @@ class Donations {
 			add_action( 'woocommerce_checkout_update_order_meta', [ __CLASS__, 'woocommerce_checkout_update_order_meta' ] );
 			add_filter( 'woocommerce_billing_fields', [ __CLASS__, 'woocommerce_billing_fields' ] );
 			add_filter( 'pre_option_woocommerce_enable_guest_checkout', [ __CLASS__, 'disable_guest_checkout' ] );
-			add_action( 'template_redirect', [ __CLASS__, 'handle_cart' ] );
+			add_action( 'woocommerce_before_cart', [ __CLASS__, 'handle_cart' ] );
 			add_filter( 'amp_skip_post', [ __CLASS__, 'should_skip_amp' ], 10, 2 );
 		}
 	}
@@ -855,18 +855,13 @@ class Donations {
 	 * If WC is not the donations platform, the donation products should not be buyable.
 	 */
 	public static function handle_cart() {
-		if ( ! self::is_woocommerce_suite_active() ) {
-			return;
-		}
 		if ( self::is_platform_wc() ) {
 			return;
 		}
-		if ( \is_cart() || \is_checkout() ) {
-			$donation_products_ids = array_values( self::get_donation_product_child_products_ids() );
-			foreach ( WC()->cart->cart_contents as $prod_in_cart ) {
-				if ( isset( $prod_in_cart['product_id'] ) && in_array( $prod_in_cart['product_id'], $donation_products_ids ) ) {
-					WC()->cart->remove_cart_item( $prod_in_cart['key'] );
-				}
+		$donation_products_ids = array_values( self::get_donation_product_child_products_ids() );
+		foreach ( WC()->cart->cart_contents as $prod_in_cart ) {
+			if ( isset( $prod_in_cart['product_id'] ) && in_array( $prod_in_cart['product_id'], $donation_products_ids ) ) {
+				WC()->cart->remove_cart_item( $prod_in_cart['key'] );
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If the Reader Revenue platform is not set to Newspack (WooCommerce), but the WC suite is active, "buying" the donation products using WC UI should not be possible. 

See 1203536997639429-as-1203626633832534

### How to test the changes in this Pull Request:

1. Set the Reader Revenue platform to Newspack 
2. Complete the donation, via the Donate block or by directly buying using a WC product link (e.g. `/product/donate-one-time/`
3. Switch the Reader Revenue platform to a different one
4. Visit the WC product page, add it to cart
5. Navigate to the cart, observe it is empty

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->