### PR TITLE
fix(wc-to-esp): total amount field value

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -185,7 +185,8 @@ class WooCommerce_Connection {
 		// One-time donation.
 		if ( empty( $order_subscriptions ) ) {
 			$metadata[ $metadata_keys['membership_status'] ] = 'Donor';
-			$metadata[ $metadata_keys['total_paid'] ]        = (float) $customer->get_total_spent() ? $customer->get_total_spent() : $order->get_total();
+			$metadata[ $metadata_keys['total_paid'] ]        = (float) $customer->get_total_spent();
+			$metadata[ $metadata_keys['total_paid'] ]       += (float) $order->get_total();
 			$metadata[ $metadata_keys['product_name'] ]      = '';
 			$order_items                                     = $order->get_items();
 			if ( $order_items ) {
@@ -234,7 +235,9 @@ class WooCommerce_Connection {
 				$metadata[ $metadata_keys['next_payment_date'] ] = $next_payment_date;
 			}
 
-			$metadata[ $metadata_keys['total_paid'] ]   = (float) $customer->get_total_spent() ? $customer->get_total_spent() : $current_subscription->get_total();
+			$metadata[ $metadata_keys['total_paid'] ]  = (float) $customer->get_total_spent();
+			$metadata[ $metadata_keys['total_paid'] ] += (float) $current_subscription->get_total();
+
 			$metadata[ $metadata_keys['product_name'] ] = '';
 			if ( $current_subscription ) {
 				$subscription_order_items = $current_subscription->get_items();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with ESP custom fields computed from a WC transaction.

### How to test the changes in this Pull Request:

1. On `master`,
1. Enable Reader Activation and set up a site with ActiveCampaign ESP and Newspack as the Reader Revenue platform
2. Make two donations, observe the `NP_Total Paid` custom field is set to the amount of the first donation  
3. Switch to this branch, repeat the test (or make a third donation), observe the custom field value reflects the correct amount

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->