### PR TITLE
fix(performance): exclude main jetpack css from delay

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -85,6 +85,7 @@ class Perfmatters {
 			'plugins/newspack-popups', // Newspack Campaigns.
 			'plugins/jetpack/modules/sharedaddy', // Jetpack's share buttons.
 			'plugins/jetpack/_inc/social-logos', // Jetpack's social logos CSS.
+			'plugins/jetpack/css/jetpack.css', // Jetpack's main CSS.
 			'/themes/newspack-', // Any Newspack theme stylesheet.
 			'cache/perfmatters', //	Perfmatters' cache.
 			'wp-includes',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The bundled `jetpack/css/jetpack.css` includes rules that were previously in `plugins/jetpack/modules/sharedaddy` and `plugins/jetpack/_inc/social-logos`. This excludes the bundled CSS from the delay strategy so it renders on load time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->