### PR TITLE
fix(ras): check that unblock exists before calling it

### DIFF
--- a/assets/wizards/engagement/components/prompt.tsx
+++ b/assets/wizards/engagement/components/prompt.tsx
@@ -124,7 +124,9 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 
 	const savePrompt = ( slug: string, data: InputValues ) => {
 		return new Promise< void >( ( res, rej ) => {
-			unblock();
+			if ( unblock ) {
+				unblock();
+			}
 			setError( false );
 			setSuccess( false );
 			setInFlight( true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an intermittent error introduced by #2453. Sometimes the `hooks.usePrompt` method doesn't return a function before the `savePrompt` method is called and attempts to call `unblock`. This avoids a JS error in that case.

### How to test the changes in this Pull Request:

1. Follow testing instructions in #2453. Observe that if you make changes and save a prompt ASAP quickly, you'll sometimes see a JS error: `Uncaught (in promise) TypeError: unblock is not a function`
2. Check out this branch and repeat. Confirm that you don't see the error, and that the prompt still works when you try to navigate away from the page with unsaved changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->