### PR TITLE
feat(ras): enable custom contact metadata prefixes

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -213,7 +213,7 @@ export default withWizardScreen( () => {
 						<TextControl
 							label={ __( 'Metadata field prefix', 'newspack' ) }
 							help={ __(
-								'A string to prefix metadata fields attached to each contact synced to the ESP.',
+								'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_',
 								'newspack'
 							) }
 							{ ...getSharedProps( 'metadata_prefix', 'text' ) }

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -210,6 +210,14 @@ export default withWizardScreen( () => {
 							) }
 							{ ...getSharedProps( 'sync_esp_delete' ) }
 						/>
+						<TextControl
+							label={ __( 'Metadata field prefix', 'newspack' ) }
+							help={ __(
+								'A string to prefix metadata fields attached to each contact synced to the ESP.',
+								'newspack'
+							) }
+							{ ...getSharedProps( 'metadata_prefix', 'text' ) }
+						/>
 						{ isActiveCampaign && (
 							<ActiveCampaign
 								value={ { masterList: config.active_campaign_master_list } }

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -163,14 +163,16 @@ class Mailchimp {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function reader_registered( $timestamp, $data, $client_id ) {
-		$metadata = [
-			'NP_Account' => $data['user_id'],
+		$prefix      = Newspack_Newsletters::get_metadata_prefix();
+		$account_key = Newspack_Newsletters::get_metadata_key( 'account' );
+		$metadata    = [
+			$account_key => $data['user_id'],
 		];
 		if ( isset( $data['metadata']['current_page_url'] ) ) {
-			$metadata['NP_Registration Page'] = $data['metadata']['current_page_url'];
+			$metadata[ $prefix . 'Registration Page' ] = $data['metadata']['current_page_url'];
 		}
 		if ( isset( $data['metadata']['registration_method'] ) ) {
-			$metadata['NP_Registration Method'] = $data['metadata']['registration_method'];
+			$metadata[ $prefix . 'Registration Method' ] = $data['metadata']['registration_method'];
 		}
 		self::put( $data['email'], $metadata );
 	}
@@ -203,7 +205,7 @@ class Mailchimp {
 
 		// Remove "product name" from metadata, we'll use
 		// 'donation_subscription_new' action for this data.
-		unset( $metadata[ $keys['product_name'] ] );
+		unset( $metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] );
 
 		self::put( $email, $metadata );
 	}
@@ -219,14 +221,16 @@ class Mailchimp {
 		if ( empty( $data['platform_data']['order_id'] ) ) {
 			return;
 		}
+		$account_key  = Newspack_Newsletters::get_metadata_key( 'account' );
 		$metadata     = [
-			'NP_Account' => $data['user_id'],
+			$account_key => $data['user_id'],
 		];
 		$order_id     = $data['platform_data']['order_id'];
 		$product_id   = Donations::get_order_donation_product_id( $order_id );
 		$product_name = get_the_title( $product_id );
 
-		$metadata['NP_Product Name'] = $product_name;
+		$key              = Newspack_Newsletters::get_metadata_key( 'product_name' );
+		$metadata[ $key ] = $product_name;
 
 		self::put( $data['email'], $metadata );
 	}

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -42,7 +42,12 @@ class Newspack_Newsletters {
 			return self::METADATA_PREFIX;
 		}
 
-		return $prefix;
+		/**
+		 * Filters the string used to prefix custom fields synced to Newsletter ESPs.
+		 *
+		 * @param string $prefix Prefix to prepend the field name.
+		 */
+		return apply_filters( 'newspack_newsletters_metadata_prefix', $prefix );
 	}
 
 	/**
@@ -61,32 +66,42 @@ class Newspack_Newsletters {
 	}
 
 	/**
+	 * Given a field name, prepend it with the metadata field prefix.
+	 *
+	 * @param string $name Field name to prepend.
+	 *
+	 * @return string Prefixed field name.
+	 */
+	public static function get_metadata_key( $name ) {
+		return self::get_metadata_prefix() . $name;
+	}
+
+	/**
 	 * Metadata keys map for Reader Activation.
 	 *
 	 * @return array
 	 */
 	public static function get_metadata_keys() {
-		$metadata_prefix = self::get_metadata_prefix();
 		return [
-			'account'              => $metadata_prefix . 'Account',
-			'registration_date'    => $metadata_prefix . 'Registration Date',
-			'connected_account'    => $metadata_prefix . 'Connected Account',
-			'signup_page'          => $metadata_prefix . 'Signup Page',
-			'signup_page_utm'      => $metadata_prefix . 'Signup UTM: ',
-			'newsletter_selection' => $metadata_prefix . 'Newsletter Selection',
+			'account'              => self::get_metadata_key( 'Account' ),
+			'registration_date'    => self::get_metadata_key( 'Registration Date' ),
+			'connected_account'    => self::get_metadata_key( 'Connected Account' ),
+			'signup_page'          => self::get_metadata_key( 'Signup Page' ),
+			'signup_page_utm'      => self::get_metadata_key( 'Signup UTM: ' ),
+			'newsletter_selection' => self::get_metadata_key( 'Newsletter Selection' ),
 			// Payment-related.
-			'membership_status'    => $metadata_prefix . 'Membership Status',
-			'payment_page'         => $metadata_prefix . 'Payment Page',
-			'payment_page_utm'     => $metadata_prefix . 'Payment UTM: ',
-			'sub_start_date'       => $metadata_prefix . 'Current Subscription Start Date',
-			'sub_end_date'         => $metadata_prefix . 'Current Subscription End Date',
-			'billing_cycle'        => $metadata_prefix . 'Billing Cycle',
-			'recurring_payment'    => $metadata_prefix . 'Recurring Payment',
-			'last_payment_date'    => $metadata_prefix . 'Last Payment Date',
-			'last_payment_amount'  => $metadata_prefix . 'Last Payment Amount',
-			'product_name'         => $metadata_prefix . 'Product Name',
-			'next_payment_date'    => $metadata_prefix . 'Next Payment Date',
-			'total_paid'           => $metadata_prefix . 'Total Paid',
+			'membership_status'    => self::get_metadata_key( 'Membership Status' ),
+			'payment_page'         => self::get_metadata_key( 'Payment Page' ),
+			'payment_page_utm'     => self::get_metadata_key( 'Payment UTM: ' ),
+			'sub_start_date'       => self::get_metadata_key( 'Current Subscription Start Date' ),
+			'sub_end_date'         => self::get_metadata_key( 'Current Subscription End Date' ),
+			'billing_cycle'        => self::get_metadata_key( 'Billing Cycle' ),
+			'recurring_payment'    => self::get_metadata_key( 'Recurring Payment' ),
+			'last_payment_date'    => self::get_metadata_key( 'Last Payment Date' ),
+			'last_payment_amount'  => self::get_metadata_key( 'Last Payment Amount' ),
+			'product_name'         => self::get_metadata_key( 'Product Name' ),
+			'next_payment_date'    => self::get_metadata_key( 'Next Payment Date' ),
+			'total_paid'           => self::get_metadata_key( 'Total Paid' ),
 		];
 	}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -172,6 +172,7 @@ final class Reader_Activation {
 			'terms_text'                  => __( 'By signing up, you agree to our Terms and Conditions.', 'newspack' ),
 			'terms_url'                   => '',
 			'sync_esp'                    => true,
+			'metadata_prefix'             => Newspack_Newsletters::get_metadata_prefix(),
 			'sync_esp_delete'             => true,
 			'active_campaign_master_list' => '',
 			'emails'                      => Emails::get_emails( array_values( Reader_Activation_Emails::EMAIL_TYPES ), false ),
@@ -250,6 +251,10 @@ final class Reader_Activation {
 		if ( is_bool( $value ) ) {
 			$value = intval( $value );
 		}
+		if ( 'metadata_prefix' === $key ) {
+			return Newspack_Newsletters::update_metadata_prefix( $value );
+		}
+
 		return \update_option( self::OPTIONS_PREFIX . $key, $value );
 	}
 

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -177,8 +177,7 @@ class WooCommerce_Connection {
 			return;
 		}
 
-		$metadata_keys = Newspack_Newsletters::get_metadata_keys();
-		$user_id       = $order->get_customer_id();
+		$user_id = $order->get_customer_id();
 		if ( ! $user_id ) {
 			return;
 		}
@@ -188,73 +187,73 @@ class WooCommerce_Connection {
 			'registration_method' => 'woocommerce-order',
 		];
 
-		$metadata[ $metadata_keys['account'] ]           = $order->get_customer_id();
-		$metadata[ $metadata_keys['registration_date'] ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
-		$metadata[ $metadata_keys['payment_page'] ]      = \wc_get_checkout_url();
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'account' ) ]           = $order->get_customer_id();
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_date' ) ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'payment_page' ) ]      = \wc_get_checkout_url();
 
 		$order_subscriptions = wcs_get_subscriptions_for_order( $order->get_id() );
 
 		// One-time donation.
 		if ( empty( $order_subscriptions ) ) {
-			$metadata[ $metadata_keys['membership_status'] ] = 'Donor';
-			$metadata[ $metadata_keys['total_paid'] ]        = (float) $customer->get_total_spent();
-			$metadata[ $metadata_keys['total_paid'] ]       += (float) $order->get_total();
-			$metadata[ $metadata_keys['product_name'] ]      = '';
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Donor';
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ]        = (float) $customer->get_total_spent();
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ]       += (float) $order->get_total();
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ]      = '';
 			$order_items                                     = $order->get_items();
 			if ( $order_items ) {
-				$metadata[ $metadata_keys['product_name'] ] = reset( $order_items )->get_name();
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = reset( $order_items )->get_name();
 			}
-			$metadata[ $metadata_keys['last_payment_amount'] ] = $order->get_total();
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'last_payment_amount' ) ] = $order->get_total();
 			$order_date_paid                                   = $order->get_date_paid();
 			if ( null !== $order_date_paid ) {
-				$metadata[ $metadata_keys['last_payment_date'] ] = $order_date_paid->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'last_payment_date' ) ] = $order_date_paid->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
 			}
 
 			// Subscription donation.
 		} else {
 			$current_subscription = reset( $order_subscriptions );
 
-			$metadata[ $metadata_keys['membership_status'] ] = 'Donor';
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Donor';
 			if ( 'active' === $current_subscription->get_status() || 'pending' === $current_subscription->get_status() ) {
 				if ( 'month' === $current_subscription->get_billing_period() ) {
-					$metadata[ $metadata_keys['membership_status'] ] = 'Monthly Donor';
+					$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Monthly Donor';
 				}
 
 				if ( 'year' === $current_subscription->get_billing_period() ) {
-					$metadata[ $metadata_keys['membership_status'] ] = 'Yearly Donor';
+					$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Yearly Donor';
 				}
 			} else {
 				if ( 'month' === $current_subscription->get_billing_period() ) {
-					$metadata[ $metadata_keys['membership_status'] ] = 'Ex-Monthly Donor';
+					$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Ex-Monthly Donor';
 				}
 
 				if ( 'year' === $current_subscription->get_billing_period() ) {
-					$metadata[ $metadata_keys['membership_status'] ] = 'Ex-Yearly Donor';
+					$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Ex-Yearly Donor';
 				}
 			}
 
-			$metadata[ $metadata_keys['sub_start_date'] ]      = $current_subscription->get_date( 'start' );
-			$metadata[ $metadata_keys['sub_end_date'] ]        = $current_subscription->get_date( 'end' ) ? $current_subscription->get_date( 'end' ) : '';
-			$metadata[ $metadata_keys['billing_cycle'] ]       = $current_subscription->get_billing_period();
-			$metadata[ $metadata_keys['recurring_payment'] ]   = $current_subscription->get_total();
-			$metadata[ $metadata_keys['last_payment_date'] ]   = $current_subscription->get_date( 'last_order_date_paid' ) ? $current_subscription->get_date( 'last_order_date_paid' ) : gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT );
-			$metadata[ $metadata_keys['last_payment_amount'] ] = $current_subscription->get_total();
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'sub_start_date' ) ]      = $current_subscription->get_date( 'start' );
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'sub_end_date' ) ]        = $current_subscription->get_date( 'end' ) ? $current_subscription->get_date( 'end' ) : '';
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'billing_cycle' ) ]       = $current_subscription->get_billing_period();
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'recurring_payment' ) ]   = $current_subscription->get_total();
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'last_payment_date' ) ]   = $current_subscription->get_date( 'last_order_date_paid' ) ? $current_subscription->get_date( 'last_order_date_paid' ) : gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT );
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'last_payment_amount' ) ] = $current_subscription->get_total();
 
 			// When a WC Subscription is terminated, the next payment date is set to 0. We don't want to sync that – the next payment date should remain as it was
 			// in the event of cancellation.
 			$next_payment_date = $current_subscription->get_date( 'next_payment' );
 			if ( $next_payment_date ) {
-				$metadata[ $metadata_keys['next_payment_date'] ] = $next_payment_date;
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'next_payment_date' ) ] = $next_payment_date;
 			}
 
