### PR TITLE
fix(modal-checkout): provide conversion URL for ESP

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -192,7 +192,12 @@ class WooCommerce_Connection {
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_date' ) ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
 
 		if ( false === $payment_page_url ) {
-			$payment_page_url = \wc_get_checkout_url();
+			$referer_from_order = $order->get_meta( '_newspack_referer' );
+			if ( empty( $referer_from_order ) ) {
+				$payment_page_url = \wc_get_checkout_url();
+			} else {
+				$payment_page_url = $referer_from_order;
+			}
 		}
 		$metadata['current_page_url'] = $payment_page_url;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

With the new modal checkout, the URL metadata will be derived from the `/checkout` page (rendered in a modal), and not the conversion URL. This PR fixes that.

### How to test the changes in this Pull Request:

1. On `master`, with Newspack set as the RR platform, RAS enabled, and AC connected as the ESP, make a donation
2. Observe that the contact created has `NP_Payment Page` and `NP_Signup page` set to the checkout page
3. Switch to this branch, visit the page with the Donate block and add some UTM params (e.g. `my-site.com/donate?utm_campaign=spring23`)
4. Observe that the contact created has the correct `NP_Payment Page` and `NP_Signup page` fields set, as well as the appropriate `NP_Payment UTM: *`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->