### PR TITLE
feat(data-events): standardize the use of "user_id" and "email"

### DIFF
--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -48,6 +48,7 @@ When a reader verifies their email address.
 | Name      | Type      |
 | --------- | --------- |
 | `user_id` | `integer` |
+| `email`   | `string`  |
 
 ### `newsletter_subscribed`
 
@@ -55,6 +56,8 @@ When a reader subscribes to newsletter lists from Newspack Newsletters subscript
 
 | Name       | Type       |
 | ---------- | ---------- |
+| `user_id`  | `integer`  |
+| `email`    | `string`   |
 | `provider` | `string`   |
 | `contact`  | `array`    |
 | `lists`    | `string[]` |
@@ -65,6 +68,8 @@ When a reader updates their lists subscription from Newspack Newsletters.
 
 | Name            | Type       |
 | --------------- | ---------- |
+| `user_id`       | `integer`  |
+| `email`         | `string`   |
 | `provider`      | `string`   |
 | `email`         | `string`   |
 | `lists_added`   | `string[]` |
@@ -104,9 +109,9 @@ When a WooCommerce Subscription is cancelled.
 
 | Name              | Type     |
 | ----------------- | -------- |
-| `subscription_id` | `int`    |
 | `user_id`         | `int`    |
 | `email`           | `string` |
+| `subscription_id` | `int`    |
 | `amount`          | `float`  |
 | `currency`        | `string` |
 | `recurrence`      | `string` |
@@ -118,9 +123,9 @@ When a WooCommerce Subscription status changes.
 
 | Name              | Type     |
 | ----------------- | -------- |
-| `subscription_id` | `int`    |
 | `user_id`         | `int`    |
 | `email`           | `string` |
+| `subscription_id` | `int`    |
 | `status_before`   | `string` |
 | `status_after`    | `string` |
 | `amount`          | `float`  |

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -55,6 +55,7 @@ Data_Events::register_listener(
 	function( $user ) {
 		return [
 			'user_id' => $user->ID,
+			'email'   => $user->user_email,
 		];
 	}
 );
@@ -72,7 +73,10 @@ Data_Events::register_listener(
 		if ( true !== $result ) {
 			return;
 		}
+		$user = get_user_by( 'email', $contact['email'] );
 		return [
+			'user_id'  => $user ? $user->ID : null,
+			'email'    => $contact['email'],
 			'provider' => $provider,
 			'contact'  => $contact,
 			'lists'    => $lists,
@@ -93,9 +97,11 @@ Data_Events::register_listener(
 		if ( true !== $result ) {
 			return;
 		}
+		$user = get_user_by( 'email', $email );
 		return [
-			'provider'      => $provider,
+			'user_id'       => $user ? $user->ID : null,
 			'email'         => $email,
+			'provider'      => $provider,
 			'lists_added'   => $lists_added,
 			'lists_removed' => $lists_removed,
 		];
@@ -187,9 +193,9 @@ Data_Events::register_listener(
 			return;
 		}
 		return [
-			'subscription_id' => $subscription->get_id(),
 			'user_id'         => $subscription->get_customer_id(),
 			'email'           => $subscription->get_billing_email(),
+			'subscription_id' => $subscription->get_id(),
 			'amount'          => (float) $subscription->get_total(),
 			'currency'        => $subscription->get_currency(),
 			'recurrence'      => get_post_meta( $product_id, '_subscription_period', true ),
@@ -210,9 +216,9 @@ Data_Events::register_listener(
 			return;
 		}
 		return [
-			'subscription_id' => $subscription->get_id(),
 			'user_id'         => $subscription->get_customer_id(),
 			'email'           => $subscription->get_billing_email(),
+			'subscription_id' => $subscription->get_id(),
 			'status_before'   => $status_from,
 			'status_after'    => $status_to,
 			'amount'          => (float) $subscription->get_total(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR standardizes the use of `user_id` and `email` across all existing listeners. This allows for easier integration with general-purpose connections.

### How to test the changes in this Pull Request:

1. Make sure you have RAS enabled
2. Add a generic handler for payload debugging:
```php
\Newspack\Data_Events::register_handler(
	function( $action_name, $timestamp, $data, $client_id ) {
		error_log( "Action $action_name dispatched with data: " . print_r( $data, true ) . " at $timestamp" );
	}
);
```
3. On a fresh session perform all the actions changed:
   1. Register a new reader
   2. Subscribe to a newsletter using the Newspack Newsletters block
   3. Update your newsletter subscription through the "My Account" page
5. Confirm all payloads include `user_id` and `email` data

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->