### PR TITLE
feat(perfmatters): add fonts settings to defaults

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -216,8 +216,9 @@ class Perfmatters {
 		if ( ! isset( $options['fonts'] ) ) {
 			$options['fonts'] = [];
 		}
-		$options['lazyload']['display_swap']       = true;
-		$options['lazyload']['local_google_fonts'] = true;
+		$options['fonts']['disable_google_fonts'] = false;
+		$options['fonts']['display_swap']         = true;
+		$options['fonts']['local_google_fonts']   = true;
 
 		return $options;
 	}

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -212,6 +212,13 @@ class Perfmatters {
 		$options['lazyload']['youtube_preview_thumbnails'] = true;
 		$options['lazyload']['image_dimensions']           = true;
 
+		// Fonts.
+		if ( ! isset( $options['fonts'] ) ) {
+			$options['fonts'] = [];
+		}
+		$options['lazyload']['display_swap']       = true;
+		$options['lazyload']['local_google_fonts'] = true;
+
 		return $options;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds [local Google Fonts hosting](https://perfmatters.io/docs/host-google-fonts-locally/) and [Display Swap](https://perfmatters.io/docs/font-display-swap/) settings to Perfmatters baseline settings.
 
### How to test the changes in this Pull Request:

Verify that (unless `NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS` env. variable is set) the aforementioned settings are turned on in Perfmatters settings by default. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->