### PR TITLE
fix(jetpack): preserve image src for photon srcset filter

### DIFF
--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -47,7 +47,7 @@ class Jetpack {
 	 * @param int[]  $size_array    The size array for srcset.
 	 * @param string $image_src     The 'src' of the image.
 	 * @param array  $image_meta    The image meta.
-	 * @param int    $attachment_id The iamge attachment ID.
+	 * @param int    $attachment_id The image attachment ID.
 	 *
 	 * @return array An array of Photon image urls and widths.
 	 */

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -43,15 +43,15 @@ class Jetpack {
 	/**
 	 * Filters an array of image `srcset` values, adding Photon urls for additional sizes.
 	 *
-	 * @param array $sources       An array of image urls and widths.
-	 * @param array $size_array    The size array for srcset.
-	 * @param array $image_src     The image srcs.
-	 * @param array $image_meta    The image meta.
-	 * @param int   $attachment_id Attachment ID.
+	 * @param array  $sources       An array of image urls and widths.
+	 * @param int[]  $size_array    The size array for srcset.
+	 * @param string $image_src     The 'src' of the image.
+	 * @param array  $image_meta    The image meta.
+	 * @param int    $attachment_id The iamge attachment ID.
 	 *
 	 * @return array An array of Photon image urls and widths.
 	 */
-	public static function filter_srcset_array( $sources = array(), $size_array = array(), $image_src = array(), $image_meta = array(), $attachment_id = 0 ) {
+	public static function filter_srcset_array( $sources, $size_array, $image_src, $image_meta, $attachment_id ) {
 		if ( ! class_exists( 'Jetpack' ) || ! \Jetpack::is_module_active( 'photon' ) ) {
 			return $sources;
 		}

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -70,11 +70,8 @@ class Jetpack {
 			if ( isset( $sources[ $w ] ) ) {
 				continue;
 			}
-			if ( ! empty( $attachment_id ) ) {
-				$url = \wp_get_attachment_url( $attachment_id );
-			}
 			$sources[ $w ] = [
-				'url'        => \jetpack_photon_url( $url, [ 'w' => $w ] ),
+				'url'        => \jetpack_photon_url( $image_src, [ 'w' => $w ] ),
 				'descriptor' => 'w',
 				'value'      => $w,
 			];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Preserves the incoming image src when filtering new srcset values.

Fixes an issue when a cropped version of the image is being rendered, which should have the desired crop preserved when generating the new srcset URL.

### How to test the changes in this Pull Request:

1. Check out this branch and visit a page with Homepage Posts Block with square thumbnails (confirm the source image is not 1:1)
3. Inspect the image and open the URL for 370 width size from the srcset in a new window
4. Confirm the image is square

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->