### PR TITLE
fix(perfmatters): exlcude Newspack CSS from being delayed

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -81,6 +81,7 @@ class Perfmatters {
 		return [
 			'plugins/newspack-blocks', // Newspack Blocks.
 			'plugins/newspack-newsletters', // Newspack Newsletters.
+			'plugins/newspack-plugin', // Newspack main plugin.
 			'plugins/newspack-popups', // Newspack Campaigns.
 			'plugins/jetpack/modules/sharedaddy', // Jetpack's share buttons.
 			'plugins/jetpack/_inc/social-logos', // Jetpack's social logos CSS.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Excludes front-end stylesheets from the Newspack main plugin from being delayed by Perfmatters. Delaying our own CSS can result in unexpected styles for RAS-related elements in the header and nav menus, especially noticeable at mobile breakpoints.

### How to test the changes in this Pull Request:

1. On a site with RAS and Perfmatters enabled, visit the site in a fresh session while in a mobile viewport.
2. Without interacting with the site at all, observe that the My Account link looks improperly styled on page load. Specifically, it will appear without contrast checking (so it'll look grey instead of white on a dark header background color), the "Sign In" label will be displayed when it should be hidden, and the entire button will appear on its own line below the site logo and hamburger menu icon instead of in line with them.

<img width="103" alt="Screen Shot 2023-05-16 at 10 21 08 AM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/cba8c35f-645f-49da-8d98-b4f9c803b883">

3. If you interact with the page in any way (clicking on it or scrolling) you should observe that the proper styles snap in:

<img width="83" alt="Screen Shot 2023-05-16 at 10 23 47 AM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/f5fde7f9-27bd-432f-a502-057e06b6bbbb">

4. Check out this PR, repeat step 2, and confirm that the styles load immediately instead of only after you interact with the page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->