### PR TITLE
feat(amp-deprecation): polyfills for some AMP tags

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -157,7 +157,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
-		include_once NEWSPACK_ABSPATH . 'includes/polyfills/class-polyfills.php';
+		include_once NEWSPACK_ABSPATH . 'includes/polyfills/class-amp-polyfills.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-performance.php';
 
 		if ( Donations::is_platform_nrh() ) {

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -157,6 +157,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
+		include_once NEWSPACK_ABSPATH . 'includes/polyfills/class-polyfills.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-performance.php';
 
 		if ( Donations::is_platform_nrh() ) {

--- a/includes/polyfills/class-amp-polyfills.php
+++ b/includes/polyfills/class-amp-polyfills.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Polyfills.
+ * AMP_Polyfills.
  *
  * @package Newspack
  */
@@ -12,9 +12,9 @@ use \WP_Error;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Manages settings for Polyfills.
+ * Manages settings for AMP_Polyfills.
  */
-class Polyfills {
+class AMP_Polyfills {
 	/**
 	 * Add hooks.
 	 */
@@ -114,4 +114,4 @@ class Polyfills {
 		return $content;
 	}
 }
-Polyfills::init();
+AMP_Polyfills::init();

--- a/includes/polyfills/class-polyfills.php
+++ b/includes/polyfills/class-polyfills.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Polyfills.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use \WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages settings for Polyfills.
+ */
+class Polyfills {
+	/**
+	 * Add hooks.
+	 */
+	public static function init() {
+		add_filter( 'the_content', [ __CLASS__, 'amp_tags' ], 1, 1 );
+	}
+
+	/**
+	 * Insert HTML into a DOMDocument.
+	 *
+	 * @param \DOMDocument $dom DOMDocument.
+	 * @param string       $html HTML.
+	 * @param \DOMElement  $tag Tag.
+	 */
+	private static function insert_html( $dom, $html, $tag ) {
+		$replacement = $dom->createElement( 'div' );
+		$fragment    = $dom->createDocumentFragment();
+		$fragment->appendXML( $html );
+		foreach ( $fragment->childNodes as $node ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$imported_node = $dom->importNode( $node, true );
+			$replacement->appendChild( $imported_node );
+		}
+		$tag->parentNode->replaceChild( $replacement, $tag ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	}
+
+	/**
+	 * Polyfill AMP tags.
+	 *
+	 * @param string $content Content.
+	 */
+	public static function amp_tags( $content ) {
+		// If the AMP plugin is active, don't do anything.
+		if ( function_exists( 'amp_is_canonical' ) ) {
+			return $content;
+		}
+
+		// Polyfill amp-img and amp-iframe. These both have a src attribute, so we can use a regex to replace them.
+		$content = preg_replace(
+			'/<amp-(img|iframe)([^>]+)src="([^"]+)"([^>]*)>/',
+			'<\1 \2src="\3"\4></\1>',
+			$content
+		);
+
+		$has_amp_fit_text = false !== stripos( $content, '<amp-fit-text' );
+		$has_amp_youtube  = false !== stripos( $content, '<amp-youtube' );
+
+		if ( $has_amp_fit_text || $has_amp_youtube ) {
+			$dom = new \DomDocument();
+			libxml_use_internal_errors( true );
+			$dom->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ) );
+			$xpath = new \DOMXpath( $dom );
+
+			// Process amp-fit-text tags.
+			if ( $has_amp_fit_text ) {
+				foreach ( $xpath->query( '//amp-fit-text' ) as $tag ) {
+					$outer_html = $dom->saveHTML( $tag );
+					// AMP plugin used to (https://github.com/ampproject/amp-wp/pull/5729) have a feature to wrap
+					// headings in amp-fit-text, but it was removed. The enclosing amp-fit-text tag will be stripped,
+					// leaving the original heading tag.
+					$html = preg_replace( '/<amp-fit-text[^>]*>(.*)<\/amp-fit-text>/', '\1', $outer_html );
+					self::insert_html( $dom, $html, $tag );
+					$content = $dom->saveHTML();
+				}
+			}
+
+			// Process amp-youtube tags.
+			if ( $has_amp_youtube ) {
+				foreach ( $xpath->query( '//amp-youtube' ) as $tag ) {
+					$yt_id = false;
+					foreach ( $tag->attributes as $attribute ) {
+						if ( 'data-videoid' === $attribute->name ) {
+							$yt_id = $attribute->value;
+						}
+					}
+					if ( $yt_id ) {
+						// Return a YouTube embed block.
+						$video_url = 'https://www.youtube.com/watch?v=' . $yt_id;
+						$html      = '<div><!-- wp:embed {"url":"' . $video_url . '","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+                            <figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+                            ' . $video_url . '
+                            </div></figure>
+                        <!-- /wp:embed --></div>';
+						self::insert_html( $dom, $html, $tag );
+						$content = $dom->saveHTML();
+					}
+				}
+			}
+		}
+
+		return $content;
+	}
+}
+Polyfills::init();

--- a/includes/polyfills/class-polyfills.php
+++ b/includes/polyfills/class-polyfills.php
@@ -51,10 +51,16 @@ class Polyfills {
 			return $content;
 		}
 
-		// Polyfill amp-img and amp-iframe. These both have a src attribute, so we can use a regex to replace them.
+		// Polyfill amp-img.
 		$content = preg_replace(
-			'/<amp-(img|iframe)([^>]+)src="([^"]+)"([^>]*)>/',
-			'<\1 \2src="\3"\4></\1>',
+			'/<amp-img([^>]*)>[^<]*<\/amp-img>/',
+			'<img\1>', // img is a void element.
+			$content
+		);
+		// Polyfill amp-iframe.
+		$content = preg_replace(
+			'/<amp-iframe([^>]*)>[^<]*<\/amp-iframe>/',
+			'<iframe\1></iframe>',
 			$content
 		);
 
@@ -98,7 +104,8 @@ class Polyfills {
                             </div></figure>
                         <!-- /wp:embed --></div>';
 						self::insert_html( $dom, $html, $tag );
-						$content = $dom->saveHTML();
+						$body    = $dom->getElementsByTagName( 'body' )->item( 0 );
+						$content = preg_replace( '/<\/?body>/', '', $dom->saveHTML( $body ) );
 					}
 				}
 			}

