### PR TITLE
feat: add handoff message for prerequisites

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -69,6 +69,7 @@ class ActionCard extends Component {
 			toggleChecked,
 			toggleOnChange,
 			hasGreyHeader,
+			hasWhiteHeader,
 			isPending,
 			expandable = false,
 		} = this.props;
@@ -80,12 +81,14 @@ class ActionCard extends Component {
 			'newspack-action-card',
 			simple && 'newspack-card--is-clickable',
 			hasGreyHeader && 'newspack-card--has-grey-header',
+			hasWhiteHeader && 'newspack-card--has-white-header',
 			hasChildren && 'newspack-card--has-children',
 			indent && 'newspack-card--indent',
 			isSmall && 'is-small',
 			isMedium && 'is-medium',
 			checkbox && 'has-checkbox',
 			expandable && 'is-expandable',
+			actionContent && 'has-action-content',
 			className
 		);
 		const backgroundImageStyles = url => {

--- a/assets/components/src/action-card/style.scss
+++ b/assets/components/src/action-card/style.scss
@@ -146,6 +146,24 @@
 		}
 	}
 
+	// Nested children
+
+	&.newspack-card--has-children {
+		.newspack-action-card {
+			&:first-child {
+				margin-top: 32px;
+			}
+
+			+ .newspack-action-card {
+				margin-top: 16px !important;
+			}
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+	}
+
 	// Has grey header
 
 	&.newspack-card--has-grey-header {
@@ -154,6 +172,11 @@
 		&.newspack-card--has-children {
 			.newspack-action-card__region-top {
 				border-bottom: 1px solid wp-colors.$gray-300;
+			}
+
+			.is-small > .newspack-action-card__region-top {
+				padding-bottom: 8px;
+				padding-top: 8px;
 			}
 		}
 
@@ -165,6 +188,13 @@
 			p {
 				color: color.adjust( wp-colors.$gray-700, $lightness: -0.75% );
 			}
+		}
+	}
+
+	&.newspack-card--has-white-header {
+		.newspack-action-card__region-top {
+			background-color: transparent;
+			border: none !important;
 		}
 	}
 
@@ -348,6 +378,12 @@
 				margin-top: 0;
 			}
 		}
+
+		&.newspack-action-card__region-children {
+			.newspack-notice {
+				margin-top: 32px;
+			}
+		}
 	}
 
 	// Image
@@ -424,6 +460,15 @@
 			&.is-medium .newspack-action-card__region-children {
 				padding-left: 56px;
 			}
+		}
+	}
+
+	// Action content with multiple buttons
+	&.has-action-content .newspack-action-card__region-right {
+		flex-direction: row;
+
+		.components-button + .components-button {
+			margin-left: 8px;
 		}
 	}
 

--- a/assets/components/src/consts.js
+++ b/assets/components/src/consts.js
@@ -1,2 +1,3 @@
 export const NEWSPACK_SITE_URL = 'https://newspack.com';
 export const NEWSPACK_SUPPORT_URL = `${ NEWSPACK_SITE_URL }/support`;
+export const HANDOFF_KEY = 'newspack_wizar_handoff';

--- a/assets/components/src/consts.js
+++ b/assets/components/src/consts.js
@@ -1,3 +1,3 @@
 export const NEWSPACK_SITE_URL = 'https://newspack.com';
 export const NEWSPACK_SUPPORT_URL = `${ NEWSPACK_SITE_URL }/support`;
-export const HANDOFF_KEY = 'newspack_wizar_handoff';
+export const HANDOFF_KEY = 'newspack_wizard_handoff_message';

--- a/assets/components/src/notice/index.js
+++ b/assets/components/src/notice/index.js
@@ -28,6 +28,7 @@ class Notice extends Component {
 			className,
 			debugMode,
 			isError,
+			isHandoff,
 			isHelp,
 			isSuccess,
 			isWarning,
@@ -41,6 +42,7 @@ class Notice extends Component {
 			className,
 			debugMode && 'newspack-notice__is-debug',
 			isError && 'newspack-notice__is-error',
+			isHandoff && 'newspack-notice__is-handoff',
 			isHelp && 'newspack-notice__is-help',
 			isSuccess && 'newspack-notice__is-success',
 			isWarning && 'newspack-notice__is-warning'

--- a/assets/components/src/notice/style.scss
+++ b/assets/components/src/notice/style.scss
@@ -48,6 +48,11 @@
 		}
 	}
 
