### PR TITLE
fix(perfmatters): exclude Jetpack and Newsletters css delay

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -80,6 +80,8 @@ class Perfmatters {
 	private static function unused_css_excluded_stylesheets() {
 		return [
 			'plugins/newspack-blocks', // Newspack Blocks.
+			'plugins/newspack-newsletters', // Newspack Newsletters.
+			'plugins/jetpack/modules/sharedaddy', // Jetpack's share buttons.
 			'/themes/newspack-', // Any Newspack theme stylesheet.
 			'wp-includes',
 		];

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -82,6 +82,7 @@ class Perfmatters {
 			'plugins/newspack-blocks', // Newspack Blocks.
 			'plugins/newspack-newsletters', // Newspack Newsletters.
 			'plugins/jetpack/modules/sharedaddy', // Jetpack's share buttons.
+			'plugins/jetpack/_inc/social-logos', // Jetpack's social logos CSS.
 			'/themes/newspack-', // Any Newspack theme stylesheet.
 			'wp-includes',
 		];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Remove CSS delay from Jetpack's sharing buttons and Newspack Newsletters (Subscription Form block)

### How to test the changes in this Pull Request:

1. Make sure you have Perfmatters installed and active
2. Configure JP's sharing buttons on your instance and confirm the CSS is rendered immediately
3. Add a Newsletters Subscription Form block to page, visit and confirm the `subscribeBlock.css` is loaded immediately

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->