### PR TITLE
Ensure .hooks is excluded from the dist ZIP

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,7 @@
 *.config.js
 .git
 .gitlab-ci.yml
+.hooks
 .travis.yml
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently, `.hooks` is being included in the release archive. This change ensures it isn't.

### How to test the changes in this Pull Request:

1. Run `npm run release:archive`
2. Open the built archive
3. Confirm it does not contain a `.hooks` directory

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->