### PR TITLE
feat(data-events): donation listeners

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -254,6 +254,29 @@ class Donations {
 	}
 
 	/**
+	 * Get the donation product ID for the order.
+	 *
+	 * @param int $order_id Order ID.
+	 *
+	 * @return int|false The donation product ID or false.
+	 */
+	public static function get_order_donation_product_id( $order_id ) {
+		$donation_products = self::get_donation_product_child_products_ids();
+		if ( empty( array_filter( $donation_products ) ) ) {
+			return;
+		}
+		$order          = new \WC_Order( $order_id );
+		$order_items    = $order->get_items();
+		$donation_items = array_filter(
+			$order_items,
+			function ( $item ) use ( $donation_products ) {
+				return in_array( $item->get_product_id(), $donation_products, true );
+			}
+		);
+		return ! empty( $donation_items ) ? array_values( $donation_items )[0]->get_product_id() : false;
+	}
+
+	/**
 	 * Get the donation settings.
 	 *
 	 * @return Array of donation settings or WP_Error if WooCommerce is not set up.

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -109,6 +109,10 @@ When a WooCommerce Subscription is cancelled.
 | `subscription_id` | `int`    |
 | `user_id`         | `int`    |
 | `email`           | `string` |
+| `amount`          | `float`  |
+| `currency`        | `string` |
+| `recurrence`      | `string` |
+| `platform`        | `string` |
 
 ### `donation_subscription_changed`
 
@@ -121,6 +125,10 @@ When a WooCommerce Subscription status changes.
 | `email`           | `string` |
 | `status_before`   | `string` |
 | `status_after`    | `string` |
+| `amount`          | `float`  |
+| `currency`        | `string` |
+| `recurrence`      | `string` |
+| `platform`        | `string` |
 
 ## Registering a new action
 

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -80,6 +80,58 @@ When a reader updates their lists subscription from Newspack Newsletters.
 | `lists_added`   | `string[]` |
 | `lists_removed` | `string[]` |
 
+### `donation_new`
+
+When there's a new donation, either through Stripe or Newspack (WooCommerce) platforms.
+
+### Data
+
+| Name            | Type     |
+| --------------- | -------- |
+| `user_id`       | `int`    |
+| `email`         | `string` |
+| `amount`        | `float`  |
+| `currency`      | `string` |
+| `recurrence`    | `string` |
+| `platform`      | `string` |
+| `platform_data` | `array`  |
+
+### `donation_subscription_new`
+
+When there's a new WooCommerce Subscription. This action does not replace the `donation_new` that create the subscription.
+
+| Name            | Type     |
+| --------------- | -------- |
+| `user_id`       | `int`    |
+| `email`         | `string` |
+| `amount`        | `float`  |
+| `currency`      | `string` |
+| `recurrence`    | `string` |
+| `platform`      | `string` |
+| `platform_data` | `array`  |
+
+### `donation_subscription_cancelled`
+
+When a WooCommerce Subscription is cancelled.
+
+| Name              | Type     |
+| ----------------- | -------- |
+| `subscription_id` | `int`    |
+| `user_id`         | `int`    |
+| `email`           | `string` |
+
+### `donation_subscription_changed`
+
+When a WooCommerce Subscription status changes.
+
+| Name              | Type     |
+| ----------------- | -------- |
+| `subscription_id` | `int`    |
+| `user_id`         | `int`    |
+| `email`           | `string` |
+| `status_before`   | `string` |
+| `status_after`    | `string` |
+
 ## Registering a new action
 
 To dispatch an event, an action must first be registered with the following:

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -74,8 +74,6 @@ When a reader updates their lists subscription from Newspack Newsletters.
 
 When there's a new donation, either through Stripe or Newspack (WooCommerce) platforms.
 
-### Data
-
 | Name            | Type     |
 | --------------- | -------- |
 | `user_id`       | `int`    |

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -26,8 +26,6 @@ These events are registered by the Newspack Plugin and available by default.
 
 When a reader registers.
 
-#### Data
-
 | Name       | Type      |
 | ---------- | --------- |
 | `user_id`  | `integer` |
@@ -38,8 +36,6 @@ When a reader registers.
 
 When a reader authenticates.
 
-#### Data
-
 | Name      | Type      |
 | --------- | --------- |
 | `user_id` | `integer` |
@@ -49,8 +45,6 @@ When a reader authenticates.
 
 When a reader verifies their email address.
 
-#### Data
-
 | Name      | Type      |
 | --------- | --------- |
 | `user_id` | `integer` |
@@ -58,8 +52,6 @@ When a reader verifies their email address.
 ### `newsletter_subscribed`
 
 When a reader subscribes to newsletter lists from Newspack Newsletters subscription.
-
-#### Data
 
 | Name       | Type       |
 | ---------- | ---------- |
@@ -70,8 +62,6 @@ When a reader subscribes to newsletter lists from Newspack Newsletters subscript
 ### `newsletter_updated`
 
 When a reader updates their lists subscription from Newspack Newsletters.
-
-#### Data
 
 | Name            | Type       |
 | --------------- | ---------- |

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -9,6 +9,7 @@ namespace Newspack\Data_Events;
 
 use Newspack\Data_Events;
 use Newspack\Reader_Activation;
+use Newspack\Donations;
 
 /**
  * For when a reader registers.
@@ -118,7 +119,7 @@ Data_Events::register_listener(
 			'amount'        => (float) $order->get_total(),
 			'currency'      => $order->get_currency(),
 			'recurrence'    => get_post_meta( $product_id, '_subscription_period', true ),
-			'platform'      => 'newspack',
+			'platform'      => 'wc',
 			'platform_data' => [
 				'order_id'   => $order_id,
 				'product_id' => $product_id,
@@ -177,10 +178,18 @@ Data_Events::register_listener(
 		if ( 'cancelled' !== $status_to ) {
 			return;
 		}
+		$product_id = Donations::get_order_donation_product_id( $subscription->get_id() );
+		if ( ! $product_id ) {
+			return;
+		}
 		return [
 			'subscription_id' => $subscription->get_id(),
 			'user_id'         => $subscription->get_customer_id(),
 			'email'           => $subscription->get_billing_email(),
+			'amount'          => (float) $subscription->get_total(),
+			'currency'        => $subscription->get_currency(),
+			'recurrence'      => get_post_meta( $product_id, '_subscription_period', true ),
+			'platform'        => Donations::get_platform_slug(),
 		];
 	}
 );
@@ -192,12 +201,20 @@ Data_Events::register_listener(
 	'woocommerce_subscription_status_updated',
 	'donation_subscription_changed',
 	function( $subscription, $status_to, $status_from ) {
+		$product_id = Donations::get_order_donation_product_id( $subscription->get_id() );
+		if ( ! $product_id ) {
+			return;
+		}
 		return [
 			'subscription_id' => $subscription->get_id(),
 			'user_id'         => $subscription->get_customer_id(),
 			'email'           => $subscription->get_billing_email(),
 			'status_before'   => $status_from,
 			'status_after'    => $status_to,
+			'amount'          => (float) $subscription->get_total(),
+			'currency'        => $subscription->get_currency(),
+			'recurrence'      => get_post_meta( $product_id, '_subscription_period', true ),
+			'platform'        => Donations::get_platform_slug(),
 		];
 	}
 );

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -166,3 +166,38 @@ Data_Events::register_listener(
 		return $data;
 	}
 );
+
+/**
+ * For when a WooCommerce Subscription is cancelled.
+ */
+Data_Events::register_listener(
+	'woocommerce_subscription_status_updated',
+	'donation_subscription_cancelled',
+	function( $subscription, $status_from, $status_to ) {
+		if ( 'cancelled' !== $status_to ) {
+			return;
+		}
+		return [
+			'subscription_id' => $subscription->get_id(),
+			'user_id'         => $subscription->get_customer_id(),
+			'email'           => $subscription->get_billing_email(),
+		];
+	}
+);
+
+/**
+ * For when a WooCommerce Subscription status changes.
+ */
+Data_Events::register_listener(
+	'woocommerce_subscription_status_updated',
+	'donation_subscription_changed',
+	function( $subscription, $status_from, $status_to ) {
+		return [
+			'subscription_id' => $subscription->get_id(),
+			'user_id'         => $subscription->get_customer_id(),
+			'email'           => $subscription->get_billing_email(),
+			'status_before'   => $status_from,
+			'status_after'    => $status_to,
+		];
+	}
+);

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -173,7 +173,7 @@ Data_Events::register_listener(
 Data_Events::register_listener(
 	'woocommerce_subscription_status_updated',
 	'donation_subscription_cancelled',
-	function( $subscription, $status_from, $status_to ) {
+	function( $subscription, $status_to, $status_from ) {
 		if ( 'cancelled' !== $status_to ) {
 			return;
 		}
@@ -191,7 +191,7 @@ Data_Events::register_listener(
 Data_Events::register_listener(
 	'woocommerce_subscription_status_updated',
 	'donation_subscription_changed',
-	function( $subscription, $status_from, $status_to ) {
+	function( $subscription, $status_to, $status_from ) {
 		return [
 			'subscription_id' => $subscription->get_id(),
 			'user_id'         => $subscription->get_customer_id(),

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -100,3 +100,23 @@ Data_Events::register_listener(
 		];
 	}
 );
+
+/**
+ * For when there's a new donation through the Stripe platform.
+ */
+Data_Events::register_listener(
+	'newspack_stripe_new_donation',
+	'donation_new',
+	function( $client_id, $donation_data, $newsletter_email ) {
+		return [
+			'client_id'     => $client_id,
+			'amount'        => $donation_data['amount'],
+			'platform'      => 'stripe',
+			'platform_data' => [
+				'client_id'        => $client_id,
+				'donation_data'    => $donation_data,
+				'newsletter_email' => $newsletter_email,
+			],
+		];
+	}
+);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR tweaks the hook into `woocommerce_checkout_order_processed` so it's more easily accessible for other parts of the code that might want to reach donation processing. There shouldn't be any change into how the `sync_reader_from_order()` behaves.

The following donation-related listeners are added:

### `donation_new`

When there's a new donation, either through Stripe or Newspack (WooCommerce) platforms.

### Data

| Name            | Type     |
| --------------- | -------- |
| `user_id`       | `int`    |
| `email`         | `string` |
| `amount`        | `float`  |
| `currency`      | `string` |
| `recurrence`    | `string` |
| `platform`      | `string` |
| `platform_data` | `array`  |

### `donation_subscription_new`

When there's a new WooCommerce Subscription. This action does not replace the `donation_new` that create the subscription.

| Name            | Type     |
| --------------- | -------- |
| `user_id`       | `int`    |
| `email`         | `string` |
| `amount`        | `float`  |
| `currency`      | `string` |
| `recurrence`    | `string` |
| `platform`      | `string` |
| `platform_data` | `array`  |

### `donation_subscription_cancelled`

When a WooCommerce Subscription is cancelled.

| Name              | Type     |
| ----------------- | -------- |
| `subscription_id` | `int`    |
| `user_id`         | `int`    |
| `email`           | `string` |
| `amount`          | `float`  |
| `currency`        | `string` |
| `recurrence`      | `string` |
| `platform`        | `string` |

### `donation_subscription_changed`

When a WooCommerce Subscription status changes.

| Name              | Type     |
| ----------------- | -------- |
| `subscription_id` | `int`    |
| `user_id`         | `int`    |
| `email`           | `string` |
| `status_before`   | `string` |
| `status_after`    | `string` |
| `amount`          | `float`  |
| `currency`        | `string` |
| `recurrence`      | `string` |
| `platform`        | `string` |

### How to test the changes in this Pull Request:

1. Make sure you have the following constants:
```
define( 'NEWSPACK_AMP_PLUS_ENABLED', true );
define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );
define( 'NEWSPACK_LOG_LEVEL', 2 );
```
2. Make sure you have the Reader Revenue Newspack (WooCommerce) platform configured
3. Make a new one-time donation using the donation block
4. Confirm you see the logs with `[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::dispatch]: Dispatching action "donation_new" via Action Scheduler.`
5. Visit WooCommerce's Status -> Scheduled Actions
6. Confirm you see the `newspack_data_events_as_dispatch ` hook with `donation_new` as well
7. Now make a recurring donation (subscription) and confirm you see the same with: `donation_subscription_new`, `donation_subscription_changed` (switching from `pending` to `active`)
8. WIth Reader Activation enabled, make sure you have ActiveCampaign configured with a master list
9. Make a donation with a new email and confirm the contact data with donation details is being updated to ActiveCampaign as expected
10. Switch the platform to Stripe and repeats steps from 3 to 7

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->