### PR TITLE
fix(webhooks): check if endpoint exists

### DIFF
--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -580,10 +580,12 @@ final class Webhooks {
 		if ( ! $endpoint ) {
 			self::add_request_error( $request_id, __( 'Endpoint not found.', 'newspack' ) );
 			self::kill_request( $request_id );
+			return;
 		}
 		if ( $endpoint && $endpoint['disabled'] ) {
 			self::add_request_error( $request_id, __( 'Endpoint is disabled.', 'newspack' ) );
 			self::kill_request( $request_id );
+			return;
 		}
 
 		$errors = self::get_request_errors( $request_id );

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -581,7 +581,7 @@ final class Webhooks {
 			self::add_request_error( $request_id, __( 'Endpoint not found.', 'newspack' ) );
 			self::kill_request( $request_id );
 		}
-		if ( $endpoint['disabled'] ) {
+		if ( $endpoint && $endpoint['disabled'] ) {
 			self::add_request_error( $request_id, __( 'Endpoint is disabled.', 'newspack' ) );
 			self::kill_request( $request_id );
 		}

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -582,7 +582,7 @@ final class Webhooks {
 			self::kill_request( $request_id );
 			return;
 		}
-		if ( $endpoint && $endpoint['disabled'] ) {
+		if ( $endpoint['disabled'] ) {
 			self::add_request_error( $request_id, __( 'Endpoint is disabled.', 'newspack' ) );
 			self::kill_request( $request_id );
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small webhooks issue. 

### How to test the changes in this Pull Request:

1. Create a webhook in the Engagement wizard and then delete it 
2. Trigger an action
3. On `master`, PHP will warn that `$endpoint` is null or empty
4. On this branch, there should be no such warnings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->