### PR TITLE
fix: if My Account is set to shown in RAS, show in Customizer at all breakpoints

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -642,7 +642,7 @@ final class Reader_Activation {
 		$locations = self::get_setting( 'account_link_menu_locations' );
 
 		/** Do not alter items for authenticated non-readers */
-		if ( \is_user_logged_in() && ! self::is_user_reader( \wp_get_current_user() ) ) {
+		if ( \is_user_logged_in() && ! self::is_user_reader( \wp_get_current_user() ) && ! \is_customize_preview() ) {
 			return $output;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A redo of #2333 without the unwanted Composer changes. The "Sign In"/"My Account" button from RAS isn't showing up in the Customizer preview at large viewport sizes (when the content area of the preview minus the sidebar is >960px). I figure it probably should since it likely has a largeish impact on how the header appears. The mobile version does appear at smaller sizes; it's just the larger button that doesn't appear.

### How to test the changes in this Pull Request:

1. On `master`, enable RAS and the "Enable Sign In/Account link" option.
2. At a large viewport size, observe that the button appears in the header on the front-end in a new session, but not in the Customizer while logged in as an admin.
3. Check out this branch and confirm that now it does appear in the Customizer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->