### PR TITLE
feat(wc): force allowing subscription switching

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -1018,7 +1018,7 @@ class WooCommerce_Connection {
 	 * @param bool $can_switch Whether the subscription amount can be switched.
 	 */
 	public static function force_allow_switching_subscription_amount( $can_switch ) {
-		if ( defined( 'NEWSPACK_PREVENT_FORCE_ALLOW_SWITCHING' ) && NEWSPACK_PREVENT_FORCE_ALLOW_SWITCHING ) {
+		if ( defined( 'NEWSPACK_PREVENT_WC_SUBS_ALLOW_SWITCHING_OVERRIDE' ) && NEWSPACK_PREVENT_WC_SUBS_ALLOW_SWITCHING_OVERRIDE ) {
 			return $can_switch;
 		}
 		return 'yes';

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -1013,7 +1013,7 @@ class WooCommerce_Connection {
 	}
 
 	/**
-	 * Force allow switching the subscription amount.
+	 * Force allow switching the subscription amount unless the NEWSPACK_PREVENT_WC_SUBS_ALLOW_SWITCHING_OVERRIDE constant is set
 	 *
 	 * @param bool $can_switch Whether the subscription amount can be switched.
 	 */

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -40,6 +40,7 @@ class WooCommerce_Connection {
 	 */
 	public static function init() {
 		\add_action( 'admin_init', [ __CLASS__, 'disable_woocommerce_setup' ] );
+		\add_filter( 'option_woocommerce_subscriptions_allow_switching_nyp_price', [ __CLASS__, 'force_allow_switching_subscription_amount' ] );
 
 		// WooCommerce Subscriptions.
 		\add_action( 'add_meta_boxes', [ __CLASS__, 'remove_subscriptions_schedule_meta_box' ], 45 );
@@ -1009,6 +1010,18 @@ class WooCommerce_Connection {
 			}
 		}
 		return $post_data;
+	}
+
+	/**
+	 * Force allow switching the subscription amount.
+	 *
+	 * @param bool $can_switch Whether the subscription amount can be switched.
+	 */
+	public static function force_allow_switching_subscription_amount( $can_switch ) {
+		if ( defined( 'NEWSPACK_PREVENT_FORCE_ALLOW_SWITCHING' ) && NEWSPACK_PREVENT_FORCE_ALLOW_SWITCHING ) {
+			return $can_switch;
+		}
+		return 'yes';
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

With this change, donors will always be able to switch subscription amounts, unless the `NEWSPACK_PREVENT_FORCE_ALLOW_SWITCHING` env. flag is set. 

See 1203981098043663-as-1204007355707594

### How to test the changes in this Pull Request:

1. On `master`, 
1. Set the Reader Revenue platform to Newspack
2. Remove the `woocommerce_subscriptions_allow_switching_nyp_price` option from the DB, if present
3. Make a recurring donation, log in to `/my-account`, and observe that in "My Subscriptions" -> "Subscription totals" table there is no "Change price" button
4. Switch to this branch, reload the page, observe the button is there (the subscription amount can be updated)
5. Add `NEWSPACK_PREVENT_FORCE_ALLOW_SWITCHING` env. flag to the site, reload the page, observe the button is gone now

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->