### PR TITLE
fix(webhooks): endpoint requests modal label

### DIFF
--- a/assets/wizards/connections/views/main/webhooks.js
+++ b/assets/wizards/connections/views/main/webhooks.js
@@ -37,6 +37,11 @@ const getDisplayUrl = url => {
 	return displayUrl;
 };
 
+const getEndpointLabel = endpoint => {
+	const { label, url } = endpoint;
+	return label || getDisplayUrl( url );
+};
+
 const getEndpointTitle = endpoint => {
 	const { label, url } = endpoint;
 	return (
@@ -361,7 +366,7 @@ const Webhooks = () => {
 						{ sprintf(
 							// translators: %s is the endpoint title (shortened URL).
 							__( 'Most recent requests for %s', 'newspack' ),
-							getEndpointTitle( viewing )
+							getEndpointLabel( viewing )
 						) }
 					</p>
 					{ viewing.requests.length > 0 ? (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the label of the endpoint name while viewing its requests modal.

### How to test the changes in this Pull Request:

1. Make sure you have `define( 'NEWSPACK_EXPERIMENTAL_WEBHOOKS', true );`
2. While in the master branch, visit the Newspack -> Connections page and set up an endpoint with a **Label** if you haven't already
3. Click on the 3 dots menu and click "View requests"
4. Confirm the `[object Object]` in the text
5. Check out this branch and confirm the text has a proper label for the endpoint
6. Edit the endpoint, leave **Label** blank and save
7. View the requests and confirm the label is replaced with the shortened URL

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->