### PR TITLE
Stripe: create native WC Subscriptions (if a flag is set)

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -413,6 +413,24 @@ class Donations {
 	}
 
 	/**
+	 * Map donation frequency code to a human readable string.
+	 *
+	 * @param string $frequency Frequency code.
+	 */
+	public static function get_donation_name_by_frequency( $frequency ) {
+		switch ( $frequency ) {
+			case 'once':
+				return __( 'One-Time Donation', 'newspack' );
+			case 'month':
+				return __( 'Monthly Donation', 'newspack' );
+			case 'year':
+				return __( 'Yearly Donation', 'newspack' );
+			default:
+				return __( 'Donation', 'newspack' );
+		}
+	}
+
+	/**
 	 * Create missing donations products.
 	 *
 	 * @param array $args Info that will be used to create the products.

--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -80,15 +80,34 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Retrieve configured payment gateways.
+	 *
+	 * @param bool $only_enabled Whether to return only the enabled gateways.
+	 * @return Array Array of payment gateways.
+	 */
+	public static function get_payment_gateways( $only_enabled = false ) {
+		if ( ! class_exists( '\WC_Payment_Gateways' ) ) {
+			return [];
+		}
+		$gateways = \WC_Payment_Gateways::instance()->payment_gateways();
+		if ( $only_enabled ) {
+			return array_filter(
+				$gateways,
+				function( $gateway ) {
+					return 'yes' === $gateway->enabled;
+				}
+			);
+		}
+		return $gateways;
+	}
+
+	/**
 	 * Retrieve Stripe data
 	 *
 	 * @return Array Array of Stripe data.
 	 */
 	public function stripe_data() {
-		if ( ! class_exists( 'WC_Payment_Gateways' ) ) {
-			return Stripe_Connection::get_default_stripe_data();
-		}
-		$gateways = WC_Payment_Gateways::instance()->payment_gateways();
+		$gateways = self::get_payment_gateways();
 		if ( ! isset( $gateways['stripe'] ) ) {
 			return Stripe_Connection::get_default_stripe_data();
 		}

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -123,7 +123,10 @@ class Newspack_Newsletters {
 				}
 
 				$current_page_url = isset( $contact['metadata'], $contact['metadata']['current_page_url'] ) ? $contact['metadata']['current_page_url'] : null;
-				if ( ! $current_page_url ) {
+				if ( $current_page_url ) {
+					// Don't send this metadata to ESP, it will be used to populate signup and payment page URLs' fields.
+					unset( $contact['metadata']['current_page_url'] );
+				} else {
 					global $wp;
 					$current_page_url = home_url( add_query_arg( array(), $wp->request ) );
 				}

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -108,6 +108,7 @@ class WooCommerce_Connection {
 		$item->set_product( \wc_get_product( $product_id ) );
 		$item->set_total( $amount );
 		$item->set_subtotal( $amount );
+		$item->save();
 		return $item;
 	}
 
@@ -623,6 +624,8 @@ class WooCommerce_Connection {
 						$subscription->add_order_note( sprintf( __( 'Newspack subscription with frequency: %s. The recurring payment and the subscription will be handled in Stripe, so you\'ll see "Manual renewal" as the payment method in WooCommerce.', 'newspack' ), $frequency ) );
 						$subscription->update_status( 'active' ); // Settings status via method (not in wcs_create_subscription), to make WCS recalculate dates.
 					}
+					// Mint a new item – subscription is a new WC order.
+					$item = self::get_donation_order_item( $frequency, $order_data['amount'] );
 					$subscription->add_item( $item );
 					$subscription->calculate_totals();
 

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -610,7 +610,7 @@ class WooCommerce_Connection {
 			 * Handle WooCommerce Subscriptions - new subscription.
 			 */
 			if ( 'created' === $subscription_status ) {
-				// A subscription needs a valid user. If not user ID is provided, attribute the
+				// A subscription needs a valid user. If no user ID is provided, attribute the
 				// subscription to the user with the supplied email address.
 				if ( empty( $order_data['user_id'] ) ) {
 					$user = \get_user_by( 'email', $order_data['email'] );

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -584,6 +584,16 @@ class WooCommerce_Connection {
 			 * Handle WooCommerce Subscriptions - new subscription.
 			 */
 			if ( 'created' === $subscription_status ) {
+				// A subscription needs a valid user. If not user ID is provided, attribute the
+				// subscription to the user with the supplied email address.
+				if ( empty( $order_data['user_id'] ) ) {
+					$user = \get_user_by( 'email', $order_data['email'] );
+					if ( ! $user || \is_wp_error( $user ) ) {
+						Logger::error( 'Could not find user by email.' );
+					}
+					$order->set_customer_id( $user->ID );
+					$order->save();
+				}
 				$subscription = \wcs_create_subscription(
 					[
 						'start_date'       => self::convert_timestamp_to_date( $order_data['date'] ),

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -615,9 +615,18 @@ class WooCommerce_Connection {
 				if ( empty( $order_data['user_id'] ) ) {
 					$user = \get_user_by( 'email', $order_data['email'] );
 					if ( ! $user || \is_wp_error( $user ) ) {
-						Logger::error( 'Could not find user by email.' );
+						Logger::log( 'Could not find user by email, creating a user.' );
+						$display_name = explode( '@', $order_data['email'], 2 )[0];
+						$user_id      = \wc_create_new_customer(
+							$order_data['email'],
+							\sanitize_user( $order_data['email'], true ),
+							\wp_generate_password(),
+							[ 'display_name' => $display_name ]
+						);
+						$order->set_customer_id( $user_id );
+					} else {
+						$order->set_customer_id( $user->ID );
 					}
-					$order->set_customer_id( $user->ID );
 					$order->save();
 				}
 				$subscription = \wcs_create_subscription(

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -789,15 +789,8 @@ class Stripe_Connection {
 
 			// In this mode, WC will create a subscription for the customer, instead of using
 			// native Stripe subscriptions.
-			$is_wc_first         = false;
 			$is_wc_first_enabled = defined( 'NEWSPACK_USE_WC_SUBSCRIPTIONS_WITH_STRIPE_PLATFORM' ) && NEWSPACK_USE_WC_SUBSCRIPTIONS_WITH_STRIPE_PLATFORM;
-			if ( $is_wc_first_enabled && Donations::is_woocommerce_suite_active() ) {
-				$gateways = WooCommerce_Configuration_Manager::get_payment_gateways( true );
-				// Check if Stripe (Credit Card) is the only payment gateway enabled.
-				if ( 1 === count( $gateways ) && isset( $gateways['stripe'] ) ) {
-					$is_wc_first = true;
-				}
-			}
+			$is_wc_first         = $is_wc_first_enabled && Donations::is_woocommerce_suite_active();
 
 			$payment_intent_payload = [
 				'amount'      => $amount_raw,

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -789,8 +789,15 @@ class Stripe_Connection {
 
 			// In this mode, WC will create a subscription for the customer, instead of using
 			// native Stripe subscriptions.
+			$is_wc_first         = false;
 			$is_wc_first_enabled = defined( 'NEWSPACK_USE_WC_SUBSCRIPTIONS_WITH_STRIPE_PLATFORM' ) && NEWSPACK_USE_WC_SUBSCRIPTIONS_WITH_STRIPE_PLATFORM;
-			$is_wc_first         = $is_wc_first_enabled && Donations::is_woocommerce_suite_active();
+			if ( $is_wc_first_enabled && Donations::is_woocommerce_suite_active() ) {
+				$gateways = WooCommerce_Configuration_Manager::get_payment_gateways( true );
+				// Check if Stripe (Credit Card) is the only payment gateway enabled.
+				if ( 1 === count( $gateways ) && isset( $gateways['stripe'] ) ) {
+					$is_wc_first = true;
+				}
+			}
 
 			$payment_intent_payload = [
 				'amount'      => $amount_raw,

--- a/includes/reader-revenue/stripe/class-stripe-webhooks.php
+++ b/includes/reader-revenue/stripe/class-stripe-webhooks.php
@@ -236,11 +236,22 @@ class Stripe_Webhooks {
 
 		$payload = $request['data']['object'];
 
-		// If order_id is set in the metadata, this was not created by this integration.
-		// This can happen when WC Subscriptions w/ Stripe Gateway was active before using this integration.
-		// In such a situation, WCS continues to charge subscribers, but since the platform is set to this integration,
-		// the webhook will still be exectuted for these payments, resulting in duplicate WC orders.
+		// If order_id is set in the metadata, this is a charge created by WC.
 		if ( isset( $payload['metadata']['order_id'] ) ) {
+			// Update the associated order and subscription.
+			if ( isset( $payload['metadata']['is_newspack'] ) && $payload['metadata']['is_newspack'] && Donations::is_woocommerce_suite_active() ) {
+				$balance_transaction = Stripe_Connection::get_balance_transaction( $payload['balance_transaction'] );
+				WooCommerce_Connection::update_order(
+					$payload['metadata']['order_id'],
+					[
+						// On order completed, the connected subscription will be activated if it exists.
+						'status'     => 'completed',
+						'stripe_id'  => $payload['id'],
+						'stripe_fee' => Stripe_Connection::normalise_amount( $balance_transaction['fee'], $payload['currency'] ),
+						'stripe_net' => Stripe_Connection::normalise_amount( $balance_transaction['net'], $payload['currency'] ),
+					]
+				);
+			}
 			return;
 		}
 

--- a/tests/unit-tests/stripe-connection.php
+++ b/tests/unit-tests/stripe-connection.php
@@ -102,18 +102,14 @@ class Newspack_Test_Stripe extends WP_UnitTestCase {
 	public static function test_stripe_handle_donation() {
 		self::configure_stripe_as_platform();
 		$donation_config = [
-			'amount'            => 100,
-			'frequency'         => 'once',
-			'email_address'     => 'foo@bar.baz',
-			'full_name'         => 'Boo Bar',
-			'token_data'        => [
-				'id'   => 'tok_123',
-				'type' => 'card',
-				'card' => [ 'id' => 'card_number_one' ],
-			],
-			'client_metadata'   => [],
-			'payment_metadata'  => [],
-			'payment_method_id' => 'pm_123',
+			'amount'                     => 100,
+			'frequency'                  => 'once',
+			'email_address'              => 'foo@bar.baz',
+			'full_name'                  => 'Boo Bar',
+			'stripe_tokenization_method' => null,
+			'stripe_source_id'           => 'src_123',
+			'client_metadata'            => [],
+			'payment_metadata'           => [],
 		];
 		$response        = Stripe_Connection::handle_donation( $donation_config );
 		self::assertEquals(

--- a/tests/unit-tests/stripe-connection.php
+++ b/tests/unit-tests/stripe-connection.php
@@ -102,14 +102,14 @@ class Newspack_Test_Stripe extends WP_UnitTestCase {
 	public static function test_stripe_handle_donation() {
 		self::configure_stripe_as_platform();
 		$donation_config = [
-			'amount'                     => 100,
-			'frequency'                  => 'once',
-			'email_address'              => 'foo@bar.baz',
-			'full_name'                  => 'Boo Bar',
-			'stripe_tokenization_method' => null,
-			'stripe_source_id'           => 'src_123',
-			'client_metadata'            => [],
-			'payment_metadata'           => [],
+			'amount'              => 100,
+			'frequency'           => 'once',
+			'email_address'       => 'foo@bar.baz',
+			'full_name'           => 'Boo Bar',
+			'tokenization_method' => null,
+			'source_id'           => 'src_123',
+			'client_metadata'     => [],
+			'payment_metadata'    => [],
 		];
 		$response        = Stripe_Connection::handle_donation( $donation_config );
 		self::assertEquals(

--- a/tests/unit-tests/stripe-connection.php
+++ b/tests/unit-tests/stripe-connection.php
@@ -108,6 +108,7 @@ class Newspack_Test_Stripe extends WP_UnitTestCase {
 			'full_name'         => 'Boo Bar',
 			'token_data'        => [
 				'id'   => 'tok_123',
+				'type' => 'card',
 				'card' => [ 'id' => 'card_number_one' ],
 			],
 			'client_metadata'   => [],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes the way Stripe donations are handled, so that it's possible that instead of a Stripe Subscription, a WC Subscriptions' Subscription is created for recurring payments. 

There is an underlying change in how Stripe API is interacted with. The way to charge a customer is either through [Sources](https://stripe.com/docs/api/sources), [Tokens](https://stripe.com/docs/api/tokens), or [Payment Methods](https://stripe.com/docs/api/payment_methods) – the latter [replaces the former two](https://stripe.com/docs/payments/payment-methods/transitioning). This integration has used Payment Methods, but since [WC Stripe Gateway uses a Source to process WC Subscriptions renewals](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/compat/trait-wc-stripe-subscriptions.php#L245-L247), the integration was updated to use Sources instead of Payment Methods.  

### How to test the changes in this Pull Request:

There are two ways to pay, and two modes of payment. When testing, ideally test all four scenarios (let's name them with letters for easier communication):

|         | Once | Recurring (e.g. monthly) 
|--------------|-----------|--|
| Card form | A | B  | 
| PaymentRequest (e.g. Apple Pay)      | C | D

1. Set up Stripe, ensure the site is reachable by Stripe webhooks
2. Ensure the WC suite is active, and "Stripe – Credit Card (Stripe)" set as the sole payment method in WC
1. Test the payment scenarios for regressions – the recurring payments should result in Stripe Subscriptions shadowed by sync'd WC Subscriptions (which can't be edited, etc.)
3. Set the `NEWSPACK_USE_WC_SUBSCRIPTIONS_WITH_STRIPE_PLATFORM` environment flag to `true`
4. Test the payment scenarios with this new configuration – recurring payments should result in WC Subscriptions and one-time charges in Stripe (_not_ Stripe Subscriptions)
5. Open the WC Subscriptions (scenarios B & D) in WP admin renew them manually (via the "Subscription actions" meta box)
7. Observe that the two subscriptions were renewed:
    1. Each got a new Stripe charge (successful)
    2. Each got a renewal order in WC
8. Disable the Stripe gateway in WC, observe that a recurring donation results in a Stripe Subscription

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->