### PR TITLE
feat: rename ga4 events

### DIFF
--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -19,7 +19,7 @@ final class Popups {
 	/**
 	 * The name of the action for form submissions
 	 */
-	const FORM_SUBMISSION = 'form_submission';
+	const FORM_SUBMISSION = 'form_submission_received';
 
 	/**
 	 * The name of the action for form submissions
@@ -39,55 +39,55 @@ final class Popups {
 	public static function init() {
 		Data_Events::register_listener(
 			'newspack_reader_registration_form_processed',
-			'campaign_interaction',
+			'prompt_interaction',
 			[ __CLASS__, 'registration_submission' ]
 		);
 
 		Data_Events::register_listener(
 			'newspack_reader_registration_form_processed',
-			'campaign_interaction',
+			'prompt_interaction',
 			[ __CLASS__, 'registration_submission_with_status' ]
 		);
 
 		Data_Events::register_listener(
 			'newspack_newsletters_subscribe_form_processed',
-			'campaign_interaction',
+			'prompt_interaction',
 			[ __CLASS__, 'newsletter_submission' ]
 		);
 
 		Data_Events::register_listener(
 			'newspack_newsletters_subscribe_form_processed',
-			'campaign_interaction',
+			'prompt_interaction',
 			[ __CLASS__, 'newsletter_submission_with_status' ]
 		);
 
 		Data_Events::register_listener(
 			'newspack_data_event_dispatch_donation_new',
-			'campaign_interaction',
+			'prompt_interaction',
 			[ __CLASS__, 'donation_submission_success' ]
 		);
 
 		Data_Events::register_listener(
 			'newspack_stripe_handle_donation_before',
-			'campaign_interaction',
+			'prompt_interaction',
 			[ __CLASS__, 'donation_submission_stripe' ]
 		);
 
 		Data_Events::register_listener(
 			'newspack_stripe_handle_donation_error',
-			'campaign_interaction',
+			'prompt_interaction',
 			[ __CLASS__, 'donation_submission_stripe_error' ]
 		);
 
 		Data_Events::register_listener(
 			'newspack_data_event_dispatch_woocommerce_donation_order_processed',
-			'campaign_interaction',
+			'prompt_interaction',
 			[ __CLASS__, 'donation_submission_woocommerce' ]
 		);
 
 		Data_Events::register_listener(
 			'newspack_data_event_dispatch_woocommerce_order_failed',
-			'campaign_interaction',
+			'prompt_interaction',
 			[ __CLASS__, 'donation_submission_woocommerce_error' ]
 		);
 
@@ -108,12 +108,12 @@ final class Popups {
 			return $data;
 		}
 
-		$data['campaign_id']    = $popup['id'];
-		$data['campaign_title'] = $popup['title'];
+		$data['prompt_id']    = $popup['id'];
+		$data['prompt_title'] = $popup['title'];
 
 		if ( isset( $popup['options'] ) ) {
-			$data['campaign_frequency'] = $popup['options']['frequency'] ?? '';
-			$data['campaign_placement'] = $popup['options']['placement'] ?? '';
+			$data['prompt_frequency'] = $popup['options']['frequency'] ?? '';
+			$data['prompt_placement'] = $popup['options']['placement'] ?? '';
 		}
 
 		$watched_blocks = [
@@ -122,11 +122,11 @@ final class Popups {
 			'newsletters_subscription' => 'newspack-newsletters/subscribe',
 		];
 
-		$data['campaign_blocks'] = [];
+		$data['prompt_blocks'] = [];
 
 		foreach ( $watched_blocks as $key => $block_name ) {
 			if ( has_block( $block_name, $popup['content'] ) ) {
-				$data['campaign_blocks'][] = $key;
+				$data['prompt_blocks'][] = $key;
 			}
 		}
 

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -35,7 +35,7 @@ class GA4 {
 		'donation_new',
 		'donation_subscription_cancelled',
 		'newsletter_subscribed',
-		'campaign_interaction',
+		'prompt_interaction',
 	];
 
 	/**
@@ -153,20 +153,20 @@ class GA4 {
 	 *
 	 * In those cases, we rely on the metadata added to the order/subscription via the `newspack_stripe_handle_donation_payment_metadata` filter.
 	 *
-	 * This filter fixes both the donation_new event and the campaign_interaction with action form_submission_success that relies on this event.
+	 * This filter fixes both the donation_new event and the prompt_interaction with action form_submission_success that relies on this event.
 	 *
 	 * @param array  $body The event body.
 	 * @param string $event_name The event name.
 	 * @return array
 	 */
 	public static function filter_donation_new_event_body( $body, $event_name ) {
-		if ( ! empty( $body['data']['ga_client_id'] ) || ( 'donation_new' !== $event_name && 'campaign_interaction' !== $event_name ) ) {
+		if ( ! empty( $body['data']['ga_client_id'] ) || ( 'donation_new' !== $event_name && 'prompt_interaction' !== $event_name ) ) {
 			return $body;
 		}
 
 		if ( 'donation_new' === $event_name ) {
 			$order_id = $body['data']['platform_data']['order_id'];
-		} else { // campaign_interaction.
+		} else { // prompt_interaction.
 			$order_id = $body['data']['interaction_data']['donation_order_id'] ?? false;
 		}
 
@@ -315,14 +315,14 @@ class GA4 {
 	}
 
 	/**
-	 * Handler for the campaign_interaction event.
+	 * Handler for the prompt_interaction event.
 	 *
 	 * @param int   $params The GA4 event parameters.
 	 * @param array $data      Data associated with the Data Events api event.
 	 *
 	 * @return array $params The final version of the GA4 event params that will be sent to GA.
 	 */
-	public static function handle_campaign_interaction( $params, $data ) {
+	public static function handle_prompt_interaction( $params, $data ) {
 		$transformed_data = $data;
 		// remove data added in the body filter.
 		unset( $transformed_data['ga_params'] );
@@ -336,12 +336,12 @@ class GA4 {
 	/**
 	 * Sanitizes the popup params to be sent as params for GA events
 	 *
-	 * @param array $popup_params The popup params as they are returned by Newspack\Data_Events\Popups::get_popup_metadata and by the campaign_interaction data.
+	 * @param array $popup_params The popup params as they are returned by Newspack\Data_Events\Popups::get_popup_metadata and by the prompt_interaction data.
 	 * @return array
 	 */
 	public static function sanitize_popup_params( $popup_params ) {
 		// Invalid input.
-		if ( ! is_array( $popup_params ) || ! isset( $popup_params['campaign_id'] ) ) {
+		if ( ! is_array( $popup_params ) || ! isset( $popup_params['prompt_id'] ) ) {
 			return [];
 		}
 		$santized = $popup_params;
@@ -349,9 +349,9 @@ class GA4 {
 		unset( $santized['interaction_data'] );
 		$santized = array_merge( $santized, $popup_params['interaction_data'] );
 
-		unset( $santized['campaign_blocks'] );
-		foreach ( $popup_params['campaign_blocks'] as $block ) {
-			$santized[ 'campaign_has_' . $block ] = 1;
+		unset( $santized['prompt_blocks'] );
+		foreach ( $popup_params['prompt_blocks'] as $block ) {
+			$santized[ 'prompt_has_' . $block ] = 1;
 		}
 		return $santized;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Renames the ga4 event as per discussion in 1204238302518911-as-1204276585598715
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Make sure you have `define('NEWSPACK_EXPERIMENTAL_GA4_EVENTS', true);`
2. Set up promtps
3. Interact with prompts
4. See the events with new names in GA

![Captura de tela de 2023-06-06 10-26-09](https://github.com/Automattic/newspack-plugin/assets/971483/e385c6af-fdac-43f2-9183-fc437f70a33e)
![Captura de tela de 2023-06-06 10-26-16](https://github.com/Automattic/newspack-plugin/assets/971483/b0aa99da-c737-4c6f-ab90-7031c0204bde)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->