### PR TITLE
Update/normalize donation events

### DIFF
--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -108,28 +108,31 @@ Data_Events::register_listener(
 	}
 );
 
+
 /**
- * For when there's a new donation through WooCommerce.
+ * For when a Subscription is confirmed.
  */
 Data_Events::register_listener(
-	'newspack_donation_order_processed',
-	'donation_new',
-	function( $order_id, $product_id ) {
-		$order = \wc_get_order( $order_id );
-		if ( ! $order ) {
+	'woocommerce_subscription_status_updated',
+	'donation_subscription_new',
+	function( $subscription, $status_to, $status_from ) {
+		if ( 'active' !== $status_to || 'pending' !== $status_from ) {
+			return;
+		}
+		$product_id = Donations::get_order_donation_product_id( $subscription->get_id() );
+		error_log( 'checking subcription is a product donation' );
+		error_log( print_r( $product_id, true ) );
+		if ( ! $product_id ) {
 			return;
 		}
 		return [
-			'user_id'       => $order->get_customer_id(),
-			'email'         => $order->get_billing_email(),
-			'amount'        => (float) $order->get_total(),
-			'currency'      => $order->get_currency(),
-			'recurrence'    => get_post_meta( $product_id, '_subscription_period', true ),
-			'platform'      => 'wc',
-			'platform_data' => [
-				'order_id'   => $order_id,
-				'product_id' => $product_id,
-			],
+			'user_id'         => $subscription->get_customer_id(),
+			'email'           => $subscription->get_billing_email(),
+			'subscription_id' => $subscription->get_id(),
+			'amount'          => (float) $subscription->get_total(),
+			'currency'        => $subscription->get_currency(),
+			'recurrence'      => get_post_meta( $product_id, '_subscription_period', true ),
+			'platform'        => Donations::get_platform_slug(),
 		];
 	}
 );
@@ -138,10 +141,9 @@ Data_Events::register_listener(
  * For when there's a new donation through the Stripe platform.
  */
 Data_Events::register_listener(
-	'newspack_new_donation_woocommerce',
+	'woocommerce_order_status_pending_to_completed',
 	'donation_new',
-	function( $order, $client_id ) {
-		$order_id   = $order->get_id();
+	function( $order_id, $order ) {
 		$product_id = Donations::get_order_donation_product_id( $order_id );
 		if ( ! $product_id ) {
 			return;
@@ -152,29 +154,13 @@ Data_Events::register_listener(
 			'amount'        => (float) $order->get_total(),
 			'currency'      => $order->get_currency(),
 			'recurrence'    => \get_post_meta( $product_id, '_subscription_period', true ),
-			'platform'      => 'stripe',
+			'platform'      => Donations::get_platform_slug(),
 			'platform_data' => [
 				'order_id'   => $order_id,
 				'product_id' => $product_id,
-				'client_id'  => $client_id,
+				'client_id'  => $order->get_meta( NEWSPACK_CLIENT_ID_COOKIE_NAME ),
 			],
 		];
-	}
-);
-
-/**
- * For when there's a new donation subscription.
- *
- * This will be fetched from a new donation, so we're hooking into the 'donation_new' dispatch.
- */
-Data_Events::register_listener(
-	'newspack_data_event_dispatch_donation_new',
-	'donation_subscription_new',
-	function( $timestamp, $data ) {
-		if ( ! in_array( $data['recurrence'], [ 'month', 'year' ] ) ) {
-			return;
-		}
-		return $data;
 	}
 );
 

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -656,6 +656,11 @@ class WooCommerce_Connection {
 					}
 					self::add_wc_stripe_gateway_metadata( $subscription, $wc_subscription_payload );
 					self::add_universal_order_data( $subscription, $order_data );
+
+					// Mint a new item – subscription is a new WC order.
+					$item = self::get_donation_order_item( $frequency, $order_data['amount'] );
+					$subscription->add_item( $item );
+
 					if ( false === $stripe_subscription_id ) {
 						$subscription->add_order_note( __( 'This subscription was created via Newspack.', 'newspack' ) );
 					} else {
@@ -663,9 +668,6 @@ class WooCommerce_Connection {
 						$subscription->add_order_note( sprintf( __( 'Newspack subscription with frequency: %s. The recurring payment and the subscription will be handled in Stripe, so you\'ll see "Manual renewal" as the payment method in WooCommerce.', 'newspack' ), $frequency ) );
 						$subscription->update_status( 'active' ); // Settings status via method (not in wcs_create_subscription), to make WCS recalculate dates.
 					}
-					// Mint a new item – subscription is a new WC order.
-					$item = self::get_donation_order_item( $frequency, $order_data['amount'] );
-					$subscription->add_item( $item );
 					$subscription->calculate_totals();
 
 					if ( false === $stripe_subscription_id ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Normalizes the `donation_new` event so it works the same way in both platforms.

Before the change in this PR, donations processed through Woocommerce would trigger a `donation_new` event before they were confirmed, while in Stripe it would only be triggered after confirmation.

Now the event is only triggered after confirmation in both platforms.

We keep the current WooCommerce listener as a new event called `donation_order_processed` as suggested in p1676562193774819-slack-1676536201.225739 (even though I'm not sure we need it)

### How to test the changes in this Pull Request:

1. Add the following snippet to your site:

```PHP
Data_Events::register_handler( 'debug_donation_new_events', 'donation_new' );

function debug_donation_new_events( $timestamp, $data, $user_id ) {
	error_log( print_r( $data, true ) );
}

Data_Events::register_handler( 'debug_donation_subscription_new_events', 'donation_subscription_new' );

function debug_donation_subscription_new_events( $timestamp, $data, $user_id ) {
	error_log( print_r( $data, true ) );
}
```
2. Set up Stripe as the Reader Revenue platform
3. Make donations
4. Watch the logs and make sure you see the correct events being triggered at the correct times, with the correct data
5. Do the same for the Newspack platform and confirm they are consistent
6. Make sure to test with cards that will return failed payments to make sure events are not triggered in those situations


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->