### PR TITLE
fix: change default auth strategy to "link"

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -270,7 +270,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 					emailInput.focus();
 				}
 			}
-			setFormAction( readerActivation.getAuthStrategy() || 'pwd' );
+			setFormAction( readerActivation.getAuthStrategy() || 'link' );
 			readerActivation.on( 'reader', () => {
 				if ( readerActivation.getOTPHash() ) {
 					setFormAction( 'otp' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Modifies the RAS' default auth strategy from password to link.

### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have AMP Plus and RAS enabled
2. On a fresh session (incognito) click to Sign In
3. Confirm you're prompted to use the "link" authentication strategy
4. Switch to password and close the modal
5. On a new tab (same session) open the "Sign In" modal again and confirm "password" auth strategy is preserved

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->