### PR TITLE
feat: Add popup events to GA4

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -413,9 +413,9 @@ function process_form() {
 	$metadata['current_page_url']    = home_url( add_query_arg( array(), $metadata['referer'] ) );
 	$metadata['registration_method'] = 'registration-block';
 
-	$popup_id = isset( $_REQUEST['newspack_popup_id'] ) ? (int) $_REQUEST['newspack_popup_id'] : false;
+	$popup_id                      = isset( $_REQUEST['newspack_popup_id'] ) ? (int) $_REQUEST['newspack_popup_id'] : false;
+	$metadata['newspack_popup_id'] = $popup_id;
 	if ( $popup_id ) {
-		$metadata['newspack_popup_id']   = $popup_id;
 		$metadata['registration_method'] = 'registration-block-popup';
 	}
 
@@ -426,9 +426,9 @@ function process_form() {
 	 *
 	 * @param string              $email   Email address of the reader.
 	 * @param int|false|\WP_Error $user_id The created user ID in case of registration, false if not created or a WP_Error object.
-	 * @param int|false           $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
+	 * @param array               $metadata Array with metadata about the user being registered.
 	 */
-	\do_action( 'newspack_reader_registration_form_processed', $email, $user_id, $popup_id );
+	\do_action( 'newspack_reader_registration_form_processed', $email, $user_id, $metadata );
 
 	if ( \is_wp_error( $user_id ) ) {
 		return send_form_response( $user_id );

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -186,7 +186,7 @@ When a user interacts with a Newspack Popup's campaign prompt.
 | `campaign_blocks`    | `array`  | Array containing the blocks that are inside the campaign. Only 3 blocks are tracked: `donation`, `registration` and `newsletters_subscription` |
 | `action`             | `string` | `form_submission`, `form_submission_success` or `form_submission_failure`                                                                      |
 | `action_type`        | `string` | `donation`, `registration` or `newsletters_subscription`                                                                                       |
-| `interaction_data`   | `array`  | Depending on the actino type, it will return different information about the interaction.                                                      |
+| `interaction_data`   | `array`  | Depending on the action type, it will contain different information about the interaction.                                                      |
 
 #### Possible values for `interaction_data`
 

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -71,37 +71,75 @@ When a reader updates their lists subscription from Newspack Newsletters.
 | `user_id`       | `integer`  |
 | `email`         | `string`   |
 | `provider`      | `string`   |
-| `email`         | `string`   |
 | `lists_added`   | `string[]` |
 | `lists_removed` | `string[]` |
+
+### `woocommerce_donation_order_processed`
+
+For when there's a new donation processed through WooCommerce.
+
+| Name            | Type     | Obs                                                    |
+| --------------- | -------- | ------------------------------------------------------ |
+| `user_id`       | `int`    |                                                        |
+| `email`         | `string` |                                                        |
+| `amount`        | `float`  |                                                        |
+| `currency`      | `string` |                                                        |
+| `recurrence`    | `string` |                                                        |
+| `platform`      | `string` | Always `wc` in this case                               |
+| `referer`       | `string` |                                                        |
+| `popup_id`      | `string` | If the donation was triggered by a popup, the popup ID |
+| `platform_data` | `array`  |                                                        |
+
+### `woocommerce_order_failed`
+
+For when there's a new donation payment failed through WooCommerce.
+Known issue: If the user tries to pay again after a failed payment, and the payment fails for a second time,
+the order is already marked as failed so this hook will not trigger.
+
+| Name            | Type     | Obs                                                    |
+| --------------- | -------- | ------------------------------------------------------ |
+| `user_id`       | `int`    |                                                        |
+| `email`         | `string` |                                                        |
+| `amount`        | `float`  |                                                        |
+| `currency`      | `string` |                                                        |
+| `recurrence`    | `string` |                                                        |
+| `platform`      | `string` | Always `wc` in this case                               |
+| `referer`       | `string` |                                                        |
+| `popup_id`      | `string` | If the donation was triggered by a popup, the popup ID |
+| `platform_data` | `array`  |                                                        |
+
 
 ### `donation_new`
 
 When there's a new donation, either through Stripe or Newspack (WooCommerce) platforms.
 
-| Name            | Type     |
-| --------------- | -------- |
-| `user_id`       | `int`    |
-| `email`         | `string` |
-| `amount`        | `float`  |
-| `currency`      | `string` |
-| `recurrence`    | `string` |
-| `platform`      | `string` |
-| `platform_data` | `array`  |
+| Name            | Type     | Obs                                                    |
+| --------------- | -------- | ------------------------------------------------------ |
+| `user_id`       | `int`    |                                                        |
+| `email`         | `string` |                                                        |
+| `amount`        | `float`  |                                                        |
+| `currency`      | `string` |                                                        |
+| `recurrence`    | `string` |                                                        |
+| `platform`      | `string` |                                                        |
+| `referer`       | `string` |                                                        |
+| `popup_id`      | `string` | If the donation was triggered by a popup, the popup ID |
+| `platform_data` | `array`  |                                                        |
 
 ### `donation_subscription_new`
 
 When there's a new WooCommerce Subscription. This action does not replace the `donation_new` that create the subscription.
 
-| Name            | Type     |
-| --------------- | -------- |
-| `user_id`       | `int`    |
-| `email`         | `string` |
-| `amount`        | `float`  |
-| `currency`      | `string` |
-| `recurrence`    | `string` |
-| `platform`      | `string` |
-| `platform_data` | `array`  |
+| Name              | Type     | Obs                                                    |
+| ----------------- | -------- | ------------------------------------------------------ |
+| `user_id`         | `int`    |                                                        |
+| `email`           | `string` |                                                        |
+| `subscription_id` | `int`    |                                                        |
+| `amount`          | `float`  |                                                        |
+| `currency`        | `string` |                                                        |
+| `recurrence`      | `string` |                                                        |
+| `platform`        | `string` |                                                        |
+| `referer`         | `string` |                                                        |
+| `popup_id`        | `string` | If the donation was triggered by a popup, the popup ID |
 
 ### `donation_subscription_cancelled`
 
@@ -139,16 +177,16 @@ When a WooCommerce Subscription status changes.
 
 When a user interacts with a Newspack Popup's campaign prompt.
 
-| Name                              | Type      |
-| --------------------------------- | --------- |
-| `campaign_id`                     | `int`     |
-| `campaign_title`                  | `string`  |
-| `campaign_frequency`              | `string`  |
-| `campaign_placement`              | `string`  |
-| `campaign_has_registration_block` | `boolean` |
-| `campaign_has_donation_block`     | `boolean` |
-| `campaign_has_newsletter_block`   | `boolean` |
-| `action`                          | `string`  |
+| Name                 | Type     | Obs                                                                                                                                            |
+| -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `campaign_id`        | `int`    |                                                                                                                                                |
+| `campaign_title`     | `string` |                                                                                                                                                |
+| `campaign_frequency` | `string` |                                                                                                                                                |
+| `campaign_placement` | `string` |                                                                                                                                                |
+| `campaign_blocks`    | `array`  | Array containing the blocks that are inside the campaign. Only 3 blocks are tracked: `donation`, `registration` and `newsletters_subscription` |
+| `action`             | `string` | `form_submission`, `form_submission_success` or `form_submission_failure`                                                                      |
+| `action_type`        | `string` | `donation`, `registration` or `newsletters_subscription`                                                                                       |
+| `interaction_data`   | `array`  | Depending on the actino type, it will return different information about the interaction.                                                      |
 
 ## Registering a new action
 

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -188,7 +188,7 @@ When a user interacts with a Newspack Popup's campaign prompt.
 | `action_type`        | `string` | `donation`, `registration` or `newsletters_subscription`                                                                                       |
 | `interaction_data`   | `array`  | Depending on the actino type, it will return different information about the interaction.                                                      |
 
-#### structure of interaction_data:
+#### Possible values for `interaction_data`
 
 If `action_type` is `registration`:
 

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -188,6 +188,33 @@ When a user interacts with a Newspack Popup's campaign prompt.
 | `action_type`        | `string` | `donation`, `registration` or `newsletters_subscription`                                                                                       |
 | `interaction_data`   | `array`  | Depending on the actino type, it will return different information about the interaction.                                                      |
 
+#### structure of interaction_data:
+
+If `action_type` is `registration`:
+
+| Name                  | Type     |
+| --------------------- | -------- |
+| `registration_method` | `string` |
+
+If `action_type` is `newsletters_subscription`:
+
+| Name                  | Type     |
+| --------------------- | -------- |
+| `newsletters_subscription_method` | `string` |
+
+If `action_type` is `donation`:
+
+| Name                  | Type     | Obs                                                                                              |
+| --------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `donation_order_id`   | `string` | Only for successful donations in any platform' or any processed/failed donations via Woocommerce |
+| `donation_amount`     | `string` |                                                                                                  |
+| `donation_currency`   | `string` |                                                                                                  |
+| `donation_recurrence` | `string` |                                                                                                  |
+| `donation_platform`   | `string` |                                                                                                  |
+| `donation_error`      | `string` | Only for failed donations via Stripe                                                             |
+
+
+
 ## Registering a new action
 
 To dispatch an event, an action must first be registered with the following:

--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -120,6 +120,10 @@ final class Popups {
 		$data['campaign_has_donation_block']     = has_block( 'newspack-blocks/donate', $popup['content'] );
 		$data['campaign_has_newsletter_block']   = has_block( 'newspack-newsletters/subscribe', $popup['content'] );
 
+		$data['registration_data'] = [];
+		$data['donation_data']     = [];
+		$data['newsletter_data']   = [];
+
 		return $data;
 	}
 
@@ -130,10 +134,11 @@ final class Popups {
 	 *
 	 * @param string              $email   Email address of the reader.
 	 * @param int|false|\WP_Error $user_id The created user ID in case of registration, false if not created or a WP_Error object.
-	 * @param int|false           $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
+	 * @param array               $metadata Array with metadata about the user being registered.
 	 * @return ?array
 	 */
-	public static function registration_submission( $email, $user_id, $popup_id ) {
+	public static function registration_submission( $email, $user_id, $metadata ) {
+		$popup_id = $metadata['newspack_popup_id'];
 		if ( ! $popup_id ) {
 			return;
 		}
@@ -141,7 +146,11 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action' => self::FORM_SUBMISSION,
+				'action'            => self::FORM_SUBMISSION,
+				'referer'           => $metadata['referer'],
+				'registration_data' => [
+					'registration_method' => $metadata['newsletters_subscription_method'],
+				],
 			]
 		);
 	}
@@ -153,10 +162,11 @@ final class Popups {
 	 *
 	 * @param string              $email   Email address of the reader.
 	 * @param int|false|\WP_Error $user_id The created user ID in case of registration, false if not created or a WP_Error object.
-	 * @param int|false           $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
+	 * @param array               $metadata Array with metadata about the user being registered.
 	 * @return ?array
 	 */
-	public static function registration_submission_with_status( $email, $user_id, $popup_id ) {
+	public static function registration_submission_with_status( $email, $user_id, $metadata ) {
+		$popup_id = $metadata['newspack_popup_id'];
 		if ( ! $popup_id ) {
 			return;
 		}
@@ -168,7 +178,11 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action' => $action,
+				'action'            => $action,
+				'referer'           => $metadata['referer'],
+				'registration_data' => [
+					'registration_method' => $metadata['newsletters_subscription_method'],
+				],
 			]
 		);
 	}
@@ -192,9 +206,11 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'                         => self::FORM_SUBMISSION,
-				'newsletter_subscription_method' => $metadata['newsletters_subscription_method'],
-				'referer'                        => $metadata['current_page_url'],
+				'action'          => self::FORM_SUBMISSION,
+				'referer'         => $metadata['current_page_url'],
+				'newsletter_data' => [
+					'newsletter_subscription_method' => $metadata['newsletters_subscription_method'],
+				],
 			]
 		);
 	}