--- a/tests/unit-tests/amp-polyfills.php
+++ b/tests/unit-tests/amp-polyfills.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests the AMP Polyfills.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Polyfills;
+
+/**
+ * Tests the AMP Polyfills.
+ */
+class Amp_Polyfills extends WP_UnitTestCase {
+
+	/**
+	 * Data provider for test_image.
+	 *
+	 * @return array
+	 */
+	public function image_data() {
+		return [
+			[
+				'<amp-img src="https://example.com/image.jpg" width="100" height="100"></amp-img>',
+				'<img src="https://example.com/image.jpg" width="100" height="100"></img>',
+			],
+			[
+				'<amp-img class="test" src="https://example.com/image.jpg" width="100" height="100"></amp-img>',
+				'<img class="test" src="https://example.com/image.jpg" width="100" height="100"/>',
+			],
+			[
+				'<amp-img src="https://example.com/image.jpg"></amp-img><p>something</p><amp-img src="https://example.com/image.jpg"></amp-img>something',
+				'<img src="https://example.com/image.jpg"></img><p>something</p><img src="https://example.com/image.jpg"></img>something',
+			],
+
+		];
+	}
+
+	/**
+	 * Tests the image polyfill.
+	 *
+	 * @param string $input Input content.
+	 * @param string $expected Expected output.
+	 * @return void
+	 * @dataProvider image_data
+	 */
+	public function test_image( $input, $expected ) {
+		$this->assertSame( $expected, Polyfills::amp_tags( $input ) );
+	}
+
+	/**
+	 * Data provider for test_iframe.
+	 *
+	 * @return array
+	 */
+	public function iframe_data() {
+		return [
+			[
+				'<amp-iframe src="https://example.com/image.jpg" width="100" height="100"></amp-iframe>',
+				'<iframe src="https://example.com/image.jpg" width="100" height="100"></iframe>',
+			],
+			[
+				'<amp-iframe class="test" src="https://example.com/image.jpg" width="100" height="100"></amp-iframe>',
+				'<iframe class="test" src="https://example.com/image.jpg" width="100" height="100"></img>',
+			],
+			[
+				'<amp-iframe src="https://example.com/image.jpg"></amp-iframe><p>something</p><amp-iframe src="https://example.com/image.jpg"></amp-iframe>something',
+				'<iframe src="https://example.com/image.jpg"></iframe><p>something</p><iframe src="https://example.com/image.jpg"></iframe>something',
+			],
+
+		];
+	}
+
+	/**
+	 * Tests the image polyfill.
+	 *
+	 * @param string $input Input content.
+	 * @param string $expected Expected output.
+	 * @return void
+	 * @dataProvider iframe_data
+	 */
+	public function test_iframe( $input, $expected ) {
+		$this->assertSame( $expected, Polyfills::amp_tags( $input ) );
+	}
+
+	/**
+	 * Data provider for test_youtube.
+	 *
+	 * @return array
+	 */
+	public function test_youtube_data() {
+		return [
+			[
+				'<amp-youtube data-videoid="mGENRKrdoGY" layout="responsive" width="480" height="270" ></amp-youtube>',
+				'<div><!-- wp:embed {"url":"https://www.youtube.com/watch?v=mGENRKrdoGY","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+                            <figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+                            https://www.youtube.com/watch?v=mGENRKrdoGY
+                            </div></figure>
+                        <!-- /wp:embed --></div>',
+			],
+
+		];
+	}
+
+	/**
+	 * Tests the image polyfill.
+	 *
+	 * @param string $input Input content.
+	 * @param string $expected Expected output.
+	 * @return void
+	 * @dataProvider test_youtube_data
+	 */
+	public function test_youtube( $input, $expected ) {
+		$this->assertSame( str_replace( ' ', '', $expected ), str_replace( ' ', '', Polyfills::amp_tags( $input ) ) );
+	}
+
+}

