### PR TITLE
fix(ads): remove fixed height setting

### DIFF
--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -201,19 +201,6 @@ const Placements = () => {
 								</Card>
 							);
 						} ) }
-					<ToggleControl
-						label={ __( 'Use fixed height', 'newspack' ) }
-						help={ __(
-							'Avoid content layout shift by using the ad unit height as fixed height for this placement. This is recommended if an ad is guaranteed to be shown across all devices.',
-							'newspack'
-						) }
-						checked={ !! placement.data?.fixed_height }
-						onChange={ value => {
-							setPlacements(
-								set( [ editingPlacement, 'data', 'fixed_height' ], value, placements )
-							);
-						} }
-					/>
 					{ placement.supports?.indexOf( 'stick_to_top' ) > -1 && (
 						<ToggleControl
 							label={ __( 'Stick to Top', 'newspack' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Remove the Ads' per-placement setting for fixed height.

Further details and instructions at https://github.com/Automattic/newspack-ads/pull/590

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->