### PR TITLE
Stripe Subscriptions to WC subscriptions migrator

### DIFF
--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -108,8 +108,9 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function stripe_data() {
 		$gateways = self::get_payment_gateways();
+		$defaults = Stripe_Connection::get_default_stripe_data();
 		if ( ! isset( $gateways['stripe'] ) ) {
-			return Stripe_Connection::get_default_stripe_data();
+			return $defaults;
 		}
 		$stripe      = $gateways['stripe'];
 		$stripe_data = [
@@ -120,7 +121,7 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 			'testPublishableKey' => $stripe->get_option( 'test_publishable_key', '' ),
 			'testSecretKey'      => $stripe->get_option( 'test_secret_key', '' ),
 		];
-		return $stripe_data;
+		return \wp_parse_args( $stripe_data, $defaults );
 	}
 
 	/**

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -362,7 +362,7 @@ class WooCommerce_Connection {
 	 * @param string $stripe_subscription_id Stripe Subscription ID.
 	 * @return WC_Subscription|false Subscription object or false.
 	 */
-	private static function get_subscription_by_stripe_subscription_id( $stripe_subscription_id ) {
+	public static function get_subscription_by_stripe_subscription_id( $stripe_subscription_id ) {
 		if ( ! function_exists( 'wcs_get_subscription' ) ) {
 			return false;
 		}
@@ -393,7 +393,7 @@ class WooCommerce_Connection {
 		$order->set_billing_email( $order_data['email'] );
 		$order->set_billing_first_name( $order_data['name'] );
 
-		if ( $order_data['subscribed'] ) {
+		if ( isset( $order_data['subscribed'] ) && $order_data['subscribed'] ) {
 			$order->add_order_note( __( 'Donor has opted-in to your newsletter.', 'newspack' ) );
 		}
 
@@ -634,14 +634,16 @@ class WooCommerce_Connection {
 					}
 					$order->save();
 				}
-				$subscription = \wcs_create_subscription(
-					[
-						'start_date'       => self::convert_timestamp_to_date( $order_data['date'] ),
-						'order_id'         => $order->get_id(),
-						'billing_period'   => $frequency,
-						'billing_interval' => 1, // Every billing period (not e.g. every *second* month).
-					]
-				);
+				$subscription_creation_payload = [
+					'start_date'       => self::convert_timestamp_to_date( $order_data['date'] ),
+					'order_id'         => $order->get_id(),
+					'billing_period'   => $frequency,
+					'billing_interval' => 1, // Every billing period (not e.g. every *second* month).
+				];
+				if ( isset( $order_data['wc_subscription_status'] ) ) {
+					$subscription_creation_payload['status'] = $order_data['wc_subscription_status'];
+				}
+				$subscription = \wcs_create_subscription( $subscription_creation_payload );
 
 				if ( is_wp_error( $subscription ) ) {
 					Logger::error( 'Error creating WC subscription: ' . $subscription->get_error_message() );
@@ -705,8 +707,8 @@ class WooCommerce_Connection {
 		}
 
 		return [
-			'order_id'        => $order ? $order->get_id() : false,
-			'subscription_id' => $subscription ? $subscription->get_id() : false,
+			'order_id'        => ( ! \is_wp_error( $order ) && $order ) ? $order->get_id() : false,
+			'subscription_id' => ( ! \is_wp_error( $subscription ) && $subscription ) ? $subscription->get_id() : false,
 		];
 	}
 

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -435,7 +435,7 @@ class WooCommerce_Connection {
 	 * @param WC_Order $order Order object. Can be a subscription or an order.
 	 * @param array    $metadata Metadata.
 	 */
-	private static function add_wc_stripe_gateway_metadata( $order, $metadata ) {
+	public static function add_wc_stripe_gateway_metadata( $order, $metadata ) {
 		$order->set_payment_method( 'stripe' );
 
 		if ( isset( $metadata['stripe_id'] ) ) {

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -297,7 +297,17 @@ class Stripe_Sync {
 			'sync-to-esp' => false, // Sync data to the ESP.
 			'dry-run'     => false,
 		];
-		$passed_args  = array_merge( $default_args, $assoc_args );
+
+		\WP_CLI::log(
+			'
+
+Running data backfill from Stripe...
+
+		'
+		);
+
+
+		$passed_args = array_merge( $default_args, $assoc_args );
 		if ( false !== $passed_args['dry-run'] ) {
 			\WP_CLI::warning( __( 'This is a dry run, no changes will be made.', 'newspack' ) );
 		}
@@ -363,7 +373,15 @@ class Stripe_Sync {
 		$force_override = ! empty( $assoc_args['force'] );
 		$batch_size     = ! empty( $assoc_args['batch-size'] ) ? intval( $assoc_args['batch-size'] ) : 10;
 
-		$customers = self::get_batch_of_customers_for_stripe_connect_to_stripe( $batch_size );
+		\WP_CLI::log(
+			'
+
+Running Stripe Connect to Stripe Subscriptions Migration...
+
+		'
+		);
+
+		$customers = self::get_batch_of_customers_with_subscriptions( $batch_size );
 		while ( $customers ) {
 			$customer = array_shift( $customers );
 
@@ -481,7 +499,7 @@ class Stripe_Sync {
 				);
 				\WP_CLI::log( sprintf( '    * Created subscription: %s with next renewal at %s', $subscription->id, gmdate( 'Y-m-d', $existing_subscription->current_period_end ) ) );
 			} catch ( \Throwable $e ) {
-				\WP_CLI::error( sprintf( 'Failed to create subscription: %s', $e->getMessage() ) );
+				\WP_CLI::warning( sprintf( 'Failed to create subscription: %s', $e->getMessage() ) );
 			}
 
 			try {

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -385,7 +385,7 @@ Running Stripe Connect to Stripe Subscriptions Migration...
 		while ( $customers ) {
 			$customer = array_shift( $customers );
 
-			self::process_customer_for_stripe_connect_to_stripe(
+			self::process_stripe_subscriber(
 				$customer,
 				[
 					'dry_run'                     => $is_dry_run,
@@ -395,7 +395,47 @@ Running Stripe Connect to Stripe Subscriptions Migration...
 
 			// Get the next batch.
 			if ( empty( $customers ) ) {
-				$customers = self::get_batch_of_customers_for_stripe_connect_to_stripe( $batch_size, $customer->id );
+				$customers = self::get_batch_of_customers_with_subscriptions( $batch_size, $customer->id );
+			}
+		}
+
+		\WP_CLI::success( 'Finished processing.' );
+	}
+
+	/**
+	 * CLI command for migrating Stripe Subscriptions from Stripe Connect to a regular Stripe account.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public static function sync_stripe_subscriptions_to_wc( $args, $assoc_args ) {
+		$is_dry_run = ! empty( $assoc_args['dry-run'] );
+		$batch_size = ! empty( $assoc_args['batch-size'] ) ? intval( $assoc_args['batch-size'] ) : 10;
+
+		\WP_CLI::log(
+			'
+
+Running Stripe to WC Subscriptions Migration...
+
+		'
+		);
+
+
+		$customers = self::get_batch_of_customers_with_subscriptions( $batch_size );
+		while ( $customers ) {
+			$customer = array_shift( $customers );
+
+			self::process_stripe_subscriber(
+				$customer,
+				[
+					'dry_run'       => $is_dry_run,
+					'migrate_to_wc' => true,
+				]
+			);
+
+			// Get the next batch.
+			if ( empty( $customers ) ) {
+				$customers = self::get_batch_of_customers_with_subscriptions( $batch_size, $customer->id );
 			}
 		}
 
@@ -409,13 +449,14 @@ Running Stripe Connect to Stripe Subscriptions Migration...
 	 * @param string $last_customer_id Stripe ID of customer to get results after, essentially the offset.
 	 * @return array Array of Stripe customers.
 	 */
-	protected static function get_batch_of_customers_for_stripe_connect_to_stripe( $limit, $last_customer_id = false ) {
+	protected static function get_batch_of_customers_with_subscriptions( $limit, $last_customer_id = false ) {
 		$stripe = Stripe_Connection::get_stripe_client();
 		try {
 			$params = [
 				'limit'  => $limit,
 				'expand' => [
 					'data.subscriptions',
+					'data.sources',
 				],
 			];
 
@@ -430,21 +471,23 @@ Running Stripe Connect to Stripe Subscriptions Migration...
 	}
 
 	/**
-	 * Process one customer's Stripe subscriptions and migrate them to Newspack Stripe subscriptions.
+	 * Process one customer's Stripe subscriptions and migrate them.
 	 *
 	 * @param Stripe_Customer $customer Stripe customer object.
 	 * @param array           $args Params to control migration behavior.
 	 */
-	protected static function process_customer_for_stripe_connect_to_stripe( $customer, $args ) {
+	protected static function process_stripe_subscriber( $customer, $args ) {
 		$dry_run                     = ! empty( $args['dry_run'] );
 		$force_subscription_override = ! empty( $args['force_subscription_override'] );
+		$migrate_to_wc               = ! empty( $args['migrate_to_wc'] ) && true === $args['migrate_to_wc'];
 
 		$stripe        = Stripe_Connection::get_stripe_client();
 		$stripe_prices = Stripe_Connection::get_donation_prices();
 
 		\WP_CLI::log( sprintf( 'Processing customer: %s', $customer->email ) );
 		if ( empty( $customer->subscriptions ) || empty( $customer->subscriptions->data ) ) {
-			\WP_CLI::log( '  - No subscriptions found for customer. Skipping. A future version of this tool will handle the case where we want to turn one-time Stripe payments into Stripe subscriptions.' );
+			// A future version of this tool will handle the case where we want to turn one-time Stripe payments into Stripe subscriptions.
+			\WP_CLI::log( '  - No active subscriptions found for customer. Skipping.' );
 			return;
 		}
 
@@ -477,36 +520,142 @@ Running Stripe Connect to Stripe Subscriptions Migration...
 				\WP_CLI::log( sprintf( '    * Found subscription item: $%s/%s', $existing_subscription_item_price / 100, $frequency ) );
 			}
 
-			if ( $dry_run ) {
-				\WP_CLI::log( sprintf( '    * Would have created subscription with next renewal at %s', gmdate( 'Y-m-d', $existing_subscription->current_period_end ) ) );
-				return;
+			$subscription_id = false;
 
-			}
-
-			// Create new subscriptions.
+			// Create a new subscription (or make a sync'd subscription billable).
 			try {
-				$subscription = $stripe->subscriptions->create(
-					[
-						'customer'             => $customer->id,
-						'items'                => $new_subscription_items,
-						'payment_behavior'     => 'allow_incomplete',
-						'billing_cycle_anchor' => $existing_subscription->current_period_end,
-						'trial_end'            => $existing_subscription->current_period_end,
-						'metadata'             => [
-							'subscription_migrated_to_newspack' => gmdate( 'c' ),
-						],
-					]
-				);
-				\WP_CLI::log( sprintf( '    * Created subscription: %s with next renewal at %s', $subscription->id, gmdate( 'Y-m-d', $existing_subscription->current_period_end ) ) );
+				if ( $migrate_to_wc ) {
+					$chargeable_sources = array_filter(
+						$customer->sources->data,
+						function( $source ) {
+							return 'chargeable' === $source->status;
+						}
+					);
+					if ( empty( $chargeable_sources ) ) {
+						\WP_CLI::warning( 'No chargeable source for this customer, a subscription cannot be created.' );
+					} else {
+						$source_id = $chargeable_sources[0]->id;
+
+						// Check if this subscription is already synchronised (shadowed) in WooCommerce.
+						$subscription = WooCommerce_connection::get_subscription_by_stripe_subscription_id( $existing_subscription->id );
+						if ( $subscription ) {
+							$subscription_id = $subscription->get_id();
+							if ( $dry_run ) {
+								\WP_CLI::log(
+									sprintf(
+										'    * Would update WC Subscription #%s, which was already synced from Stripe but not renewed by WC.',
+										$subscription_id
+									)
+								);
+							} else {
+								// If this subscription is already synchronised,
+								// attach a source so it's billable and remove the link to the Stripe subscription.
+								$subscription->add_meta_data( '_stripe_source_id', $source_id );
+								// Delete the 'link' to a Stripe subscription, so it's not sync'd anymore.
+								$subscription->delete_meta_data( WooCommerce_Connection::SUBSCRIPTION_STRIPE_ID_META_KEY );
+								\WP_CLI::success( sprintf( 'Updated WC Subscription #%s, which was already synced from Stripe but not renewed by WC (now it will).', $subscription_id ) );
+							}
+						} else {
+							// Create a new WooCommerce subscription, starting at the current period start.
+							$currency                = $existing_subscription->currency;
+							$amount_normalised       = Stripe_Connection::normalise_amount( $existing_subscription->quantity, $currency );
+							$first_subscription_item = $existing_subscription->items->data[0];
+							$frequency               = $first_subscription_item->price->recurring->interval;
+
+							$wc_order_payload = [
+								'status'                 => 'completed',
+								'subscription_status'    => 'created',
+								'wc_subscription_status' => 'active',
+								'email'                  => $customer->email,
+								'name'                   => $customer->name,
+								'stripe_customer_id'     => $customer->id,
+								'stripe_source_id'       => $source_id,
+								'date'                   => $existing_subscription->current_period_start,
+								'amount'                 => $amount_normalised,
+								'frequency'              => $frequency,
+								'currency'               => strtoupper( $currency ),
+								'client_id'              => $customer->metadata->clientId,
+								'user_id'                => $customer->metadata->userId,
+							];
+
+							if ( $dry_run ) {
+								\WP_CLI::log(
+									sprintf(
+										'    * Would create a WC Subscription with frequency of %s and amount of %s.',
+										$frequency,
+										$amount_normalised
+									)
+								);
+								$subscription_id = true;
+							} else {
+								// Create the WC Subscription.
+								$wc_transaction_creation_data = WooCommerce_Connection::create_transaction( $wc_order_payload );
+								$subscription_id              = $wc_transaction_creation_data['subscription_id'];
+								$subscription                 = \wcs_get_subscription( $subscription_id );
+								\WP_CLI::success( sprintf( 'Created subscription: %s with next renewal at %s', $subscription_id, gmdate( 'Y-m-d', $existing_subscription->current_period_end ) ) );
+							}
+						}
+
+						if ( $subscription ) {
+							// Add the cancelled Stripe subscription ID to the meta data, so it can be found later.
+							$subscription->add_meta_data( 'cancelled-' . WooCommerce_Connection::SUBSCRIPTION_STRIPE_ID_META_KEY, $existing_subscription->id );
+							$subscription->add_order_note(
+								sprintf(
+									// translators: %s is the Stripe subscription ID.
+									__( 'This subscription has been migrated from Stripe. It will now be fully manageable in WooCommerce. You can find the cancelled Stripe subscription by ID %s', 'newspack' ),
+									$existing_subscription->id
+								)
+							);
+							$subscription->save();
+						}
+					}
+				} else {
+					if ( $dry_run ) {
+						\WP_CLI::log(
+							sprintf(
+								'    * Would create a Stripe subscription with next renewal at %s',
+								gmdate( 'Y-m-d', $existing_subscription->current_period_end )
+							)
+						);
+						$subscription_id = true;
+					} else {
+						$subscription    = $stripe->subscriptions->create(
+							[
+								'customer'             => $customer->id,
+								'items'                => $new_subscription_items,
+								'payment_behavior'     => 'allow_incomplete',
+								'billing_cycle_anchor' => $existing_subscription->current_period_end,
+								'trial_end'            => $existing_subscription->current_period_end,
+								'metadata'             => [
+									'subscription_migrated_to_newspack' => gmdate( 'c' ),
+								],
+							]
+						);
+						$subscription_id = $subscription->id;
+						\WP_CLI::success( sprintf( 'Created subscription: %s with next renewal at %s', $subscription_id, gmdate( 'Y-m-d', $existing_subscription->current_period_end ) ) );
+					}
+				}
 			} catch ( \Throwable $e ) {
 				\WP_CLI::warning( sprintf( 'Failed to create subscription: %s', $e->getMessage() ) );
 			}
 
-			try {
-				$stripe->subscriptions->cancel( $existing_subscription->id );
-				\WP_CLI::log( sprintf( '    * Cancelled old subscription: %s', $existing_subscription->id ) );
-			} catch ( \Throwable $e ) {
-				\WP_CLI::error( sprintf( 'Failed to cancel subscription: %s', $e->getMessage() ) );
+			if ( false === $subscription_id ) {
+				if ( ! $dry_run ) {
+					\WP_CLI::warning( 'A subscription was not created, so the existing Stripe subscription will not be cancelled.' );
+				}
+			} else {
+				try {
+					if ( $dry_run ) {
+						\WP_CLI::log(
+							sprintf( '    * Would cancel Stripe subscription %s.', $existing_subscription->id )
+						);
+					} else {
+						$stripe->subscriptions->cancel( $existing_subscription->id );
+						\WP_CLI::success( sprintf( 'Cancelled old subscription: %s', $existing_subscription->id ) );
+					}
+				} catch ( \Throwable $e ) {
+					\WP_CLI::warning( sprintf( 'Failed to cancel subscription: %s', $e->getMessage() ) );
+				}
 			}
 		}
 	}
@@ -524,6 +673,27 @@ Running Stripe Connect to Stripe Subscriptions Migration...
 			[ __CLASS__, 'data_backfill' ],
 			[
 				'shortdesc' => __( 'Backfill WC Customers from Stripe database.', 'newspack' ),
+			]
+		);
+
+		\WP_CLI::add_command(
+			'newspack stripe sync-stripe-subscriptions-to-wc',
+			[ __CLASS__, 'sync_stripe_subscriptions_to_wc' ],
+			[
+				'shortdesc' => __( 'Migrate subscribtions from Stripe to WC', 'newspack' ),
+				'synopsis'  => [
+					[
+						'type'     => 'flag',
+						'name'     => 'dry-run',
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'batch-size',
+						'default'  => 10,
+						'optional' => true,
+					],
+				],
 			]
 		);
 

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -594,7 +594,7 @@ Running Stripe to WC Subscriptions Migration...
 						}
 					}
 
-					if ( $subscription ) {
+					if ( $subscription && ! $dry_run ) {
 						// Add the cancelled Stripe subscription ID to the meta data, so it can be found later.
 						$subscription->add_meta_data( 'cancelled-' . WooCommerce_Connection::SUBSCRIPTION_STRIPE_ID_META_KEY, $existing_subscription->id );
 						$subscription->add_order_note(

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -439,6 +439,11 @@ class Stripe_Sync {
 				continue;
 			}
 
+			if ( 'active' !== $existing_subscription->status ) {
+				\WP_CLI::log( '  - Subscription is not active. Skipping.' );
+				return;
+			}
+
 			$new_subscription_items = [];
 
 			foreach ( $existing_subscription->items->data as $existing_subscription_item ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A migration script that turns Stripe Subscriptions into WooCommerce Subscriptions.

Closes 1204005426582602-as-1203870488073017

### How to test the changes in this Pull Request:

1. Set up the site to use Stripe as the Reader Revenue platform and ensure the test site is reachable for webhooks
2. Ensure the WooCommerce suite is active, so the Stripe data will be synchronised to WC
3. Make a recurring donation twice, observe two WC Subscriptions were created to shadow (sync) the Stripe subscriptions
4. Delete one of the WC Subscriptions (ideally via CLI – `$ wp post delete <sub-id>`)
5. Run the migration in dry-run mode – `$ wp newspack stripe sync-stripe-subscriptions-to-wc --dry-run`
6. Observe the output and note that neither Stripe nor WooCommerce subscriptions were updated
7. Now run the migration for real – `$ wp newspack stripe sync-stripe-subscriptions-to-wc`
8. Observe the output, it should successfully migration both and cancel the Stripe subscriptions
9. Verify that the Stripe subscriptions have been cancelled in the [Stripe dashboard](https://dashboard.stripe.com)
10. Observe that the WC Subscriptions have received helpful order notes about the process ("This subscription has been migrated…") 
11. Observe that both WC Subscriptions have `cancelled-newspack-stripe-subscription-id` metadata, with the Stripe subscription ID as value

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->