### PR TITLE
feat(plugin-installer): handle premium plugins in PluginInstaller

### DIFF
--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -173,6 +173,7 @@ class ActionCard extends Component {
 									</Handoff>
 								) : onClick || hasInternalLink ? (
 									<Button
+										disabled={ disabled }
 										isLink
 										href={ href }
 										onClick={ onClick }

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -189,12 +189,21 @@ class PluginInstaller extends Component {
 					slugs.length > 0 &&
 					slugs.map( slug => {
 						const plugin = pluginInfo[ slug ];
-						const { Name, Description, Status, installationStatus, notification } = plugin;
+						const { Name, Description, Download, Status, installationStatus, notification } =
+							plugin;
 						const isWaiting = installationStatus === PLUGIN_STATE_INSTALLING;
 						const isButton = ! isWaiting && Status !== 'active';
+						const installable = Download || pluginInstalled( Status );
 						let actionText;
 						if ( installationStatus === PLUGIN_STATE_INSTALLING ) {
-							actionText = __( 'Installing…' );
+							actionText = 'inactive' === Status ? __( 'Activating…' ) : __( 'Installing…' );
+						} else if ( ! installable ) {
+							actionText = (
+								<span className="newspack-plugin-installer__status">
+									{ __( 'Contact Newspack support to install', 'newspack' ) }
+									<span className="newspack-checkbox-icon" />
+								</span>
+							);
 						} else if ( Status === 'uninstalled' ) {
 							actionText = (
 								<span className="newspack-plugin-installer__status">
@@ -230,6 +239,7 @@ class PluginInstaller extends Component {
 								key={ slug }
 								title={ Name }
 								description={ Description }
+								disabled={ ! installable }
 								actionText={ actionText }
 								isSmall={ isSmall }
 								isWaiting={ isWaiting }

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -155,6 +155,7 @@ class PluginInstaller extends Component {
 	render() {
 		const { autoInstall, isSmall, withoutFooterButton } = this.props;
 		const { pluginInfo } = this.state;
+		const { is_atomic: isAtomic } = window;
 		const slugs = Object.keys( pluginInfo );
 
 		// Store all plugin status info for installer button text value based on current status.
@@ -200,7 +201,9 @@ class PluginInstaller extends Component {
 						} else if ( ! installable ) {
 							actionText = (
 								<span className="newspack-plugin-installer__status">
-									{ __( 'Contact Newspack support to install', 'newspack' ) }
+									{ isAtomic
+										? __( 'Contact Newspack support to install', 'newspack' )
+										: __( 'Plugin must be installed manually', 'newspack' ) }
 									<span className="newspack-checkbox-icon" />
 								</span>
 							);

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -140,6 +140,7 @@ abstract class Wizard {
 			'is_debug_mode'       => Newspack::is_debug_mode(),
 			'has_completed_setup' => get_option( NEWSPACK_SETUP_COMPLETE ),
 			'site_title'          => get_option( 'blogname' ),
+			'is_atomic'           => defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID,
 		];
 
 		if ( class_exists( 'Newspack_Popups_Segmentation' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A small tweak to the PluginInstaller component that disables the "Install" action button if the plugin can't be installed programmatically (e.g. if the plugin is a premium plugin without a public download link). Previously the component would attempt to install but fail with an error message due to lacking a URL to install from, which is a subpar user experience.

Also tweaks the message shown while activating a plugin to "Activating...". Previously this said "Installing..." whether installing or activating a plugin.

Closes `1204498218048567/1204685119775505`.

### How to test the changes in this Pull Request:

This applies to any instance of the PluginInstaller and any plugin that lacks a `Download` property in [`class-plugin-manager.php`](https://github.com/Automattic/newspack-plugin/blob/master/includes/class-plugin-manager.php#L39), but the easiest place to test is in the new Reader Activation wizard:

1. Delete `woocommerce` (publicly downloadable) and the premium `woocommerce-subscriptions` and `woocommerce-name-your-price` plugins.
2. Visit **Newspack > Engagement > Reader Activation** and confirm that WooCommerce can be installed from here, but the other two plugins cannot, and show a message to contact Newspack support for those plugins.

<img width="1055" alt="Screen Shot 2023-05-31 at 4 46 37 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/9ae55655-456a-4fda-8926-6c41eb837fb9">

3. Manually install the plugins but do not activate.
4. Refresh the wizard, and confirm that the plugins can now be activated (since they're already installed, just inactive) and that they show an "Activating..." message while activating.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->