### PR TITLE
feat(ras): mailchimp audience config

### DIFF
--- a/assets/wizards/engagement/components/mailchimp.js
+++ b/assets/wizards/engagement/components/mailchimp.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Notice, SectionHeader, SelectControl } from '../../../components/src';
+
+export default function ActiveCampaign( { value, onChange } ) {
+	const [ inFlight, setInFlight ] = useState( false );
+	const [ lists, setLists ] = useState( [] );
+	const [ error, setError ] = useState( false );
+	const fetchLists = () => {
+		setError( false );
+		setInFlight( true );
+		apiFetch( {
+			path: '/newspack-newsletters/v1/lists',
+		} )
+			.then( res => setLists( res.filter( list => ! list.type ) ) )
+			.catch( setError )
+			.finally( () => setInFlight( false ) );
+	};
+	useEffect( fetchLists, [] );
+	const handleChange = key => val => onChange && onChange( key, val );
+	return (
+		<>
+			{ error && (
+				<Notice
+					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+					isError
+				/>
+			) }
+			<SectionHeader
+				title={ __( 'Mailchimp', 'newspack' ) }
+				description={ __( 'Settings for the Mailchimp integration.', 'newspack' ) }
+			/>
+			<SelectControl
+				label={ __( 'Audience ID', 'newspack' ) }
+				help={ __( 'Choose an audience to receive reader activity data.', 'newspack' ) }
+				disabled={ inFlight }
+				value={ value.audienceId }
+				onChange={ handleChange( 'audienceId' ) }
+				options={ [
+					{ value: '', label: __( 'None', 'newspack' ) },
+					...lists.map( list => ( { label: list.name, value: list.id } ) ),
+				] }
+			/>
+		</>
+	);
+}

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -23,6 +23,7 @@ import {
 } from '../../../../components/src';
 import Prerequisite from '../../components/prerequisite';
 import ActiveCampaign from '../../components/active-campaign';
