### PR TITLE
WCS & Stripe: add payment metadata and update renewal description

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -990,7 +990,8 @@ class WooCommerce_Connection {
 			}
 			// Add the description only for Newspack-created subscriptions.
 			if ( self::CREATED_VIA_NAME === $subscription->get_created_via() ) {
-				$post_data['description'] = self::create_payment_description(
+				$post_data['metadata']['origin'] = 'newspack';
+				$post_data['description']        = self::create_payment_description(
 					[
 						'order_id'        => $order->get_id(),
 						'subscription_id' => $subscription_id,

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -50,6 +50,7 @@ class WooCommerce_Connection {
 		}
 		\add_filter( 'woocommerce_subscriptions_can_user_renew_early', [ __CLASS__, 'prevent_subscription_early_renewal' ], 11, 2 );
 		\add_filter( 'woocommerce_subscription_is_manual', [ __CLASS__, 'set_syncd_subscriptions_as_manual' ], 11, 2 );
+		\add_filter( 'wc_stripe_generate_payment_request', [ __CLASS__, 'stripe_gateway_payment_request_data' ], 10, 2 );
 
 		// WooCommerce Memberships.
 		\add_action( 'wc_memberships_user_membership_created', [ __CLASS__, 'wc_membership_created' ], 10, 2 );
@@ -937,6 +938,68 @@ class WooCommerce_Connection {
 			}
 		}
 		return $renewal_errors;
+	}
+
+	/**
+	 * Create a payment description for Stripe Gateway.
+	 *
+	 * @param array  $order_data An array of order data, containing the order ID and subscription ID, if applicable.
+	 * @param string $frequency The frequency of the donation.
+	 */
+	public static function create_payment_description( $order_data, $frequency ) {
+
+		if ( $order_data['subscription_id'] ) {
+			return sprintf(
+				/* translators: %s: Product name */
+				__( 'Newspack %1$s (Order #%2$d, Subscription #%3$d)', 'newspack' ),
+				Donations::get_donation_name_by_frequency( $frequency ),
+				$order_data['order_id'],
+				$order_data['subscription_id']
+			);
+		} else {
+			return sprintf(
+				/* translators: %s: Product name */
+				__( 'Newspack %1$s (Order #%2$d)', 'newspack' ),
+				Donations::get_donation_name_by_frequency( $frequency ),
+				$order_data['order_id']
+			);
+		}
+	}
+
+	/**
+	 * Filter post request made by the Stripe Gateway for Stripe payments.
+	 *
+	 * @param array     $post_data An array of metadata.
+	 * @param \WC_Order $order The order object.
+	 */
+	public static function stripe_gateway_payment_request_data( $post_data, $order ) {
+		if ( ! function_exists( 'wcs_get_subscriptions_for_renewal_order' ) ) {
+			return $post_data;
+		}
+		$related_subscriptions = \wcs_get_subscriptions_for_renewal_order( $order );
+		if ( ! empty( $related_subscriptions ) ) {
+			// In theory, there should be just one subscription per renewal.
+			$subscription    = reset( $related_subscriptions );
+			$subscription_id = $subscription->get_id();
+			// Add subscription ID to any renewal.
+			$post_data['metadata']['subscription_id'] = $subscription_id;
+			if ( \wcs_order_contains_renewal( $order ) ) {
+				$post_data['metadata']['subscription_status'] = 'renewed';
+			} else {
+				$post_data['metadata']['subscription_status'] = 'created';
+			}
+			// Add the description only for Newspack-created subscriptions.
+			if ( self::CREATED_VIA_NAME === $subscription->get_created_via() ) {
+				$post_data['description'] = self::create_payment_description(
+					[
+						'order_id'        => $order->get_id(),
+						'subscription_id' => $subscription_id,
+					],
+					$subscription->get_billing_period()
+				);
+			}
+		}
+		return $post_data;
 	}
 }
 

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -534,6 +534,7 @@ class WooCommerce_Connection {
 	 * Add a donation transaction to WooCommerce.
 	 *
 	 * @param object $order_data Order data.
+	 * @return array Data of created order and subscription, if applicable.
 	 */
 	public static function create_transaction( $order_data ) {
 		if ( isset( $order_data['stripe_id'] ) ) {
@@ -574,6 +575,9 @@ class WooCommerce_Connection {
 				$subscription_status = 'renewed';
 			}
 		}
+
+		$order        = false;
+		$subscription = false;
 
 		/**
 		 * Disable the emails sent to admin & customer after a subscription renewal order is completed.
@@ -699,7 +703,10 @@ class WooCommerce_Connection {
 			$wc_memberships_membership_plans->grant_access_to_membership_from_order( $order );
 		}
 
-		return $order->get_id();
+		return [
+			'order_id'        => $order ? $order->get_id() : false,
+			'subscription_id' => $subscription ? $subscription->get_id() : false,
+		];
 	}
 
 	/**

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -879,6 +879,7 @@ class Stripe_Connection {
 							'order_id'            => $wc_transaction_creation_data['order_id'],
 							'payment_type'        => 'recurring',
 							'subscription_status' => 'created',
+							'origin'              => 'newspack',
 						];
 						if ( $wc_transaction_creation_data['subscription_id'] ) {
 							$payment_intent_meta['subscription_id'] = $wc_transaction_creation_data['subscription_id'];

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -803,7 +803,7 @@ class Stripe_Connection {
 			// because WC Stripe Gateway is source-based.
 
 			// Mark the payment as coming from Newspack.
-			$payment_metadata['is_newspack'] = true;
+			$payment_metadata['origin'] = 'newspack';
 
 			// Data for WC Stripe Gateway.
 			$payment_metadata['payment_type']        = $is_recurring ? 'recurring' : 'once';
@@ -879,7 +879,6 @@ class Stripe_Connection {
 							'order_id'            => $wc_transaction_creation_data['order_id'],
 							'payment_type'        => 'recurring',
 							'subscription_status' => 'created',
-							'origin'              => 'newspack',
 						];
 						if ( $wc_transaction_creation_data['subscription_id'] ) {
 							$payment_intent_meta['subscription_id'] = $wc_transaction_creation_data['subscription_id'];

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -867,7 +867,9 @@ class Stripe_Connection {
 					if ( $is_recurring ) {
 						$wc_order_payload['subscription_status'] = 'created';
 					}
-					$wc_order_id = WooCommerce_Connection::create_transaction( $wc_order_payload );
+
+					$wc_transaction_creation_data = WooCommerce_Connection::create_transaction( $wc_order_payload );
+					$wc_order_id                  = $wc_transaction_creation_data['order_id'];
 					if ( ! \is_wp_error( $wc_order_id ) ) {
 						// Trigger the ESP data sync, which would normally happen on checkout.
 						$payment_page_url = isset( $client_metadata['current_page_url'] ) ? $client_metadata['current_page_url'] : false;

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -875,17 +875,21 @@ class Stripe_Connection {
 						$payment_page_url = isset( $client_metadata['current_page_url'] ) ? $client_metadata['current_page_url'] : false;
 						WooCommerce_Connection::sync_reader_from_order( $wc_order_id, false, $payment_page_url );
 
+						$payment_intent_meta = [
+							'order_id'            => $wc_transaction_creation_data['order_id'],
+							'payment_type'        => 'recurring',
+							'subscription_status' => 'created',
+						];
+						if ( $wc_transaction_creation_data['subscription_id'] ) {
+							$payment_intent_meta['subscription_id'] = $wc_transaction_creation_data['subscription_id'];
+						}
+
 						// Update the metadata on the payment intent with the order ID.
 						$stripe->paymentIntents->update(
 							$payment_intent['id'],
 							[
-								'description' => sprintf(
-									/* translators: %s: Product name */
-									__( 'Newspack %1$s (Order #%2$d)', 'newspack' ),
-									Donations::get_donation_name_by_frequency( $frequency ),
-									$wc_order_id
-								),
-								'metadata'    => [ 'order_id' => $wc_order_id ],
+								'description' => WooCommerce_Connection::create_payment_description( $wc_transaction_creation_data, $frequency ),
+								'metadata'    => $payment_intent_meta,
 							]
 						);
 					}

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -158,9 +158,9 @@ class Stripe_Sync {
 			} else {
 				// This is a charge without an order. Create a new order.
 				if ( ! $is_dry_run ) {
-					$order_id = WooCommerce_Connection::create_transaction( $transation_payload );
+					$wc_transaction_creation_data = WooCommerce_Connection::create_transaction( $wc_order_payload );
 					// translators: Order ID.
-					\WP_CLI::success( sprintf( __( 'Created WC order: %d.', 'newspack' ), $order_id ) );
+					\WP_CLI::success( sprintf( __( 'Created WC order: %d.', 'newspack' ), $wc_transaction_creation_data['order_id'] ) );
 				}
 				self::$results['wc_orders_created'] ++;
 			}

