### PR TITLE
feat: add pid to Logger

### DIFF
--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -49,7 +49,22 @@ class Logger {
 		$caller_prefix = $caller ? "[$caller]" : '';
 		$type_prefix   = 'info' != $type ? "[$type]" : '';
 
-		error_log( '[' . $header . ']' . $caller_prefix . strtoupper( $type_prefix ) . ': ' . $message ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( self::get_pid() . '[' . $header . ']' . $caller_prefix . strtoupper( $type_prefix ) . ': ' . $message ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+	}
+
+	/**
+	 * Get the current process ID and format it to the output in a way that keeps it aligned.
+	 *
+	 * @return string The process ID surrounded by brackets and followed by spaces to always match at least 7 characters.
+	 */
+	private static function get_pid() {
+		$pid = '[' . getmypid() . ']';
+		$len = strlen( $pid );
+		while ( $len < 7 ) {
+			$pid .= ' ';
+			$len++;
+		}
+		return $pid;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When debugging Async actions in the back-end, sometimes it's useful to be able to easily identify events that are happening across multiple requests. One way of doing this is by looking at the PHP process ID. A different process ID will mean a different request. All log entries under the same pid mean they happened during the same request.

This has been useful while debugging our new Data Events API

### How to test the changes in this Pull Request:

1. Inspect your log
2. Browse the site and perform actions that will generate logs
3. See the pid added to the log prefix

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->