@@ -222,9 +238,11 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'                         => $action,
-				'newsletter_subscription_method' => $metadata['newsletters_subscription_method'],
-				'referer'                        => $metadata['current_page_url'],
+				'action'          => $action,
+				'referer'         => $metadata['current_page_url'],
+				'newsletter_data' => [
+					'newsletter_subscription_method' => $metadata['newsletters_subscription_method'],
+				],
 			]
 		);
 	}
@@ -245,12 +263,14 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'              => self::FORM_SUBMISSION_SUCCESS,
-				'donation_amount'     => $data['amount'],
-				'donation_currency'   => $data['currency'],
-				'donation_recurrence' => $data['recurrence'],
-				'donation_platform'   => $data['platform'],
-				'referer'             => $data['referer'],
+				'action'        => self::FORM_SUBMISSION_SUCCESS,
+				'referer'       => $data['referer'],
+				'donation_data' => [
+					'donation_amount'     => $data['amount'],
+					'donation_currency'   => $data['currency'],
+					'donation_recurrence' => $data['recurrence'],
+					'donation_platform'   => $data['platform'],
+				],
 			]
 		);
 	}
@@ -271,12 +291,14 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'              => self::FORM_SUBMISSION,
-				'donation_amount'     => $config['amount'],
-				'donation_currency'   => $stripe_data['currency'],
-				'donation_recurrence' => $config['frequency'],
-				'donation_platform'   => 'stripe',
-				'referer'             => $config['payment_metadata']['referer'],
+				'action'        => self::FORM_SUBMISSION,
+				'referer'       => $config['payment_metadata']['referer'],
+				'donation_data' => [
+					'donation_amount'     => $config['amount'],
+					'donation_currency'   => $stripe_data['currency'],
+					'donation_recurrence' => $config['frequency'],
+					'donation_platform'   => 'stripe',
+				],
 			]
 		);
 	}
