### PR TITLE
Add/popups donation events

### DIFF
--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -539,7 +539,7 @@ class Salesforce {
 		$order_id = isset( $args['id'] ) ? $args['id'] : 0;
 		$order    = \wc_get_order( $order_id );
 
-		if ( is_wp_error( $response ) ) {
+		if ( is_wp_error( $response ) && is_a( $order, 'WC_Order' ) ) {
 			$order->add_order_note(
 				sprintf(
 					// Translators: Note added to order when sync is unsuccessful.
@@ -547,7 +547,7 @@ class Salesforce {
 					$response->get_error_message()
 				)
 			);
-		} else {
+		} elseif ( is_a( $order, 'WC_Order' ) ) {
 			$order->add_order_note( __( 'Order successfully synced to Salesforce.', 'newspack' ) );
 		}
 
@@ -579,10 +579,10 @@ class Salesforce {
 	 * @return array|WP_Error Array containing synced contact and opportunity data, or WP_Error.
 	 */
 	private static function sync_salesforce( $order ) {
-		$order_id      = is_a( $order, 'WC_Order' ) ? $order->get_id() : $order['id'];
+		$order_id      = is_a( $order, 'WC_Order' ) ? $order->get_id() : $order['id'] ?? false;
 		$order_details = self::parse_wc_order_data( $order );
 
-		if ( empty( $order_details ) ) {
+		if ( empty( $order_details ) || is_wp_error( $order_details ) ) {
 			return \rest_ensure_response(
 				new \WP_Error(
 					'newspack_salesforce_invalid_order',

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -122,12 +122,13 @@ Data_Events::register_listener(
 		if ( ! $order ) {
 			return;
 		}
+		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
 		return [
 			'user_id'       => $order->get_customer_id(),
 			'email'         => $order->get_billing_email(),
 			'amount'        => (float) $order->get_total(),
 			'currency'      => $order->get_currency(),
-			'recurrence'    => get_post_meta( $product_id, '_subscription_period', true ),
+			'recurrence'    => empty( $recurrence ) ? 'once' : $recurrence,
 			'platform'      => 'wc',
 			'referer'       => $order->get_meta( '_newspack_referer' ),
 			'popup_id'      => $order->get_meta( '_newspack_popup_id' ),
@@ -153,13 +154,14 @@ Data_Events::register_listener(
 		if ( ! $product_id ) {
 			return;
 		}
+		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
 
 		return [
 			'user_id'       => $order->get_customer_id(),
 			'email'         => $order->get_billing_email(),
 			'amount'        => (float) $order->get_total(),
 			'currency'      => $order->get_currency(),
-			'recurrence'    => \get_post_meta( $product_id, '_subscription_period', true ),
+			'recurrence'    => empty( $recurrence ) ? 'once' : $recurrence,
 			'platform'      => Donations::get_platform_slug(),
 			'referer'       => $order->get_meta( '_newspack_referer' ),
 			'popup_id'      => $order->get_meta( '_newspack_popup_id' ),
@@ -186,13 +188,14 @@ Data_Events::register_listener(
 		if ( ! $product_id ) {
 			return;
 		}
+		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
 		return [
 			'user_id'         => $subscription->get_customer_id(),
 			'email'           => $subscription->get_billing_email(),
 			'subscription_id' => $subscription->get_id(),
 			'amount'          => (float) $subscription->get_total(),
 			'currency'        => $subscription->get_currency(),
-			'recurrence'      => get_post_meta( $product_id, '_subscription_period', true ),
+			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
 			'platform'        => Donations::get_platform_slug(),
 			'referer'         => $subscription->get_meta( '_newspack_referer' ),
 			'popup_id'        => $subscription->get_meta( '_newspack_popup_id' ),
@@ -211,13 +214,14 @@ Data_Events::register_listener(
 		if ( ! $product_id ) {
 			return;
 		}
+		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
 
 		return [
 			'user_id'       => $order->get_customer_id(),
 			'email'         => $order->get_billing_email(),
 			'amount'        => (float) $order->get_total(),
 			'currency'      => $order->get_currency(),
-			'recurrence'    => \get_post_meta( $product_id, '_subscription_period', true ),
+			'recurrence'    => empty( $recurrence ) ? 'once' : $recurrence,
 			'platform'      => Donations::get_platform_slug(),
 			'referer'       => $order->get_meta( '_newspack_referer' ),
 			'popup_id'      => $order->get_meta( '_newspack_popup_id' ),
@@ -244,13 +248,14 @@ Data_Events::register_listener(
 		if ( ! $product_id ) {
 			return;
 		}
+		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
 		return [
 			'user_id'         => $subscription->get_customer_id(),
 			'email'           => $subscription->get_billing_email(),
 			'subscription_id' => $subscription->get_id(),
 			'amount'          => (float) $subscription->get_total(),
 			'currency'        => $subscription->get_currency(),
-			'recurrence'      => get_post_meta( $product_id, '_subscription_period', true ),
+			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
 			'platform'        => Donations::get_platform_slug(),
 		];
 	}
@@ -267,6 +272,7 @@ Data_Events::register_listener(
 		if ( ! $product_id ) {
 			return;
 		}
+		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
 		return [
 			'user_id'         => $subscription->get_customer_id(),
 			'email'           => $subscription->get_billing_email(),
@@ -275,7 +281,7 @@ Data_Events::register_listener(
 			'status_after'    => $status_to,
 			'amount'          => (float) $subscription->get_total(),
 			'currency'        => $subscription->get_currency(),
-			'recurrence'      => get_post_meta( $product_id, '_subscription_period', true ),
+			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
 			'platform'        => Donations::get_platform_slug(),
 		];
 	}

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -113,7 +113,7 @@ Data_Events::register_listener(
  */
 Data_Events::register_listener(
 	'newspack_donation_order_processed',
-	'donation_order_processed',
+	'woocommerce_donation_order_processed',
 	function( $order_id, $product_id ) {
 		$order = \wc_get_order( $order_id );
 		if ( ! $order ) {
@@ -126,6 +126,8 @@ Data_Events::register_listener(
 			'currency'      => $order->get_currency(),
 			'recurrence'    => get_post_meta( $product_id, '_subscription_period', true ),
 			'platform'      => 'wc',
+			'referer'       => $order->get_meta( '_newspack_referer' ),
+			'popup_id'      => $order->get_meta( '_newspack_popup_id' ),
 			'platform_data' => [
 				'order_id'   => $order_id,
 				'product_id' => $product_id,
@@ -134,6 +136,38 @@ Data_Events::register_listener(
 	}
 );
 
+/**
+ * For when there's a new donation payment failed through WooCommerce.
+ *
+ * Known issue: If the user tries to pay again after a failed payment, and the payment fails for a second time,
+ * the order is already marked as failed so this hook will not trigger.
+ */
+Data_Events::register_listener(
+	'woocommerce_order_status_failed',
+	'woocommerce_order_failed',
+	function( $order_id, $order ) {
+		$product_id = Donations::get_order_donation_product_id( $order_id );
+		if ( ! $product_id ) {
+			return;
+		}
+
+		return [
+			'user_id'       => $order->get_customer_id(),
+			'email'         => $order->get_billing_email(),
+			'amount'        => (float) $order->get_total(),
+			'currency'      => $order->get_currency(),
+			'recurrence'    => \get_post_meta( $product_id, '_subscription_period', true ),
+			'platform'      => Donations::get_platform_slug(),
+			'referer'       => $order->get_meta( '_newspack_referer' ),
+			'popup_id'      => $order->get_meta( '_newspack_popup_id' ),
+			'platform_data' => [
+				'order_id'   => $order_id,
+				'product_id' => $product_id,
+				'client_id'  => $order->get_meta( NEWSPACK_CLIENT_ID_COOKIE_NAME ),
+			],
+		];
+	}
+);
 
 /**
  * For when a Subscription is confirmed.
@@ -157,6 +191,8 @@ Data_Events::register_listener(
 			'currency'        => $subscription->get_currency(),
 			'recurrence'      => get_post_meta( $product_id, '_subscription_period', true ),
 			'platform'        => Donations::get_platform_slug(),
+			'referer'         => $subscription->get_meta( '_newspack_referer' ),
+			'popup_id'        => $subscription->get_meta( '_newspack_popup_id' ),
 		];
 	}
 );
@@ -165,13 +201,14 @@ Data_Events::register_listener(
  * For when there's a new donation confirmed
  */
 Data_Events::register_listener(
-	'woocommerce_order_status_pending_to_completed',
+	'woocommerce_order_status_completed',
 	'donation_new',
 	function( $order_id, $order ) {
 		$product_id = Donations::get_order_donation_product_id( $order_id );
 		if ( ! $product_id ) {
 			return;
 		}
+
 		return [
 			'user_id'       => $order->get_customer_id(),
 			'email'         => $order->get_billing_email(),
@@ -179,6 +216,8 @@ Data_Events::register_listener(
 			'currency'      => $order->get_currency(),
 			'recurrence'    => \get_post_meta( $product_id, '_subscription_period', true ),
 			'platform'      => Donations::get_platform_slug(),
+			'referer'       => $order->get_meta( '_newspack_referer' ),
+			'popup_id'      => $order->get_meta( '_newspack_popup_id' ),
 			'platform_data' => [
 				'order_id'   => $order_id,
 				'product_id' => $product_id,

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -750,6 +750,16 @@ class Stripe_Connection {
 	public static function handle_donation( $config ) {
 		Stripe_Webhooks::validate_or_create_webhooks( true );
 
+		$stripe_data = self::get_stripe_data();
+
+		/**
+		 * Fires at the top of the handle_donation method on the Stripe Connection class, just before it handles the donation.
+		 *
+		 * @param array $config Data about the donation.
+		 * @param array $stripe_data Data about the Stripe connection.
+		 */
+		do_action( 'newspack_stripe_handle_donation_before', $config, $stripe_data );
+
 		$response = [
 			'error'  => null,
 			'status' => null,
@@ -783,6 +793,14 @@ class Stripe_Connection {
 			);
 			if ( \is_wp_error( $customer ) ) {
 				$response['error'] = $customer->get_error_message();
+				/**
+				 * Fires at handle_donation method on the Stripe Connection class, when there's an error in the donation.
+				 *
+				 * @param object $config Data about the donation.
+				 * @param array $stripe_data Data about the Stripe connection.
+				 * @param string $error_message Error message.
+				 */
+				do_action( 'newspack_stripe_handle_donation_error', $config, $stripe_data, $response['error'] );
 				return $response;
 			}
 
@@ -934,6 +952,10 @@ class Stripe_Connection {
 			}
 		} catch ( \Throwable $e ) {
 			$response['error'] = $e->getMessage();
+			/**
+			 * This hook is documented above
+			 */
+			do_action( 'newspack_stripe_handle_donation_error', $config, $stripe_data, $response['error'] );
 		}
 		return $response;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the popup events for Donations

### How to test the changes in this Pull Request:

Setup
1. Make sure you have the latest version (`master`) of the popups and blocks plugins
2. Not required, but I suggest checking out this fix on the newsletters plugin -> https://github.com/Automattic/newspack-newsletters/pull/1101
3. add this to your site:
```PHP
add_action(
	'plugins_loaded',
	function() {
		Data_Events::register_handler( 'debug_popups_events', 'campaign_interaction' );

	}
);

function debug_popups_events( $timestamp, $data, $user_id ) {
	error_log( print_r( $data, true ) );
}
```
4. Setup a Donation block inside a popup
5. Setup a Donation block in a page, not inside a popup

Now let's test

Now we are going to make donations in the following ways:
* With Stripe and Newspack as Reader Revenue platform
* For each platform, one recurring donation and one one-time donation
* For each type of donation, one with a valid card (4242424242424242) and one with a failing card (4000000000000002)
* Also, for each platform, make one donation from inside the block that is not in a popup

Inspect the logs while you do the donation. For each donation you should see 2 `campaign_interaction` events being fired
```
[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::dispatch]: Dispatching action "campaign_interaction" via Action Scheduler.
```
(for Stripe, the second one might take a little while, as it happens when the Stripe server reaches your site via webhook)

When the events handlers are fired, you will see one event with `action = form_submission` and one with `form_submission_sucess`or `form_submission_failure` depending on the case.

Here's an example:
```
(
    [campaign_id] => 143
    [campaign_title] => Inline Donation (secondary)
    [campaign_frequency] => always
    [campaign_placement] => inline
    [campaign_has_registration_block] => 
    [campaign_has_donation_block] => 1
    [campaign_has_newsletter_block] => 
    [action] => form_submission_success
    [donation_amount] => 15.76
    [donation_currency] => BRL
    [donation_recurrence] => month
    [donation_platform] => stripe
    [referer] => /2023/02/07/egestas-praesent-curabitur-aptent-nunc-vel-laoreet-neque-tristique-pretium-condimentum/
)
```
Make sure all events have the right information.

Make sure donations done from the block on the page does not trigger any `campaign_interaction` event

Known issue: when using woocommerce and the transaction fails, yo are are able to try again. If the transaction fails again a second time, the form submission failure will not be triggered. I could not find a hook for that. Since woocommerce uses the same order and its status is already failed, the statuc change action is not fired


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->