### PR TITLE
feat(my-account): display stripe billing link regardless of RR platform

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -78,8 +78,12 @@ class WooCommerce_My_Account {
 	 * @param array $items Items.
 	 */
 	public static function my_account_menu_items( $items ) {
-		if ( ! Donations::is_platform_stripe() ) {
-			return $items;
+		// If the user has a Stripe customer ID, they're a Stripe customer (regardless of the donations platform).
+		// Add a nav item for Stripe's billing portal.
+		$stripe_customer_id = self::get_current_user_stripe_id();
+		if ( false !== $stripe_customer_id ) {
+			$custom_endpoints = [ self::BILLING_ENDPOINT => __( 'Billing', 'newspack' ) ];
+			$items            = array_slice( $items, 0, 1, true ) + $custom_endpoints + array_slice( $items, 1, null, true );
 		}
 
 		$default_disabled_items = [];
@@ -144,13 +148,7 @@ class WooCommerce_My_Account {
 			}
 		}
 
-		// Add a nav item for Stripe's billing portal.
-		$stripe_customer_id = self::get_current_user_stripe_id();
-		if ( false === $stripe_customer_id ) {
-			return $items;
-		}
-		$custom_endpoints = [ self::BILLING_ENDPOINT => __( 'Billing', 'newspack' ) ];
-		return array_slice( $items, 0, 1, true ) + $custom_endpoints + array_slice( $items, 1, null, true );
+		return $items;
 	}
 
 	/**
@@ -417,9 +415,6 @@ class WooCommerce_My_Account {
 	 * Add the necessary endpoints to rewrite rules.
 	 */
 	public static function add_rewrite_endpoints() {
-		if ( ! Donations::is_platform_stripe() ) {
-			return;
-		}
 		\add_rewrite_endpoint( self::BILLING_ENDPOINT, EP_PAGES );
 		if ( ! \get_option( '_newspack_has_set_up_custom_billing_endpoint' ) ) {
 			\flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Current behavior: The Stripe billing portal link is only shown if Stripe is the current active Reader Revenue platform. This means if the platform was Stripe at one point but subsequently changed, readers who donated via Stripe can no longer self-serve their own subscription management.

Desired behavior: Rather than tie the portal link to the active RR platform, the logic should check whether the currently logged-in reader has any Stripe subscriptions associated with their account.

Closes 1203869877018965-as-1203870488073009

### How to test the changes in this Pull Request:

1. On `master`,
1. Set RR platform to Stripe and make a recurring donation. Log to "My Account" page 
2. Observe the "Billing" link is among the menu items
3. Switch RR platform to Newspack
4. As the logged-in donor, observe the "Billing" item is missing
5. Switch to this branch, reload the page – observe the "Billing" item is there

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->