### PR TITLE
fix: bail silently when recaptcha key is not set

### DIFF
--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -272,7 +272,13 @@ export function getCaptchaToken( action = 'submit' ) {
 		}
 
 		const { captcha_site_key: captchaSiteKey } = newspack_reader_activation_data;
-		if ( ! grecaptcha?.ready || ! captchaSiteKey ) {
+
+		// If the site key is not set, bail with an empty token.
+		if ( ! captchaSiteKey ) {
+			return res( '' );
+		}
+
+		if ( ! grecaptcha?.ready ) {
 			rej( 'Error loading the reCaptcha library.' );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When the reCAPTCHA library is loaded, RAS' library assumes it should be used and renders an error when submitting a form if the connection is not configured.

This PR tweaks the token fetch to bail silently when a site key is not set.

### How to test the changes in this Pull Request:

1. While on the master branch, make sure you have RAS configured and reCAPTCHA **not** configured
2. Install the [reCAPTCHA for WooCommerce](https://wordpress.org/plugins/recaptcha-woo/) plugin
3. Place a "Reader Registration" block
4. Submit the form and confirm you see a reCAPTCHA error
5. Check out this branch, repeat step 4, and confirm the error is gone
6. Enable and configure reCAPTCHA in the Connections wizard
7. Repeat step 4 and confirm it also works with reCAPTCHA

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->