### PR TITLE
add Newspack multi-brand plugin wizard CSS class

### DIFF
--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -8,6 +8,7 @@
 // Reset Padding of the Admin Page
 
 .toplevel_page_newspack:not( .menu-top ),
+.toplevel_page_newspack-multi-branded-sites:not( .menu-top ),
 body[class*='newspack_page_newspack-'],
 body[class*='admin_page_newspack-'] {
 	background: white;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As we're using Newspack Components for the new [Newspack Multi-brands Site plugin](https://github.com/Automattic/newspack-multibranded-site), this PR adds its class to the Wizard Component styling.

### How to test the changes in this Pull Request:

1. Install the new [Newspack Multi-brands Site plugin](https://github.com/Automattic/newspack-multibranded-site).
2. Pull [this PR](https://github.com/Automattic/newspack-multibranded-site/pull/2) if it's not already merged. Switch to this PR in Newspack-plugin.
3. Navigate to the Multi-brands admin menu.
4. Notice the white background and no left margin on the wizard screen (the brands' list).

Thank you

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->