### PR TITLE
Fix/perfmatters defaults adjustments

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -85,6 +85,15 @@ class Perfmatters {
 	}
 
 	/**
+	 * Selectors to exclude from the "Unused CSS" feature.
+	 */
+	private static function unused_css_excluded_selectors() {
+		return [
+			'body',
+		];
+	}
+
+	/**
 	 * URLs to preconnect to.
 	 *
 	 * @param array $existing_urls Existing URLs to filter out.
@@ -119,7 +128,6 @@ class Perfmatters {
 		// Basic options.
 		$options['disable_emojis']              = true;
 		$options['disable_dashicons']           = true;
-		$options['remove_global_styles']        = true;
 		$options['disable_woocommerce_scripts'] = true;
 		// "The cart fragments feature and or AJAX request in WooCommerce is used to update the cart
 		// total without refreshing the page."
@@ -130,7 +138,10 @@ class Perfmatters {
 		if ( ! isset( $options['assets'] ) ) {
 			$options['assets'] = [];
 		}
-		$defer_js_exclusions           = [ 'wp-includes' ];
+		$defer_js_exclusions           = [
+			'wp-includes',
+			'jwplayer.com', // This platform won't work if the JS is deferred.
+		];
 		$options['assets']['defer_js'] = true;
 		if ( isset( $options['assets']['js_exclusions'] ) && is_array( $options['assets']['js_exclusions'] ) ) {
 			$options['assets']['js_exclusions'] = array_unique(
@@ -169,6 +180,16 @@ class Perfmatters {
 			);
 		} else {
 			$options['assets']['rucss_excluded_stylesheets'] = self::unused_css_excluded_stylesheets();
+		}
+		if ( isset( $options['assets']['rucss_excluded_selectors'] ) && is_array( $options['assets']['rucss_excluded_selectors'] ) ) {
+			$options['assets']['rucss_excluded_selectors'] = array_unique(
+				array_merge(
+					$options['assets']['rucss_excluded_selectors'],
+					self::unused_css_excluded_selectors()
+				)
+			);
+		} else {
+			$options['assets']['rucss_excluded_selectors'] = self::unused_css_excluded_selectors();
 		}
 
 		// Preload.

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -18,6 +18,7 @@ class Perfmatters {
 	 */
 	public static function init() {
 		add_filter( 'option_perfmatters_options', [ __CLASS__, 'set_defaults' ] );
+		add_action( 'admin_notices', [ __CLASS__, 'admin_notice' ] );
 	}
 
 	/**
@@ -212,6 +213,18 @@ class Perfmatters {
 		$options['lazyload']['image_dimensions']           = true;
 
 		return $options;
+	}
+
+	/**
+	 * Add an admin notice.
+	 */
+	public static function admin_notice() {
+		if ( 'settings_page_perfmatters' !== get_current_screen()->id ) {
+			return;
+		}
+		echo '<div class="notice notice-warning"><p>'
+		. __( 'Newspack plugin is overriding Perfmatters settings. You can use the <code>NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS</code> flag to disable that behavior.', 'newspack' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		. '</p></div>';
 	}
 }
 Perfmatters::init();

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -80,6 +80,7 @@ class Perfmatters {
 		return [
 			'donateStreamlined.css',
 			'/themes/newspack-', // Any Newspack theme stylesheet.
+			'wp-includes',
 		];
 	}
 

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -17,7 +17,6 @@ class Perfmatters {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_filter( 'default_option_perfmatters_options', [ __CLASS__, 'set_defaults' ] );
 		add_filter( 'option_perfmatters_options', [ __CLASS__, 'set_defaults' ] );
 	}
 
@@ -118,9 +117,6 @@ class Perfmatters {
 	 * @param array $options Perfmatters options.
 	 */
 	public static function set_defaults( $options = [] ) {
-		if ( ! isset( $_GET['newspack-perfmatters-defaults'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return $options;
-		}
 		if ( defined( 'NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS' ) && NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS ) {
 			return $options;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

- Removes feature flag on Perfmatters defaults (https://github.com/Automattic/newspack-plugin/pull/2156)
- Updates the defaults
- Removes superflous use of [`default_option_perfmatters_options` filter](https://github.com/WordPress/wordpress-develop/blob/6.1/src/wp-includes/option.php#L188) – `option_perfmatters_options` filter is [ran anyway later](https://github.com/WordPress/wordpress-develop/blob/6.1/src/wp-includes/option.php#L253).

### How to test the changes in this Pull Request:

1. Install the Perfmatters plugin
2. Observe that the defaults are applied (see https://github.com/Automattic/newspack-plugin/pull/2156)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->