### PR TITLE
fix(wizards): broken rendering in WP 6.2

### DIFF
--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -24,16 +24,19 @@ const Recaptcha = () => {
 	const [ settings, setSettings ] = useState( {} );
 	const [ settingsToUpdate, setSettingsToUpdate ] = useState( {} );
 
-	// Check the Mailchimp connectivity status.
-	useEffect( async () => {
-		setIsLoading( true );
-		try {
-			setSettings( await apiFetch( { path: '/newspack/v1/recaptcha' } ) );
-		} catch ( e ) {
-			setError( e.message || __( 'Error fetching settings.', 'newspack' ) );
-		} finally {
-			setIsLoading( false );
-		}
+	// Check the reCAPTCHA connectivity status.
+	useEffect( () => {
+		const fetchSettings = async () => {
+			setIsLoading( true );
+			try {
+				setSettings( await apiFetch( { path: '/newspack/v1/recaptcha' } ) );
+			} catch ( e ) {
+				setError( e.message || __( 'Error fetching settings.', 'newspack' ) );
+			} finally {
+				setIsLoading( false );
+			}
+		};
+		fetchSettings();
 	}, [] );
 
 	const updateSettings = async data => {

--- a/assets/wizards/engagement/views/social/pixel.js
+++ b/assets/wizards/engagement/views/social/pixel.js
@@ -22,15 +22,18 @@ export default function Pixel( {
 	const [ error, setError ] = useState( null );
 	const [ settings, setSettings ] = useState( null );
 
-	useEffect( async () => {
-		setInFlight( true );
-		try {
-			const response = await apiFetch( { path: apiEndpoint } );
-			setSettings( response );
-		} catch ( err ) {
-			setSettings( null );
-		}
-		setInFlight( false );
+	useEffect( () => {
+		const fetchSettings = async () => {
+			setInFlight( true );
+			try {
+				const response = await apiFetch( { path: apiEndpoint } );
+				setSettings( response );
+			} catch ( err ) {
+				setSettings( null );
+			}
+			setInFlight( false );
+		};
+		fetchSettings();
 	}, [] );
 
 	const handleChange = ( key, value ) => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The invalid usage of useEffect hook broke navigation on the Engagement wizard. 

Related: #2335, #2269 

### How to test the changes in this Pull Request:

1. Set WP to 6.2 (`wp core update --version=6.2-beta1`)
2. On `master`, navigate to the Engagement wizard, click on the "Social" tab and then on "Recirculation" tab
3. Observe a blank screen of death 
4. Switch to this branch, rebuild, observe the Recirculation screen loads when navigating from the Social screen

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->