### PR TITLE
fix: disable autofill for recaptcha inputs

### DIFF
--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -103,6 +103,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 							tokenField = document.createElement( 'input' );
 							tokenField.setAttribute( 'type', 'hidden' );
 							tokenField.setAttribute( 'name', 'captcha_token' );
+							tokenField.setAttribute( 'autocomplete', 'off' );
 							form.appendChild( tokenField );
 						}
 						tokenField.value = captchaToken;

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -367,6 +367,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 							tokenField = document.createElement( 'input' );
 							tokenField.setAttribute( 'type', 'hidden' );
 							tokenField.setAttribute( 'name', 'captcha_token' );
+							tokenField.setAttribute( 'autocomplete', 'off' );
 							form.appendChild( tokenField );
 						}
 						tokenField.value = captchaToken;

--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -112,7 +112,7 @@ const Recaptcha = () => {
 									setSettingsToUpdate( { ...settingsToUpdate, site_key: value } )
 								}
 								disabled={ isLoading }
-								autocomplete="off"
+								autoComplete="off"
 							/>
 							<TextControl
 								type="password"
@@ -122,7 +122,7 @@ const Recaptcha = () => {
 									setSettingsToUpdate( { ...settingsToUpdate, site_secret: value } )
 								}
 								disabled={ isLoading }
-								autocomplete="off"
+								autoComplete="off"
 							/>
 						</Grid>
 					</>

--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -29,7 +29,9 @@ const Recaptcha = () => {
 		const fetchSettings = async () => {
 			setIsLoading( true );
 			try {
-				setSettings( await apiFetch( { path: '/newspack/v1/recaptcha' } ) );
+				const fetchedSettings = await apiFetch( { path: '/newspack/v1/recaptcha' } );
+				setSettings( fetchedSettings );
+				setSettingsToUpdate( fetchedSettings );
 			} catch ( e ) {
 				setError( e.message || __( 'Error fetching settings.', 'newspack' ) );
 			} finally {
@@ -104,7 +106,7 @@ const Recaptcha = () => {
 						) }
 						<Grid noMargin rowGap={ 16 }>
 							<TextControl
-								value={ settingsToUpdate?.site_key || settings.site_key }
+								value={ settingsToUpdate?.site_key }
 								label={ __( 'Site Key', 'newspack' ) }
 								onChange={ value =>
 									setSettingsToUpdate( { ...settingsToUpdate, site_key: value } )
@@ -114,7 +116,7 @@ const Recaptcha = () => {
 							/>
 							<TextControl
 								type="password"
-								value={ settingsToUpdate?.site_secret || settings.site_secret }
+								value={ settingsToUpdate?.site_secret }
 								label={ __( 'Site Secret', 'newspack' ) }
 								onChange={ value =>
 									setSettingsToUpdate( { ...settingsToUpdate, site_secret: value } )

--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -110,6 +110,7 @@ const Recaptcha = () => {
 									setSettingsToUpdate( { ...settingsToUpdate, site_key: value } )
 								}
 								disabled={ isLoading }
+								autocomplete="off"
 							/>
 							<TextControl
 								type="password"
@@ -119,6 +120,7 @@ const Recaptcha = () => {
 									setSettingsToUpdate( { ...settingsToUpdate, site_secret: value } )
 								}
 								disabled={ isLoading }
+								autocomplete="off"
 							/>
 						</Grid>
 					</>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures that the `input` elements used by reCAPTCHA is not autofilled by the browser, in both admin and front-end contexts.

Note that I wasn't able to replicate the autofilling issue in either case, but adding the `autocomplete="off"` attribute _should_ prevent the field from getting autofilled by most browsers. See also https://github.com/Automattic/newspack-newsletters/pull/1203

Closes `1204751246381643/1204838932706810`.

### How to test the changes in this Pull Request:

1. Turn on autofill for your browser and ensure that there is a saved email address that will automatically autofill any email inputs.
2. Delete prior credentials: `wp option delete newspack_recaptcha_site_key && wp option delete newspack_recaptcha_site_secret`
3. Test on `master` first, with reCAPTCHA v3 enabled in the Connections wizard.
4. In the admin, go to **Newspack > Connections** and expand the reCAPTCHA panel. Does the field autofill with an email address?
5. In the admin, confirm that you can clear the values of the input fields and save, and that the empty values persist after saving + refreshing. (You may still see a warning about invalid site key/secret, but this doesn't prevent you from saving empty values).
6. On the front-end, submit a registration or login form. Does it fail?
7. Check out this branch and test again. The form should submit without errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->