### PR TITLE
feat(webhooks): support label for endpoints

### DIFF
--- a/assets/wizards/connections/style.scss
+++ b/assets/wizards/connections/style.scss
@@ -14,8 +14,18 @@
 			font-size: 0.8em;
 		}
 
-		.newspack-action-card__title {
+		&__label {
+			margin-right: 8px;
+		}
+		&__url {
 			font-family: Consolas, monaco, monospace;
+			font-size: 0.8em;
+			color: wp-colors.$gray-900;
+		}
+
+		.newspack-action-card__title {
+			display: flex;
+			align-items: center;
 		}
 	}
 	&__test-response {

--- a/assets/wizards/connections/views/main/webhooks.js
+++ b/assets/wizards/connections/views/main/webhooks.js
@@ -29,11 +29,22 @@ import {
 	Popover,
 } from '../../../../components/src';
 
-const getEndpointTitle = endpoint => {
-	if ( endpoint.url.length > 45 ) {
-		return `${ endpoint.url.slice( 8, 38 ) }...${ endpoint.url.slice( -10 ) }`;
+const getDisplayUrl = url => {
+	let displayUrl = url.slice( 8 );
+	if ( url.length > 45 ) {
+		displayUrl = `${ url.slice( 8, 38 ) }...${ url.slice( -10 ) }`;
 	}
-	return endpoint.url.slice( 8 );
+	return displayUrl;
+};
+
+const getEndpointTitle = endpoint => {
+	const { label, url } = endpoint;
+	return (
+		<>
+			{ label && <span className="newspack-webhooks__endpoint__label">{ label }</span> }
+			<span className="newspack-webhooks__endpoint__url">{ getDisplayUrl( url ) }</span>
+		</>
+	);
 };
 
 const getRequestStatusIcon = status => {
@@ -308,7 +319,7 @@ const Webhooks = () => {
 					description={ sprintf(
 						/* translators: %s: endpoint title */
 						__( 'Are you sure you want to remove the endpoint %s?', 'newspack' ),
-						`"${ getEndpointTitle( deleting ) }"`
+						`"${ getDisplayUrl( deleting.url ) }"`
 					) }
 					onClose={ () => setDeleting( false ) }
 					onConfirm={ () => deleteEndpoint( deleting ) }
@@ -327,12 +338,12 @@ const Webhooks = () => {
 							? sprintf(
 									/* translators: %s: endpoint title */
 									__( 'Are you sure you want to enable the endpoint %s?', 'newspack' ),
-									`"${ getEndpointTitle( toggling ) }"`
+									`"${ getDisplayUrl( toggling.url ) }"`
 							  )
 							: sprintf(
 									/* translators: %s: endpoint title */
 									__( 'Are you sure you want to disable the endpoint %s?', 'newspack' ),
-									`"${ getEndpointTitle( toggling ) }"`
+									`"${ getDisplayUrl( toggling.url ) }"`
 							  )
 					}
 					endpoint={ toggling }
@@ -475,6 +486,16 @@ const Webhooks = () => {
 						</Card>
 					</Grid>
 					<hr />
+					<TextControl
+						label={ __( 'Label (optional)', 'newspack' ) }
+						help={ __(
+							'A label to help you identify this endpoint. It will not be sent to the endpoint.',
+							'newspack'
+						) }
+						value={ editing.label }
+						onChange={ value => setEditing( { ...editing, label: value } ) }
+						disabled={ inFlight }
+					/>
 					<Grid columns={ 1 } gutter={ 16 }>
 						<h3>{ __( 'Actions', 'newspack' ) }</h3>
 						<CheckboxControl

--- a/includes/data-events/class-api.php
+++ b/includes/data-events/class-api.php
@@ -131,6 +131,10 @@ final class Api {
 			'disabled' => [
 				'type' => 'boolean',
 			],
+			'label'    => [
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
 		];
 	}
 
@@ -262,6 +266,9 @@ final class Api {
 				$args['global'],
 				$args['disabled']
 			);
+		}
+		if ( is_string( $request->get_param( 'label' ) ) ) {
+			Webhooks::update_endpoint_label( $endpoint['id'], $request->get_param( 'label' ) );
 		}
 		if ( \is_wp_error( $endpoint ) ) {
 			return $endpoint;

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -202,7 +202,7 @@ final class Webhooks {
 	 * @param array  $actions Array of action names.
 	 * @param bool   $global  Whether the endpoint should be triggered for all actions.
 	 *
-	 * @return int|WP_Error Endpoint ID or error.
+	 * @return array|WP_Error Endpoint or error.
 	 */
 	public static function create_endpoint( $url, $actions = [], $global = false ) {
 		$endpoint = \wp_insert_term(
@@ -217,7 +217,7 @@ final class Webhooks {
 		}
 		\update_term_meta( $endpoint['term_id'], 'actions', $actions );
 		\update_term_meta( $endpoint['term_id'], 'global', $global );
-		return $endpoint['term_id'];
+		return self::get_endpoint( $endpoint['term_id'] );
 	}
 
 	/**
@@ -229,7 +229,7 @@ final class Webhooks {
 	 * @param bool   $global   Whether the endpoint should be triggered for all actions.
 	 * @param bool   $disabled Whether the endpoint is disabled.
 	 *
-	 * @return array|WP_Error
+	 * @return array|WP_Error Endpoint or error.
 	 */
 	public static function update_endpoint( $id, $url, $actions = [], $global = false, $disabled = false ) {
 		$endpoint = \get_term( $id, self::ENDPOINT_TAXONOMY, ARRAY_A );
@@ -247,7 +247,7 @@ final class Webhooks {
 		\update_term_meta( $endpoint['term_id'], 'actions', $actions );
 		\update_term_meta( $endpoint['term_id'], 'global', $global );
 		\update_term_meta( $endpoint['term_id'], 'disabled', $disabled );
-		return $endpoint;
+		return self::get_endpoint( $endpoint['term_id'] );
 	}
 
 	/**
@@ -263,6 +263,21 @@ final class Webhooks {
 			return new WP_Error( 'newspack_webhooks_endpoint_not_found', __( 'Webhook endpoint not found.', 'newspack' ) );
 		}
 		\wp_delete_term( $id, self::ENDPOINT_TAXONOMY );
+	}
+
+	/**
+	 * Update a webhook endpoint label.
+	 *
+	 * @param int    $id    Endpoint ID.
+	 * @param string $label Endpoint label.
+	 *
+	 * @return void|WP_Error Error if endpoint not found.
+	 */
+	public static function update_endpoint_label( $id, $label ) {
+		if ( ! get_term( $id, self::ENDPOINT_TAXONOMY ) ) {
+			return new \WP_Error( 'newspack_webhooks_endpoint_not_found', __( 'Webhook endpoint not found.', 'newspack' ) );
+		}
+		\update_term_meta( $id, 'label', $label );
 	}
 
 	/**
@@ -302,6 +317,7 @@ final class Webhooks {
 			'url'            => $endpoint->name,
 			'actions'        => (array) \get_term_meta( $endpoint->term_id, 'actions', true ),
 			'global'         => (bool) \get_term_meta( $endpoint->term_id, 'global', true ),
+			'label'          => \get_term_meta( $endpoint->term_id, 'label', true ),
 			'disabled'       => $disabled,
 			'disabled_error' => $disabled ? \get_term_meta( $endpoint->term_id, 'disabled_error', true ) : null,
 		];

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -65,15 +65,15 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 			'https://example.com/webhook',
 			[],
 			true
-		);
+		)['id'];
 		$this->action_endpoint         = Data_Events\Webhooks::create_endpoint(
 			'https://example.com/webhook/test_action',
 			[ 'test_action' ]
-		);
+		)['id'];
 		$this->missing_action_endpoint = Data_Events\Webhooks::create_endpoint(
 			'https://example.com/webhook/missing_action',
 			[ 'missing_action' ]
-		);
+		)['id'];
 		$this->endpoints               = [
 			$this->global_endpoint,
 			$this->action_endpoint,
@@ -104,6 +104,20 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 				$this->assertEquals( [], $endpoint['actions'] );
 				$this->assertEquals( true, $endpoint['global'] );
 				$this->assertEquals( false, $endpoint['disabled'] );
+			}
+		}
+	}
+
+	/**
+	 * Test updating an endpoint label.
+	 */
+	public function test_update_endpoint_label() {
+		$id = $this->global_endpoint;
+		Data_Events\Webhooks::update_endpoint_label( $id, 'Test Label' );
+		$endpoints = Data_Events\Webhooks::get_endpoints();
+		foreach ( $endpoints as $endpoint ) {
+			if ( $endpoint['id'] === $id ) {
+				$this->assertEquals( 'Test Label', $endpoint['label'] );
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces an optional label to webhook endpoints for easier identification:

<img width="730" alt="Captura de Tela 2023-02-01 às 17 51 50" src="https://user-images.githubusercontent.com/820752/216160684-c2a3b718-0947-451b-9bce-d05a5a5b6e68.png">

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/820752/216160442-a810c361-756a-4173-88fe-a6310f4dd3e8.png">

### How to test the changes in this Pull Request:

1. Checkout this branch and make sure you have `define( 'NEWSPACK_EXPERIMENTAL_WEBHOOKS', true );` set
2. Visit the Connections wizard and create a new webhook
3. Set a label and save
4. Confirm the title includes the label
5. Edit the endpoint to a different label
6. Confirm the it's updated
7. Edit the endpoint and clear the label
8. Confirm it no longer shows a label in its title

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->