### PR TITLE
fix(recaptcha): selector for response input in WC checkout

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -330,7 +330,10 @@ final class Recaptcha {
 					field.type  = 'hidden';
 					field.name  = 'g-recaptcha-response';
 					field.value = token;
-					document.getElementById( 'place_order' ).before( field );
+					var form = document.querySelector('form.checkout');
+					if ( form ) {
+						form.appendChild( field );
+					}
 				} );
 			} );
 		</script>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There have been reports of the reCAPTCHA response input not being appended to the form. This change ensures that the input is appended as a child of the checkout form.

### How to test the changes in this Pull Request:

Same as #2447 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->