### PR TITLE
fix(perfmatters): add twitter.com to JS delay list

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -65,6 +65,7 @@ class Perfmatters {
 			// Third-party services.
 			'disqus',
 			'recaptcha',
+			'twitter.com',
 			// Advertising.
 			'googletag.pubads',
 			'adsbygoogle.js',


### PR DESCRIPTION
https://github.com/Automattic/newspack-plugin/pull/2360 was supposed to be a hotfix, but the base branch was erroneously set to `master`. 