### PR TITLE
fix(memberships): remove content filters from excerpt

### DIFF
--- a/assets/memberships-gate/editor.js
+++ b/assets/memberships-gate/editor.js
@@ -6,7 +6,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Fragment, useEffect } from '@wordpress/element';
-import { Button, TextControl, CheckboxControl, SelectControl, Notice } from '@wordpress/components';
+import { Button, TextControl, CheckboxControl, SelectControl } from '@wordpress/components';
 import { PluginDocumentSettingPanel, PluginPostStatusInfo } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 

--- a/assets/memberships-gate/editor.js
+++ b/assets/memberships-gate/editor.js
@@ -6,8 +6,8 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Fragment, useEffect } from '@wordpress/element';
-import { Button, TextControl, CheckboxControl, SelectControl } from '@wordpress/components';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { Button, TextControl, CheckboxControl, SelectControl, Notice } from '@wordpress/components';
+import { PluginDocumentSettingPanel, PluginPostStatusInfo } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 
 /**
@@ -34,18 +34,7 @@ const overlaySizes = [
 	{ value: 'full-width', label: __( 'Full Width', 'newspack' ) },
 ];
 
-const GateEdit = ( { editPost, createNotice, meta } ) => {
-	useEffect( () => {
-		if ( newspack_memberships_gate.has_campaigns ) {
-			createNotice(
-				'info',
-				__(
-					'Newspack Campaigns: Prompts will not be displayed when rendering a gated content.',
-					'newspack'
-				)
-			);
-		}
-	}, [] );
+const GateEdit = ( { editPost, meta } ) => {
 	useEffect( () => {
 		const wrapper = document.querySelector( '.editor-styles-wrapper' );
 		if ( ! wrapper ) {
@@ -59,6 +48,16 @@ const GateEdit = ( { editPost, createNotice, meta } ) => {
 	}, [ meta.style, meta.overlay_size ] );
 	return (
 		<Fragment>
+			{ newspack_memberships_gate.has_campaigns && (
+				<PluginPostStatusInfo>
+					<p>
+						{ __(
+							"Newspack Campaign prompts won't be displayed when rendering gated content.",
+							'newspack'
+						) }
+					</p>
+				</PluginPostStatusInfo>
+			) }
 			<PluginDocumentSettingPanel
 				name="memberships-gate-styles-panel"
 				title={ __( 'Styles', 'newspack' ) }
@@ -147,11 +146,7 @@ const GateEditWithSelect = compose( [
 	} ),
 	withDispatch( dispatch => {
 		const { editPost } = dispatch( 'core/editor' );
-		const { createNotice } = dispatch( 'core/notices' );
-		return {
-			editPost,
-			createNotice,
-		};
+		return { editPost };
 	} ),
 ] )( GateEdit );
 

--- a/includes/plugins/class-wc-memberships.php
+++ b/includes/plugins/class-wc-memberships.php
@@ -35,6 +35,7 @@ class WC_Memberships {
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_filter( 'wc_memberships_notice_html', [ __CLASS__, 'notice_html' ], 100 );
 		add_filter( 'wc_memberships_restricted_content_excerpt', [ __CLASS__, 'excerpt' ], 100, 3 );
+		add_filter( 'wc_memberships_message_excerpt_apply_the_content_filter', '__return_false' );
 		add_action( 'wp_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
 		add_action( 'wp_footer', [ __CLASS__, 'render_js' ] );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a hotfix for the current alpha release.

Prevents an infinite loop on Woo Memberships when the restricted content uses the "Query Loop" block or "Homepage Posts" block.

**UPDATE**: Catching a ride in this hotfix, 44ea11517575e3b9abd4b3933d9669f146b831be updates the location of the "Newspack Campaigns" notice from the native notices API to post status info:

<img width="287" alt="image" src="https://user-images.githubusercontent.com/820752/229924770-fa5609ec-1f56-4b41-8092-8ca6c1b2b305.png">


### How to test the changes in this Pull Request:

1. While in the alpha or master branch edit a restricted post to include a Homepage Posts block
2. Access the post anonymously and confirm the infinite loop
3. Check out this branch and confirm the post renders and is restricted
4. With Newspack Campaigns installed and active confirm you see the notice above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->