### PR TITLE
Disable WC emails sent on sub. renewal for Stripe sync'd subs

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -472,6 +472,12 @@ class WooCommerce_Connection {
 			}
 		}
 
+		/**
+		 * Disable the emails sent to admin & customer after a subscription renewal order is completed.
+		 */
+		\add_filter( 'woocommerce_email_enabled_customer_completed_renewal_order', '__return_false' );
+		\add_filter( 'woocommerce_email_enabled_new_renewal_order', '__return_false' );
+
 		if ( 'renewed' === $subscription_status ) {
 			/**
 			 * Handle WooCommerce Subscriptions - subscription renewal. This will create a new order
@@ -485,8 +491,8 @@ class WooCommerce_Connection {
 				$order->save();
 				Logger::log( 'Updated WC subscription with id: ' . $subscription->get_id() . ' with a new order of id: ' . $order->get_id() );
 			} else {
-				// Linked subscription not found, just create an order. Temporarily disable the
-				// "New Order" email, since this is a renewal.
+				// Linked subscription not found, just create an order.
+				// Temporarily disable the "New Order" email, since this is a renewal.
 				\add_filter( 'woocommerce_email_enabled_new_order', '__return_false' );
 				$order = self::create_order( $order_data, $item );
 				\remove_filter( 'woocommerce_email_enabled_new_order', '__return_false' );
@@ -533,6 +539,9 @@ class WooCommerce_Connection {
 				}
 			}
 		}
+
+		\remove_filter( 'woocommerce_email_enabled_customer_completed_renewal_order', '__return_false' );
+		\remove_filter( 'woocommerce_email_enabled_new_renewal_order', '__return_false' );
 
 		/**
 		 * Handle WooCommerce Memberships.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For WC Subscriptions which just shadow Stripe subscriptions ("synchronised subscriptions"), there's no need to send emails to the customer and admin on subscription renewal. The customer will receive Newspack-configured "Thank You" email, and for the admin it was reported to be unhelpful to receive an email on renewal.  

### How to test the changes in this Pull Request:

1. Follow steps in https://github.com/Automattic/newspack-plugin/pull/1936 to set up Stripe test clock with a subscription
2. Advance time by a month, observe (e.g. via Mailhog) that only one email is sent on subscription renewal – the "Thank You" Newspack-configured email. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->