### PR TITLE
feat(data-events): mailchimp connector

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -82,6 +82,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-webhooks.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/listeners.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/connectors/class-mailchimp.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/analytics/class-analytics.php';

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -92,9 +92,9 @@ class Mailchimp {
 					$fields_ids[ $field['merge_id'] ] = $field_name;
 				}
 				// If field name is found, add it to the payload.
-				if ( ! empty( $field_name ) ) {
+				if ( ! empty( $field_name ) && isset( $data[ $field_name ] ) ) {
 					$merge_fields[ $field['tag'] ] = $data[ $field_name ];
-					unset( $data[ $field['name'] ] );
+					unset( $data[ $field_name ] );
 				}
 			}
 			// Create remaining fields.

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -23,7 +23,7 @@ class Mailchimp {
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( true === Reader_Activation::get_setting( 'sync_esp' ) ) {
+		if ( Reader_Activation::is_enabled() && true === Reader_Activation::get_setting( 'sync_esp' ) ) {
 			Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
 			Data_Events::register_handler( [ __CLASS__, 'donation_new' ], 'donation_new' );
 		}
@@ -36,9 +36,7 @@ class Mailchimp {
 	 */
 	private static function get_audience_id() {
 		/** TODO: UI for handling Mailchimp's master list in RAS. */
-		if ( Reader_Activation::is_enabled() ) {
-			$audience_id = Reader_Activation::get_setting( 'mailchimp_audience_id' );
-		}
+		$audience_id = Reader_Activation::get_setting( 'mailchimp_audience_id' );
 		/** Attempt to use list ID from "Mailchimp for WooCommerce" */
 		if ( ! $audience_id && function_exists( 'mailchimp_get_list_id' ) ) {
 			$audience_id = mailchimp_get_list_id();

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -159,7 +159,16 @@ class Mailchimp {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function reader_registered( $timestamp, $data, $client_id ) {
-		self::put( $data['email'], $data['metadata'] );
+		$metadata = [
+			'NP_Account' => $data['user_id'],
+		];
+		if ( isset( $data['metadata']['current_page_url'] ) ) {
+			$metadata['NP_Registration Page'] = $data['metadata']['current_page_url'];
+		}
+		if ( isset( $data['metadata']['registration_method'] ) ) {
+			$metadata['NP_Registration Method'] = $data['metadata']['registration_method'];
+		}
+		self::put( $data['email'], $metadata );
 	}
 
 	/**

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -147,10 +147,22 @@ class Mailchimp {
 		$order_id = $data['platform_data']['order_id'];
 		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id );
 
-		// We don't want to overwrite the registration method.
-		unset( $contact['metadata']['registration_method'] );
+		if ( ! $contact ) {
+			return;
+		}
 
-		self::put( $contact['email'], $contact['metadata'] );
+		$email    = $contact['email'];
+		$metadata = $contact['metadata'];
+		$keys     = Newspack_Newsletters::$metadata_keys;
+
+		// Only use metadata defined in 'Newspack_Newsletters'.
+		$metadata = array_intersect_key( $metadata, array_flip( $keys ) );
+
+		// Remove "product name" from metadata. This requires a better strategy
+		// since it's updated on every different donation.
+		unset( $metadata[ $keys['product_name'] ] );
+
+		self::put( $email, $metadata );
 	}
 }
 new Mailchimp();

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Newspack Data Events Mailchimp Connector
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Data_Events\Connectors;
+
+use \Newspack\Data_Events;
+use \Newspack\Mailchimp_API;
+use \Newspack\Newspack_Newsletters;
+use \Newspack\Reader_Activation;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main Class.
+ */
+class Mailchimp {
+
+	/**
+	 * Merge fields.
+	 *
+	 * @var array
+	 */
+	public static $fields = [
+		'FNAME' => 'first_name',
+		'LNAME' => 'last_name',
+	];
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
+	}
+
+	/**
+	 * Get audience ID.
+	 *
+	 * @return string|bool Audience ID or false if not set.
+	 */
+	public static function get_audience_id() {
+		/** TODO: UI for handling Mailchimp's master list in RAS. */
+		if ( Reader_Activation::is_enabled() ) {
+			$audience_id = Reader_Activation::get_setting( 'mailchimp_audience_id' );
+		}
+		/** Attempt to use list ID from "Mailchimp for WooCommerce" */
+		if ( ! $audience_id && function_exists( 'mailchimp_get_list_id' ) ) {
+			$audience_id = mailchimp_get_list_id();
+		}
+		return ! empty( $audience_id ) ? $audience_id : false;
+	}
+
+	/**
+	 * Handle a reader registering.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 */
+	public static function reader_registered( $timestamp, $data, $client_id ) {
+		$email = $data['email'];
+
+		$audience_id = self::get_audience_id();
+		if ( ! $audience_id ) {
+			return;
+		}
+		$hash = md5( strtolower( $email ) );
+		Mailchimp_API::put(
+			"lists/$audience_id/members/$hash",
+			[
+				'email_address' => $email,
+				'status_if_new' => 'transactional',
+			]
+		);
+	}
+}
+new Mailchimp();

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -23,8 +23,10 @@ class Mailchimp {
 	 * Constructor.
 	 */
 	public function __construct() {
-		Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
-		Data_Events::register_handler( [ __CLASS__, 'donation_new' ], 'donation_new' );
+		if ( true === Reader_Activation::get_setting( 'sync_esp' ) ) {
+			Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
+			Data_Events::register_handler( [ __CLASS__, 'donation_new' ], 'donation_new' );
+		}
 	}
 
 	/**

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -79,28 +79,41 @@ class Mailchimp {
 		];
 		if ( ! empty( $data ) ) {
 			$merge_fields    = [];
+			$fields_ids      = \get_option( 'newspack_data_mailchimp_fields', [] );
 			$existing_fields = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" );
 			foreach ( $existing_fields['merge_fields'] as $field ) {
-				if ( isset( $data[ $field['name'] ] ) ) {
-					$merge_fields[ $field['tag'] ] = $data[ $field['name'] ];
+				$field_name = '';
+				if ( isset( $fields_ids[ $field['merge_id'] ] ) ) {
+					// Match locally stored merge field ID.
+					$field_name = $fields_ids[ $field['merge_id'] ];
+				} elseif ( isset( $data[ $field['name'] ] ) ) {
+					// Match by merge field name.
+					$field_name                       = $field['name'];
+					$fields_ids[ $field['merge_id'] ] = $field_name;
+				}
+				// If field name is found, add it to the payload.
+				if ( ! empty( $field_name ) ) {
+					$merge_fields[ $field['tag'] ] = $data[ $field_name ];
 					unset( $data[ $field['name'] ] );
 				}
 			}
-			$remaining_fields = array_keys( $data );
 			// Create remaining fields.
+			$remaining_fields = array_keys( $data );
 			foreach ( $remaining_fields as $field_name ) {
-				$created_field                         = Mailchimp_API::post(
+				$created_field                            = Mailchimp_API::post(
 					"lists/$audience_id/merge-fields",
 					[
 						'name' => $field_name,
 						'type' => self::get_merge_field_type( $data[ $field_name ] ),
 					]
 				);
-				$merge_fields[ $created_field['tag'] ] = $data[ $field_name ];
+				$merge_fields[ $created_field['tag'] ]    = $data[ $field_name ];
+				$fields_ids[ $created_field['merge_id'] ] = $field_name;
 			}
 			if ( ! empty( $merge_fields ) ) {
 				$payload['merge_fields'] = $merge_fields;
 			}
+			\update_option( 'newspack_data_mailchimp_fields', $fields_ids );
 		}
 		Mailchimp_API::put(
 			"lists/$audience_id/members/$hash",

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -24,7 +24,11 @@ class Mailchimp {
 	 * Constructor.
 	 */
 	public function __construct() {
-		if ( Reader_Activation::is_enabled() && true === Reader_Activation::get_setting( 'sync_esp' ) ) {
+		if (
+			defined( 'NEWSPACK_DATA_EVENTS_MAILCHIMP' ) && NEWSPACK_DATA_EVENTS_MAILCHIMP &&
+			Reader_Activation::is_enabled() &&
+			true === Reader_Activation::get_setting( 'sync_esp' )
+		) {
 			Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
 			Data_Events::register_handler( [ __CLASS__, 'donation_new' ], 'donation_new' );
 			Data_Events::register_handler( [ __CLASS__, 'donation_subscription_new' ], 'donation_subscription_new' );

--- a/includes/oauth/class-mailchimp-api.php
+++ b/includes/oauth/class-mailchimp-api.php
@@ -80,18 +80,7 @@ class Mailchimp_API {
 	 * @return WP_REST_Response
 	 */
 	public static function api_mailchimp_auth_status() {
-		// 'newspack_mailchimp_api_key' is a new option introduced to manage MC API key accross Newspack plugins.
-		// Keeping the old option for backwards compatibility.
-		$mailchimp_api_key = get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) );
-		$endpoint          = self::get_api_endpoint_from_key( $mailchimp_api_key );
-
-		if ( ! $mailchimp_api_key || ! $endpoint ) {
-			return \rest_ensure_response( [] );
-		}
-
-		$key_is_valid_response = self::is_valid_api_key( $endpoint, $mailchimp_api_key );
-
-		return $key_is_valid_response;
+		return self::is_valid_api_key();
 	}
 
 	/**
@@ -106,7 +95,7 @@ class Mailchimp_API {
 			return new \WP_Error( 'wrong_parameter', __( 'Invalid Mailchimp API Key.', 'newspack' ) );
 		}
 
-		$key_is_valid_response = self::is_valid_api_key( $endpoint, $request['api_key'] );
+		$key_is_valid_response = self::is_valid_api_key( $request['api_key'] );
 
 		if ( ! is_wp_error( $key_is_valid_response ) ) {
 			update_option( 'newspack_mailchimp_api_key', $request['api_key'] );
@@ -143,74 +132,40 @@ class Mailchimp_API {
 	/**
 	 * Check API Key validity
 	 *
-	 * @param string $endpoint Mailchimp API Endpoint.
 	 * @param string $api_key Mailchimp API Key.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private static function is_valid_api_key( $endpoint, $api_key ) {
+	private static function is_valid_api_key( $api_key = '' ) {
 		// Mailchimp API root endpoint returns details about the Mailchimp user account.
-		$response = wp_safe_remote_get(
-			$endpoint,
-			[
-				'headers' => [
-					'Accept'        => 'application/json',
-					'Content-Type'  => 'application/json',
-					'Authorization' => "Basic $api_key",
-				],
-			]
-		);
-
+		$response = self::request( 'GET', '', [], $api_key );
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			$parsed_response = json_decode( $response['body'], true );
-
-			return new \WP_Error(
-				'newspack_mailchimp_api',
-				array_key_exists( 'title', $parsed_response ) ? $parsed_response['title'] : __( 'Request failed.', 'newspack' )
-			);
-		}
-
-		$response_body = json_decode( $response['body'], true );
-		return \rest_ensure_response( [ 'username' => $response_body['username'] ] );
-	}
-
-	/**
-	 * Get the Mailchimp API endpoint.
-	 *
-	 * @return string|WP_Error the API endpoint or an error if the API key is not set.
-	 */
-	public static function get_endpoint() {
-		// 'newspack_mailchimp_api_key' is a new option introduced to manage MC API key accross Newspack plugins.
-		// Keeping the old option for backwards compatibility.
-		$mailchimp_api_key = get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) );
-		if ( ! $mailchimp_api_key ) {
-			return new \WP_Error( 'newspack_mailchimp_api', __( 'Mailchimp API key is not set.', 'newspack' ) );
-		}
-		return self::get_api_endpoint_from_key( $mailchimp_api_key );
+		return \rest_ensure_response( [ 'username' => $response['username'] ] );
 	}
 
 	/**
 	 * Perform Mailchimp API Request
 	 *
-	 * @param string $method HTTP method.
-	 * @param string $path API path.
-	 * @param array  $data Data to send.
+	 * @param string $method  HTTP method.
+	 * @param string $path    API path.
+	 * @param array  $data    Data to send.
+	 * @param string $api_key Optional API key to override the default one.
 	 *
 	 * @return array|WP_Error response body or error.
 	 */
-	public static function request( $method, $path, $data = [] ) {
-		$endpoint = self::get_endpoint();
-		if ( \is_wp_error( $endpoint ) ) {
-			return $endpoint;
+	public static function request( $method, $path = '', $data = [], $api_key = '' ) {
+		if ( empty( $api_key ) ) {
+			// 'newspack_mailchimp_api_key' is a new option introduced to manage MC API key accross Newspack plugins.
+			// Keeping the old option for backwards compatibility.
+			$api_key = \get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) );
 		}
-
-		// 'newspack_mailchimp_api_key' is a new option introduced to manage MC API key accross Newspack plugins.
-		// Keeping the old option for backwards compatibility.
-		$api_key = \get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) );
-		$url     = $endpoint . '/' . $path;
-		$config  = [
+		$endpoint = self::get_api_endpoint_from_key( $api_key );
+		if ( ! $endpoint ) {
+			return new \WP_Error( 'wrong_parameter', __( 'Invalid Mailchimp API Key.', 'newspack' ) );
+		}
+		$url    = $endpoint . '/' . $path;
+		$config = [
 			'method'  => $method,
 			'headers' => [
 				'Accept'        => 'application/json',
@@ -243,7 +198,7 @@ class Mailchimp_API {
 	 *
 	 * @return array|WP_Error API response or error.
 	 */
-	public static function get( $path ) {
+	public static function get( $path = '' ) {
 		return self::request( 'GET', $path );
 	}
 
@@ -255,7 +210,7 @@ class Mailchimp_API {
 	 *
 	 * @return array|WP_Error API response or error.
 	 */
-	public static function put( $path, $data ) {
+	public static function put( $path = '', $data ) {
 		return self::request( 'PUT', $path, $data );
 	}
 }

--- a/includes/oauth/class-mailchimp-api.php
+++ b/includes/oauth/class-mailchimp-api.php
@@ -213,6 +213,18 @@ class Mailchimp_API {
 	public static function put( $path = '', $data ) {
 		return self::request( 'PUT', $path, $data );
 	}
+
+	/**
+	 * Perform a POST request to Mailchimp's API
+	 *
+	 * @param string $path API path.
+	 * @param array  $data Data to send.
+	 *
+	 * @return array|WP_Error API response or error.
+	 */
+	public static function post( $path = '', $data ) {
+		return self::request( 'POST', $path, $data );
+	}
 }
 
 new Mailchimp_API();

--- a/includes/oauth/class-mailchimp-api.php
+++ b/includes/oauth/class-mailchimp-api.php
@@ -210,7 +210,7 @@ class Mailchimp_API {
 	 *
 	 * @return array|WP_Error API response or error.
 	 */
-	public static function put( $path = '', $data ) {
+	public static function put( $path = '', $data = [] ) {
 		return self::request( 'PUT', $path, $data );
 	}
 
@@ -222,7 +222,7 @@ class Mailchimp_API {
 	 *
 	 * @return array|WP_Error API response or error.
 	 */
-	public static function post( $path = '', $data ) {
+	public static function post( $path = '', $data = [] ) {
 		return self::request( 'POST', $path, $data );
 	}
 }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -174,6 +174,7 @@ final class Reader_Activation {
 			'sync_esp'                    => true,
 			'sync_esp_delete'             => true,
 			'active_campaign_master_list' => '',
+			'mailchimp_audience_id'       => '',
 			'emails'                      => Emails::get_emails( array_values( Reader_Activation_Emails::EMAIL_TYPES ), false ),
 			'sender_name'                 => Emails::get_from_name(),
 			'sender_email_address'        => Emails::get_from_email(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements the Mailchimp connector using Data Events, producing a result similar to what is achieved for ActiveCampaign with RAS.

Just like the AC implementation, this also requires a "master list", or a single audience, to send the data to. It will automatically fetch from the "Mailchimp for WooCommerce" plugin setting if it's not configured in the RAS setting `mailchimp_audience_id`.

The UI for configuring Mailchimp's master list should be built next, not in this PR.

The data transformation borrows the logic from `WooCommerce_Connection`, by moving the contact generation portion to a `get_contact_from_order( $order )` method so it can be reused.

The same logic used for ActiveCampaign in `Newspack\Newspack_Newsletters` is not reproduced, meaning:
 - No UTM integration
 - `NP_Product Name` is removed. This value will change with every different purchase, it's not clear to me the purpose of treating it as a singular contact data. Perhaps we need a better strategy for this?

The contact is upserted as soon as registered, with `status` set to `transactional` if it's new (not yet subscribed), through a handler attached to the `reader_registered` action.

Purchase updates are sent through a handler at the `donation_new` action. The order data is transformed with `WooCommerce_Connection::get_contact_from_order( $order );`.

### How to test the changes in this Pull Request:

1. Make sure you have the following constants:
```php
define( 'NEWSPACK_AMP_PLUS_ENABLED', true );
define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );
define( 'NEWSPACK_LOG_LEVEL', 2 );
```
2. Make sure you have Mailchimp connected and reader revenue configured with either Stripe or Newspack platform
3. Install the `Mailchimp for WooCommerce` plugin configure with the same account and set it to an audience (this is required only until we have our own UI for setting the master list)
4. Configure a Reader Registration prompt
5. In a fresh session, register a reader through the prompt **without** subscribing to newsletters
6. Wait until `Executing action handlers for "reader_registered"` is logged
7. Confirm the contact is created in Mailchimp with the status `transactional` and the following merge fields filled:
   1. `NP_Account`
   2. `NP_Registration Page`
   3. `NP_Registration Method`
8. Make a purchase and confirm the data from `get_contact_from_order()` is updated to the same contact
9. Through the "My Account" page subscribe to the newsletter and confirm the you're subscribed without any merge field data being altered/removed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->