### PR TITLE
Optimise Newspack Ads' inline JS

### DIFF
--- a/includes/analytics/class-analytics-events.php
+++ b/includes/analytics/class-analytics-events.php
@@ -483,15 +483,8 @@ class Analytics_Events {
 				self::$js_events[ $event['on'] ] += 1;
 			}
 
-			// Remove unnecessary whitespace.
-			$html = preg_replace(
-				[ '/(<script>|,|\(|\)|\{|\}|;|\&\&)\s+/', '/\s+(<script>|,|\(|\)|\{|\}|;|\&\&)/' ],
-				'\1',
-				ob_get_clean()
-			);
-
 			// Other integrations can use this filter if they need to add a custom JS event handler.
-			$event_js = apply_filters( 'newspack_analytics_event_js', $html, $event );
+			$event_js = apply_filters( 'newspack_analytics_event_js', ob_get_clean(), $event );
 			echo $event_js; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}

--- a/includes/class-performance.php
+++ b/includes/class-performance.php
@@ -36,6 +36,8 @@ class Performance {
 		add_filter( 'newspack_blocks_homepage_posts_block_attributes', [ __CLASS__, 'optimise_homepage_posts_block' ] );
 		add_action( 'newspack_theme_before_page_content', [ __CLASS__, 'mark_page_content_rendering_start' ] );
 		add_filter( 'newspack_analytics_event_js', [ __CLASS__, 'optimize_js' ] );
+		add_filter( 'newspack_ads_frontend_js', [ __CLASS__, 'optimize_js' ] );
+		add_filter( 'newspack_ads_lazy_loading_js', [ __CLASS__, 'optimize_js' ] );
 	}
 
 	/**

--- a/includes/class-performance.php
+++ b/includes/class-performance.php
@@ -35,6 +35,20 @@ class Performance {
 	public static function init() {
 		add_filter( 'newspack_blocks_homepage_posts_block_attributes', [ __CLASS__, 'optimise_homepage_posts_block' ] );
 		add_action( 'newspack_theme_before_page_content', [ __CLASS__, 'mark_page_content_rendering_start' ] );
+		add_filter( 'newspack_analytics_event_js', [ __CLASS__, 'optimize_js' ] );
+	}
+
+	/**
+	 * Optimise JS code.
+	 *
+	 * @param string $js_code JS code.
+	 */
+	public static function optimize_js( $js_code ) {
+		return preg_replace(
+			[ '/(<script>|,|\(|\)|\{|\}|;|\&\&)\s+/', '/\s+(<script>|,|\(|\)|\{|\}|;|\&\&)/' ],
+			'\1',
+			$js_code
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Minifies inline JS produced by Newspack Ads plugin by removing unnecessary whitespace. 

### How to test the changes in this Pull Request:

0. Switch to `feat/optmise-fe-js` branch of `newspack-ads`
1. Configure a site to use GAM for ads
2. Visit a page, look at page source – observe the inline JS (search for e.g. "boundsContainers") is minified (whitespace removed)
3. Observe that ads load fine (the JS is working)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->