### PR TITLE
Only display author filter for posts

### DIFF
--- a/includes/author-filter/class-author-filter.php
+++ b/includes/author-filter/class-author-filter.php
@@ -61,14 +61,19 @@ class Author_Filter {
 	 */
 	public static function author_filters_admin( $post_type ) {
 
-		// Disable this for sites with co authors plus enabled until we fix its issue with large sites.
-		if ( self::is_coauthors_plus_enabled( $post_type ) ) {
+		/**
+		 * Filters the post types that will have the author filter.
+		 *
+		 * @param array $filterable_post_types Array with post types slugs.
+		 */
+		$filterable_post_types = apply_filters( 'newspack_author_filter_post_types', [ 'post' ] );
+
+		if ( ! in_array( $post_type, $filterable_post_types, true ) ) {
 			return;
 		}
 
-		$excluded_post_types = [ 'attachment', 'revision', 'nav_menu_item' ];
-
-		if ( in_array( $post_type, $excluded_post_types, true ) ) {
+		// Disable this for sites with co authors plus enabled until we fix its issue with large sites.
+		if ( self::is_coauthors_plus_enabled( $post_type ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When first introduced in https://github.com/Automattic/newspack-plugin/pull/1985, it seemed a good idea to enable this filter for custom post types, but now it looks (at least to me) that we are interfering in other plugins behavior.

Posts page is where this filter is most useful anyway. Plugins that register custom post types might not want to have this filter on their CPT page.

### How to test the changes in this Pull Request:

1. Confirm that the filter still shows for posts and work
2. Confirm it does not show up for Pages or other custom post types

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->