### PR TITLE
fix: Avoid falal error on Reader Revenue wizard

### DIFF
--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -246,6 +246,10 @@ const BillingFields = () => {
 
 	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
 
+	if ( ! wizardData.donation_data || 'errors' in wizardData.donation_data ) {
+		return null;
+	}
+
 	const changeHandler = path => value =>
 		updateWizardSettings( {
 			slug: 'newspack-reader-revenue-wizard',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a check to avoid the wizard to break if the site is in a specific state.

### How to test the changes in this Pull Request:

I don't really know how to reproduce the state in which the site would error without this fix, but I do have a database dump that reproduces it. Ask me if you want it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->