### PR TITLE
refactor: use get_popup_metadata method from Campaigns plugin

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Recaptcha {
 	const SCRIPT_HANDLE  = 'newspack-recaptcha';
-	const THRESHOLD      = 0.1;
+	const THRESHOLD      = 0.5;
 	const OPTIONS_PREFIX = 'newspack_recaptcha_';
 
 	/**

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Recaptcha {
 	const SCRIPT_HANDLE  = 'newspack-recaptcha';
-	const THRESHOLD      = 0.5;
+	const THRESHOLD      = 0.1;
 	const OPTIONS_PREFIX = 'newspack_recaptcha_';
 
 	/**

--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -7,7 +7,7 @@
 
 namespace Newspack\Data_Events;
 
-use Newspack_Popups_Model;
+use Newspack_Popups_Data_Api;
 use Newspack\Data_Events;
 use WP_Error;
 
@@ -94,48 +94,6 @@ final class Popups {
 	}
 
 	/**
-	 * Extract the relevant data from a popup.
-	 *
-	 * @param int|array $popup The popup ID or object.
-	 * @return array
-	 */
-	public static function get_popup_metadata( $popup ) {
-		if ( is_numeric( $popup ) ) {
-			$popup = Newspack_Popups_Model::retrieve_popup_by_id( $popup );
-		}
-		$data = [];
-		if ( ! $popup ) {
-			return $data;
-		}
-
-		$data['prompt_id']    = $popup['id'];
-		$data['prompt_title'] = $popup['title'];
-
-		if ( isset( $popup['options'] ) ) {
-			$data['prompt_frequency'] = $popup['options']['frequency'] ?? '';
-			$data['prompt_placement'] = $popup['options']['placement'] ?? '';
-		}
-
-		$watched_blocks = [
-			'registration'             => 'newspack/reader-registration',
-			'donation'                 => 'newspack-blocks/donate',
-			'newsletters_subscription' => 'newspack-newsletters/subscribe',
-		];
-
-		$data['prompt_blocks'] = [];
-
-		foreach ( $watched_blocks as $key => $block_name ) {
-			if ( has_block( $block_name, $popup['content'] ) ) {
-				$data['prompt_blocks'][] = $key;
-			}
-		}
-
-		$data['interaction_data'] = [];
-
-		return $data;
-	}
-
-	/**
 	 * A listener for the registration block form submission
 	 *
 	 * Will trigger the event with "form_submission" as action in all cases.
@@ -150,7 +108,7 @@ final class Popups {
 		if ( ! $popup_id ) {
 			return;
 		}
-		$popup_data = self::get_popup_metadata( $popup_id );
+		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		return array_merge(
 			$popup_data,
 			[
@@ -183,7 +141,7 @@ final class Popups {
 		if ( ! $user_id || \is_wp_error( $user_id ) ) {
 			$action = self::FORM_SUBMISSION_FAILURE;
 		}
-		$popup_data = self::get_popup_metadata( $popup_id );
+		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		return array_merge(
 			$popup_data,
 			[
@@ -212,7 +170,7 @@ final class Popups {
 		if ( ! $popup_id ) {
 			return;
 		}
-		$popup_data = self::get_popup_metadata( $popup_id );
+		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		return array_merge(
 			$popup_data,
 			[
@@ -245,7 +203,7 @@ final class Popups {
 		if ( ! $result || \is_wp_error( $result ) ) {
 			$action = self::FORM_SUBMISSION_FAILURE;
 		}
-		$popup_data = self::get_popup_metadata( $popup_id );
+		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		return array_merge(
 			$popup_data,
 			[
@@ -271,7 +229,7 @@ final class Popups {
 		if ( ! $popup_id ) {
 			return;
 		}
-		$popup_data = self::get_popup_metadata( $popup_id );
+		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		return array_merge(
 			$popup_data,
 			[
@@ -301,7 +259,7 @@ final class Popups {
 		if ( ! $popup_id ) {
 			return;
 		}
-		$popup_data = self::get_popup_metadata( $popup_id );
+		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		return array_merge(
 			$popup_data,
 			[
@@ -331,7 +289,7 @@ final class Popups {
 		if ( ! $popup_id ) {
 			return;
 		}
-		$popup_data = self::get_popup_metadata( $popup_id );
+		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		return array_merge(
 			$popup_data,
 			[
@@ -361,7 +319,7 @@ final class Popups {
 		if ( ! $popup_id ) {
 			return;
 		}
-		$popup_data = self::get_popup_metadata( $popup_id );
+		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		return array_merge(
 			$popup_data,
 			[
@@ -391,7 +349,7 @@ final class Popups {
 		if ( ! $popup_id ) {
 			return;
 		}
-		$popup_data = self::get_popup_metadata( $popup_id );
+		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		return array_merge(
 			$popup_data,
 			[
@@ -410,4 +368,5 @@ final class Popups {
 	}
 
 }
+
 Popups::init();

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -14,6 +14,7 @@ use Newspack\Data_Events\Connectors\GA4\Event;
 use Newspack\Data_Events\Popups as Popups_Events;
 use Newspack\Logger;
 use Newspack\Reader_Activation;
+use Newspack_Popups_Data_Api;
 use WC_Order;
 use WP_Error;
 
@@ -328,32 +329,9 @@ class GA4 {
 		unset( $transformed_data['ga_params'] );
 		unset( $transformed_data['ga_client_id'] );
 
-		$transformed_data = self::sanitize_popup_params( $transformed_data );
+		$transformed_data = Newspack_Popups_Data_Api::prepare_popup_params_for_ga( $transformed_data );
 
 		return array_merge( $params, $transformed_data );
-	}
-
-	/**
-	 * Sanitizes the popup params to be sent as params for GA events
-	 *
-	 * @param array $popup_params The popup params as they are returned by Newspack\Data_Events\Popups::get_popup_metadata and by the prompt_interaction data.
-	 * @return array
-	 */
-	public static function sanitize_popup_params( $popup_params ) {
-		// Invalid input.
-		if ( ! is_array( $popup_params ) || ! isset( $popup_params['prompt_id'] ) ) {
-			return [];
-		}
-		$santized = $popup_params;
-
-		unset( $santized['interaction_data'] );
-		$santized = array_merge( $santized, $popup_params['interaction_data'] );
-
-		unset( $santized['prompt_blocks'] );
-		foreach ( $popup_params['prompt_blocks'] as $block ) {
-			$santized[ 'prompt_has_' . $block ] = 1;
-		}
-		return $santized;
 	}
 
 	/**
@@ -365,8 +343,8 @@ class GA4 {
 	 * @return array
 	 */
 	public static function get_sanitized_popup_params( $popup_id ) {
-		$popup_params = Popups_Events::get_popup_metadata( $popup_id );
-		return self::sanitize_popup_params( $popup_params );
+		$popup_params = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
+		return Newspack_Popups_Data_Api::prepare_popup_params_for_ga( $popup_params );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-popups/pull/1136 moves the method to normalize Newspack Campaigns prompt analytics data to the Newspack Campaigns plugin. This PR updates the Data Events class that handles Campaigns-related events to use that method.

Closes `1204238302518911/1204772076279088`.

### How to test the changes in this Pull Request:

Smoke test the GA4 events sent in [`class-popups.php`](https://github.com/Automattic/newspack-plugin/blob/master/includes/data-events/class-popups.php). The data should be the same, with the addition of some donation-related metadata added to an `action_value` param for donation events ([details](https://github.com/Automattic/newspack-popups/pull/1134)).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->