### PR TITLE
feat: add 'article_view' reader activity data

### DIFF
--- a/assets/memberships-gate/metering.js
+++ b/assets/memberships-gate/metering.js
@@ -90,10 +90,16 @@ function meter( store ) {
 			gate.parentNode.removeChild( gate );
 		} );
 	}
-	// Add current content to read content.
-	if ( ! locked && ! data.content.includes( settings.post_id ) ) {
-		data.content.push( settings.post_id );
-		store.set( 'metering', data );
+	if ( ! locked ) {
+		// Push article_view activity.
+		if ( settings.article_view ) {
+			window.newspackRAS.push( [ settings.article_view.name, settings.article_view.data ] );
+		}
+		// Add current content to read content.
+		if ( ! data.content.includes( settings.post_id ) ) {
+			data.content.push( settings.post_id );
+			store.set( 'metering', data );
+		}
 	}
 }
 

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -42,6 +42,28 @@ export function getActivities( action ) {
 }
 
 /**
+ * Get all unique activities from a given action by a given iteratee.
+ *
+ * @param {string}          action   Action name.
+ * @param {string|Function} iteratee Iteratee or a data key.
+ *
+ * @return {Array} Unique activities.
+ */
+export function getUniqueActivitiesBy( action, iteratee ) {
+	const activities = getActivities( action );
+	const unique = [];
+	const seen = {};
+	for ( const activity of activities ) {
+		const value = typeof iteratee === 'function' ? iteratee( activity ) : activity.data[ iteratee ];
+		if ( ! seen[ value ] ) {
+			unique.push( activity );
+			seen[ value ] = true;
+		}
+	}
+	return unique;
+}
+
+/**
  * Reader functions.
  */
 
