### PR TITLE
fix(cli): setup config path

### DIFF
--- a/includes/cli/class-setup.php
+++ b/includes/cli/class-setup.php
@@ -164,7 +164,7 @@ class Setup {
 	 * @return void
 	 */
 	private function amp_plus() {
-		$wpconfig = new WPConfigTransformer( ABSPATH . '/wp-config.php' );
+		$wpconfig = new WPConfigTransformer( WP_CLI\Utils\locate_wp_config() );
 		$wpconfig->update( 'constant', 'NEWSPACK_AMP_PLUS_ENABLED', 'true', [ 'raw' => true ] );
 		WP_CLI::success( 'AMP Plus configured.' );
 	}
@@ -175,7 +175,7 @@ class Setup {
 	 * @return void
 	 */
 	private function ras_beta() {
-		$wpconfig = new WPConfigTransformer( ABSPATH . '/wp-config.php' );
+		$wpconfig = new WPConfigTransformer( WP_CLI\Utils\locate_wp_config() );
 		$wpconfig->update( 'constant', 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', 'true', [ 'raw' => true ] );
 		WP_CLI::success( 'RAS enabled.' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The `wp-config.php` might not always be where the `setup` CLI command assumed!

### How to test the changes in this Pull Request:

1. Run the CLI setup command (`wp newspack setup`) observe that it properly updates the `wp-config.php` regardless of whether it's run on the development environment or on a live site

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->