### PR TITLE
feat: start new RAS settings page

### DIFF
--- a/assets/memberships-gate/editor.js
+++ b/assets/memberships-gate/editor.js
@@ -1,0 +1,115 @@
+/* globals newspack_memberships_gate */
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { Fragment, useEffect } from '@wordpress/element';
+import { Button, TextControl, CheckboxControl } from '@wordpress/components';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+const styles = [
+	{ name: 'inline', label: __( 'Inline', 'newspack' ) },
+	{ name: 'overlay', label: __( 'Overlay (soon)', 'newspack' ) },
+];
+
+const GateEdit = ( { editPost, createNotice, meta } ) => {
+	useEffect( () => {
+		if ( newspack_memberships_gate.has_campaigns ) {
+			createNotice(
+				'info',
+				__(
+					'Newspack Campaigns: Prompts will not be displayed when rendering a gated content.',
+					'newspack'
+				)
+			);
+		}
+	}, [] );
+	return (
+		<Fragment>
+			<PluginDocumentSettingPanel
+				name="memberships-gate-styles-panel"
+				title={ __( 'Styles', 'newspack' ) }
+			>
+				<div className="newspack-memberships-gate-style-selector">
+					{ styles.map( style => (
+						<Button
+							key={ style.name }
+							variant={ meta.style === style.name ? 'primary' : 'secondary' }
+							isPressed={ meta.style === style.name }
+							onClick={ () => editPost( { meta: { style: style.name } } ) }
+							aria-current={ meta.style === style.name }
+							disabled={ style.name === 'overlay' }
+						>
+							{ style.label }
+						</Button>
+					) ) }
+				</div>
+				{ meta.style === 'inline' && (
+					<CheckboxControl
+						label={ __( 'Apply fade to last paragraph', 'newspack' ) }
+						checked={ meta.inline_fade }
+						onChange={ value => editPost( { meta: { inline_fade: value } } ) }
+						help={ __(
+							'Whether to apply a gradient fade effect before rendering the gate.',
+							'newspack'
+						) }
+					/>
+				) }
+			</PluginDocumentSettingPanel>
+			<PluginDocumentSettingPanel
+				name="memberships-gate-settings-panel"
+				title={ __( 'Settings', 'newspack' ) }
+			>
+				<TextControl
+					type="number"
+					value={ meta.visible_paragraphs }
+					label={ __( 'Default paragraph count', 'newspack' ) }
+					onChange={ value => editPost( { meta: { visible_paragraphs: value } } ) }
+					help={ __(
+						'Number of paragraphs that readers can see above the content gate.',
+						'newspack'
+					) }
+				/>
+				<hr />
+				<CheckboxControl
+					label={ __( 'Use “More” tag to manually place content gate', 'newspack' ) }
+					checked={ meta.use_more_tag }
+					onChange={ value => editPost( { meta: { use_more_tag: value } } ) }
+					help={ __(
+						'Override the default paragraph count on pages where a “More” block has been placed.',
+						'newspack'
+					) }
+				/>
+			</PluginDocumentSettingPanel>
+		</Fragment>
+	);
+};
+
+const GateEditWithSelect = compose( [
+	withSelect( select => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const meta = getEditedPostAttribute( 'meta' );
+		return { meta };
+	} ),
+	withDispatch( dispatch => {
+		const { editPost } = dispatch( 'core/editor' );
+		const { createNotice } = dispatch( 'core/notices' );
+		return {
+			editPost,
+			createNotice,
+		};
+	} ),
+] )( GateEdit );
+
+registerPlugin( 'newspack-memberships-gate', {
+	render: GateEditWithSelect,
+	icon: null,
+} );

--- a/assets/memberships-gate/editor.scss
+++ b/assets/memberships-gate/editor.scss
@@ -1,0 +1,21 @@
+@use '~@wordpress/base-styles/colors' as wp-colors;
+
+.edit-post-post-visibility {
+	display: none;
+}
+
+.newspack-memberships-gate-style-selector {
+	display: grid;
+	gap: 8px;
+	grid-template-columns: repeat( 2, 1fr );
+	margin-bottom: 16px;
+
+	.components-button {
+		justify-content: center;
+
+		&.is-secondary {
+			box-shadow: inset 0 0 0 1px wp-colors.$gray-400;
+			color: wp-colors.$gray-900;
+		}
+	}
+}

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -130,7 +130,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 					const messageContentElement = container.querySelector(
 						'.newspack-reader__auth-form__response__content'
 					);
-					if ( messageContentElement ) {
+					if ( messageContentElement && form ) {
 						form.replaceWith( messageContentElement.parentNode );
 					}
 				}

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -112,6 +112,7 @@ export default withWizardScreen( () => {
 							'Newspack’s Reader Activation system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. ',
 							'newspack'
 						) }
+						{ /** TODO: Update this URL with the real one once the docs are ready. */ }
 						<ExternalLink href={ 'https://help.newspack.com' }>
 							{ __( 'Learn more', 'newspack-plugin' ) }
 						</ExternalLink>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -1,3 +1,4 @@
+/* global newspack_engagement_wizard */
 /**
  * WordPress dependencies
  */
@@ -25,6 +26,7 @@ import ActiveCampaign from './active-campaign';
 export default withWizardScreen( () => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ config, setConfig ] = useState( {} );
+	const [ membershipsConfig, setMembershipsConfig ] = useState( {} );
 	const [ error, setError ] = useState( false );
 	const [ allReady, setAllReady ] = useState( false );
 	const [ isActiveCampaign, setIsActiveCampaign ] = useState( false );
@@ -39,9 +41,10 @@ export default withWizardScreen( () => {
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
 		} )
