### PR TITLE
fix(perfmatters): do not delay CSS from Newspack Campaigns or Perfmatters’ own cache

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -81,9 +81,11 @@ class Perfmatters {
 		return [
 			'plugins/newspack-blocks', // Newspack Blocks.
 			'plugins/newspack-newsletters', // Newspack Newsletters.
+			'plugins/newspack-popups', // Newspack Campaigns.
 			'plugins/jetpack/modules/sharedaddy', // Jetpack's share buttons.
 			'plugins/jetpack/_inc/social-logos', // Jetpack's social logos CSS.
 			'/themes/newspack-', // Any Newspack theme stylesheet.
+			'cache/perfmatters', //	Perfmatters' cache.
 			'wp-includes',
 		];
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Excludes CSS from Newspack Campaigns and Perfmatters' own Google Fonts cache from being delayed upon pageload. Should help prevent CLS (cumulative layout shift) resulting from those styles being delayed, which should in theory generally improve PSI scores across the board. In one test site these changes alone resulted in a PSI improvement from 15 to 49 on the same page.

Closes `1204323000227084/1204483195828244`.

### How to test the changes in this Pull Request:

This one might be tough to test positively because it depends on a lot of site-specific factors. But let's give it a try:

1. Make sure you test on a site that can be accessed by the [PSI testing tool](https://pagespeed.web.dev).
2. Publish a Campaigns prompt with an Above-Header placement and make sure it it's pretty vertically large, so that if it were to be displayed it would push the page content down pretty far. Assign it to a segment that _won't_ match an anonymous reader, like "Has Donated", so that it won't display on first pageview.
3. Grab a Google Font with lots of variations. [Roboto](https://fonts.google.com/specimen/Roboto) is a good one—select all the styles and weights so it creates a somewhat large CSS file, or just use this URL: `https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap`
4. Paste the big Google Font CSS into the Customizer > Typography field, set your primary font to the selected font and save/publish.
5. View the site front-end. Observe that there's a [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) effect on first load. In particular, the Above Header prompt will be displayed briefly before it disappears, and text content will appear in a system font briefly before switching to the Google Font. If you have a very fast internet connection, it might not be noticeable, so you might need to throttle your connection to see it.
6. Take a PSI score using the [tool](https://pagespeed.web.dev) and note the score.
7. Check out this branch and repeat steps 5-6. There should be a marked improvement in both FOUC time and PSI score, particularly the Cumulative Layout Shift (CLS) metric of that score.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->