### PR TITLE
feat(ras-defaults): warn if navigating away from wizard with unsaved changes

### DIFF
--- a/assets/wizards/engagement/components/prompt.tsx
+++ b/assets/wizards/engagement/components/prompt.tsx
@@ -39,12 +39,14 @@ import {
 	Notice,
 	TextControl,
 	WebPreview,
+	hooks,
 } from '../../../components/src';
 
 // Note: Schema and types for the `prompt` prop is defined in Newspack Campaigns: https://github.com/Automattic/newspack-popups/blob/master/includes/schemas/class-prompts.php
 export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: PromptProps ) {
 	const [ values, setValues ] = useState< InputValues | Record< string, never > >( {} );
 	const [ error, setError ] = useState< false | { message: string } >( false );
+	const [ isDirty, setIsDirty ] = useState< boolean >( false );
 	const [ success, setSuccess ] = useState< false | string >( false );
 	const [ image, setImage ] = useState< null | Attachment >( null );
 	const [ isSavingFromPreview, setIsSavingFromPreview ] = useState( false );
@@ -115,8 +117,14 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 		return `${ previewURL }?${ stringify( { ...abbreviatedKeys } ) }`;
 	};
 
+	const unblock = hooks.usePrompt(
+		isDirty,
+		__( 'You have unsaved changes. Discard changes?', 'newspack' )
+	);
+
 	const savePrompt = ( slug: string, data: InputValues ) => {
 		return new Promise< void >( ( res, rej ) => {
+			unblock();
 			setError( false );
 			setSuccess( false );
 			setInFlight( true );
@@ -131,6 +139,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 				.then( ( fetchedPrompts: Array< PromptType > ) => {
 					setPrompts( fetchedPrompts );
 					setSuccess( __( 'Prompt saved.', 'newspack' ) );
+					setIsDirty( false );
 					res();
 				} )
 				.catch( err => {
@@ -154,9 +163,13 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 			description={ sprintf(
 				// Translators: Status of the prompt.
 				__( 'Status: %s', 'newspack' ),
-				prompt.ready ? __( 'Ready', 'newspack' ) : __( 'Pending', 'newspack' )
+				isDirty
+					? __( 'Unsaved changes', 'newspack' )
+					: prompt.ready
+					? __( 'Ready', 'newspack' )
+					: __( 'Pending', 'newspack' )
 			) }
-			checkbox={ prompt.ready ? 'checked' : 'unchecked' }
+			checkbox={ prompt.ready && ! isDirty ? 'checked' : 'unchecked' }
 		>
 			{
 				<Grid columns={ 2 } gutter={ 64 } className="newspack-ras-campaign__grid">
@@ -192,6 +205,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 															toUpdate[ field.name ].push( option.id );
 														}
 														setValues( toUpdate );
+														setIsDirty( true );
 													} }
 												/>
 											</BaseControl>
@@ -211,9 +225,8 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 
 											const toUpdate = { ...values };
 											toUpdate[ field.name ] = value;
-											if ( JSON.stringify( toUpdate ) !== JSON.stringify( values ) ) {
-											}
 											setValues( toUpdate );
+											setIsDirty( true );
 										} }
 										placeholder={ field.default }
 										rows={ 10 }
@@ -232,9 +245,8 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 
 											const toUpdate = { ...values };
 											toUpdate[ field.name ] = value;
-											if ( JSON.stringify( toUpdate ) !== JSON.stringify( values ) ) {
-											}
 											setValues( toUpdate );
+											setIsDirty( true );
 										} }
 										placeholder={ field.default }
 										value={ values[ field.name ] || '' }
@@ -255,6 +267,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 												if ( toUpdate[ field.name ] !== values[ field.name ] ) {
 												}
 												setValues( toUpdate );
+												setIsDirty( true );
 												if ( attachment?.url ) {
 													setImage( attachment );
 												} else {

--- a/assets/wizards/engagement/components/types.ts
+++ b/assets/wizards/engagement/components/types.ts
@@ -223,4 +223,5 @@ export type PromptProps = {
 	setInFlight: ( inFlight: boolean ) => void;
 	prompt: PromptType;
 	setPrompts: ( prompts: boolean | Array< PromptType > ) => void;
+	unblock: () => void;
 };

--- a/assets/wizards/engagement/views/reader-activation/campaign.js
+++ b/assets/wizards/engagement/views/reader-activation/campaign.js
@@ -87,7 +87,7 @@ export default withWizardScreen( () => {
 				>
 					{ __( 'Continue', 'newspack' ) }
 				</Button>
-				<Button isSecondary disabled={ inFlight } href="#/">
+				<Button isSecondary disabled={ inFlight } href="#/reader-activation">
 					{ __( 'Back', 'newspack' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If you make changes to the prompt settings in the RAS setup prompt wizard and try to navigate away from the wizard without saving, this will pop up a browser warning.

<img width="1063" alt="Screen Shot 2023-05-11 at 5 19 16 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/7b257cde-5fea-4c33-89bb-5364403618df">

**Note:** For some reason, unlike the same feature in the **Campaigns > Segmentation** dashboard, React Router will not reset the route if you block the navigation by selecting "cancel" when prompted. I couldn't figure out why, but if someone can help me figure it out I'm happy to update the PR.

### How to test the changes in this Pull Request:

1. Delete the `newspack_reader_activation_enabled` option on your test site.
2. Navigate to `<domain>/wp-admin/admin.php?page=newspack-engagement-wizard#/reader-activation/campaign` and make some changes to prompts without saving. Confirm that the prompt's status changes to indicate that there are "Unsaved changes", and if the prompt was previously saved and ready, the ready status is removed.
3. Try to navigate to another route in the wizard, or refresh the page/close the browser tab. Confirm you see a warning asking you to confirm as in the above screenshot. (Note that if trying to refresh or close the browser tab, you will see a generic warning instead of the custom message—this is due to browser limitations in setting the message on the `beforeunload` event.)
4. Repeat step 2, but this time save the unsaved prompt(s) before trying to navigate away, and confirm that you can without being warned.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->