### PR TITLE
Update/ga4 backend destinations

### DIFF
--- a/includes/data-events/connectors/ga4/README.md
+++ b/includes/data-events/connectors/ga4/README.md
@@ -14,11 +14,8 @@ For now, the credentials must be manually added to the database. You will need y
 Store this info in the database:
 ```
 wp option set ga4_measurement_id "G-XXXXXXXXXX"
-wp option set ga4_api_secret YYYYYYYYYYYYYYYYYYY
+wp option set ga4_measurement_protocol_secret YYYYYYYYYYYYYYYYYYY
 ```
-
-This is still experimental, so you'll need to add this to wp-config:
-`define( 'NEWSPACK_EXPERIMENTAL_GA4_EVENTS', true );`
 
 ## Events being tracked
 

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -406,22 +406,22 @@ class GA4 {
 			$payload['user_id'] = $user_id;
 		}
 
-		$destinations = [
+		$properties = [
 			self::get_credentials(),
 		];
 
 		/**
-		 * Filters the destinations of the GA4 events in the GA4 Data Events connector.
+		 * Filters the properties of the GA4 events in the GA4 Data Events connector.
 		 *
-		 * Each destination is an array with two keys: `measurement_id` and `measurement_protocol_secret`.
+		 * Each property is an array with two keys: `measurement_id` and `measurement_protocol_secret`.
 		 *
-		 * @param array $destinations The destinations.
+		 * @param array $properties The properties.
 		 */
-		$destinations = apply_filters( 'newspack_data_events_ga4_destinations', $destinations );
+		$properties = apply_filters( 'newspack_data_events_ga4_properties', $properties );
 
-		foreach ( $destinations as $destination ) {
+		foreach ( $properties as $property ) {
 
-			$url = self::get_api_url( $destination['measurement_id'] ?? '', $destination['measurement_protocol_secret'] ?? '' );
+			$url = self::get_api_url( $property['measurement_id'] ?? '', $property['measurement_protocol_secret'] ?? '' );
 
 			if ( is_wp_error( $url ) ) {
 				self::log( sprintf( 'Error sending event - %s - Error: %s', $event->get_name(), $url->get_error_message() ) );
@@ -435,7 +435,7 @@ class GA4 {
 				]
 			);
 
-			self::log( sprintf( 'Event sent to %s - %s - Client ID: %s', $destination['measurement_id'], $event->get_name(), $client_id ) );
+			self::log( sprintf( 'Event sent to %s - %s - Client ID: %s', $property['measurement_id'], $event->get_name(), $client_id ) );
 		}
 
 	}

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -504,6 +504,4 @@ class GA4 {
 	}
 }
 
-if ( defined( 'NEWSPACK_EXPERIMENTAL_GA4_EVENTS' ) && NEWSPACK_EXPERIMENTAL_GA4_EVENTS ) {
-	add_action( 'plugins_loaded', array( 'Newspack\Data_Events\Connectors\GA4', 'init' ) );
-}
+add_action( 'plugins_loaded', array( 'Newspack\Data_Events\Connectors\GA4', 'init' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes the feature flag for GA4 back-end events.

Add the ability to send the events to more than one property via a filter.

### How to test the changes in this Pull Request:

1. Have your site connected with two different properties in GA
2. Make sure you are running Newspack Manager on https://github.com/Automattic/newspack-manager/pull/128
3. Add the options that will set the "local" GA property:

```
update_option( 'ga4_measurement_protocol_secret', 'xxx' );
update_option( 'ga4_measurement_id', 'G-XXX' );
```

5. Add the option that will set the property that is handled by Newspack Manager:

```
update_option( 'newspack_ga4_info', [ 'measurement_id'=>'G-ZZZ, 'measurement_protocol_secret'=>'zzz'  ] );
```

6. Visit your site and open the two GA Real time dashboards
7. Interact with your site and perform actions that will trigger back-end events, like submitting forms from a prompt
8. Check that the back end events, such as `np_reader_registered` and `np_prompt_interaction` with a `form_submission_received` as the `action` param.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->