--- a/tests/unit-tests/amp-polyfills.php
+++ b/tests/unit-tests/amp-polyfills.php
@@ -5,12 +5,12 @@
  * @package Newspack\Tests
  */
 
-use Newspack\Polyfills;
+use Newspack\AMP_Polyfills;
 
 /**
  * Tests the AMP Polyfills.
  */
-class Amp_Polyfills extends WP_UnitTestCase {
+class Newspack_AMP_Polyfills extends WP_UnitTestCase {
 
 	/**
 	 * Data provider for test_amp_polyfills_image.
@@ -44,7 +44,7 @@ class Amp_Polyfills extends WP_UnitTestCase {
 	 * @dataProvider image_data
 	 */
 	public function test_amp_polyfills_image( $input, $expected ) {
-		$this->assertSame( $expected, Polyfills::amp_tags( $input ) );
+		$this->assertSame( $expected, AMP_Polyfills::amp_tags( $input ) );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class Amp_Polyfills extends WP_UnitTestCase {
 	 * @dataProvider iframe_data
 	 */
 	public function test_amp_polyfills_iframe( $input, $expected ) {
-		$this->assertSame( $expected, Polyfills::amp_tags( $input ) );
+		$this->assertSame( $expected, AMP_Polyfills::amp_tags( $input ) );
 	}
 
 	/**
@@ -110,6 +110,6 @@ class Amp_Polyfills extends WP_UnitTestCase {
 	 * @dataProvider youtube_data
 	 */
 	public function test_amp_polyfills_youtube( $input, $expected ) {
-		$this->assertSame( str_replace( ' ', '', $expected ), str_replace( ' ', '', Polyfills::amp_tags( $input ) ) );
+		$this->assertSame( str_replace( ' ', '', $expected ), str_replace( ' ', '', AMP_Polyfills::amp_tags( $input ) ) );
 	}
 }

--- a/tests/unit-tests/amp-polyfills.php
+++ b/tests/unit-tests/amp-polyfills.php
@@ -13,7 +13,7 @@ use Newspack\Polyfills;
 class Amp_Polyfills extends WP_UnitTestCase {
 
 	/**
-	 * Data provider for test_image.
+	 * Data provider for test_amp_polyfills_image.
 	 *
 	 * @return array
 	 */
@@ -21,15 +21,15 @@ class Amp_Polyfills extends WP_UnitTestCase {
 		return [
 			[
 				'<amp-img src="https://example.com/image.jpg" width="100" height="100"></amp-img>',
-				'<img src="https://example.com/image.jpg" width="100" height="100"></img>',
+				'<img src="https://example.com/image.jpg" width="100" height="100">',
 			],
 			[
-				'<amp-img class="test" src="https://example.com/image.jpg" width="100" height="100"></amp-img>',
-				'<img class="test" src="https://example.com/image.jpg" width="100" height="100"/>',
+				'<amp-img class="test" src="https://example.com/image.jpg" width="100" height="100">something inside</amp-img>',
+				'<img class="test" src="https://example.com/image.jpg" width="100" height="100">',
 			],
 			[
 				'<amp-img src="https://example.com/image.jpg"></amp-img><p>something</p><amp-img src="https://example.com/image.jpg"></amp-img>something',
-				'<img src="https://example.com/image.jpg"></img><p>something</p><img src="https://example.com/image.jpg"></img>something',
+				'<img src="https://example.com/image.jpg"><p>something</p><img src="https://example.com/image.jpg">something',
 			],
 
 		];
@@ -43,12 +43,12 @@ class Amp_Polyfills extends WP_UnitTestCase {
 	 * @return void
 	 * @dataProvider image_data
 	 */
-	public function test_image( $input, $expected ) {
+	public function test_amp_polyfills_image( $input, $expected ) {
 		$this->assertSame( $expected, Polyfills::amp_tags( $input ) );
 	}
 
 	/**
-	 * Data provider for test_iframe.
+	 * Data provider for test_amp_polyfills_iframe.
 	 *
 	 * @return array
 	 */
@@ -60,7 +60,7 @@ class Amp_Polyfills extends WP_UnitTestCase {
 			],
 			[
 				'<amp-iframe class="test" src="https://example.com/image.jpg" width="100" height="100"></amp-iframe>',
-				'<iframe class="test" src="https://example.com/image.jpg" width="100" height="100"></img>',
+				'<iframe class="test" src="https://example.com/image.jpg" width="100" height="100"></iframe>',
 			],
 			[
 				'<amp-iframe src="https://example.com/image.jpg"></amp-iframe><p>something</p><amp-iframe src="https://example.com/image.jpg"></amp-iframe>something',
@@ -78,24 +78,24 @@ class Amp_Polyfills extends WP_UnitTestCase {
 	 * @return void
 	 * @dataProvider iframe_data
 	 */
-	public function test_iframe( $input, $expected ) {
+	public function test_amp_polyfills_iframe( $input, $expected ) {
 		$this->assertSame( $expected, Polyfills::amp_tags( $input ) );
 	}
 
 	/**
-	 * Data provider for test_youtube.
+	 * Data provider for test_amp_polyfills_youtube.
 	 *
 	 * @return array
 	 */
-	public function test_youtube_data() {
+	public function youtube_data() {
 		return [
 			[
 				'<amp-youtube data-videoid="mGENRKrdoGY" layout="responsive" width="480" height="270" ></amp-youtube>',
-				'<div><!-- wp:embed {"url":"https://www.youtube.com/watch?v=mGENRKrdoGY","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+				'<div><div><!-- wp:embed {"url":"https://www.youtube.com/watch?v=mGENRKrdoGY","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
                             <figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
                             https://www.youtube.com/watch?v=mGENRKrdoGY
                             </div></figure>
-                        <!-- /wp:embed --></div>',
+                        <!-- /wp:embed --></div></div>',
 			],
 
 		];
@@ -107,10 +107,9 @@ class Amp_Polyfills extends WP_UnitTestCase {
 	 * @param string $input Input content.
 	 * @param string $expected Expected output.
 	 * @return void
-	 * @dataProvider test_youtube_data
+	 * @dataProvider youtube_data
 	 */
-	public function test_youtube( $input, $expected ) {
+	public function test_amp_polyfills_youtube( $input, $expected ) {
 		$this->assertSame( str_replace( ' ', '', $expected ), str_replace( ' ', '', Polyfills::amp_tags( $input ) ) );
 	}
-
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If a site relied on AMP, it may have some AMP tags in content. When the AMP plugin is deactivated, these tags won't render anymore, since AMP is not HTML. 

This PR adds a few light polyfills for most commonly used (and easy-to-replace) AMP tags. These polyfills are not 1:1 replacements for AMP tags – AMP-specific attributes like `layout` will not be handled. This is because AMP tags were never meant to be inserted on pages (AMP plugin should convert HTML into AMP-HTML), but if that happened for some reason, Newspack should ensure at least something is rendered when it's possible.   

### How to test the changes in this Pull Request:

1. On `master`,
1. Ensure AMP plugin is deactivated on the site
2. With a HTML block (or code editor) insert the following content into a page or post:

<details>
<summary>Click to expand code</summary>
<code>
&lt;!-- wp:html -->
&lt;h1>amp-youtube&lt;/h1>
&lt;amp-youtube data-videoid="mGENRKrdoGY" layout="responsive" width="480" height="270">&lt;/amp-youtube>
&lt;h1>amp-fit-text&lt;/h1>
&lt;amp-fit-text layout="fixed-height" min-font-size="6" max-font-size="72" height="80">&lt;h3 id="h-subscribe">Subscribe:&lt;/h3>&lt;/amp-fit-text>
&lt;h1>amp-image&lt;/h1>
&lt;amp-img width="428" height="642" layout="fixed" src="https://images.unsplash.com/photo-1677590396087-d0835963aeca?fit=crop&amp;w=428&amp;q=60" placeholder="" style="margin: auto">&lt;/amp-img>
&lt;h1>amp-iframe&lt;/h1>
&lt;amp-iframe width="200" height="100" sandbox="allow-scripts allow-same-origin" layout="responsive" frameborder="0" src="https://www.google.com/maps/embed/v1/place?key=AIzaSyAyAS599A2GGPKTmtNr9CptD61LE4gN6oQ&amp;q=iceland">
&lt;/amp-iframe>
&lt;!-- /wp:html -->
</code>
</details>

5. Visit the post, you should see nothing rendered for all AMP tags besides the `amp-fit-text`
6. Switch to this branch, reload the page, observe that the tags render a YT video, an image, and an iframe, preserving the original attributes like `width` and `height` 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->