--- a/includes/reader-revenue/stripe/class-stripe-webhooks.php
+++ b/includes/reader-revenue/stripe/class-stripe-webhooks.php
@@ -239,7 +239,7 @@ class Stripe_Webhooks {
 		// If order_id is set in the metadata, this is a charge created by WC.
 		if ( isset( $payload['metadata']['order_id'] ) ) {
 			// Update the associated order and subscription.
-			if ( isset( $payload['metadata']['is_newspack'] ) && $payload['metadata']['is_newspack'] && Donations::is_woocommerce_suite_active() ) {
+			if ( isset( $payload['metadata']['origin'] ) && 'newspack' === $payload['metadata']['origin'] && Donations::is_woocommerce_suite_active() ) {
 				$balance_transaction = Stripe_Connection::get_balance_transaction( $payload['balance_transaction'] );
 				WooCommerce_Connection::update_order(
 					$payload['metadata']['order_id'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WC Stripe Gateway plugin adds little metadata to any Stripe payment. It's not possible to learn that a payment was related to a specific subscription. WCSG only adds the `order_id` metadata and indicates a WC Subscription with a `payment_type='recurring'` metadata.

To make any third-party integrations more aware of what WCS is doing in Stripe:

- `subscription_id` will be added to any payments which are WC Subscriptions renewals
- `subscription_status` will be added, either `created` or `renewed`
- additionally, for Newspack-originating subscriptions, the payment description will be updated to `Newspack <frequency> Donation (Order <id>, Subscription <id>)` (e.g. `Newspack Monthly Donation (Order #756, Subscription #757)`)

### How to test the changes in this Pull Request:

1. Set up Stripe, ensure the site is reachable by Stripe webhooks
1. Ensure the WC suite is active, and "Stripe – Credit Card (Stripe)" set as the only payment method in WC
1. Set the environment variable `NEWSPACK_USE_WC_SUBSCRIPTIONS_WITH_STRIPE_PLATFORM` to `true` (see https://github.com/Automattic/newspack-plugin/pull/2251)
2. Make a recurring donation using SDB 
3. Open the resulting WC Subscription in WP Admin an renew it manually (via the "Subscription actions" meta box) 
4. Go to Stripe dashboard, inspect the initial payment and the renewal payment – both should have `subscription_id` meta set (to the applicable value), the first one should have the `subscription_status` meta set to `created`, and the second one to `renewed`.  Both should have `origin` meta set to `newspack`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->