### PR TITLE
fix: remove reCaptcha for WC plugin

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -199,13 +199,6 @@ class Plugin_Manager {
 				'PluginURI'   => esc_url( 'https://github.com/xwp/pwa-wp' ),
 				'Download'    => 'wporg',
 			],
-			'recaptcha-for-woocommerce'     => [
-				'Name'        => esc_html__( 'reCaptcha for WooCommerce', 'newspack' ),
-				'Description' => esc_html__( 'Protect your eCommerce store from malicious and automated attacks by using reCaptcha for WooCommerce.', 'newspack' ),
-				'Author'      => esc_html__( 'I13 Web Solution', 'newspack' ),
-				'PluginURI'   => esc_url( 'https://woocommerce.com/products/recaptcha-for-woocommerce/' ),
-				'AuthorURI'   => esc_url( 'https://woocommerce.com/vendor/i13-web-solution/' ),
-			],
 			'redirection'                   => [
 				'Name'        => esc_html__( 'Redirection', 'newspack' ),
 				'Description' => esc_html__( 'Manage all your 301 redirects and monitor 404 errors.', 'newspack' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since #2447 our reCAPTCHA v3 implementation is automatically added to the WC checkout flow. Having another plugin like reCaptcha for WooCommerce simultaneously may cause unexpected behavior and should be discouraged.

This PR removes the suggestion to use a 3rd party plugin to prioritize our implementation.

### How to test the changes in this Pull Request:

Check out this branch, visit the Plugins page and confirm the reCaptcha for WooCommerce plugin is no longer nested inside "Newspack".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->