### PR TITLE
feat(jetpack-photon): additional srcset sizes

### DIFF
--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -33,10 +33,54 @@ class Jetpack {
 		add_filter( 'newspack_amp_plus_sanitized', [ __CLASS__, 'jetpack_modules_amp_plus' ], 10, 2 );
 		add_action( 'wp_head', [ __CLASS__, 'fix_instant_search_sidebar_display' ], 10 );
 		add_filter( 'jetpack_lazy_images_skip_image_with_attributes', [ __CLASS__, 'skip_lazy_loading_on_feeds' ], 10 );
+		add_filter( 'wp_calculate_image_srcset', [ __CLASS__, 'filter_srcset_array' ], 100, 5 );
 
 		// Disables Google Analytics.
 		add_filter( 'jetpack_active_modules', array( __CLASS__, 'remove_google_analytics_from_active' ), 10, 2 );
 		add_filter( 'jetpack_get_available_modules', array( __CLASS__, 'remove_google_analytics_from_available' ) );
+	}
+
+	/**
+	 * Filters an array of image `srcset` values, adding Photon urls for additional sizes.
+	 *
+	 * @param array $sources       An array of image urls and widths.
+	 * @param array $size_array    The size array for srcset.
+	 * @param array $image_src     The image srcs.
+	 * @param array $image_meta    The image meta.
+	 * @param int   $attachment_id Attachment ID.
+	 *
+	 * @return array An array of Photon image urls and widths.
+	 */
+	public static function filter_srcset_array( $sources = array(), $size_array = array(), $image_src = array(), $image_meta = array(), $attachment_id = 0 ) {
+		if ( ! class_exists( 'Jetpack' ) || ! \Jetpack::is_module_active( 'photon' ) ) {
+			return $sources;
+		}
+		if ( ! function_exists( 'jetpack_photon_url' ) ) {
+			return $sources;
+		}
+
+		/**
+		 * Filter the additional sizes to add to the srcset.
+		 *
+		 * @param array $additional_sizes An array of additional sizes to add to the srcset.
+		 */
+		$additional_sizes = apply_filters( 'newspack_photon_srcset_additional_sizes', [ 370, 400 ] );
+
+		foreach ( $additional_sizes as $w ) {
+			if ( isset( $sources[ $w ] ) ) {
+				continue;
+			}
+			if ( ! empty( $attachment_id ) ) {
+				$url = \wp_get_attachment_url( $attachment_id );
+			}
+			$sources[ $w ] = [
+				'url'        => \jetpack_photon_url( $url, [ 'w' => $w ] ),
+				'descriptor' => 'w',
+				'value'      => $w,
+			];
+		}
+
+		return $sources;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Implements additional `srcset` sizes for Jetpack Photon to resize. These should cover common mobile viewports and improve load time.

### How to test the changes in this Pull Request:

1. Confirm you have Jetpack configured with `✅ Enable site accelerator` and `✅ Speed up image load times` under the **Performance** tab
2. Visit a post with images and inspect the source
3. Confirm the `srcset` attribute includes images with the sizes 370 and 400
4. Disable photon, refresh the page and confirm the image renders without issues and without the additional `srcset`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->