### PR TITLE
feat: hook reCAPTCHA v3 to WooCommerce checkout

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -317,13 +317,13 @@ final class Recaptcha {
 		if ( ! self::can_use_captcha() ) {
 			return;
 		}
-		$settings = self::get_settings();
+		$site_key = self::get_setting( 'site_key' );
 		?>
 		<script src="<?php echo \esc_url( self::get_script_url() ); ?>"></script>
 		<script>
 			grecaptcha.ready( function() {
 				grecaptcha.execute(
-					'<?php echo \esc_attr( $settings['site_key'] ); ?>',
+					'<?php echo \esc_attr( $site_key ); ?>',
 					{ action: 'checkout' }
 				).then( function( token ) {
 					var field   = document.createElement('input');

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -23,6 +23,7 @@ final class Recaptcha {
 	public static function init() {
 		\add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'register_script' ] );
+		\add_action( 'init', [ __CLASS__, 'woocommerce_hooks' ] );
 	}
 
 	/**
@@ -65,16 +66,27 @@ final class Recaptcha {
 	}
 
 	/**
+	 * Get the reCAPTCHA v3 script URL.
+	 *
+	 * @return string
+	 */
+	private static function get_script_url() {
+		if ( ! self::can_use_captcha() ) {
+			return '';
+		}
+		$captcha_site_key = self::get_setting( 'site_key' );
+		return 'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key;
+	}
+
+	/**
 	 * Register the reCAPTCHA v3 script.
 	 */
 	public static function register_script() {
 		if ( self::can_use_captcha() ) {
-			$captcha_site_key = self::get_setting( 'site_key' );
-
 			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			\wp_register_script(
 				self::SCRIPT_HANDLE,
-				\esc_url( 'https://www.google.com/recaptcha/api.js?render=' . $captcha_site_key ),
+				\esc_url( self::get_script_url() ),
 				null,
 				null,
 				true
@@ -285,6 +297,58 @@ final class Recaptcha {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Hook reCAPTCHA v3 to WooCommerce.
+	 */
+	public static function woocommerce_hooks() {
+		// Add reCAPTCHA v3 to the checkout form.
+		\add_action( 'woocommerce_after_checkout_form', [ __CLASS__, 'add_recaptcha_to_checkout' ] );
+
+		// Verify reCAPTCHA v3 on checkout submission.
+		\add_action( 'woocommerce_checkout_process', [ __CLASS__, 'verify_recaptcha_on_checkout' ] );
+	}
+
+	/**
+	 * Add reCAPTCHA v3 to checkout.
+	 */
+	public static function add_recaptcha_to_checkout() {
+		if ( ! self::can_use_captcha() ) {
+			return;
+		}
+		$settings = self::get_settings();
+		?>
+		<script src="<?php echo \esc_url( self::get_script_url() ); ?>"></script>
+		<script>
+			grecaptcha.ready( function() {
+				grecaptcha.execute(
+					'<?php echo \esc_attr( $settings['site_key'] ); ?>',
+					{ action: 'checkout' }
+				).then( function( token ) {
+					var field   = document.createElement('input');
+					field.type  = 'hidden';
+					field.name  = 'g-recaptcha-response';
+					field.value = token;
+					document.getElementById( 'place_order' ).before( field );
+				} );
+			} );
+		</script>
+		<?php
+	}
+
+	/**
+	 * Verify reCAPTCHA v3 on checkout submission.
+	 */
+	public static function verify_recaptcha_on_checkout() {
+		if ( ! self::can_use_captcha() ) {
+			return;
+		}
+		$token = isset( $_POST['g-recaptcha-response'] ) ? sanitize_text_field( wp_unslash( $_POST['g-recaptcha-response'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$check = self::verify_captcha( $token );
+		if ( \is_wp_error( $check ) ) {
+			\wc_add_notice( $check->get_error_message(), 'error' );
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements reCAPTCHA v3 to WooCommerce checkout.

### How to test the changes in this Pull Request:

1. Checkout this branch and change the [reCAPTCHA threshold](https://github.com/Automattic/newspack-plugin/blob/2b0af0b41addac3e47b67c3833af2daa2c9410f6/includes/class-recaptcha.php#L17) to `1.0`
2. Visit the Newspack -> Connections page and make sure you have reCAPTCHA v3 enabled and configured
3. Deactivate any other reCAPTCHA related plugin you may have
4. With the Reader Revenue set to "Newspack" attempt to donate
5. Confirm you get a captcha error
6. Change the threshold back to `0.5`
7. Donate again and confirm it works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->