### PR TITLE
feat(amp-deprecation): polyfill amp-vimeo tag

### DIFF
--- a/includes/polyfills/class-amp-polyfills.php
+++ b/includes/polyfills/class-amp-polyfills.php
@@ -41,6 +41,28 @@ class AMP_Polyfills {
 	}
 
 	/**
+	 * Get embeed HTML for a video.
+	 *
+	 * @param string $type Video type.
+	 * @param string $id Video ID.
+	 */
+	private static function get_video_embed_html( $type, $id ) {
+		switch ( $type ) {
+			case 'vimeo':
+				$video_url = 'https://vimeo.com/' . $id;
+				break;
+			default:
+				$video_url = 'https://www.youtube.com/watch?v=' . $id;
+				break;
+		}
+		return '<div><!-- wp:embed {"url":"' . $video_url . '","type":"video","providerNameSlug":"' . $type . '","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+			<figure class="wp-block-embed is-type-video is-provider-' . $type . ' wp-block-embed-' . $type . ' wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+			' . $video_url . '
+			</div></figure>
+		<!-- /wp:embed --></div>';
+	}
+
+	/**
 	 * Polyfill AMP tags.
 	 *
 	 * @param string $content Content.
@@ -66,8 +88,9 @@ class AMP_Polyfills {
 
 		$has_amp_fit_text = false !== stripos( $content, '<amp-fit-text' );
 		$has_amp_youtube  = false !== stripos( $content, '<amp-youtube' );
+		$has_amp_vimeo    = false !== stripos( $content, '<amp-vimeo' );
 
-		if ( $has_amp_fit_text || $has_amp_youtube ) {
+		if ( $has_amp_fit_text || $has_amp_youtube || $has_amp_vimeo ) {
 			$dom = new \DomDocument();
 			libxml_use_internal_errors( true );
 			$dom->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ) );
@@ -96,14 +119,24 @@ class AMP_Polyfills {
 						}
 					}
 					if ( $yt_id ) {
-						// Return a YouTube embed block.
-						$video_url = 'https://www.youtube.com/watch?v=' . $yt_id;
-						$html      = '<div><!-- wp:embed {"url":"' . $video_url . '","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
-                            <figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
-                            ' . $video_url . '
-                            </div></figure>
-                        <!-- /wp:embed --></div>';
-						self::insert_html( $dom, $html, $tag );
+						self::insert_html( $dom, self::get_video_embed_html( 'youtube', $yt_id ), $tag );
+						$body    = $dom->getElementsByTagName( 'body' )->item( 0 );
+						$content = preg_replace( '/<\/?body>/', '', $dom->saveHTML( $body ) );
+					}
+				}
+			}
+
+			// Process amp-vimeo tags.
+			if ( $has_amp_vimeo ) {
+				foreach ( $xpath->query( '//amp-vimeo' ) as $tag ) {
+					$vimeo_id = false;
+					foreach ( $tag->attributes as $attribute ) {
+						if ( 'data-videoid' === $attribute->name ) {
+							$vimeo_id = $attribute->value;
+						}
+					}
+					if ( $vimeo_id ) {
+						self::insert_html( $dom, self::get_video_embed_html( 'vimeo', $vimeo_id ), $tag );
 						$body    = $dom->getElementsByTagName( 'body' )->item( 0 );
 						$content = preg_replace( '/<\/?body>/', '', $dom->saveHTML( $body ) );
 					}

--- a/tests/unit-tests/amp-polyfills.php
+++ b/tests/unit-tests/amp-polyfills.php
@@ -110,6 +110,7 @@ class Newspack_AMP_Polyfills extends WP_UnitTestCase {
 	 * @dataProvider youtube_data
 	 */
 	public function test_amp_polyfills_youtube( $input, $expected ) {
-		$this->assertSame( str_replace( ' ', '', $expected ), str_replace( ' ', '', AMP_Polyfills::amp_tags( $input ) ) );
+		$actual = preg_replace( '/\s+/', '', AMP_Polyfills::amp_tags( $input ) );
+		$this->assertSame( preg_replace( '/\s+/', '', $expected ), $actual );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Building on #2308, this polyfills [`amp-vimeo`](https://amp.dev/documentation/components/websites/amp-vimeo) tag. 

Ideally, these changes should also be released as hotfix after https://github.com/Automattic/newspack-plugin/pull/2371 is merged.

### How to test the changes in this Pull Request:

1. Same protocol as in https://github.com/Automattic/newspack-plugin/pull/2308, but insert an `amp-vimeo` tag (e.g. `<amp-vimeo data-videoid="27246366" layout="responsive" width="480" height="270"></amp-vimeo>`)
2. Ensure the tag loads a vimeo embed when AMP plugin is off.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->