### PR TITLE
fix(ras): total paid sum race condition

### DIFF
--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -58,7 +58,7 @@ class WooCommerce_Connection {
 		\add_action( 'wc_memberships_user_membership_created', [ __CLASS__, 'wc_membership_created' ], 10, 2 );
 
 		// WC Subscriptions hooks in and creates subscription at priority 100, so use priority 101.
-		\add_action( 'woocommerce_checkout_order_processed', [ __CLASS__, 'order_processed' ], 101 );
+		\add_action( 'woocommerce_order_status_completed', [ __CLASS__, 'order_processed' ], 101 );
 		\add_action( 'option_woocommerce_subscriptions_failed_scheduled_actions', [ __CLASS__, 'filter_subscription_scheduled_actions_errors' ] );
 
 		\add_action( 'wp_login', [ __CLASS__, 'sync_reader_on_customer_login' ], 10, 2 );
@@ -208,7 +208,6 @@ class WooCommerce_Connection {
 		if ( empty( $order_subscriptions ) ) {
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Donor';
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ]        = (float) $customer->get_total_spent();
-			$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ]       += (float) $order->get_total();
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ]      = '';
 			$order_items = $order->get_items();
 			if ( $order_items ) {

--- a/includes/reader-revenue/class-woocommerce-connection.php
+++ b/includes/reader-revenue/class-woocommerce-connection.php
@@ -58,7 +58,7 @@ class WooCommerce_Connection {
 		\add_action( 'wc_memberships_user_membership_created', [ __CLASS__, 'wc_membership_created' ], 10, 2 );
 
 		// WC Subscriptions hooks in and creates subscription at priority 100, so use priority 101.
-		\add_action( 'woocommerce_order_status_completed', [ __CLASS__, 'order_processed' ], 101 );
+		\add_action( 'woocommerce_checkout_order_processed', [ __CLASS__, 'order_processed' ], 101 );
 		\add_action( 'option_woocommerce_subscriptions_failed_scheduled_actions', [ __CLASS__, 'filter_subscription_scheduled_actions_errors' ] );
 
 		\add_action( 'wp_login', [ __CLASS__, 'sync_reader_on_customer_login' ], 10, 2 );
@@ -208,7 +208,12 @@ class WooCommerce_Connection {
 		if ( empty( $order_subscriptions ) ) {
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Donor';
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ]        = (float) $customer->get_total_spent();
-			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ]      = '';
+
+			if ( 'pending' === $order->get_status() ) {
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ] += (float) $order->get_total();
+			}
+
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = '';
 			$order_items = $order->get_items();
 			if ( $order_items ) {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = reset( $order_items )->get_name();
@@ -256,8 +261,11 @@ class WooCommerce_Connection {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'next_payment_date' ) ] = $next_payment_date;
 			}
 
-			$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ]  = (float) $customer->get_total_spent();
-			$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ] += (float) $current_subscription->get_total();
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ] = (float) $customer->get_total_spent();
+
+			if ( 'pending' === $order->get_status() ) {
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ] += (float) $current_subscription->get_total();
+			}
 
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = '';
 			if ( $current_subscription ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a possible race condition when calculating the total amount paid per donor when syncing the donor's info to the connected ESP. At the `woocommerce_checkout_order_processed` hook, the order status may be `pending` or `complete`, so the `$customer->get_total_spent()` method may or may not already include the order being processed in the total amount. This fix checks whether the status is `pending` and only adds the processing order amount to the total if it's still pending.

### How to test the changes in this Pull Request:

1. On `release`, with your reader revenue platform set to Newspack, ensure that RAS is setup and that the `NEWSPACK_EXPERIMENTAL_READER_ACTIVATION` and `NEWSPACK_DATA_EVENTS_MAILCHIMP` flags are set in wp-config. Test the following with ActiveCampaign.
2. On the front-end, make a one-time donation as a new reader.
3. In the connected ESP, find the contact and observe that the `NP_Total Paid` amount is double what you'd expect. On subsequent donations the total would reflect the true total plus the amount from the latest order (because the latest order is added twice).
4. Check out this branch and repeat with a one-time donation, then a subscription donation. Confirm that the totals are synced correctly to the ESP for the first and subsequent donations.
5. Change your ESP connection to Mailchimp and repeat step 4.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->