### PR TITLE
feat: Add GA4 Newsletters subscriptions events

### DIFF
--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -31,6 +31,7 @@ class GA4 {
 	public static $watched_events = [
 		'reader_logged_in',
 		'reader_registered',
+		'newsletter_subscribed',
 	];
 
 	/**
@@ -164,6 +165,32 @@ class GA4 {
 		if ( ! empty( $data['metadata']['referer'] ) ) {
 			$params['referer'] = substr( $data['metadata']['referer'], 0, 100 );
 		}
+		return $params;
+	}
+
+	/**
+	 * Handler for the newsletter_subscribed event.
+	 *
+	 * @param int   $params The GA4 event parameters.
+	 * @param array $data      Data associated with the Data Events api event.
+	 *
+	 * @return array $params The final version of the GA4 event params that will be sent to GA.
+	 */
+	public static function handle_newsletter_subscribed( $params, $data ) {
+		$metadata = $data['contact']['metadata'] ?? [];
+		if ( ! empty( $metadata['newspack_popup_id'] ) ) {
+			$params = array_merge( $params, Popups_Events::get_popup_metadata( $metadata['newspack_popup_id'] ) );
+		}
+		$params['newsletters_subscription_method'] = $metadata['newsletters_subscription_method'] ?? '';
+		$params['referer']                         = $metadata['current_page_url'] ?? '';
+
+		// In case the subscription happened as part of the registration process, we should also have the registration method.
+		$params['registration_method'] = $metadata['registration_method'] ?? '';
+
+		$lists = $data['lists'];
+		sort( $lists );
+		$params['lists'] = implode( ',', $lists );
+
 		return $params;
 	}
 

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -61,16 +61,19 @@ Data_Events::register_listener(
 );
 
 /**
- * For when a contact is added to newsletter lists.
+ * For when a new contact is added to newsletter lists for the first time.
  */
 Data_Events::register_listener(
 	'newspack_newsletters_add_contact',
 	'newsletter_subscribed',
-	function( $provider, $contact, $lists, $result ) {
+	function( $provider, $contact, $lists, $result, $is_updating ) {
 		if ( empty( $lists ) ) {
 			return;
 		}
-		if ( true !== $result ) {
+		if ( is_wp_error( $result ) ) {
+			return;
+		}
+		if ( $is_updating ) {
 			return;
 		}
 		$user = get_user_by( 'email', $contact['email'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Connects the Donation events to GA4.

### How to test the changes in this Pull Request:

Get the GA4 credentials. You will need your measurement ID and an API secret.

* api_secret - Required. An API SECRET generated in the Google Analytics UI. To create a new secret, navigate to:
    Admin > Data Streams > choose your stream > Measurement Protocol > Create
* measurement_id - Required. The measurement ID associated with a stream. Found in the Google Analytics UI under:
    Admin > Data Streams > choose your stream > Measurement ID

Store this info in the database:
```
wp option set ga4_measurement_id "G-XXXXXXXXXX"
wp option set ga4_api_secret YYYYYYYYYYYYYYYYYYY
```
Now, let's test:

1. Make sure RAS is active and that you have a registered reader
2. Make sure to add this constant to wp-config
```
define( 'NEWSPACK_LOG_LEVEL', 2 );
define( 'NEWSPACK_EXPERIMENTAL_GA4_EVENTS', true );
```
3. Add this debug line to the `handle_newsletter_subscribed` method in `includes/data-events/connectors/ga4/class-ga4.php` line 193
```PHP
error_log( print_r( $params, true ) );
```

4. Set up the following:
* A newsletter subscription block in a page
* A newsletter subscription block in a Campaign prompt
* A registration block with the option to also subscribe the user to a newsletter

5. Make sure popups and blocks plugins are up to date
6. Checkout https://github.com/Automattic/newspack-newsletters/pull/1109 in the Newsletters plugin
7. Now let's subscribe to a newsletter in all 3 scenarios above and see if the data is correct in the error log:

```
Example of data subscribing via a block in a page:
Array
(
    [logged_in] => no
    [ga_session_id] => 1678208797
    [newsletters_subscription_method] => newsletters-subscription-block
    [referer] => https://leogermani.jurassic.tube/register/
    [registration_method] => 
    [lists] => 73abe2ca-c126-11ea-bfa8-d4ae529a7b12,b8dee78e-e95c-11eb-8c42-fa163e4dd890
)
```

```
Example of data subscribing via a block in a popup:
Array
(
    [logged_in] => no
    [ga_session_id] => 1678208475
    [campaign_id] => 145
    [campaign_title] => Inline Newsletter Signup (secondary)
    [campaign_frequency] => always
    [campaign_placement] => inline
    [campaign_has_registration_block] => 
    [campaign_has_donation_block] => 
    [campaign_has_newsletter_block] => 1
    [newsletters_subscription_method] => newsletters-subscription-block
    [referer] => https://leogermani.jurassic.tube/2023/02/07/auctor-tincidunt-dictumst-vitae-neque-tempus-accumsan/
    [registration_method] => 
    [lists] => 73abe2ca-c126-11ea-bfa8-d4ae529a7b12
)
```

```
Example of data subscribing via a registration block inside a popup:
Array
(
    [logged_in] => yes
    [ga_session_id] => 1678208696
    [is_reader] => yes
    [campaign_id] => 139
    [campaign_title] => Registration Overlay
    [campaign_frequency] => always
    [campaign_placement] => center
    [campaign_has_registration_block] => 1
    [campaign_has_donation_block] => 
    [campaign_has_newsletter_block] => 
    [newsletters_subscription_method] => reader-registration
    [referer] => https://leogermani.jurassic.tube/
    [registration_method] => registration-block-popup
    [lists] => 73abe2ca-c126-11ea-bfa8-d4ae529a7b12,b8dee78e-e95c-11eb-8c42-fa163e4dd890
)
```
8. Open the Google Analytics dashboard in the Realtime report and also check if the `newsletter_subscribed` event is being fired with the correct data

![Captura de tela de 2023-03-07 14-51-43](https://user-images.githubusercontent.com/971483/223507230-32bf2fe6-1a4b-4581-a6a2-2528b0de04a6.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->