+import Mailchimp from '../../components/mailchimp';
 import { HANDOFF_KEY } from '../../../../components/src/consts';
 
 export default withWizardScreen( () => {
@@ -32,6 +33,7 @@ export default withWizardScreen( () => {
 	const [ error, setError ] = useState( false );
 	const [ allReady, setAllReady ] = useState( false );
 	const [ isActiveCampaign, setIsActiveCampaign ] = useState( false );
+	const [ isMailchimp, setIsMailchimp ] = useState( false );
 	const [ prerequisites, setPrerequisites ] = useState( null );
 	const [ missingPlugins, setMissingPlugins ] = useState( [] );
 	const [ showAdvanced, setShowAdvanced ] = useState( false );
@@ -79,6 +81,9 @@ export default withWizardScreen( () => {
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/newsletters',
 		} ).then( data => {
+			setIsMailchimp(
+				data?.settings?.newspack_newsletters_service_provider?.value === 'mailchimp'
+			);
 			setIsActiveCampaign(
 				data?.settings?.newspack_newsletters_service_provider?.value === 'active_campaign'
 			);
@@ -280,6 +285,16 @@ export default withWizardScreen( () => {
 								) }
 								{ ...getSharedProps( 'metadata_prefix', 'text' ) }
 							/>
+							{ isMailchimp && (
+								<Mailchimp
+									value={ { audienceId: config.mailchimp_audience_id } }
+									onChange={ ( key, value ) => {
+										if ( key === 'audienceId' ) {
+											updateConfig( 'mailchimp_audience_id', value );
+										}
+									} }
+								/>
+							) }
 							{ isActiveCampaign && (
 								<ActiveCampaign
 									value={ { masterList: config.active_campaign_master_list } }
@@ -299,6 +314,7 @@ export default withWizardScreen( () => {
 								saveConfig( {
 									newsletters_label: config.newsletters_label, // TODO: Deprecate this in favor of user input via the prompt copy wizard.
 									metadata_prefix: config.metadata_prefix,
+									mailchimp_audience_id: config.mailchimp_audience_id,
 									active_campaign_master_list: config.active_campaign_master_list,
 								} );
 							} }

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -112,13 +112,17 @@ class Mailchimp {
 		// Create remaining fields.
 		$remaining_fields = array_keys( $data );
 		foreach ( $remaining_fields as $field_name ) {
-			$created_field                            = Mailchimp_API::post(
+			$created_field = Mailchimp_API::post(
 				"lists/$audience_id/merge-fields",
 				[
 					'name' => $field_name,
 					'type' => self::get_merge_field_type( $data[ $field_name ] ),
 				]
 			);
+			// Skip field if it failed to create.
+			if ( is_wp_error( $created_field ) ) {
+				continue;
+			}
 			$merge_fields[ $created_field['tag'] ]    = $data[ $field_name ];
 			$fields_ids[ $created_field['merge_id'] ] = $field_name;
 		}
@@ -151,7 +155,7 @@ class Mailchimp {
 		}
 
 		// Upsert the contact.
-		Mailchimp_API::put(
+		$res = Mailchimp_API::put(
 			"lists/$audience_id/members/$hash",
 			$payload
 		);

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -24,11 +24,14 @@ class Mailchimp {
 	 * Constructor.
 	 */
 	public function __construct() {
-		if (
-			defined( 'NEWSPACK_DATA_EVENTS_MAILCHIMP' ) && NEWSPACK_DATA_EVENTS_MAILCHIMP &&
-			Reader_Activation::is_enabled() &&
-			true === Reader_Activation::get_setting( 'sync_esp' )
-		) {
+		add_action( 'init', [ __CLASS__, 'register_handlers' ] );
+	}
+
+	/**
+	 * Register handlers.
+	 */
+	public static function register_handlers() {
+		if ( Reader_Activation::is_enabled() && true === Reader_Activation::get_setting( 'sync_esp' ) ) {
 			Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
 			Data_Events::register_handler( [ __CLASS__, 'donation_new' ], 'donation_new' );
 			Data_Events::register_handler( [ __CLASS__, 'donation_subscription_new' ], 'donation_subscription_new' );
@@ -41,7 +44,6 @@ class Mailchimp {
 	 * @return string|bool Audience ID or false if not set.
 	 */
 	private static function get_audience_id() {
-		/** TODO: UI for handling Mailchimp's master list in RAS. */
 		$audience_id = Reader_Activation::get_setting( 'mailchimp_audience_id' );
 		/** Attempt to use list ID from "Mailchimp for WooCommerce" */
 		if ( ! $audience_id && function_exists( 'mailchimp_get_list_id' ) ) {

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -155,7 +155,7 @@ class Mailchimp {
 		}
 
 		// Upsert the contact.
-		$res = Mailchimp_API::put(
+		Mailchimp_API::put(
 			"lists/$audience_id/members/$hash",
 			$payload
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allow the Mailchimp audience to be configured for RAS integration. Also removes the `NEWSPACK_DATA_EVENTS_MAILCHIMP` feature flag.

<img width="1132" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/a875caea-9571-447e-873d-6138321eed7c">

### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have Mailchimp as your ESP and RAS properly configured
2. Navigate to the "Newspack -> Engagement" page and while in the "Reader Activation" tab, click on "Show Advanced Settings"
3. Scroll down and confirm you see the Mailchimp integration section like in the image above
4. Select an audience and save
5. Refresh the page and confirm the saved audience persists
6. In a new session, register a new reader and make a donation
7. Wait until the event dispatches execute the handlers (with `define( 'NEWSPACK_LOG_LEVEL', 2 );` you should see:
```
[NEWSPACK-DATA-EVENTS][Newspack\Data_Events::handle]: Executing global action handlers for "donation_new".
```
8. Go to your Mailchimp audience and confirm the contact is updated with `NP_` prefixed metadata

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->