-			$metadata[ $metadata_keys['total_paid'] ]  = (float) $customer->get_total_spent();
-			$metadata[ $metadata_keys['total_paid'] ] += (float) $current_subscription->get_total();
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ]  = (float) $customer->get_total_spent();
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ] += (float) $current_subscription->get_total();
 
-			$metadata[ $metadata_keys['product_name'] ] = '';
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = '';
 			if ( $current_subscription ) {
 				$subscription_order_items = $current_subscription->get_items();
 				if ( $subscription_order_items ) {
-					$metadata[ $metadata_keys['product_name'] ] = reset( $subscription_order_items )->get_name();
+					$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = reset( $subscription_order_items )->get_name();
 				}
 			}
 		}

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -174,11 +174,6 @@ class WooCommerce_Connection {
 			$order = new \WC_Order( $order );
 		}
 
-		if ( self::CREATED_VIA_NAME === $order->get_created_via() ) {
-			// Only sync orders not created via the Stripe integration.
-			return;
-		}
-
 		$user_id = $order->get_customer_id();
 		if ( ! $user_id ) {
 			return false;

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -177,7 +177,7 @@ class WooCommerce_Connection {
 			return;
 		}
 
-		$metadata_keys = Newspack_Newsletters::$metadata_keys;
+		$metadata_keys = Newspack_Newsletters::get_metadata_keys();
 		$user_id       = $order->get_customer_id();
 		if ( ! $user_id ) {
 			return;

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -492,18 +492,18 @@ class Stripe_Connection {
 	 * @param int    $date Date.
 	 */
 	public static function create_recurring_payment_metadata( $frequency, $amount, $currency, $date ) {
-		$metadata                                        = [];
-		$metadata_keys                                   = Newspack_Newsletters::get_metadata_keys();
-		$amount_normalised                               = self::normalise_amount( $amount, $currency );
-		$payment_date                                    = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $date );
-		$metadata[ $metadata_keys['billing_cycle'] ]     = $frequency;
-		$metadata[ $metadata_keys['recurring_payment'] ] = $amount_normalised;
-		$metadata[ $metadata_keys['membership_status'] ] = self::get_membership_status_field_value( $frequency );
-		$next_payment_date                               = date_format( date_add( date_create( 'now' ), date_interval_create_from_date_string( '1 ' . $frequency ) ), Newspack_Newsletters::METADATA_DATE_FORMAT );
-		$metadata[ $metadata_keys['next_payment_date'] ] = $next_payment_date;
-		$metadata[ $metadata_keys['sub_start_date'] ]    = $payment_date;
+		$metadata          = [];
+		$amount_normalised = self::normalise_amount( $amount, $currency );
+		$payment_date      = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $date );
+		$next_payment_date = date_format( date_add( date_create( 'now' ), date_interval_create_from_date_string( '1 ' . $frequency ) ), Newspack_Newsletters::METADATA_DATE_FORMAT );
+
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'billing_cycle' ) ]     = $frequency;
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'recurring_payment' ) ] = $amount_normalised;
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = self::get_membership_status_field_value( $frequency );
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'next_payment_date' ) ] = $next_payment_date;
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'sub_start_date' ) ]    = $payment_date;
 		// In case this was previously set after a previous cancelled subscription, clear it.
