### PR TITLE
fix(ads): proper usage of useEffect cleanup function

### DIFF
--- a/assets/wizards/advertising/components/ad-refresh-control/index.js
+++ b/assets/wizards/advertising/components/ad-refresh-control/index.js
@@ -84,14 +84,17 @@ export default function AdRefreshControlSettings() {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ error, setError ] = useState( null );
 	const [ settings, setSettings ] = useState( null );
-	useEffect( async () => {
-		setInFlight( true );
-		try {
-			setSettings( await apiFetch( { path: '/newspack-ads/v1/ad-refresh-control' } ) );
-		} catch ( err ) {
-			setSettings( null );
-		}
-		setInFlight( false );
+	useEffect( () => {
+		const fetchSettings = async () => {
+			setInFlight( true );
+			try {
+				setSettings( await apiFetch( { path: '/newspack-ads/v1/ad-refresh-control' } ) );
+			} catch ( err ) {
+				setSettings( null );
+			}
+			setInFlight( false );
+		};
+		fetchSettings();
 	}, [] );
 	const handleChange = ( key, value ) => {
 		setSettings( {

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -98,23 +98,26 @@ const Placements = () => {
 	};
 
 	// Fetch placements, providers and bidders.
-	useEffect( async () => {
-		setInFlight( true );
-		await placementsApiFetch( { path: '/newspack-ads/v1/placements' } );
-		try {
-			const data = await apiFetch( { path: '/newspack-ads/v1/providers' } );
-			setProviders( data );
-		} catch ( err ) {
-			setError( err );
-		}
-		try {
-			const data = await apiFetch( { path: '/newspack-ads/v1/bidders' } );
-			setBidders( data );
-		} catch ( err ) {
-			setBiddersError( err );
-		}
-		setInitialized( true );
-		setInFlight( false );
+	useEffect( () => {
+		const fetchData = async () => {
+			setInFlight( true );
+			await placementsApiFetch( { path: '/newspack-ads/v1/placements' } );
+			try {
+				const data = await apiFetch( { path: '/newspack-ads/v1/providers' } );
+				setProviders( data );
+			} catch ( err ) {
+				setError( err );
+			}
+			try {
+				const data = await apiFetch( { path: '/newspack-ads/v1/bidders' } );
+				setBidders( data );
+			} catch ( err ) {
+				setBiddersError( err );
+			}
+			setInitialized( true );
+			setInFlight( false );
+		};
+		fetchData();
 	}, [] );
 
 	// Silently refetch placements data when exiting edit modal.

--- a/assets/wizards/advertising/views/suppression/index.js
+++ b/assets/wizards/advertising/views/suppression/index.js
@@ -30,7 +30,7 @@ const Suppression = () => {
 		apiFetch( { path: '/newspack-ads/v1/suppression' } ).then( setConfig );
 	};
 	const fetchPostTypes = () => {
-		return apiFetch( {
+		apiFetch( {
 			path: addQueryArgs( '/wp/v2/types', { context: 'edit' } ),
 		} )
 			.then( result => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an incorrect usage of the `useEffect` hook in some instances of the Advertising wizard. The return of the hook must be either `undefined` or a valid cleanup function.

Related #2269

### How to test the changes in this Pull Request:

No changes should be visible on the latest stable version of WP (6.1.1):

1. Visit the Advertising wizard and navigate through all the tabs
2. Confirm all data from the wizards are loaded and rendered as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->