### PR TITLE
feat: allow external links in dashboard via a filter

### DIFF
--- a/assets/wizards/dashboard/views/dashboardCard.js
+++ b/assets/wizards/dashboard/views/dashboardCard.js
@@ -30,7 +30,7 @@ class DashboardCard extends Component {
 	 * Render.
 	 */
 	render() {
-		const { name, description, slug, url } = this.props;
+		const { name, description, slug, url, is_external } = this.props;
 		const iconMap = {
 			'site-design': typography,
 			'reader-revenue': payment,
@@ -47,6 +47,7 @@ class DashboardCard extends Component {
 		return (
 			<ButtonCard
 				href={ url }
+				{ ...( is_external && { target: '_blank' } ) }
 				title={ name }
 				desc={ description }
 				icon={ iconMap[ slug ] || plugins }

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -116,6 +116,19 @@ class Dashboard extends Wizard {
 			],
 		];
 
+		/**
+		 * Filters the dashboard items.
+		 *
+		 * @param array          $dashboard  {
+		 *    Dashboard items.
+		 *
+		 *    @type string   $slug        Slug.
+		 *    @type string   $name        Displayed name.
+		 *    @type string   $url         URL to redirect to.
+		 *    @type string   $description Item description.
+		 *    @type bool     $is_externam If true, the URL will be opened in a new window. Optional.
+		 * }
+		 */
 		return apply_filters( 'newspack_plugin_dashboard_items', $dashboard );
 	}
 

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -116,7 +116,7 @@ class Dashboard extends Wizard {
 			],
 		];
 
-		return $dashboard;
+		return apply_filters( 'newspack_plugin_dashboard_items', $dashboard );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows the dashboard links to be filterable, so a plugin may add something.

### How to test the changes in this Pull Request:

Ping me for specific instructions. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->