### PR TITLE
feat(ras): add NRH support for setup wizard

### DIFF
--- a/assets/components/src/autocomplete-with-suggestions/style.scss
+++ b/assets/components/src/autocomplete-with-suggestions/style.scss
@@ -56,6 +56,7 @@
 
 	.newspack-autocomplete-tokenfield__help {
 		font-size: inherit;
+		margin-bottom: 8px !important;
 	}
 
 	.components-form-token-field {

--- a/assets/components/src/handoff-message/index.js
+++ b/assets/components/src/handoff-message/index.js
@@ -23,7 +23,16 @@ export default function HandoffMessage() {
 			} else {
 				setHandoffMessage( false );
 			}
+
+			// Clean up the notification if navigating away from the relevant page.
+			if ( handoff?.url && -1 < window.location.href.indexOf( handoff.url ) ) {
+				window.localStorage.removeItem( HANDOFF_KEY );
+				setHandoffMessage( false );
+			}
 		}, 100 );
+
+		// Clean up the notification when unmounting.
+		return () => window.localStorage.removeItem( HANDOFF_KEY );
 	}, [] );
 	if ( ! handoffMessage ) return null;
 	return <Notice isHandoff isDismissible={ false } rawHTML noticeText={ handoffMessage } />;

--- a/assets/components/src/handoff-message/index.js
+++ b/assets/components/src/handoff-message/index.js
@@ -25,7 +25,7 @@ export default function HandoffMessage() {
 			}
 
 			// Clean up the notification if navigating away from the relevant page.
-			if ( handoff?.url && -1 < window.location.href.indexOf( handoff.url ) ) {
+			if ( handoff?.url && -1 === window.location.href.indexOf( handoff.url ) ) {
 				window.localStorage.removeItem( HANDOFF_KEY );
 				setHandoffMessage( false );
 			}

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -138,6 +138,7 @@ export default function Prerequisite( {
 																	? '</a>'
 																	: ''
 															),
+															url: href,
 														} )
 													);
 												}

