### PR TITLE
fix: add filter to prompt conflicts check

### DIFF
--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -4,6 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * External dependencies.
@@ -339,20 +340,27 @@ export const warningForPopup = ( prompts, prompt ) => {
 			);
 		} );
 
-		if ( 0 < conflictingPrompts.length ) {
+		const filteredConflictingPrompts = applyFilters(
+			'newspack.wizards.campaigns.conflictingPrompts',
+			conflictingPrompts,
+			prompt,
+			prompts
+		);
+
+		if ( 0 < filteredConflictingPrompts.length ) {
 			return (
 				<>
 					<strong>
 						{ sprintf(
 							// Translators: %s: 'Conflicts' or 'Conflict' depending on number of conflicts.
 							__( '%s detected:', 'newspack' ),
-							1 < conflictingPrompts.length
+							1 < filteredConflictingPrompts.length
 								? __( 'Conflicts', 'newspack' )
 								: __( 'Conflict', 'newspack' )
 						) }
 					</strong>
 					<ul>
-						{ conflictingPrompts.map( conflictingPrompt => (
+						{ filteredConflictingPrompts.map( conflictingPrompt => (
 							<li key={ conflictingPrompt.id }>
 								<p data-testid={ `conflict-warning-${ prompt.id }` }>
 									<strong>{ sprintf( '%s: ', conflictingPrompt.title ) }</strong>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add a filter to the check for prompt conflicts.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-multibranded-site/pull/19

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->