-		$metadata[ $metadata_keys['sub_end_date'] ] = '';
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'sub_end_date' ) ] = '';
 		return $metadata;
 	}
 

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -492,17 +492,18 @@ class Stripe_Connection {
 	 * @param int    $date Date.
 	 */
 	public static function create_recurring_payment_metadata( $frequency, $amount, $currency, $date ) {
-		$metadata          = [];
-		$amount_normalised = self::normalise_amount( $amount, $currency );
-		$payment_date      = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $date );
-		$metadata[ Newspack_Newsletters::$metadata_keys['billing_cycle'] ]     = $frequency;
-		$metadata[ Newspack_Newsletters::$metadata_keys['recurring_payment'] ] = $amount_normalised;
-		$metadata[ Newspack_Newsletters::$metadata_keys['membership_status'] ] = self::get_membership_status_field_value( $frequency );
-		$next_payment_date = date_format( date_add( date_create( 'now' ), date_interval_create_from_date_string( '1 ' . $frequency ) ), Newspack_Newsletters::METADATA_DATE_FORMAT );
-		$metadata[ Newspack_Newsletters::$metadata_keys['next_payment_date'] ] = $next_payment_date;
-		$metadata[ Newspack_Newsletters::$metadata_keys['sub_start_date'] ]    = $payment_date;
+		$metadata                                        = [];
+		$metadata_keys                                   = Newspack_Newsletters::get_metadata_keys();
+		$amount_normalised                               = self::normalise_amount( $amount, $currency );
+		$payment_date                                    = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $date );
+		$metadata[ $metadata_keys['billing_cycle'] ]     = $frequency;
+		$metadata[ $metadata_keys['recurring_payment'] ] = $amount_normalised;
+		$metadata[ $metadata_keys['membership_status'] ] = self::get_membership_status_field_value( $frequency );
+		$next_payment_date                               = date_format( date_add( date_create( 'now' ), date_interval_create_from_date_string( '1 ' . $frequency ) ), Newspack_Newsletters::METADATA_DATE_FORMAT );
+		$metadata[ $metadata_keys['next_payment_date'] ] = $next_payment_date;
+		$metadata[ $metadata_keys['sub_start_date'] ]    = $payment_date;
 		// In case this was previously set after a previous cancelled subscription, clear it.
