### PR TITLE
feat: customizable receipt emails for Woo

### DIFF
--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -54,7 +54,7 @@ const ReaderRevenueWizard = () => {
 			label: __( 'Emails', 'newspack' ),
 			path: '/emails',
 			render: Views.Emails,
-			isHidden: usedPlatform !== STRIPE,
+			isHidden: usedPlatform !== NEWSPACK && usedPlatform !== STRIPE,
 		},
 		{
 			label: __( 'Address', 'newspack' ),

--- a/assets/wizards/readerRevenue/views/emails/index.js
+++ b/assets/wizards/readerRevenue/views/emails/index.js
@@ -59,6 +59,8 @@ const Emails = () => {
 						href={ email.edit_link }
 						description={ email.description }
 						actionText={ __( 'Edit', 'newspack' ) }
+						toggleChecked={ email.enabled }
+						toggleOnChange={ () => console.log( email ) }
 						{ ...( isActive
 							? {}
 							: {

--- a/assets/wizards/readerRevenue/views/emails/index.js
+++ b/assets/wizards/readerRevenue/views/emails/index.js
@@ -3,6 +3,7 @@
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -17,9 +18,35 @@ import { values } from 'lodash';
 import { PluginInstaller, ActionCard, Notice } from '../../../../components/src';
 
 const EMAILS = values( newspack_reader_revenue.emails );
+const postType = newspack_reader_revenue.email_cpt;
 
 const Emails = () => {
 	const [ pluginsReady, setPluginsReady ] = useState( null );
+	const [ error, setError ] = useState( false );
+	const [ inFlight, setInFlight ] = useState( false );
+	const [ emails, setEmails ] = useState( EMAILS );
+
+	const updateStatus = ( postId, status ) => {
+		setError( false );
+		setInFlight( true );
+		apiFetch( {
+			path: `/wp/v2/${ postType }/${ postId }`,
+			method: 'post',
+			data: { status },
+		} )
+			.then( () => {
+				setEmails(
+					emails.map( email => {
+						if ( email.post_id === postId ) {
+							return { ...email, status };
+						}
+						return email;
+					} )
+				);
+			} )
+			.catch( setError )
+			.finally( () => setInFlight( false ) );
+	};
 
 	if ( false === pluginsReady ) {
 		return (
@@ -31,10 +58,7 @@ const Emails = () => {
 					) }
 				</Notice>
 				<Notice isError>
-					{ __(
-						'Until this feature is configured, default Stripe receipts will be used.',
-						'newspack'
-					) }
+					{ __( 'Until this feature is configured, default receipts will be used.', 'newspack' ) }
 				</Notice>
 				<PluginInstaller
 					style={ pluginsReady ? { display: 'none' } : {} }
@@ -49,28 +73,36 @@ const Emails = () => {
 
 	return (
 		<>
-			{ EMAILS.map( email => {
+			{ emails.map( email => {
 				const isActive = email.status === 'publish';
 				return (
 					<ActionCard
 						key={ email.post_id }
+						disabled={ inFlight }
 						title={ email.label }
 						titleLink={ email.edit_link }
 						href={ email.edit_link }
 						description={ email.description }
 						actionText={ __( 'Edit', 'newspack' ) }
-						toggleChecked={ email.enabled }
-						toggleOnChange={ () => console.log( email ) }
+						toggleChecked={ isActive }
+						toggleOnChange={ value => updateStatus( email.post_id, value ? 'publish' : 'draft' ) }
 						{ ...( isActive
 							? {}
 							: {
 									notification: __(
-										'This email is not active – the default Stripe receipt will be used. Edit and publish the email to activate it.',
+										'This email is not active. The default receipt will be used.',
 										'newspack'
 									),
-									notificationLevel: 'error',
+									notificationLevel: 'info',
 							  } ) }
-					/>
+					>
+						{ error && (
+							<Notice
+								noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+								isError
+							/>
+						) }
+					</ActionCard>
 				);
 			} ) }
 		</>

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -15,7 +15,6 @@ defined( 'ABSPATH' ) || exit;
 class Emails {
 	const POST_TYPE              = 'newspack_rr_email'; // "Reader Revenue" emails, for legacy reasons.
 	const EMAIL_CONFIG_NAME_META = 'newspack_email_type'; // "type" for legacy reasons.
-	const EMAIL_OPTION_PREFIX    = 'newspack_email_enabled_'; // Prefix for enabled option key.
 
 	/**
 	 * Initialize.
@@ -287,7 +286,7 @@ class Emails {
 			return false;
 		}
 		$email_config = self::get_email_config_by_type( $type );
-		if ( ! $email_config || 'publish' !== $email_config['status'] || ! $email_config['enabled'] ) {
+		if ( ! $email_config || 'publish' !== $email_config['status'] ) {
 			return false;
 		}
 		return true;
@@ -347,10 +346,6 @@ class Emails {
 			'status'         => get_post_status( $post_id ),
 			'html_payload'   => $html_payload,
 		];
-
-		if ( null !== $type ) {
-			$serialized_email['enabled'] = \get_option( self::EMAIL_OPTION_PREFIX . $type, Donations::is_platform_stripe() );
-		}
 
 		return $serialized_email;
 	}

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
 class Emails {
 	const POST_TYPE              = 'newspack_rr_email'; // "Reader Revenue" emails, for legacy reasons.
 	const EMAIL_CONFIG_NAME_META = 'newspack_email_type'; // "type" for legacy reasons.
+	const EMAIL_OPTION_PREFIX    = 'newspack_email_enabled_'; // Prefix for enabled option key.
 
 	/**
 	 * Initialize.
@@ -286,7 +287,7 @@ class Emails {
 			return false;
 		}
 		$email_config = self::get_email_config_by_type( $type );
-		if ( ! $email_config || 'publish' !== $email_config['status'] ) {
+		if ( ! $email_config || 'publish' !== $email_config['status'] || ! $email_config['enabled'] ) {
 			return false;
 		}
 		return true;
@@ -346,6 +347,10 @@ class Emails {
 			'status'         => get_post_status( $post_id ),
 			'html_payload'   => $html_payload,
 		];
+
+		if ( null !== $type ) {
+			$serialized_email['enabled'] = \get_option( self::EMAIL_OPTION_PREFIX . $type, Donations::is_platform_stripe() );
+		}
 
 		return $serialized_email;
 	}

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -1077,8 +1077,8 @@ class WooCommerce_Connection {
 	 * @return bool
 	 */
 	public static function send_customizable_receipt_email( $enable, $order, $class ) {
-		// If we don't have a valid order, bail.
-		if ( ! is_a( $order, 'WC_Order' ) ) {
+		// If we don't have a valid order, or the customizable email isn't enabled, bail.
+		if ( ! is_a( $order, 'WC_Order' ) || ! Emails::can_send_email( Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'] ) ) {
 			return $enable;
 		}
 
@@ -1113,7 +1113,6 @@ class WooCommerce_Connection {
 			$placeholders
 		);
 
-		// Fall back to default email if the custom one failed to send.
 		return false;
 	}
 }

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -41,6 +41,7 @@ class WooCommerce_Connection {
 	public static function init() {
 		\add_action( 'admin_init', [ __CLASS__, 'disable_woocommerce_setup' ] );
 		\add_filter( 'option_woocommerce_subscriptions_allow_switching_nyp_price', [ __CLASS__, 'force_allow_switching_subscription_amount' ] );
+		\add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'send_customizable_receipt_email' ], 10, 3 );
 
 		// WooCommerce Subscriptions.
 		\add_action( 'add_meta_boxes', [ __CLASS__, 'remove_subscriptions_schedule_meta_box' ], 45 );
@@ -1053,6 +1054,56 @@ class WooCommerce_Connection {
 			return $can_switch;
 		}
 		return 'yes';
+	}
+
+	/**
+	 * Send the customizable receipt email instead of WooCommerce's default receipt.
+	 *
+	 * @param bool     $enable Whether to send the default receipt email.
+	 * @param WC_Order $order The order object for the receipt email.
+	 * @param WC_Email $class Instance of the WC_Email class.
+	 *
+	 * @return bool
+	 */
+	public static function send_customizable_receipt_email( $enable, $order, $class ) {
+		// If we don't have a valid order, bail.
+		if ( ! is_a( $order, 'WC_Order' ) ) {
+			return $enable;
+		}
+
+		$currency = $order->get_currency();
+		$symbol   = newspack_get_currency_symbol( $currency );
+		$total    = $order->get_total();
+		$created  = $order->get_date_created();
+
+		// Replace content placeholders.
+		$placeholders = [
+			[
+				'template' => '*AMOUNT*',
+				'value'    => 'USD' === $currency ? $symbol . $total : $total . $symbol,
+			],
+			[
+				'template' => '*DATE*',
+				'value'    => $created->date_i18n(),
+			],
+			[
+				'template' => '*PAYMENT_METHOD*',
+				'value'    => __( 'Card', 'newspack' ) . ' – ' . $order->get_payment_method(),
+			],
+			[
+				'template' => '*RECEIPT_URL*',
+				'value'    => sprintf( '<a href="%s">%s</a>', $order->get_view_order_url(), __( 'My Account', 'newspack' ) ),
+			],
+		];
+
+		$sent = Emails::send_email(
+			Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'],
+			$order->get_billing_email(),
+			$placeholders
+		);
+
+		// Fall back to default email if the custom one failed to send.
+		return false;
 	}
 }
 

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -554,6 +554,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			'newspack_reader_revenue',
 			[
 				'emails'                  => Emails::get_emails( [ Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'] ], false ),
+				'email_cpt'               => Emails::POST_TYPE,
 				'salesforce_redirect_url' => Salesforce::get_redirect_url(),
 			]
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows the customizable Newspack receipt email to be used in place of WooCommerce's default receipt email. Also provides a toggle switch to enable or disable this behavior. It's enabled by default, but if turned off, the default WooCommerce or Stripe receipt emails will be sent instead (in case the publisher wants to keep those default receipts for whatever reason).

Closes `1204005426582602/1204087028603366`.

### How to test the changes in this Pull Request:

1. On a test site using the "Newspack" reader revenue platform, check out this branch.
2. Visit **Newspack > Reader Revenue > Emails** in WP admin and confirm you see the Receipt email as an option here.

<img width="971" alt="Screen Shot 2023-05-17 at 2 48 33 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/f9b378bc-a82a-45bd-80c0-575099457d9b">

3. Confirm you can edit the email, update its content, and save.
4. On the front-end, make a donation.
5. Confirm that the receipt email received at the donor's email address is the customizable one you edited in step 3.
6. Back in the wizard, toggle off the receipt email. Confirm that it shows a disabled state, and confirm that the state persists after refreshing:

<img width="971" alt="Screen Shot 2023-05-17 at 2 51 00 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/9cbb84e9-7bf3-4ca1-a323-b6f9e5afaf87">

7. Make another donation and this time confirm that the default WooCommerce receipt email gets sent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->