### PR TITLE
fix: prevent page auto-scroll when RAS is enabled

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -236,7 +236,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 			/**
 			 * Handle auth form action selection.
 			 */
-			function setFormAction( action ) {
+			function setFormAction( action, shouldFocus = false ) {
 				if ( 'otp' === action ) {
 					if ( ! readerActivation.getOTPHash() ) {
 						return;
@@ -262,12 +262,14 @@ window.newspackRAS.push( function ( readerActivation ) {
 					const label = 'register' === action ? labels.register : labels.signin;
 					container.querySelector( 'h2' ).textContent = label;
 				} catch {}
-				if ( action === 'pwd' && emailInput.value ) {
-					passwordInput.focus();
-				} else if ( action === 'otp' ) {
-					otpCodeInput.focus();
-				} else {
-					emailInput.focus();
+				if ( shouldFocus ) {
+					if ( action === 'pwd' && emailInput.value ) {
+						passwordInput.focus();
+					} else if ( action === 'otp' ) {
+						otpCodeInput.focus();
+					} else {
+						emailInput.focus();
+					}
 				}
 			}
 			setFormAction( readerActivation.getAuthStrategy() || 'link' );
@@ -279,7 +281,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 			container.querySelectorAll( '[data-set-action]' ).forEach( item => {
 				item.addEventListener( 'click', function ( ev ) {
 					ev.preventDefault();
-					setFormAction( ev.target.getAttribute( 'data-set-action' ) );
+					setFormAction( ev.target.getAttribute( 'data-set-action' ), true );
 				} );
 			} );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue that was reported on one live site, but may appear on more. 

The RAS JS was focusing on an input on page load. If the input was hidden with CSS, it would not be focused on, but if for some reason the CSS was delayed or stripped, the input would be focused on and the page would scroll to where the input was – in this case the bottom of the page. 

### How to test the changes in this Pull Request:

1. On `master`, ensure RAS is enabled and the header sign-in link is rendered
2. Visit the page, and block the `/wp-content/plugins/newspack-plugin/dist/reader-auth.css` file from loading in the devtools network tab, reload and observe the page is scrolled to bottom on load
3. Switch to this branch, observe the issue cannot be reproduced
4. Open the sign-in modal by clicking the header link and ensure that the input is focused when switching sign-in methods ("sign in using a…" text link)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->