### PR TITLE
fix: remove 'username' from Twitter menu label

### DIFF
--- a/assets/wizards/seo/views/settings/index.js
+++ b/assets/wizards/seo/views/settings/index.js
@@ -78,7 +78,7 @@ class Settings extends Component {
 							placeholder={ __( 'https://facebook.com/page', 'newspack' ) }
 						/>
 						<TextControl
-							label={ __( 'Twitter Username', 'newspack' ) }
+							label={ __( 'Twitter', 'newspack' ) }
 							onChange={ value => onChange( { urls: { ...urls, twitter: value } } ) }
 							value={ twitter }
 							placeholder={ __( 'username', 'newspack' ) }

--- a/includes/class-profile.php
+++ b/includes/class-profile.php
@@ -42,7 +42,7 @@ class Profile {
 			],
 			[
 				'key'         => 'twitter_site',
-				'label'       => __( 'Twitter Username', 'newspack' ),
+				'label'       => __( 'Twitter', 'newspack' ),
 				'placeholder' => __( 'username', 'newspack' ),
 			],
 			[

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -2770,7 +2770,7 @@ msgid "Facebook page URL"
 msgstr ""
 
 #: assets/wizards/seo/views/social/index.js:40
-msgid "Twitter username"
+msgid "Twitter"
 msgstr ""
 
 #: assets/wizards/seo/views/social/index.js:45


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

As part of an accessibility review done for one of our publishers, we received feedback that the menu label "Twitter username" is sub-optimal for links pointing to a site's Twitter feed -- it's not really accurate since it's doesn't reflect what the link truly does. 

This PR removes the 'username' part of the Twitter label; because the way the plugin is set up, this also involves removing it from the visual label above the text field in the setup wizard and on the SEO screen. In my testing, this seems okay -- it's less clear that you should only enter your twitter username, but the validation on the field removes `https://twitter.com` if it's added by accident so it seems okay. 

See 1200550061930446-as-1203785172630073

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Run through the Newspack Wizard and add a full Twitter URL (https://twitter.com/newspackpub) instead of just the username.
3. At the end, view the front-end of the site, and use the element inspector to confirm that the Twitter label is just "Twitter" in the social links menu. 

![image](https://github.com/Automattic/newspack-plugin/assets/177561/1401bc37-dabf-4813-8115-4011b6210727)

4. Navigate to WP Admin > Newspack > SEO and confirm only the Twitter username was saved in the settings (this is just to make sure removing the "username" part of the label doesn't mess things up!). 

Unfortunately this won't fix sites that are already live, but the menu label can be manually edited in the Customizer to remove "username" if it's an issue for them.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->