### PR TITLE
feat: add a Add new button to subscription lists

### DIFF
--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -198,10 +198,20 @@ export const SubscriptionLists = ( { onUpdate } ) => {
 	}
 	return (
 		<>
-			<SectionHeader
-				title={ __( 'Subscription Lists', 'newspack' ) }
-				description={ __( 'Manage the lists available for subscription.', 'newspack' ) }
-			/>
+			<Card headerActions noBorder>
+				<SectionHeader
+					title={ __( 'Subscription Lists', 'newspack' ) }
+					description={ __( 'Manage the lists available for subscription.', 'newspack' ) }
+				/>
+				{ newspack_engagement_wizard.new_subscription_lists_url && (
+					<Button
+						variant="secondary"
+						href={ newspack_engagement_wizard.new_subscription_lists_url }
+					>
+						{ __( 'Add New', 'newspack' ) }
+					</Button>
+				) }
+			</Card>
 			{ error && (
 				<Notice
 					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -1,3 +1,4 @@
+/* global newspack_engagement_wizard */
 /**
  * Internal dependencies
  */

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -347,12 +347,18 @@ class Engagement_Wizard extends Wizard {
 			true
 		);
 
+		$data = [
+			'has_reader_activation' => defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) && NEWSPACK_EXPERIMENTAL_READER_ACTIVATION,
+		];
+
+		if ( method_exists( 'Newspack\Newsletters\Subscription_Lists', 'get_add_new_url' ) ) {
+			$data['new_subscription_lists_url'] = \Newspack\Newsletters\Subscription_Lists::get_add_new_url();
+		}
+
 		\wp_localize_script(
 			'newspack-engagement-wizard',
 			'newspack_engagement_wizard',
-			[
-				'has_reader_activation' => defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) && NEWSPACK_EXPERIMENTAL_READER_ACTIVATION,
-			]
+			$data
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds an "Add new" button to the Subscription Lists

### How to test the changes in this Pull Request:

1. Checkout https://github.com/Automattic/newspack-newsletters/pull/1102 on the newsletters plugin
2. Go to Newspack > Engagement > Newsletters
3. See that there's a Add new button in the Subscription Lists settings (if Active Campaign, Constant Contact or Mailchimp are selected)
4. Click the add new button and confirm you are able to create a list
5. Click the "Back to Subscription Lists management" and confirm you go back to the wizard
6. Known issue: when you change the provider, the button is not updated immediately, it needs a refresh (example: if you change from Mailchimp to Campaign Monitor, the button will still be there, even though this provider does not support it

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->