### PR TITLE
fix(onboarding): handoff message component

### DIFF
--- a/assets/components/src/handoff-message/index.js
+++ b/assets/components/src/handoff-message/index.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import { HANDOFF_KEY } from '../consts';
+import { Notice } from '../';
+
+/**
+ * Handoff Message Component.
+ */
+export default function HandoffMessage() {
+	const [ handoffMessage, setHandoffMessage ] = useState( false );
+	useEffect( () => {
+		// Slight delay to allow for localStorage to be updated by RAS component.
+		setTimeout( () => {
+			const handoff = JSON.parse( localStorage.getItem( HANDOFF_KEY ) );
+			if ( handoff?.message ) {
+				setHandoffMessage( handoff.message );
+			} else {
+				setHandoffMessage( false );
+			}
+		}, 100 );
+	}, [] );
+	if ( ! handoffMessage ) return null;
+	return <Notice isHandoff isDismissible={ false } rawHTML noticeText={ handoffMessage } />;
+}

--- a/assets/components/src/index.js
+++ b/assets/components/src/index.js
@@ -11,6 +11,7 @@ export { default as CustomSelectControl } from './custom-select-control';
 export { default as FormTokenField } from './form-token-field';
 export { default as Footer } from './footer';
 export { default as Handoff } from './handoff';
+export { default as HandoffMessage } from './handoff-message';
 export { default as InfoButton } from './info-button';
 export { default as ImageUpload } from './image-upload';
 export { default as GlobalNotices } from './global-notices';

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -2,14 +2,12 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
 import { category } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { Button, Handoff, NewspackIcon, Notice, TabbedNavigation } from '../';
-import { HANDOFF_KEY } from '../consts';
+import { Button, Handoff, NewspackIcon, Notice, HandoffMessage, TabbedNavigation } from '../';
 import { buttonProps } from '../../../shared/js/';
 import './style.scss';
 
@@ -23,7 +21,6 @@ import classnames from 'classnames';
  */
 export default function withWizardScreen( WrappedComponent, { hidePrimaryButton } = {} ) {
 	const WrappedWithWizardScreen = props => {
-		const [ handoffMessage, setHandoffMessage ] = useState( false );
 		const {
 			className,
 			buttonText,
@@ -37,14 +34,6 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 			renderAboveContent,
 			disableUpcomingInTabbedNavigation,
 		} = props;
-
-		useEffect( () => {
-			const handoff = JSON.parse( localStorage.getItem( HANDOFF_KEY ) );
-
-			if ( handoff?.message ) {
-				setHandoffMessage( handoff.message );
-			}
-		}, [] );
 
 		const retrievedButtonProps = buttonProps( buttonAction );
 		const retrievedSecondaryButtonProps = buttonProps( secondaryButtonAction );
@@ -99,9 +88,7 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 					/>
 				) }
 
-				{ handoffMessage && (
-					<Notice isHandoff isDismissible={ false } rawHTML noticeText={ handoffMessage } />
-				) }
+				<HandoffMessage />
 
 				<div className={ classnames( 'newspack-wizard newspack-wizard__content', className ) }>
 					{ typeof renderAboveContent === 'function' ? renderAboveContent() : null }

--- a/assets/components/src/wizard/index.js
+++ b/assets/components/src/wizard/index.js
@@ -7,19 +7,26 @@ import classnames from 'classnames';
  * WordPress dependencies.
  */
 import { useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { category } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { Footer, Notice, Button, NewspackIcon, TabbedNavigation, PluginInstaller } from '../';
+import {
+	Footer,
+	Notice,
+	Button,
+	NewspackIcon,
+	TabbedNavigation,
+	PluginInstaller,
+	HandoffMessage,
+} from '../';
 import Router from '../proxied-imports/router';
 import registerStore, { WIZARD_STORE_NAMESPACE } from './store';
 import { useWizardData } from './store/utils';
 import WizardError from './components/WizardError';
-import { HANDOFF_KEY } from '../consts';
 
 registerStore();
 
@@ -35,21 +42,12 @@ const Wizard = ( {
 	renderAboveSections,
 	requiredPlugins = [],
 } ) => {
-	const [ handoffMessage, setHandoffMessage ] = useState( false );
 	const isLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isLoading() );
 	const isQuietLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() );
 
 	// Trigger initial data fetch. Some sections might not use the wizard data,
 	// but for consistency, fetching is triggered regardless of the section.
 	useSelect( select => select( WIZARD_STORE_NAMESPACE ).getWizardAPIData( apiSlug ) );
-
-	useEffect( () => {
-		const handoff = JSON.parse( localStorage.getItem( HANDOFF_KEY ) );
-
-		if ( handoff?.message ) {
-			setHandoffMessage( handoff.message );
-		}
-	}, [] );
 
 	let displayedSections = sections.filter( section => ! section.isHidden );
 
@@ -112,9 +110,7 @@ const Wizard = ( {
 							<WizardError />
 						</TabbedNavigation>
 					) }
-					{ handoffMessage && (
-						<Notice isHandoff isDismissible={ false } rawHTML noticeText={ handoffMessage } />
-					) }
+					<HandoffMessage />
 
 					<Switch>
 						{ displayedSections.map( ( section, index ) => {

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -32,13 +32,13 @@ import {
 export const NewspackNewsletters = ( {
 	className,
 	onUpdate,
-	authUrl = false,
-	setAuthUrl,
-	isOnboarding = true,
 	initialProvider,
-	setInitialProvider,
 	newslettersConfig,
-	setLockedLists,
+	isOnboarding = true,
+	authUrl = false,
+	setInitialProvider = () => {},
+	setAuthUrl = () => {},
+	setLockedLists = () => {},
 } ) => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ error, setError ] = useState( false );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Restores the onboarding wizard by moving the RAS' Handoff message logic to a separate component.

This PR also fixes the "Newsletters" section of the Services onboarding wizard. It's currently broken due to recently implemented properties that are not available when rendering the component in this wizard.

### How to test the changes in this Pull Request:

1. While in the release branch, create a fresh Newspack site
2. Confirm the wizard breaks after creating sample content
3. Check out this branch, refresh, and confirm the wizard renders
4. While in the Services of the onboarding wizard, toggle the Newsletters section, configure and save
5. Finish the onboarding wizard and enable RAS for this site
6. Visit the RAS wizard and confirm the handoff message behaves as expected while going through the steps

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->