### PR TITLE
fix: allow campaign prompts to render on metered content

### DIFF
--- a/assets/memberships-gate/metering.js
+++ b/assets/memberships-gate/metering.js
@@ -50,6 +50,11 @@ function lockContent() {
 	if ( ! content ) {
 		return;
 	}
+	// Remove campaign prompts.
+	const prompts = document.querySelectorAll( '.newspack-popup' );
+	prompts.forEach( prompt => {
+		prompt.parentNode.removeChild( prompt );
+	} );
 	const visibleParagraphs = settings.visible_paragraphs;
 	const articleElements = document.querySelectorAll( '.entry-content > *' );
 	const moreIndex = content.innerHTML.indexOf( '<!--more-->' );

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -471,7 +471,7 @@ class Memberships {
 	 * @return bool
 	 */
 	public static function disable_popups( $disabled ) {
-		if ( self::has_gate() && self::is_post_restricted() ) {
+		if ( self::has_gate() && self::is_post_restricted() && ! Metering::is_metering() ) {
 			return true;
 		}
 		return $disabled;

--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -118,7 +118,7 @@ class Metering {
 		}
 
 		// Remove the default restriction handler from 'SkyVerge\WooCommerce\Memberships\Restrictions\Posts::restrict_post'.
-		if ( self::is_frontend_metering() || self::is_logged_in_metering_allowed() ) {
+		if ( self::is_metering() ) {
 			$restriction_instance = \wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance();
 			\remove_action( 'the_post', spl_object_hash( $restriction_instance ) . 'restrict_post', 0 );
 		}
@@ -259,6 +259,16 @@ class Metering {
 		self::$logged_in_metering_cache[ $post_id ] = apply_filters( 'newspack_memberships_is_logged_in_metering_allowed', $allowed, $post_id );
 
 		return self::$logged_in_metering_cache[ $post_id ];
+	}
+
+	/**
+	 * Whether the content should be allowed to render. If it's frontend metered,
+	 * it will be handled by the frontend metering strategy.
+	 *
+	 * @return bool
+	 */
+	public static function is_metering() {
+		return self::is_frontend_metering() || self::is_logged_in_metering_allowed();
 	}
 }
 Metering::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When the metering functionality allows content restricted by WC Memberships to render, it doesn't account for campaign prompts, which are still suppressed.

This PR and https://github.com/Automattic/newspack-popups/pull/1152 makes the prompts suppression aware of metering logic.

If the content is locked through front-end metering, the metering script will remove prompts from the DOM.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-popups/pull/1152
2. Make sure you have WC Memberships and RAS prompts configured
3. Configure the gate to have 1 anonymous and 1 registered view
4. Visit an article in incognito and confirm it renders the prompts
5. Visit another article and confirm you render the gate and no prompts render
6. Register, visit another article and confirm it renders with prompts
7. Visit another article and confirm you see the gate and no prompts

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->