### PR TITLE
fix: ensure migrated Stripe subs have next_payment scheduled

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -701,6 +701,14 @@ class WooCommerce_Connection {
 						update_post_meta( $subscription_id, self::SUBSCRIPTION_STRIPE_ID_META_KEY, $stripe_subscription_id );
 					}
 
+					// Ensure the next payment is scheduled.
+					$next_payment_date = $subscription->calculate_date( 'next_payment' );
+					$subscription->update_dates(
+						[
+							'next_payment' => $next_payment_date,
+						]
+					);
+
 					$subscription->save();
 
 					Logger::log( 'Created WC subscription with id: ' . $subscription_id );

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -482,6 +482,9 @@ class WooCommerce_Connection {
 		if ( isset( $metadata['stripe_intent_id'] ) ) {
 			$order->add_meta_data( '_stripe_intent_id', $metadata['stripe_intent_id'] );
 		}
+		if ( isset( $metadata['stripe_next_payment_date'] ) ) {
+			$order->add_meta_data( '_stripe_next_payment_date', $metadata['stripe_next_payment_date'] );
+		}
 		if ( 'completed' === $order->get_status() ) {
 			$order->add_meta_data( '_stripe_charge_captured', 'yes' );
 		}
@@ -702,7 +705,7 @@ class WooCommerce_Connection {
 					}
 
 					// Ensure the next payment is scheduled.
-					$next_payment_date = $subscription->calculate_date( 'next_payment' );
+					$next_payment_date = isset( $order_data['stripe_next_payment_date'] ) ? self::convert_timestamp_to_date( $order_data['stripe_next_payment_date'] ) : $subscription->calculate_date( 'next_payment' );
 					$subscription->update_dates(
 						[
 							'next_payment' => $next_payment_date,

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -457,6 +457,75 @@ Running Stripe to WC Subscriptions Migration...
 	}
 
 	/**
+	 * CLI command for finding previously migrated Stripe Subscriptions in Woo and ensuring they have a next payment date set.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public static function set_next_payment_dates_for_migrated_subscriptions( $args, $assoc_args ) {
+		$is_dry_run = ! empty( $assoc_args['dry-run'] );
+		$batch_size = ! empty( $assoc_args['batch-size'] ) ? intval( $assoc_args['batch-size'] ) : 10;
+
+		\WP_CLI::log(
+			'
+
+Running script to set next payment dates on migrated subscriptions...
+
+		'
+		);
+
+
+		$migrated_subscriptions = self::get_migrated_subscriptions( $batch_size );
+		$offset                 = 0;
+		$processed              = 0;
+		while ( $migrated_subscriptions ) {
+			$subscription_id = array_shift( $migrated_subscriptions );
+
+			// Set next payment date.
+			$subscription = \wcs_get_subscription( $subscription_id );
+			if ( $subscription ) {
+				\WP_CLI::log(
+					sprintf(
+						'Found subscription with ID %d and start date %s.',
+						$subscription_id,
+						$subscription->get_date( 'start' )
+					)
+				);
+
+				// Get the next payment date.
+				$next_payment_date = $subscription->get_date( 'next_payment' );
+
+				// If there's no next payment, set it.
+				if ( ! $next_payment_date ) {
+					$next_payment_date = $subscription->calculate_date( 'next_payment' );
+					\WP_CLI::log( sprintf( 'No next payment date set. Setting to %s.', $next_payment_date ) );
+
+					if ( ! $is_dry_run ) {
+						$subscription->update_dates(
+							[
+								'next_payment' => $next_payment_date,
+							]
+						);
+
+						$subscription->save();
+					}
+					$processed ++;
+				} else {
+					\WP_CLI::log( sprintf( 'Next payment date already set to %s. Skipping.', $next_payment_date ) );
+				}
+			}
+
+			// Get the next batch.
+			if ( empty( $migrated_subscriptions ) ) {
+				$offset                += $batch_size;
+				$migrated_subscriptions = self::get_migrated_subscriptions( $batch_size, $offset );
+			}
+		}
+
+		\WP_CLI::success( sprintf( 'Finished processing %d subscriptions.', $processed ) );
+	}
+
+	/**
 	 * Get a batch of customers for the Stripe-Connect-to-Stripe CLI tool.
 	 *
 	 * @param int    $limit Number of customers to fetch.
@@ -482,6 +551,29 @@ Running Stripe to WC Subscriptions Migration...
 		} catch ( \Throwable $e ) {
 			\WP_CLI::error( sprintf( 'Could not process all customers: %s', $e->getMessage() ) );
 		}
+	}
+
+	/**
+	 * Get a batch of migrated subscriptions.
+	 *
+	 * @param int $batch_size Number of subscriptions to fetch.
+	 * @param int $offset Offset to start at.
+	 * @return array Array of WC Subscriptions.
+	 */
+	protected static function get_migrated_subscriptions( $batch_size = 0, $offset = 0 ) {
+		$args = [
+			'fields'         => 'ids',
+			'offset'         => $offset,
+			'post_status'    => 'wc-active',
+			'post_type'      => 'shop_subscription',
+			'posts_per_page' => $batch_size,
+			'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'key'     => 'cancelled-newspack-stripe-subscription-id',
+				'compare' => 'EXISTS',
+			],
+		];
+
+		return \get_posts( $args );
 	}
 
 	/**
@@ -691,7 +783,28 @@ Running Stripe to WC Subscriptions Migration...
 			'newspack stripe sync-stripe-subscriptions-to-wc',
 			[ __CLASS__, 'sync_stripe_subscriptions_to_wc' ],
 			[
-				'shortdesc' => __( 'Migrate subscribtions from Stripe to WC', 'newspack' ),
+				'shortdesc' => __( 'Migrate subscriptions from Stripe to WC', 'newspack' ),
+				'synopsis'  => [
+					[
+						'type'     => 'flag',
+						'name'     => 'dry-run',
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'batch-size',
+						'default'  => 10,
+						'optional' => true,
+					],
+				],
+			]
+		);
+
+		\WP_CLI::add_command(
+			'newspack stripe set-next-payment-dates-for-migrated-subscriptions',
+			[ __CLASS__, 'set_next_payment_dates_for_migrated_subscriptions' ],
+			[
+				'shortdesc' => __( 'Ensure that all migrated subscriptions have a next payment date.', 'newspack' ),
 				'synopsis'  => [
 					[
 						'type'     => 'flag',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Plugs a hole in the migration script for migrating Stripe subscriptions to WooCommerce. When programmatically creating subscriptions via code, Woo does not automatically schedule next payment dates—this must be done explicitly. This PR ensures this is done, and also implements a script to retroactively look up any previously migrated subscriptions and schedule next payment dates for any that are missing them. 

~Note that the scheduled next payment date won't always be in line with the start date of the subscription (e.g. if started April 3, the next payment would normally be May 3), but it should fall within 2 weeks of that date. This is because the calculate_date method is based on the current timetamp rather than the subscription's start date.~ We were able to get around this in d4978df by explicitly setting the scheduled date to the next payment date from Stripe.

Also adds a `--force` flag to the `sync-stripe-subscriptions-to-wc` script which will allow us to migrate Stripe subscriptions that were created via a migration from Pico.

### How to test the changes in this Pull Request:

1. While on `master` or `release`, set the Reader Revenue platform for your test site to "Stripe".
2. Make a monthly or annual donation via the SDB and confirm that the subscription gets created in your Stripe account.
3. Run `wp newspack stripe sync-stripe-subscriptions-to-wc` via CLI to migrate the subscription to WooCommerce.
4. In the **WooCommerce > Subscriptions** dashboard, observe that the subscription was migrated, but that it lacks a scheduled "next payment" date.
5. Check out this branch. Run `wp newspack stripe set-next-payment-dates-for-migrated-subscriptions`.
6. Confirm that the script outputs a message stating that your previous subscription was updated with a next payment date, e.g.

> No next payment date set. Setting to YYYY-MM-DD.

7. Make another new monthly or annual donation (still while on Stripe).
8. Run `wp newspack stripe sync-stripe-subscriptions-to-wc` again and this time confirm that the migrated subscription is created with a scheduled next payment date.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->