### PR TITLE
Add/popup info to donations

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -702,7 +702,7 @@ class Donations {
 			$order->add_meta_data( '_newspack_popup_id', $values['newspack_popup_id'] );
 		}
 		if ( ! empty( $values['referer'] ) ) {
-			$order->add_meta_data( '_referer', $values['referer'] );
+			$order->add_meta_data( '_newspack_referer', $values['referer'] );
 		}
 	}
 

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -402,7 +402,7 @@ class WooCommerce_Connection {
 		}
 
 		if ( ! empty( $order_data['referer'] ) ) {
-			$order->add_meta_data( '_referer', $order_data['referer'] );
+			$order->add_meta_data( '_newspack_referer', $order_data['referer'] );
 		}
 
 		if ( ! empty( $order_data['newspack_popup_id'] ) ) {

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -401,6 +401,14 @@ class WooCommerce_Connection {
 			$order->add_meta_data( NEWSPACK_CLIENT_ID_COOKIE_NAME, $order_data['client_id'] );
 		}
 
+		if ( ! empty( $order_data['referer'] ) ) {
+			$order->add_meta_data( '_referer', $order_data['referer'] );
+		}
+
+		if ( ! empty( $order_data['newspack_popup_id'] ) ) {
+			$order->add_meta_data( '_newspack_popup_id', $order_data['newspack_popup_id'] );
+		}
+
 		if ( ! empty( $order_data['user_id'] ) ) {
 			$order->set_customer_id( $order_data['user_id'] );
 		}

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -1158,6 +1158,8 @@ class Stripe_Connection {
 			'client_id'                     => $customer['metadata']['clientId'],
 			'user_id'                       => $customer['metadata']['userId'],
 			'subscribed'                    => self::has_customer_opted_in_to_newsletters( $customer ),
+			'referer'                       => $payment['referer'] ?? null,
+			'newspack_popup_id'             => $payment['newspack_popup_id'] ?? null,
 		];
 	}
 

--- a/includes/reader-revenue/stripe/class-stripe-webhooks.php
+++ b/includes/reader-revenue/stripe/class-stripe-webhooks.php
@@ -267,19 +267,19 @@ class Stripe_Webhooks {
 				$client_id         = isset( $customer['metadata']['clientId'] ) ? $customer['metadata']['clientId'] : null;
 				$origin            = isset( $customer['metadata']['origin'] ) ? $customer['metadata']['origin'] : null;
 
-				$referer = '';
-				if ( isset( $metadata['referer'] ) ) {
-					$referer = $metadata['referer'];
-				}
-
-				$frequency = Stripe_Connection::get_frequency_of_payment( $payment );
-
+				$referer           = $metadata['referer'] ?? '';
+				$newspack_popup_id = $metadata['newspack_popup_id'] ?? '';
 				if ( $payment['invoice'] ) {
 					$invoice = Stripe_Connection::get_invoice( $payment['invoice'] );
-					if ( ! \is_wp_error( $invoice ) && isset( $invoice['metadata']['referer'] ) ) {
-						$referer = $invoice['metadata']['referer'];
+					if ( ! \is_wp_error( $invoice ) ) {
+						$referer           = $invoice['metadata']['referer'] ?? $referer;
+						$newspack_popup_id = $invoice['metadata']['newspack_popup_id'] ?? $newspack_popup_id;
 					}
 				}
+				$payment['referer']           = $referer;
+				$payment['newspack_popup_id'] = $newspack_popup_id;
+
+				$frequency = Stripe_Connection::get_frequency_of_payment( $payment );
 
 				// Update data in Newsletters provider.
 				$was_customer_added_to_mailing_list = false;

--- a/tests/unit-tests/stripe-connection.php
+++ b/tests/unit-tests/stripe-connection.php
@@ -156,6 +156,8 @@ class Newspack_Test_Stripe extends WP_UnitTestCase {
 			'invoice'             => 'in_123',
 			'created'             => 1234567890,
 			'balance_transaction' => 'txn_123',
+			'referer'             => 'sample_referer',
+			'newspack_popup_id'   => 123,
 		];
 		self::assertEquals(
 			Stripe_Connection::create_wc_transaction_payload( $customer, $payment ),
@@ -175,6 +177,8 @@ class Newspack_Test_Stripe extends WP_UnitTestCase {
 				'client_id'                     => 'abc123',
 				'user_id'                       => 42,
 				'subscribed'                    => null,
+				'referer'                       => 'sample_referer',
+				'newspack_popup_id'             => 123,
 			]
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds `referer` and `popup` information to the Donate process via the donation block.

It depends on https://github.com/Automattic/newspack-blocks/pull/1378 and https://github.com/Automattic/newspack-popups/pull/1060

This will allow us to have more information about where the donation is coming from when firing our Data Api events.

### How to test the changes in this Pull Request:

1. Checkout this PR, https://github.com/Automattic/newspack-blocks/pull/1378 and https://github.com/Automattic/newspack-popups/pull/1060 
2. Set Stripe as the Reader Revenue platform
3. Create a Campaign prompt with a Donation block
4. Make a recurring donation through this prompt
5. After confirmation, go to Woocommerce > Orders and Woocommerce > Subscriptions and check the ID of the order and the subscription that were created
6. Check the database and confirm the two of them have a `_referer` and a `_newspack_popup_id` post_meta values.
7. Repeat steps 4 to 6 making a One Time donation
8. Repeat steps 4 to 7 with Newspack as the Revenue platform
9. add the Donation block to a regular page (not a campaign prompt)
10. make a donation through this page and confirm it works and the `_newspack_popup_id` metadata is not created

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->