### PR TITLE
feat(performance): minify all inline CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ release
 # Tests
 codecov/
 coverage/
+.phpunit.result.cache

--- a/includes/class-performance.php
+++ b/includes/class-performance.php
@@ -35,6 +35,9 @@ class Performance {
 	public static function init() {
 		add_filter( 'newspack_blocks_homepage_posts_block_attributes', [ __CLASS__, 'optimise_homepage_posts_block' ] );
 		add_action( 'newspack_theme_before_page_content', [ __CLASS__, 'mark_page_content_rendering_start' ] );
+
+		add_action( 'template_redirect', [ __CLASS__, 'process_output_html' ] );
+		add_filter( 'newspack_output_html', [ __CLASS__, 'minify_inline_style_tags' ] );
 	}
 
 	/**
@@ -60,6 +63,62 @@ class Performance {
 			self::$current_homepage_posts_block++;
 		}
 		return $attributes;
+	}
+
+	/**
+	 * Process the HTML output.
+	 */
+	public static function process_output_html() {
+		if ( defined( 'NEWSPACK_DISABLE_HTML_PERF_PROCESSING' ) && NEWSPACK_DISABLE_HTML_PERF_PROCESSING ) {
+			return;
+		}
+		if ( ! has_filter( 'newspack_output_html' ) ) {
+			return;
+		}
+		if ( is_embed() || is_feed() || is_preview() || is_customize_preview() ) {
+			return;
+		}
+		ob_start(
+			function( $html ) {
+				if ( stripos( $html, '<html' ) === false || stripos( $html, '</body>' ) === false || stripos( $html, '<xsl:stylesheet' ) !== false ) {
+					return $html;
+				}
+				return (string) apply_filters( 'newspack_output_html', $html );
+			}
+		);
+	}
+
+	/**
+	 * Minify a CSS string.
+	 *
+	 * @param string $css CSS string.
+	 */
+	private static function minify_css( $css ) {
+		// Remove comments.
+		$css = preg_replace( '/\/\*(?:(?!\*\/).)*\*\//is', '', $css );
+		// Remove whitespace.
+		$css = preg_replace(
+			[ '/(,|\{|\}|;|\*\/)\s+/', '/\s+(,|\{|\}|;|\*\/)/' ],
+			'\1',
+			$css
+		);
+		return trim( $css );
+	}
+
+	/**
+	 * Minify inline CSS.
+	 *
+	 * @param string $html HTML string.
+	 */
+	public static function minify_inline_style_tags( $html ) {
+		return preg_replace_callback(
+			'/(<style[^>]*>)(.*?)(<\/style>)/si',
+			function( $matches ) {
+				return $matches[1] . self::minify_css( $matches[2] ) . $matches[3];
+			},
+			$html
+		);
+
 	}
 }
 Performance::init();

--- a/tests/unit-tests/performance.php
+++ b/tests/unit-tests/performance.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Tests the Performance optmisations.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Performance;
+
+/**
+ * Tests the performance optmisations.
+ */
+class Newspack_Test_Newspack_Performance extends WP_UnitTestCase {
+	/**
+	 * Test CSS minification.
+	 */
+	public function test_performance_css_minification() {
+		$html_with_style_tags = '<html>
+			<style>
+				/* Here is a comment*/
+				/**
+				 * And this is a multi-line comment, with a link: https://example.com/hello-world
+				 */
+				body {
+					color: red;
+				}
+			</style>
+		</html>';
+		self::assertEquals(
+			'<html>
+			<style>body{color: red;}</style>
+		</html>',
+			Newspack\Performance::minify_inline_style_tags( $html_with_style_tags ),
+			'Minifies inline CSS.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds minification of all inline CSS. The minification will remove whitespace and comments. 

### How to test the changes in this Pull Request:

1. On `master`, load a page and inspect the source
2. Observe that there are `<style>` tags with CSS, which contains unnecessary whitespace and comments
3. Switch to this branch, reload the page
4. Observe the inline CSS is minified
5. Smoke-test how the page renders, to ensure the minification did not break any CSS

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->