### PR TITLE
Fix WPSEO & CAP author archives

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -152,6 +152,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-wordpress-seo.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
 

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -17,9 +17,7 @@ class Patches {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_reusable_blocks_menu_link' ] );
-		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
 		add_filter( 'map_meta_cap', [ __CLASS__, 'prevent_accidental_page_deletion' ], 10, 4 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'maybe_display_author_page' ] );
 		add_action( 'pre_get_posts', [ __CLASS__, 'restrict_others_posts' ] );
@@ -86,38 +84,10 @@ class Patches {
 	}
 
 	/**
-	 * Use the Co-Author in Slack preview metadata instead of the regular post author if needed.
-	 *
-	 * @param array $slack_data Array of data which will be output in twitter:data tags.
-	 * @return array Modified $slack_data
-	 */
-	public static function use_cap_for_slack_preview( $slack_data ) {
-		if ( function_exists( 'coauthors' ) && is_single() && isset( $slack_data[ __( 'Written by', 'wordpress-seo' ) ] ) ) {
-			$slack_data[ __( 'Written by', 'wordpress-seo' ) ] = coauthors( null, null, null, null, false );
-		}
-
-		return $slack_data;
-	}
-
-	/**
 	 * Add a menu link in WP Admin to easily edit and manage reusable blocks.
 	 */
 	public static function add_reusable_blocks_menu_link() {
 		add_submenu_page( 'edit.php', 'manage_reusable_blocks', __( 'Reusable Blocks' ), 'edit_posts', 'edit.php?post_type=wp_block', '', 2 );
-	}
-
-	/**
-	 * On Atomic infrastructure, URLs are `http` for Facebook requests.
-	 * This forces the `og:url` to `http` for consistency, to prevent 301 redirect loop issues.
-	 *
-	 * @param string $og_url The opengraph URL.
-	 * @return string modified $og_url
-	 */
-	public static function http_ogurls( $og_url ) {
-		if ( defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID ) {
-			$og_url = str_replace( 'https:', 'http:', $og_url );
-		}
-		return $og_url;
 	}
 
 	/**

--- a/includes/plugins/class-wordpress-seo.php
+++ b/includes/plugins/class-wordpress-seo.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Yoast (wordpress-seo) integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class WordPress_SEO {
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
+		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
+	}
+
+	/**
+	 * Use the Co-Author in Slack preview metadata instead of the regular post author if needed.
+	 *
+	 * @param array $slack_data Array of data which will be output in twitter:data tags.
+	 * @return array Modified $slack_data
+	 */
+	public static function use_cap_for_slack_preview( $slack_data ) {
+		if ( function_exists( 'coauthors' ) && is_single() && isset( $slack_data[ __( 'Written by', 'wordpress-seo' ) ] ) ) {
+			$slack_data[ __( 'Written by', 'wordpress-seo' ) ] = coauthors( null, null, null, null, false );
+		}
+
+		return $slack_data;
+	}
+
+	/**
+	 * On Atomic infrastructure, URLs are `http` for Facebook requests.
+	 * This forces the `og:url` to `http` for consistency, to prevent 301 redirect loop issues.
+	 *
+	 * @param string $og_url The opengraph URL.
+	 * @return string modified $og_url
+	 */
+	public static function http_ogurls( $og_url ) {
+		if ( defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID ) {
+			$og_url = str_replace( 'https:', 'http:', $og_url );
+		}
+		return $og_url;
+	}
+}
+WordPress_SEO::init();

--- a/includes/plugins/class-wordpress-seo.php
+++ b/includes/plugins/class-wordpress-seo.php
@@ -19,6 +19,7 @@ class WordPress_SEO {
 	public static function init() {
 		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
 		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
+		add_filter( 'wpseo_robots_array', [ __CLASS__, 'allow_indexing_guest_author_archive' ], 10, 2 );
 	}
 
 	/**
@@ -47,6 +48,44 @@ class WordPress_SEO {
 			$og_url = str_replace( 'https:', 'http:', $og_url );
 		}
 		return $og_url;
+	}
+
+	/**
+	 * CoAuthors Plus and Yoast are incompatible where the author archives for guest authors are output as noindex.
+	 * This filter will determine if we're on an author archive and reset the robots.txt string properly.
+	 *
+	 * See https://github.com/Yoast/wordpress-seo/issues/9147.
+	 *
+	 * @param string                 $robots       The meta robots directives to be echoed.
+	 * @param Indexable_Presentation $presentation The presentation of an indexable.
+	 */
+	public static function allow_indexing_guest_author_archive( $robots, $presentation ) {
+		if ( ! is_author() ) {
+			return $robots;
+		}
+
+		if ( ! is_a( $presentation, '\Yoast\WP\SEO\Presentations\Indexable_Author_Archive_Presentation' ) ) {
+			return $robots;
+		}
+
+		$post_type = get_post_type( get_queried_object_id() );
+		if ( 'guest-author' !== $post_type ) {
+			return $robots;
+		}
+
+		/*
+		 * If this is a guest author archive and hasn't manually been set to noindex,
+		 * make sure the robots.txt string is set properly.
+		 */
+		if ( empty( $presentation->model->is_robots_noindex ) || 0 === intval( $presentation->model->is_robots_noindex ) ) {
+			if ( ! is_array( $robots ) ) {
+				$robots = [];
+			}
+			$robots['index']  = 'index';
+			$robots['follow'] = 'follow';
+		}
+
+		return $robots;
 	}
 }
 WordPress_SEO::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1506

### How to test the changes in this Pull Request:

1. On `master`, ensure Yoast plugin is active and visit a guest author's archive page
2. View page source, observe the `<meta name='robots' content='noindex, follow' />` tag is there – preventing search engines from indexing the site
3. Switch to this branch, reload the page, observe the tag has now a different value (`<meta name='robots' content='index, follow, max-image-preview:large' />`), allowing for indexing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->