### PR TITLE
feat(reader-registration): add recaptcha panel in the editor

### DIFF
--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -9,7 +9,7 @@ import { intersection } from 'lodash';
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import {
 	useBlockProps,
@@ -198,6 +198,30 @@ export default function ReaderRegistrationEdit( {
 						) }
 					</PanelBody>
 				) }
+				<PanelBody title={ __( 'Spam protection', 'newspack' ) }>
+					<p>
+						{ sprintf(
+							// translators: %s is either 'enabled' or 'disabled'.
+							__( 'reCAPTCHA v3 is currently %s.', 'newspack' ),
+							newspack_blocks.has_recaptcha
+								? __( 'enabled', 'newspack' )
+								: __( 'disabled', 'newspack' )
+						) }
+					</p>
+					{ ! newspack_blocks.has_recaptcha && (
+						<p>
+							{ __(
+								"It's highly recommended that you enable reCAPTCHA v3 protection to prevent spambots from using this form!",
+								'newspack'
+							) }
+						</p>
+					) }
+					<p>
+						<a href={ newspack_blocks.recaptcha_url }>
+							{ __( 'Configure your reCAPTCHA settings.', 'newspack' ) }
+						</a>
+					</p>
+				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
 				<div className="newspack-registration__state-bar">

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -45,6 +45,8 @@ final class Blocks {
 				'google_logo_svg'         => file_get_contents( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/blocks/reader-registration/icons/google.svg' ),
 				'reader_activation_terms' => Reader_Activation::get_setting( 'terms_text' ),
 				'reader_activation_url'   => Reader_Activation::get_setting( 'terms_url' ),
+				'has_recaptcha'           => Recaptcha::can_use_captcha(),
+				'recaptcha_url'           => admin_url( 'admin.php?page=newspack-connections-wizard' ),
 			]
 		);
 		\wp_enqueue_style(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements a panel in the block editor to indicate the usage of reCAPTCHA v3.

<img width="279" alt="image" src="https://user-images.githubusercontent.com/820752/229831362-c7bdc807-75f4-4f28-a7c2-b3dbb6e2c89c.png">

<img width="280" alt="image" src="https://user-images.githubusercontent.com/820752/229831460-ec8bac89-dd7d-4720-9d31-ea2b37cef842.png">

### How to test the changes in this Pull Request:

1. Add a reader registration block, and confirm you see the new panel
2. Edit the reCAPTCHA v3 settings and confirm the panel changes if reCAPTCHA is configured or not

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->