-		$metadata[ Newspack_Newsletters::$metadata_keys['sub_end_date'] ] = '';
+		$metadata[ $metadata_keys['sub_end_date'] ] = '';
 		return $metadata;
 	}
 

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -181,7 +181,7 @@ class Stripe_Sync {
 			'name'  => $customer->name,
 		];
 
-		$metadata_keys = Newspack_Newsletters::$metadata_keys;
+		$metadata_keys = Newspack_Newsletters::get_metadata_keys();
 		$metadata      = [
 			$metadata_keys['total_paid'] => Stripe_Connection::get_customer_ltv( $customer->id ),
 		];
@@ -534,4 +534,3 @@ class Stripe_Sync {
 }
 
 Stripe_Sync::init();
-

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -181,9 +181,8 @@ class Stripe_Sync {
 			'name'  => $customer->name,
 		];
 
-		$metadata_keys = Newspack_Newsletters::get_metadata_keys();
-		$metadata      = [
-			$metadata_keys['total_paid'] => Stripe_Connection::get_customer_ltv( $customer->id ),
+		$metadata = [
+			Newspack_Newsletters::get_metadata_key( 'total_paid' ) => Stripe_Connection::get_customer_ltv( $customer->id ),
 		];
 
 		$last_payments = Stripe_Connection::get_customer_transactions( $customer->id, false, 1 );
@@ -196,18 +195,18 @@ class Stripe_Sync {
 			$payment           = $last_payments[0];
 			$amount_normalised = Stripe_Connection::normalise_amount( $payment['amount'], $payment['currency'] );
 			$frequency         = Stripe_Connection::get_frequency_of_payment( $payment );
-			$metadata[ $metadata_keys['last_payment_date'] ]   = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payment['created'] );
-			$metadata[ $metadata_keys['last_payment_amount'] ] = $amount_normalised;
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'last_payment_date' ) ]   = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payment['created'] );
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'last_payment_amount' ) ] = $amount_normalised;
 			if ( 'once' !== $frequency ) {
-				$metadata[ $metadata_keys['billing_cycle'] ] = $frequency;
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'billing_cycle' ) ] = $frequency;
 			}
