### PR TITLE
Standardize Stripe API version around latest version

### DIFF
--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -634,7 +634,12 @@ class Stripe_Connection {
 	public static function get_stripe_client() {
 		$secret_key = self::get_stripe_secret_key();
 		if ( $secret_key ) {
-			return new \Stripe\StripeClient( $secret_key );
+			return new \Stripe\StripeClient(
+				[
+					'api_key'        => $secret_key,
+					'stripe_version' => '2022-11-15',
+				]
+			);
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes at least one issue around the Stripe API and standardizes the Stripe API version across Newspack. I've simply picked the latest stable version.

Each Stripe account [has a default version of the Stripe API](https://stripe.com/docs/development/dashboard/request-logs#view-your-default-api-version), and this introduces inconsistencies because different API versions have different features available. For example, [the search endpoint used in the RAS backfill script](https://github.com/Automattic/newspack-plugin/blob/master/includes/reader-revenue/stripe/class-stripe-connection.php#L179) is only available [in Stripe versions `2020-08-27 ` or greater](https://stripe.com/docs/search#minimum-api-version), so if a site has a default Stripe API version less than that (e.g. `2018-05-21`), the RAS backfill script throws `Warning: Error fetching customer invoices: Could not fetch customer's charges.` errors on every customer.

### How to test the changes in this Pull Request:

1. After checking out this PR, change the `stripe_version` bit to `2018-05-21`
2. Try `wp newspack stripe sync-customers --dry-run=1`. Observe the above error is thrown on each customer.
3. Use the latest Stripe version from this PR. Try the command again. Observe it works nicely.
4. Try donating and other Stripe-based actions and verify those still work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->