### PR TITLE
fix: update required fields for editing My Account details

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -429,8 +429,11 @@ class WooCommerce_My_Account {
 	 * @param array $required_fields Required fields.
 	 */
 	public static function remove_required_fields( $required_fields ) {
-		if ( ! Donations::is_platform_stripe() ) {
-			return $required_fields;
+		if ( Donations::is_platform_wc() ) {
+			return [
+				'account_display_name' => __( 'Display name', 'newspack' ),
+				'account_email'        => __( 'Email address', 'newspack' ),
+			];
 		}
 		return [];
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a silly bug that prevents the account details from being editable in the My Account page. Currently only the Display Name is available to edit, but when saving any changes to that field, an error message prevents the changes from persisting despite the First Name and Last Name fields not existing on the page:

<img width="1092" alt="Screen Shot 2023-06-23 at 2 28 22 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/8e834e11-5a38-4283-a2d7-0d588baab200">

### How to test the changes in this Pull Request:

1. On `release` or `master`, log into a reader account and go to the My Account page. Try to update your Display Name to something else and observe that you can't (see screenshot above).
2. Check out this branch and confirm that you now can.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->