### PR TITLE
fix: don’t assume the site URL is at the root domain

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/campaign.js
+++ b/assets/wizards/engagement/views/reader-activation/campaign.js
@@ -1,3 +1,5 @@
+/* global newspack_engagement_wizard */
+
 /**
  * WordPress dependencies
  */
@@ -23,6 +25,7 @@ export default withWizardScreen( () => {
 	const [ error, setError ] = useState( false );
 	const [ prompts, setPrompts ] = useState( null );
 	const [ allReady, setAllReady ] = useState( false );
+	const { reader_activation_url } = newspack_engagement_wizard;
 
 	const fetchPrompts = () => {
 		setError( false );
@@ -83,11 +86,11 @@ export default withWizardScreen( () => {
 				<Button
 					isPrimary
 					disabled={ inFlight || ! allReady }
-					href="/wp-admin/admin.php?page=newspack-engagement-wizard#/reader-activation/complete"
+					href={ `${ reader_activation_url }/complete` }
 				>
 					{ __( 'Continue', 'newspack' ) }
 				</Button>
-				<Button isSecondary disabled={ inFlight } href="#/reader-activation">
+				<Button isSecondary disabled={ inFlight } href={ reader_activation_url }>
 					{ __( 'Back', 'newspack' ) }
 				</Button>
 			</div>

--- a/assets/wizards/engagement/views/reader-activation/complete.js
+++ b/assets/wizards/engagement/views/reader-activation/complete.js
@@ -1,3 +1,5 @@
+/* global newspack_engagement_wizard */
+
 /**
  * WordPress dependencies
  */
@@ -16,14 +18,8 @@ import {
 	Card,
 	Notice,
 	ProgressBar,
-	Router,
 	StepsList,
 } from '../../../../components/src';
-
-/**
- * External dependencies
- */
-const { useHistory } = Router;
 
 const listItems = [
 	__(
@@ -64,7 +60,7 @@ export default withWizardScreen( () => {
 	const [ progressLabel, setProgressLabel ] = useState( false );
 	const [ completed, setCompleted ] = useState( false );
 	const timer = useRef();
-	const history = useHistory();
+	const { reader_activation_url } = newspack_engagement_wizard;
 
 	useEffect( () => {
 		if ( timer.current ) {
@@ -84,7 +80,7 @@ export default withWizardScreen( () => {
 			setProgressLabel( __( 'Done!', 'newspack' ) );
 			setTimeout( () => {
 				setInFlight( false );
-				history.push( '/reader-activation' );
+				window.location = reader_activation_url;
 			}, 3000 );
 		}
 	}, [ completed, progress ] );
@@ -158,11 +154,7 @@ export default withWizardScreen( () => {
 				</Card>
 			) }
 			<div className="newspack-buttons-card">
-				<Button
-					isSecondary
-					disabled={ inFlight }
-					href="/wp-admin/admin.php?page=newspack-engagement-wizard#/reader-activation/campaign"
-				>
+				<Button isSecondary disabled={ inFlight } href={ `${ reader_activation_url }/campaign` }>
 					{ __( 'Back', 'newspack' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Several links/buttons in the RAS setup wizard have hard-coded admin URLs that assume that the site's URL is at the root domain. This will break sites whose URLs are in a subdirectory, e.g. `https://domain.com/subdirectory`.

### How to test the changes in this Pull Request:

1. Set up a WP multisite using subdirectories. Create two sub-sites and install/set up Newspack on both.
2. Attempt to complete the RAS setup wizard in each site's dashboard. Observe that at a certain point, you'll find yourself redirected to the wrong URL (the root domain, or the multisite's main site, instead of the site you're editing).
3. Check out this branch and repeat step 2. Confirm that you remain within the correct subsite's dashboard all the way through to the end of the wizard completion.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->