### PR TITLE
fix(ads-wizards): settings saving

### DIFF
--- a/assets/components/src/plugin-settings/index.js
+++ b/assets/components/src/plugin-settings/index.js
@@ -90,6 +90,7 @@ class PluginSettings extends Component {
 			},
 		} )
 			.then( settings => {
+				this.setState( { settings } );
 				if ( 'function' === typeof afterUpdate ) {
 					afterUpdate( settings );
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with editing Ads Wizards settings.

@miguelpeixe – asking for your 👀 since you are most intimate with this part of the code. 

### How to test the changes in this Pull Request:

1. On `master`, open up the Advertising Wizard
2. Toggle or untoggle one of the top-level options (e.g. "Custom Ad Label", observe that the UI does not update 
3. Switch to this branch, confirm that the issue is not reproducible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->