@@ -298,13 +320,15 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'              => self::FORM_SUBMISSION_FAILURE,
-				'donation_amount'     => $config['amount'],
-				'donation_currency'   => $stripe_data['currency'],
-				'donation_recurrence' => $config['frequency'],
-				'donation_platform'   => 'stripe',
-				'donation_error'      => $error_message,
-				'referer'             => $config['payment_metadata']['referer'],
+				'action'        => self::FORM_SUBMISSION_FAILURE,
+				'referer'       => $config['payment_metadata']['referer'],
+				'donation_data' => [
+					'donation_amount'     => $config['amount'],
+					'donation_currency'   => $stripe_data['currency'],
+					'donation_recurrence' => $config['frequency'],
+					'donation_platform'   => 'stripe',
+					'donation_error'      => $error_message,
+				],
 			]
 		);
 	}
@@ -325,12 +349,14 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'              => self::FORM_SUBMISSION,
-				'donation_amount'     => $data['amount'],
-				'donation_currency'   => $data['currency'],
-				'donation_recurrence' => $data['recurrence'],
-				'donation_platform'   => $data['platform'],
-				'referer'             => $data['referer'],
+				'action'        => self::FORM_SUBMISSION,
+				'referer'       => $data['referer'],
+				'donation_data' => [
+					'donation_amount'     => $data['amount'],
+					'donation_currency'   => $data['currency'],
+					'donation_recurrence' => $data['recurrence'],
+					'donation_platform'   => $data['platform'],
+				],
 			]
 		);
 	}