-			$membership_status                               = Stripe_Connection::get_membership_status_field_value( $frequency );
-			$metadata[ $metadata_keys['membership_status'] ] = $membership_status;
+			$membership_status = Stripe_Connection::get_membership_status_field_value( $frequency );
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = $membership_status;
 
 			if ( Donations::is_woocommerce_suite_active() ) {
 				$wc_product_id = Donations::get_donation_product( $frequency );
 				try {
-					$metadata[ $metadata_keys['product_name'] ] = \wc_get_product( $wc_product_id )->get_name();
+					$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = \wc_get_product( $wc_product_id )->get_name();
 				} catch ( \Throwable $th ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 					// Fail silently.
 				}
@@ -223,20 +222,20 @@ class Stripe_Sync {
 				);
 				$metadata                   = array_merge( $recurring_related_metadata, $metadata );
 				if ( 'active' !== $subscription['status'] ) {
-					$metadata[ $metadata_keys['membership_status'] ] = 'Ex-' . $membership_status;
+					$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Ex-' . $membership_status;
 				}
 				if ( $subscription['ended_at'] ) {
-					$metadata[ $metadata_keys['sub_end_date'] ] = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $subscription['ended_at'] );
+					$metadata[ Newspack_Newsletters::get_metadata_key( 'sub_end_date' ) ] = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $subscription['ended_at'] );
 				} else {
-					unset( $metadata[ $metadata_keys['sub_end_date'] ] );
+					unset( $metadata[ Newspack_Newsletters::get_metadata_key( 'sub_end_date' ) ] );
 				}
 			}
 		}
 
 		$wp_user = get_user_by( 'email', $email_address );
 		if ( $wp_user ) {
-			$metadata[ $metadata_keys['account'] ]           = $wp_user->ID;
-			$metadata[ $metadata_keys['registration_date'] ] = date_format( date_create( $wp_user->data->user_registered ), Newspack_Newsletters::METADATA_DATE_FORMAT );
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'account' ) ]           = $wp_user->ID;
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_date' ) ] = date_format( date_create( $wp_user->data->user_registered ), Newspack_Newsletters::METADATA_DATE_FORMAT );
 		}
 
 		$contact['metadata'] = $metadata;

