### PR TITLE
fix: skip HPB optimisations on AMP

### DIFF
--- a/includes/class-performance.php
+++ b/includes/class-performance.php
@@ -68,6 +68,11 @@ class Performance {
 	 * @param array $attributes Block attributes.
 	 */
 	public static function optimise_homepage_posts_block( $attributes ) {
+		// Bail on AMP pages. These attributes may cause issues on AMP.
+		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+			return $attributes;
+		}
+
 		if ( self::$is_rendering_page_content ) {
 			if ( 0 === self::$current_homepage_posts_block ) {
 				$attributes['disableImageLazyLoad'] = true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Though I could not reproduce the issue locally, #2236 has caused issues on AMP pages on live sites. The optimisation from that PR is not necessary on AMP pages anyway, because AMP filters out the `fetchpriority` attribute. 

This PR skips the optimisation if the rendered page is AMP. 

### How to test the changes in this Pull Request:

1. Insert a Homepage Posts Block as the first block on a page, observe that the images are rendered in AMP and without AMP. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->