@@ -351,12 +377,14 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'              => self::FORM_SUBMISSION_FAILURE,
-				'donation_amount'     => $data['amount'],
-				'donation_currency'   => $data['currency'],
-				'donation_recurrence' => $data['recurrence'],
-				'donation_platform'   => $data['platform'],
-				'referer'             => $data['referer'],
+				'action'        => self::FORM_SUBMISSION_FAILURE,
+				'referer'       => $data['referer'],
+				'donation_data' => [
+					'donation_amount'     => $data['amount'],
+					'donation_currency'   => $data['currency'],
+					'donation_recurrence' => $data['recurrence'],
+					'donation_platform'   => $data['platform'],
+				],
 			]
 		);
 	}

--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -116,13 +116,21 @@ final class Popups {
 			$data['campaign_placement'] = $popup['options']['placement'] ?? '';
 		}
 
-		$data['campaign_has_registration_block'] = has_block( 'newspack/reader-registration', $popup['content'] );
-		$data['campaign_has_donation_block']     = has_block( 'newspack-blocks/donate', $popup['content'] );
-		$data['campaign_has_newsletter_block']   = has_block( 'newspack-newsletters/subscribe', $popup['content'] );
+		$watched_blocks = [
+			'registration'             => 'newspack/reader-registration',
+			'donation'                 => 'newspack-blocks/donate',
+			'newsletters_subscription' => 'newspack-newsletters/subscribe',
+		];
 
-		$data['registration_data'] = [];
-		$data['donation_data']     = [];
-		$data['newsletter_data']   = [];
+		$data['campaign_blocks'] = [];
+
+		foreach ( $watched_blocks as $key => $block_name ) {
+			if ( has_block( $block_name, $popup['content'] ) ) {
+				$data['campaign_blocks'][] = $key;
+			}
+		}
+
+		$data['interaction_data'] = [];
 
 		return $data;
 	}
@@ -146,10 +154,11 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'            => self::FORM_SUBMISSION,
-				'referer'           => $metadata['referer'],
-				'registration_data' => [
-					'registration_method' => $metadata['newsletters_subscription_method'],
+				'action'           => self::FORM_SUBMISSION,
+				'action_type'      => 'registration',
+				'referer'          => $metadata['referer'],
+				'interaction_data' => [
+					'registration_method' => $metadata['registration_method'],
 				],
 			]
 		);
@@ -178,10 +187,11 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'            => $action,
-				'referer'           => $metadata['referer'],
-				'registration_data' => [
-					'registration_method' => $metadata['newsletters_subscription_method'],
+				'action'           => $action,
+				'action_type'      => 'registration',
+				'referer'          => $metadata['referer'],
+				'interaction_data' => [
+					'registration_method' => $metadata['registration_method'],
 				],
 			]
 		);
@@ -206,10 +216,11 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'          => self::FORM_SUBMISSION,
-				'referer'         => $metadata['current_page_url'],
-				'newsletter_data' => [
-					'newsletter_subscription_method' => $metadata['newsletters_subscription_method'],
+				'action'           => self::FORM_SUBMISSION,
+				'action_type'      => 'newsletters_subscription',
+				'referer'          => $metadata['current_page_url'],
+				'interaction_data' => [
+					'newsletters_subscription_method' => $metadata['newsletters_subscription_method'],
 				],
 			]
 		);
@@ -238,10 +249,11 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'          => $action,
-				'referer'         => $metadata['current_page_url'],
-				'newsletter_data' => [
-					'newsletter_subscription_method' => $metadata['newsletters_subscription_method'],
+				'action'           => $action,
+				'action_type'      => 'newsletters_subscription',
+				'referer'          => $metadata['current_page_url'],
+				'interaction_data' => [
+					'newsletters_subscription_method' => $metadata['newsletters_subscription_method'],
 				],
 			]
 		);
