### PR TITLE
fix: show handoff to finish Newspack setup only if setup is incomplete

### DIFF
--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -116,6 +116,10 @@ class Handoff_Banner {
 	 * @return bool
 	 */
 	public static function needs_handoff_return_ui() {
+		if ( get_option( NEWSPACK_SETUP_COMPLETE, true ) ) {
+			return false;
+		}
+
 		return get_option( NEWSPACK_HANDOFF ) ? true : false;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents the handoff banner to complete Newspack setup from being displayed in WP admin if Newspack setup has already been completed. Note that this doesn't fix a related issue in which the handoff banner causes non-block-editor admin pages to be unscrollable.

Closes `1204068745367915/1204165700596247`.

### How to test the changes in this Pull Request:

1. On `master`, on a site that's already been setup with Newspack, force the handoff banner to be displayed by setting an option via WP CLI: `wp option set newspack_handoff 1`
2. Observe in the WP admin dashboard that the banner appears and prevents non-block-editor pages from scrolling.
3. Check out this branch, confirm that the banner no longer appears and that all admin pages are scrollable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->