### PR TITLE
fix: perfmatters default settings updates

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -17,7 +17,7 @@ class Perfmatters {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_action( 'init', [ __CLASS__, 'update_option' ] );
+		add_action( 'admin_init', [ __CLASS__, 'update_option' ] );
 		add_filter( 'option_perfmatters_options', [ __CLASS__, 'set_defaults' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'admin_notice' ] );
 	}

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -17,8 +17,21 @@ class Perfmatters {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
+		add_action( 'init', [ __CLASS__, 'update_option' ] );
 		add_filter( 'option_perfmatters_options', [ __CLASS__, 'set_defaults' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'admin_notice' ] );
+	}
+
+	/**
+	 * Ensures that our default settings are persisted in the database.
+	 * Overwrites existing options unless the NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS constant is set.
+	 */
+	public static function update_option() {
+		if ( defined( 'NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS' ) && NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS ) {
+			return;
+		}
+
+		\update_option( 'perfmatters_options', self::get_defaults() );
 	}
 
 	/**
@@ -121,15 +134,13 @@ class Perfmatters {
 	}
 
 	/**
-	 * Set default options for Perfmatters.
+	 * Get Newspack default options for Perfmatters.
 	 *
-	 * @param array $options Perfmatters options.
+	 * @param array $options Initial options. Optional.
+	 *
+	 * @return array Newspack default options.
 	 */
-	public static function set_defaults( $options = [] ) {
-		if ( defined( 'NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS' ) && NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS ) {
-			return $options;
-		}
-
+	private static function get_defaults( $options = [] ) {
 		// Basic options.
 		$options['disable_emojis']              = true;
 		$options['disable_dashicons']           = true;
@@ -174,6 +185,7 @@ class Perfmatters {
 			$options['assets']['delay_js_inclusions'] = self::scripts_to_delay();
 		}
 		$options['assets']['delay_timeout'] = true;
+		$options['assets']['fastclick']     = true;
 
 		// Unused CSS.
 		$options['assets']['remove_unused_css'] = true;
@@ -227,6 +239,24 @@ class Perfmatters {
 		$options['fonts']['disable_google_fonts'] = false;
 		$options['fonts']['display_swap']         = true;
 		$options['fonts']['local_google_fonts']   = true;
+
+		return $options;
+	}
+
+	/**
+	 * Set default options for Perfmatters.
+	 * Overwrites existing options unless the NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS constant is set.
+	 *
+	 * @param array $options Perfmatters options.
+	 *
+	 * @return array Newspack default options.
+	 */
+	public static function set_defaults( $options = [] ) {
+		if ( defined( 'NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS' ) && NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS ) {
+			return $options;
+		}
+
+		$options = self::get_defaults( $options );
 
 		return $options;
 	}

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -17,21 +17,8 @@ class Perfmatters {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_action( 'admin_init', [ __CLASS__, 'update_option' ] );
 		add_filter( 'option_perfmatters_options', [ __CLASS__, 'set_defaults' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'admin_notice' ] );
-	}
-
-	/**
-	 * Ensures that our default settings are persisted in the database.
-	 * Overwrites existing options unless the NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS constant is set.
-	 */
-	public static function update_option() {
-		if ( defined( 'NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS' ) && NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS ) {
-			return;
-		}
-
-		\update_option( 'perfmatters_options', self::get_defaults() );
 	}
 
 	/**
@@ -252,13 +239,14 @@ class Perfmatters {
 	 * @return array Newspack default options.
 	 */
 	public static function set_defaults( $options = [] ) {
+		$defaults = self::get_defaults( $options );
+
+		// Ensure our defaults remain the default, but can be overwritten.
 		if ( defined( 'NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS' ) && NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS ) {
-			return $options;
+			return array_merge( $defaults, $options );
 		}
 
-		$options = self::get_defaults( $options );
-
-		return $options;
+		return $defaults;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Makes two changes to the way we set Perfmatters defaults:

1. Ensures that the "fastclick" option is enabled to avoid a bug affecting iOS, where the first page interaction sometimes take two taps to trigger
2. Persists our Newspack default settings to the database, so that if the `NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS` option is added to wp-config.php, those settings can be tweaked without reverting back to Perfmatters' own defaults.

Closes `1200550061930446/1204481257627340` and `1204616440912018/1204616586582340`.

### How to test the changes in this Pull Request:

#### Fastclick

1. On `master` or `release`, using an iPhone browser, visit a front-end page that will render an overlay prompt.
2. Wait until the overlay pops up. You may have to scroll the page to get it to appear on iOS; this appears to be an OS-level performance feature.
3. Tap on the close button to dismiss the overlay. Observe that it takes two taps to close.
4. Unpublish the prompt or visit a page that won't render the prompt.
5. Tap on the hamburger menu. Observe that it takes two taps to open the menu.
6. Check out this branch and repeat steps 2-5. Confirm that each action only takes one tap, this time.

#### Persisting options

Because of the way we allow certain (but not most) options to be tweaked, this requires two steps.

#### Testing without changing the defaults

1. On `master` or `release`, delete your Perfmatters options: `wp option delete perfmatters_options`
2. Visit **Settings > Perfmatters** in WP admin. Observe that our default option settings are reflected despite deleting the option in step 1.
3. Add `define( 'NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS', true );` to your wp-config.php file.
4. Refresh the Perfmatters settings page and observe that the Newspack default settings are lost.
5. Check out this branch and repeat steps 2-4. This time confirm that the Newspack default settings persist even after adding the constant.
6. Change some settings and save. Confirm that your changed settings persist.

#### Testing after changing the defaults

1. While still on this branch, remove or disable the `NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS` constant from your wp-config and delete the Perfmatters option again: `wp option delete perfmatters_options`
2. Visit **Settings > Perfmatters** in WP admin. Observe that our default option settings are reflected again despite deleting the option in step 1.
3. Go to **Assets** and add some text the "Delayed scripts" and "Excluded stylesheets" fields (which we allow to be tweaked even when forcing our defaults). Save and confirm the edits persist after a refresh.
4. Re-add the `NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS` constant and refresh. Confirm that the options still reflect both the Newspack defaults with your edits from step 3 persisted.
5. Edit some options that we normally don't allow to be changed, such as "Defer JavaScript" and "Remove unused CSS". Save and confirm that these edits are now persisted, so that you can effectively tweak and overwrite the Newspack defaults.
6. Play with other settings and confirm that you can change all Perfmatters settings.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->