### PR TITLE
Improved handling of trial subscriptions in ESP sync

### DIFF
--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -229,7 +229,7 @@ class Stripe_Sync {
 					$subscription['start_date']
 				);
 				$metadata                   = array_merge( $recurring_related_metadata, $metadata );
-				if ( ! in_array( $subscription['status'], [ 'active', 'trialing' ] ) ) {
+				if ( ! in_array( $subscription['status'], [ 'active', 'trialing' ], true ) ) {
 					$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Ex-' . $membership_status;
 				}
 				if ( $subscription['ended_at'] ) {

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -212,7 +212,15 @@ class Stripe_Sync {
 				}
 			}
 
-			$subscription = Stripe_Connection::get_subscription_from_payment( $payment );
+			// Check if there are any active subscriptions.
+			$subscriptions = Stripe_Connection::get_subscriptions_of_customer( $customer->id );
+			if ( ! empty( $subscriptions['data'] ) ) {
+				$subscription = reset( $subscriptions['data'] );
+			} else {
+				// If there are no active subscriptions, see if there used to be a subscription.
+				$subscription = Stripe_Connection::get_subscription_from_payment( $payment );
+			}
+
 			if ( $subscription ) {
 				$recurring_related_metadata = Stripe_Connection::create_recurring_payment_metadata(
 					$frequency,
@@ -221,7 +229,7 @@ class Stripe_Sync {
 					$subscription['start_date']
 				);
 				$metadata                   = array_merge( $recurring_related_metadata, $metadata );
-				if ( 'active' !== $subscription['status'] ) {
+				if ( ! in_array( $subscription['status'], [ 'active', 'trialing' ] ) ) {
 					$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Ex-' . $membership_status;
 				}
 				if ( $subscription['ended_at'] ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [this issue](https://app.asana.com/0/1200133283755575/1204276644179086)

After running [the command](https://github.com/Automattic/newspack-plugin/blob/fix/trial-sync/includes/reader-revenue/stripe/class-stripe-sync.php#L712) to cancel Stripe subscriptions and re-create them as Stripe Donate Block subscriptions, the re-created subscriptions are in 'trialing' status until their next renewal date in Stripe (so we don't charge the customers until they would normally have been charged). 

Then, when we run [the ESP backfill command](https://github.com/Automattic/newspack-plugin/blob/fix/trial-sync/includes/reader-revenue/stripe/class-stripe-sync.php#L684), these customers incorrectly show up in the ESP with the 'Ex-Monthly Donor' or 'Ex-Yearly Donor' status because the backfill checks the subscription associated with the last payment, but that subscription was cancelled by the first command. 

This PR adjusts the logic a little to prevent this situation.

### How to test the changes in this Pull Request:

1. Set up Reader Revenue with the legacy Stripe platform and connect it to ActiveCampaign.
2. Before applying this PR, make a monthly donation. Run `wp newspack stripe sync-stripe-connect-to-stripe`. In Stripe you should now see that the previous Stripe subscription was cancelled and there is a new active trialing subscription in its place:

<img width="1463" alt="Screenshot 2023-03-31 at 1 42 52 PM" src="https://user-images.githubusercontent.com/7317227/229226036-ba19ac8d-2263-4d65-aa17-4164353d8dc5.png">
<img width="1456" alt="Screenshot 2023-03-31 at 1 42 45 PM" src="https://user-images.githubusercontent.com/7317227/229226042-863bbe25-25ab-46ea-aceb-dc69ba698a33.png">

4. Run `wp newspack stripe sync-customers --sync-to-wc=0 --sync-to-esp=1`. In ActiveCampaign you should see the donor and the status should say 'Ex-Monthly Donor' (though the customer has an active subscription in trial):

<img width="507" alt="Screenshot 2023-03-31 at 1 20 58 PM" src="https://user-images.githubusercontent.com/7317227/229226472-6905124d-d849-4bcf-af8e-672281709850.png">

5. Apply this patch. Run `wp newspack stripe sync-customers --sync-to-wc=0 --sync-to-esp=1`. In ActiveCampaign you should now see the correct status as 'Monthly Donor':

<img width="465" alt="Screenshot 2023-03-31 at 1 33 14 PM" src="https://user-images.githubusercontent.com/7317227/229226677-95de3298-4053-4d7c-a450-9eac55f2c645.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->