+	&__is-handoff {
+		background: color.adjust( wp-colors.$alert-yellow, $lightness: 30% );
+		margin-top: 0;
+	}
+
 	&__is-help {
 		background: colors.$primary-050;
 

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -2,12 +2,14 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
 import { category } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { Button, Handoff, NewspackIcon, Notice, TabbedNavigation } from '../';
+import { HANDOFF_KEY } from '../consts';
 import { buttonProps } from '../../../shared/js/';
 import './style.scss';
 
@@ -21,6 +23,7 @@ import classnames from 'classnames';
  */
 export default function withWizardScreen( WrappedComponent, { hidePrimaryButton } = {} ) {
 	const WrappedWithWizardScreen = props => {
+		const [ handoffMessage, setHandoffMessage ] = useState( false );
 		const {
 			className,
 			buttonText,
@@ -34,6 +37,15 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 			renderAboveContent,
 			disableUpcomingInTabbedNavigation,
 		} = props;
+
+		useEffect( () => {
+			const handoff = JSON.parse( localStorage.getItem( HANDOFF_KEY ) );
+
+			if ( handoff?.message ) {
+				setHandoffMessage( handoff.message );
+			}
+		}, [] );
+
 		const retrievedButtonProps = buttonProps( buttonAction );
 		const retrievedSecondaryButtonProps = buttonProps( secondaryButtonAction );
 		const SecondaryCTAComponent = retrievedSecondaryButtonProps.plugin ? Handoff : Button;
@@ -85,6 +97,10 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 						disableUpcoming={ disableUpcomingInTabbedNavigation }
 						items={ tabbedNavigation.filter( item => ! item.isHiddenInNav ) }
 					/>
+				) }
+
+				{ handoffMessage && (
+					<Notice isHandoff isDismissible={ false } rawHTML noticeText={ handoffMessage } />
 				) }
 
 				<div className={ classnames( 'newspack-wizard newspack-wizard__content', className ) }>

--- a/assets/components/src/wizard/index.js
+++ b/assets/components/src/wizard/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies.
  */
 import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { category } from '@wordpress/icons';
 
@@ -19,6 +19,7 @@ import Router from '../proxied-imports/router';
 import registerStore, { WIZARD_STORE_NAMESPACE } from './store';
 import { useWizardData } from './store/utils';
 import WizardError from './components/WizardError';
+import { HANDOFF_KEY } from '../consts';
 
 registerStore();
 
@@ -34,12 +35,21 @@ const Wizard = ( {
 	renderAboveSections,
 	requiredPlugins = [],
 } ) => {
+	const [ handoffMessage, setHandoffMessage ] = useState( false );
 	const isLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isLoading() );
 	const isQuietLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() );
 
 	// Trigger initial data fetch. Some sections might not use the wizard data,
 	// but for consistency, fetching is triggered regardless of the section.
 	useSelect( select => select( WIZARD_STORE_NAMESPACE ).getWizardAPIData( apiSlug ) );
+
+	useEffect( () => {
+		const handoff = JSON.parse( localStorage.getItem( HANDOFF_KEY ) );
+
+		if ( handoff?.message ) {
+			setHandoffMessage( handoff.message );
+		}
+	}, [] );
 
 	let displayedSections = sections.filter( section => ! section.isHidden );
 
