### PR TITLE
chore(data-events): add docs for campaigns listeners

### DIFF
--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -133,6 +133,23 @@ When a WooCommerce Subscription status changes.
 | `recurrence`      | `string` |
 | `platform`        | `string` |
 
+## Newspack Popups Actions
+
+### `campaign_interaction`
+
+When a user interacts with a Newspack Popup's campaign prompt.
+
+| Name                              | Type      |
+| --------------------------------- | --------- |
+| `campaign_id`                     | `int`     |
+| `campaign_title`                  | `string`  |
+| `campaign_frequency`              | `string`  |
+| `campaign_placement`              | `string`  |
+| `campaign_has_registration_block` | `boolean` |
+| `campaign_has_donation_block`     | `boolean` |
+| `campaign_has_newsletter_block`   | `boolean` |
+| `action`                          | `string`  |
+
 ## Registering a new action
 
 To dispatch an event, an action must first be registered with the following:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add docs to data events Campaigns' listeners

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->