### PR TITLE
feat(sign-in): body class when in modal and url hash

### DIFF
--- a/assets/memberships-gate/overlay.scss
+++ b/assets/memberships-gate/overlay.scss
@@ -85,7 +85,8 @@
 	}
 }
 
-.newspack-modal-checkout-open {
+.newspack-modal-checkout-open,
+.newspack-signin {
 	.newspack-memberships {
 		&__overlay-gate {
 			display: none !important;

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -65,7 +65,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 		let accountLinks, triggerLinks;
 		const initLinks = function () {
 			accountLinks = document.querySelectorAll( '.newspack-reader__account-link' );
-			triggerLinks = document.querySelectorAll( '[data-newspack-reader-account-link]' );
+			triggerLinks = document.querySelectorAll(
+				`[data-newspack-reader-account-link],[href="${ newspack_reader_activation_data.account_url }"]`
+			);
 			triggerLinks.forEach( link => {
 				link.addEventListener( 'click', handleAccountLinkClick );
 			} );

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -72,12 +72,16 @@ window.newspackRAS.push( function ( readerActivation ) {
 				link.addEventListener( 'click', handleAccountLinkClick );
 			} );
 		};
-		window.addEventListener( 'hashchange', function ( ev ) {
+		const handleHashChange = function ( ev ) {
 			if ( window.location.hash === '#' + SIGN_IN_MODAL_HASH ) {
-				ev.preventDefault();
+				if ( ev ) {
+					ev.preventDefault();
+				}
 				handleAccountLinkClick();
 			}
-		} );
+		};
+		window.addEventListener( 'hashchange', handleHashChange );
+		handleHashChange();
 		initLinks();
 		/** Re-initialize links in case the navigation DOM was modified by a third-party. */
 		setTimeout( initLinks, 1000 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Support opening the sign-in modal through a hash: `https://example.com/#signin_modal`. This allows for more flexible placement of sign-in links.

To also increase coverage, any link to `/my-account` will also trigger the modal.

Also simplifies how we hide other overlays when in the modal by using a body class.

### How to test the changes in this Pull Request:

1. Check out this branch and visit your site with the `#signin_modal` hash at the end
2. Confirm the modal is rendered
3. Close the modal and confirm the hash is updated and empty
4. Confirm RAS and Memberships are enabled and configure the content gate with "Overlay" style and a link to `#signin_modal`
5. Visit the gated content, click the created link, and confirm the gate overlay hides
6. Edit the content gate and replace the link href to the "My Account" page
7. Repeat step 5 and confirm it behaves the same
8. Check out https://github.com/Automattic/newspack-popups/pull/1094 and create an overlay prompt with the Reader Registration Block
9. Visit a page that renders the prompt and click "Sign in" from the block link
10. Confirm the overlay is hidden while in the Sign In modal

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->