### PR TITLE
feat(perfmatters): improve config

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -79,7 +79,7 @@ class Perfmatters {
 	 */
 	private static function unused_css_excluded_stylesheets() {
 		return [
-			'donateStreamlined.css',
+			'plugins/newspack-blocks', // Newspack Blocks.
 			'/themes/newspack-', // Any Newspack theme stylesheet.
 			'wp-includes',
 		];
@@ -139,6 +139,7 @@ class Perfmatters {
 		$defer_js_exclusions           = [
 			'wp-includes',
 			'jwplayer.com', // This platform won't work if the JS is deferred.
+			'adsrvr.org', // This platform won't work if the JS is deferred.
 		];
 		$options['assets']['defer_js'] = true;
 		if ( isset( $options['assets']['js_exclusions'] ) && is_array( $options['assets']['js_exclusions'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweak Perfmatters baseline config: 

- all Newspack Blocks CSS should be loaded immediately
- `adsrvr.org` scripts should not be deferred – this makes some ads not display

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->