### PR TITLE
feat(sign-in): support "register modal" hash url

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -50,7 +50,8 @@ const convertFormDataToObject = ( formData, includedFields = [] ) =>
 		return acc;
 	}, {} );
 
-const SIGN_IN_MODAL_HASH = 'signin_modal';
+const SIGN_IN_MODAL_HASHES = [ 'signin_modal', 'register_modal' ];
+let currentHash;
 
 window.newspackRAS = window.newspackRAS || [];
 
@@ -73,7 +74,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 			} );
 		};
 		const handleHashChange = function ( ev ) {
-			if ( window.location.hash === '#' + SIGN_IN_MODAL_HASH ) {
+			currentHash = window.location.hash.replace( '#', '' );
+			if ( SIGN_IN_MODAL_HASHES.includes( currentHash ) ) {
 				if ( ev ) {
 					ev.preventDefault();
 				}
@@ -216,7 +218,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 					container.classList.remove( 'newspack-reader__auth-form__visible' );
 					container.style.display = 'none';
 					document.body.classList.remove( 'newspack-signin' );
-					if ( window.location.hash === '#' + SIGN_IN_MODAL_HASH ) {
+					if ( SIGN_IN_MODAL_HASHES.includes( window.location.hash.replace( '#', '' ) ) ) {
 						history.pushState(
 							'',
 							document.title,
@@ -272,7 +274,18 @@ window.newspackRAS.push( function ( readerActivation ) {
 					}
 				}
 			}
-			setFormAction( readerActivation.getAuthStrategy() || 'link' );
+			setFormAction(
+				currentHash === 'register_modal' ? 'register' : readerActivation.getAuthStrategy() || 'link'
+			);
+			window.addEventListener( 'hashchange', () => {
+				if ( SIGN_IN_MODAL_HASHES.includes( currentHash ) ) {
+					setFormAction(
+						currentHash === 'register_modal'
+							? 'register'
+							: readerActivation.getAuthStrategy() || 'link'
+					);
+				}
+			} );
 			readerActivation.on( 'reader', () => {
 				if ( readerActivation.getOTPHash() ) {
 					setFormAction( 'otp' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Similar to #2414, implements a hash that opens the Sign In modal but in the `register` action state. This allows for shortcut links to this state of the form.

### How to test the changes in this Pull Request:

1. Check out this branch
2. Edit or draft a new page, add a link to `#register_modal` and another link to `#signin_modal`, and save
3. Visit the page, click the `#register_modal` link and confirm it opens the modal in the register state
4. Click to close and confirm the hash is cleared from the URL
5. Click on the `#signin_modal` link and confirm the form opens in sign in state
6. Click to close and confirm the hash is cleared from the URL

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->