### PR TITLE
fix: toggling settings section

### DIFF
--- a/assets/components/src/plugin-settings/index.js
+++ b/assets/components/src/plugin-settings/index.js
@@ -90,6 +90,13 @@ class PluginSettings extends Component {
 			},
 		} )
 			.then( settings => {
+				this.setState( {
+					settings: {
+						...this.state.settings,
+						[ sectionKey ]: settings[ sectionKey ],
+					},
+					error: null,
+				} );
 				if ( 'function' === typeof afterUpdate ) {
 					afterUpdate( settings );
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#2259 introduced a bug due to [this change](https://github.com/Automattic/newspack-plugin/pull/2259/files#diff-d6c8c253ecb3a9dc1b1a6945d0672b6e2dd35c4f25b62359524f8c838981c6c9L93-L94). The API results not being updated back to the component, the activation toggle doesn't change update on success.

This PR restores the update but preserves the original intention of the removal, which is to not let a section update affect the values of other rendered sections.

Closes #2336

### How to test the changes in this Pull Request:

Confirm #2336 is no longer reproducible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->