### PR TITLE
feat: require all woo plugins for RAS

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -37,7 +37,10 @@ export default withWizardScreen( () => {
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
 		} )
-			.then( setConfig )
+			.then( ( { config: fetchedConfig, pluginsStatus } ) => {
+				setHasPlugins( pluginsStatus );
+				setConfig( fetchedConfig );
+			} )
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
 	};
@@ -53,18 +56,7 @@ export default withWizardScreen( () => {
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
 	};
-	const fetchPluginStatus = () => {
-		setError( false );
-		setInFlight( true );
-		apiFetch( {
-			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation-plugins',
-		} )
-			.then( setHasPlugins )
-			.catch( setError )
-			.finally( () => setInFlight( false ) );
-	};
 	useEffect( fetchConfig, [] );
-	useEffect( fetchPluginStatus, [] );
 	useEffect( () => {
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/newsletters',
@@ -107,7 +99,7 @@ export default withWizardScreen( () => {
 				<PluginInstaller
 					isWaiting={ inFlight }
 					plugins={ [ 'woocommerce', 'woocommerce-subscriptions', 'woocommerce-name-your-price' ] }
-					onStatus={ ( { complete } ) => complete && fetchPluginStatus() }
+					onStatus={ ( { complete } ) => complete && fetchConfig() }
 					withoutFooterButton={ true }
 				/>
 			</>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -27,7 +27,7 @@ export default withWizardScreen( () => {
 	const [ config, setConfig ] = useState( {} );
 	const [ error, setError ] = useState( false );
 	const [ isActiveCampaign, setIsActiveCampaign ] = useState( false );
-	const [ hasPlugins, setHasPlugins ] = useState( true );
+	const [ hasPlugins, setHasPlugins ] = useState( false );
 	const updateConfig = ( key, val ) => {
 		setConfig( { ...config, [ key ]: val } );
 	};
@@ -54,11 +54,14 @@ export default withWizardScreen( () => {
 			.finally( () => setInFlight( false ) );
 	};
 	const fetchPluginStatus = () => {
+		setError( false );
+		setInFlight( true );
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation-plugins',
 		} )
 			.then( setHasPlugins )
-			.catch( setError );
+			.catch( setError )
+			.finally( () => setInFlight( false ) );
 	};
 	useEffect( fetchConfig, [] );
 	useEffect( fetchPluginStatus, [] );

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -27,7 +27,7 @@ export default withWizardScreen( () => {
 	const [ config, setConfig ] = useState( {} );
 	const [ error, setError ] = useState( false );
 	const [ isActiveCampaign, setIsActiveCampaign ] = useState( false );
-	const [ hasPlugins, setHasPlugins ] = useState( false );
+	const [ hasPlugins, setHasPlugins ] = useState( null );
 	const updateConfig = ( key, val ) => {
 		setConfig( { ...config, [ key ]: val } );
 	};

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -27,6 +27,7 @@ export default withWizardScreen( () => {
 	const [ config, setConfig ] = useState( {} );
 	const [ error, setError ] = useState( false );
 	const [ isActiveCampaign, setIsActiveCampaign ] = useState( false );
+	const [ hasPlugins, setHasPlugins ] = useState( true );
 	const updateConfig = ( key, val ) => {
 		setConfig( { ...config, [ key ]: val } );
 	};
@@ -52,7 +53,15 @@ export default withWizardScreen( () => {
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
 	};
+	const fetchPluginStatus = () => {
+		apiFetch( {
+			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation-plugins',
+		} )
+			.then( setHasPlugins )
+			.catch( setError );
+	};
 	useEffect( fetchConfig, [] );
+	useEffect( fetchPluginStatus, [] );
 	useEffect( () => {
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/newsletters',
@@ -83,7 +92,7 @@ export default withWizardScreen( () => {
 
 	const emails = Object.values( config.emails || {} );
 
-	if ( ! inFlight && false === config.plugins_configured ) {
+	if ( false === hasPlugins ) {
 		return (
 			<>
 				<Notice isError>
@@ -94,8 +103,8 @@ export default withWizardScreen( () => {
 				</Notice>
 				<PluginInstaller
 					isWaiting={ inFlight }
-					plugins={ [ 'woocommerce', 'woocommerce-subscriptions' ] }
-					onStatus={ ( { complete } ) => complete && fetchConfig() }
+					plugins={ [ 'woocommerce', 'woocommerce-subscriptions', 'woocommerce-name-your-price' ] }
+					onStatus={ ( { complete } ) => complete && fetchPluginStatus() }
 					withoutFooterButton={ true }
 				/>
 			</>

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -180,7 +180,6 @@ final class Reader_Activation {
 			'sender_name'                 => Emails::get_from_name(),
 			'sender_email_address'        => Emails::get_from_email(),
 			'contact_email_address'       => Emails::get_reply_to_email(),
-			'plugins_configured'          => self::is_woocommerce_active(),
 		];
 
 		/**
@@ -265,7 +264,13 @@ final class Reader_Activation {
 	 * @return boolean True if all required plugins are active, otherwise false.
 	 */
 	public static function is_woocommerce_active() {
-		return class_exists( 'WooCommerce' ) && class_exists( 'WC_Subscriptions' );
+		$is_active = Donations::is_woocommerce_suite_active();
+
+		if ( \is_wp_error( $is_active ) ) {
+			return false;
+		}
+
+		return $is_active;
 	}
 
 	/**

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -90,6 +90,15 @@ class Engagement_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/reader-activation-plugins',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_fetch_plugin_status' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/reader-activation',
@@ -195,6 +204,15 @@ class Engagement_Wizard extends Wizard {
 	 */
 	public function api_get_reader_activation_settings() {
 		return rest_ensure_response( Reader_Activation::get_settings() );
+	}
+
+	/**
+	 * Get all Wizard Data
+	 *
+	 * @return WP_REST_Response containing ad units info.
+	 */
+	public function api_fetch_plugin_status() {
+		return \rest_ensure_response( Reader_Activation::is_woocommerce_active() );
 	}
 
 	/**

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -90,15 +90,6 @@ class Engagement_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
-		\register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/reader-activation-plugins',
-			[
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'api_fetch_plugin_status' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-			]
-		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/reader-activation',
@@ -203,16 +194,12 @@ class Engagement_Wizard extends Wizard {
 	 * @return WP_REST_Response
 	 */
 	public function api_get_reader_activation_settings() {
-		return rest_ensure_response( Reader_Activation::get_settings() );
-	}
-
-	/**
-	 * Get all Wizard Data
-	 *
-	 * @return WP_REST_Response containing ad units info.
-	 */
-	public function api_fetch_plugin_status() {
-		return \rest_ensure_response( Reader_Activation::is_woocommerce_active() );
+		return rest_ensure_response(
+			[
+				'config'        => Reader_Activation::get_settings(),
+				'pluginsStatus' => Reader_Activation::is_woocommerce_active(),
+			]
+		);
 	}
 
 	/**

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -80,7 +80,6 @@ class Reader_Revenue_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
-
 		// Save basic data about reader revenue platform.
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Separates out the plugin requirements check from options-based RAS settings, and requires all WooCommerce plugins and extensions for RAS.

Closes 1203695565716937/1203706216921098.

### How to test the changes in this Pull Request:

1. On a site with Reader Activation enabled, visit **Newspack > Engagement > Reader Activation**.
2. Disable the following plugins one-by-one, and confirm that the Reader Activation settings page is replaced by a plugin installer component if any of them is missing:

<img width="1119" alt="Screen Shot 2023-01-31 at 3 35 21 PM" src="https://user-images.githubusercontent.com/2230142/215899211-9f2e7af6-ec5e-49f0-b45f-4b3d5b301b9b.png">

3. Confirm that the settings page reappears automatically after installing/activating all required plugins.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->