### PR TITLE
fix: use newer stripe api version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.99.2-hotfix.1](https://github.com/Automattic/newspack-plugin/compare/v1.99.1...v1.99.2-hotfix.1) (2023-01-18)
+
+
+### Bug Fixes
+
+* use newer stripe api version ([b5d1fc7](https://github.com/Automattic/newspack-plugin/commit/b5d1fc7804df7329bc3ad43b19341962705e46e8))
+
 ## [1.99.1](https://github.com/Automattic/newspack-plugin/compare/v1.99.0...v1.99.1) (2022-12-19)
 
 

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -628,7 +628,12 @@ class Stripe_Connection {
 	public static function get_stripe_client() {
 		$secret_key = self::get_stripe_secret_key();
 		if ( $secret_key ) {
-			return new \Stripe\StripeClient( $secret_key );
+			return new \Stripe\StripeClient(
+				[
+					'api_key'        => $secret_key,
+					'stripe_version' => '2022-11-15',
+				]
+			);
 		}
 	}
 

--- a/newspack.php
+++ b/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 1.99.1
+ * Version: 1.99.2-hotfix.1
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '1.99.1' );
+define( 'NEWSPACK_PLUGIN_VERSION', '1.99.2-hotfix.1' );
 
 // Load language files.
 load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack",
-  "version": "1.99.1",
+  "version": "1.99.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack",
-      "version": "1.99.1",
+      "version": "1.99.2-hotfix.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack",
-  "version": "1.99.1",
+  "version": "1.99.2-hotfix.1",
   "description": "The Newspack plugin. https://newspack.pub",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-plugin/issues"


### PR DESCRIPTION
https://github.com/Automattic/newspack-plugin/pull/2234 as a hotfix. 