### PR TITLE
feat: Remove the campaign rendered event

### DIFF
--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -23,12 +23,6 @@ final class Popups {
 	 */
 	public static function init() {
 		Data_Events::register_listener(
-			'newspack_campaigns_after_campaign_render',
-			'campaign_interaction',
-			[ __CLASS__, 'campaign_rendered' ]
-		);
-
-		Data_Events::register_listener(
 			'newspack_reader_registration_form_processed',
 			'campaign_interaction',
 			[ __CLASS__, 'registration_submission' ]
@@ -80,22 +74,6 @@ final class Popups {
 		$data['has_newsletter_block']   = has_block( 'newspack-newsletters/subscribe', $popup['content'] );
 
 		return $data;
-	}
-
-	/**
-	 * A listener for the moment when a campaign is rendered.
-	 *
-	 * @param array $popup The popup representation.
-	 * @return ?array
-	 */
-	public static function campaign_rendered( $popup ) {
-		$popup_data = self::get_popup_metadata( $popup );
-		return array_merge(
-			$popup_data,
-			[
-				'action' => 'rendered',
-			]
-		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We should not trigger an event when a campaign is rendered.

1. This happens all the time, and since we are using Action Scheduler to trigger events, this could overflow our database with events
2. This event does not tell us anything useful. The campaigns are rendered all the time, even when the user doesn't match the segment and won't see the popup. So we can't use this to build funnels and calculating conversion rates.
3. The page output will be cached. So the counts of renders will not match the times the campaign was rendered for users. Again, this count won't be useful in our analytics to build funnels.

### How to test the changes in this Pull Request:

1. Nothing really. Just make sure you don't see `[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::dispatch]: Dispatching action "campaign_interaction" via Action Scheduler.` in the logs when just loading a page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->