### PR TITLE
feat: campaigns listeners for the data events api

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -201,6 +201,14 @@ function render_block( $attrs, $content ) {
 					<p class="newspack-registration__description"><?php echo \wp_kses_post( $attrs['description'] ); ?></p>
 				<?php endif; ?>
 				<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
+				<?php
+				/**
+				 * Action to add custom fields before the form fields of the registration block.
+				 *
+				 * @param array $attrs Block attributes.
+				 */
+				do_action( 'newspack_registration_before_form_fields', $attrs );
+				?>
 				<div class="newspack-registration__form-content">
 					<?php
 					if ( ! empty( $lists ) ) {
@@ -404,6 +412,12 @@ function process_form() {
 	$metadata['current_page_url']    = home_url( add_query_arg( array(), \wp_get_referer() ) );
 	$metadata['registration_method'] = 'registration-block';
 
+	$popup_id = isset( $_REQUEST['newspack_popup_id'] ) ? (int) $_REQUEST['newspack_popup_id'] : false;
+	if ( $popup_id ) {
+		$metadata['popup_id']            = $popup_id;
+		$metadata['registration_method'] = 'registration-block-popup';
+	}
+
 	$user_id = Reader_Activation::register_reader( $email, '', true, $metadata );
 
 	/**
@@ -411,8 +425,9 @@ function process_form() {
 	 *
 	 * @param string              $email   Email address of the reader.
 	 * @param int|false|\WP_Error $user_id The created user ID in case of registration, false if not created or a WP_Error object.
+	 * @param int|false           $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
 	 */
-	\do_action( 'newspack_reader_registration_form_processed', $email, $user_id );
+	\do_action( 'newspack_reader_registration_form_processed', $email, $user_id, $popup_id );
 
 	if ( \is_wp_error( $user_id ) ) {
 		return send_form_response( $user_id );

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -82,6 +82,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-webhooks.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/listeners.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-popups.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/connectors/ga4/class-ga4.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/connectors/class-mailchimp.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';

--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -158,7 +158,7 @@ final class Popups {
 	 * @param int|false      $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
 	 * @return ?array
 	 */
-	public static function newsletter_submission( $email, $result, $popup_id ) {
+	public static function newsletter_submission( $email, $result, $popup_id = false ) {
 		if ( ! $popup_id ) {
 			return;
 		}
@@ -181,7 +181,7 @@ final class Popups {
 	 * @param int|false      $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
 	 * @return ?array
 	 */
-	public static function newsletter_submission_with_status( $email, $result, $popup_id ) {
+	public static function newsletter_submission_with_status( $email, $result, $popup_id = false ) {
 		if ( ! $popup_id ) {
 			return;
 		}

--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -155,9 +155,10 @@ final class Popups {
 	 *
 	 * @param string         $email  Email address of the reader.
 	 * @param array|WP_Error $result Contact data if it was added, or error otherwise.
+	 * @param int|false      $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
 	 * @return ?array
 	 */
-	public static function newsletter_submission( $email, $result ) {
+	public static function newsletter_submission( $email, $result, $popup_id ) {
 		if ( ! $popup_id ) {
 			return;
 		}
@@ -177,9 +178,10 @@ final class Popups {
 	 *
 	 * @param string         $email  Email address of the reader.
 	 * @param array|WP_Error $result Contact data if it was added, or error otherwise.
+	 * @param int|false      $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
 	 * @return ?array
 	 */
-	public static function newsletter_submission_with_status( $email, $result ) {
+	public static function newsletter_submission_with_status( $email, $result, $popup_id ) {
 		if ( ! $popup_id ) {
 			return;
 		}

--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Newspack Data Events Popups helper.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Data_Events;
+
+use Newspack_Popups_Model;
+use Newspack\Data_Events;
+use WP_Error;
+
+/**
+ * Class to register the Popups listeners.
+ */
+final class Popups {
+
+	/**
+	 * Initialize the class by registering the listeners.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		Data_Events::register_listener(
+			'newspack_campaigns_after_campaign_render',
+			'campaign_interaction',
+			[ __CLASS__, 'campaign_rendered' ]
+		);
+
+		Data_Events::register_listener(
+			'newspack_reader_registration_form_processed',
+			'campaign_interaction',
+			[ __CLASS__, 'registration_submission' ]
+		);
+
+		Data_Events::register_listener(
+			'newspack_reader_registration_form_processed',
+			'campaign_interaction',
+			[ __CLASS__, 'registration_submission_with_status' ]
+		);
+
+		Data_Events::register_listener(
+			'newspack_newsletters_subscribe_form_processed',
+			'campaign_interaction',
+			[ __CLASS__, 'newsletter_submission' ]
+		);
+
+		Data_Events::register_listener(
+			'newspack_newsletters_subscribe_form_processed',
+			'campaign_interaction',
+			[ __CLASS__, 'newsletter_submission_with_status' ]
+		);
+	}
+
+	/**
+	 * Extract the relevant data from a popup.
+	 *
+	 * @param int|array $popup The popup ID or object.
+	 * @return array
+	 */
+	public static function get_popup_metadata( $popup ) {
+		if ( is_numeric( $popup ) ) {
+			$popup = Newspack_Popups_Model::retrieve_popup_by_id( $popup );
+		}
+		$data = [];
+		if ( ! $popup ) {
+			return $data;
+		}
+
+		$data['title'] = $popup['title'];
+
+		if ( isset( $popup['options'] ) ) {
+			$data['frequency'] = $popup['options']['frequency'] ?? '';
+			$data['placement'] = $popup['options']['placement'] ?? '';
+		}
+
+		$data['has_registration_block'] = has_block( 'newspack/reader-registration', $popup['content'] );
+		$data['has_donation_block']     = false; // TODO.
+		$data['has_newsletter_block']   = has_block( 'newspack-newsletters/subscribe', $popup['content'] );
+
+		return $data;
+	}
+
+	/**
+	 * A listener for the moment when a campaign is rendered.
+	 *
+	 * @param array $popup The popup representation.
+	 * @return ?array
+	 */
+	public static function campaign_rendered( $popup ) {
+		$popup_data = self::get_popup_metadata( $popup );
+		return array_merge(
+			$popup_data,
+			[
+				'action' => 'rendered',
+			]
+		);
+	}
+
+	/**
+	 * A listener for the registration block form submission
+	 *
+	 * Will trigger the event with "form_submission" as action in all cases.
+	 *
+	 * @param string              $email   Email address of the reader.
+	 * @param int|false|\WP_Error $user_id The created user ID in case of registration, false if not created or a WP_Error object.
+	 * @param int|false           $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
+	 * @return ?array
+	 */
+	public static function registration_submission( $email, $user_id, $popup_id ) {
+		if ( ! $popup_id ) {
+			return;
+		}
+		$popup_data = self::get_popup_metadata( $popup_id );
+		return array_merge(
+			$popup_data,
+			[
+				'action' => 'form_submission',
+			]
+		);
+	}
+
+	/**
+	 * A listener for the registration block form submission
+	 *
+	 * Will trigger the event with "form_submission_success" or "form_submission_failure" as action.
+	 *
+	 * @param string              $email   Email address of the reader.
+	 * @param int|false|\WP_Error $user_id The created user ID in case of registration, false if not created or a WP_Error object.
+	 * @param int|false           $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
+	 * @return ?array
+	 */
+	public static function registration_submission_with_status( $email, $user_id, $popup_id ) {
+		if ( ! $popup_id ) {
+			return;
+		}
+		$action = 'form_submission_success';
+		if ( ! $user_id || \is_wp_error( $user_id ) ) {
+			$action = 'form_submission_failure';
+		}
+		$popup_data = self::get_popup_metadata( $popup_id );
+		return array_merge(
+			$popup_data,
+			[
+				'action' => $action,
+			]
+		);
+	}
+
+	/**
+	 * A listener for the registration block form submission
+	 *
+	 * Will trigger the event with "form_submission" as action in all cases.
+	 *
+	 * @param string         $email  Email address of the reader.
+	 * @param array|WP_Error $result Contact data if it was added, or error otherwise.
+	 * @return ?array
+	 */
+	public static function newsletter_submission( $email, $result ) {
+		if ( ! $popup_id ) {
+			return;
+		}
+		$popup_data = self::get_popup_metadata( $popup_id );
+		return array_merge(
+			$popup_data,
+			[
+				'action' => 'form_submission',
+			]
+		);
+	}
+
+	/**
+	 * A listener for the registration block form submission
+	 *
+	 * Will trigger the event with "form_submission_success" or "form_submission_failure" as action.
+	 *
+	 * @param string         $email  Email address of the reader.
+	 * @param array|WP_Error $result Contact data if it was added, or error otherwise.
+	 * @return ?array
+	 */
+	public static function newsletter_submission_with_status( $email, $result ) {
+		if ( ! $popup_id ) {
+			return;
+		}
+		$action = 'form_submission_success';
+		if ( ! $result || \is_wp_error( $result ) ) {
+			$action = 'form_submission_failure';
+		}
+		$popup_data = self::get_popup_metadata( $popup_id );
+		return array_merge(
+			$popup_data,
+			[
+				'action' => $action,
+			]
+		);
+	}
+
+}
+Popups::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds new events to the Data Events API to track interaction with Campaigns on the back-end.

In order to track the "lifecycle" of a campaign, we trigger a series of the same event, called "campaign_interaction", with `action` values for each state. It can be 
* `rendered`: for when the campaign is rendered in the page (not necessarily seen by the user)
*  `form_submission`: for when there's a submission to a form inside a popup. We are adding a `newspack_popup_id` to forms inside a popup to be able to identify it. We'll need to handle all forms we need to to track in this way. This PR does it for the Registration and Newsletter Subscription blocks.
* `form_submission_success`: for when the form submission returns success
* `form_submission_failure`: for when the form submission fails


### How to test the changes in this Pull Request:

1. Checkout this PR. Checkout https://github.com/Automattic/newspack-popups/pull/1057 in the popups plugin, and https://github.com/Automattic/newspack-newsletters/pull/1087 in the newsletters plugin
2. Create a prompt that displays the Registration block and make it appear on your site
3. Add this snippet to your site:

```PHP
Data_Events::register_handler( 'debug_popups_events', 'campaign_interaction' );

function debug_popups_events( $timestamp, $data, $user_id ) {
	error_log( print_r( $data, true ) );
}
```
4. Watch the error log
5. Load a page where the prompt will be displayed
6. Register through the prompt
7. Confirm registration works
8. Check your log after all the handlers are executed (you might need to refresh the page a couple of times, or you can go to Tools > Action Scheduler and manually run the `campaign_interaction` events)
9. In your log, you should be able to find this sequence:

```
[21-Feb-2023 14:05:11 UTC] [NEWSPACK-DATA-EVENTS][Newspack\Data_Events::handle]: Executing action handlers for "campaign_interaction".
[21-Feb-2023 14:05:11 UTC] Array
(
    [title] => Registration Overlay
    [frequency] => always
    [placement] => center
    [has_registration_block] => 1
    [has_donation_block] => 
    [has_newsletter_block] =>
    [action] => rendered
)

[21-Feb-2023 14:05:57 UTC] [NEWSPACK-DATA-EVENTS][Newspack\Data_Events::handle]: Executing action handlers for "campaign_interaction".
[21-Feb-2023 14:05:57 UTC] Array
(
    [title] => Registration Overlay
    [frequency] => always
    [placement] => center
    [has_registration_block] => 1
    [has_donation_block] => 
    [has_newsletter_block] =>
    [action] => form_submission
)

[21-Feb-2023 14:05:57 UTC] [NEWSPACK-DATA-EVENTS][Newspack\Data_Events::handle]: Executing action handlers for "campaign_interaction".
[21-Feb-2023 14:05:57 UTC] Array
(
    [title] => Registration Overlay
    [frequency] => always
    [placement] => center
    [has_registration_block] => 1 
    [has_donation_block] => 
    [has_newsletter_block] => 
    [action] => form_submission_success
)
```

10. Logout and visit the site again
11. Try to register again with the same email
12. Check your logs and see that you have the same events fired, but now the last one is `form_submission_failure` instead of `success`.
13. Repeat steps  5 to 9 but now with a Newsletters Subscription block.
14. On the logs, you should see `has_newsletter_block` as `1`
15. Trying to subscribe to the same newsletter again with the same email won't trigger an failure - we don't consider this an error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->