### PR TITLE
feat: add help info for preset prompts

### DIFF
--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -43,7 +43,7 @@ export default function Prerequisite( {
 								<>
 									{ ' ' }
 									<ExternalLink href={ prerequisite.help_url }>
-										{ __( 'Learn more', 'newspack-plugin' ) }
+										{ __( 'Learn more', 'newspack' ) }
 									</ExternalLink>
 								</>
 							) }

--- a/assets/wizards/engagement/components/prompt.tsx
+++ b/assets/wizards/engagement/components/prompt.tsx
@@ -4,7 +4,14 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { BaseControl, CheckboxControl, TextareaControl } from '@wordpress/components';
+import {
+	BaseControl,
+	CheckboxControl,
+	ExternalLink,
+	Path,
+	SVG,
+	TextareaControl,
+} from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { Fragment, useEffect, useState } from '@wordpress/element';
 
@@ -33,6 +40,17 @@ import {
 	TextControl,
 	WebPreview,
 } from '../../../components/src';
+
+const previewIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M4.5001 13C5.17092 13.3354 5.17078 13.3357 5.17066 13.3359L5.17346 13.3305C5.1767 13.3242 5.18233 13.3135 5.19036 13.2985C5.20643 13.2686 5.23209 13.2218 5.26744 13.1608C5.33819 13.0385 5.44741 12.8592 5.59589 12.6419C5.89361 12.2062 6.34485 11.624 6.95484 11.0431C8.17357 9.88241 9.99767 8.75 12.5001 8.75C15.0025 8.75 16.8266 9.88241 18.0454 11.0431C18.6554 11.624 19.1066 12.2062 19.4043 12.6419C19.5528 12.8592 19.662 13.0385 19.7328 13.1608C19.7681 13.2218 19.7938 13.2686 19.8098 13.2985C19.8179 13.3135 19.8235 13.3242 19.8267 13.3305L19.8295 13.3359C19.8294 13.3357 19.8293 13.3354 20.5001 13C21.1709 12.6646 21.1708 12.6643 21.1706 12.664L21.1702 12.6632L21.1693 12.6614L21.1667 12.6563L21.1588 12.6408C21.1522 12.6282 21.1431 12.6108 21.1315 12.5892C21.1083 12.5459 21.0749 12.4852 21.0311 12.4096C20.9437 12.2584 20.8146 12.0471 20.6428 11.7956C20.2999 11.2938 19.7823 10.626 19.0798 9.9569C17.6736 8.61759 15.4977 7.25 12.5001 7.25C9.50252 7.25 7.32663 8.61759 5.92036 9.9569C5.21785 10.626 4.70033 11.2938 4.35743 11.7956C4.1856 12.0471 4.05654 12.2584 3.96909 12.4096C3.92533 12.4852 3.89191 12.5459 3.86867 12.5892C3.85705 12.6108 3.84797 12.6282 3.84141 12.6408L3.83346 12.6563L3.8309 12.6614L3.82997 12.6632L3.82959 12.664C3.82943 12.6643 3.82928 12.6646 4.5001 13ZM12.5001 16C14.4331 16 16.0001 14.433 16.0001 12.5C16.0001 10.567 14.4331 9 12.5001 9C10.5671 9 9.0001 10.567 9.0001 12.5C9.0001 14.433 10.5671 16 12.5001 16Z"
+			fill="#3366FF"
+		/>
+	</SVG>
+);
 
 // Note: Schema and types for the `prompt` prop is defined in Newspack Campaigns: https://github.com/Automattic/newspack-popups/blob/master/includes/schemas/class-prompts.php
 export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: PromptProps ) {
@@ -131,6 +149,8 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 		} );
 	};
 
