### PR TITLE
fix(donations): empty cart on donation checkout

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -659,7 +659,7 @@ class Donations {
 				return;
 			}
 
-			self::remove_donations_from_cart();
+			\WC()->cart->empty_cart();
 
 			\WC()->cart->add_to_cart(
 				$product_id,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Clearing out just donation products when creating the donation checkout can create a weird experience when combined with subscription products that may have been previously added to cart.

This change implements emptying the cart when creating a donation checkout instead of just clearing donation products.

### How to test the changes in this Pull Request:

1. While on master, make sure you have a subscription product and attach it to a Checkout Button block in a page
2. Visit the page, click the button to checkout the subscription and exit the modal
3. Visit a page with the donate block and click to donate
4. Confirm you have both products on checkout
5. Check out this branch, repeat steps 2 and 3 and confirm the checkout consists only of the donation product

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->