### PR TITLE
fix: block AdThrive plugin from being installed or activated

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -401,6 +401,18 @@ class Plugin_Manager {
 	}
 
 	/**
+	 * Get an array of blocked plugin slugs.
+	 * These plugins are not allowed on Newspack sites, for whatever reason.
+	 *
+	 * @return array Array of blocked plugin slugs.
+	 */
+	public static function get_blocked_plugin_slugs() {
+		return [
+			'adthrive-ads',
+		];
+	}
+
+	/**
 	 * Get info about all the unmanaged plugins that are installed.
 	 *
 	 * @return array of plugin info.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Blocks certain plugins from being installed or activated via the WP Plugins and Add New plugin screens, but does not prevent the plugins from being functional if already installed and activated.

Closes `1200550061930446/1204187151254807`.

### How to test the changes in this Pull Request:

1. On a fresh site, go to Plugins > Add New and search for the AdThrive plugin.
2. Confirm that you can't install or activate it from this screen:

<img width="493" alt="Screen Shot 2023-03-23 at 6 53 40 PM" src="https://user-images.githubusercontent.com/2230142/227396822-463bd215-c6ad-4f9f-a6a6-171b131bc2bd.png">

3. Using WP CLI, install the plugin anyway: `wp plugin install adthrive-ads`
4. Go to Plugins in WP admin and confirm that you can't activate it from this screen:

<img width="1468" alt="Screen Shot 2023-03-23 at 6 55 25 PM" src="https://user-images.githubusercontent.com/2230142/227397045-c0fc5586-5e76-4df5-b138-db1b882ea699.png">

5. Using WP CLI, activate it anyway: `wp plugin activate adthrive-ads`
6. Confirm that the plugin is fully functional if already installed/activated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->