### PR TITLE
feat: bootstrap GA4 connector

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -82,6 +82,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-webhooks.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/listeners.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/connectors/ga4/class-ga4.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/analytics/class-analytics.php';

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -103,7 +103,6 @@ final class Data_Events {
 			sprintf( 'Executing global action handlers for "%s".', $action_name ),
 			self::LOGGER_HEADER
 		);
-
 		foreach ( self::$global_handlers as $handler ) {
 			try {
 				call_user_func( $handler, $action_name, $timestamp, $data, $client_id );

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -276,6 +276,11 @@ final class Data_Events {
 			return new WP_Error( 'newspack_data_events_action_not_registered', __( 'Action not registered.', 'newspack' ) );
 		}
 
+		// Append User Agent to the data so we can identify it in the async requests.
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			$data['user_agent'] = sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+		}
+
 		$timestamp = time();
 		$client_id = null;
 		if ( $use_client_id ) {

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -43,7 +43,7 @@ final class Data_Events {
 	public static function init() {
 		\add_action( 'wp_ajax_' . self::ACTION, [ __CLASS__, 'maybe_handle' ] );
 		\add_action( 'wp_ajax_nopriv_' . self::ACTION, [ __CLASS__, 'maybe_handle' ] );
-		\add_action( 'newspack_data_events_as_dispatch', [ __CLASS__, 'handle' ], 10, 4 );
+		\add_action( 'newspack_data_events_as_dispatch', [ __CLASS__, 'handle' ], 10, 5 );
 	}
 
 	/**
@@ -80,11 +80,12 @@ final class Data_Events {
 			\wp_die();
 		}
 
-		$timestamp = isset( $_POST['timestamp'] ) ? \sanitize_text_field( \wp_unslash( $_POST['timestamp'] ) ) : null;
-		$data      = isset( $_POST['data'] ) ? $_POST['data'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$client_id = isset( $_POST['client_id'] ) ? \sanitize_text_field( \wp_unslash( $_POST['client_id'] ) ) : null;
+		$timestamp  = isset( $_POST['timestamp'] ) ? \sanitize_text_field( \wp_unslash( $_POST['timestamp'] ) ) : null;
+		$data       = isset( $_POST['data'] ) ? $_POST['data'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$client_id  = isset( $_POST['client_id'] ) ? \sanitize_text_field( \wp_unslash( $_POST['client_id'] ) ) : null;
+		$user_agent = isset( $_POST['user_agent'] ) ? \sanitize_text_field( \wp_unslash( $_POST['user_agent'] ) ) : null;
 
-		self::handle( $action_name, $timestamp, $data, $client_id );
+		self::handle( $action_name, $timestamp, $data, $client_id, $user_agent );
 
 		\wp_die();
 	}
@@ -96,13 +97,20 @@ final class Data_Events {
 	 * @param int    $timestamp   Timestamp.
 	 * @param array  $data        Data.
 	 * @param string $client_id   Client ID.
+	 * @param string $user_agent  The User agent of the original request.
 	 */
-	public static function handle( $action_name, $timestamp, $data, $client_id ) {
+	public static function handle( $action_name, $timestamp, $data, $client_id, $user_agent = null ) {
 		// Execute global handlers.
 		Logger::log(
 			sprintf( 'Executing global action handlers for "%s".', $action_name ),
 			self::LOGGER_HEADER
 		);
+
+		// Override user agent with the user agent of the request that triggered the event.
+		if ( $user_agent ) {
+			$_SERVER['HTTP_USER_AGENT'] = $user_agent; // phpcs:ignore
+		}
+
 		foreach ( self::$global_handlers as $handler ) {
 			try {
 				call_user_func( $handler, $action_name, $timestamp, $data, $client_id );
@@ -276,15 +284,16 @@ final class Data_Events {
 			return new WP_Error( 'newspack_data_events_action_not_registered', __( 'Action not registered.', 'newspack' ) );
 		}
 
-		// Append User Agent to the data so we can identify it in the async requests.
-		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			$data['user_agent'] = sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-		}
-
 		$timestamp = time();
 		$client_id = null;
 		if ( $use_client_id ) {
 			$client_id = Reader_Activation::get_client_id();
+		}
+
+		// Append User Agent to the body so we can identify it in the async requests.
+		$user_agent = null;
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			$user_agent = sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
 		}
 
 		/**
@@ -317,6 +326,7 @@ final class Data_Events {
 			'timestamp'   => $timestamp,
 			'data'        => $data,
 			'client_id'   => $client_id,
+			'user_agent'  => $user_agent,
 		];
 
 		/**

--- a/includes/data-events/connectors/ga4/class-event.php
+++ b/includes/data-events/connectors/ga4/class-event.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Newspack GA4 Event
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Data_Events\Connectors\GA4;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main Class.
+ */
+class Event {
+
+	/**
+	 * The maximum number of parameters an event can have, according to the documentation.
+	 *
+	 * @var int
+	 */
+	const MAX_PARAMS = 25;
+
+	/**
+	 * Event name.
+	 *
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * Event parameters.
+	 *
+	 * @var array
+	 */
+	private $params;
+
+	/**
+	 * Constructor.
+	 *
+	 * @throws \Exception If event name or params are invalid.
+	 * @param string $name Event name.
+	 * @param array  $params Event parameters.
+	 */
+	public function __construct( $name, $params = [] ) {
+		$this->set_name( $name );
+		$this->set_params( $params );
+	}
+
+	/**
+	 * Validates the event parameters names and values
+	 *
+	 * @param array $params An array of event parameters.
+	 * @return bool
+	 */
+	public static function validate_params( $params ) {
+		if ( count( $params ) > self::MAX_PARAMS ) {
+			return false;
+		}
+
+		foreach ( $params as $name => $value ) {
+			if ( ! self::validate_name( $name ) ) {
+				return false;
+			}
+			if ( ! self::validate_param_value( $value ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks whether a event or parameter name is valid
+	 *
+	 * Event and parameter names must be 40 characters or fewer, may only contain alpha-numeric characters and underscores, and must start with an alphabetic character.
+	 *
+	 * @param string $name The event or parameter name.
+	 * @return bool
+	 */
+	public static function validate_name( $name ) {
+		if ( ! is_string( $name ) || ! preg_match( '/^[a-zA-Z0-9]{1}[a-zA-Z0-9_]{1,39}$/', $name ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Checks whether a event or parameter name is valid
+	 *
+	 * Parameter values must be 100 characters or fewer
+	 *
+	 * @param string $value The parameter value.
+	 * @return bool
+	 */
+	public static function validate_param_value( $value ) {
+		return is_string( $value ) && strlen( $value ) <= 100;
+	}
+
+	/**
+	 * Get event name.
+	 *
+	 * @return string Event name.
+	 */
+	public function get_name() {
+		return $this->name;
+	}
+
+	/**
+	 * Get event parameters.
+	 *
+	 * @return array Event parameters.
+	 */
+	public function get_params() {
+		return $this->params;
+	}
+
+	/**
+	 * Sets the event parameters if they are valid. Throws exception if not.
+	 *
+	 * @param array $params The event parameters.
+	 * @throws \Exception If the event parameters are invalid.
+	 * @return void
+	 */
+	public function set_params( $params ) {
+		if ( ! $this->validate_params( $params ) ) {
+			throw new \Exception( 'Invalid event parameters. Limit is 25 parameters, included the default parameters. Values must have a max of 100 characters.' );
+		}
+		$this->params = $params;
+	}
+
+	/**
+	 * Sets the event name if it is valid. Throws exception if not.
+	 *
+	 * @param string $name The event name.
+	 * @throws \Exception If the event name is invalid.
+	 * @return void
+	 */
+	public function set_name( $name ) {
+		if ( ! $this->validate_name( $name ) ) {
+			throw new \Exception( 'Event and parameter names must be 40 characters or fewer, may only contain alpha-numeric characters and underscores, and must start with an alphabetic character.' );
+		}
+		$this->name = $name;
+	}
+
+	/**
+	 * Get event as an array.
+	 *
+	 * @return array Event as an array.
+	 */
+	public function to_array() {
+		return [
+			'name'   => $this->get_name(),
+			'params' => $this->get_params(),
+		];
+	}
+}

--- a/includes/data-events/connectors/ga4/class-event.php
+++ b/includes/data-events/connectors/ga4/class-event.php
@@ -79,7 +79,7 @@ class Event {
 	 * @return bool
 	 */
 	public static function validate_name( $name ) {
-		if ( ! is_string( $name ) || ! preg_match( '/^[a-zA-Z0-9]{1}[a-zA-Z0-9_]{1,39}$/', $name ) ) {
+		if ( ! is_string( $name ) || ! preg_match( '/^[a-zA-Z]{1}[a-zA-Z0-9_]{1,39}$/', $name ) ) {
 			return false;
 		}
 		return true;

--- a/includes/data-events/connectors/ga4/class-event.php
+++ b/includes/data-events/connectors/ga4/class-event.php
@@ -94,6 +94,10 @@ class Event {
 	 * @return bool
 	 */
 	public static function validate_param_value( $value ) {
+		// Let's play nice and convert integers.
+		if ( is_int( $value ) ) {
+			$value = (string) $value;
+		}
 		return is_string( $value ) && strlen( $value ) <= 100;
 	}
 

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Newspack Data Events Ga4 Connector
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Data_Events\Connectors;
+
+require_once 'class-event.php';
+
+use Automattic\Jetpack\Device_Detection;
+use Newspack\Data_Events;
+use Newspack\Data_Events\Connectors\GA4\Event;
+use Newspack\Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main Class.
+ */
+class GA4 {
+
+	/**
+	 * Initialize the class and registers the handlers
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		Data_Events::register_handler( [ __CLASS__, 'handle_reader_logged_in' ], 'reader_logged_in' );
+	}
+
+	/**
+	 * Handler for the reader_logged_in event.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 *
+	 * @return void
+	 */
+	public static function handle_reader_logged_in( $timestamp, $data, $client_id ) {
+
+		$params = array_merge(
+			self::get_default_params( $data['user_agent'] ?? '' ),
+			[ 'user_id' => $data['user_id'] ]
+		);
+		$event  = new Event( 'reader_login', $params );
+		self::send_event( $event, $client_id );
+	}
+
+	/**
+	 * Get the default parameters that are added to all events
+	 *
+	 * @param string $user_agent User agent header.
+	 * @return array
+	 */
+	private static function get_default_params( $user_agent = '' ) {
+		$params = [
+			'logged_in' => is_user_logged_in() ? 'yes' : 'no',
+		];
+
+		if ( class_exists( 'Automattic\Jetpack\Device_Detection' ) && $user_agent ) {
+			$device                = Device_Detection::is_phone( $user_agent ) ? 'phone' : ( Device_Detection::is_tablet( $user_agent ) ? 'tablet' : 'desktop' );
+			$params['device_type'] = $device;
+		}
+		return $params;
+	}
+
+	/**
+	 * Gets the credentials for the GA4 API.
+	 *
+	 * @return array
+	 */
+	private static function get_credentials() {
+		$api_secret     = get_option( 'ga4_api_secret' );
+		$measurement_id = get_option( 'ga4_measurement_id' );
+		return compact( 'api_secret', 'measurement_id' );
+	}
+
+	/**
+	 * Gets the API URL for GA4
+	 *
+	 * @return WP_Error|string
+	 */
+	public static function get_api_url() {
+		$credentials    = self::get_credentials();
+		$api_secret     = $credentials['api_secret'];
+		$measurement_id = $credentials['measurement_id'];
+		if ( ! $api_secret || ! $measurement_id ) {
+			return new WP_Error( 'missing_credentials', 'Missing GA4 API credentials.' );
+		}
+		return add_query_arg(
+			[
+				'api_secret'     => $api_secret,
+				'measurement_id' => $measurement_id,
+			],
+			'https://www.google-analytics.com/mp/collect'
+		);
+	}
+
+	/**
+	 * Sends an event to GA4.
+	 *
+	 * @param Event  $event The event object.
+	 * @param string $user_id User identifier. Use Reader_Activation::get_client_id().
+	 * @return void
+	 */
+	private static function send_event( Event $event, $user_id = null ) {
+
+		$url = self::get_api_url();
+
+		if ( is_wp_error( $url ) ) {
+			return;
+		}
+
+		$client_id = self::extract_cid_from_cookies();
+
+		$payload = [
+			'client_id' => $client_id,
+			'events'    => [
+				$event->to_array(),
+			],
+		];
+
+		if ( $user_id ) {
+			$payload['user_id'] = $user_id;
+		}
+
+		wp_remote_post(
+			$url,
+			[
+				'body' => wp_json_encode( $payload ),
+			]
+		);
+
+		self::log( sprintf( 'Event sent - %s', $name ) );
+
+	}
+
+	/**
+	 * Extracts the Client ID from the _ga cookie
+	 *
+	 * If the cookie is not found, it will be created
+	 *
+	 * @return string
+	 */
+	private static function extract_cid_from_cookies() {
+
+		if ( isset( $_COOKIE['_ga'] ) ) {
+			$cookie_pieces = explode( '.', $_COOKIE['_ga'], 3 ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( 1 === count( $cookie_pieces ) ) {
+				$cid = reset( $cookie_pieces );
+			} else {
+				list( $version, $domain_depth, $cid ) = $cookie_pieces;
+			}
+		} elseif ( isset( $_SERVER['HTTP_HOST'] ) ) {
+			$host           = sanitize_text_field( $_SERVER['HTTP_HOST'] );
+			$time           = time();
+			$cid            = wp_rand( 1000000000, 2147483647 ) . ".{$time}";
+			$num_components = count( explode( '.', preg_replace( '/^www\./', '', $host ) ) );
+			$ga             = "GA1.{$num_components}.{$cid}";
+			setcookie( '_ga', $ga, $time + 63115200, '/', $host, false, false ); // phpcs:ignore
+			$_COOKIE['_ga'] = $ga; // phpcs:ignore
+		} else {
+			$cid = 555;
+		}
+
+		return $cid;
+	}
+
+	/**
+	 * Log a message.
+	 *
+	 * @param string $message Message to log.
+	 */
+	private static function log( $message ) {
+		Logger::log( $message, 'NEWSPACK-DATA-EVENTS-GA4' );
+	}
+}
+
+GA4::init();

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -167,11 +167,9 @@ class GA4 {
 	/**
 	 * Extracts the Client ID from the _ga cookie
 	 *
-	 * @throws \Exception If the _ga cookie is missing.
-	 * @return string
+	 * @return ?string
 	 */
 	private static function extract_cid_from_cookies() {
-
 		if ( isset( $_COOKIE['_ga'] ) ) {
 			$cookie_pieces = explode( '.', $_COOKIE['_ga'], 3 ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			if ( 1 === count( $cookie_pieces ) ) {
@@ -179,11 +177,8 @@ class GA4 {
 			} else {
 				list( $version, $domain_depth, $cid ) = $cookie_pieces;
 			}
-		} else {
-			throw new \Exception( 'Missing _ga Cookie' );
+			return $cid;
 		}
-
-		return $cid;
 	}
 
 	/**

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -9,7 +9,6 @@ namespace Newspack\Data_Events\Connectors;
 
 require_once 'class-event.php';
 
-use Automattic\Jetpack\Device_Detection;
 use Newspack\Data_Events;
 use Newspack\Data_Events\Connectors\GA4\Event;
 use Newspack\Logger;
@@ -124,10 +123,11 @@ class GA4 {
 	/**
 	 * Sends an event to GA4.
 	 *
-	 * @param Event  $event The event object.
+	 * @param Event  $event     The event object.
 	 * @param string $client_id The GA client ID obtained from the cookie.
 	 * @param int    $timestamp The timestamp of the event.
-	 * @param string $user_id User identifier. Use Reader_Activation::get_client_id().
+	 * @param string $user_id   User identifier. Use Reader_Activation::get_client_id().
+	 *
 	 * @throws \Exception If the credentials are missing.
 	 * @return void
 	 */
@@ -167,6 +167,7 @@ class GA4 {
 	/**
 	 * Extracts the Client ID from the _ga cookie
 	 *
+	 * @throws \Exception If the _ga cookie is missing.
 	 * @return string
 	 */
 	private static function extract_cid_from_cookies() {
@@ -179,7 +180,7 @@ class GA4 {
 				list( $version, $domain_depth, $cid ) = $cookie_pieces;
 			}
 		} else {
-			$cid = 555;
+			throw new \Exception( 'Missing _ga Cookie' );
 		}
 
 		return $cid;

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -61,11 +61,6 @@ class GA4 {
 			'logged_in' => is_user_logged_in() ? 'yes' : 'no',
 		];
 
-		if ( class_exists( 'Automattic\Jetpack\Device_Detection' ) ) {
-			self::log( 'Detecting device using user agent: ' . $_SERVER['HTTP_USER_AGENT'] ?? '(empty)' ); // phpcs:ignore
-			$device                = Device_Detection::is_phone() ? 'phone' : ( Device_Detection::is_tablet() ? 'tablet' : 'desktop' );
-			$params['device_type'] = $device;
-		}
 		return $params;
 	}
 

--- a/tests/unit-tests/ga4-connector.php
+++ b/tests/unit-tests/ga4-connector.php
@@ -27,7 +27,7 @@ class Newspack_Test_GA4_Connector extends WP_UnitTestCase {
 			],
 			[
 				'123_asd',
-				true,
+				false,
 			],
 			[
 				'_asd123',

--- a/tests/unit-tests/ga4-connector.php
+++ b/tests/unit-tests/ga4-connector.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Tests the GA 4 connector.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Data_Events\Connectors\GA4\Event;
+
+/**
+ * Tests the GA 4 connector.
+ */
+class Newspack_Test_GA4_Connector extends WP_UnitTestCase {
+
+	/**
+	 * Data provider for test_validate_name
+	 */
+	public function validate_name_data() {
+		return [
+			[
+				'asd123',
+				true,
+			],
+			[
+				'asd_123',
+				true,
+			],
+			[
+				'123_asd',
+				true,
+			],
+			[
+				'_asd123',
+				false,
+			],
+			[
+				'asd 123',
+				false,
+			],
+			'40 chars' => [
+				'iiiiiiiiiOiiiiiiiiiOiiiiiiiiiOiiiiiiiiiO',
+				true,
+			],
+			'41 chars' => [
+				'iiiiiiiiiOiiiiiiiiiOiiiiiiiiiOiiiiiiiiiOi',
+				false,
+			],
+			[
+				'asd123#',
+				false,
+			],
+		];
+	}
+
+	/**
+	 * Tests the validate_name method
+	 *
+	 * @param string $name The event name.
+	 * @param bool   $expected The expected result.
+	 * @dataProvider validate_name_data
+	 */
+	public function test_validate_name( $name, $expected ) {
+		$this->assertEquals( $expected, Event::validate_name( $name ) );
+	}
+
+	/**
+	 * Ensures validate_name dont accept special chars
+	 */
+	public function test_validate_name_special_chars() {
+		$special_chars = [
+			'!',
+			'@',
+			'#',
+			'$',
+			'%',
+			'^',
+			'&',
+			'*',
+			'(',
+			')',
+			'-',
+			'=',
+			'+',
+			'[',
+			']',
+			'{',
+			'}',
+			'\\',
+			'|',
+			';',
+			':',
+			'"',
+			"'",
+			'<',
+			'>',
+			',',
+			'.',
+			'/',
+			'?',
+			'~',
+			'`',
+		];
+		foreach ( $special_chars as $char ) {
+			$this->assertFalse( Event::validate_name( 'asd123' . $char ) );
+		}
+	}
+}

--- a/tests/unit-tests/ga4-connector.php
+++ b/tests/unit-tests/ga4-connector.php
@@ -104,4 +104,158 @@ class Newspack_Test_GA4_Connector extends WP_UnitTestCase {
 			$this->assertFalse( Event::validate_name( 'asd123' . $char ) );
 		}
 	}
+
+	/**
+	 * Data provider for test_validate_param_name
+	 */
+	public function validate_param_value_data() {
+		return [
+			[
+				'dsl2390ijd2m, #asd',
+				true,
+			],
+			[
+				123123232,
+				true,
+			],
+			[
+				'iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0',
+				true,
+			],
+			[
+				'iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0iiiiiiiii0i',
+				false,
+			],
+			[
+				[ 123 ],
+				false,
+			],
+			[
+				(object) [ 'asd' => 123 ],
+				false,
+			],
+			[
+				true,
+				false,
+			],
+		];
+	}
+
+	/**
+	 * Tests the validate_param_value method
+	 *
+	 * @param string $value The param value.
+	 * @param bool   $expected The expected result.
+	 * @dataProvider validate_param_value_data
+	 */
+	public function test_validate_param_value( $value, $expected ) {
+		$this->assertEquals( $expected, Event::validate_param_value( $value ) );
+	}
+
+	/**
+	 * Tests the validate_params method
+	 *
+	 * @param array $params The parameters array.
+	 * @param bool  $expected The expected result.
+	 * @dataProvider validate_params_data
+	 */
+	public function test_validate_params( $params, $expected ) {
+		$this->assertEquals( $expected, Event::validate_params( $params ) );
+	}
+
+	/**
+	 * Data provider for test_validate_params
+	 */
+	public function validate_params_data() {
+		return [
+			[
+				[
+					'param1' => 'value1',
+					'param2' => 'value2',
+					'param3' => 'value3',
+					'param4' => 'value4',
+				],
+				true,
+			],
+			[
+				[
+					'invalid' => false,
+					'param2'  => 'value2',
+					'param3'  => 'value3',
+					'param4'  => 'value4',
+				],
+				false,
+			],
+			[
+				[
+					'_invalid' => 'value1',
+					'param2'   => 'value2',
+					'param3'   => 'value3',
+					'param4'   => 'value4',
+				],
+				false,
+			],
+			[
+				[
+					'param1'  => 'value1',
+					'param2'  => 'value2',
+					'param3'  => 'value3',
+					'param4'  => 'value4',
+					'param5'  => 'value5',
+					'param6'  => 'value6',
+					'param7'  => 'value7',
+					'param8'  => 'value8',
+					'param9'  => 'value9',
+					'param10' => 'value10',
+					'param11' => 'value11',
+					'param12' => 'value12',
+					'param13' => 'value13',
+					'param14' => 'value14',
+					'param15' => 'value15',
+					'param16' => 'value16',
+					'param17' => 'value17',
+					'param18' => 'value18',
+					'param19' => 'value19',
+					'param20' => 'value20',
+					'param21' => 'value21',
+					'param22' => 'value22',
+					'param23' => 'value23',
+					'param24' => 'value24',
+					'param25' => 'value25',
+					'param26' => 'value26',
+				],
+				false,
+			],
+			[
+				[
+					'param1'  => 'value1',
+					'param2'  => 'value2',
+					'param3'  => 'value3',
+					'param4'  => 'value4',
+					'param5'  => 'value5',
+					'param6'  => 'value6',
+					'param7'  => 'value7',
+					'param8'  => 'value8',
+					'param9'  => 'value9',
+					'param10' => 'value10',
+					'param11' => 'value11',
+					'param12' => 'value12',
+					'param13' => 'value13',
+					'param14' => 'value14',
+					'param15' => 'value15',
+					'param16' => 'value16',
+					'param17' => 'value17',
+					'param18' => 'value18',
+					'param19' => 'value19',
+					'param20' => 'value20',
+					'param21' => 'value21',
+					'param22' => 'value22',
+					'param23' => 'value23',
+					'param24' => 'value24',
+					'param25' => 'value25',
+				],
+				true,
+			],
+		];
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This pull request bootstraps the GA4 connector for our Data Events api and registers one first handler.

### How to test the changes in this Pull Request:

Get the GA4 credentials. You will need your measurement ID and an API secret.

* api_secret - Required. An API SECRET generated in the Google Analytics UI. To create a new secret, navigate to:
    Admin > Data Streams > choose your stream > Measurement Protocol > Create
* measurement_id - Required. The measurement ID associated with a stream. Found in the Google Analytics UI under:
    Admin > Data Streams > choose your stream > Measurement ID

Store this info in the database:
```
wp option set ga4_measurement_id "G-XXXXXXXXXX"
wp option set ga4_api_secret YYYYYYYYYYYYYYYYYYY
```
Now, let's test:

1. Make sure RAS is active and that you have a registered reader
2. Make sure to add this constant to wp-config
```
define( 'NEWSPACK_LOG_LEVEL', 2 );
define( 'NEWSPACK_EXPERIMENTAL_GA4_EVENTS', true );
```
3. Brwose the site in different/browser devices and watch the pageviews and user appear on the GA Real time dashboard
4. Login with a reader (either via password or OTP)
5. Watch the `reader_login` event being fired in the logs
```
[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::dispatch]: Dispatching action "reader_logged_in" via Action Scheduler.
```
6. Watch the handler being triggered and sending the `reader_login` GA event:
```
[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::handle]: Executing action handlers for "reader_logged_in".
[NEWSPACK-DATA-EVENTS-GA4][Newspack\Data_Events\Connectors\GA4::log]: Event sent - reader_login
```

7. Go to the Google Analytics Realtime dashboard and watch the events coming in

![Captura de tela de 2023-01-19 17-56-27](https://user-images.githubusercontent.com/971483/214316354-6ecca55d-7f5b-4506-82fa-b87162fd9979.png)

8. Do this a couple of times and confirm all the events are coming in and have the `logged_in` and `ga_session_id` params.
![Captura de tela de 2023-01-23 17-12-40](https://user-images.githubusercontent.com/971483/214316577-08597347-1840-464e-9cf1-2d0f647793df.png)

(Note, `logged_in` is a global param added to all events, it may not make much sense in this particular event, but this is fine)

9. Compare the `ga_session_id` param of the `reader_login` event with the others events like `page_view` or `session_start`. They should match. There should be one session id for each device/browser you use.

10. Make sure the number of user and sessions did not increase after the `reader_login` events were fired.

11. Disable woocommerce and test this being triggered without Action Scheduler

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->