### PR TITLE
fix(data-events): mailchimp metadata keys

### DIFF
--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -196,12 +196,18 @@ class Mailchimp {
 			return;
 		}
 
-		$email    = $contact['email'];
-		$metadata = $contact['metadata'];
-		$keys     = Newspack_Newsletters::$metadata_keys;
+		$email         = $contact['email'];
+		$metadata      = $contact['metadata'];
+		$keys          = Newspack_Newsletters::$metadata_keys;
+		$prefixed_keys = array_map(
+			function( $key ) {
+				return Newspack_Newsletters::get_metadata_key( $key );
+			},
+			array_values( array_flip( $keys ) )
+		);
 
 		// Only use metadata defined in 'Newspack_Newsletters'.
-		$metadata = array_intersect_key( $metadata, array_flip( $keys ) );
+		$metadata = array_intersect_key( $metadata, array_flip( $prefixed_keys ) );
 
 		// Remove "product name" from metadata, we'll use
 		// 'donation_subscription_new' action for this data.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since #2249, the way `Newspack_Newsletters::$metadata_keys` are handled is a little different and the Mailchimp connector was not parsing them properly.

This PR tweaks it so the keys are properly parsed for updating Mailchimp contacts.

### How to test the changes in this Pull Request:

1. While in the master branch, add `error_log( print_r( $metadata, true ) );` to line 205
2. Make sure you have Mailchimp connected and the following constant: `define( 'NEWSPACK_DATA_EVENTS_MAILCHIMP', true );`
3. Make a donation through the Donate Block and wait for the data event to get processed
4. Confirm the error logged is an empty array
5. Check out this branch, add `error_log( print_r( $metadata, true ) );` to line 211
6. Repeat step 3 and confirm the error logged contains all the meta

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->