@@ -263,6 +285,7 @@ const readerActivation = {
 	off,
 	dispatchActivity,
 	getActivities,
+	getUniqueActivitiesBy,
 	setReaderEmail,
 	setAuthenticated,
 	refreshAuthentication,

--- a/assets/reader-activation/index.test.js
+++ b/assets/reader-activation/index.test.js
@@ -2,6 +2,7 @@ import {
 	store,
 	dispatchActivity,
 	getActivities,
+	getUniqueActivitiesBy,
 	setReaderEmail,
 	setAuthenticated,
 	getReader,
@@ -50,6 +51,39 @@ describe( 'newspackReaderActivation', () => {
 		dispatchActivity( activity.action, activity.data );
 		expect( typeof getActivities( 'test-timestamp' )[ 0 ].timestamp ).toBe( 'number' );
 	} );
+	it( 'should get unique activities by key', () => {
+		const activity1 = {
+			action: 'test-unique',
+			data: {
+				test: 'test',
+			},
+		};
+		const activity2 = {
+			action: 'test-unique',
+			data: {
+				test: 'test',
+			},
+		};
+		dispatchActivity( activity1.action, activity1.data );
+		dispatchActivity( activity2.action, activity2.data );
+		expect( getUniqueActivitiesBy( 'test-unique', 'test' ) ).toEqual( [ activity1 ] );
+	} );
+	it('should get unique activities by iteratee', () => {
+		const activity1 = {
+			action: 'test-unique-iteratee',
+			data: {
+				test: 'test',
+			},
+		};
+		const activity2 = {
+			action: 'test-unique-iteratee',
+			data: {
+				test: 'test',
+			},
+		};
+		dispatchActivity( activity1.action, activity1.data );
+		dispatchActivity( activity2.action, activity2.data );
+		expect( getUniqueActivitiesBy( 'test-unique-iteratee', activity => activity.data.test ) ).toEqual( [ activity1 ] );
 	it( 'should store reader email', () => {
 		const email = 'test@example.com';
 		setReaderEmail( email );

--- a/assets/reader-activation/index.test.js
+++ b/assets/reader-activation/index.test.js
@@ -68,7 +68,7 @@ describe( 'newspackReaderActivation', () => {
 		dispatchActivity( activity2.action, activity2.data );
 		expect( getUniqueActivitiesBy( 'test-unique', 'test' ) ).toEqual( [ activity1 ] );
 	} );
-	it('should get unique activities by iteratee', () => {
+	it( 'should get unique activities by iteratee', () => {
 		const activity1 = {
 			action: 'test-unique-iteratee',
 			data: {
@@ -83,7 +83,10 @@ describe( 'newspackReaderActivation', () => {
 		};
 		dispatchActivity( activity1.action, activity1.data );
 		dispatchActivity( activity2.action, activity2.data );
-		expect( getUniqueActivitiesBy( 'test-unique-iteratee', activity => activity.data.test ) ).toEqual( [ activity1 ] );
+		expect(
+			getUniqueActivitiesBy( 'test-unique-iteratee', activity => activity.data.test )
+		).toEqual( [ activity1 ] );
+	} );
 	it( 'should store reader email', () => {
 		const email = 'test@example.com';
 		setReaderEmail( email );

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -41,6 +41,7 @@ class Memberships {
 		add_action( 'wp_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
 		add_action( 'wp_footer', [ __CLASS__, 'render_js' ] );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
+		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 
 		include __DIR__ . '/class-block-patterns.php';
 		include __DIR__ . '/class-metering.php';
@@ -475,6 +476,18 @@ class Memberships {
 			return true;
 		}
 		return $disabled;
+	}
+
+	/**
+	 * Suppress 'article_view' reader activity on locked posts.
+	 *
+	 * @param array $activity Activity.
+	 */
+	public static function suppress_article_view_activity( $activity ) {
+		if ( ( self::is_post_restricted() && ! Metering::is_logged_in_metering_allowed() ) || Metering::is_frontend_metering() ) {
+			return false;
+		}
+		return $activity;
 	}
 }
 Memberships::init();

--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -18,6 +18,11 @@ class Metering {
 	const METERING_META_KEY = 'np_memberships_metering';
 
 	/**
+	 * Article view activity to be handled by frontend metering.
+	 */
+	private static $article_view = null;
+
+	/**
 	 * Cache of the user's metering status for posts.
 	 *
 	 * @var boolean[] Map of post IDs to booleans.
@@ -30,7 +35,8 @@ class Metering {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'wp', [ __CLASS__, 'handle_restriction' ], 11 );
-		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
+		add_action( 'wp_footer', [ __CLASS__, 'enqueue_scripts' ] );
+		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'get_article_view' ], 20 );
 	}
 
 	/**
@@ -102,6 +108,7 @@ class Metering {
 				'count'              => \get_post_meta( $gate_post_id, 'metering_anonymous_count', true ),
 				'period'             => \get_post_meta( $gate_post_id, 'metering_period', true ),
 				'post_id'            => get_the_ID(),
+				'article_view'       => self::$article_view,
 			]
 		);
 	}
@@ -269,6 +276,19 @@ class Metering {
 	 */
 	public static function is_metering() {
 		return self::is_frontend_metering() || self::is_logged_in_metering_allowed();
+	}
+
+	/**
+	 * Store the article view activity push for use in the frontend metering
+	 * strategy.
+	 *
+	 * @param array $activity Activity data.
+	 *
+	 * @return array
+	 */
+	public static function get_article_view( $activity )  {
+		self::$article_view = $activity;
+		return $activity;
 	}
 }
 Metering::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements `article_view` reader activity to the reader data library integrated with memberships and metering.

Content locked from memberships and front-end or back-end metering strategies should not push an `article_view` activity.

This PR also implements the `getUniqueActivitiesBy( name, iteratee )` helper function to allow fetching unique activity based on its data, e.g.:

```js
const uniquePostsViews = ras.getUniqueActivitiesBy( 'article_view', 'post_id' );
```

### How to test the changes in this Pull Request:

1. Make sure you have WC Memberships configured with content gating and metering (anonymous and registered readers)
2. On a fresh anonymous session visit an article
3. Open DevTools and navigate to the localStorage
4. Confirm there's a new item in the `newspack_reader_1_activity` array similar to this:
```js
{
  "action": "article_view",
  "data": {
    "post_id": 120,
    "permalink": "https://example.com/montes-egestas-a-neque-morbi-cras-maecenas-senectus-molestie-in-congue-consequat-sed/",
    "categories": [ 4, 3 ],
    "tags": [],
    "author": "johndoe"
  },
  "timestamp": 1687530871161
}
```
5. Navigate until content is locked and confirm the anonymous metering locked content does not push a new activity
6. Register and do the same with registered metering, navigate confirming activities are pushed until it locks and no longer pushes
7. Become a member and confirm activity pushes as a member
8. Deactivate WC Memberships, navigate and confirm activity continues to push correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->