### PR TITLE
feat: if rendering media tags, ensure proper nesting

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -595,7 +595,7 @@ class RSS {
 						<media:description><?php echo esc_html( $caption ); ?></media:description>
 						<?php endif; ?>
 						<media:thumbnail url="<?php echo esc_url( $thumbnail_data[0] ); ?>" width="<?php echo esc_attr( $thumbnail_data[1] ); ?>" height="<?php echo esc_attr( $thumbnail_data[2] ); ?>" />
-						</media:content>
+					</media:content>
 					<?php
 				}
 			}

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -586,10 +586,16 @@ class RSS {
 			if ( $thumbnail_id ) {
 				$thumbnail_data = wp_get_attachment_image_src( $thumbnail_id, 'full' );
 				if ( $thumbnail_data ) {
+					$caption = get_the_post_thumbnail_caption();
 					?>
-					<media:description><?php echo esc_html( get_the_post_thumbnail_caption() ); ?></media:description>
-					<media:thumbnail url="<?php echo esc_url( $thumbnail_data[0] ); ?>" width="<?php echo esc_attr( $thumbnail_data[1] ); ?>" height="<?php echo esc_attr( $thumbnail_data[2] ); ?>" />
-					<media:content type="image/jpeg" url="<?php echo esc_url( $thumbnail_data[0] ); ?>" />
+					<media:content type="image/jpeg" url="<?php echo esc_url( $thumbnail_data[0] ); ?>">
+						<?php
+						if ( ! empty( $caption ) ) :
+							?>
+						<media:description><?php echo esc_html( $caption ); ?></media:description>
+						<?php endif; ?>
+						<media:thumbnail url="<?php echo esc_url( $thumbnail_data[0] ); ?>" width="<?php echo esc_attr( $thumbnail_data[1] ); ?>" height="<?php echo esc_attr( $thumbnail_data[2] ); ?>" />
+						</media:content>
 					<?php
 				}
 			}

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -588,10 +588,8 @@ class RSS {
 				if ( $thumbnail_data ) {
 					$caption = get_the_post_thumbnail_caption();
 					?>
-					<media:content type="image/jpeg" url="<?php echo esc_url( $thumbnail_data[0] ); ?>">
-						<?php
-						if ( ! empty( $caption ) ) :
-							?>
+					<media:content type="<?php echo esc_attr( get_post_mime_type( $thumbnail_id ) ); ?>" url="<?php echo esc_url( $thumbnail_data[0] ); ?>">
+						<?php if ( ! empty( $caption ) ) : ?>
 						<media:description><?php echo esc_html( $caption ); ?></media:description>
 						<?php endif; ?>
 						<media:thumbnail url="<?php echo esc_url( $thumbnail_data[0] ); ?>" width="<?php echo esc_attr( $thumbnail_data[1] ); ?>" height="<?php echo esc_attr( $thumbnail_data[2] ); ?>" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If rendering `<media:thumbnails>` and `<media:description>` tags, ensures that they're nested as sub-elements of `<media:content>`, as specified in the [RSS spec](https://www.rssboard.org/media-rss#media-content).

Also fetches the image mimetype from the attachment ID instead of assuming all images are JPEG (images may be PNG).

Closes 1200550061930446/1203716238122802.

### How to test the changes in this Pull Request:

1. In **Newspack > Syndication**, enable the RSS Enhancements module.
2. Go to **RSS Feeds** and create a new feed. In the feed settings, under "Technical Settings" check the **Add post featured images in <media:> tags** and **Add featured image at the top of feed content** boxes. Save the feed.
3. Copy the feed URL and validate at https://validator.w3.org/feed/. Confirm that the feed is valid and that the featured images are represented by `<media:content>` elements, and that the images and captions are in `<media:thumbnails>` and `<media:description>` elements, respectively, nested inside the `<media:content>` elements.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->