### PR TITLE
fix(ras-defaults): check for required plugins in RAS setup wizard

### DIFF
--- a/assets/wizards/engagement/components/types.ts
+++ b/assets/wizards/engagement/components/types.ts
@@ -96,6 +96,9 @@ export type PrequisiteProps = {
 	// Schema for prequisite object is defined in PHP class Reader_Activation::get_prerequisites_status().
 	prerequisite: {
 		active: boolean;
+		plugins?: {
+			[ pluginName: string ]: boolean; // Are the required plugins active?
+		};
 		label: string;
 		description: string;
 		warning?: string;

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -386,6 +386,9 @@ final class Reader_Activation {
 			],
 			'esp'              => [
 				'active'       => self::is_esp_configured(),
+				'plugins'      => [
+					'newspack-newsletters' => class_exists( '\Newspack_Newsletters' ),
+				],
 				'label'        => __( 'Email Service Provider (ESP)', 'newspack' ),
 				'description'  => __( 'Connect to your ESP to register readers with their email addresses and send newsletters.', 'newspack' ),
 				'instructions' => __( 'Connect to your email service provider (ESP) and enable at least one subscription list.', 'newspack' ),
@@ -424,6 +427,12 @@ final class Reader_Activation {
 			],
 			'reader_revenue'   => [
 				'active'       => self::is_reader_revenue_ready(),
+				'plugins'      => [
+					'newspack-blocks'             => class_exists( '\Newspack_Blocks' ),
+					'woocommerce'                 => function_exists( 'WC' ),
+					'woocommerce-subscriptions'   => class_exists( 'WC_Subscriptions_Product' ),
+					'woocommerce-name-your-price' => class_exists( 'WC_Name_Your_Price_Helpers' ),
+				],
 				'label'        => __( 'Reader Revenue', 'newspack' ),
 				'description'  => __( 'Setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack' ),
 				'instructions' => __( 'Set platform to "Newspack" and configure your default donation settings.', 'newspack' ),
@@ -433,6 +442,9 @@ final class Reader_Activation {
 			],
 			'ras_campaign'     => [
 				'active'         => self::is_ras_campaign_configured(),
+				'plugins'        => [
+					'newspack-popups' => class_exists( '\Newspack_Popups_Model' ),
+				],
 				'label'          => __( 'Reader Activation Campaign', 'newspack' ),
 				'description'    => __( 'Building a set of prompts with default segments and settings allows for an improved experience optimized for Reader Activation.', 'newspack' ),
 				'help_url'       => 'https://help.newspack.com/engagement/reader-activation-system',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a required plugin check to the RAS setup wizard, and if any are missing, presents a UI to install and/or activate them before showing the setup wizard.

### How to test the changes in this Pull Request:

1. Check out this branch. Deactivate or uninstall some or all of the following plugins:
  - Newspack Blocks
  - Newspack Newsletters
  - Newspack Campaigns
  - WooCommerce
  - WooCommerce Subscriptions
  - WooCommerce Name Your Price

2. Visit the **Newspack > Engagement > Reader Activation** page.
3. Confirm that the UI prompts you to activate the required plugins before proceeding:

<img width="1047" alt="Screen Shot 2023-05-05 at 4 18 15 PM" src="https://user-images.githubusercontent.com/2230142/236577721-1a42c3d8-dc5d-4914-b571-c1c2ff9bf36b.png">

4. Install and/or activate all of the required plugins. Confirm that after a few seconds, the usual prerequisite checklist UI becomes available and allows you to proceed with RAS setup.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->