+	const helpInfo = prompt.help_info || null;
+
 	return (
 		<ActionCard
 			isMedium
@@ -145,7 +165,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 			checkbox={ prompt.ready ? 'checked' : 'unchecked' }
 		>
 			{
-				<Grid columns={ 2 } gutter={ 16 } className="newspack-ras-campaign__grid">
+				<Grid columns={ 2 } gutter={ 64 } className="newspack-ras-campaign__grid">
 					<div className="newspack-ras-campaign__fields">
 						{ prompt.user_input_fields.map( ( field: InputField ) => (
 							<Fragment key={ field.name }>
@@ -264,37 +284,67 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 							/>
 						) }
 						{ success && <Notice noticeText={ success } isSuccess /> }
-						<Button
-							isPrimary
-							onClick={ () => savePrompt( prompt.slug, values ) }
-							disabled={ inFlight }
-						>
-							{ inFlight
-								? __( 'Saving…', 'newspack' )
-								: sprintf(
-										// Translators: Save or Update settings.
-										__( '%s prompt settings', 'newspack' ),
-										prompt.ready ? __( 'Update', 'newspack' ) : __( 'Save', 'newspack' )
-								  ) }
-						</Button>
-						<WebPreview
-							url={ getPreviewUrl( prompt ) }
-							renderButton={ ( { showPreview }: { showPreview: () => void } ) => (
-								<Button
-									disabled={ inFlight }
-									isSecondary
-									onClick={ async () => {
-										if ( isDirty ) {
-											await savePrompt( prompt.slug, values );
-										}
-										showPreview();
-									} }
-								>
-									{ __( 'Preview prompt', 'newspack' ) }
-								</Button>
-							) }
-						/>
+						<div className="newspack-buttons-card">
+							<Button
+								isPrimary
+								onClick={ () => savePrompt( prompt.slug, values ) }
+								disabled={ inFlight }
+							>
+								{ inFlight
+									? __( 'Saving…', 'newspack' )
+									: sprintf(
+											// Translators: Save or Update settings.
+											__( '%s prompt settings', 'newspack' ),
+											prompt.ready ? __( 'Update', 'newspack' ) : __( 'Save', 'newspack' )
+									  ) }
+							</Button>
+							<WebPreview
+								url={ getPreviewUrl( prompt ) }
+								renderButton={ ( { showPreview }: { showPreview: () => void } ) => (
+									<Button
+										disabled={ inFlight }
+										icon={ previewIcon }
+										isSecondary
+										onClick={ async () => {
+											if ( isDirty ) {
+												await savePrompt( prompt.slug, values );
+											}
+											showPreview();
+										} }
+									>
+										{ __( 'Preview prompt', 'newspack' ) }
+									</Button>
+								) }
+							/>
+						</div>
 					</div>
+					{ helpInfo && (
+						<div className="newspack-ras-campaign__help">
+							{ helpInfo.screenshot && <img src={ helpInfo.screenshot } alt={ prompt.title } /> }
+							{ helpInfo.description && (
+								<p>
+									<span dangerouslySetInnerHTML={ { __html: helpInfo.description } } />{ ' ' }
+									{ helpInfo.url && (
+										<ExternalLink href={ helpInfo.url }>
+											{ __( 'Learn more', 'newspack' ) }
+										</ExternalLink>
+									) }
+								</p>
+							) }
+							{ helpInfo.recommendations && (
+								<>
+									<h4 className="newspack-ras-campaign__recommendation-heading">
+										{ __( 'We recommend', 'newspack' ) }
+									</h4>
+									<ul>
+										{ helpInfo.recommendations.map( ( recommendation, index ) => (
+											<li key={ index } dangerouslySetInnerHTML={ { __html: recommendation } } />
+										) ) }
+									</ul>
+								</>
+							) }
+						</div>
+					) }
 				</Grid>
 			}
 		</ActionCard>

--- a/assets/wizards/engagement/components/prompt.tsx
+++ b/assets/wizards/engagement/components/prompt.tsx
@@ -338,7 +338,9 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 									</h4>
 									<ul>
 										{ helpInfo.recommendations.map( ( recommendation, index ) => (
-											<li key={ index } dangerouslySetInnerHTML={ { __html: recommendation } } />
+											<li key={ index }>
+												<span dangerouslySetInnerHTML={ { __html: recommendation } } />
+											</li>
 										) ) }
 									</ul>
 								</>

--- a/assets/wizards/engagement/components/types.ts
+++ b/assets/wizards/engagement/components/types.ts
@@ -135,6 +135,12 @@ export type PromptType = {
 	featured_image_id?: number;
 	options: PromptOptions;
 	user_input_fields: [ InputField ];
+	help_info?: {
+		screenshot?: string;
+		recommendations?: Array< string >;
+		description?: string;
+		url?: string;
+	};
 	ready?: boolean;
 };
 

--- a/assets/wizards/engagement/views/reader-activation/style.scss
+++ b/assets/wizards/engagement/views/reader-activation/style.scss
@@ -73,9 +73,13 @@
 		}
 
 		ul {
-			color: wp-colors.$gray-600;
+			color: var( --wp-admin-theme-color );
 			list-style: disc;
 			padding-left: 24px;
+
+			li span {
+				color: wp-colors.$gray-700;
+			}
 		}
 	}
 }

--- a/assets/wizards/engagement/views/reader-activation/style.scss
+++ b/assets/wizards/engagement/views/reader-activation/style.scss
@@ -1,8 +1,16 @@
+@use '~@wordpress/base-styles/colors' as wp-colors;
+
 .newspack-card:not(.newspack-settings__no-border) .newspack-action-card__region-children > .newspack-grid.newspack-ras-campaign__grid {
 	margin-top: 0 !important;
 }
 
 .newspack-ras-campaign {
+	&__prompt-wizard {
+		.newspack-buttons-card {
+			margin-top: 32px;
+		}
+	}
+
 	&__fields {
 		.newspack-text-control,
 		.newspack-textarea-control {
@@ -41,18 +49,33 @@
 			margin-top: 8px;
 		}
 
-		.components-button + .components-button {
-			margin-left: 16px;
-		}
-
 		.newspack-image-upload {
 			margin-top: 0;
 		}
+
+		.newspack-buttons-card {
+			margin-bottom: 0;
+			flex-direction: row;
+		}
 	}
 
-	&__prompt-wizard {
-		.newspack-buttons-card {
+	&__help {
+		img {
+			display: block;
+			margin: 16px auto;
+			width: 100%;
+		}
+
+		.newspack-ras-campaign__recommendation-heading {
+			letter-spacing: 0.01em;
 			margin-top: 32px;
+			text-transform: uppercase;
+		}
+
+		ul {
+			color: wp-colors.$gray-600;
+			list-style: disc;
+			padding-left: 24px;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds static help copy and screenshots according to the latest i3 designs.

<img width="964" alt="Screen Shot 2023-04-19 at 5 09 35 PM" src="https://user-images.githubusercontent.com/2230142/233218699-8661516a-ec06-4d45-8d45-02d38b621b3f.png">


### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-popups/pull/1096.
2. Proceed to the default prompt setup wizard as in #2399.
3. Expand each card and confirm that the right side of the card displays relevant help info and screenshots.
4. Also confirm that the "Preview" buttons in each card have a new :eye: icon.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->