### PR TITLE
fix(ras-defaults): feedback from QA

### DIFF
--- a/assets/components/src/notice/style.scss
+++ b/assets/components/src/notice/style.scss
@@ -53,6 +53,7 @@
 		margin-top: 0;
 		position: sticky;
 		top: 46px;
+		z-index: 100;
 
 		@media ( min-width: 782px ) {
 			top: 32px;

--- a/assets/components/src/notice/style.scss
+++ b/assets/components/src/notice/style.scss
@@ -51,6 +51,12 @@
 	&__is-handoff {
 		background: color.adjust( wp-colors.$alert-yellow, $lightness: 30% );
 		margin-top: 0;
+		position: sticky;
+		top: 46px;
+
+		@media ( min-width: 782px ) {
+			top: 32px;
+		}
 	}
 
 	&__is-help {

--- a/assets/components/src/section-header/index.js
+++ b/assets/components/src/section-header/index.js
@@ -21,6 +21,7 @@ const SectionHeader = ( {
 	isWhite = false,
 	noMargin = false,
 	title,
+	id = null,
 } ) => {
 	const classes = classnames(
 		'newspack-section-header',
@@ -34,8 +35,8 @@ const SectionHeader = ( {
 
 	return (
 		<Grid columns={ 1 } gutter={ 8 } className={ classes }>
-			{ typeof title === 'string' && <HeadingTag>{ title }</HeadingTag> }
-			{ typeof title === 'function' && <HeadingTag>{ title() }</HeadingTag> }
+			{ typeof title === 'string' && <HeadingTag id={ id || null }>{ title }</HeadingTag> }
+			{ typeof title === 'function' && <HeadingTag id={ id || null }>{ title() }</HeadingTag> }
 			{ typeof description === 'string' && <p>{ description }</p> }
 			{ typeof description === 'function' && <p>{ description() }</p> }
 		</Grid>

--- a/assets/components/src/section-header/index.js
+++ b/assets/components/src/section-header/index.js
@@ -3,11 +3,6 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { useEffect, useRef } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import { Grid } from '..';
@@ -28,18 +23,6 @@ const SectionHeader = ( {
 	title,
 	id = null,
 } ) => {
-	// If #id is in the URL, scroll to it on render.
-	const ref = useRef();
-	useEffect( () => {
-		const params = new Proxy( new URLSearchParams( window.location.search ), {
-			get: ( searchParams, prop ) => searchParams.get( prop ),
-		} );
-		const scrollToId = params.scrollTo;
-		if ( scrollToId && scrollToId === id ) {
-			ref.current.scrollIntoView( { behavior: 'smooth' } );
-		}
-	}, [] );
-
 	const classes = classnames(
 		'newspack-section-header',
 		centered && 'newspack-section-header--is-centered',
@@ -51,7 +34,7 @@ const SectionHeader = ( {
 	const HeadingTag = `h${ heading }`;
 
 	return (
-		<div id={ id } ref={ ref }>
+		<div id={ id }>
 			<Grid columns={ 1 } gutter={ 8 } className={ classes }>
 				{ typeof title === 'string' && <HeadingTag>{ title }</HeadingTag> }
 				{ typeof title === 'function' && <HeadingTag>{ title() }</HeadingTag> }

--- a/assets/components/src/section-header/index.js
+++ b/assets/components/src/section-header/index.js
@@ -3,6 +3,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { Grid } from '..';
@@ -23,6 +28,19 @@ const SectionHeader = ( {
 	title,
 	id = null,
 } ) => {
+	// If id is in the URL as a scrollTo param, scroll to it on render.
+	const ref = useRef();
+	useEffect( () => {
+		const params = new Proxy( new URLSearchParams( window.location.search ), {
+			get: ( searchParams, prop ) => searchParams.get( prop ),
+		} );
+		const scrollToId = params.scrollTo;
+		if ( scrollToId && scrollToId === id ) {
+			// Let parent scroll action run before running this.
+			window.setTimeout( () => ref.current.scrollIntoView( { behavior: 'smooth' } ), 250 );
+		}
+	}, [] );
+
 	const classes = classnames(
 		'newspack-section-header',
 		centered && 'newspack-section-header--is-centered',
@@ -34,7 +52,7 @@ const SectionHeader = ( {
 	const HeadingTag = `h${ heading }`;
 
 	return (
-		<div id={ id }>
+		<div id={ id } ref={ ref }>
 			<Grid columns={ 1 } gutter={ 8 } className={ classes }>
 				{ typeof title === 'string' && <HeadingTag>{ title }</HeadingTag> }
 				{ typeof title === 'function' && <HeadingTag>{ title() }</HeadingTag> }

--- a/assets/components/src/section-header/index.js
+++ b/assets/components/src/section-header/index.js
@@ -3,6 +3,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { Grid } from '..';
@@ -23,6 +28,18 @@ const SectionHeader = ( {
 	title,
 	id = null,
 } ) => {
+	// If #id is in the URL, scroll to it on render.
+	const ref = useRef();
+	useEffect( () => {
+		const params = new Proxy( new URLSearchParams( window.location.search ), {
+			get: ( searchParams, prop ) => searchParams.get( prop ),
+		} );
+		const scrollToId = params.scrollTo;
+		if ( scrollToId && scrollToId === id ) {
+			ref.current.scrollIntoView( { behavior: 'smooth' } );
+		}
+	}, [] );
+
 	const classes = classnames(
 		'newspack-section-header',
 		centered && 'newspack-section-header--is-centered',
@@ -34,12 +51,14 @@ const SectionHeader = ( {
 	const HeadingTag = `h${ heading }`;
 
 	return (
-		<Grid columns={ 1 } gutter={ 8 } className={ classes }>
-			{ typeof title === 'string' && <HeadingTag id={ id || null }>{ title }</HeadingTag> }
-			{ typeof title === 'function' && <HeadingTag id={ id || null }>{ title() }</HeadingTag> }
-			{ typeof description === 'string' && <p>{ description }</p> }
-			{ typeof description === 'function' && <p>{ description() }</p> }
-		</Grid>
+		<div id={ id } ref={ ref }>
+			<Grid columns={ 1 } gutter={ 8 } className={ classes }>
+				{ typeof title === 'string' && <HeadingTag>{ title }</HeadingTag> }
+				{ typeof title === 'function' && <HeadingTag>{ title() }</HeadingTag> }
+				{ typeof description === 'string' && <p>{ description }</p> }
+				{ typeof description === 'function' && <p>{ description() }</p> }
+			</Grid>
+		</div>
 	);
 };
 

--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -23,7 +23,6 @@ const Recaptcha = () => {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ settings, setSettings ] = useState( {} );
 	const [ settingsToUpdate, setSettingsToUpdate ] = useState( {} );
-	const prevLoading = useRef( isLoading );
 
 	// Check the reCAPTCHA connectivity status.
 	useEffect( () => {
@@ -39,24 +38,6 @@ const Recaptcha = () => {
 		};
 		fetchSettings();
 	}, [] );
-
-	useEffect( () => {
-		if ( ! prevLoading.current && isLoading ) {
-			// If #id is in the URL, scroll to it once the component start fetching status.
-			const params = new Proxy( new URLSearchParams( window.location.search ), {
-				get: ( searchParams, prop ) => searchParams.get( prop ),
-			} );
-			const scrollToId = params.scrollTo;
-			if ( 'recaptcha' === scrollToId ) {
-				const el = document.getElementById( scrollToId );
-
-				if ( el ) {
-					el.scrollIntoView( { behavior: 'smooth' } );
-				}
-			}
-		}
-		prevLoading.current = isLoading;
-	}, [ isLoading ] );
 
 	const updateSettings = async data => {
 		setError( null );

--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -23,6 +23,7 @@ const Recaptcha = () => {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ settings, setSettings ] = useState( {} );
 	const [ settingsToUpdate, setSettingsToUpdate ] = useState( {} );
+	const prevLoading = useRef( isLoading );
 
 	// Check the reCAPTCHA connectivity status.
 	useEffect( () => {
@@ -38,6 +39,24 @@ const Recaptcha = () => {
 		};
 		fetchSettings();
 	}, [] );
+
+	useEffect( () => {
+		if ( ! prevLoading.current && isLoading ) {
+			// If #id is in the URL, scroll to it once the component start fetching status.
+			const params = new Proxy( new URLSearchParams( window.location.search ), {
+				get: ( searchParams, prop ) => searchParams.get( prop ),
+			} );
+			const scrollToId = params.scrollTo;
+			if ( 'recaptcha' === scrollToId ) {
+				const el = document.getElementById( scrollToId );
+
+				if ( el ) {
+					el.scrollIntoView( { behavior: 'smooth' } );
+				}
+			}
+		}
+		prevLoading.current = isLoading;
+	}, [ isLoading ] );
 
 	const updateSettings = async data => {
 		setError( null );

--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -60,14 +60,14 @@ const Recaptcha = () => {
 
 	return (
 		<>
-			<SectionHeader title={ __( 'reCAPTCHA v3', 'newspack' ) } />
+			<SectionHeader id="recaptcha" title={ __( 'reCAPTCHA v3', 'newspack' ) } />
 			<ActionCard
 				isMedium
-				title={ __( 'Enable reCAPTCHA', 'newspack' ) }
+				title={ __( 'Enable reCAPTCHA v3', 'newspack' ) }
 				description={ () => (
 					<p>
 						{ __(
-							'Enabling reCAPTCHA can help protect your site against bot attacks and credit card testing.',
+							'Enabling reCAPTCHA v3 can help protect your site against bot attacks and credit card testing.',
 							'newspack'
 						) }{ ' ' }
 						<ExternalLink href="https://www.google.com/recaptcha/admin/create">

--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -65,7 +65,7 @@ const Recaptcha = () => {
 				isMedium
 				title={ __( 'Enable reCAPTCHA v3', 'newspack' ) }
 				description={ () => (
-					<p>
+					<>
 						{ __(
 							'Enabling reCAPTCHA v3 can help protect your site against bot attacks and credit card testing.',
 							'newspack'
@@ -73,7 +73,7 @@ const Recaptcha = () => {
 						<ExternalLink href="https://www.google.com/recaptcha/admin/create">
 							{ __( 'Get started' ) }
 						</ExternalLink>
-					</p>
+					</>
 				) }
 				hasGreyHeader={ !! settings.use_captcha }
 				toggleChecked={ !! settings.use_captcha }

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -23,8 +23,22 @@ export default function Prerequisite( {
 }: PrequisiteProps ) {
 	const { href } = prerequisite;
 
+	// If the prerequisite is active but has empty fields, show a warning.
+	const hasEmptyFields = () => {
+		if ( prerequisite.active && prerequisite.fields && prerequisite.warning ) {
+			const emptyValues = Object.keys( prerequisite.fields ).filter(
+				fieldName => '' === config[ fieldName ]
+			);
+			if ( emptyValues.length ) {
+				return prerequisite.warning;
+			}
+		}
+		return null;
+	};
+
 	return (
 		<ActionCard
+			className="newspack-ras-wizard__prerequisite"
 			isMedium
 			expandable
 			collapse={ prerequisite.active }
@@ -35,6 +49,8 @@ export default function Prerequisite( {
 				prerequisite.active ? __( 'Ready', 'newspack' ) : __( 'Pending', 'newspack' )
 			) }
 			checkbox={ prerequisite.active ? 'checked' : 'unchecked' }
+			notificationLevel="info"
+			notification={ hasEmptyFields() }
 		>
 			{
 				// Inner card content.

--- a/assets/wizards/engagement/components/prompt.tsx
+++ b/assets/wizards/engagement/components/prompt.tsx
@@ -198,7 +198,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 										) ) }
 									</BaseControl>
 								) }
-								{ 'string' === field.type && field.max_length && 100 < field.max_length && (
+								{ 'string' === field.type && field.max_length && 150 < field.max_length && (
 									<TextareaControl
 										className="newspack-textarea-control"
 										label={ field.label }
@@ -220,7 +220,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 										value={ values[ field.name ] || '' }
 									/>
 								) }
-								{ 'string' === field.type && field.max_length && 100 >= field.max_length && (
+								{ 'string' === field.type && field.max_length && 150 >= field.max_length && (
 									<TextControl
 										label={ field.label }
 										disabled={ inFlight }

--- a/assets/wizards/engagement/components/types.ts
+++ b/assets/wizards/engagement/components/types.ts
@@ -98,6 +98,7 @@ export type PrequisiteProps = {
 		active: boolean;
 		label: string;
 		description: string;
+		warning?: string;
 		instructions?: string;
 		help_url: string;
 		fields?: {

--- a/assets/wizards/engagement/views/reader-activation/style.scss
+++ b/assets/wizards/engagement/views/reader-activation/style.scss
@@ -116,3 +116,11 @@
 		}
 	}
 }
+
+.newspack-ras-wizard {
+	&__prerequisite.newspack-card.newspack-action-card  {
+		.newspack-action-card__notification.newspack-action-card__region-children .newspack-notice {
+			margin-top: 0;
+		}
+	}
+}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -174,7 +174,7 @@ final class Reader_Activation {
 			'enabled_account_link'        => true,
 			'account_link_menu_locations' => [ 'tertiary-menu' ],
 			'newsletters_label'           => __( 'Subscribe to our newsletters:', 'newspack' ),
-			'terms_text'                  => __( 'By signing up, you agree to our Terms and Conditions.', 'newspack' ),
+			'terms_text'                  => '',
 			'terms_url'                   => '',
 			'sync_esp'                    => true,
 			'metadata_prefix'             => Newspack_Newsletters::get_metadata_prefix(),
@@ -224,14 +224,6 @@ final class Reader_Activation {
 			return null;
 		}
 		$value = \get_option( self::OPTIONS_PREFIX . $name, $config[ $name ] );
-
-		// If fetching terms URL, set the default here as \get_permalink and \get_post_status aren't available on the init hook.
-		if ( 'terms_url' === $name && empty( $value ) ) {
-			$privacy_policy_page_id = \get_option( 'wp_page_for_privacy_policy' );
-			if ( ! empty( $privacy_policy_page_id ) && 'publish' === \get_post_status( $privacy_policy_page_id ) ) {
-				$value = \get_permalink( $privacy_policy_page_id );
-			}
-		}
 
 		// Use default value type for casting bool option value.
 		if ( is_bool( $config[ $name ] ) ) {
@@ -329,13 +321,14 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Are the Terms & Conditions settings configured?
+	 * Are the Legal Pages settings configured?
+	 * Allows for blank values.
 	 */
 	public static function is_terms_configured() {
 		$terms_text = \get_option( self::OPTIONS_PREFIX . 'terms_text', false );
 		$terms_url  = \get_option( self::OPTIONS_PREFIX . 'terms_url', false );
 
-		return ! empty( $terms_text ) && ! empty( $terms_url );
+		return is_string( $terms_text ) && is_string( $terms_url );
 	}
 
 	/**
@@ -379,14 +372,15 @@ final class Reader_Activation {
 				'label'       => __( 'Legal Pages', 'newspack' ),
 				'description' => __( 'Displaying legal pages like Privacy Policy and Terms of Service on your site is recommended for allowing readers to register and access their account.', 'newspack-plugin' ),
 				'help_url'    => 'https://help.newspack.com/engagement/reader-activation-system',
+				'warning'     => __( 'Privacy policies that tell users how you collect and use their data are essential for running a  trustworthy website. While rules and regulations can differ by country, certain legal pages might be required by law.', 'newspack' ),
 				'fields'      => [
 					'terms_text' => [
-						'label'       => __( 'Terms & Conditions Text', 'newspack' ),
-						'description' => __( 'Terms and conditions text to display on registration.', 'newspack-plugin' ),
+						'label'       => __( 'Legal Pages Disclaimer Text', 'newspack' ),
+						'description' => __( 'Legal pages disclaimer text to display on registration.', 'newspack-plugin' ),
 					],
 					'terms_url'  => [
-						'label'       => __( 'Terms & Conditions URL', 'newspack' ),
-						'description' => __( 'URL to the page containing the terms and conditions.', 'newspack-plugin' ),
+						'label'       => __( 'Legal Pages URL', 'newspack' ),
+						'description' => __( 'URL to the page containing the privacy policy or terms of service.', 'newspack-plugin' ),
 					],
 				],
 			],

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -419,7 +419,7 @@ final class Reader_Activation {
 				'description'  => __( 'Connecting to a Google reCAPTCHA v3 account enables enhanced anti-spam for all Newspack sign-up blocks.', 'newspack' ),
 				'instructions' => __( 'Enable reCAPTCHA v3 and enter your account credentials.', 'newspack' ),
 				'help_url'     => 'https://help.newspack.com/engagement/reader-activation-system',
-				'href'         => \admin_url( '/admin.php?page=newspack-connections-wizard#recaptcha' ),
+				'href'         => \admin_url( '/admin.php?page=newspack-connections-wizard&scrollTo=recaptcha' ),
 				'action_text'  => __( 'reCAPTCHA settings' ),
 			],
 			'reader_revenue'   => [

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -421,11 +421,11 @@ final class Reader_Activation {
 			],
 			'recaptcha'        => [
 				'active'       => method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha(),
-				'label'        => __( 'reCAPTCHA', 'newspack' ),
-				'description'  => __( 'Connecting to a Google reCAPTCHA account enables enhanced anti-spam for all Newspack sign-up blocks.', 'newspack' ),
-				'instructions' => __( 'Enable reCAPTCHA and enter your account credentials.', 'newspack' ),
+				'label'        => __( 'reCAPTCHA v3', 'newspack' ),
+				'description'  => __( 'Connecting to a Google reCAPTCHA v3 account enables enhanced anti-spam for all Newspack sign-up blocks.', 'newspack' ),
+				'instructions' => __( 'Enable reCAPTCHA v3 and enter your account credentials.', 'newspack' ),
 				'help_url'     => 'https://help.newspack.com/engagement/reader-activation-system',
-				'href'         => \admin_url( '/admin.php?page=newspack-connections-wizard' ),
+				'href'         => \admin_url( '/admin.php?page=newspack-connections-wizard#recaptcha' ),
 				'action_text'  => __( 'reCAPTCHA settings' ),
 			],
 			'reader_revenue'   => [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements the following changes:

* Makes the legal pages section optional (you can save with empty values to skip this step) and adds a warning if the fields are empty
* The link to the reCAPTCHA settings page will automatically scroll to that section of the Connections wizard page
* (with https://github.com/Automattic/newspack-popups/pull/1109) Increases the max-length of Heading and Button Label input fields for all default RAS prompts

### How to test the changes in this Pull Request:

1. Check out https://github.com/Automattic/newspack-popups/pull/1109 and delete the Terms options: `wp option delete newspack_reader_activation_terms_text && wp option delete newspack_reader_activation_terms_url`
2. Visit the **Engagement > Reader Activation** wizard. Confirm that the Legal Pages card is in a Pending state.
3. Expand the Legal Pages card and save without entering any info in the fields to skip. Confirm that the card enters a ready state, but with a warning:

<img width="1058" alt="Screen Shot 2023-05-03 at 11 59 00 AM" src="https://user-images.githubusercontent.com/2230142/236024216-729f78ca-c9f2-4846-b480-d312c1f24b97.png">

4. Expand the reCAPTCHA card and click the button to Set/Update settings. Confirm that the Connections page automatically scrolls down to the reCAPTCHA section after the page loads.
5. Complete all prerequisites and proceed to the default prompts wizard. (run `wp option delete newspack_reader_activation_enabled` if the button leads to the Campaigns wizard instead of the prompt setup wizard).
6. Confirm that the fields for headings have a max-length of 120 and the button labels have a max-length of 40, now. Confirm that you can enter text up to these max lengths.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->