### PR TITLE
feat: update RAS settings layout to i3 designs

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { Icon, check, chevronDown, chevronUp } from '@wordpress/icons';
 
@@ -20,198 +20,203 @@ import './style.scss';
  */
 import classnames from 'classnames';
 
-const ActionCard = props => {
-	const [ expanded, setExpanded ] = useState( false );
-	const {
-		badge,
-		className,
-		checkbox,
-		children,
-		disabled,
-		title,
-		description,
-		handoff,
-		editLink,
-		href,
-		notification,
-		notificationLevel,
-		notificationHTML,
-		actionContent,
-		actionText,
-		secondaryActionText,
-		secondaryDestructive,
-		image,
-		imageLink,
-		indent,
-		isSmall,
-		isMedium,
-		simple,
-		onClick,
-		onSecondaryActionClick,
-		isWaiting,
-		titleLink,
-		toggleChecked,
-		toggleOnChange,
-		hasGreyHeader,
-		isPending,
-		expandable = false,
-		collapse = false,
-	} = props;
-
-	useEffect( () => {
-		// If the card is expanded and the collapse prop is true, collapse the card.
-		if ( collapse && expanded ) {
-			setExpanded( false );
-		}
-	}, [ collapse ] );
-
-	const hasChildren = notification || children;
-	const classes = classnames(
-		'newspack-action-card',
-		simple && 'newspack-card--is-clickable',
-		hasGreyHeader && 'newspack-card--has-grey-header',
-		hasChildren && 'newspack-card--has-children',
-		indent && 'newspack-card--indent',
-		isSmall && 'is-small',
-		isMedium && 'is-medium',
-		checkbox && 'has-checkbox',
-		expandable && 'is-expandable',
-		className
-	);
-	const backgroundImageStyles = url => {
-		return url ? { backgroundImage: `url(${ url })` } : {};
+class ActionCard extends Component {
+	state = {
+		expanded: false,
 	};
-	const titleProps =
-		toggleOnChange && ! titleLink && ! disabled
-			? { onClick: () => toggleOnChange( ! toggleChecked ), tabIndex: '0' }
-			: {};
-	const hasInternalLink = href && href.indexOf( 'http' ) !== 0;
-	const isDisplayingSecondaryAction = secondaryActionText && onSecondaryActionClick;
-	const badges = ! Array.isArray( badge ) && badge ? [ badge ] : badge;
-	return (
-		<Card className={ classes } onClick={ simple && onClick }>
-			<div className="newspack-action-card__region newspack-action-card__region-top">
-				{ toggleOnChange && (
-					<ToggleControl
-						checked={ toggleChecked }
-						onChange={ toggleOnChange }
-						disabled={ disabled }
-					/>
-				) }
-				{ image && ! toggleOnChange && (
-					<div className="newspack-action-card__region newspack-action-card__region-left">
-						<a href={ imageLink }>
-							<div
-								className="newspack-action-card__image"
-								style={ backgroundImageStyles( image ) }
-							/>
-						</a>
-					</div>
-				) }
-				{ checkbox && ! toggleOnChange && (
-					<div className="newspack-action-card__region newspack-action-card__region-left">
-						<span
-							className={ classnames(
-								'newspack-checkbox-icon',
-								'is-primary',
-								'checked' === checkbox && 'newspack-checkbox-icon--checked',
-								isPending && 'newspack-checkbox-icon--pending'
-							) }
-						>
-							{ 'checked' === checkbox && <Icon icon={ check } /> }
-						</span>
-					</div>
-				) }
-				<div className="newspack-action-card__region newspack-action-card__region-center">
-					<Grid columns={ 1 } gutter={ 8 } noMargin>
-						<h2>
-							<span className="newspack-action-card__title" { ...titleProps }>
-								{ titleLink ? <a href={ titleLink }>{ title }</a> : title }
+
+	componentDidUpdate() {
+		if ( this.props.collapse && this.state.expanded ) {
+			this.setState( { expanded: false } );
+		}
+	}
+
+	render() {
+		const {
+			badge,
+			className,
+			checkbox,
+			children,
+			disabled,
+			title,
+			description,
+			handoff,
+			editLink,
+			href,
+			notification,
+			notificationLevel,
+			notificationHTML,
+			actionContent,
+			actionText,
+			secondaryActionText,
+			secondaryDestructive,
+			image,
+			imageLink,
+			indent,
+			isSmall,
+			isMedium,
+			simple,
+			onClick,
+			onSecondaryActionClick,
+			isWaiting,
+			titleLink,
+			toggleChecked,
+			toggleOnChange,
+			hasGreyHeader,
+			isPending,
+			expandable = false,
+		} = this.props;
+
+		const { expanded } = this.state;
+
+		const hasChildren = notification || children;
+		const classes = classnames(
+			'newspack-action-card',
+			simple && 'newspack-card--is-clickable',
+			hasGreyHeader && 'newspack-card--has-grey-header',
+			hasChildren && 'newspack-card--has-children',
+			indent && 'newspack-card--indent',
+			isSmall && 'is-small',
+			isMedium && 'is-medium',
+			checkbox && 'has-checkbox',
+			expandable && 'is-expandable',
+			className
+		);
+		const backgroundImageStyles = url => {
+			return url ? { backgroundImage: `url(${ url })` } : {};
+		};
+		const titleProps =
+			toggleOnChange && ! titleLink && ! disabled
+				? { onClick: () => toggleOnChange( ! toggleChecked ), tabIndex: '0' }
+				: {};
+		const hasInternalLink = href && href.indexOf( 'http' ) !== 0;
+		const isDisplayingSecondaryAction = secondaryActionText && onSecondaryActionClick;
+		const badges = ! Array.isArray( badge ) && badge ? [ badge ] : badge;
+		return (
+			<Card className={ classes } onClick={ simple && onClick }>
+				<div className="newspack-action-card__region newspack-action-card__region-top">
+					{ toggleOnChange && (
+						<ToggleControl
+							checked={ toggleChecked }
+							onChange={ toggleOnChange }
+							disabled={ disabled }
+						/>
+					) }
+					{ image && ! toggleOnChange && (
+						<div className="newspack-action-card__region newspack-action-card__region-left">
+							<a href={ imageLink }>
+								<div
+									className="newspack-action-card__image"
+									style={ backgroundImageStyles( image ) }
+								/>
+							</a>
+						</div>
+					) }
+					{ checkbox && ! toggleOnChange && (
+						<div className="newspack-action-card__region newspack-action-card__region-left">
+							<span
+								className={ classnames(
+									'newspack-checkbox-icon',
+									'is-primary',
+									'checked' === checkbox && 'newspack-checkbox-icon--checked',
+									isPending && 'newspack-checkbox-icon--pending'
+								) }
+							>
+								{ 'checked' === checkbox && <Icon icon={ check } /> }
 							</span>
-							{ badges?.length &&
-								badges.map( ( badgeText, i ) => (
-									<span key={ `badge-${ i }` } className="newspack-action-card__badge">
-										{ badgeText }
-									</span>
+						</div>
+					) }
+					<div className="newspack-action-card__region newspack-action-card__region-center">
+						<Grid columns={ 1 } gutter={ 8 } noMargin>
+							<h2>
+								<span className="newspack-action-card__title" { ...titleProps }>
+									{ titleLink ? <a href={ titleLink }>{ title }</a> : title }
+								</span>
+								{ badges?.length &&
+									badges.map( ( badgeText, i ) => (
+										<span key={ `badge-${ i }` } className="newspack-action-card__badge">
+											{ badgeText }
+										</span>
+									) ) }
+							</h2>
+							{ description && (
+								<p>
+									{ typeof description === 'string' && description }
+									{ typeof description === 'function' && description() }
+								</p>
+							) }
+						</Grid>
+					</div>
+					{ ! expandable && ( actionText || isDisplayingSecondaryAction || actionContent ) && (
+						<div className="newspack-action-card__region newspack-action-card__region-right">
+							{ /* eslint-disable no-nested-ternary */ }
+							{ actionContent && actionContent }
+							{ actionText &&
+								( handoff ? (
+									<Handoff plugin={ handoff } editLink={ editLink } compact isLink>
+										{ actionText }
+									</Handoff>
+								) : onClick || hasInternalLink ? (
+									<Button
+										isLink
+										href={ href }
+										onClick={ onClick }
+										className="newspack-action-card__primary_button"
+									>
+										{ actionText }
+									</Button>
+								) : href ? (
+									<ExternalLink href={ href } className="newspack-action-card__primary_button">
+										{ actionText }
+									</ExternalLink>
+								) : (
+									<div className="newspack-action-card__container">
+										{ actionText }
+										{ isWaiting && <Waiting isRight /> }
+									</div>
 								) ) }
-						</h2>
-						{ description && (
-							<p>
-								{ typeof description === 'string' && description }
-								{ typeof description === 'function' && description() }
-							</p>
-						) }
-					</Grid>
-				</div>
-				{ ! expandable && ( actionText || isDisplayingSecondaryAction || actionContent ) && (
-					<div className="newspack-action-card__region newspack-action-card__region-right">
-						{ /* eslint-disable no-nested-ternary */ }
-						{ actionContent && actionContent }
-						{ actionText &&
-							( handoff ? (
-								<Handoff plugin={ handoff } editLink={ editLink } compact isLink>
-									{ actionText }
-								</Handoff>
-							) : onClick || hasInternalLink ? (
+							{ /* eslint-enable no-nested-ternary */ }
+							{ isDisplayingSecondaryAction && (
 								<Button
 									isLink
-									href={ href }
-									onClick={ onClick }
-									className="newspack-action-card__primary_button"
+									onClick={ onSecondaryActionClick }
+									className="newspack-action-card__secondary_button"
+									isDestructive={ secondaryDestructive }
 								>
-									{ actionText }
+									{ secondaryActionText }
 								</Button>
-							) : href ? (
-								<ExternalLink href={ href } className="newspack-action-card__primary_button">
-									{ actionText }
-								</ExternalLink>
-							) : (
-								<div className="newspack-action-card__container">
-									{ actionText }
-									{ isWaiting && <Waiting isRight /> }
-								</div>
-							) ) }
-						{ /* eslint-enable no-nested-ternary */ }
-						{ isDisplayingSecondaryAction && (
-							<Button
-								isLink
-								onClick={ onSecondaryActionClick }
-								className="newspack-action-card__secondary_button"
-								isDestructive={ secondaryDestructive }
-							>
-								{ secondaryActionText }
-							</Button>
+							) }
+						</div>
+					) }
+					{ expandable && (
+						<Button onClick={ () => this.setState( { expanded: ! expanded } ) }>
+							<Icon icon={ expanded ? chevronUp : chevronDown } height={ 24 } width={ 24 } />
+						</Button>
+					) }
+				</div>
+				{ notification && (
+					<div className="newspack-action-card__notification newspack-action-card__region-children">
+						{ 'error' === notificationLevel && (
+							<Notice noticeText={ notification } isError rawHTML={ notificationHTML } />
+						) }
+						{ 'info' === notificationLevel && (
+							<Notice noticeText={ notification } rawHTML={ notificationHTML } />
+						) }
+						{ 'success' === notificationLevel && (
+							<Notice noticeText={ notification } isSuccess rawHTML={ notificationHTML } />
+						) }
+						{ 'warning' === notificationLevel && (
+							<Notice noticeText={ notification } isWarning rawHTML={ notificationHTML } />
 						) }
 					</div>
 				) }
-				{ expandable && (
-					<Button onClick={ () => setExpanded( ! expanded ) }>
-						<Icon icon={ expanded ? chevronUp : chevronDown } height={ 24 } width={ 24 } />
-					</Button>
+				{ children && ( ( expandable && expanded ) || ! expandable ) && (
+					<div className="newspack-action-card__region-children">{ children }</div>
 				) }
-			</div>
-			{ notification && (
-				<div className="newspack-action-card__notification newspack-action-card__region-children">
-					{ 'error' === notificationLevel && (
-						<Notice noticeText={ notification } isError rawHTML={ notificationHTML } />
-					) }
-					{ 'info' === notificationLevel && (
-						<Notice noticeText={ notification } rawHTML={ notificationHTML } />
-					) }
-					{ 'success' === notificationLevel && (
-						<Notice noticeText={ notification } isSuccess rawHTML={ notificationHTML } />
-					) }
-					{ 'warning' === notificationLevel && (
-						<Notice noticeText={ notification } isWarning rawHTML={ notificationHTML } />
-					) }
-				</div>
-			) }
-			{ children && ( ( expandable && expanded ) || ! expandable ) && (
-				<div className="newspack-action-card__region-children">{ children }</div>
-			) }
-		</Card>
-	);
-};
+			</Card>
+		);
+	}
+}
 
 ActionCard.defaultProps = {
 	toggleChecked: false,

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -25,12 +25,18 @@ class ActionCard extends Component {
 		expanded: false,
 	};
 
-	componentDidUpdate() {
-		if ( this.props.collapse && this.state.expanded ) {
+	/**
+	 * When the collapse prop is updated to true, collapse the card if already expanded.
+	 */
+	componentDidUpdate( prevProps ) {
+		if ( ! prevProps.collapse && this.props.collapse && this.state.expanded ) {
 			this.setState( { expanded: false } );
 		}
 	}
 
+	/**
+	 * Render.
+	 */
 	render() {
 		const {
 			badge,
@@ -68,6 +74,8 @@ class ActionCard extends Component {
 		} = this.props;
 
 		const { expanded } = this.state;
+
+		console.log( this.props, expanded );
 
 		const hasChildren = notification || children;
 		const classes = classnames(

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -65,6 +65,7 @@ const ActionCard = props => {
 		indent && 'newspack-card--indent',
 		isSmall && 'is-small',
 		isMedium && 'is-medium',
+		checkbox && 'has-checkbox',
 		expandable && 'is-expandable',
 		className
 	);

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -5,9 +5,9 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { ExternalLink, ToggleControl } from '@wordpress/components';
-import { Icon, check } from '@wordpress/icons';
+import { Icon, check, chevronDown, chevronUp } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -20,184 +20,188 @@ import './style.scss';
  */
 import classnames from 'classnames';
 
-class ActionCard extends Component {
-	backgroundImageStyles = url => {
+const ActionCard = props => {
+	const [ expanded, setExpanded ] = useState( false );
+	const {
+		badge,
+		className,
+		checkbox,
+		children,
+		disabled,
+		title,
+		description,
+		handoff,
+		editLink,
+		href,
+		notification,
+		notificationLevel,
+		notificationHTML,
+		actionContent,
+		actionText,
+		secondaryActionText,
+		secondaryDestructive,
+		image,
+		imageLink,
+		indent,
+		isSmall,
+		isMedium,
+		simple,
+		onClick,
+		onSecondaryActionClick,
+		isWaiting,
+		titleLink,
+		toggleChecked,
+		toggleOnChange,
+		hasGreyHeader,
+		isPending,
+		expandable = false,
+	} = props;
+	const hasChildren = notification || children;
+	const classes = classnames(
+		'newspack-action-card',
+		simple && 'newspack-card--is-clickable',
+		hasGreyHeader && 'newspack-card--has-grey-header',
+		hasChildren && 'newspack-card--has-children',
+		indent && 'newspack-card--indent',
+		isSmall && 'is-small',
+		isMedium && 'is-medium',
+		expandable && 'is-expandable',
+		className
+	);
+	const backgroundImageStyles = url => {
 		return url ? { backgroundImage: `url(${ url })` } : {};
 	};
-
-	/**
-	 * Render
-	 */
-	render() {
-		const {
-			badge,
-			className,
-			checkbox,
-			children,
-			disabled,
-			title,
-			description,
-			handoff,
-			editLink,
-			href,
-			notification,
-			notificationLevel,
-			notificationHTML,
-			actionContent,
-			actionText,
-			secondaryActionText,
-			secondaryDestructive,
-			image,
-			imageLink,
-			indent,
-			isSmall,
-			isMedium,
-			simple,
-			onClick,
-			onSecondaryActionClick,
-			isWaiting,
-			titleLink,
-			toggleChecked,
-			toggleOnChange,
-			hasGreyHeader,
-			isPending,
-		} = this.props;
-		const hasChildren = notification || children;
-		const classes = classnames(
-			'newspack-action-card',
-			simple && 'newspack-card--is-clickable',
-			hasGreyHeader && 'newspack-card--has-grey-header',
-			hasChildren && 'newspack-card--has-children',
-			indent && 'newspack-card--indent',
-			isSmall && 'is-small',
-			isMedium && 'is-medium',
-			className
-		);
-		const titleProps =
-			toggleOnChange && ! titleLink && ! disabled
-				? { onClick: () => toggleOnChange( ! toggleChecked ), tabIndex: '0' }
-				: {};
-		const hasInternalLink = href && href.indexOf( 'http' ) !== 0;
-		const isDisplayingSecondaryAction = secondaryActionText && onSecondaryActionClick;
-		const badges = ! Array.isArray( badge ) && badge ? [ badge ] : badge;
-		return (
-			<Card className={ classes } onClick={ simple && onClick }>
-				<div className="newspack-action-card__region newspack-action-card__region-top">
-					{ toggleOnChange && (
-						<ToggleControl
-							checked={ toggleChecked }
-							onChange={ toggleOnChange }
-							disabled={ disabled }
-						/>
-					) }
-					{ image && ! toggleOnChange && (
-						<div className="newspack-action-card__region newspack-action-card__region-left">
-							<a href={ imageLink }>
-								<div
-									className="newspack-action-card__image"
-									style={ this.backgroundImageStyles( image ) }
-								/>
-							</a>
-						</div>
-					) }
-					{ checkbox && ! toggleOnChange && (
-						<div className="newspack-action-card__region newspack-action-card__region-left">
-							<span
-								className={ classnames(
-									'newspack-checkbox-icon',
-									'is-primary',
-									'checked' === checkbox && 'newspack-checkbox-icon--checked',
-									isPending && 'newspack-checkbox-icon--pending'
-								) }
-							>
-								{ 'checked' === checkbox && <Icon icon={ check } /> }
-							</span>
-						</div>
-					) }
-					<div className="newspack-action-card__region newspack-action-card__region-center">
-						<Grid columns={ 1 } gutter={ 8 } noMargin>
-							<h2>
-								<span className="newspack-action-card__title" { ...titleProps }>
-									{ titleLink ? <a href={ titleLink }>{ title }</a> : title }
-								</span>
-								{ badges?.length &&
-									badges.map( ( badgeText, i ) => (
-										<span key={ `badge-${ i }` } className="newspack-action-card__badge">
-											{ badgeText }
-										</span>
-									) ) }
-							</h2>
-							{ description && (
-								<p>
-									{ typeof description === 'string' && description }
-									{ typeof description === 'function' && description() }
-								</p>
-							) }
-						</Grid>
+	const titleProps =
+		toggleOnChange && ! titleLink && ! disabled
+			? { onClick: () => toggleOnChange( ! toggleChecked ), tabIndex: '0' }
+			: {};
+	const hasInternalLink = href && href.indexOf( 'http' ) !== 0;
+	const isDisplayingSecondaryAction = secondaryActionText && onSecondaryActionClick;
+	const badges = ! Array.isArray( badge ) && badge ? [ badge ] : badge;
+	return (
+		<Card className={ classes } onClick={ simple && onClick }>
+			<div className="newspack-action-card__region newspack-action-card__region-top">
+				{ toggleOnChange && (
+					<ToggleControl
+						checked={ toggleChecked }
+						onChange={ toggleOnChange }
+						disabled={ disabled }
+					/>
+				) }
+				{ image && ! toggleOnChange && (
+					<div className="newspack-action-card__region newspack-action-card__region-left">
+						<a href={ imageLink }>
+							<div
+								className="newspack-action-card__image"
+								style={ backgroundImageStyles( image ) }
+							/>
+						</a>
 					</div>
-					{ ( actionText || isDisplayingSecondaryAction || actionContent ) && (
-						<div className="newspack-action-card__region newspack-action-card__region-right">
-							{ /* eslint-disable no-nested-ternary */ }
-							{ actionContent && actionContent }
-							{ actionText &&
-								( handoff ? (
-									<Handoff plugin={ handoff } editLink={ editLink } compact isLink>
-										{ actionText }
-									</Handoff>
-								) : onClick || hasInternalLink ? (
-									<Button
-										isLink
-										href={ href }
-										onClick={ onClick }
-										className="newspack-action-card__primary_button"
-									>
-										{ actionText }
-									</Button>
-								) : href ? (
-									<ExternalLink href={ href } className="newspack-action-card__primary_button">
-										{ actionText }
-									</ExternalLink>
-								) : (
-									<div className="newspack-action-card__container">
-										{ actionText }
-										{ isWaiting && <Waiting isRight /> }
-									</div>
+				) }
+				{ checkbox && ! toggleOnChange && (
+					<div className="newspack-action-card__region newspack-action-card__region-left">
+						<span
+							className={ classnames(
+								'newspack-checkbox-icon',
+								'is-primary',
+								'checked' === checkbox && 'newspack-checkbox-icon--checked',
+								isPending && 'newspack-checkbox-icon--pending'
+							) }
+						>
+							{ 'checked' === checkbox && <Icon icon={ check } /> }
+						</span>
+					</div>
+				) }
+				<div className="newspack-action-card__region newspack-action-card__region-center">
+					<Grid columns={ 1 } gutter={ 8 } noMargin>
+						<h2>
+							<span className="newspack-action-card__title" { ...titleProps }>
+								{ titleLink ? <a href={ titleLink }>{ title }</a> : title }
+							</span>
+							{ badges?.length &&
+								badges.map( ( badgeText, i ) => (
+									<span key={ `badge-${ i }` } className="newspack-action-card__badge">
+										{ badgeText }
+									</span>
 								) ) }
-							{ /* eslint-enable no-nested-ternary */ }
-							{ isDisplayingSecondaryAction && (
+						</h2>
+						{ description && (
+							<p>
+								{ typeof description === 'string' && description }
+								{ typeof description === 'function' && description() }
+							</p>
+						) }
+					</Grid>
+				</div>
+				{ ! expandable && ( actionText || isDisplayingSecondaryAction || actionContent ) && (
+					<div className="newspack-action-card__region newspack-action-card__region-right">
+						{ /* eslint-disable no-nested-ternary */ }
+						{ actionContent && actionContent }
+						{ actionText &&
+							( handoff ? (
+								<Handoff plugin={ handoff } editLink={ editLink } compact isLink>
+									{ actionText }
+								</Handoff>
+							) : onClick || hasInternalLink ? (
 								<Button
 									isLink
-									onClick={ onSecondaryActionClick }
-									className="newspack-action-card__secondary_button"
-									isDestructive={ secondaryDestructive }
+									href={ href }
+									onClick={ onClick }
+									className="newspack-action-card__primary_button"
 								>
-									{ secondaryActionText }
+									{ actionText }
 								</Button>
-							) }
-						</div>
-					) }
-				</div>
-				{ notification && (
-					<div className="newspack-action-card__notification newspack-action-card__region-children">
-						{ 'error' === notificationLevel && (
-							<Notice noticeText={ notification } isError rawHTML={ notificationHTML } />
-						) }
-						{ 'info' === notificationLevel && (
-							<Notice noticeText={ notification } rawHTML={ notificationHTML } />
-						) }
-						{ 'success' === notificationLevel && (
-							<Notice noticeText={ notification } isSuccess rawHTML={ notificationHTML } />
-						) }
-						{ 'warning' === notificationLevel && (
-							<Notice noticeText={ notification } isWarning rawHTML={ notificationHTML } />
+							) : href ? (
+								<ExternalLink href={ href } className="newspack-action-card__primary_button">
+									{ actionText }
+								</ExternalLink>
+							) : (
+								<div className="newspack-action-card__container">
+									{ actionText }
+									{ isWaiting && <Waiting isRight /> }
+								</div>
+							) ) }
+						{ /* eslint-enable no-nested-ternary */ }
+						{ isDisplayingSecondaryAction && (
+							<Button
+								isLink
+								onClick={ onSecondaryActionClick }
+								className="newspack-action-card__secondary_button"
+								isDestructive={ secondaryDestructive }
+							>
+								{ secondaryActionText }
+							</Button>
 						) }
 					</div>
 				) }
-				{ children && <div className="newspack-action-card__region-children">{ children }</div> }
-			</Card>
-		);
-	}
-}
+				{ expandable && (
+					<Button onClick={ () => setExpanded( ! expanded ) }>
+						<Icon icon={ expanded ? chevronUp : chevronDown } height={ 24 } width={ 24 } />
+					</Button>
+				) }
+			</div>
+			{ notification && (
+				<div className="newspack-action-card__notification newspack-action-card__region-children">
+					{ 'error' === notificationLevel && (
+						<Notice noticeText={ notification } isError rawHTML={ notificationHTML } />
+					) }
+					{ 'info' === notificationLevel && (
+						<Notice noticeText={ notification } rawHTML={ notificationHTML } />
+					) }
+					{ 'success' === notificationLevel && (
+						<Notice noticeText={ notification } isSuccess rawHTML={ notificationHTML } />
+					) }
+					{ 'warning' === notificationLevel && (
+						<Notice noticeText={ notification } isWarning rawHTML={ notificationHTML } />
+					) }
+				</div>
+			) }
+			{ children && ( ( expandable && expanded ) || ! expandable ) && (
+				<div className="newspack-action-card__region-children">{ children }</div>
+			) }
+		</Card>
+	);
+};
 
 ActionCard.defaultProps = {
 	toggleChecked: false,

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -75,8 +75,6 @@ class ActionCard extends Component {
 
 		const { expanded } = this.state;
 
-		console.log( this.props, expanded );
-
 		const hasChildren = notification || children;
 		const classes = classnames(
 			'newspack-action-card',

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { Icon, check, chevronDown, chevronUp } from '@wordpress/icons';
 
@@ -55,7 +55,16 @@ const ActionCard = props => {
 		hasGreyHeader,
 		isPending,
 		expandable = false,
+		collapse = false,
 	} = props;
+
+	useEffect( () => {
+		// If the card is expanded and the collapse prop is true, collapse the card.
+		if ( collapse && expanded ) {
+			setExpanded( false );
+		}
+	}, [ collapse ] );
+
 	const hasChildren = notification || children;
 	const classes = classnames(
 		'newspack-action-card',

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -393,6 +393,19 @@
 		font-style: italic;
 	}
 
+	// Expandable card children
+
+	&.is-expandable {
+		.newspack-action-card__region-children {
+			border-top: 1px solid wp-colors.$gray-200;
+			padding-top: 24px;
+		}
+
+		&.is-medium .newspack-action-card__region-children {
+			padding-top: 32px;
+		}
+	}
+
 	// Multiple Cards
 
 	& + & {

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -404,6 +404,20 @@
 		&.is-medium .newspack-action-card__region-children {
 			padding-top: 32px;
 		}
+
+		&.has-checkbox {
+			.newspack-action-card__region-children {
+				padding-left: 72px;
+			}
+
+			&.is-small .newspack-action-card__region-children {
+				padding-left: 64px;
+			}
+
+			&.is-medium .newspack-action-card__region-children {
+				padding-left: 56px;
+			}
+		}
 	}
 
 	// Multiple Cards

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -397,7 +397,7 @@
 
 	&.is-expandable {
 		.newspack-action-card__region-children {
-			border-top: 1px solid wp-colors.$gray-200;
+			border-top: 1px solid wp-colors.$gray-100;
 			padding-top: 24px;
 		}
 

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -433,6 +433,16 @@ class ComponentsDemo extends Component {
 						handoff="jetpack"
 						editLink="admin.php?page=jetpack#/settings"
 					/>
+					<ActionCard
+						expandable
+						title={ __( 'Expandable', 'newspack' ) }
+						description={ __(
+							' An example of an action card with expandable inner content.',
+							'newspack'
+						) }
+					>
+						<p>{ __( 'Some inner content to display when the card is expanded.', 'newspack' ) }</p>
+					</ActionCard>
 					<Card>
 						<h2>{ __( 'Image Uploader', 'newspack' ) }</h2>
 						<ImageUpload

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -112,6 +112,7 @@ export default withWizardScreen( () => {
 							'Newspack’s Reader Activation system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. ',
 							'newspack'
 						) }
+						{ /** TODO: Update this URL with the real one once the docs are ready. */ }
 						<ExternalLink href={ 'https://help.newspack.com' }>
 							{ __( 'Learn more', 'newspack-plugin' ) }
 						</ExternalLink>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -203,7 +203,6 @@ export default withWizardScreen( () => {
 								) }
 								{
 									// Form fields.
-									// TODO: Refactor so that the save button saves only these fields.
 									prerequisites[ key ].fields && (
 										<Grid columns={ 2 } gutter={ 16 }>
 											<div>
@@ -249,9 +248,12 @@ export default withWizardScreen( () => {
 										<Grid columns={ 2 } gutter={ 16 }>
 											<div>
 												<Button isPrimary href={ prerequisites[ key ].href }>
+													{ /* eslint-disable no-nested-ternary */ }
 													{ ( prerequisites[ key ].active
 														? __( 'Update ', 'newspack' )
-														: __( 'Save ', 'newspack' ) ) + prerequisites[ key ].action_text }
+														: prerequisites[ key ].fields
+														? __( 'Save ', 'newspack' )
+														: __( 'Configure ', 'newspack' ) ) + prerequisites[ key ].action_text }
 												</Button>
 											</div>
 										</Grid>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -166,7 +166,7 @@ export default withWizardScreen( () => {
 					<ActionCard
 						key={ key }
 						isMedium
-						expandable // TODO: If the status goes from Pending to Ready, close the card.
+						expandable
 						collapse={ prerequisites[ key ].active }
 						title={ prerequisites[ key ].label }
 						description={ sprintf(
@@ -394,10 +394,7 @@ export default withWizardScreen( () => {
 							} }
 							disabled={ inFlight }
 						>
-							{
-								// TODO: Refactor so that this button only saves advanced settings.
-								__( 'Save advanced settings', 'newspack' )
-							}
+							{ __( 'Save advanced settings', 'newspack' ) }
 						</Button>
 					</div>
 				</Card>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -167,6 +167,7 @@ export default withWizardScreen( () => {
 						key={ key }
 						isMedium
 						expandable // TODO: If the status goes from Pending to Ready, close the card.
+						collapse={ prerequisites[ key ].active }
 						title={ prerequisites[ key ].label }
 						description={ sprintf(
 							/* translators: %s: Prerequisite status */

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { CheckboxControl, ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -10,15 +10,15 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import {
+	ActionCard,
 	Button,
 	Card,
 	Grid,
 	Notice,
-	PluginInstaller,
 	SectionHeader,
 	TextControl,
+	Waiting,
 	withWizardScreen,
-	ActionCard,
 } from '../../../../components/src';
 import ActiveCampaign from './active-campaign';
 
@@ -26,8 +26,11 @@ export default withWizardScreen( () => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ config, setConfig ] = useState( {} );
 	const [ error, setError ] = useState( false );
+	const [ allReady, setAllReady ] = useState( false );
+	const [ setupComplete, setSetupComplete ] = useState( false );
 	const [ isActiveCampaign, setIsActiveCampaign ] = useState( false );
-	const [ hasPlugins, setHasPlugins ] = useState( null );
+	const [ prerequisites, setPrerequisites ] = useState( null );
+	const [ showAdvanced, setShowAdvanced ] = useState( false );
 	const updateConfig = ( key, val ) => {
 		setConfig( { ...config, [ key ]: val } );
 	};
@@ -37,8 +40,9 @@ export default withWizardScreen( () => {
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
 		} )
-			.then( ( { config: fetchedConfig, pluginsStatus } ) => {
-				setHasPlugins( pluginsStatus );
+			.then( ( { config: fetchedConfig, prerequisites_status, setup_complete } ) => {
+				setPrerequisites( prerequisites_status );
+				setSetupComplete( setup_complete );
 				setConfig( fetchedConfig );
 			} )
 			.catch( setError )
@@ -66,6 +70,19 @@ export default withWizardScreen( () => {
 			);
 		} );
 	}, [] );
+	useEffect( () => {
+		const _allReady =
+			prerequisites &&
+			Object.keys( prerequisites ).reduce( ( acc, key ) => {
+				if ( ! prerequisites[ key ]?.active ) {
+					return false;
+				}
+
+				return acc;
+			}, true );
+
+		setAllReady( _allReady );
+	}, [ prerequisites ] );
 
 	const getSharedProps = ( configKey, type = 'checkbox' ) => {
 		const props = {
@@ -87,159 +104,219 @@ export default withWizardScreen( () => {
 
 	const emails = Object.values( config.emails || {} );
 
-	if ( false === hasPlugins ) {
-		return (
-			<>
-				<Notice isError>
-					{ __(
-						'Please activate WooCommerce and WooCommerce Subscriptions plugins to use Reader Activation features.',
-						'newspack'
-					) }
-				</Notice>
-				<PluginInstaller
-					isWaiting={ inFlight }
-					plugins={ [ 'woocommerce', 'woocommerce-subscriptions', 'woocommerce-name-your-price' ] }
-					onStatus={ ( { complete } ) => complete && fetchConfig() }
-					withoutFooterButton={ true }
-				/>
-			</>
-		);
-	}
-
 	return (
 		<>
+			<SectionHeader
+				title={ __( 'Reader Activation', 'newspack' ) }
+				description={ () => (
+					<>
+						{ __(
+							'An easy way to let readers register for your site, sign up for newsletters, or become donors and paid members. ',
+							'newspack'
+						) }
+						<ExternalLink href={ 'https://help.newspack.com' }>
+							{ __( 'Learn more', 'newspack-plugin' ) }
+						</ExternalLink>
+					</>
+				) }
+			/>
 			{ error && (
 				<Notice
 					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
 					isError
 				/>
 			) }
-			<Card noBorder>
-				<SectionHeader
-					title={ __( 'Reader Activation', 'newspack' ) }
-					description={ __( 'Configure a set of features for reader activation.', 'newspack' ) }
+			{ prerequisites && ! allReady && ! setupComplete && (
+				<Notice
+					noticeText={ __( 'Complete these settings to enable Reader Activation.', 'newspack' ) }
+					isWarning
 				/>
-				<CheckboxControl
-					label={ __( 'Enable Reader Activation', 'newspack' ) }
-					help={ __( 'Whether to enable reader activation features for your site.', 'newspack' ) }
-					{ ...getSharedProps( 'enabled' ) }
-				/>
-				<hr />
-				<CheckboxControl
-					label={ __( 'Enable Sign In/Account link', 'newspack' ) }
-					help={ __(
-						'Display an account link in the site header. It will allow readers to register and access their account.',
+			) }
+			{ ! prerequisites && ! setupComplete && (
+				<>
+					<Waiting isLeft />
+					{ __( 'Retrieving status…', 'newspack' ) }
+				</>
+			) }
+			{ ! setupComplete &&
+				prerequisites &&
+				Object.keys( prerequisites ).map( key => (
+					<ActionCard
+						key={ key }
+						isMedium
+						title={ prerequisites[ key ].label }
+						description={
+							prerequisites[ key ].active
+								? __( 'Status: Ready', 'newspack' )
+								: prerequisites[ key ].description
+						}
+						checkbox={ prerequisites[ key ].active ? 'checked' : 'unchecked' }
+						actionText={
+							prerequisites[ key ].href ? (
+								<Button isLink disabled={ inFlight } href={ prerequisites[ key ].href }>
+									{ prerequisites[ key ].active
+										? __( 'View configuration', 'newspack' )
+										: __( 'Configure', 'newspack' ) }
+								</Button>
+							) : null
+						}
+					/>
+				) ) }
+
+			{ /** TODO: Link this to the new setup wizard. */ }
+			{ prerequisites && ! setupComplete && (
+				<ActionCard
+					isMedium
+					title={ __( 'Reader Activation Campaign', 'newspack' ) }
+					description={ __(
+						'A set of prompts and segments optimized for reader activaton.',
 						'newspack'
 					) }
-					{ ...getSharedProps( 'enabled_account_link' ) }
+					checkbox="unchecked"
+					actionText={ __( 'Waiting for all settings to be ready', 'newspack' ) }
 				/>
-				<Grid columns={ 2 } gutter={ 16 }>
-					<TextControl
-						label={ __( 'Terms & Conditions Text', 'newspack' ) }
-						help={ __( 'Terms and conditions text to display on registration.', 'newspack' ) }
-						{ ...getSharedProps( 'terms_text', 'text' ) }
+			) }
+			{ setupComplete && (
+				<>
+					{ /** TODO: Make this notice appear only when RAS setup is first completed. */ }
+					<Notice
+						noticeText={ __( 'Congratulations! Reader Activation is enabled.', 'newspack' ) }
+						isSuccess
 					/>
-					<TextControl
-						label={ __( 'Terms & Conditions URL', 'newspack' ) }
-						help={ __( 'URL to the page containing the terms and conditions.', 'newspack' ) }
-						{ ...getSharedProps( 'terms_url', 'text' ) }
+					<ActionCard
+						isMedium
+						title={ __( 'Reader Activation', 'newspack' ) }
+						description={ __( 'Status: Enabled', 'newspack' ) }
+						checkbox="checked"
 					/>
-				</Grid>
-				<hr />
-				{ emails?.length > 0 && (
-					<>
-						<SectionHeader
-							title={ __( 'Emails', 'newspack' ) }
-							description={ __( 'Customize emails sent to readers.', 'newspack' ) }
+				</>
+			) }
+			<hr />
+			<Button variant="link" onClick={ () => setShowAdvanced( ! showAdvanced ) }>
+				{ sprintf(
+					// Translators: Show or Hide advanced settings.
+					__( '%s Advanced Settings', 'newspack' ),
+					showAdvanced ? __( 'Hide', 'newspack' ) : __( 'Show', 'newspack' )
+				) }
+			</Button>
+			{ showAdvanced && (
+				<Card noBorder>
+					<CheckboxControl
+						label={ __( 'Enable Sign In/Account link', 'newspack' ) }
+						help={ __(
+							'Display an account link in the site header. It will allow readers to register and access their account.',
+							'newspack'
+						) }
+						{ ...getSharedProps( 'enabled_account_link' ) }
+					/>
+					<Grid columns={ 2 } gutter={ 16 }>
+						<TextControl
+							label={ __( 'Terms & Conditions Text', 'newspack' ) }
+							help={ __( 'Terms and conditions text to display on registration.', 'newspack' ) }
+							{ ...getSharedProps( 'terms_text', 'text' ) }
 						/>
 						<TextControl
-							label={ __( 'Sender name', 'newspack' ) }
-							{ ...getSharedProps( 'sender_name', 'text' ) }
+							label={ __( 'Terms & Conditions URL', 'newspack' ) }
+							help={ __( 'URL to the page containing the terms and conditions.', 'newspack' ) }
+							{ ...getSharedProps( 'terms_url', 'text' ) }
 						/>
-						<Grid columns={ 2 } gutter={ 16 }>
-							<TextControl
-								label={ __( 'Sender email address', 'newspack' ) }
-								{ ...getSharedProps( 'sender_email_address', 'text' ) }
+					</Grid>
+					<hr />
+					{ emails?.length > 0 && (
+						<>
+							<SectionHeader
+								title={ __( 'Emails', 'newspack' ) }
+								description={ __( 'Customize emails sent to readers.', 'newspack' ) }
 							/>
 							<TextControl
-								label={ __( 'Contact email address', 'newspack' ) }
+								label={ __( 'Sender name', 'newspack' ) }
+								{ ...getSharedProps( 'sender_name', 'text' ) }
+							/>
+							<Grid columns={ 2 } gutter={ 16 }>
+								<TextControl
+									label={ __( 'Sender email address', 'newspack' ) }
+									{ ...getSharedProps( 'sender_email_address', 'text' ) }
+								/>
+								<TextControl
+									label={ __( 'Contact email address', 'newspack' ) }
+									help={ __(
+										'This email will be used as "Reply-To" for transactional emails as well.',
+										'newspack'
+									) }
+									{ ...getSharedProps( 'contact_email_address', 'text' ) }
+								/>
+							</Grid>
+							{ emails.map( email => (
+								<ActionCard
+									key={ email.post_id }
+									title={ email.label }
+									titleLink={ email.edit_link }
+									href={ email.edit_link }
+									description={ email.description }
+									actionText={ __( 'Edit', 'newspack' ) }
+								/>
+							) ) }
+							<hr />
+						</>
+					) }
+
+					<SectionHeader
+						title={ __( 'Email Service Provider Settings', 'newspack' ) }
+						description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
+					/>
+					<TextControl
+						label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
+						help={ __(
+							'The text to display while subscribing to newsletters on the registration modal.',
+							'newspack'
+						) }
+						{ ...getSharedProps( 'newsletters_label', 'text' ) }
+					/>
+					<CheckboxControl
+						label={ __( 'Synchronize reader to ESP', 'newspack' ) }
+						help={ __(
+							'Whether to synchronize reader data to the ESP. A contact will be created on reader registration if the ESP supports contacts without a list subscription.',
+							'newspack'
+						) }
+						{ ...getSharedProps( 'sync_esp' ) }
+					/>
+					{ config.sync_esp && (
+						<>
+							<CheckboxControl
+								label={ __( 'Delete contact on reader deletion', 'newspack' ) }
 								help={ __(
-									'This email will be used as "Reply-To" for transactional emails as well.',
+									"If the reader's email is verified, delete contact from ESP on reader deletion. ESP synchronization must be enabled.",
 									'newspack'
 								) }
-								{ ...getSharedProps( 'contact_email_address', 'text' ) }
+								{ ...getSharedProps( 'sync_esp_delete' ) }
 							/>
-						</Grid>
-						{ emails.map( email => (
-							<ActionCard
-								key={ email.post_id }
-								title={ email.label }
-								titleLink={ email.edit_link }
-								href={ email.edit_link }
-								description={ email.description }
-								actionText={ __( 'Edit', 'newspack' ) }
+							<TextControl
+								label={ __( 'Metadata field prefix', 'newspack' ) }
+								help={ __(
+									'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_',
+									'newspack'
+								) }
+								{ ...getSharedProps( 'metadata_prefix', 'text' ) }
 							/>
-						) ) }
-						<hr />
-					</>
-				) }
-
-				<SectionHeader
-					title={ __( 'Email Service Provider Settings', 'newspack' ) }
-					description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
-				/>
-				<TextControl
-					label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
-					help={ __(
-						'The text to display while subscribing to newsletters on the registration modal.',
-						'newspack'
-					) }
-					{ ...getSharedProps( 'newsletters_label', 'text' ) }
-				/>
-				<CheckboxControl
-					label={ __( 'Synchronize reader to ESP', 'newspack' ) }
-					help={ __(
-						'Whether to synchronize reader data to the ESP. A contact will be created on reader registration if the ESP supports contacts without a list subscription.',
-						'newspack'
-					) }
-					{ ...getSharedProps( 'sync_esp' ) }
-				/>
-				{ config.sync_esp && (
-					<>
-						<CheckboxControl
-							label={ __( 'Delete contact on reader deletion', 'newspack' ) }
-							help={ __(
-								"If the reader's email is verified, delete contact from ESP on reader deletion. ESP synchronization must be enabled.",
-								'newspack'
+							{ isActiveCampaign && (
+								<ActiveCampaign
+									value={ { masterList: config.active_campaign_master_list } }
+									onChange={ ( key, value ) => {
+										if ( key === 'masterList' ) {
+											updateConfig( 'active_campaign_master_list', value );
+										}
+									} }
+								/>
 							) }
-							{ ...getSharedProps( 'sync_esp_delete' ) }
-						/>
-						<TextControl
-							label={ __( 'Metadata field prefix', 'newspack' ) }
-							help={ __(
-								'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_',
-								'newspack'
-							) }
-							{ ...getSharedProps( 'metadata_prefix', 'text' ) }
-						/>
-						{ isActiveCampaign && (
-							<ActiveCampaign
-								value={ { masterList: config.active_campaign_master_list } }
-								onChange={ ( key, value ) => {
-									if ( key === 'masterList' ) {
-										updateConfig( 'active_campaign_master_list', value );
-									}
-								} }
-							/>
-						) }
-					</>
-				) }
-			</Card>
-			<div className="newspack-buttons-card">
-				<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
-					{ __( 'Save Changes', 'newspack' ) }
-				</Button>
-			</div>
+						</>
+					) }
+					<div className="newspack-buttons-card">
+						<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
+							{ __( 'Save Changes', 'newspack' ) }
+						</Button>
+					</div>
+				</Card>
+			) }
 		</>
 	);
 } );

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -35,7 +35,7 @@ export default withWizardScreen( () => {
 	const updateConfig = ( key, val ) => {
 		setConfig( { ...config, [ key ]: val } );
 	};
-	const fetchConfig = ( updateInFlight = true ) => {
+	const fetchConfig = () => {
 		setError( false );
 		setInFlight( true );
 		apiFetch( {
@@ -47,7 +47,7 @@ export default withWizardScreen( () => {
 				setMembershipsConfig( memberships );
 			} )
 			.catch( setError )
-			.finally( () => updateInFlight && setInFlight( false ) );
+			.finally( () => setInFlight( false ) );
 	};
 	const saveConfig = data => {
 		setError( false );

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { CheckboxControl, ExternalLink } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -27,7 +27,6 @@ export default withWizardScreen( () => {
 	const [ config, setConfig ] = useState( {} );
 	const [ error, setError ] = useState( false );
 	const [ allReady, setAllReady ] = useState( false );
-	const [ setupComplete, setSetupComplete ] = useState( false );
 	const [ isActiveCampaign, setIsActiveCampaign ] = useState( false );
 	const [ prerequisites, setPrerequisites ] = useState( null );
 	const [ showAdvanced, setShowAdvanced ] = useState( false );
@@ -40,9 +39,8 @@ export default withWizardScreen( () => {
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
 		} )
-			.then( ( { config: fetchedConfig, prerequisites_status, setup_complete } ) => {
+			.then( ( { config: fetchedConfig, prerequisites_status } ) => {
 				setPrerequisites( prerequisites_status );
-				setSetupComplete( setup_complete );
 				setConfig( fetchedConfig );
 			} )
 			.catch( setError )
@@ -111,7 +109,7 @@ export default withWizardScreen( () => {
 				description={ () => (
 					<>
 						{ __(
-							'An easy way to let readers register for your site, sign up for newsletters, or become donors and paid members. ',
+							'Newspack’s Reader Activation system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. ',
 							'newspack'
 						) }
 						<ExternalLink href={ 'https://help.newspack.com' }>
@@ -126,20 +124,19 @@ export default withWizardScreen( () => {
 					isError
 				/>
 			) }
-			{ prerequisites && ! allReady && ! setupComplete && (
+			{ prerequisites && ! allReady && (
 				<Notice
-					noticeText={ __( 'Complete these settings to enable Reader Activation.', 'newspack' ) }
+					noticeText={ __( 'Complete the settings to enable Reader Activation.', 'newspack' ) }
 					isWarning
 				/>
 			) }
-			{ ! prerequisites && ! setupComplete && (
+			{ ! prerequisites && (
 				<>
 					<Waiting isLeft />
 					{ __( 'Retrieving status…', 'newspack' ) }
 				</>
 			) }
-			{ ! setupComplete &&
-				prerequisites &&
+			{ prerequisites &&
 				Object.keys( prerequisites ).map( key => (
 					<ActionCard
 						key={ key }
@@ -164,32 +161,17 @@ export default withWizardScreen( () => {
 				) ) }
 
 			{ /** TODO: Link this to the new setup wizard. */ }
-			{ prerequisites && ! setupComplete && (
+			{ prerequisites && (
 				<ActionCard
 					isMedium
 					title={ __( 'Reader Activation Campaign', 'newspack' ) }
 					description={ __(
-						'A set of prompts and segments optimized for reader activaton.',
+						'Building a set of prompts with default segments and settings optimized for Reader Activation allows for an improved reader experience around site registration, newsletter sign-up, and donation in order to drive industry-leading conversion rates.',
 						'newspack'
 					) }
 					checkbox="unchecked"
 					actionText={ __( 'Waiting for all settings to be ready', 'newspack' ) }
 				/>
-			) }
-			{ setupComplete && (
-				<>
-					{ /** TODO: Make this notice appear only when RAS setup is first completed. */ }
-					<Notice
-						noticeText={ __( 'Congratulations! Reader Activation is enabled.', 'newspack' ) }
-						isSuccess
-					/>
-					<ActionCard
-						isMedium
-						title={ __( 'Reader Activation', 'newspack' ) }
-						description={ __( 'Status: Enabled', 'newspack' ) }
-						checkbox="checked"
-					/>
-				</>
 			) }
 			<hr />
 			<Button variant="link" onClick={ () => setShowAdvanced( ! showAdvanced ) }>
@@ -201,14 +183,6 @@ export default withWizardScreen( () => {
 			</Button>
 			{ showAdvanced && (
 				<Card noBorder>
-					<CheckboxControl
-						label={ __( 'Enable Sign In/Account link', 'newspack' ) }
-						help={ __(
-							'Display an account link in the site header. It will allow readers to register and access their account.',
-							'newspack'
-						) }
-						{ ...getSharedProps( 'enabled_account_link' ) }
-					/>
 					<Grid columns={ 2 } gutter={ 16 }>
 						<TextControl
 							label={ __( 'Terms & Conditions Text', 'newspack' ) }
@@ -225,8 +199,8 @@ export default withWizardScreen( () => {
 					{ emails?.length > 0 && (
 						<>
 							<SectionHeader
-								title={ __( 'Emails', 'newspack' ) }
-								description={ __( 'Customize emails sent to readers.', 'newspack' ) }
+								title={ __( 'Transactional Emails', 'newspack' ) }
+								description={ __( 'Customize the content of transactional emails.', 'newspack' ) }
 							/>
 							<TextControl
 								label={ __( 'Sender name', 'newspack' ) }
@@ -264,6 +238,7 @@ export default withWizardScreen( () => {
 						title={ __( 'Email Service Provider Settings', 'newspack' ) }
 						description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
 					/>
+					{ /** TODO: Deprecate this option. This field should be populated by user input in the prompt setup wizard. */ }
 					<TextControl
 						label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
 						help={ __(
@@ -272,24 +247,8 @@ export default withWizardScreen( () => {
 						) }
 						{ ...getSharedProps( 'newsletters_label', 'text' ) }
 					/>
-					<CheckboxControl
-						label={ __( 'Synchronize reader to ESP', 'newspack' ) }
-						help={ __(
-							'Whether to synchronize reader data to the ESP. A contact will be created on reader registration if the ESP supports contacts without a list subscription.',
-							'newspack'
-						) }
-						{ ...getSharedProps( 'sync_esp' ) }
-					/>
 					{ config.sync_esp && (
 						<>
-							<CheckboxControl
-								label={ __( 'Delete contact on reader deletion', 'newspack' ) }
-								help={ __(
-									"If the reader's email is verified, delete contact from ESP on reader deletion. ESP synchronization must be enabled.",
-									'newspack'
-								) }
-								{ ...getSharedProps( 'sync_esp_delete' ) }
-							/>
 							<TextControl
 								label={ __( 'Metadata field prefix', 'newspack' ) }
 								help={ __(

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -161,12 +161,13 @@ export default withWizardScreen( () => {
 					<ActionCard
 						key={ key }
 						isMedium
+						expandable
 						title={ prerequisites[ key ].label }
-						description={
-							prerequisites[ key ].active
-								? __( 'Status: Ready', 'newspack' )
-								: prerequisites[ key ].description
-						}
+						description={ sprintf(
+							/* translators: %s: Prerequisite status */
+							__( 'Status: %s', 'newspack' ),
+							prerequisites[ key ].active ? __( 'Ready', 'newspack' ) : __( 'Pending', 'newspack' )
+						) }
 						checkbox={ prerequisites[ key ].active ? 'checked' : 'unchecked' }
 						actionText={
 							prerequisites[ key ].href ? (
@@ -177,7 +178,9 @@ export default withWizardScreen( () => {
 								</Button>
 							) : null
 						}
-					/>
+					>
+						Test child content
+					</ActionCard>
 				) ) }
 
 			{ /** TODO: Link this to the new setup wizard. */ }

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -49,13 +49,13 @@ export default withWizardScreen( () => {
 			.catch( setError )
 			.finally( () => updateInFlight && setInFlight( false ) );
 	};
-	const saveConfig = () => {
+	const saveConfig = data => {
 		setError( false );
 		setInFlight( true );
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
 			method: 'post',
-			data: config,
+			data,
 		} )
 			.then( ( { config: fetchedConfig, prerequisites_status, memberships } ) => {
 				setPrerequisites( prerequisites_status );
@@ -104,6 +104,7 @@ export default withWizardScreen( () => {
 				props.value = config[ configKey ] || '';
 				break;
 		}
+
 		return props;
 	};
 
@@ -214,7 +215,19 @@ export default withWizardScreen( () => {
 													/>
 												) ) }
 
-												<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
+												<Button
+													isPrimary
+													onClick={ () => {
+														const dataToSave = {};
+
+														Object.keys( prerequisites[ key ].fields ).forEach( fieldName => {
+															dataToSave[ fieldName ] = config[ fieldName ];
+														} );
+
+														saveConfig( dataToSave );
+													} }
+													disabled={ inFlight }
+												>
 													{ inFlight
 														? __( 'Saving…', 'newspack' )
 														: sprintf(
@@ -367,7 +380,17 @@ export default withWizardScreen( () => {
 						</>
 					) }
 					<div className="newspack-buttons-card">
-						<Button isPrimary onClick={ saveConfig } disabled={ inFlight }>
+						<Button
+							isPrimary
+							onClick={ () => {
+								saveConfig( {
+									newsletters_label: config.newsletters_label, // TODO: Deprecate this in favor of user input via the prompt copy wizard.
+									metadata_prefix: config.metadata_prefix,
+									active_campaign_master_list: config.active_campaign_master_list,
+								} );
+							} }
+							disabled={ inFlight }
+						>
 							{
 								// TODO: Refactor so that this button only saves advanced settings.
 								__( 'Save advanced settings', 'newspack' )

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -243,7 +243,7 @@ export default withWizardScreen( () => {
 									)
 								}
 								{
-									// Link to another settings page.
+									// Link to another settings page or update config in place.
 									prerequisites[ key ].href && prerequisites[ key ].action_text && (
 										<Grid columns={ 2 } gutter={ 16 }>
 											<div>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -166,7 +166,7 @@ export default withWizardScreen( () => {
 					isMedium
 					title={ __( 'Reader Activation Campaign', 'newspack' ) }
 					description={ __(
-						'Building a set of prompts with default segments and settings optimized for Reader Activation allows for an improved reader experience around site registration, newsletter sign-up, and donation in order to drive industry-leading conversion rates.',
+						'Building a set of prompts with default segments and settings allows for an improved experience optimized for Reader Activation.',
 						'newspack'
 					) }
 					checkbox="unchecked"

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -152,8 +152,8 @@ export default withWizardScreen( () => {
 							prerequisites[ key ].href ? (
 								<Button isLink disabled={ inFlight } href={ prerequisites[ key ].href }>
 									{ prerequisites[ key ].active
-										? __( 'View configuration', 'newspack' )
-										: __( 'Configure', 'newspack' ) }
+										? __( 'View setup', 'newspack' )
+										: __( 'Set up', 'newspack' ) }
 								</Button>
 							) : null
 						}

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -382,7 +382,7 @@ class Emails {
 	public static function get_reply_to_email() {
 		$reply_to_email = get_bloginfo( 'admin_email' );
 		if ( Reader_Activation::is_enabled() ) {
-			$reply_to_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'contact_email_address', self::get_from_email() );
+			$reply_to_email = get_option( Reader_Activation::OPTIONS_PREFIX . 'contact_email_address', $reply_to_email );
 		}
 		return apply_filters( 'newspack_reply_to_email', $reply_to_email );
 	}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -276,10 +276,10 @@ final class Reader_Activation {
 	/**
 	 * Is the Newspack Newsletters plugin configured with an ESP?
 	 */
-	public static function is_newsletters_configured() {
+	public static function is_esp_configured() {
 		$newsletters_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-newsletters' );
 
-		return $newsletters_configuration_manager->is_configured();
+		return $newsletters_configuration_manager->is_esp_set_up();
 	}
 
 	/**
@@ -297,7 +297,7 @@ final class Reader_Activation {
 				'description' => __( 'Displaying Terms and Conditions on your site is necessary to allow readers to register and access their account.', 'newspack-plugin' ),
 			],
 			'esp'              => [
-				'active'      => self::is_newsletters_configured(),
+				'active'      => self::is_esp_configured(),
 				'label'       => __( 'Email Service Provider (ESP)', 'newspack' ),
 				'description' => __( 'Connecting your ESP with the right settings is necessary to register readers with their email addresses, send account related emails and newsletters.', 'newspack' ),
 				'href'        => \admin_url( '/admin.php?page=newspack-engagement-wizard#/newsletters' ),

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -166,7 +166,7 @@ final class Reader_Activation {
 	private static function get_settings_config() {
 		$settings_config = [
 			'enabled'                     => true,
-			'enabled_account_link'        => false,
+			'enabled_account_link'        => true,
 			'account_link_menu_locations' => [ 'tertiary-menu' ],
 			'newsletters_label'           => __( 'Subscribe to our newsletters:', 'newspack' ),
 			'terms_text'                  => __( 'By signing up, you agree to our Terms and Conditions.', 'newspack' ),
@@ -285,34 +285,45 @@ final class Reader_Activation {
 	/**
 	 * Get the status of the prerequisites for enabling reader activation.
 	 * TODO: Finalize the list of prerequisites and all copy.
+	 * TODO: Establish schema for input fields to be shown in expandable cards.
 	 *
 	 * @return array Array of prerequisites to complete.
 	 */
 	public static function get_prerequisites_status() {
 		$prerequisites = [
 			// TODO: Remove example prerequisite.
-			'example_slug' => [
+			'example_slug'     => [
 				'active'      => false,
 				'label'       => __( 'Example requirement', 'newspack' ),
 				'description' => __( 'Boilerplate config for inactive prerequisite.', 'newspack-plugin' ),
 			],
-			'woocommerce'  => [
-				'active'      => self::is_woocommerce_active(),
-				'label'       => __( 'WooCommerce', 'newspack' ),
-				'description' => __( 'WooCommerce and required plugin extensions.', 'newspack' ),
-				'href'        => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
+			'terms_conditions' => [
+				'active'      => false,
+				'label'       => __( 'Terms & Conditions', 'newspack' ),
+				'description' => __( 'Displaying Terms and Conditions on your site is necessary to allow readers to register and access their account.', 'newspack-plugin' ),
 			],
-			'esp'          => [
+			'esp'              => [
 				'active'      => self::is_newsletters_configured(),
-				'label'       => __( 'Newspack Newsletters', 'newspack' ),
-				'description' => __( 'Newspack Newsletters must be configured with a valid ESP connection.', 'newspack' ),
+				'label'       => __( 'Email Service Provider (ESP)', 'newspack' ),
+				'description' => __( 'Connecting your ESP with the right settings is necessary to register readers with their email addresses, send account related emails and newsletters.', 'newspack' ),
 				'href'        => \admin_url( '/admin.php?page=newspack-engagement-wizard#/newsletters' ),
 			],
-			'recaptcha'    => [
+			'emails'           => [
+				'active'      => false,
+				'label'       => __( 'Transactional Emails', 'newspack' ),
+				'description' => __( 'Boilerplate config for inactive prerequisite.', 'newspack-plugin' ),
+			],
+			'recaptcha'        => [
 				'active'      => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),
 				'label'       => __( 'reCAPTCHA', 'newspack' ),
-				'description' => __( 'A reCAPTCHA v3 connection is required to secure reader input forms.', 'newspack' ),
+				'description' => __( 'Connecting to a Google reCAPTCHA account enables enhanced anti-spam security for newsletter signup, user account, and payment forms rendered by Newspack tools.', 'newspack' ),
 				'href'        => \admin_url( '/admin.php?page=newspack-connections-wizard' ),
+			],
+			'reader_revenue'   => [
+				'active'      => self::is_woocommerce_active(),
+				'label'       => __( 'Reader Revenue', 'newspack' ),
+				'description' => __( 'Selecting WooCommerce as reader revenue platform and setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack' ),
+				'href'        => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
 			],
 		];
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -283,6 +283,27 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Are the Terms & Conditions settings configured?
+	 */
+	public static function is_terms_configured() {
+		$terms_text = \get_option( self::OPTIONS_PREFIX . 'terms_text', false );
+		$terms_url  = \get_option( self::OPTIONS_PREFIX . 'terms_url', false );
+
+		return ! empty( $terms_text ) && ! empty( $terms_url );
+	}
+
+	/**
+	 * Are Transaction Email settings configured?
+	 */
+	public static function is_transactional_email_configured() {
+		$sender_name           = \get_option( self::OPTIONS_PREFIX . 'sender_name', false );
+		$sender_email          = \get_option( self::OPTIONS_PREFIX . 'sender_email_address', false );
+		$contact_email_address = \get_option( self::OPTIONS_PREFIX . 'contact_email_address', false );
+
+		return ! empty( $sender_name ) && ! empty( $sender_email ) && ! empty( $contact_email_address );
+	}
+
+	/**
 	 * Get the status of the prerequisites for enabling reader activation.
 	 * TODO: Finalize the list of prerequisites and all copy.
 	 * TODO: Establish schema for input fields to be shown in expandable cards.
@@ -292,32 +313,64 @@ final class Reader_Activation {
 	public static function get_prerequisites_status() {
 		$prerequisites = [
 			'terms_conditions' => [
-				'active'      => false,
+				'active'      => self::is_terms_configured(),
 				'label'       => __( 'Terms & Conditions', 'newspack' ),
 				'description' => __( 'Displaying Terms and Conditions on your site is necessary to allow readers to register and access their account.', 'newspack-plugin' ),
+				'help_url'    => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'fields'      => [
+					'terms_text' => [
+						'label'       => __( 'Terms & Conditions Text', 'newspack' ),
+						'description' => __( 'Terms and conditions text to display on registration.', 'newspack-plugin' ),
+					],
+					'terms_url'  => [
+						'label'       => __( 'Terms & Conditions URL', 'newspack' ),
+						'description' => __( 'URL to the page containing the terms and conditions.', 'newspack-plugin' ),
+					],
+				],
 			],
 			'esp'              => [
 				'active'      => self::is_esp_configured(),
 				'label'       => __( 'Email Service Provider (ESP)', 'newspack' ),
 				'description' => __( 'Connecting your ESP with the right settings is necessary to register readers with their email addresses, send account related emails and newsletters.', 'newspack' ),
+				'help_url'    => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
 				'href'        => \admin_url( '/admin.php?page=newspack-engagement-wizard#/newsletters' ),
+				'action_text' => __( 'ESP settings' ),
 			],
 			'emails'           => [
-				'active'      => false,
+				'active'      => self::is_transactional_email_configured(),
 				'label'       => __( 'Transactional Emails', 'newspack' ),
 				'description' => __( 'Your sender name and email address determines how readers find emails related to their account in their inbox.', 'newspack-plugin' ),
+				'help_url'    => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'fields'      => [
+					'sender_name'           => [
+						'label'       => __( 'Sender Name', 'newspack' ),
+						'description' => __( 'Name to use as the sender of transactional emails.', 'newspack-plugin' ),
+					],
+					'sender_email_address'  => [
+						'label'       => __( 'Sender Email Address', 'newspack' ),
+						'description' => __( 'Email address to use as the sender of transactional emails.', 'newspack-plugin' ),
+					],
+					'contact_email_address' => [
+						'label'       => __( 'Contact Email Address', 'newspack' ),
+						'description' => __( 'This email will be used as "Reply-To" for transactional emails as well.', 'newspack-plugin' ),
+					],
+				],
 			],
 			'recaptcha'        => [
 				'active'      => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),
 				'label'       => __( 'reCAPTCHA', 'newspack' ),
 				'description' => __( 'Connecting to a Google reCAPTCHA account enables enhanced anti-spam security for newsletter signup, user account, and payment forms rendered by Newspack tools.', 'newspack' ),
+				'help_url'    => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
 				'href'        => \admin_url( '/admin.php?page=newspack-connections-wizard' ),
+				'action_text' => __( 'reCAPTCHA settings' ),
 			],
 			'reader_revenue'   => [
 				'active'      => self::is_woocommerce_active(),
 				'label'       => __( 'Reader Revenue', 'newspack' ),
 				'description' => __( 'Selecting WooCommerce as reader revenue platform and setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack' ),
+				'help_url'    => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
 				'href'        => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
+				'action_text' => __( 'Reader Revenue settings' ),
 			],
 		];
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -291,12 +291,6 @@ final class Reader_Activation {
 	 */
 	public static function get_prerequisites_status() {
 		$prerequisites = [
-			// TODO: Remove example prerequisite.
-			'example_slug'     => [
-				'active'      => false,
-				'label'       => __( 'Example requirement', 'newspack' ),
-				'description' => __( 'Boilerplate config for inactive prerequisite.', 'newspack-plugin' ),
-			],
 			'terms_conditions' => [
 				'active'      => false,
 				'label'       => __( 'Terms & Conditions', 'newspack' ),
@@ -311,7 +305,7 @@ final class Reader_Activation {
 			'emails'           => [
 				'active'      => false,
 				'label'       => __( 'Transactional Emails', 'newspack' ),
-				'description' => __( 'Boilerplate config for inactive prerequisite.', 'newspack-plugin' ),
+				'description' => __( 'Your sender name and email address determines how readers find emails related to their account in their inbox.', 'newspack-plugin' ),
 			],
 			'recaptcha'        => [
 				'active'      => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -274,6 +274,52 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Is the Newspack Newsletters plugin configured with an ESP?
+	 */
+	public static function is_newsletters_configured() {
+		$newsletters_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-newsletters' );
+
+		return $newsletters_configuration_manager->is_configured();
+	}
+
+	/**
+	 * Get the status of the prerequisites for enabling reader activation.
+	 * TODO: Finalize the list of prerequisites and all copy.
+	 *
+	 * @return array Array of prerequisites to complete.
+	 */
+	public static function get_prerequisites_status() {
+		$prerequisites = [
+			// TODO: Remove example prerequisite.
+			'example_slug' => [
+				'active'      => false,
+				'label'       => __( 'Example requirement', 'newspack' ),
+				'description' => __( 'Boilerplate config for inactive prerequisite.', 'newspack-plugin' ),
+			],
+			'woocommerce'  => [
+				'active'      => self::is_woocommerce_active(),
+				'label'       => __( 'WooCommerce', 'newspack' ),
+				'description' => __( 'WooCommerce and required plugin extensions.', 'newspack' ),
+				'href'        => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
+			],
+			'esp'          => [
+				'active'      => self::is_newsletters_configured(),
+				'label'       => __( 'Newspack Newsletters', 'newspack' ),
+				'description' => __( 'Newspack Newsletters must be configured with a valid ESP connection.', 'newspack' ),
+				'href'        => \admin_url( '/admin.php?page=newspack-engagement-wizard#/newsletters' ),
+			],
+			'recaptcha'    => [
+				'active'      => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),
+				'label'       => __( 'reCAPTCHA', 'newspack' ),
+				'description' => __( 'A reCAPTCHA v3 connection is required to secure reader input forms.', 'newspack' ),
+				'href'        => \admin_url( '/admin.php?page=newspack-connections-wizard' ),
+			],
+		];
+
+		return $prerequisites;
+	}
+
+	/**
 	 * Whether reader activation is enabled.
 	 *
 	 * @param bool $strict If true, check both the environment constant and the setting.

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -227,7 +227,13 @@ class Engagement_Wizard extends Wizard {
 		foreach ( $args as $key => $value ) {
 			Reader_Activation::update_setting( $key, $value );
 		}
-		return rest_ensure_response( Reader_Activation::get_settings() );
+		return rest_ensure_response(
+			[
+				'config'               => Reader_Activation::get_settings(),
+				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
+				'memberships'          => self::get_memberships_settings(),
+			]
+		);
 	}
 
 	/**

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -196,8 +196,9 @@ class Engagement_Wizard extends Wizard {
 	public function api_get_reader_activation_settings() {
 		return rest_ensure_response(
 			[
-				'config'        => Reader_Activation::get_settings(),
-				'pluginsStatus' => Reader_Activation::is_woocommerce_active(),
+				'config'               => Reader_Activation::get_settings(),
+				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
+				'setup_complete'       => false, // TODO: Make this dynamic.
 			]
 		);
 	}

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -198,7 +198,6 @@ class Engagement_Wizard extends Wizard {
 			[
 				'config'               => Reader_Activation::get_settings(),
 				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
-				'setup_complete'       => false, // TODO: Make this dynamic.
 			]
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the design of the new RAS settings page to the latest i3 designs. This PR covers only the first settings page in **Newspack > Engagement > Reader Activation**. The setup wizard for Campaigns defaults will come in a future PR.

<img width="1205" alt="Screen Shot 2023-04-03 at 4 04 29 PM" src="https://user-images.githubusercontent.com/2230142/229637491-378ad7a9-0092-4729-8129-112b23ebebce.png">

### How to test the changes in this Pull Request:

1. Start with a fresh test site (JN). Install the plugin from this branch and run `wp newspack setup` to scaffold the site with default Newspack settings.
2. Visit **Newspack > Engagement > Reader Activation** to view the checklist of prerequisites that need to be completed before RAS Campaigns defaults can be configured.

<img width="1065" alt="Screen Shot 2023-04-03 at 4 11 36 PM" src="https://user-images.githubusercontent.com/2230142/229638543-5b810818-ba94-4173-b0d4-252cf2adda9d.png">

3. Expand each card and complete the setup.
  - For cards that contain fields and a "Save settings" button, fill out the required fields and click "Save" (note that some fields will be prepopulated with suggested settings, but you still need to click "save" to complete the prerequisite). After saving, confirm that a.) the card collapses automatically with a "status: ready" state, and b.) if you re-expand the card, the button label changes to say "Update settings" instead of "Save settings."
  - For cards that link out to a separate page to complete configuration, complete the required config and then go back to the **Newspack > Engagement > Reader Activation** page. Confirm that the card updates to say "status: ready" after completing the required configuration.
4. The last card ("Reader Activation Campaign") is just a placeholder for now. For this PR, just confirm that the action button is disabled with a "Waiting for all settings to be ready" label until all other settings are ready, after which the button should change to an active "Set up Reader Activation campaign" button which currently does nothing but will redirect to the prompt setup wizard in a future PR.
5. Also confirm that the "Complete the settings to enable Reader Activation" banner at the top of the page disappears after you complete all steps (in a future PR this will happen only after you complete the not-yet-existent prompt setup wizard).
6. Expand the Advanced Settings panel and confirm that the "Save advanced settings" button now only saves changes from the fields in advanced settings, not elsewhere on the page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->