--- a/assets/wizards/readerRevenue/views/nrh-settings/index.js
+++ b/assets/wizards/readerRevenue/views/nrh-settings/index.js
@@ -30,7 +30,6 @@ const NRHSettings = () => {
 	}, [] );
 
 	const changeHandler = ( key, value ) => {
-		console.log( key, value );
 		return updateWizardSettings( {
 			slug: READER_REVENUE_WIZARD_SLUG,
 			path: [ 'platform_data', key ],
@@ -97,14 +96,13 @@ const NRHSettings = () => {
 							'newspack'
 						) }
 						onChange={ items => {
-							console.log( items );
 							if ( ! items || ! items.length ) {
 								setSelectedPage( null );
-								return changeHandler( 'newspack_popups_donor_landing_page', 0 );
+								return changeHandler( 'donor_landing_page', null );
 							}
 							const item = items[ 0 ];
 							setSelectedPage( item );
-							return changeHandler( 'newspack_popups_donor_landing_page', item.value );
+							return changeHandler( 'donor_landing_page', item );
 						} }
 						postTypes={ [ { slug: 'page', label: 'Page' } ] }
 						postTypeLabel={ __( 'page', 'newspack' ) }

--- a/assets/wizards/readerRevenue/views/nrh-settings/index.js
+++ b/assets/wizards/readerRevenue/views/nrh-settings/index.js
@@ -3,28 +3,47 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Grid, TextControl, Wizard } from '../../../../components/src';
+import {
+	ActionCard,
+	AutocompleteWithSuggestions,
+	Button,
+	Grid,
+	TextControl,
+	Wizard,
+} from '../../../../components/src';
 import { READER_REVENUE_WIZARD_SLUG } from '../../constants';
 
 const NRHSettings = () => {
+	const [ selectedPage, setSelectedPage ] = useState( null );
 	const wizardData = Wizard.useWizardData( 'reader-revenue' );
 	const { updateWizardSettings, saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
 
-	const changeHandler = key => value =>
-		updateWizardSettings( {
+	useEffect( () => {
+		if ( wizardData?.platform_data?.donor_landing_page ) {
+			setSelectedPage( wizardData.platform_data.donor_landing_page );
+		}
+	}, [] );
+
+	const changeHandler = ( key, value ) => {
+		console.log( key, value );
+		return updateWizardSettings( {
 			slug: READER_REVENUE_WIZARD_SLUG,
 			path: [ 'platform_data', key ],
 			value,
 		} );
+	};
 	const onSave = () =>
 		saveWizardSettings( {
 			slug: READER_REVENUE_WIZARD_SLUG,
 			payloadPath: [ 'platform_data' ],
 		} );
+
+	const settings = wizardData?.platform_data || {};
 
 	return (
 		<ActionCard
@@ -38,27 +57,62 @@ const NRHSettings = () => {
 				</Button>
 			}
 		>
-			<Grid columns={ 3 }>
-				<TextControl
-					label={ __( 'Organization ID', 'newspack' ) }
-					placeholder="exampleid"
-					value={ wizardData.platform_data?.nrh_organization_id || '' }
-					onChange={ changeHandler( 'nrh_organization_id' ) }
-				/>
-				<TextControl
-					label={ __( 'Custom domain (optional)', 'newspack' ) }
-					help={ __( 'Enter the raw domain without protocol or slashes.' ) }
-					placeholder="donate.example.com"
-					value={ wizardData.platform_data?.nrh_custom_domain || '' }
-					onChange={ changeHandler( 'nrh_custom_domain' ) }
-				/>
-				<TextControl
-					label={ __( 'Salesforce Campaign ID (optional)', 'newspack' ) }
-					placeholder="exampleid"
-					value={ wizardData.platform_data?.nrh_salesforce_campaign_id || '' }
-					onChange={ changeHandler( 'nrh_salesforce_campaign_id' ) }
-				/>
-			</Grid>
+			<div>
+				<Grid columns={ 3 }>
+					<TextControl
+						label={ __( 'Organization ID', 'newspack' ) }
+						placeholder="exampleid"
+						value={ settings?.nrh_organization_id || '' }
+						onChange={ value => changeHandler( 'nrh_organization_id', value ) }
+					/>
+					<TextControl
+						label={ __( 'Custom domain (optional)', 'newspack' ) }
+						help={ __( 'Enter the raw domain without protocol or slashes.' ) }
+						placeholder="donate.example.com"
+						value={ settings?.nrh_custom_domain || '' }
+						onChange={ value => changeHandler( 'nrh_custom_domain', value ) }
+					/>
+					<TextControl
+						label={ __( 'Salesforce Campaign ID (optional)', 'newspack' ) }
+						placeholder="exampleid"
+						value={ settings?.nrh_salesforce_campaign_id || '' }
+						onChange={ value => changeHandler( 'nrh_salesforce_campaign_id', value ) }
+					/>
+				</Grid>
+			</div>
+			{ settings.hasOwnProperty( 'donor_landing_page' ) && (
+				<div>
+					<hr />
+					<h3>{ __( 'Post-Donation Landing Page', 'newspack' ) }</h3>
+					<p className="components-base-control__help">
+						{ __(
+							'Set a page on your site as a post-donation landing page. Once a reader donates and lands on this page, they will be considered a donor.',
+							'newspack'
+						) }
+					</p>
+					<AutocompleteWithSuggestions
+						label={ __( 'Search for a New Donation Landing Page', 'newspack' ) }
+						help={ __(
+							'Begin typing page title, click autocomplete result to select.',
+							'newspack'
+						) }
+						onChange={ items => {
+							console.log( items );
+							if ( ! items || ! items.length ) {
+								setSelectedPage( null );
+								return changeHandler( 'newspack_popups_donor_landing_page', 0 );
+							}
+							const item = items[ 0 ];
+							setSelectedPage( item );
+							return changeHandler( 'newspack_popups_donor_landing_page', item.value );
+						} }
+						postTypes={ [ { slug: 'page', label: 'Page' } ] }
+						postTypeLabel={ __( 'page', 'newspack' ) }
+						postTypeLabelPlural={ __( 'pages', 'newspack' ) }
+						selectedItems={ selectedPage ? [ selectedPage ] : [] }
+					/>
+				</div>
+			) }
 		</ActionCard>
 	);
 };

--- a/assets/wizards/readerRevenue/views/nrh-settings/index.js
+++ b/assets/wizards/readerRevenue/views/nrh-settings/index.js
@@ -83,15 +83,15 @@ const NRHSettings = () => {
 			{ settings.hasOwnProperty( 'donor_landing_page' ) && (
 				<div>
 					<hr />
-					<h3>{ __( 'Post-Donation Landing Page', 'newspack' ) }</h3>
+					<h3>{ __( 'Donor Landing Page', 'newspack' ) }</h3>
 					<p className="components-base-control__help">
 						{ __(
-							'Set a page on your site as a post-donation landing page. Once a reader donates and lands on this page, they will be considered a donor.',
+							'Set a page on your site as a donor landing page. Once a reader donates and lands on this page, they will be considered a donor.',
 							'newspack'
 						) }
 					</p>
 					<AutocompleteWithSuggestions
-						label={ __( 'Search for a New Donation Landing Page', 'newspack' ) }
+						label={ __( 'Search for a New Donor Landing Page', 'newspack' ) }
 						help={ __(
 							'Begin typing page title, click autocomplete result to select.',
 							'newspack'

--- a/includes/class-nrh.php
+++ b/includes/class-nrh.php
@@ -89,7 +89,7 @@ class NRH {
 				$settings[ $key ] = $value;
 			} elseif ( 'donor_landing_page' === $key && method_exists( '\Newspack_Popups_Settings', 'update_setting' ) ) {
 				// Update the donor landing page in Campaigns settings.
-				\Newspack_Popups_Settings::update_setting( 'donor_settings', 'newspack_popups_donor_landing_page', ! empty( $value['value'] ) ? $value['value'] : 0 );
+				\Newspack_Popups_Settings::update_setting( 'donor_settings', 'newspack_popups_donor_landing_page', ! empty( $value['value'] ) ? (string) $value['value'] : 0 );
 			}
 		}
 

--- a/includes/class-nrh.php
+++ b/includes/class-nrh.php
@@ -87,9 +87,9 @@ class NRH {
 		foreach ( $data as $key => $value ) {
 			if ( in_array( $key, self::$allowed_keys, true ) ) {
 				$settings[ $key ] = $value;
-			} elseif ( 'newspack_popups_donor_landing_page' === $key && class_exists( '\Newspack_Popups_Settings' ) ) {
+			} elseif ( 'donor_landing_page' === $key && method_exists( '\Newspack_Popups_Settings', 'update_setting' ) ) {
 				// Update the donor landing page in Campaigns settings.
-				\update_option( $key, $value );
+				\Newspack_Popups_Settings::update_setting( 'donor_settings', 'newspack_popups_donor_landing_page', ! empty( $value['value'] ) ? $value['value'] : 0 );
 			}
 		}
 

--- a/includes/class-nrh.php
+++ b/includes/class-nrh.php
@@ -38,8 +38,22 @@ class NRH {
 	 *
 	 * @return array Array of settings.
 	 */
-	private static function get_settings() {
-		return \get_option( NEWSPACK_NRH_CONFIG, [] );
+	public static function get_settings() {
+		$settings = \get_option( NEWSPACK_NRH_CONFIG, [] );
+
+		if ( method_exists( '\Newspack_Popups_Settings', 'donor_landing_page' ) ) {
+			$settings['donor_landing_page'] = null;
+			$donor_landing_page             = \Newspack_Popups_Settings::donor_landing_page();
+
+			if ( $donor_landing_page ) {
+				$settings['donor_landing_page'] = [
+					'label' => \get_the_title( $donor_landing_page ),
+					'value' => $donor_landing_page,
+				];
+			}
+		}
+
+		return $settings;
 	}
 
 	/**
@@ -50,7 +64,7 @@ class NRH {
 	 *
 	 * @return string|boolean Value of setting if found, false otherwise.
 	 */
-	private static function get_setting( $key ) {
+	public static function get_setting( $key ) {
 		if ( ! in_array( $key, self::$allowed_keys, true ) ) {
 			return false;
 		}
@@ -73,8 +87,14 @@ class NRH {
 		foreach ( $data as $key => $value ) {
 			if ( in_array( $key, self::$allowed_keys, true ) ) {
 				$settings[ $key ] = $value;
+			} elseif ( 'newspack_popups_donor_landing_page' === $key && class_exists( '\Newspack_Popups_Settings' ) ) {
+				// Update the donor landing page in Campaigns settings.
+				\update_option( $key, $value );
 			}
 		}
+
+		// Don't want to save this extra key which is used only for the front-end display.
+		unset( $settings['donor_landing_page'] );
 
 		return \update_option( NEWSPACK_NRH_CONFIG, $settings );
 	}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -311,13 +311,20 @@ final class Reader_Activation {
 	 * Platform must be "Newspack" and all donation settings must be configured.
 	 */
 	public static function is_reader_revenue_ready() {
+		$ready             = false;
 		$donation_settings = Donations::get_donation_settings();
 
 		if ( \is_wp_error( $donation_settings ) ) {
-			return false;
+			return $ready;
 		}
 
-		return Donations::is_platform_wc();
+		if ( Donations::is_platform_wc() ) {
+			$ready = true;
+		} elseif ( Donations::is_platform_nrh() && NRH::get_setting( 'nrh_organization_id' ) && method_exists( '\Newspack_Popups_Settings', 'donor_landing_page' ) && \Newspack_Popups_Settings::donor_landing_page() ) {
+			$ready = true;
+		}
+
+		return $ready;
 	}
 
 	/**
@@ -435,7 +442,7 @@ final class Reader_Activation {
 				],
 				'label'        => __( 'Reader Revenue', 'newspack' ),
 				'description'  => __( 'Setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack' ),
-				'instructions' => __( 'Set platform to "Newspack" and configure your default donation settings.', 'newspack' ),
+				'instructions' => __( 'Set platform to "Newspack" or "News Revenue Hub" and configure your default donation settings. If using News Revenue Hub, set an Organization ID and a Post-Donation Landing Page in News Revenue Hub Settings.', 'newspack' ),
 				'help_url'     => 'https://help.newspack.com/engagement/reader-activation-system',
 				'href'         => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
 				'action_text'  => __( 'Reader Revenue settings' ),

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -442,7 +442,7 @@ final class Reader_Activation {
 				],
 				'label'        => __( 'Reader Revenue', 'newspack' ),
 				'description'  => __( 'Setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack' ),
-				'instructions' => __( 'Set platform to "Newspack" or "News Revenue Hub" and configure your default donation settings. If using News Revenue Hub, set an Organization ID and a Post-Donation Landing Page in News Revenue Hub Settings.', 'newspack' ),
+				'instructions' => __( 'Set platform to "Newspack" or "News Revenue Hub" and configure your default donation settings. If using News Revenue Hub, set an Organization ID and a Donor Landing Page in News Revenue Hub Settings.', 'newspack' ),
 				'help_url'     => 'https://help.newspack.com/engagement/reader-activation-system',
 				'href'         => \admin_url( '/admin.php?page=newspack-reader-revenue-wizard' ),
 				'action_text'  => __( 'Reader Revenue settings' ),

--- a/includes/util.php
+++ b/includes/util.php
@@ -21,7 +21,7 @@ define( 'NEWSPACK_API_URL', get_site_url() . '/wp-json/' . NEWSPACK_API_NAMESPAC
  */
 function newspack_clean( $var ) {
 	if ( is_array( $var ) ) {
-		return array_map( 'newspack_clean', $var );
+		return array_map( 'Newspack\newspack_clean', $var );
 	} else {
 		return is_scalar( $var ) ? sanitize_text_field( $var ) : $var;
 	}

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -89,21 +89,21 @@ class Reader_Revenue_Wizard extends Wizard {
 				'callback'            => [ $this, 'api_update' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'platform'                           => [
+					'platform'                   => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 						'validate_callback' => [ $this, 'api_validate_platform' ],
 					],
-					'nrh_organization_id'                => [
+					'nrh_organization_id'        => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 						'validate_callback' => [ $this, 'api_validate_not_empty' ],
 					],
-					'nrh_custom_domain'                  => [
+					'nrh_custom_domain'          => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
-					'nrh_salesforce_campaign_id'         => [
+					'nrh_salesforce_campaign_id' => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
-					'newspack_popups_donor_landing_page' => [
+					'donor_landing_page'         => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
 				],

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -89,18 +89,21 @@ class Reader_Revenue_Wizard extends Wizard {
 				'callback'            => [ $this, 'api_update' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'platform'                   => [
+					'platform'                           => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 						'validate_callback' => [ $this, 'api_validate_platform' ],
 					],
-					'nrh_organization_id'        => [
+					'nrh_organization_id'                => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 						'validate_callback' => [ $this, 'api_validate_not_empty' ],
 					],
-					'nrh_custom_domain'          => [
+					'nrh_custom_domain'                  => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
-					'nrh_salesforce_campaign_id' => [
+					'nrh_salesforce_campaign_id'         => [
+						'sanitize_callback' => 'Newspack\newspack_clean',
+					],
+					'newspack_popups_donor_landing_page' => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
 				],
@@ -480,7 +483,7 @@ class Reader_Revenue_Wizard extends Wizard {
 				$args
 			);
 		} elseif ( Donations::is_platform_nrh() ) {
-			$nrh_config            = get_option( NEWSPACK_NRH_CONFIG, [] );
+			$nrh_config            = NRH::get_settings();
 			$args['platform_data'] = wp_parse_args( $nrh_config, $args['platform_data'] );
 		} elseif ( Donations::is_platform_stripe() ) {
 			$are_webhooks_valid = Stripe_Webhooks::validate_or_create_webhooks();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-popups/pull/1124, allows sites using NRH as the reader revenue platform to enable RAS via the setup wizard, as long as they have an org ID and a donor landing page (for Campaigns segmentation) specified. Because the setting for Donor Landing Page is somewhat hidden in the Campaigns plugin settings page, but the setting is mostly relevant for sites using NRH or "Other' platforms, this PR duplicates the field in NRH settings so that all RAS prerequisites can be satisfied in one place.

Also fixes a minor bug where the hand-off message shown when visiting other settings pages from the RAS prerequisites page persists a little too long.

### How to test the changes in this Pull Request:

1. To start, check out https://github.com/Automattic/newspack-popups/pull/1124, then **deactivate** the Newspack Campaigns plugin and delete these relevant settings:
  - `wp option delete nrh_organization_id`
  - `wp option delete newspack_popups_donor_landing_page`

2. In **Newspack > Reader Revenue**, set the platform to "News Revenue Hub".
3. Go to **News Revenue Hub Settings** and confirm that the three standard fields here work (Organization ID, Custom domain, Salesforce Campaign ID) and persist after saving/refreshing the page.
4. Activate Newspack Campaigns and refresh the NRH Settings page. Confirm there's a new field here for Donor Landing page:

<img width="1062" alt="Screen Shot 2023-06-02 at 2 59 44 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/3770f9a1-2278-434f-8261-4f1ef6f9a361">

5. Don't do anything here yet. Go to **Newspack > Engagement > Reader Activation** and confirm that the Reader Revenue prerequisite is unchecked/incomplete. Expand the panel and click the button to go back to Reader Revenue settings.
6. Confirm you see a notification banner stating "Set platform to "Newspack" or "News Revenue Hub" and configure your default donation settings. If using News Revenue Hub, set an Organization ID and a Donor Landing Page in News Revenue Hub Settings."
7. Navigate to another WP admin page, then go back to the Reader Revenue wizard and confirm that the banner is no longer displayed after navigating away.
8. Go back to **News Revenue Hub Settings** and enter an Organization ID and choose a Donor Landing Page. Save and confirm that all settings persist after refreshing.
9. Go back to the Reader Activation wizard and confirm that the Reader Revenue prerequisite is now satisfied/checked.
10. On the front-end, visit the site as a new reader. Register/sign up for newsletters and confirm that you're correctly segmented in the "Registered, signed up for at least one newsletter, but has not donated" segment.
11. Visit the donor landing page you set in step 8. This should mark you as a donor in Campaigns.
12. Continue navigating the site and confirm that you now no longer match any default RAS segment. You can also turn on debug mode in Campaigns (add a `?newspack-campaigns-debug param to the URL` and inspect the Campaigns API response's debug object to confirm that there's a reader event with type `donation` and context `nrh`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->