### PR TITLE
feat(ras): remove env flag requirements for RAS functionality

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -28,7 +28,7 @@ function register_block() {
 	);
 
 	// No need to register block styles if Reader Activation is disabled.
-	if ( ! Reader_Activation::is_enabled( false ) ) {
+	if ( ! Reader_Activation::is_enabled() ) {
 		return;
 	}
 

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -1,4 +1,3 @@
-/* global newspack_engagement_wizard */
 import '../../shared/js/public-path';
 
 /**
@@ -81,11 +80,18 @@ class EngagementWizard extends Component {
 		const { relatedPostsEnabled, relatedPostsError, relatedPostsMaxAge, relatedPostsUpdated } =
 			this.state;
 
-		const defaultPath = newspack_engagement_wizard.has_reader_activation
-			? '/reader-activation'
-			: '/newsletters';
-
+		const defaultPath = '/reader-activation';
 		const tabbed_navigation = [
+			{
+				label: __( 'Reader Activation', 'newspack' ),
+				path: '/reader-activation',
+				exact: true,
+				activeTabPaths: [
+					'/reader-activation',
+					'/reader-activation/campaign',
+					'/reader-activation/complete',
+				],
+			},
 			{
 				label: __( 'Newsletters', 'newspack' ),
 				path: '/newsletters',
@@ -105,18 +111,6 @@ class EngagementWizard extends Component {
 				path: '/recirculation',
 			},
 		];
-		if ( newspack_engagement_wizard.has_reader_activation ) {
-			tabbed_navigation.unshift( {
-				label: __( 'Reader Activation', 'newspack' ),
-				path: '/reader-activation',
-				exact: true,
-				activeTabPaths: [
-					'/reader-activation',
-					'/reader-activation/campaign',
-					'/reader-activation/complete',
-				],
-			} );
-		}
 		const props = {
 			headerText: __( 'Engagement', 'newspack' ),
 			tabbedNavigation: tabbed_navigation,
@@ -126,46 +120,40 @@ class EngagementWizard extends Component {
 				<HashRouter hashType="slash">
 					<Switch>
 						{ pluginRequirements }
-						{ newspack_engagement_wizard.has_reader_activation && (
-							<Route
-								path="/reader-activation"
-								exact
-								render={ () => (
-									<ReaderActivation
-										subHeaderText={ __( 'Configure your reader activation settings', 'newspack' ) }
-										{ ...props }
-									/>
-								) }
-							/>
-						) }
-						{ newspack_engagement_wizard.has_reader_activation && (
-							<Route
-								path="/reader-activation/campaign"
-								render={ () => (
-									<ReaderActivationCampaign
-										subHeaderText={ __(
-											'Preview and customize the reader activation prompts',
-											'newspack'
-										) }
-										{ ...props }
-									/>
-								) }
-							/>
-						) }
-						{ newspack_engagement_wizard.has_reader_activation && (
-							<Route
-								path="/reader-activation/complete"
-								render={ () => (
-									<ReaderActivationComplete
-										subHeaderText={ __(
-											'Preview and customize the reader activation prompts',
-											'newspack'
-										) }
-										{ ...props }
-									/>
-								) }
-							/>
-						) }
+						<Route
+							path="/reader-activation"
+							exact
+							render={ () => (
+								<ReaderActivation
+									subHeaderText={ __( 'Configure your reader activation settings', 'newspack' ) }
+									{ ...props }
+								/>
+							) }
+						/>
+						<Route
+							path="/reader-activation/campaign"
+							render={ () => (
+								<ReaderActivationCampaign
+									subHeaderText={ __(
+										'Preview and customize the reader activation prompts',
+										'newspack'
+									) }
+									{ ...props }
+								/>
+							) }
+						/>
+						<Route
+							path="/reader-activation/complete"
+							render={ () => (
+								<ReaderActivationComplete
+									subHeaderText={ __(
+										'Preview and customize the reader activation prompts',
+										'newspack'
+									) }
+									{ ...props }
+								/>
+							) }
+						/>
 						<Route
 							path="/newsletters"
 							render={ () => (

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -39,7 +39,7 @@ final class Blocks {
 			'newspack_blocks',
 			[
 				'has_newsletters'         => method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ),
-				'has_reader_activation'   => Reader_Activation::is_enabled( false ),
+				'has_reader_activation'   => Reader_Activation::is_enabled(),
 				'newsletters_url'         => Wizards::get_wizard( 'engagement' )->newsletters_settings_url(),
 				'has_google_oauth'        => Google_OAuth::is_oauth_configured(),
 				'google_logo_svg'         => file_get_contents( dirname( NEWSPACK_PLUGIN_FILE ) . '/assets/blocks/reader-registration/icons/google.svg' ),

--- a/includes/cli/class-setup.php
+++ b/includes/cli/class-setup.php
@@ -163,7 +163,6 @@ class Setup {
 	 */
 	private function ras_beta() {
 		$wpconfig = new WPConfigTransformer( WP_CLI\Utils\locate_wp_config() );
-		$wpconfig->update( 'constant', 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', 'true', [ 'raw' => true ] );
 		WP_CLI::success( 'RAS enabled.' );
 	}
 }

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -25,7 +25,6 @@ class Mailchimp {
 	 */
 	public function __construct() {
 		if (
-			defined( 'NEWSPACK_DATA_EVENTS_MAILCHIMP' ) && NEWSPACK_DATA_EVENTS_MAILCHIMP &&
 			Reader_Activation::is_enabled() &&
 			true === Reader_Activation::get_setting( 'sync_esp' )
 		) {

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -25,6 +25,7 @@ class Mailchimp {
 	 */
 	public function __construct() {
 		if (
+			defined( 'NEWSPACK_DATA_EVENTS_MAILCHIMP' ) && NEWSPACK_DATA_EVENTS_MAILCHIMP &&
 			Reader_Activation::is_enabled() &&
 			true === Reader_Activation::get_setting( 'sync_esp' )
 		) {

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -459,27 +459,16 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Whether reader activation is enabled.
-	 *
-	 * @param bool $strict If true, check both the environment constant and the setting.
-	 *                     If false, only check for the constant.
+	 * Whether reader activation features should be enabled.
 	 *
 	 * @return bool True if reader activation is enabled.
 	 */
-	public static function is_enabled( $strict = true ) {
+	public static function is_enabled() {
 		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
 			return true;
 		}
 
-		$is_enabled = defined( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION' ) && NEWSPACK_EXPERIMENTAL_READER_ACTIVATION;
-
-		if ( ! $strict ) {
-			return $is_enabled;
-		}
-
-		if ( $is_enabled ) {
-			$is_enabled = (bool) \get_option( self::OPTIONS_PREFIX . 'enabled', false );
-		}
+		$is_enabled = (bool) \get_option( self::OPTIONS_PREFIX . 'enabled', false );
 
 		/**
 		 * Filters whether reader activation is enabled.

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -395,7 +395,6 @@ class Engagement_Wizard extends Wizard {
 		);
 
 		$data = [
-			'has_reader_activation' => Reader_Activation::is_enabled( false ),
 			'has_memberships'       => class_exists( 'WC_Memberships' ),
 			'reader_activation_url' => \admin_url( 'admin.php?page=newspack-engagement-wizard#/reader-activation' ),
 		];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes the requirement for a `NEWSPACK_EXPERIMENTAL_READER_ACTIVATION` environment flag to access the RAS setup wizard. Any site can now self-enable RAS features by completing the setup wizard.

### How to test the changes in this Pull Request:

1. Remove the `NEWSPACK_EXPERIMENTAL_READER_ACTIVATION` flag from `wp-config.php`, if present. Also remove the RAS option if present to reset your site to a pre-RAS state: `wp option delete newspack_reader_activation_enabled`
2. Edit a post or page and confirm that you cannot insert a Reader Registration block (this block is only available once RAS is enabled).
3. Visit **Newspack > Engagement** and confirm that the default page is the Reader Activation dashboard.
4. Visit the prompt wizard of this dashboard and confirm you can edit and preview all prompts, including the Registration prompt (the Reg block will still be rendered in previews even if not available in the editor).
5. Complete RAS setup and confirm that all features work as expected in the admin (you can add and edit Registration blocks to any prompt or post) and on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->