### PR TITLE
feat: optimise the HP block that renders first on a page

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -154,6 +154,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-performance.php';
 
 		if ( Donations::is_platform_nrh() ) {
 			include_once NEWSPACK_ABSPATH . 'includes/class-nrh.php';

--- a/includes/class-performance.php
+++ b/includes/class-performance.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Performance management.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages settings for Performance.
+ */
+class Performance {
+	/**
+	 * Whether page content is rendered now.
+	 *
+	 * @var bool
+	 */
+	public static $is_rendering_page_content = false;
+
+	/**
+	 * Index of currently rendered Homepage Post Block.
+	 *
+	 * @var int
+	 */
+	public static $current_homepage_posts_block = 0;
+
+	/**
+	 * Add hooks.
+	 */
+	public static function init() {
+		add_filter( 'newspack_blocks_homepage_posts_block_attributes', [ __CLASS__, 'optimise_homepage_posts_block' ] );
+		add_action( 'newspack_theme_before_page_content', [ __CLASS__, 'mark_page_content_rendering_start' ] );
+	}
+
+	/**
+	 * Mark page content rendering start.
+	 */
+	public static function mark_page_content_rendering_start() {
+		self::$is_rendering_page_content = true;
+	}
+
+	/**
+	 * Turn of image lazy loading for the first two homepage posts blocks rendered on a page.
+	 * These first blocks are likely to contain the Largest Contentful Paint image, which should
+	 * not be deprioritised by lazy-loading, and should be prioritized with the fetchpriority hint.
+	 *
+	 * @param array $attributes Block attributes.
+	 */
+	public static function optimise_homepage_posts_block( $attributes ) {
+		if ( self::$is_rendering_page_content ) {
+			if ( 0 === self::$current_homepage_posts_block ) {
+				$attributes['disableImageLazyLoad'] = true;
+				$attributes['fetchPriority']        = 'high';
+			}
+			self::$current_homepage_posts_block++;
+		}
+		return $attributes;
+	}
+}
+Performance::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Optimises the first two Homepage Posts blocks that appear on a page.

[It's recommended](https://web.dev/top-cwv-2023/#ensure-the-lcp-resource-is-prioritized) to prioritise the Largest Contentful Paint image (the above-the-fold, largest image) by setting a `fetchpriority="high"` attribute on the `img` element, and _not to deprioritize_ it by lazy-loading. 

We already have the block-level setting to disable lazy loading (https://github.com/Automattic/newspack-blocks/pull/970), but this solution goes a step further by forcing it on first two HP blocks rendered on a page. 

### How to test the changes in this Pull Request:

0. On `master`, visit the standard Newspack homepage (you can reset the HP layout in the setup wizard, at `/wp-admin/admin.php?page=newspack-setup-wizard#/design`)
1. Load the homepage, observe the image(s) in the first (top) HP blocks have `loading="lazy"` attributes set, and don't have the `fetchpriority` attribute set
2. Switch to this branch 
3. Switch `newspack-theme` repository to `feat/page-content-hooks` branch
4. Switch `newspack-blocks` repository to `feat/hpb-fetch-priority-attr` branch
5. Reload the homepage, observe the image(s) in the first two HP blocks have no `loading="lazy"` attribute and do have the `fetchpriority="high"` attribute

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->