--- a/includes/reader-revenue/stripe/class-stripe-webhooks.php
+++ b/includes/reader-revenue/stripe/class-stripe-webhooks.php
@@ -244,6 +244,8 @@ class Stripe_Webhooks {
 			return;
 		}
 
+		$metadata_keys = Newspack_Newsletters::get_metadata_keys();
+
 		switch ( $request['type'] ) {
 			case 'charge.succeeded':
 				$payment  = $payload;
@@ -292,18 +294,18 @@ class Stripe_Webhooks {
 						$customer_ltv = Stripe_Connection::get_customer_ltv( $customer['id'] );
 						if ( ! \is_wp_error( $customer_ltv ) ) {
 							$total_paid = $customer_ltv + $amount_normalised;
-							$contact['metadata'][ Newspack_Newsletters::$metadata_keys['total_paid'] ] = $total_paid;
+							$contact['metadata'][ $metadata_keys['total_paid'] ] = $total_paid;
 						}
 
 						$contact['metadata'] = array_merge(
 							$contact['metadata'],
 							[
-								Newspack_Newsletters::$metadata_keys['last_payment_date']   => $payment_date,
-								Newspack_Newsletters::$metadata_keys['last_payment_amount'] => $amount_normalised,
+								$metadata_keys['last_payment_date']   => $payment_date,
+								$metadata_keys['last_payment_amount'] => $amount_normalised,
 							]
 						);
 
-						$metadata[ Newspack_Newsletters::$metadata_keys['membership_status'] ] = Stripe_Connection::get_membership_status_field_value( $frequency );
+						$metadata[ $metadata_keys['membership_status'] ] = Stripe_Connection::get_membership_status_field_value( $frequency );
 						if ( 'once' !== $frequency ) {
 							$contact['metadata'] = array_merge(
 								Stripe_Connection::create_recurring_payment_metadata( $frequency, $payment['amount'], $payment['currency'], $payment['created'] ),
@@ -311,7 +313,7 @@ class Stripe_Webhooks {
 							);
 						}
 						if ( isset( $customer['metadata']['userId'] ) ) {
-							$contact['metadata'][ Newspack_Newsletters::$metadata_keys['account'] ] = $customer['metadata']['userId'];
+							$contact['metadata'][ $metadata_keys['account'] ] = $customer['metadata']['userId'];
 						}
 						if ( isset( $customer['metadata']['current_page_url'] ) ) {
 							$contact['metadata']['current_page_url'] = $customer['metadata']['current_page_url'];
@@ -331,7 +333,7 @@ class Stripe_Webhooks {
 							$wc_product_id = Donations::get_donation_product( $frequency );
 							try {
 								$wc_product = \wc_get_product( $wc_product_id );
-								$contact['metadata'][ Newspack_Newsletters::$metadata_keys['product_name'] ] = $wc_product->get_name();
+								$contact['metadata'][ $metadata_keys['product_name'] ] = $wc_product->get_name();
 							} catch ( \Throwable $th ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 								// Fail silently.
 							}
@@ -425,12 +427,12 @@ class Stripe_Webhooks {
 						$contact      = [
 							'email'    => $customer['email'],
 							'metadata' => [
-								Newspack_Newsletters::$metadata_keys['sub_end_date']   => $sub_end_date,
+								$metadata_keys['sub_end_date']   => $sub_end_date,
 							],
 						];
 						if ( 0 === $active_subs && in_array( $payload['plan']['interval'], [ 'month', 'year' ] ) ) {
 							$membership_status = 'Ex-' . Stripe_Connection::get_membership_status_field_value( $payload['plan']['interval'] );
-							$contact['metadata'][ Newspack_Newsletters::$metadata_keys['membership_status'] ] = $membership_status;
+							$contact['metadata'][ $metadata_keys['membership_status'] ] = $membership_status;
 						}
 						\Newspack_Newsletters_Subscription::add_contact( $contact );
 					}
@@ -490,7 +492,7 @@ class Stripe_Webhooks {
 						if ( $payload['cancel_at'] ) {
 							// Cancellation was scheduled.
 							$sub_end_date = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payload['cancel_at'] );
-							$contact['metadata'][ Newspack_Newsletters::$metadata_keys['sub_end_date'] ] = $sub_end_date;
+							$contact['metadata'][ $metadata_keys['sub_end_date'] ] = $sub_end_date;
 						} elseif ( 'active' === $payload['status'] ) {
 							// An update to an active subscription (or activation of it).
 							$plan                = $payload['plan'];

--- a/includes/reader-revenue/stripe/class-stripe-webhooks.php
+++ b/includes/reader-revenue/stripe/class-stripe-webhooks.php
@@ -244,8 +244,6 @@ class Stripe_Webhooks {
 			return;
 		}
 
-		$metadata_keys = Newspack_Newsletters::get_metadata_keys();
-
 		switch ( $request['type'] ) {
 			case 'charge.succeeded':
 				$payment  = $payload;
@@ -294,18 +292,18 @@ class Stripe_Webhooks {
 						$customer_ltv = Stripe_Connection::get_customer_ltv( $customer['id'] );
 						if ( ! \is_wp_error( $customer_ltv ) ) {
 							$total_paid = $customer_ltv + $amount_normalised;
-							$contact['metadata'][ $metadata_keys['total_paid'] ] = $total_paid;
+							$contact['metadata'][ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ] = $total_paid;
 						}
 
 						$contact['metadata'] = array_merge(
 							$contact['metadata'],
 							[
-								$metadata_keys['last_payment_date']   => $payment_date,
-								$metadata_keys['last_payment_amount'] => $amount_normalised,
+								Newspack_Newsletters::get_metadata_key( 'last_payment_date' )   => $payment_date,
+								Newspack_Newsletters::get_metadata_key( 'last_payment_amount' ) => $amount_normalised,
 							]
 						);
 
-						$metadata[ $metadata_keys['membership_status'] ] = Stripe_Connection::get_membership_status_field_value( $frequency );
+						$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = Stripe_Connection::get_membership_status_field_value( $frequency );
 						if ( 'once' !== $frequency ) {
 							$contact['metadata'] = array_merge(
 								Stripe_Connection::create_recurring_payment_metadata( $frequency, $payment['amount'], $payment['currency'], $payment['created'] ),
@@ -313,7 +311,7 @@ class Stripe_Webhooks {
 							);
 						}
 						if ( isset( $customer['metadata']['userId'] ) ) {
-							$contact['metadata'][ $metadata_keys['account'] ] = $customer['metadata']['userId'];
+							$contact['metadata'][ Newspack_Newsletters::get_metadata_key( 'account' ) ] = $customer['metadata']['userId'];
 						}
 						if ( isset( $customer['metadata']['current_page_url'] ) ) {
 							$contact['metadata']['current_page_url'] = $customer['metadata']['current_page_url'];
@@ -333,7 +331,7 @@ class Stripe_Webhooks {
 							$wc_product_id = Donations::get_donation_product( $frequency );
 							try {
 								$wc_product = \wc_get_product( $wc_product_id );
-								$contact['metadata'][ $metadata_keys['product_name'] ] = $wc_product->get_name();
+								$contact['metadata'][ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = $wc_product->get_name();
 							} catch ( \Throwable $th ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 								// Fail silently.
 							}
@@ -427,12 +425,12 @@ class Stripe_Webhooks {
 						$contact      = [
 							'email'    => $customer['email'],
 							'metadata' => [
-								$metadata_keys['sub_end_date']   => $sub_end_date,
+								Newspack_Newsletters::get_metadata_key( 'sub_end_date' )   => $sub_end_date,
 							],
 						];
 						if ( 0 === $active_subs && in_array( $payload['plan']['interval'], [ 'month', 'year' ] ) ) {
 							$membership_status = 'Ex-' . Stripe_Connection::get_membership_status_field_value( $payload['plan']['interval'] );
-							$contact['metadata'][ $metadata_keys['membership_status'] ] = $membership_status;
+							$contact['metadata'][ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = $membership_status;
 						}
 						\Newspack_Newsletters_Subscription::add_contact( $contact );
 					}
@@ -492,7 +490,7 @@ class Stripe_Webhooks {
 						if ( $payload['cancel_at'] ) {
 							// Cancellation was scheduled.
 							$sub_end_date = gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $payload['cancel_at'] );
-							$contact['metadata'][ $metadata_keys['sub_end_date'] ] = $sub_end_date;
+							$contact['metadata'][ Newspack_Newsletters::get_metadata_key( 'sub_end_date' ) ] = $sub_end_date;
 						} elseif ( 'active' === $payload['status'] ) {
 							// An update to an active subscription (or activation of it).
 							$plan                = $payload['plan'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a field to the RAS settings page to set the prefix for contact metadata field keys. Defaults to `NP_` which ensures continuity on sites already using RAS.

<img width="1081" alt="Screen Shot 2023-01-24 at 4 38 43 PM" src="https://user-images.githubusercontent.com/2230142/214445181-e226c011-bb2f-4ee8-b7c7-50b7374ca91c.png">

Closes 1200550061930446/1203749513702559.

### How to test the changes in this Pull Request:

1. On a site with RAS enabled and connected to ActiveCampaign, visit the **Newspack > Engagement > Reader Activation** dashboard. Confirm there's a new "Metadata Field Prefix" field if the the "Synchronize reader to ESP" is enabled, and that it's set to `NP_`.
2. Without making changes, smoke test the field syncing to ensure that it still works with the default behavior: make a donation and ensure that the contact is created in ActiveCampaign with all the Newspack fields prefixed with `NP_`.
3. Update the "Metadata Field Prefix" field to a new string and save.
4. Make a new donation using the same email address as in step 2. Confirm in AC that the contact now has a new set of fields with the prefix you set in step 3 which contain the most updated data, in addition to the `NP_` fields from before. (The old fields will remain to prevent data loss, but will no longer be synced or updated unless you reset the prefix.)
5. Make a new donation in a new session with a different email address. Confirm in AC that the data for this contact is only synced to the fields with the new prefix.

* Note: The new fields will appear in the General Details field group in ActiveCampaign. They can be moved to a different group in the AC dashboard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->