### PR TITLE
fix: allow high-res youtube thumbs via constant

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -19,6 +19,7 @@ class Perfmatters {
 	public static function init() {
 		add_filter( 'option_perfmatters_options', [ __CLASS__, 'set_defaults' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'admin_notice' ] );
+		add_filter( 'perfmatters_lazyload_youtube_thumbnail_resolution', [ __CLASS__, 'maybe_serve_high_res_youtube_thumbs' ] );
 	}
 
 	/**
@@ -244,6 +245,26 @@ class Perfmatters {
 		echo '<div class="notice notice-warning"><p>'
 		. __( 'Newspack plugin is overriding Perfmatters settings. You can use the <code>NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS</code> flag to disable that behavior.', 'newspack' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		. '</p></div>';
+	}
+
+	/**
+	 * Serve high resolution YouTube thumbnails if a constant is set.
+	 *
+	 * @param string $resolution Resolution.
+	 */
+	public static function maybe_serve_high_res_youtube_thumbs( $resolution ) {
+		// Use standard-res thumbnails if the constant is not set.
+		if ( ! defined( 'NEWSPACK_PERFMATTERS_USE_HIGH_RES_YOUTUBE_IMAGES' ) || ! NEWSPACK_PERFMATTERS_USE_HIGH_RES_YOUTUBE_IMAGES ) {
+			return $resolution;
+		}
+
+		// Use standard-res thumbnails on mobile devices.
+		if ( ( function_exists( 'jetpack_is_mobile' ) && \jetpack_is_mobile() ) || \wp_is_mobile() ) { // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_is_mobile_wp_is_mobile
+			return $resolution;
+		}
+
+		// Use high-res thumbnails on desktop devices.
+		return 'maxresdefault';
 	}
 }
 Perfmatters::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is a quick fix to satisfy a publisher request to force Perfmatters to use high-resolution YouTube thumbnails in YT embeds. The reason we're doing this via a constant is that it's a tradeoff—it will result in a slight decrease in CWV scores, so it's not clear that it should be a default behavior. And it's also unclear whether this is something most sites would want the ability to set, so there's no need to implement UI for now.

### How to test the changes in this Pull Request:

1. On a site with Perfmatters enabled, embed a YouTube video into a post. Try this one, which is easy to see the difference in resolution because of the high-contrast text: https://www.youtube.com/watch?v=XZxWRaxqxGI
2. View on the front-end in a large desktop browser window. Observe that the thumbnail looks a bit pixelated and blurry.
3. Check out this branch and add `define( 'NEWSPACK_PERFMATTERS_USE_HIGH_RES_YOUTUBE_IMAGES', true );` to your wp-config.php.
4. Refresh on the front-end and confirm that the thumbnail is now high-resolution and crisp.
5. View the same post on a mobile device and confirm that the thumbnail is still lower-resolution on that device (because speed is paramount on mobile devices).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->