### PR TITLE
fix: don't show gate unless attached to a specific post

### DIFF
--- a/includes/plugins/class-wc-memberships.php
+++ b/includes/plugins/class-wc-memberships.php
@@ -328,13 +328,13 @@ class WC_Memberships {
 	 * @param array  $message_args associative array of message arguments.
 	 */
 	public static function notice_html( $notice, $message_body, $message_code, $message_args ) {
-		// Don't show gate unless attached to a specific post.
-		if ( empty( $message_args['post'] ) ) {
-			return '';
-		}
 		// If the gate is not available, don't mess with the notice.
 		if ( ! self::has_gate() ) {
 			return $notice;
+		}
+		// Don't show gate unless attached to a specific post.
+		if ( empty( $message_args['post'] ) ) {
+			return '';
 		}
 		// If rendering the content in a loop, don't render the gate.
 		if ( get_queried_object_id() !== get_the_ID() ) {

--- a/includes/plugins/class-wc-memberships.php
+++ b/includes/plugins/class-wc-memberships.php
@@ -33,7 +33,7 @@ class WC_Memberships {
 		add_action( 'admin_init', [ __CLASS__, 'handle_edit_gate' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
-		add_filter( 'wc_memberships_notice_html', [ __CLASS__, 'notice_html' ], 100 );
+		add_filter( 'wc_memberships_notice_html', [ __CLASS__, 'notice_html' ], 100, 4 );
 		add_filter( 'wc_memberships_restricted_content_excerpt', [ __CLASS__, 'excerpt' ], 100, 3 );
 		add_filter( 'wc_memberships_message_excerpt_apply_the_content_filter', '__return_false' );
 		add_action( 'wp_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
@@ -323,8 +323,15 @@ class WC_Memberships {
 	 * Filter the notice HTML.
 	 *
 	 * @param string $notice Notice HTML.
+	 * @param string $message_body original message content.
+	 * @param string $message_code message code.
+	 * @param array  $message_args associative array of message arguments.
 	 */
-	public static function notice_html( $notice ) {
+	public static function notice_html( $notice, $message_body, $message_code, $message_args ) {
+		// Don't show gate unless attached to a specific post.
+		if ( empty( $message_args['post'] ) ) {
+			return '';
+		}
 		// If the gate is not available, don't mess with the notice.
 		if ( ! self::has_gate() ) {
 			return $notice;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

An alpha hotfix. Fixes some weird content gate behavior in the current alpha version, so needs to be merged before the alphas are deployed.

When a WC Membership plan is created and associated with a taxonomy term, a notice is displayed when a query for that term shows its posts. This causes the content gate to be displayed in, for example, Homepage Posts blocks that query that term.

This PR simply hides the gate entirely, but an alternative solution would be to retain the WC Memberships plugin's default behavior and show the default message instead of replacing with our own gate.

### How to test the changes in this Pull Request:

1. Create a membership plan related to a specific category or tag.
2. On a post, add a Homepage Posts block targeting that term.
3. On the front-end, on `alpha` or `master`, observe that the content gate is rendered at the top of the Homepage Posts block.
4. Check out this branch and repeat step 3. Confirm that the gate is no longer shown.
5. Confirm that the gate is shown on singular posts associated with the term.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->