### PR TITLE
feat: filter existing webhooks endpoints

### DIFF
--- a/assets/wizards/connections/views/main/webhooks.js
+++ b/assets/wizards/connections/views/main/webhooks.js
@@ -68,6 +68,7 @@ const hasEndpointErrors = endpoint => {
 const EndpointActions = ( {
 	disabled,
 	position = 'bottom left',
+	isSystem,
 	onEdit = () => {},
 	onDelete = () => {},
 	onView = () => {},
@@ -98,12 +99,16 @@ const EndpointActions = ( {
 					<MenuItem onClick={ onView } className="newspack-button">
 						{ __( 'View Requests', 'newspack' ) }
 					</MenuItem>
-					<MenuItem onClick={ onEdit } className="newspack-button">
-						{ __( 'Edit', 'newspack' ) }
-					</MenuItem>
-					<MenuItem onClick={ onDelete } className="newspack-button" isDestructive>
-						{ __( 'Remove', 'newspack' ) }
-					</MenuItem>
+					{ ! isSystem && (
+						<MenuItem onClick={ onEdit } className="newspack-button">
+							{ __( 'Edit', 'newspack' ) }
+						</MenuItem>
+					) }
+					{ ! isSystem && (
+						<MenuItem onClick={ onDelete } className="newspack-button" isDestructive>
+							{ __( 'Remove', 'newspack' ) }
+						</MenuItem>
+					) }
 				</Popover>
 			) }
 		</>
@@ -283,6 +288,7 @@ const Webhooks = () => {
 							toggleOnChange={ () => setToggling( endpoint ) }
 							key={ endpoint.id }
 							title={ getEndpointTitle( endpoint ) }
+							disabled={ endpoint.system }
 							description={ () => {
 								if ( endpoint.disabled && endpoint.disabled_error ) {
 									return (
@@ -312,6 +318,7 @@ const Webhooks = () => {
 									onEdit={ () => setEditing( endpoint ) }
 									onDelete={ () => setDeleting( endpoint ) }
 									onView={ () => setViewing( endpoint ) }
+									isSystem={ endpoint.system }
 								/>
 							}
 						/>

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -315,12 +315,20 @@ final class Data_Events {
 		];
 
 		/**
-		 * Filters the body of the action dispatch request.
+		 * Filters the body of the action dispatch request. Return a WP_Error if you want to cancel the dispatch.
 		 *
 		 * @param array  $body        Body.
 		 * @param string $action_name The action name.
 		 */
 		$body = apply_filters( 'newspack_data_events_dispatch_body', $body, $action_name );
+
+		if ( is_wp_error( $body ) ) {
+			Logger::log(
+				sprintf( 'Error dispatching action "%s": %s', $action_name, $body->get_error_message() ),
+				self::LOGGER_HEADER
+			);
+			return $body;
+		}
 
 		if ( self::use_action_scheduler() ) {
 			Logger::log(

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -235,9 +235,14 @@ final class Webhooks {
 	 * @param array  $actions Array of action names.
 	 * @param bool   $global  Whether the endpoint should be triggered for all actions.
 	 *
+	 * @throws \InvalidArgumentException If the ID is invalid.
 	 * @return void
 	 */
 	public static function register_system_endpoint( $id, $url, $actions = [], $global = false ) {
+
+		if ( ! is_string( $id ) || ctype_digit( $id ) || ! preg_match( '/^[a-z0-9-_]+$/', $id ) || ! empty( self::$system_endpoints[ $id ] ) ) {
+			throw new \InvalidArgumentException( 'Endpoint ID must be a unique string containing only lowercase letters, numbers, dashes and underscores, and it can not be only numerical.' );
+		}
 
 		$endpoint = [
 			'id'             => $id,

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -375,4 +375,63 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 		$requests = Data_Events\Webhooks::get_endpoint_requests( 'test-2' );
 		$this->assertSame( 1, count( $requests ) );
 	}
+
+	/**
+	 * Data provider for test_register_system_endpoints_throws
+	 *
+	 * @return array
+	 */
+	public function register_system_endpoints_throws_data() {
+		return [
+			[
+				'*j30s',
+			],
+			[
+				'asd$',
+			],
+			[
+				'asd@',
+			],
+			[
+				123,
+			],
+			[
+				'123',
+			],
+			[
+				[ 'array' ],
+			],
+			[
+				'asd_asd',
+				false,
+			],
+			[
+				'asd_asd-123',
+				false,
+			],
+			[
+				'asd-123',
+				false,
+			],
+			[
+				'asd-123', // repeated.
+				true,
+			],
+		];
+	}
+
+	/**
+	 * Test if register_system_endpoints throws on invalid IDs
+	 *
+	 * @param mixed   $id The ID to be tested.
+	 * @param boolean $should_throw Whether the test should throw an exception.
+	 * @return void
+	 * @dataProvider register_system_endpoints_throws_data
+	 */
+	public function test_register_system_endpoints_throws( $id, $should_throw = true ) {
+		if ( $should_throw ) {
+			$this->expectException( 'InvalidArgumentException' );
+		}
+		$this->assertNull( Data_Events\Webhooks::register_system_endpoint( $id, 'https://example.com/test' ) );
+	}
 }

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -362,17 +362,17 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 	 * Tests that getting endpoint requests fetch requests for system endpoints.
 	 */
 	public function test_get_endpoint_requests() {
-		Data_Events\Webhooks::register_system_endpoint( 'test', 'https://example.com/test', [], true );
-		Data_Events\Webhooks::register_system_endpoint( 'test-2', 'https://example2.com/test', [ 'test_action' ] );
+		Data_Events\Webhooks::register_system_endpoint( 'test-2', 'https://example.com/test', [], true );
+		Data_Events\Webhooks::register_system_endpoint( 'test-3', 'https://example2.com/test', [ 'test_action' ] );
 		$this->dispatch_event();
 
 		$requests = Data_Events\Webhooks::get_endpoint_requests( $this->global_endpoint );
 		$this->assertSame( 1, count( $requests ) );
 
-		$requests = Data_Events\Webhooks::get_endpoint_requests( 'test' );
+		$requests = Data_Events\Webhooks::get_endpoint_requests( 'test-2' );
 		$this->assertSame( 1, count( $requests ) );
 
-		$requests = Data_Events\Webhooks::get_endpoint_requests( 'test-2' );
+		$requests = Data_Events\Webhooks::get_endpoint_requests( 'test-3' );
 		$this->assertSame( 1, count( $requests ) );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows other plugins to programatically register endpoints.

### How to test the changes in this Pull Request:

1. Add this snippet to your site:

```PHP
add_action( 'init', function() {
    \Newspack\Data_Events\Webhooks::register_system_endpoint( 'my-id', 'https://my-url.com', [], true );
} );
```

3. Perform some actions that will dispatch events (register to a newsletters for example)
4. Confirm you see the new endopint on the Connection webhooks -> UI
5. Confirm you can't disable, edit or delete this endpoint
6. Confirm the requests are created and sent
7. Bonus point for testing the filter on the event body

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->