-			.then( ( { config: fetchedConfig, prerequisites_status } ) => {
+			.then( ( { config: fetchedConfig, prerequisites_status, memberships } ) => {
 				setPrerequisites( prerequisites_status );
 				setConfig( fetchedConfig );
+				setMembershipsConfig( memberships );
 			} )
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
@@ -101,6 +104,22 @@ export default withWizardScreen( () => {
 	};
 
 	const emails = Object.values( config.emails || {} );
+
+	const getContentGateDescription = () => {
+		let message = __(
+			'Configure the gate rendered on content with restricted access.',
+			'newspack'
+		);
+		if ( 'publish' === membershipsConfig?.gate_status ) {
+			message += ' ' + __( 'The gate is currently published.', 'newspack' );
+		} else if (
+			'draft' === membershipsConfig?.gate_status ||
+			'trash' === membershipsConfig?.gate_status
+		) {
+			message += ' ' + __( 'The gate is currently a draft.', 'newspack' );
+		}
+		return message;
+	};
 
 	return (
 		<>
@@ -234,6 +253,23 @@ export default withWizardScreen( () => {
 							<hr />
 						</>
 					) }
+
+					{ newspack_engagement_wizard.has_memberships && membershipsConfig ? (
+						<>
+							<hr />
+							<SectionHeader
+								title={ __( 'Memberships Integration', 'newspack' ) }
+								description={ __( 'Improve the reader experience on content gating.', 'newspack' ) }
+							/>
+							<ActionCard
+								title={ __( 'Content Gate', 'newspack' ) }
+								titleLink={ membershipsConfig.edit_gate_url }
+								href={ membershipsConfig.edit_gate_url }
+								description={ getContentGateDescription() }
+								actionText={ __( 'Configure', 'newspack' ) }
+							/>
+						</>
+					) : null }
 
 					<SectionHeader
 						title={ __( 'Email Service Provider Settings', 'newspack' ) }

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { CheckboxControl, ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -10,15 +10,15 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import {
+	ActionCard,
 	Button,
 	Card,
 	Grid,
 	Notice,
-	PluginInstaller,
 	SectionHeader,
 	TextControl,
+	Waiting,
 	withWizardScreen,
-	ActionCard,
 } from '../../../../components/src';
 import ActiveCampaign from './active-campaign';
 
@@ -26,8 +26,11 @@ export default withWizardScreen( () => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ config, setConfig ] = useState( {} );
 	const [ error, setError ] = useState( false );
+	const [ allReady, setAllReady ] = useState( false );
+	const [ setupComplete, setSetupComplete ] = useState( false );
 	const [ isActiveCampaign, setIsActiveCampaign ] = useState( false );
-	const [ hasPlugins, setHasPlugins ] = useState( null );
+	const [ prerequisites, setPrerequisites ] = useState( null );
+	const [ showAdvanced, setShowAdvanced ] = useState( false );
 	const updateConfig = ( key, val ) => {
 		setConfig( { ...config, [ key ]: val } );
 	};
@@ -37,8 +40,9 @@ export default withWizardScreen( () => {
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
 		} )
-			.then( ( { config: fetchedConfig, pluginsStatus } ) => {
-				setHasPlugins( pluginsStatus );
+			.then( ( { config: fetchedConfig, prerequisites_status, setup_complete } ) => {
+				setPrerequisites( prerequisites_status );
+				setSetupComplete( setup_complete );
 				setConfig( fetchedConfig );
 			} )
 			.catch( setError )
@@ -66,6 +70,19 @@ export default withWizardScreen( () => {
 			);
 		} );
 	}, [] );
+	useEffect( () => {
+		const _allReady =
+			prerequisites &&
+			Object.keys( prerequisites ).reduce( ( acc, key ) => {
+				if ( ! prerequisites[ key ]?.active ) {
+					return false;
+				}
+
+				return acc;
+			}, true );
+
+		setAllReady( _allReady );
+	}, [ prerequisites ] );
 
 	const getSharedProps = ( configKey, type = 'checkbox' ) => {
 		const props = {
@@ -87,159 +104,219 @@ export default withWizardScreen( () => {
 
 	const emails = Object.values( config.emails || {} );
 
-	if ( false === hasPlugins ) {
-		return (
-			<>
-				<Notice isError>
-					{ __(
-						'Please activate WooCommerce and WooCommerce Subscriptions plugins to use Reader Activation features.',
-						'newspack'
-					) }
-				</Notice>
-				<PluginInstaller
-					isWaiting={ inFlight }
-					plugins={ [ 'woocommerce', 'woocommerce-subscriptions', 'woocommerce-name-your-price' ] }
-					onStatus={ ( { complete } ) => complete && fetchConfig() }
-					withoutFooterButton={ true }
-				/>
-			</>
-		);
-	}
-
 	return (
 		<>
+			<SectionHeader
+				title={ __( 'Reader Activation', 'newspack' ) }
+				description={ () => (
+					<>
+						{ __(
+							'An easy way to let readers register for your site, sign up for newsletters, or become donors and paid members. ',
+							'newspack'
+						) }
+						<ExternalLink href={ 'https://help.newspack.com' }>
+							{ __( 'Learn more', 'newspack-plugin' ) }
+						</ExternalLink>
+					</>
+				) }
+			/>
 			{ error && (
 				<Notice
 					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
 					isError
 				/>
 			) }
-			<Card noBorder>
-				<SectionHeader
-					title={ __( 'Reader Activation', 'newspack' ) }
-					description={ __( 'Configure a set of features for reader activation.', 'newspack' ) }
+			{ prerequisites && ! allReady && ! setupComplete && (
+				<Notice
+					noticeText={ __( 'Complete these settings to enable Reader Activation.', 'newspack' ) }
+					isWarning
 				/>
-				<CheckboxControl
-					label={ __( 'Enable Reader Activation', 'newspack' ) }
-					help={ __( 'Whether to enable reader activation features for your site.', 'newspack' ) }
-					{ ...getSharedProps( 'enabled' ) }
-				/>
-				<hr />
-				<CheckboxControl
-					label={ __( 'Enable Sign In/Account link', 'newspack' ) }
-					help={ __(
-						'Display an account link in the site header. It will allow readers to register and access their account.',
+			) }
+			{ ! prerequisites && ! setupComplete && (
+				<>
+					<Waiting isLeft />
+					{ __( 'Retrieving status…', 'newspack' ) }
+				</>
+			) }
+			{ ! setupComplete &&
+				prerequisites &&
+				Object.keys( prerequisites ).map( key => (
+					<ActionCard
+						key={ key }
+						isMedium
+						title={ prerequisites[ key ].label }
+						description={
+							prerequisites[ key ].active
+								? __( 'Status: Ready', 'newspack' )
+								: prerequisites[ key ].description
+						}
+						checkbox={ prerequisites[ key ].active ? 'checked' : 'unchecked' }
+						actionText={
+							prerequisites[ key ].href ? (
+								<Button isLink disabled={ inFlight } href={ prerequisites[ key ].href }>
+									{ prerequisites[ key ].active
+										? __( 'View configuration', 'newspack' )
+										: __( 'Configure', 'newspack' ) }
+								</Button>
+							) : null
+						}
+					/>
+				) ) }
+
+			{ /** TODO: Link this to the new setup wizard. */ }
+			{ prerequisites && ! setupComplete && (
+				<ActionCard
+					isMedium
+					title={ __( 'Reader Activation Campaign', 'newspack' ) }
+					description={ __(
+						'A set of prompts and segments optimized for reader activaton.',
 						'newspack'
 					) }
-					{ ...getSharedProps( 'enabled_account_link' ) }
+					checkbox="unchecked"
+					actionText={ __( 'Waiting for all settings to be ready', 'newspack' ) }
 				/>
-				<Grid columns={ 2 } gutter={ 16 }>
-					<TextControl
-						label={ __( 'Terms & Conditions Text', 'newspack' ) }
-						help={ __( 'Terms and conditions text to display on registration.', 'newspack' ) }
-						{ ...getSharedProps( 'terms_text', 'text' ) }
+			) }
+			{ setupComplete && (
+				<>
+					{ /** TODO: Make this notice appear only when RAS setup is first completed. */ }
+					<Notice
+						noticeText={ __( 'Congratulations! Reader Activation is enabled.', 'newspack' ) }
+						isSuccess
 					/>
-					<TextControl
-						label={ __( 'Terms & Conditions URL', 'newspack' ) }
-						help={ __( 'URL to the page containing the terms and conditions.', 'newspack' ) }
-						{ ...getSharedProps( 'terms_url', 'text' ) }
+					<ActionCard
+						isMedium
+						title={ __( 'Reader Activation', 'newspack' ) }
+						description={ __( 'Status: Enabled', 'newspack' ) }
+						checkbox="checked"
 					/>
-				</Grid>
-				<hr />
-				{ emails?.length > 0 && (
-					<>
-						<SectionHeader
-							title={ __( 'Emails', 'newspack' ) }
-							description={ __( 'Customize emails sent to readers.', 'newspack' ) }
+				</>
+			) }
+			<hr />
+			<Button variant="link" onClick={ () => setShowAdvanced( ! showAdvanced ) }>
+				{ sprintf(
+					// Translators: Show or Hide advanced settings.
+					__( '%s Advanced Settings', 'newspack' ),
+					showAdvanced ? __( 'Hide', 'newspack' ) : __( 'Show', 'newspack' )
+				) }
+			</Button>
+			{ showAdvanced && (
+				<Card noBorder>
+					<CheckboxControl
+						label={ __( 'Enable Sign In/Account link', 'newspack' ) }
+						help={ __(
+							'Display an account link in the site header. It will allow readers to register and access their account.',
+							'newspack'
+						) }
+						{ ...getSharedProps( 'enabled_account_link' ) }
+					/>
+					<Grid columns={ 2 } gutter={ 16 }>
+						<TextControl
+							label={ __( 'Terms & Conditions Text', 'newspack' ) }
+							help={ __( 'Terms and conditions text to display on registration.', 'newspack' ) }
+							{ ...getSharedProps( 'terms_text', 'text' ) }
 						/>
 						<TextControl
-							label={ __( 'Sender name', 'newspack' ) }
-							{ ...getSharedProps( 'sender_name', 'text' ) }
+							label={ __( 'Terms & Conditions URL', 'newspack' ) }
+							help={ __( 'URL to the page containing the terms and conditions.', 'newspack' ) }
+							{ ...getSharedProps( 'terms_url', 'text' ) }
 						/>
-						<Grid columns={ 2 } gutter={ 16 }>
-							<TextControl
-								label={ __( 'Sender email address', 'newspack' ) }
-								{ ...getSharedProps( 'sender_email_address', 'text' ) }
+					</Grid>
+					<hr />
+					{ emails?.length > 0 && (
+						<>
+							<SectionHeader
+								title={ __( 'Emails', 'newspack' ) }
+								description={ __( 'Customize emails sent to readers.', 'newspack' ) }
 							/>
 							<TextControl
-								label={ __( 'Contact email address', 'newspack' ) }
+								label={ __( 'Sender name', 'newspack' ) }
+								{ ...getSharedProps( 'sender_name', 'text' ) }
+							/>
+							<Grid columns={ 2 } gutter={ 16 }>
+								<TextControl
+									label={ __( 'Sender email address', 'newspack' ) }
+									{ ...getSharedProps( 'sender_email_address', 'text' ) }
+								/>
+								<TextControl
+									label={ __( 'Contact email address', 'newspack' ) }
+									help={ __(
+										'This email will be used as "Reply-To" for transactional emails as well.',
+										'newspack'
+									) }
+									{ ...getSharedProps( 'contact_email_address', 'text' ) }
+								/>
+							</Grid>
+							{ emails.map( email => (
+								<ActionCard
+									key={ email.post_id }
+									title={ email.label }
+									titleLink={ email.edit_link }
+									href={ email.edit_link }
+									description={ email.description }
+									actionText={ __( 'Edit', 'newspack' ) }
+								/>
+							) ) }
+							<hr />
+						</>
+					) }
+
+					<SectionHeader
+						title={ __( 'Email Service Provider Settings', 'newspack' ) }
+						description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
+					/>
+					<TextControl
+						label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
+						help={ __(
+							'The text to display while subscribing to newsletters on the registration modal.',
+							'newspack'
+						) }
+						{ ...getSharedProps( 'newsletters_label', 'text' ) }
+					/>
+					<CheckboxControl
+						label={ __( 'Synchronize reader to ESP', 'newspack' ) }
+						help={ __(
+							'Whether to synchronize reader data to the ESP. A contact will be created on reader registration if the ESP supports contacts without a list subscription.',
+							'newspack'
+						) }
+						{ ...getSharedProps( 'sync_esp' ) }
+					/>
+					{ config.sync_esp && (
+						<>
+							<CheckboxControl
+								label={ __( 'Delete contact on reader deletion', 'newspack' ) }
 								help={ __(
-									'This email will be used as "Reply-To" for transactional emails as well.',
+									"If the reader's email is verified, delete contact from ESP on reader deletion. ESP synchronization must be enabled.",
 									'newspack'
 								) }
-								{ ...getSharedProps( 'contact_email_address', 'text' ) }
+								{ ...getSharedProps( 'sync_esp_delete' ) }
 							/>
-						</Grid>
-						{ emails.map( email => (
-							<ActionCard
-								key={ email.post_id }
-								title={ email.label }
-								titleLink={ email.edit_link }
-								href={ email.edit_link }
-								description={ email.description }
-								actionText={ __( 'Edit', 'newspack' ) }
+							<TextControl
+								label={ __( 'Metadata field prefix', 'newspack' ) }
+								help={ __(
+									'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_',
+									'newspack'
+								) }
+								{ ...getSharedProps( 'metadata_prefix', 'text' ) }
 							/>
-						) ) }
-						<hr />
-					</>
-				) }
-
-				<SectionHeader
-					title={ __( 'Email Service Provider Settings', 'newspack' ) }
-					description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
-				/>
-				<TextControl
-					label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
-					help={ __(
-						'The text to display while subscribing to newsletters on the registration modal.',
-						'newspack'
-					) }
-					{ ...getSharedProps( 'newsletters_label', 'text' ) }
-				/>
-				<CheckboxControl
-					label={ __( 'Synchronize reader to ESP', 'newspack' ) }
-					help={ __(
-						'Whether to synchronize reader data to the ESP. A contact will be created on reader registration if the ESP supports contacts without a list subscription.',
-						'newspack'
-					) }
-					{ ...getSharedProps( 'sync_esp' ) }
-				/>
-				{ config.sync_esp && (
-					<>
-						<CheckboxControl
-							label={ __( 'Delete contact on reader deletion', 'newspack' ) }
-							help={ __(
-								"If the reader's email is verified, delete contact from ESP on reader deletion. ESP synchronization must be enabled.",
-								'newspack'
+							{ isActiveCampaign && (
+								<ActiveCampaign
+									value={ { masterList: config.active_campaign_master_list } }
+									onChange={ ( key, value ) => {
+										if ( key === 'masterList' ) {
+											updateConfig( 'active_campaign_master_list', value );
+										}
+									} }
+								/>
 							) }
-							{ ...getSharedProps( 'sync_esp_delete' ) }
-						/>
-						<TextControl
-							label={ __( 'Metadata field prefix', 'newspack' ) }
-							help={ __(
-								'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_',
-								'newspack'
-							) }
-							{ ...getSharedProps( 'metadata_prefix', 'text' ) }
-						/>
-						{ isActiveCampaign && (
-							<ActiveCampaign
-								value={ { masterList: config.active_campaign_master_list } }
-								onChange={ ( key, value ) => {
-									if ( key === 'masterList' ) {
-										updateConfig( 'active_campaign_master_list', value );
-									}
-								} }
-							/>
-						) }
-					</>
-				) }
-			</Card>
-			<div className="newspack-buttons-card">
-				<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
-					{ __( 'Save Changes', 'newspack' ) }
-				</Button>
-			</div>
+						</>
+					) }
+					<div className="newspack-buttons-card">
+						<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
+							{ __( 'Save Changes', 'newspack' ) }
+						</Button>
+					</div>
+				</Card>
+			) }
 		</>
 	);
 } );

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { CheckboxControl, ExternalLink } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -27,7 +27,6 @@ export default withWizardScreen( () => {
 	const [ config, setConfig ] = useState( {} );
 	const [ error, setError ] = useState( false );
 	const [ allReady, setAllReady ] = useState( false );
-	const [ setupComplete, setSetupComplete ] = useState( false );
 	const [ isActiveCampaign, setIsActiveCampaign ] = useState( false );
 	const [ prerequisites, setPrerequisites ] = useState( null );
 	const [ showAdvanced, setShowAdvanced ] = useState( false );
@@ -40,9 +39,8 @@ export default withWizardScreen( () => {
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
 		} )
-			.then( ( { config: fetchedConfig, prerequisites_status, setup_complete } ) => {
+			.then( ( { config: fetchedConfig, prerequisites_status } ) => {
 				setPrerequisites( prerequisites_status );
-				setSetupComplete( setup_complete );
 				setConfig( fetchedConfig );
 			} )
 			.catch( setError )
@@ -111,7 +109,7 @@ export default withWizardScreen( () => {
 				description={ () => (
 					<>
 						{ __(
-							'An easy way to let readers register for your site, sign up for newsletters, or become donors and paid members. ',
+							'Newspack’s Reader Activation system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. ',
 							'newspack'
 						) }
 						<ExternalLink href={ 'https://help.newspack.com' }>
@@ -126,20 +124,19 @@ export default withWizardScreen( () => {
 					isError
 				/>
 			) }
-			{ prerequisites && ! allReady && ! setupComplete && (
+			{ prerequisites && ! allReady && (
 				<Notice
-					noticeText={ __( 'Complete these settings to enable Reader Activation.', 'newspack' ) }
+					noticeText={ __( 'Complete the settings to enable Reader Activation.', 'newspack' ) }
 					isWarning
 				/>
 			) }
-			{ ! prerequisites && ! setupComplete && (
+			{ ! prerequisites && (
 				<>
 					<Waiting isLeft />
 					{ __( 'Retrieving status…', 'newspack' ) }
 				</>
 			) }
-			{ ! setupComplete &&
-				prerequisites &&
+			{ prerequisites &&
 				Object.keys( prerequisites ).map( key => (
 					<ActionCard
 						key={ key }
@@ -164,32 +161,17 @@ export default withWizardScreen( () => {
 				) ) }
 
 			{ /** TODO: Link this to the new setup wizard. */ }
-			{ prerequisites && ! setupComplete && (
+			{ prerequisites && (
 				<ActionCard
 					isMedium
 					title={ __( 'Reader Activation Campaign', 'newspack' ) }
 					description={ __(
-						'A set of prompts and segments optimized for reader activaton.',
+						'Building a set of prompts with default segments and settings optimized for Reader Activation allows for an improved reader experience around site registration, newsletter sign-up, and donation in order to drive industry-leading conversion rates.',
 						'newspack'
 					) }
 					checkbox="unchecked"
 					actionText={ __( 'Waiting for all settings to be ready', 'newspack' ) }
 				/>
-			) }
-			{ setupComplete && (
-				<>
-					{ /** TODO: Make this notice appear only when RAS setup is first completed. */ }
-					<Notice
-						noticeText={ __( 'Congratulations! Reader Activation is enabled.', 'newspack' ) }
-						isSuccess
-					/>
-					<ActionCard
-						isMedium
-						title={ __( 'Reader Activation', 'newspack' ) }
-						description={ __( 'Status: Enabled', 'newspack' ) }
-						checkbox="checked"
-					/>
-				</>
 			) }
 			<hr />
 			<Button variant="link" onClick={ () => setShowAdvanced( ! showAdvanced ) }>
@@ -201,14 +183,6 @@ export default withWizardScreen( () => {
 			</Button>
 			{ showAdvanced && (
 				<Card noBorder>
-					<CheckboxControl
-						label={ __( 'Enable Sign In/Account link', 'newspack' ) }
-						help={ __(
-							'Display an account link in the site header. It will allow readers to register and access their account.',
-							'newspack'
-						) }
-						{ ...getSharedProps( 'enabled_account_link' ) }
-					/>
 					<Grid columns={ 2 } gutter={ 16 }>
 						<TextControl
 							label={ __( 'Terms & Conditions Text', 'newspack' ) }
@@ -225,8 +199,8 @@ export default withWizardScreen( () => {
 					{ emails?.length > 0 && (
 						<>
 							<SectionHeader
-								title={ __( 'Emails', 'newspack' ) }
-								description={ __( 'Customize emails sent to readers.', 'newspack' ) }
+								title={ __( 'Transactional Emails', 'newspack' ) }
+								description={ __( 'Customize the content of transactional emails.', 'newspack' ) }
 							/>
 							<TextControl
 								label={ __( 'Sender name', 'newspack' ) }
@@ -264,6 +238,7 @@ export default withWizardScreen( () => {
 						title={ __( 'Email Service Provider Settings', 'newspack' ) }
 						description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
 					/>
+					{ /** TODO: Deprecate this option. This field should be populated by user input in the prompt setup wizard. */ }
 					<TextControl
 						label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
 						help={ __(
@@ -272,24 +247,8 @@ export default withWizardScreen( () => {
 						) }
 						{ ...getSharedProps( 'newsletters_label', 'text' ) }
 					/>
-					<CheckboxControl
-						label={ __( 'Synchronize reader to ESP', 'newspack' ) }
-						help={ __(
-							'Whether to synchronize reader data to the ESP. A contact will be created on reader registration if the ESP supports contacts without a list subscription.',
-							'newspack'
-						) }
-						{ ...getSharedProps( 'sync_esp' ) }
-					/>
 					{ config.sync_esp && (
 						<>
-							<CheckboxControl
-								label={ __( 'Delete contact on reader deletion', 'newspack' ) }
-								help={ __(
-									"If the reader's email is verified, delete contact from ESP on reader deletion. ESP synchronization must be enabled.",
-									'newspack'
-								) }
-								{ ...getSharedProps( 'sync_esp_delete' ) }
-							/>
 							<TextControl
 								label={ __( 'Metadata field prefix', 'newspack' ) }
 								help={ __(

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -166,7 +166,7 @@ export default withWizardScreen( () => {
 					isMedium
 					title={ __( 'Reader Activation Campaign', 'newspack' ) }
 					description={ __(
-						'Building a set of prompts with default segments and settings optimized for Reader Activation allows for an improved reader experience around site registration, newsletter sign-up, and donation in order to drive industry-leading conversion rates.',
+						'Building a set of prompts with default segments and settings allows for an improved experience optimized for Reader Activation.',
 						'newspack'
 					) }
 					checkbox="unchecked"

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -152,8 +152,8 @@ export default withWizardScreen( () => {
 							prerequisites[ key ].href ? (
 								<Button isLink disabled={ inFlight } href={ prerequisites[ key ].href }>
 									{ prerequisites[ key ].active
-										? __( 'View configuration', 'newspack' )
-										: __( 'Configure', 'newspack' ) }
+										? __( 'View setup', 'newspack' )
+										: __( 'Set up', 'newspack' ) }
 								</Button>
 							) : null
 						}

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -246,6 +246,10 @@ const BillingFields = () => {
 
 	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
 
+	if ( ! wizardData.donation_data || 'errors' in wizardData.donation_data ) {
+		return null;
+	}
+
 	const changeHandler = path => value =>
 		updateWizardSettings( {
 			slug: 'newspack-reader-revenue-wizard',

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -155,6 +155,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-wc-memberships.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
 		include_once NEWSPACK_ABSPATH . 'includes/polyfills/class-amp-polyfills.php';

--- a/includes/plugins/class-wc-memberships.php
+++ b/includes/plugins/class-wc-memberships.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * WooCommerce Memberships integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class WC_Memberships {
+
+	const GATE_CPT = 'np_memberships_gate';
+
+	/**
+	 * Whether the gate has been rendered in this execution.
+	 *
+	 * @var boolean
+	 */
+	private static $gate_rendered = false;
+
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
+		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'admin_init', [ __CLASS__, 'redirect_cpt' ] );
+		add_action( 'admin_init', [ __CLASS__, 'handle_edit_gate' ] );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+		add_filter( 'wc_memberships_notice_html', [ __CLASS__, 'notice_html' ], 100 );
+		add_filter( 'wc_memberships_restricted_content_excerpt', [ __CLASS__, 'excerpt' ], 100, 3 );
+		add_action( 'wp_footer', [ __CLASS__, 'render_js' ] );
+		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
+	}
+
+	/**
+	 * Register post type for custom gate.
+	 */
+	public static function register_post_type() {
+		// Bail if Woo Memberships is not active.
+		if ( ! class_exists( 'WC_Memberships' ) ) {
+			return false;
+		}
+		\register_post_type(
+			self::GATE_CPT,
+			[
+				'label'        => __( 'Memberships Gate', 'newspack' ),
+				'labels'       => [
+					'item_published'         => __( 'Memberships Gate published.', 'newspack' ),
+					'item_reverted_to_draft' => __( 'Memberships Gate reverted to draft.', 'newspack' ),
+					'item_updated'           => __( 'Memberships Gate updated.', 'newspack' ),
+					'new_item'               => __( 'New Memberships Gate', 'newspack' ),
+					'edit_item'              => __( 'Edit Memberships Gate', 'newspack' ),
+					'view_item'              => __( 'View Memberships Gate', 'newspack' ),
+				],
+				'public'       => false,
+				'show_ui'      => true,
+				'show_in_menu' => false,
+				'show_in_rest' => true,
+				'supports'     => [ 'editor', 'custom-fields' ],
+			]
+		);
+	}
+
+	/**
+	 * Register gate meta.
+	 */
+	public static function register_meta() {
+		// Bail if Woo Memberships is not active.
+		if ( ! class_exists( 'WC_Memberships' ) ) {
+			return false;
+		}
+		\register_meta(
+			'post',
+			'style',
+			[
+				'object_subtype' => self::GATE_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'default'        => 'inline',
+				'single'         => true,
+			]
+		);
+		\register_meta(
+			'post',
+			'inline_fade',
+			[
+				'object_subtype' => self::GATE_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'boolean',
+				'default'        => true,
+				'single'         => true,
+			]
+		);
+		\register_meta(
+			'post',
+			'use_more_tag',
+			[
+				'object_subtype' => self::GATE_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'boolean',
+				'default'        => true,
+				'single'         => true,
+			]
+		);
+		\register_meta(
+			'post',
+			'visible_paragraphs',
+			[
+				'object_subtype' => self::GATE_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'integer',
+				'default'        => 2,
+				'single'         => true,
+			]
+		);
+	}
+
+	/**
+	 * Redirect the custom gate CPT to the Memberships wizard
+	 */
+	public static function redirect_cpt() {
+		global $pagenow;
+		if ( 'edit.php' === $pagenow && isset( $_GET['post_type'] ) && self::GATE_CPT === $_GET['post_type'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			\wp_safe_redirect( \admin_url( 'admin.php?page=newspack-engagement-wizard' ) );
+			exit;
+		}
+	}
+
+
+	/**
+	 * Enqueue block editor assets.
+	 */
+	public static function enqueue_block_editor_assets() {
+		if ( self::GATE_CPT !== get_post_type() ) {
+			return;
+		}
+		\wp_enqueue_script(
+			'newspack-memberships-gate',
+			Newspack::plugin_url() . '/dist/memberships-gate-editor.js',
+			[],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/memberships-gate-editor.js' ),
+			true
+		);
+		\wp_localize_script(
+			'newspack-memberships-gate',
+			'newspack_memberships_gate',
+			[
+				'has_campaigns' => class_exists( 'Newspack_Popups' ),
+			]
+		);
+
+		\wp_enqueue_style(
+			'newspack-memberships-gate',
+			Newspack::plugin_url() . '/dist/memberships-gate-editor.css',
+			[],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/memberships-gate-editor.css' )
+		);
+	}
+
+	/**
+	 * Set the post ID of the custom gate.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function set_gate_post_id( $post_id ) {
+		\update_option( 'newspack_memberships_gate_post_id', $post_id );
+	}
+
+	/**
+	 * Get the post ID of the custom gate.
+	 *
+	 * @return int|false Post ID or false if not set.
+	 */
+	public static function get_gate_post_id() {
+		$post_id = (int) \get_option( 'newspack_memberships_gate_post_id' );
+		return $post_id ? $post_id : false;
+	}
+
+	/**
+	 * Whether the gate is available.
+	 *
+	 * @return bool
+	 */
+	public static function has_gate() {
+		if ( ! class_exists( 'WC_Memberships' ) ) {
+			return false;
+		}
+		$post_id = self::get_gate_post_id();
+		return $post_id && 'publish' === get_post_status( $post_id );
+	}
+
+	/**
+	 * Whether the post is restricted for the current user.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return bool
+	 */
+	public static function is_post_restricted( $post_id = null ) {
+		if ( ! class_exists( 'WC_Memberships' ) ) {
+			return false;
+		}
+		if ( ! $post_id ) {
+			$post_id = get_the_ID();
+		}
+		if ( ! function_exists( 'wc_memberships_is_post_content_restricted' ) || ! wc_memberships_is_post_content_restricted( $post_id ) ) {
+			return false;
+		}
+		return ! is_user_logged_in() || ! current_user_can( 'wc_memberships_view_restricted_post_content', $post_id );
+	}
+
+	/**
+	 * Get the URL for editing the custom gate.
+	 */
+	public static function get_edit_gate_url() {
+		$action = 'newspack_edit_memberships_gate';
+		$url    = \add_query_arg( '_wpnonce', \wp_create_nonce( $action ), \admin_url( 'admin.php?action=' . $action ) );
+		return str_replace( \site_url(), '', $url );
+	}
+
+	/**
+	 * Create a post for the custom gate.
+	 */
+	public static function handle_edit_gate() {
+		if ( ! isset( $_GET['action'] ) || 'newspack_edit_memberships_gate' !== $_GET['action'] ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		check_admin_referer( 'newspack_edit_memberships_gate' );
+		$gate_post_id = self::get_gate_post_id();
+		if ( $gate_post_id && get_post( $gate_post_id ) ) {
+			// Untrash post if it's in the trash.
+			if ( 'trash' === get_post_status( $gate_post_id ) ) {
+				\wp_untrash_post( $gate_post_id );
+			}
+			// Gate found, edit it.
+			\wp_safe_redirect( \admin_url( 'post.php?post=' . $gate_post_id . '&action=edit' ) );
+			exit;
+		} else {
+			// Gate not found, create it.
+			$gate_post_id = \wp_insert_post(
+				[
+					'post_title'   => __( 'Memberships Gate', 'newspack' ),
+					'post_type'    => self::GATE_CPT,
+					'post_status'  => 'draft',
+					'post_content' => '<!-- wp:paragraph --><p>' . __( 'This post is only available to members.', 'newspack' ) . '</p><!-- /wp:paragraph -->',
+				]
+			);
+			if ( is_wp_error( $gate_post_id ) ) {
+				\wp_die( esc_html( $gate_post_id->get_error_message() ) );
+			}
+			self::set_gate_post_id( $gate_post_id );
+			\wp_safe_redirect( \admin_url( 'post.php?post=' . $gate_post_id . '&action=edit' ) );
+			exit;
+		}
+	}
+
+	/**
+	 * Filter the notice HTML.
+	 *
+	 * @param string $notice Notice HTML.
+	 */
+	public static function notice_html( $notice ) {
+		// If the gate is not available, don't mess with the notice.
+		if ( ! self::has_gate() ) {
+			return $notice;
+		}
+		// If rendering the content in a loop, don't render the gate.
+		if ( get_queried_object_id() !== get_the_ID() ) {
+			return '';
+		}
+		$gate_post_id = self::get_gate_post_id();
+		$style        = \get_post_meta( $gate_post_id, 'style', true );
+		if ( 'inline' === $style ) {
+			$notice = \apply_filters( 'the_content', \get_the_content( null, null, $gate_post_id ) );
+		} else {
+			$notice = '';
+		}
+		self::$gate_rendered = true;
+		return $notice;
+	}
+
+	/**
+	 * Filter the excerpt.
+	 *
+	 * @param string $excerpt      Excerpt.
+	 * @param object $post         Post object.
+	 * @param string $message_code Message code.
+	 *
+	 * @return string
+	 */
+	public static function excerpt( $excerpt, $post, $message_code ) {
+		// If the gate is not available, don't mess with the excerpt.
+		if ( ! self::has_gate() ) {
+			return $excerpt;
+		}
+		// If rendering the content in a loop, don't truncate the excerpt.
+		if ( get_queried_object_id() !== $post->ID ) {
+			return $excerpt;
+		}
+		$gate_post_id = self::get_gate_post_id();
+
+		$content = $post->post_content;
+
+		$use_more_tag = get_post_meta( $gate_post_id, 'use_more_tag', true );
+		// Use <!--more--> as threshold if it exists.
+		if ( $use_more_tag && strpos( $content, '<!--more-->' ) ) {
+			$content = explode( '<!--more-->', $content )[0];
+		} else {
+			$count = (int) get_post_meta( $gate_post_id, 'visible_paragraphs', true );
+			// Split into paragraphs.
+			$content = explode( '</p>', $content );
+			// Extract the first $x paragraphs only.
+			$content = array_slice( $content, 0, $count ?? 2 );
+			// Rejoin the paragraphs into a single string again.
+			$content = wp_kses_post( implode( '</p>', $content ) );
+		}
+
+		$excerpt = $content;
+
+		$style       = \get_post_meta( $gate_post_id, 'style', true );
+		$inline_fade = \get_post_meta( $gate_post_id, 'inline_fade', true );
+		if ( 'inline' === $style && $inline_fade ) {
+			$excerpt .= '<div style="pointer-events: none; height: 10em; margin-top: -10em; width: 100%; position: absolute; background: linear-gradient(180deg, rgba(255,255,255,0) 14%, rgba(255,255,255,1) 76%);"></div>';
+		}
+
+		return $excerpt;
+	}
+
+	/**
+	 * Render footer JS.
+	 *
+	 * If the gate was rendered, reload the page after 2 seconds in case RAS
+	 * detects a new reader. This allows the membership purchase to unlock the
+	 * content.
+	 */
+	public static function render_js() {
+		if ( ! self::$gate_rendered ) {
+			return;
+		}
+		?>
+		<script type="text/javascript">
+			window.newspackRAS = window.newspackRAS || [];
+			window.newspackRAS.push( function( ras ) {
+				ras.on( 'reader', function() {
+					setTimeout( function() {
+						window.location.reload();
+					}, 2000 );
+				} );
+			} );
+		</script>
+		<?php
+	}
+
+	/**
+	 * Disable popups if rendering a restricted post.
+	 *
+	 * @param bool $disabled Whether popups are disabled.
+	 *
+	 * @return bool
+	 */
+	public static function disable_popups( $disabled ) {
+		if ( self::has_gate() && self::is_post_restricted() ) {
+			return true;
+		}
+		return $disabled;
+	}
+}
+WC_Memberships::init();

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -276,10 +276,10 @@ final class Reader_Activation {
 	/**
 	 * Is the Newspack Newsletters plugin configured with an ESP?
 	 */
-	public static function is_newsletters_configured() {
+	public static function is_esp_configured() {
 		$newsletters_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-newsletters' );
 
-		return $newsletters_configuration_manager->is_configured();
+		return $newsletters_configuration_manager->is_esp_set_up();
 	}
 
 	/**
@@ -297,7 +297,7 @@ final class Reader_Activation {
 				'description' => __( 'Displaying Terms and Conditions on your site is necessary to allow readers to register and access their account.', 'newspack-plugin' ),
 			],
 			'esp'              => [
-				'active'      => self::is_newsletters_configured(),
+				'active'      => self::is_esp_configured(),
 				'label'       => __( 'Email Service Provider (ESP)', 'newspack' ),
 				'description' => __( 'Connecting your ESP with the right settings is necessary to register readers with their email addresses, send account related emails and newsletters.', 'newspack' ),
 				'href'        => \admin_url( '/admin.php?page=newspack-engagement-wizard#/newsletters' ),

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -166,7 +166,7 @@ final class Reader_Activation {
 	private static function get_settings_config() {
 		$settings_config = [
 			'enabled'                     => true,
-			'enabled_account_link'        => false,
+			'enabled_account_link'        => true,
 			'account_link_menu_locations' => [ 'tertiary-menu' ],
 			'newsletters_label'           => __( 'Subscribe to our newsletters:', 'newspack' ),
 			'terms_text'                  => __( 'By signing up, you agree to our Terms and Conditions.', 'newspack' ),
@@ -285,34 +285,45 @@ final class Reader_Activation {
 	/**
 	 * Get the status of the prerequisites for enabling reader activation.
 	 * TODO: Finalize the list of prerequisites and all copy.
+	 * TODO: Establish schema for input fields to be shown in expandable cards.
 	 *
 	 * @return array Array of prerequisites to complete.
 	 */
 	public static function get_prerequisites_status() {
 		$prerequisites = [
 			// TODO: Remove example prerequisite.
-			'example_slug' => [
+			'example_slug'     => [
 				'active'      => false,
 				'label'       => __( 'Example requirement', 'newspack' ),
 				'description' => __( 'Boilerplate config for inactive prerequisite.', 'newspack-plugin' ),
 			],
-			'woocommerce'  => [
-				'active'      => self::is_woocommerce_active(),
-				'label'       => __( 'WooCommerce', 'newspack' ),
-				'description' => __( 'WooCommerce and required plugin extensions.', 'newspack' ),
-				'href'        => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
+			'terms_conditions' => [
+				'active'      => false,
+				'label'       => __( 'Terms & Conditions', 'newspack' ),
+				'description' => __( 'Displaying Terms and Conditions on your site is necessary to allow readers to register and access their account.', 'newspack-plugin' ),
 			],
-			'esp'          => [
+			'esp'              => [
 				'active'      => self::is_newsletters_configured(),
-				'label'       => __( 'Newspack Newsletters', 'newspack' ),
-				'description' => __( 'Newspack Newsletters must be configured with a valid ESP connection.', 'newspack' ),
+				'label'       => __( 'Email Service Provider (ESP)', 'newspack' ),
+				'description' => __( 'Connecting your ESP with the right settings is necessary to register readers with their email addresses, send account related emails and newsletters.', 'newspack' ),
 				'href'        => \admin_url( '/admin.php?page=newspack-engagement-wizard#/newsletters' ),
 			],
-			'recaptcha'    => [
+			'emails'           => [
+				'active'      => false,
+				'label'       => __( 'Transactional Emails', 'newspack' ),
+				'description' => __( 'Boilerplate config for inactive prerequisite.', 'newspack-plugin' ),
+			],
+			'recaptcha'        => [
 				'active'      => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),
 				'label'       => __( 'reCAPTCHA', 'newspack' ),
-				'description' => __( 'A reCAPTCHA v3 connection is required to secure reader input forms.', 'newspack' ),
+				'description' => __( 'Connecting to a Google reCAPTCHA account enables enhanced anti-spam security for newsletter signup, user account, and payment forms rendered by Newspack tools.', 'newspack' ),
 				'href'        => \admin_url( '/admin.php?page=newspack-connections-wizard' ),
+			],
+			'reader_revenue'   => [
+				'active'      => self::is_woocommerce_active(),
+				'label'       => __( 'Reader Revenue', 'newspack' ),
+				'description' => __( 'Selecting WooCommerce as reader revenue platform and setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack' ),
+				'href'        => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
 			],
 		];
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -291,12 +291,6 @@ final class Reader_Activation {
 	 */
 	public static function get_prerequisites_status() {
 		$prerequisites = [
-			// TODO: Remove example prerequisite.
-			'example_slug'     => [
-				'active'      => false,
-				'label'       => __( 'Example requirement', 'newspack' ),
-				'description' => __( 'Boilerplate config for inactive prerequisite.', 'newspack-plugin' ),
-			],
 			'terms_conditions' => [
 				'active'      => false,
 				'label'       => __( 'Terms & Conditions', 'newspack' ),
@@ -311,7 +305,7 @@ final class Reader_Activation {
 			'emails'           => [
 				'active'      => false,
 				'label'       => __( 'Transactional Emails', 'newspack' ),
-				'description' => __( 'Boilerplate config for inactive prerequisite.', 'newspack-plugin' ),
+				'description' => __( 'Your sender name and email address determines how readers find emails related to their account in their inbox.', 'newspack-plugin' ),
 			],
 			'recaptcha'        => [
 				'active'      => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -274,6 +274,52 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Is the Newspack Newsletters plugin configured with an ESP?
+	 */
+	public static function is_newsletters_configured() {
+		$newsletters_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-newsletters' );
+
+		return $newsletters_configuration_manager->is_configured();
+	}
+
+	/**
+	 * Get the status of the prerequisites for enabling reader activation.
+	 * TODO: Finalize the list of prerequisites and all copy.
+	 *
+	 * @return array Array of prerequisites to complete.
+	 */
+	public static function get_prerequisites_status() {
+		$prerequisites = [
+			// TODO: Remove example prerequisite.
+			'example_slug' => [
+				'active'      => false,
+				'label'       => __( 'Example requirement', 'newspack' ),
+				'description' => __( 'Boilerplate config for inactive prerequisite.', 'newspack-plugin' ),
+			],
+			'woocommerce'  => [
+				'active'      => self::is_woocommerce_active(),
+				'label'       => __( 'WooCommerce', 'newspack' ),
+				'description' => __( 'WooCommerce and required plugin extensions.', 'newspack' ),
+				'href'        => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
+			],
+			'esp'          => [
+				'active'      => self::is_newsletters_configured(),
+				'label'       => __( 'Newspack Newsletters', 'newspack' ),
+				'description' => __( 'Newspack Newsletters must be configured with a valid ESP connection.', 'newspack' ),
+				'href'        => \admin_url( '/admin.php?page=newspack-engagement-wizard#/newsletters' ),
+			],
+			'recaptcha'    => [
+				'active'      => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),
+				'label'       => __( 'reCAPTCHA', 'newspack' ),
+				'description' => __( 'A reCAPTCHA v3 connection is required to secure reader input forms.', 'newspack' ),
+				'href'        => \admin_url( '/admin.php?page=newspack-connections-wizard' ),
+			],
+		];
+
+		return $prerequisites;
+	}
+
+	/**
 	 * Whether reader activation is enabled.
 	 *
 	 * @param bool $strict If true, check both the environment constant and the setting.

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -189,6 +189,18 @@ class Engagement_Wizard extends Wizard {
 	}
 
 	/**
+	 * Get memberships settings.
+	 *
+	 * @return array
+	 */
+	private static function get_memberships_settings() {
+		return [
+			'edit_gate_url' => WC_Memberships::get_edit_gate_url(),
+			'gate_status'   => get_post_status( WC_Memberships::get_gate_post_id() ),
+		];
+	}
+
+	/**
 	 * Get reader activation settings.
 	 *
 	 * @return WP_REST_Response
@@ -198,6 +210,7 @@ class Engagement_Wizard extends Wizard {
 			[
 				'config'               => Reader_Activation::get_settings(),
 				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
+				'memberships'          => self::get_memberships_settings(),
 			]
 		);
 	}
@@ -349,6 +362,7 @@ class Engagement_Wizard extends Wizard {
 
 		$data = [
 			'has_reader_activation' => defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) && NEWSPACK_EXPERIMENTAL_READER_ACTIVATION,
+			'has_memberships'       => class_exists( 'WC_Memberships' ),
 		];
 
 		if ( method_exists( 'Newspack\Newsletters\Subscription_Lists', 'get_add_new_url' ) ) {

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -196,8 +196,9 @@ class Engagement_Wizard extends Wizard {
 	public function api_get_reader_activation_settings() {
 		return rest_ensure_response(
 			[
-				'config'        => Reader_Activation::get_settings(),
-				'pluginsStatus' => Reader_Activation::is_woocommerce_active(),
+				'config'               => Reader_Activation::get_settings(),
+				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
+				'setup_complete'       => false, // TODO: Make this dynamic.
 			]
 		);
 	}

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -198,7 +198,6 @@ class Engagement_Wizard extends Wizard {
 			[
 				'config'               => Reader_Activation::get_settings(),
 				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
-				'setup_complete'       => false, // TODO: Make this dynamic.
 			]
 		);
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,7 @@ const webpackConfig = getBaseWebpackConfig(
 			),
 			'my-account': path.join( __dirname, 'includes', 'reader-revenue', 'my-account', 'index.js' ),
 			admin: path.join( __dirname, 'assets', 'admin', 'index.js' ),
+			'memberships-gate-editor': path.join( __dirname, 'assets', 'memberships-gate', 'editor.js' ),
 		},
 	}
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Scaffolds a new page layout for the RAS settings page according to the latest i2 designs. The list of prerequisites and all copy/links are TBD, so this PR contains a list of a few known requirements and a boilerplate config object to serve as a template to add more.

Because discussions are ongoing about what to do about the existing RAS settings on this page, these are simply hidden behind an "advanced settings" flag to show/hide those settings. This advanced settings section will need to be redesigned in a future PR.

The `ActionCard` component to kick off the Campaigns default prompts/segments setup is a placeholder, and is non-interactive for now.

### How to test the changes in this Pull Request:

1. Visit the **Newspack > Engagement > Reader Activation** admin page and ensure that the prerequisites are shown according to the config array in `includes/reader-activation/class-reader-activation.php` and that all the links and buttons work. Feel free to copy the existing config objects and create your own to test different scenarios. This is the state of the page before all RAS prerequisites are completed:

<img width="1195" alt="Screen Shot 2023-03-29 at 3 10 49 PM" src="https://user-images.githubusercontent.com/2230142/228668398-c673668c-3544-4895-ba31-52a8188c269a.png">

2. Open the Advanced Settings section and ensure that all of these settings options still work as in `master`, for now. Note that some fields have been removed based on discussions that they should always be set one way or another if RAS is enabled. This section will need to be redesigned in a future PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->