@@ -101,6 +111,9 @@ const Wizard = ( {
 						<TabbedNavigation items={ displayedSections }>
 							<WizardError />
 						</TabbedNavigation>
+					) }
+					{ handoffMessage && (
+						<Notice isHandoff isDismissible={ false } rawHTML noticeText={ handoffMessage } />
 					) }
 
 					<Switch>

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -110,7 +110,7 @@ export default function Prerequisite( {
 														message: sprintf(
 															// Translators: %s is specific instructions for satisfying the prerequisite.
 															__(
-																'%1$s%2$sReturn to Reader Activation to complete setup%3$s.',
+																'%1$s%2$sReturn to the Reader Activation page to complete the settings and activate%3$s.',
 																'newspack'
 															),
 															prerequisite.instructions + ' ' || '',

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -9,6 +9,7 @@ import { ExternalLink } from '@wordpress/components';
  */
 import { PrequisiteProps } from './types';
 import { ActionCard, Button, Grid, TextControl } from '../../../components/src';
+import { HANDOFF_KEY } from '../../../components/src/consts';
 
 /**
  * Expandable ActionCard for RAS prerequisites checklist.
@@ -20,6 +21,8 @@ export default function Prerequisite( {
 	prerequisite,
 	saveConfig,
 }: PrequisiteProps ) {
+	const { href } = prerequisite;
+
 	return (
 		<ActionCard
 			isMedium
@@ -92,12 +95,36 @@ export default function Prerequisite( {
 					}
 					{
 						// Link to another settings page or update config in place.
-						prerequisite.href && prerequisite.action_text && (
+						href && prerequisite.action_text && (
 							<Grid columns={ 2 } gutter={ 16 }>
 								<div>
 									{ ( ! prerequisite.hasOwnProperty( 'action_enabled' ) ||
 										prerequisite.action_enabled ) && (
-										<Button isPrimary href={ prerequisite.href }>
+										<Button
+											isPrimary
+											onClick={ () => {
+												// Set up a handoff to indicate that the user is coming from the RAS wizard page.
+												window.localStorage.setItem(
+													HANDOFF_KEY,
+													JSON.stringify( {
+														message: sprintf(
+															// Translators: %s is specific instructions for satisfying the prerequisite.
+															__(
+																'%1$s%2$sReturn to Reader Activation to complete setup%3$s.',
+																'newspack'
+															),
+															prerequisite.instructions + ' ' || '',
+															window.newspack_engagement_wizard?.reader_activation_url
+																? `<a href="${ window.newspack_engagement_wizard.reader_activation_url }">`
+																: '',
+															window.newspack_engagement_wizard?.reader_activation_url ? '</a>' : ''
+														),
+													} )
+												);
+
+												window.location.href = href;
+											} }
+										>
 											{ /* eslint-disable no-nested-ternary */ }
 											{ ( prerequisite.active
 												? __( 'Update ', 'newspack' )

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -104,23 +104,27 @@ export default function Prerequisite( {
 											isPrimary
 											onClick={ () => {
 												// Set up a handoff to indicate that the user is coming from the RAS wizard page.
-												window.localStorage.setItem(
-													HANDOFF_KEY,
-													JSON.stringify( {
-														message: sprintf(
-															// Translators: %s is specific instructions for satisfying the prerequisite.
-															__(
-																'%1$s%2$sReturn to the Reader Activation page to complete the settings and activate%3$s.',
-																'newspack'
+												if ( prerequisite.instructions ) {
+													window.localStorage.setItem(
+														HANDOFF_KEY,
+														JSON.stringify( {
+															message: sprintf(
+																// Translators: %s is specific instructions for satisfying the prerequisite.
+																__(
+																	'%1$s%2$sReturn to the Reader Activation page to complete the settings and activate%3$s.',
+																	'newspack'
+																),
+																prerequisite.instructions + ' ',
+																window.newspack_engagement_wizard?.reader_activation_url
+																	? `<a href="${ window.newspack_engagement_wizard.reader_activation_url }">`
+																	: '',
+																window.newspack_engagement_wizard?.reader_activation_url
+																	? '</a>'
+																	: ''
 															),
-															prerequisite.instructions + ' ' || '',
-															window.newspack_engagement_wizard?.reader_activation_url
-																? `<a href="${ window.newspack_engagement_wizard.reader_activation_url }">`
-																: '',
-															window.newspack_engagement_wizard?.reader_activation_url ? '</a>' : ''
-														),
-													} )
-												);
+														} )
+													);
+												}
 
 												window.location.href = href;
 											} }

--- a/assets/wizards/engagement/components/prompt.tsx
+++ b/assets/wizards/engagement/components/prompt.tsx
@@ -257,7 +257,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 										label={ field.label }
 									>
 										<ImageUpload
-											buttonLabel={ __( 'Choose image', 'newspack' ) }
+											buttonLabel={ __( 'Select file', 'newspack' ) }
 											disabled={ inFlight }
 											image={ image }
 											onChange={ ( attachment: Attachment ) => {

--- a/assets/wizards/engagement/components/types.ts
+++ b/assets/wizards/engagement/components/types.ts
@@ -9,6 +9,7 @@ declare global {
 			has_reader_activation: boolean;
 			has_memberships: boolean;
 			new_subscription_lists_url: string;
+			reader_activation_url: string;
 			preview_query_keys: {
 				background_color: string;
 				display_title: string;
@@ -97,6 +98,7 @@ export type PrequisiteProps = {
 		active: boolean;
 		label: string;
 		description: string;
+		instructions?: string;
 		help_url: string;
 		fields?: {
 			[ fieldName: string ]: {

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -161,7 +161,6 @@ class EngagementWizard extends Component {
 											'Preview and customize the reader activation prompts',
 											'newspack'
 										) }
-										{ ...props }
 									/>
 								) }
 							/>

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -161,6 +161,7 @@ class EngagementWizard extends Component {
 											'Preview and customize the reader activation prompts',
 											'newspack'
 										) }
+										{ ...props }
 									/>
 								) }
 							/>

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -38,10 +38,9 @@ export const NewspackNewsletters = ( {
 	initialProvider,
 	setInitialProvider,
 	newslettersConfig,
-	inFlight,
-	setInFlight,
 	setLockedLists,
 } ) => {
+	const [ inFlight, setInFlight ] = useState( false );
 	const [ error, setError ] = useState( false );
 	const [ config, updateConfig ] = hooks.useObjectState( {} );
 
@@ -132,7 +131,7 @@ export const NewspackNewsletters = ( {
 	};
 	useEffect( fetchConfiguration, [] );
 	const getSettingProps = key => ( {
-		inFlight,
+		disabled: inFlight,
 		value: config.settings[ key ]?.value || '',
 		checked: Boolean( config.settings[ key ]?.value ),
 		label: config.settings[ key ]?.description,
@@ -367,7 +366,6 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 
 const Newsletters = () => {
 	const [ { newslettersConfig }, updateConfiguration ] = hooks.useObjectState( {} );
-	const [ inFlight, setInFlight ] = useState( false );
 	const [ initialProvider, setInitialProvider ] = useState( '' );
 	const [ lockedLists, setLockedLists ] = useState( false );
 	const [ authUrl, setAuthUrl ] = useState( false );
@@ -376,8 +374,6 @@ const Newsletters = () => {
 		<>
 			<NewspackNewsletters
 				isOnboarding={ false }
-				inFlight={ inFlight }
-				setInFlight={ setInFlight }
 				onUpdate={ config => updateConfiguration( { newslettersConfig: config } ) }
 				authUrl={ authUrl }
 				setAuthUrl={ setAuthUrl }

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -298,7 +298,10 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 					error
 						? error?.message || __( 'Something went wrong.', 'newspack' )
 						: lockedLists
-						? __( 'Please save your settings before changing your subscription lists.', 'newspack' )
+						? __(
+								'Please save your ESP settings before changing your subscription lists.',
+								'newspack'
+						  )
 						: null
 				}
 				notificationLevel={ error ? 'error' : 'warning' }

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -20,7 +20,6 @@ import {
 	Card,
 	ActionCard,
 	Grid,
-	Notice,
 	PluginInstaller,
 	SectionHeader,
 	SelectControl,
@@ -34,11 +33,60 @@ export const NewspackNewsletters = ( {
 	className,
 	onUpdate,
 	authUrl = false,
+	setAuthUrl,
 	isOnboarding = true,
-	disabled = false,
+	initialProvider,
+	setInitialProvider,
+	newslettersConfig,
+	inFlight,
+	setInFlight,
+	setLockedLists,
 } ) => {
-	const [ error, setError ] = useState();
+	const [ error, setError ] = useState( false );
 	const [ config, updateConfig ] = hooks.useObjectState( {} );
+
+	useEffect( () => {
+		const provider = newslettersConfig?.newspack_newsletters_service_provider;
+		if ( initialProvider && provider !== initialProvider ) {
+			setLockedLists( true );
+		} else {
+			setLockedLists( false );
+		}
+		if ( ! initialProvider && provider ) {
+			setInitialProvider( provider );
+		}
+	}, [ newslettersConfig?.newspack_newsletters_service_provider ] );
+
+	useEffect( () => {
+		verifyToken( newslettersConfig?.newspack_newsletters_service_provider );
+	}, [ newslettersConfig?.newspack_newsletters_service_provider ] );
+
+	const verifyToken = provider => {
+		setAuthUrl( false );
+		if ( ! provider ) {
+			return;
+		}
+		// Constant Contact is the only provider using an OAuth strategy.
+		if ( 'constant_contact' !== provider ) {
+			return;
+		}
+		setInFlight( true );
+		apiFetch( { path: `/newspack-newsletters/v1/${ provider }/verify_token` } )
+			.then( response => {
+				if ( ! response.valid && response.auth_url ) {
+					setAuthUrl( response.auth_url );
+				} else {
+					setAuthUrl( false );
+				}
+			} )
+			.catch( () => {
+				setAuthUrl( false );
+			} )
+			.finally( () => {
+				setInFlight( false );
+			} );
+	};
+
 	const performConfigUpdate = update => {
 		updateConfig( update );
 		if ( onUpdate ) {
@@ -46,6 +94,7 @@ export const NewspackNewsletters = ( {
 		}
 	};
 	const fetchConfiguration = () => {
+		setError( false );
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/newsletters',
 		} )
@@ -67,9 +116,23 @@ export const NewspackNewsletters = ( {
 			};
 		}
 	};
+	const saveNewslettersData = async () => {
+		setError( false );
+		setInFlight( true );
+		apiFetch( {
+			path: '/newspack/v1/wizard/newspack-engagement-wizard/newsletters',
+			method: 'POST',
+			data: newslettersConfig,
+		} ).finally( () => {
+			setInitialProvider( newslettersConfig?.newspack_newsletters_service_provider );
+			verifyToken( newslettersConfig?.newspack_newsletters_service_provider );
+			setLockedLists( false );
+			setInFlight( false );
+		} );
+	};
 	useEffect( fetchConfiguration, [] );
 	const getSettingProps = key => ( {
-		disabled,
+		inFlight,
 		value: config.settings[ key ]?.value || '',
 		checked: Boolean( config.settings[ key ]?.value ),
 		label: config.settings[ key ]?.description,
@@ -85,49 +148,71 @@ export const NewspackNewsletters = ( {
 	const renderProviderSettings = () => {
 		const providerSelectProps = getSettingProps( 'newspack_newsletters_service_provider' );
 		return (
-			<Grid gutter={ 16 } columns={ 1 }>
-				{ false !== authUrl && (
-					<Card isSmall>
-						<h3>{ __( 'Authorize Application', 'newspack' ) }</h3>
-						<p>
-							{ sprintf(
-								// translators: %s is the name of the ESP.
-								__( 'Authorize %s to connect to Newspack.', 'newspack-newsletters' ),
-								getSelectedProviderName()
-							) }
-						</p>
-						<Button isSecondary onClick={ handleAuth }>
-							{ __( 'Authorize', 'newspack' ) }
-						</Button>
-					</Card>
+			<ActionCard
+				isMedium
+				title={ __( 'Email Service Provider', 'newspack' ) }
+				description={ __(
+					'Connect an email service provider (ESP) to author and send newsletters.',
+					'newspack'
 				) }
-				{ values( config.settings )
-					.filter( setting => ! setting.provider || setting.provider === providerSelectProps.value )
-					.map( setting => {
-						if ( isOnboarding && ! setting.onboarding ) {
-							return null;
-						}
-						switch ( setting.type ) {
-							case 'select':
-								return <SelectControl key={ setting.key } { ...getSettingProps( setting.key ) } />;
-							case 'checkbox':
-								return (
-									<CheckboxControl key={ setting.key } { ...getSettingProps( setting.key ) } />
-								);
-							default:
-								return (
-									<Grid columns={ 1 } gutter={ 8 } key={ setting.key }>
-										<TextControl { ...getSettingProps( setting.key ) } />
-										{ setting.help && setting.helpURL && (
-											<p>
-												<ExternalLink href={ setting.helpURL }>{ setting.help }</ExternalLink>
-											</p>
-										) }
-									</Grid>
-								);
-						}
-					} ) }
-			</Grid>
+				notification={ error ? error?.message || __( 'Something went wrong.', 'newspack' ) : null }
+				notificationLevel="error"
+				hasGreyHeader
+				actionContent={
+					<Button disabled={ inFlight } variant="primary" onClick={ saveNewslettersData }>
+						{ __( 'Save Settings', 'newspack' ) }
+					</Button>
+				}
+				disabled={ inFlight }
+			>
+				<Grid gutter={ 16 } columns={ 1 }>
+					{ false !== authUrl && (
+						<Card isSmall>
+							<h3>{ __( 'Authorize Application', 'newspack' ) }</h3>
+							<p>
+								{ sprintf(
+									// translators: %s is the name of the ESP.
+									__( 'Authorize %s to connect to Newspack.', 'newspack-newsletters' ),
+									getSelectedProviderName()
+								) }
+							</p>
+							<Button isSecondary onClick={ handleAuth }>
+								{ __( 'Authorize', 'newspack' ) }
+							</Button>
+						</Card>
+					) }
+					{ values( config.settings )
+						.filter(
+							setting => ! setting.provider || setting.provider === providerSelectProps.value
+						)
+						.map( setting => {
+							if ( isOnboarding && ! setting.onboarding ) {
+								return null;
+							}
+							switch ( setting.type ) {
+								case 'select':
+									return (
+										<SelectControl key={ setting.key } { ...getSettingProps( setting.key ) } />
+									);
+								case 'checkbox':
+									return (
+										<CheckboxControl key={ setting.key } { ...getSettingProps( setting.key ) } />
+									);
+								default:
+									return (
+										<Grid columns={ 1 } gutter={ 8 } key={ setting.key }>
+											<TextControl { ...getSettingProps( setting.key ) } />
+											{ setting.help && setting.helpURL && (
+												<p>
+													<ExternalLink href={ setting.helpURL }>{ setting.help }</ExternalLink>
+												</p>
+											) }
+										</Grid>
+									);
+							}
+						} ) }
+				</Grid>
+			</ActionCard>
 		);
 	};
 	if ( ! error && isEmpty( config ) ) {
@@ -135,12 +220,6 @@ export const NewspackNewsletters = ( {
 			<div className="flex justify-around mt4">
 				<Waiting />
 			</div>
-		);
-	}
-
-	if ( error ) {
-		return (
-			<Notice noticeText={ error.message || __( 'Something went wrong.', 'newspack' ) } isError />
 		);
 	}
 
@@ -158,7 +237,7 @@ export const NewspackNewsletters = ( {
 	);
 };
 
-export const SubscriptionLists = ( { onUpdate } ) => {
+export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) => {
 	const [ error, setError ] = useState( false );
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ lists, setLists ] = useState( [] );
@@ -195,7 +274,7 @@ export const SubscriptionLists = ( { onUpdate } ) => {
 		newLists[ index ][ name ] = value;
 		updateConfig( newLists );
 	};
-	useEffect( fetchLists, [] );
+	useEffect( fetchLists, [ initialProvider ] );
 
 	if ( ! inFlight && ! lists?.length && ! error ) {
 		return null;
@@ -211,65 +290,77 @@ export const SubscriptionLists = ( { onUpdate } ) => {
 
 	return (
 		<>
-			<Card headerActions noBorder>
-				<SectionHeader
-					title={ __( 'Subscription Lists', 'newspack' ) }
-					description={ __( 'Manage the lists available for subscription.', 'newspack' ) }
-				/>
-				{ newspack_engagement_wizard.new_subscription_lists_url && (
-					<Button
-						variant="secondary"
-						href={ newspack_engagement_wizard.new_subscription_lists_url }
-					>
-						{ __( 'Add New', 'newspack' ) }
-					</Button>
-				) }
-			</Card>
-			{ error && (
-				<Notice
-					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
-					isError
-				/>
-			) }
-			{ lists.map( ( list, index ) => (
-				<ActionCard
-					key={ list.id }
-					title={ list.name }
-					description={ list?.type_label ? list.type_label : null }
-					disabled={ inFlight }
-					toggleOnChange={ handleChange( index, 'active' ) }
-					toggleChecked={ list.active }
-					actionText={
-						list?.edit_link ? (
-							<ExternalLink href={ list.edit_link }>
-								{ __( 'Edit', 'newspack_newsletters' ) }
-							</ExternalLink>
-						) : null
-					}
-				>
-					{ list.active && 'local' !== list?.type && (
-						<>
-							<TextControl
-								label={ __( 'List title', 'newspack' ) }
-								value={ list.title }
-								disabled={ inFlight || 'local' === list?.type }
-								onChange={ handleChange( index, 'title' ) }
-							/>
-							<TextareaControl
-								label={ __( 'List description', 'newspack' ) }
-								value={ list.description }
-								disabled={ inFlight || 'local' === list?.type }
-								onChange={ handleChange( index, 'description' ) }
-							/>
-						</>
-					) }
-				</ActionCard>
-			) ) }
-			<div className="newspack-buttons-card">
-				<Button isPrimary onClick={ saveLists } disabled={ inFlight }>
-					{ __( 'Save Subscription Lists', 'newspack' ) }
-				</Button>
-			</div>
+			<ActionCard
+				isMedium
+				title={ __( 'Subscription Lists', 'newspack' ) }
+				description={ __( 'Manage the lists available to readers for subscription.', 'newspack' ) }
+				notification={
+					/* eslint-disable no-nested-ternary */
+					error
+						? error?.message || __( 'Something went wrong.', 'newspack' )
+						: lockedLists
+						? __( 'Please save your settings before changing your subscription lists.', 'newspack' )
+						: null
+				}
+				notificationLevel={ error ? 'error' : 'warning' }
+				hasGreyHeader
+				actionContent={
+					<>
+						{ newspack_engagement_wizard.new_subscription_lists_url && (
+							<Button
+								variant="secondary"
+								disabled={ inFlight || lockedLists }
+								href={ newspack_engagement_wizard.new_subscription_lists_url }
+							>
+								{ __( 'Add New', 'newspack' ) }
+							</Button>
+						) }
+						<Button isPrimary onClick={ saveLists } disabled={ inFlight || lockedLists }>
+							{ __( 'Save Subscription Lists', 'newspack' ) }
+						</Button>
+					</>
+				}
+				disabled={ inFlight || lockedLists }
+			>
+				{ ! lockedLists &&
+					lists.map( ( list, index ) => (
+						<ActionCard
+							key={ list.id }
+							isSmall
+							simple
+							hasWhiteHeader
+							title={ list.name }
+							description={ list?.type_label ? list.type_label : null }
+							disabled={ inFlight }
+							toggleOnChange={ handleChange( index, 'active' ) }
+							toggleChecked={ list.active }
+							actionText={
+								list?.edit_link ? (
+									<ExternalLink href={ list.edit_link }>
+										{ __( 'Edit', 'newspack_newsletters' ) }
+									</ExternalLink>
+								) : null
+							}
+						>
+							{ list.active && 'local' !== list?.type && (
+								<>
+									<TextControl
+										label={ __( 'List title', 'newspack' ) }
+										value={ list.title }
+										disabled={ inFlight || 'local' === list?.type }
+										onChange={ handleChange( index, 'title' ) }
+									/>
+									<TextareaControl
+										label={ __( 'List description', 'newspack' ) }
+										value={ list.description }
+										disabled={ inFlight || 'local' === list?.type }
+										onChange={ handleChange( index, 'description' ) }
+									/>
+								</>
+							) }
+						</ActionCard>
+					) ) }
+			</ActionCard>
 		</>
 	);
 };
@@ -281,85 +372,27 @@ const Newsletters = () => {
 	const [ lockedLists, setLockedLists ] = useState( false );
 	const [ authUrl, setAuthUrl ] = useState( false );
 
-	useEffect( () => {
-		const provider = newslettersConfig?.newspack_newsletters_service_provider;
-		if ( initialProvider && provider !== initialProvider ) {
-			setLockedLists( true );
-		} else {
-			setLockedLists( false );
-		}
-		if ( ! initialProvider && provider ) {
-			setInitialProvider( provider );
-		}
-	}, [ newslettersConfig?.newspack_newsletters_service_provider ] );
-
-	const verifyToken = provider => {
-		setAuthUrl( false );
-		if ( ! provider ) {
-			return;
-		}
-		// Constant Contact is the only provider using an OAuth strategy.
-		if ( 'constant_contact' !== provider ) {
-			return;
-		}
-		setInFlight( true );
-		apiFetch( { path: `/newspack-newsletters/v1/${ provider }/verify_token` } )
-			.then( response => {
-				if ( ! response.valid && response.auth_url ) {
-					setAuthUrl( response.auth_url );
-				} else {
-					setAuthUrl( false );
-				}
-			} )
-			.catch( () => {
-				setAuthUrl( false );
-			} )
-			.finally( () => {
-				setInFlight( false );
-			} );
-	};
-	useEffect( () => {
-		verifyToken( newslettersConfig?.newspack_newsletters_service_provider );
-	}, [ newslettersConfig?.newspack_newsletters_service_provider ] );
-
-	const saveNewslettersData = async () => {
-		setInFlight( true );
-		apiFetch( {
-			path: '/newspack/v1/wizard/newspack-engagement-wizard/newsletters',
-			method: 'POST',
-			data: newslettersConfig,
-		} ).finally( () => {
-			setInitialProvider( newslettersConfig?.newspack_newsletters_service_provider );
-			verifyToken( newslettersConfig?.newspack_newsletters_service_provider );
-			setLockedLists( false );
-			setInFlight( false );
-		} );
-	};
-
 	return (
 		<>
-			<Card headerActions noBorder>
-				<h2>{ __( 'Authoring', 'newspack' ) }</h2>
-				<Button disabled={ inFlight } variant="primary" onClick={ saveNewslettersData }>
-					{ __( 'Save Settings', 'newspack' ) }
-				</Button>
-			</Card>
 			<NewspackNewsletters
 				isOnboarding={ false }
-				disabled={ inFlight }
+				inFlight={ inFlight }
+				setInFlight={ setInFlight }
 				onUpdate={ config => updateConfiguration( { newslettersConfig: config } ) }
 				authUrl={ authUrl }
+				setAuthUrl={ setAuthUrl }
+				newslettersConfig={ newslettersConfig }
+				setLockedLists={ setLockedLists }
+				initialProvider={ initialProvider }
+				setInitialProvider={ setInitialProvider }
 			/>
-			{ lockedLists ? (
-				<Notice
-					noticeText={ __(
-						'Please save your settings before changing your subscription lists.',
-						'newspack'
-					) }
-					isWarning
-				/>
-			) : (
-				<SubscriptionLists />
+			<SubscriptionLists lockedLists={ lockedLists } initialProvider={ initialProvider } />
+			{ 'mailchimp' === newslettersConfig?.newspack_newsletters_service_provider && (
+				<>
+					<hr />
+					<SectionHeader title={ __( 'WooCommerce integration', 'newspack' ) } />
+					<PluginInstaller plugins={ [ 'mailchimp-for-woocommerce' ] } withoutFooterButton />
+				</>
 			) }
 		</>
 	);
@@ -368,7 +401,5 @@ const Newsletters = () => {
 export default withWizardScreen( () => (
 	<>
 		<Newsletters />
-		<SectionHeader title={ __( 'WooCommerce integration', 'newspack' ) } />
-		<PluginInstaller plugins={ [ 'mailchimp-for-woocommerce' ] } withoutFooterButton />
 	</>
 ) );

--- a/assets/wizards/engagement/views/reader-activation/complete.js
+++ b/assets/wizards/engagement/views/reader-activation/complete.js
@@ -42,9 +42,8 @@ const listItems = [
 
 const activationSteps = [
 	__( 'Setting up new segments…', 'newspack' ),
-	__( 'Generating new prompts with your saved copy…', 'newspack' ),
-	__( 'Deactivating existing prompts and segments…', 'newspack' ),
-	__( 'Activating new prompts and segments…', 'newspack' ),
+	__( 'Activating reader registration…', 'newspack' ),
+	__( 'Activating Reader Activation Campaign…', 'newspack' ),
 ];
 
 /**

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -136,8 +136,7 @@ export default withWizardScreen( () => {
 							'Newspack’s Reader Activation system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. ',
 							'newspack'
 						) }
-						{ /** TODO: Update this URL with the real one once the docs are ready. */ }
-						<ExternalLink href={ 'https://help.newspack.com' }>
+						<ExternalLink href={ 'https://help.newspack.com/engagement/reader-activation-system' }>
 							{ __( 'Learn more', 'newspack-plugin' ) }
 						</ExternalLink>
 					</>
@@ -151,7 +150,7 @@ export default withWizardScreen( () => {
 			) }
 			{ prerequisites && ! allReady && (
 				<Notice
-					noticeText={ __( 'Complete the settings to enable Reader Activation.', 'newspack' ) }
+					noticeText={ __( 'Complete these settings to enable Reader Activation.', 'newspack' ) }
 					isWarning
 				/>
 			) }
@@ -231,11 +230,10 @@ export default withWizardScreen( () => {
 						title={ __( 'Email Service Provider (ESP) Advanced Settings', 'newspack' ) }
 						description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
 					/>
-					{ /** TODO: Deprecate this option. This field should be populated by user input in the prompt setup wizard. */ }
 					<TextControl
 						label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
 						help={ __(
-							'The text to display while subscribing to newsletters on the registration modal.',
+							'The text to display while subscribing to newsletters from the sign-in modal.',
 							'newspack'
 						) }
 						{ ...getSharedProps( 'newsletters_label', 'text' ) }

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -22,6 +22,7 @@ import {
 } from '../../../../components/src';
 import Prerequisite from '../../components/prerequisite';
 import ActiveCampaign from '../../components/active-campaign';
+import { HANDOFF_KEY } from '../../../../components/src/consts';
 
 export default withWizardScreen( () => {
 	const [ inFlight, setInFlight ] = useState( false );
@@ -68,6 +69,9 @@ export default withWizardScreen( () => {
 	useEffect( () => {
 		window.scrollTo( 0, 0 );
 		fetchConfig();
+
+		// Clear the handoff when the component mounts.
+		window.localStorage.removeItem( HANDOFF_KEY );
 	}, [] );
 	useEffect( () => {
 		apiFetch( {

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -376,9 +376,9 @@ final class Reader_Activation {
 		$prerequisites = [
 			'terms_conditions' => [
 				'active'      => self::is_terms_configured(),
-				'label'       => __( 'Terms & Conditions', 'newspack' ),
-				'description' => __( 'Displaying Terms and Conditions on your site is necessary to allow readers to register and access their account.', 'newspack-plugin' ),
-				'help_url'    => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'label'       => __( 'Legal Pages', 'newspack' ),
+				'description' => __( 'Displaying legal pages like Privacy Policy and Terms of Service on your site is recommended for allowing readers to register and access their account.', 'newspack-plugin' ),
+				'help_url'    => 'https://help.newspack.com/engagement/reader-activation-system',
 				'fields'      => [
 					'terms_text' => [
 						'label'       => __( 'Terms & Conditions Text', 'newspack' ),
@@ -393,17 +393,17 @@ final class Reader_Activation {
 			'esp'              => [
 				'active'       => self::is_esp_configured(),
 				'label'        => __( 'Email Service Provider (ESP)', 'newspack' ),
-				'description'  => __( 'Connecting your ESP with the right settings is necessary to register readers with their email addresses, send account related emails and newsletters.', 'newspack' ),
-				'instructions' => __( 'Connect an email service provider (ESP) and enable at least one subscription list.', 'newspack' ),
-				'help_url'     => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'description'  => __( 'Connect to your ESP to register readers with their email addresses and send newsletters.', 'newspack' ),
+				'instructions' => __( 'Connect to your email service provider (ESP) and enable at least one subscription list.', 'newspack' ),
+				'help_url'     => 'https://help.newspack.com/engagement/reader-activation-system',
 				'href'         => \admin_url( '/admin.php?page=newspack-engagement-wizard#/newsletters' ),
 				'action_text'  => __( 'ESP settings' ),
 			],
 			'emails'           => [
 				'active'      => self::is_transactional_email_configured(),
 				'label'       => __( 'Transactional Emails', 'newspack' ),
-				'description' => __( 'Your sender name and email address determines how readers find emails related to their account in their inbox.', 'newspack-plugin' ),
-				'help_url'    => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'description' => __( 'Your sender name and email address determines how readers find emails related to their account in their inbox. To customize the content of these emails, visit Advanced Settings below.', 'newspack-plugin' ),
+				'help_url'    => 'https://help.newspack.com/engagement/reader-activation-system',
 				'fields'      => [
 					'sender_name'           => [
 						'label'       => __( 'Sender Name', 'newspack' ),
@@ -422,9 +422,9 @@ final class Reader_Activation {
 			'recaptcha'        => [
 				'active'       => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),
 				'label'        => __( 'reCAPTCHA', 'newspack' ),
-				'description'  => __( 'Connecting to a Google reCAPTCHA account enables enhanced anti-spam security for newsletter signup, user account, and payment forms rendered by Newspack tools.', 'newspack' ),
-				'instructions' => __( 'Enable reCAPTCHA and enter account credentials.', 'newspack' ),
-				'help_url'     => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'description'  => __( 'Connecting to a Google reCAPTCHA account enables enhanced anti-spam for all Newspack sign-up blocks.', 'newspack' ),
+				'instructions' => __( 'Enable reCAPTCHA and enter your account credentials.', 'newspack' ),
+				'help_url'     => 'https://help.newspack.com/engagement/reader-activation-system',
 				'href'         => \admin_url( '/admin.php?page=newspack-connections-wizard' ),
 				'action_text'  => __( 'reCAPTCHA settings' ),
 			],
@@ -432,8 +432,8 @@ final class Reader_Activation {
 				'active'       => self::is_reader_revenue_ready(),
 				'label'        => __( 'Reader Revenue', 'newspack' ),
 				'description'  => __( 'Setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack' ),
-				'instructions' => __( 'Set platform to "Newspack" and configure default donation settings.', 'newspack' ),
-				'help_url'     => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'instructions' => __( 'Set platform to "Newspack" and configure your default donation settings.', 'newspack' ),
+				'help_url'     => 'https://help.newspack.com/engagement/reader-activation-system',
 				'href'         => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
 				'action_text'  => __( 'Reader Revenue settings' ),
 			],
@@ -441,7 +441,7 @@ final class Reader_Activation {
 				'active'         => self::is_ras_campaign_configured(),
 				'label'          => __( 'Reader Activation Campaign', 'newspack' ),
 				'description'    => __( 'Building a set of prompts with default segments and settings allows for an improved experience optimized for Reader Activation.', 'newspack' ),
-				'help_url'       => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'help_url'       => 'https://help.newspack.com/engagement/reader-activation-system',
 				'href'           => self::is_ras_campaign_configured() ? \admin_url( '/admin.php?page=newspack-popups-wizard#/campaigns' ) : \admin_url( '/admin.php?page=newspack-engagement-wizard#/reader-activation/campaign' ),
 				'action_enabled' => self::is_ras_ready_to_configure(),
 				'action_text'    => __( 'Reader Activation campaign', 'newspack' ),

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -391,12 +391,13 @@ final class Reader_Activation {
 				],
 			],
 			'esp'              => [
-				'active'      => self::is_esp_configured(),
-				'label'       => __( 'Email Service Provider (ESP)', 'newspack' ),
-				'description' => __( 'Connecting your ESP with the right settings is necessary to register readers with their email addresses, send account related emails and newsletters.', 'newspack' ),
-				'help_url'    => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
-				'href'        => \admin_url( '/admin.php?page=newspack-engagement-wizard#/newsletters' ),
-				'action_text' => __( 'ESP settings' ),
+				'active'       => self::is_esp_configured(),
+				'label'        => __( 'Email Service Provider (ESP)', 'newspack' ),
+				'description'  => __( 'Connecting your ESP with the right settings is necessary to register readers with their email addresses, send account related emails and newsletters.', 'newspack' ),
+				'instructions' => __( 'Connect an email service provider (ESP) and enable at least one subscription list.', 'newspack' ),
+				'help_url'     => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'href'         => \admin_url( '/admin.php?page=newspack-engagement-wizard#/newsletters' ),
+				'action_text'  => __( 'ESP settings' ),
 			],
 			'emails'           => [
 				'active'      => self::is_transactional_email_configured(),
@@ -419,20 +420,22 @@ final class Reader_Activation {
 				],
 			],
 			'recaptcha'        => [
-				'active'      => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),
-				'label'       => __( 'reCAPTCHA', 'newspack' ),
-				'description' => __( 'Connecting to a Google reCAPTCHA account enables enhanced anti-spam security for newsletter signup, user account, and payment forms rendered by Newspack tools.', 'newspack' ),
-				'help_url'    => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
-				'href'        => \admin_url( '/admin.php?page=newspack-connections-wizard' ),
-				'action_text' => __( 'reCAPTCHA settings' ),
+				'active'       => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),
+				'label'        => __( 'reCAPTCHA', 'newspack' ),
+				'description'  => __( 'Connecting to a Google reCAPTCHA account enables enhanced anti-spam security for newsletter signup, user account, and payment forms rendered by Newspack tools.', 'newspack' ),
+				'instructions' => __( 'Enable reCAPTCHA and enter account credentials.', 'newspack' ),
+				'help_url'     => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'href'         => \admin_url( '/admin.php?page=newspack-connections-wizard' ),
+				'action_text'  => __( 'reCAPTCHA settings' ),
 			],
 			'reader_revenue'   => [
-				'active'      => self::is_reader_revenue_ready(),
-				'label'       => __( 'Reader Revenue', 'newspack' ),
-				'description' => __( 'Setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack' ),
-				'help_url'    => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
-				'href'        => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
-				'action_text' => __( 'Reader Revenue settings' ),
+				'active'       => self::is_reader_revenue_ready(),
+				'label'        => __( 'Reader Revenue', 'newspack' ),
+				'description'  => __( 'Setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack' ),
+				'instructions' => __( 'Set platform to "Newspack" and configure default donation settings.', 'newspack' ),
+				'help_url'     => 'https://help.newspack.com', // TODO: Add the correct URL to help docs.
+				'href'         => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
+				'action_text'  => __( 'Reader Revenue settings' ),
 			],
 			'ras_campaign'     => [
 				'active'         => self::is_ras_campaign_configured(),

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -397,6 +397,7 @@ class Engagement_Wizard extends Wizard {
 		$data = [
 			'has_reader_activation' => Reader_Activation::is_enabled( false ),
 			'has_memberships'       => class_exists( 'WC_Memberships' ),
+			'reader_activation_url' => \admin_url( 'admin.php?page=newspack-engagement-wizard#/reader-activation' ),
 		];
 
 		if ( method_exists( 'Newspack\Newsletters\Subscription_Lists', 'get_add_new_url' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For prerequisites that link out to another wizard page, shows a hand-off message with some instructions on what needs to be configured, and a link back to the Reader Activation wizard. The message will be displayed when clicking a button in the Reader Activation wizard that links out to another wizard page, and will persist until you revisit the Reader Activation wizard.

<img width="842" alt="Screen Shot 2023-04-25 at 5 51 05 PM" src="https://user-images.githubusercontent.com/2230142/234432079-2c3a911a-a4f5-49c0-a59c-85d71723d24d.png">

Separately but related, this PR also revamps the UI for the **Engagement > Newsletters** wizard screen so that it makes a bit more sense in context of the RAS messaging.

<img width="1081" alt="Screen Shot 2023-04-25 at 5 51 16 PM" src="https://user-images.githubusercontent.com/2230142/234432329-55c9b7e9-6f9a-4132-958e-336d02731efc.png">

Lastly, also updates the copy for the UI to the latest copy-edited version along with [this PR](https://github.com/Automattic/newspack-popups/pull/1102).

### How to test the changes in this Pull Request:

#### Hand-off message

1. Check out this branch and https://github.com/Automattic/newspack-popups/pull/1102. Visit **Engagement > Reader Activation**.
2. Expand the cards for each prerequisite that links out to a separate wizard page: ESP, reCAPTCHA, Reader Revenue.
3. Click the button for each prerequisite and confirm that a relevant message is shown just below the navigation menu that will persist until you go back to the Reader Activation wizard screen.

#### Newsletters UI

1. Visit **Engagement > Newsletters**.
2. Confirm that the UI layout is now slightly different, with ESP settings contained in its own card and Subscription Lists in their own, and action buttons for each in a consistent location. Confirm that both sections behave as expected (updating values and saving each section).
3. Confirm that the "Mailchimp for WooCommerce" integration option is only shown if Mailchimp is selected as the active ESP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->