@@ -263,9 +275,10 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'        => self::FORM_SUBMISSION_SUCCESS,
-				'referer'       => $data['referer'],
-				'donation_data' => [
+				'action'           => self::FORM_SUBMISSION_SUCCESS,
+				'action_type'      => 'donation',
+				'referer'          => $data['referer'],
+				'interaction_data' => [
 					'donation_amount'     => $data['amount'],
 					'donation_currency'   => $data['currency'],
 					'donation_recurrence' => $data['recurrence'],
@@ -291,9 +304,10 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'        => self::FORM_SUBMISSION,
-				'referer'       => $config['payment_metadata']['referer'],
-				'donation_data' => [
+				'action'           => self::FORM_SUBMISSION,
+				'action_type'      => 'donation',
+				'referer'          => $config['payment_metadata']['referer'],
+				'interaction_data' => [
 					'donation_amount'     => $config['amount'],
 					'donation_currency'   => $stripe_data['currency'],
 					'donation_recurrence' => $config['frequency'],
@@ -320,9 +334,10 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'        => self::FORM_SUBMISSION_FAILURE,
-				'referer'       => $config['payment_metadata']['referer'],
-				'donation_data' => [
+				'action'           => self::FORM_SUBMISSION_FAILURE,
+				'action_type'      => 'donation',
+				'referer'          => $config['payment_metadata']['referer'],
+				'interaction_data' => [
 					'donation_amount'     => $config['amount'],
 					'donation_currency'   => $stripe_data['currency'],
 					'donation_recurrence' => $config['frequency'],
@@ -349,9 +364,10 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'        => self::FORM_SUBMISSION,
-				'referer'       => $data['referer'],
-				'donation_data' => [
+				'action'           => self::FORM_SUBMISSION,
+				'action_type'      => 'donation',
+				'referer'          => $data['referer'],
+				'interaction_data' => [
 					'donation_amount'     => $data['amount'],
 					'donation_currency'   => $data['currency'],
 					'donation_recurrence' => $data['recurrence'],
@@ -377,9 +393,10 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action'        => self::FORM_SUBMISSION_FAILURE,
-				'referer'       => $data['referer'],
-				'donation_data' => [
+				'action'           => self::FORM_SUBMISSION_FAILURE,
+				'action_type'      => 'donation',
+				'referer'          => $data['referer'],
+				'interaction_data' => [
 					'donation_amount'     => $data['amount'],
 					'donation_currency'   => $data['currency'],
 					'donation_recurrence' => $data['recurrence'],

--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -279,6 +279,7 @@ final class Popups {
 				'action_type'      => 'donation',
 				'referer'          => $data['referer'],
 				'interaction_data' => [
+					'donation_order_id'   => $data['platform_data']['order_id'],
 					'donation_amount'     => $data['amount'],
 					'donation_currency'   => $data['currency'],
 					'donation_recurrence' => $data['recurrence'],
@@ -368,6 +369,7 @@ final class Popups {
 				'action_type'      => 'donation',
 				'referer'          => $data['referer'],
 				'interaction_data' => [
+					'donation_order_id'   => $data['platform_data']['order_id'],
 					'donation_amount'     => $data['amount'],
 					'donation_currency'   => $data['currency'],
 					'donation_recurrence' => $data['recurrence'],
@@ -397,6 +399,7 @@ final class Popups {
 				'action_type'      => 'donation',
 				'referer'          => $data['referer'],
 				'interaction_data' => [
+					'donation_order_id'   => $data['platform_data']['order_id'],
 					'donation_amount'     => $data['amount'],
 					'donation_currency'   => $data['currency'],
 					'donation_recurrence' => $data['recurrence'],

--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -180,10 +180,11 @@ final class Popups {
 	 *
 	 * @param string         $email  Email address of the reader.
 	 * @param array|WP_Error $result Contact data if it was added, or error otherwise.
-	 * @param int|false      $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
+	 * @param array          $metadata Some metadata about the subscription. Always contains `current_page_url`, `newspack_popup_id` and `newsletters_subscription_method` keys.
 	 * @return ?array
 	 */
-	public static function newsletter_submission( $email, $result, $popup_id = false ) {
+	public static function newsletter_submission( $email, $result, $metadata = [] ) {
+		$popup_id = $metadata['newspack_popup_id'];
 		if ( ! $popup_id ) {
 			return;
 		}
@@ -191,7 +192,9 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action' => self::FORM_SUBMISSION,
+				'action'                         => self::FORM_SUBMISSION,
+				'newsletter_subscription_method' => $metadata['newsletters_subscription_method'],
+				'referer'                        => $metadata['current_page_url'],
 			]
 		);
 	}
@@ -203,10 +206,11 @@ final class Popups {
 	 *
 	 * @param string         $email  Email address of the reader.
 	 * @param array|WP_Error $result Contact data if it was added, or error otherwise.
-	 * @param int|false      $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
+	 * @param array          $metadata Some metadata about the subscription. Always contains `current_page_url`, `newspack_popup_id` and `newsletters_subscription_method` keys.
 	 * @return ?array
 	 */
-	public static function newsletter_submission_with_status( $email, $result, $popup_id = false ) {
+	public static function newsletter_submission_with_status( $email, $result, $metadata = [] ) {
+		$popup_id = $metadata['newspack_popup_id'];
 		if ( ! $popup_id ) {
 			return;
 		}
@@ -218,7 +222,9 @@ final class Popups {
 		return array_merge(
 			$popup_data,
 			[
-				'action' => $action,
+				'action'                         => $action,
+				'newsletter_subscription_method' => $metadata['newsletters_subscription_method'],
+				'referer'                        => $metadata['current_page_url'],
 			]
 		);
 	}

--- a/includes/data-events/connectors/ga4/README.md
+++ b/includes/data-events/connectors/ga4/README.md
@@ -1,0 +1,98 @@
+# GA4 connector
+
+This connector listens to some events of the Data API and sends them to Google Analytics 4
+
+## Setting up
+
+For now, the credentials must be manually added to the database. You will need your measurement ID and an API secret.
+
+* api_secret - Required. An API SECRET generated in the Google Analytics UI. To create a new secret, navigate to:
+    Admin > Data Streams > choose your stream > Measurement Protocol > Create
+* measurement_id - Required. The measurement ID associated with a stream. Found in the Google Analytics UI under:
+    Admin > Data Streams > choose your stream > Measurement ID
+
+Store this info in the database:
+```
+wp option set ga4_measurement_id "G-XXXXXXXXXX"
+wp option set ga4_api_secret YYYYYYYYYYYYYYYYYYY
+```
+
+This is still experimental, so you'll need to add this to wp-config:
+`define( 'NEWSPACK_EXPERIMENTAL_GA4_EVENTS', true );`
+
+## Events being tracked
+
+### Default parameters:
+
+These parameters are added to all events:
+
+* `ga_session_id`: The GA Session ID, retrieved from the cookie
+* `logged_in`: Whether the user is logged in when the event got fired
+* `is_reader`: Whether the user is a RAS reader
+
+Note: All paramaters are strings
+
+### reader_logged_in
+
+When a user logs in
+
+No additional parameters
+
+### reader_registered
+
+When a user registers through RAS
+
+Additional parameters:
+
+* `registration_method`
+* `newspack_popup_id`: If the action was triggered from inside a popup, the popup id.
+* `referer`
+
+### donation_new
+
+When a NEW donation is completed with success
+
+Additional parameters:
+
+* `amount`
+* `currency`
+* `recurrence`
+* `platform`
+* `referer`
+* `popup_id`: If the action was triggered from inside a popup, the popup id.
+* `range`: The range of the donation amount: `under-20`, `20-50`, `51-100`, `101-200`, `201-500` or `over-500`.
+
+
+### donation_subscription_cancelled
+
+When a subscription is cancelled.
+
+Additional parameters:
+
+* `amount`
+* `currency`
+* `recurrence`
+* `platform`
+* `range`: The range of the donation amount: `under-20`, `20-50`, `51-100`, `101-200`, `201-500` or `over-500`.
+
+### newsletter_subscribed
+
+
+
+Additional parameters:
+
+* `newsletters_subscription_method`
+* `newspack_popup_id`: If the action was triggered from inside a popup, the popup id.
+* `referer`
+* `lists`: comma separated list of the list IDs the readers subscribed to (note: truncated at 100 characters)
+* `registration_method`: If the newsletter subscription was triggered by a registration form
+
+### campaign_interaction
+
+Additional parameters:
+
+* All default parameters from the `campaign_interaction` event (`campaign_id`, `campaign_frequency`, `action`, `action_type`, etc.)
+* `campaign_has_donation_block`: If the donation block was present, the value will be 1
+* `campaign_has_registration_block`: If the registration block was present, the value will be 1
+* `campaign_has_newsletters_subscription_block`: If the newsletters_subscription block was present, the value will be 1
+* All parameters inside the `interaction_data` value.

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -32,6 +32,7 @@ class GA4 {
 		'reader_logged_in',
 		'reader_registered',
 		'newsletter_subscribed',
+		'campaign_interaction',
 	];
 
 	/**
@@ -191,6 +192,18 @@ class GA4 {
 		sort( $lists );
 		$params['lists'] = implode( ',', $lists );
 
+		return $params;
+	}
+
+	/**
+	 * Handler for the campaign_interaction event.
+	 *
+	 * @param int   $params The GA4 event parameters.
+	 * @param array $data      Data associated with the Data Events api event.
+	 *
+	 * @return array $params The final version of the GA4 event params that will be sent to GA.
+	 */
+	public static function handle_campaign_interaction( $params, $data ) {
 		return $params;
 	}
 

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -138,6 +138,7 @@ class GA4 {
 			$body['data']['ga_params']['ga_session_id'] = $session_id;
 		}
 
+		$body['data']['ga_params']['is_reader'] = 'no';
 		if ( is_user_logged_in() ) {
 			$current_user                           = wp_get_current_user();
 			$body['data']['ga_params']['is_reader'] = Reader_Activation::is_user_reader( $current_user ) ? 'yes' : 'no';
@@ -178,6 +179,14 @@ class GA4 {
 			$ga_session_id = $order->get_meta( '_newspack_ga_session_id' );
 			if ( $ga_session_id ) {
 				$body['data']['ga_params']['ga_session_id'] = $ga_session_id;
+			}
+			$logged_in = $order->get_meta( '_newspack_logged_in' );
+			if ( $logged_in ) {
+				$body['data']['ga_params']['logged_in'] = $logged_in;
+			}
+			$is_reader = $order->get_meta( '_newspack_is_reader' );
+			if ( $is_reader ) {
+				$body['data']['ga_params']['is_reader'] = $is_reader;
 			}
 		}
 
@@ -320,7 +329,7 @@ class GA4 {
 		unset( $transformed_data['ga_client_id'] );
 
 		$transformed_data = self::sanitize_popup_params( $transformed_data );
-		
+
 		return array_merge( $params, $transformed_data );
 	}
 
@@ -472,7 +481,7 @@ class GA4 {
 	}
 
 	/**
-	 * Adds GA4 session and client to the payment metadata sent to Stripe
+	 * Adds additional information about the current user and session to the payment metadata sent to Stripe
 	 *
 	 * @param array $payment_metadata The payment metadata.
 	 * @param array $config The donation configuration.
@@ -481,6 +490,12 @@ class GA4 {
 	public static function filter_donation_metadata( $payment_metadata, $config ) {
 		$payment_metadata['newspack_ga_session_id'] = self::extract_sid_from_cookies();
 		$payment_metadata['newspack_ga_client_id']  = self::extract_cid_from_cookies();
+		$payment_metadata['newspack_logged_in']     = is_user_logged_in() ? 'yes' : 'no';
+		$payment_metadata['newspack_is_reader']     = 'no';
+		if ( is_user_logged_in() ) {
+			$current_user                           = wp_get_current_user();
+			$payment_metadata['newspack_is_reader'] = Reader_Activation::is_user_reader( $current_user ) ? 'yes' : 'no';
+		}
 		return $payment_metadata;
 	}
 

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -339,18 +339,18 @@ class GA4 {
 	 * @param array $popup_params The popup params as they are returned by Newspack\Data_Events\Popups::get_popup_metadata and by the campaign_interaction data.
 	 * @return array
 	 */
-	public static function sanitize_popup_params( $popup_parms ) {
+	public static function sanitize_popup_params( $popup_params ) {
 		// Invalid input.
-		if ( ! is_array( $popup_parms ) || ! isset( $popup_parms['campaign_id'] ) ) {
+		if ( ! is_array( $popup_params ) || ! isset( $popup_params['campaign_id'] ) ) {
 			return [];
 		}
-		$santized = $popup_parms;
+		$santized = $popup_params;
 
 		unset( $santized['interaction_data'] );
-		$santized = array_merge( $santized, $popup_parms['interaction_data'] );
+		$santized = array_merge( $santized, $popup_params['interaction_data'] );
 
 		unset( $santized['campaign_blocks'] );
-		foreach ( $popup_parms['campaign_blocks'] as $block ) {
+		foreach ( $popup_params['campaign_blocks'] as $block ) {
 			$santized[ 'campaign_has_' . $block ] = 1;
 		}
 		return $santized;
@@ -361,7 +361,7 @@ class GA4 {
 	 *
 	 * Ensures that the params are sanitized to be sent as GA params
 	 *
-	 * @param int $popup The popup ID.
+	 * @param int $popup_id The popup ID.
 	 * @return array
 	 */
 	public static function get_sanitized_popup_params( $popup_id ) {

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -269,10 +269,20 @@ class GA4 {
 	 * @return array $params The final version of the GA4 event params that will be sent to GA.
 	 */
 	public static function handle_campaign_interaction( $params, $data ) {
+		$transformed_data = $data;
 		// remove data added in the body filter.
-		unset( $data['ga_params'] );
-		unset( $data['ga_client_id'] );
-		return array_merge( $params, $data );
+		unset( $transformed_data['ga_params'] );
+		unset( $transformed_data['ga_client_id'] );
+
+		unset( $transformed_data['registration_data'] );
+		unset( $transformed_data['donation_data'] );
+		unset( $transformed_data['newsletter_data'] );
+
+		$transformed_data = array_merge( $transformed_data, $data['registration_data'] );
+		$transformed_data = array_merge( $transformed_data, $data['donation_data'] );
+		$transformed_data = array_merge( $transformed_data, $data['newsletter_data'] );
+
+		return array_merge( $params, $transformed_data );
 	}
 
 	/**

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -204,7 +204,10 @@ class GA4 {
 	 * @return array $params The final version of the GA4 event params that will be sent to GA.
 	 */
 	public static function handle_campaign_interaction( $params, $data ) {
-		return $params;
+		// remove data added in the body filter.
+		unset( $data['ga_params'] );
+		unset( $data['ga_client_id'] );
+		return array_merge( $params, $data );
 	}
 
 	/**

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -274,13 +274,13 @@ class GA4 {
 		unset( $transformed_data['ga_params'] );
 		unset( $transformed_data['ga_client_id'] );
 
-		unset( $transformed_data['registration_data'] );
-		unset( $transformed_data['donation_data'] );
-		unset( $transformed_data['newsletter_data'] );
+		unset( $transformed_data['interaction_data'] );
+		$transformed_data = array_merge( $transformed_data, $data['interaction_data'] );
 
-		$transformed_data = array_merge( $transformed_data, $data['registration_data'] );
-		$transformed_data = array_merge( $transformed_data, $data['donation_data'] );
-		$transformed_data = array_merge( $transformed_data, $data['newsletter_data'] );
+		unset( $transformed_data['campaign_blocks'] );
+		foreach ( $data['campaign_blocks'] as $block ) {
+			$transformed_data[ 'campaign_has_' . $block ] = 1;
+		}
 
 		return array_merge( $params, $transformed_data );
 	}

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -77,6 +77,9 @@ class GA4 {
 		if ( method_exists( __CLASS__, 'handle_' . $event_name ) ) {
 			$params = call_user_func( [ __CLASS__, 'handle_' . $event_name ], $params, $data );
 
+			// prefix event name.
+			$event_name = 'np_' . $event_name;
+
 			if ( ! Event::validate_name( $event_name ) ) {
 				throw new \Exception( 'Invalid event name' );
 			}

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -411,8 +411,11 @@ class WooCommerce_Connection {
 			$order->add_meta_data( '_newspack_referer', $order_data['referer'] );
 		}
 
-		if ( ! empty( $order_data['newspack_popup_id'] ) ) {
-			$order->add_meta_data( '_newspack_popup_id', $order_data['newspack_popup_id'] );
+		// Add all newspack_* meta data.
+		foreach ( $order_data as $key => $value ) {
+			if ( 0 === strpos( $key, 'newspack_' ) ) {
+				$order->add_meta_data( '_' . $key, $value );
+			}
 		}
 
 		if ( ! empty( $order_data['user_id'] ) ) {

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -767,13 +767,24 @@ class Stripe_Connection {
 		try {
 			$stripe = self::get_stripe_client();
 
-			$amount_raw       = $config['amount'];
-			$frequency        = $config['frequency'];
-			$email_address    = $config['email_address'];
-			$full_name        = $config['full_name'];
-			$source_id        = $config['source_id'];
-			$client_metadata  = $config['client_metadata'];
-			$payment_metadata = $config['payment_metadata'];
+			$amount_raw      = $config['amount'];
+			$frequency       = $config['frequency'];
+			$email_address   = $config['email_address'];
+			$full_name       = $config['full_name'];
+			$source_id       = $config['source_id'];
+			$client_metadata = $config['client_metadata'];
+
+			/**
+			 * Filters the payment metadata that will be sent to Stripe when a donation is made.
+			 *
+			 * Use this filter to add additinoal metadata to the payment. Every metadata prefixed with "newspack_" will be later automatically added
+			 * as a metadata to the order or subscription when we receive the webhook request from Stripe.
+			 * (Note, in the order, the metadata prefix will be "_newsapck_")
+			 *
+			 * @param array $payment_metadata The payment metadata.
+			 * @param array $config The donation configuration.
+			 */
+			$payment_metadata = apply_filters( 'newspack_stripe_handle_donation_payment_metadata', $config['payment_metadata'], $config );
 
 			if ( ! isset( $client_metadata['userId'] ) && Reader_Activation::is_enabled() ) {
 				$reader_metadata                        = $client_metadata;
@@ -1164,7 +1175,7 @@ class Stripe_Connection {
 		} else {
 			$frequency = self::get_frequency_of_payment( $payment );
 		}
-		return [
+		$payload = [
 			'email'                         => $customer['email'],
 			'name'                          => $customer['name'],
 			'stripe_id'                     => $payment['id'],
@@ -1181,8 +1192,16 @@ class Stripe_Connection {
 			'user_id'                       => $customer['metadata']['userId'],
 			'subscribed'                    => self::has_customer_opted_in_to_newsletters( $customer ),
 			'referer'                       => $payment['referer'] ?? null,
-			'newspack_popup_id'             => $payment['newspack_popup_id'] ?? null,
 		];
+
+		// Add any metadata prefixed with newspack_ to the payload.
+		foreach ( $payment as $key => $value ) {
+			if ( 0 === strpos( $key, 'newspack_' ) ) {
+				$payload[ $key ] = $value;
+			}
+		}
+
+		return $payload;
 	}
 
 	/**

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -779,7 +779,7 @@ class Stripe_Connection {
 			 *
 			 * Use this filter to add additinoal metadata to the payment. Every metadata prefixed with "newspack_" will be later automatically added
 			 * as a metadata to the order or subscription when we receive the webhook request from Stripe.
-			 * (Note, in the order, the metadata prefix will be "_newsapck_")
+			 * (Note, in the order, the metadata prefix will be "_newspack_")
 			 *
 			 * @param array $payment_metadata The payment metadata.
 			 * @param array $config The donation configuration.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Connects the Popup events to GA4.

Note that the Popup events have already been tested. This only connects them to GA4. It also adds a little more detail to the newsletter subscription events.

This PR also fixes a bug in the `donation_new` event and the `form_submission_success` event for donations. Both when using Stripe as platform.

Since the new donation in Stripe is triggered when Stripe server hits our webhook, the GA Client and Session IDs were not bein fetched by the cookie. So I had to add these information in the payment metadata and retrieve them for the order when they are marked as completed.

### How to test the changes in this Pull Request:

Since we changed the structure of the data and also fixed a bug, we should do an extensive tests of as many events as possible.

Get the GA4 credentials. You will need your measurement ID and an API secret.

* api_secret - Required. An API SECRET generated in the Google Analytics UI. To create a new secret, navigate to:
    Admin > Data Streams > choose your stream > Measurement Protocol > Create
* measurement_id - Required. The measurement ID associated with a stream. Found in the Google Analytics UI under:
    Admin > Data Streams > choose your stream > Measurement ID

Store this info in the database:
```
wp option set ga4_measurement_id "G-XXXXXXXXXX"
wp option set ga4_api_secret YYYYYYYYYYYYYYYYYYY
```
Now, let's test:

1. Make sure RAS is active and that you have a registered reader
2. Make sure to add this constant to wp-config
```
define( 'NEWSPACK_LOG_LEVEL', 2 );
define( 'NEWSPACK_EXPERIMENTAL_GA4_EVENTS', true );
```
4. Checkout the newsletters plugin on https://github.com/Automattic/newspack-newsletters/pull/1111
5. Setup a popup with a Newsletter subscription form
6. Subscribe to a newsletter via this popup
8. Visit the Google Analytics Realtime dashboard
9. See the `campaign_interaction` events coming in

![Captura de tela de 2023-03-09 13-15-59](https://user-images.githubusercontent.com/971483/224086546-fc9ee3ac-a5e7-4a08-9921-7c00d78b5ed5.png)

11. Inspect them and see check its attributes to see if the values are correct.

![Captura de tela de 2023-03-09 13-51-25](https://user-images.githubusercontent.com/971483/224097513-bf0700aa-c552-4e66-bc8e-358fd1c08279.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->