### PR TITLE
Feat/perfmatters defaults 2

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -64,7 +64,11 @@ class Perfmatters {
 			'/busting/facebook-tracking/',
 			// Twitter.
 			'ads-twitter.com',
-			// Etc.
+			// Plugins.
+			'gravityforms',
+			'mailchimp-for-woocommerce',
+			'mailchimp-for-wp',
+			// Third-party services.
 			'disqus',
 			'stripe.com',
 		];

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -76,6 +76,7 @@ class Perfmatters {
 	private static function unused_css_excluded_stylesheets() {
 		return [
 			'donateStreamlined.css',
+			'/themes/newspack-', // Any Newspack theme stylesheet.
 		];
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adjusts the Perfmatters' defaults (https://github.com/Automattic/newspack-plugin/pull/2156) so that:

- three commonly used plugins' front-end JS is delayed
- our theme's CSS is not removed in "unused CSS" feature

### How to test the changes in this Pull Request:

1. Install Perfmatters plugin and visit the front-end with the `?newspack-perfmatters-defaults` URL param
2. Observe that any JS from Gravityforms, Mailchimp For WooCommerce, or MC4WP plugins is delayed, without negative impact on these plugins' functionality
3. Observe that theme's CSS is loaded right away (ass opposed to some CSS deemed "unused" by Perfmatters).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->