### PR TITLE
feat(amp): polyfill lightbox effect

### DIFF
--- a/assets/other-scripts/lightbox/index.js
+++ b/assets/other-scripts/lightbox/index.js
@@ -1,0 +1,52 @@
+import './style.scss';
+
+/**
+ * Specify a function to execute when the DOM is fully loaded.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
+ *
+ * @param {Function} callback A function to execute after the DOM is ready.
+ * @return {void}
+ */
+function domReady( callback ) {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+	if (
+		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+	) {
+		return void callback();
+	}
+	// DOMContentLoaded has not fired yet, delay callback until then.
+	document.addEventListener( 'DOMContentLoaded', callback );
+}
+
+/**
+ * A lightweight lightbox.
+ */
+const createLightbox = url => {
+	const lightboxContainer = document.createElement( 'div' );
+	lightboxContainer.classList.add( 'newspack-img-lightbox' );
+	const lightboxImgEl = document.createElement( 'img' );
+	const lightboxCloseEl = document.createElement( 'div' );
+	lightboxCloseEl.classList.add( 'newspack-img-lightbox__close' );
+	lightboxCloseEl.innerHTML = '+';
+	lightboxCloseEl.onclick = () => {
+		document.body.removeChild( lightboxContainer );
+		document.body.classList.remove( 'newspack-has-img-lightbox' );
+	};
+	lightboxImgEl.src = url;
+	lightboxContainer.appendChild( lightboxImgEl );
+	lightboxContainer.appendChild( lightboxCloseEl );
+	document.body.appendChild( lightboxContainer );
+	document.body.classList.add( 'newspack-has-img-lightbox' );
+};
+
+domReady( function () {
+	[ ...document.querySelectorAll( 'figure[data-lightbox]' ) ].forEach( lightboxEl => {
+		lightboxEl.addEventListener( 'click', () => {
+			createLightbox( lightboxEl.querySelector( 'img' ).src );
+		} );
+	} );
+} );

--- a/assets/other-scripts/lightbox/style.scss
+++ b/assets/other-scripts/lightbox/style.scss
@@ -1,0 +1,26 @@
+body.newspack-has-img-lightbox {
+	overflow: hidden !important;
+}
+
+.newspack-img-lightbox {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100vw;
+	height: 100vh;
+	display: flex;
+	justify-content: space-around;
+	align-items: center;
+	background: black;
+	&__close {
+		position: absolute;
+		top: 14px;
+		right: 10px;
+		color: white;
+		transform: rotate( 45deg );
+		font-size: 55px;
+		line-height: 20px;
+		font-family: system-ui;
+		cursor: pointer;
+	}
+}

--- a/assets/other-scripts/lightbox/style.scss
+++ b/assets/other-scripts/lightbox/style.scss
@@ -4,6 +4,7 @@ body.newspack-has-img-lightbox {
 
 .newspack-img-lightbox {
 	position: fixed;
+	z-index: 99999;
 	top: 0;
 	left: 0;
 	width: 100vw;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Polyfills AMP's "Add lightbox effect" feature of the core image block:

<img width="285" alt="image" src="https://user-images.githubusercontent.com/7383192/223384672-3edd5a24-28c1-4798-bbad-ca247df49aa4.png">

Note that a similar feature [exists in Jetpack](https://jetpack.com/support/carousel/) (if the image links to the attachment page), but it causes the page to load a lot of markup and carousel-related JS, which is not optimal from a performance standpoint. 

### How to test the changes in this Pull Request:

1. Ensure AMP is enabled, insert an image block in a post or page, and toggle "Add lightbox effect" in the block settings in the sidebar ("AMP Settings" panel)
2. Deactivate the AMP plugin, load the frontend 
3. Click on the image, observe it goes full-screen with a black background and a close icon in the top-right corner
4. Click the close icon, observe the full-screen view disappearing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->