### PR TITLE
Fix: Temprory Adunit displayed on the list

### DIFF
--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -103,6 +103,9 @@ class AdvertisingWizard extends Component {
 			quiet: true,
 		} );
 
+	/**
+	 * On cancel save/update ad unit.
+	 */
 	onAdUnitCancel = () => {
 		this.fetchAdvertisingData();
 	};

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -103,6 +103,10 @@ class AdvertisingWizard extends Component {
 			quiet: true,
 		} );
 
+	onAdUnitCancel = () => {
+		this.fetchAdvertisingData();
+	};
+
 	/**
 	 * Delete an ad unit.
 	 *
@@ -250,6 +254,7 @@ class AdvertisingWizard extends Component {
 											} )
 											.catch( () => {} )
 									}
+									onCancel={ this.onAdUnitCancel }
 									tabbedNavigation={ tabs }
 								/>
 							) }
@@ -270,6 +275,7 @@ class AdvertisingWizard extends Component {
 												routeProps.history.push( '/google_ad_manager' );
 											} )
 										}
+										onCancel={ this.onAdUnitCancel }
 										tabbedNavigation={ tabs }
 									/>
 								);

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -65,7 +65,7 @@ class AdUnit extends Component {
 	 * Render.
 	 */
 	render() {
-		const { adUnit, service, onSave } = this.props;
+		const { adUnit, service, onSave, onCancel } = this.props;
 		const { id, code, fluid = false, name = '' } = adUnit;
 		const isLegacy = adUnit.is_legacy;
 		const isExistingAdUnit = id !== 0;
@@ -182,7 +182,7 @@ class AdUnit extends Component {
 					>
 						{ __( 'Save', 'newspack' ) }
 					</Button>
-					<Button variant="secondary" href={ `#/${ service }` }>
+					<Button variant="secondary" onClick={ () => onCancel() } href={ `#/${ service }` }>
 						{ __( 'Cancel', 'newspack' ) }
 					</Button>
 				</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
1. On Ad wizard if user wants to edit any ads specification and instead of saving changes he `cancels` the change, still the current change are reflected on the list and are gone once refresh the page.
2. This PR fixes this issue and changes would not be saved in state once user cancel the changes and list would show previous change only.

Closes #1220.

### How to test the changes in this Pull Request:

1. Visit the Advertising Wizard
2. Edit an ad unit – add a few sizes
3. Click "Cancel"
4. Observe the sizes are now not listed as unit's sizes on the list

### Screencast for current change
[NewspackIssue1220.webm](https://user-images.githubusercontent.com/58802366/218004851-2d6cb056-30c9-4035-8fa5-bc1656fc23b9.webm)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->