### PR TITLE
feat(data-events): broader coverage for 'reader_registered'

### DIFF
--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -59,7 +59,7 @@ class GA4 {
 	 */
 	public static function can_use_ga4() {
 		$properties = self::get_ga4_properties();
-		return ! empty( $propeties ) && ! empty( $properties[0]['measurement_id'] );
+		return ! empty( $properties ) && ! empty( $properties[0]['measurement_id'] );
 	}
 
 	/**

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -58,7 +58,8 @@ class GA4 {
 	 * @return bool
 	 */
 	public static function can_use_ga4() {
-		return ! empty( self::get_ga4_properties() );
+		$properties = self::get_ga4_properties();
+		return ! empty( $propeties ) && ! empty( $properties[0]['measurement_id'] );
 	}
 
 	/**

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -53,6 +53,37 @@ class GA4 {
 	}
 
 	/**
+	 * Whether GA4 can be used.
+	 *
+	 * @return bool
+	 */
+	public static function can_use_ga4() {
+		return ! empty( self::get_ga4_properties() );
+	}
+
+	/**
+	 * Get the GA4 properties to send events to.
+	 *
+	 * @return array
+	 */
+	private static function get_ga4_properties() {
+		$properties = [
+			self::get_credentials(),
+		];
+
+		/**
+		 * Filters the properties of the GA4 events in the GA4 Data Events connector.
+		 *
+		 * Each property is an array with two keys: `measurement_id` and `measurement_protocol_secret`.
+		 *
+		 * @param array $properties The properties.
+		 */
+		$properties = apply_filters( 'newspack_data_events_ga4_properties', $properties );
+
+		return $properties;
+	}
+
+	/**
 	 * Global handler for the Data Events API.
 	 *
 	 * @param string $event_name The event name.
@@ -65,6 +96,9 @@ class GA4 {
 	 */
 	public static function global_handler( $event_name, $timestamp, $data, $user_id ) {
 		if ( ! in_array( $event_name, self::$watched_events, true ) ) {
+			return;
+		}
+		if ( ! self::can_use_ga4() ) {
 			return;
 		}
 
@@ -126,6 +160,9 @@ class GA4 {
 		if ( ! in_array( $event_name, self::$watched_events, true ) ) {
 			return $body;
 		}
+		if ( ! self::can_use_ga4() ) {
+			return $body;
+		}
 
 		$body['data']['ga_client_id'] = self::extract_cid_from_cookies();
 
@@ -161,6 +198,9 @@ class GA4 {
 	 * @return array
 	 */
 	public static function filter_donation_new_event_body( $body, $event_name ) {
+		if ( ! self::can_use_ga4() ) {
+			return $body;
+		}
 		if ( ! empty( $body['data']['ga_client_id'] ) || ( 'donation_new' !== $event_name && 'prompt_interaction' !== $event_name ) ) {
 			return $body;
 		}
@@ -406,18 +446,7 @@ class GA4 {
 			$payload['user_id'] = $user_id;
 		}
 
-		$properties = [
-			self::get_credentials(),
-		];
-
-		/**
-		 * Filters the properties of the GA4 events in the GA4 Data Events connector.
-		 *
-		 * Each property is an array with two keys: `measurement_id` and `measurement_protocol_secret`.
-		 *
-		 * @param array $properties The properties.
-		 */
-		$properties = apply_filters( 'newspack_data_events_ga4_properties', $properties );
+		$properties = self::get_ga4_properties();
 
 		foreach ( $properties as $property ) {
 

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -15,16 +15,18 @@ use Newspack\Donations;
  * For when a reader registers.
  */
 Data_Events::register_listener(
-	'newspack_registered_reader',
+	'user_register',
 	'reader_registered',
-	function( $email, $authenticate, $user_id, $existing_user, $metadata ) {
-		if ( $existing_user ) {
+	function( $user_id, $userdata ) {
+		$user = \get_user_by( 'id', $user_id );
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
 			return null;
 		}
+		$metadata = \get_user_meta( $user_id, 'np_registration_metadata', true );
 		return [
 			'user_id'  => $user_id,
-			'email'    => $email,
-			'metadata' => $metadata,
+			'email'    => $userdata['user_email'],
+			'metadata' => $metadata ? $metadata : [],
 		];
 	}
 );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1566,6 +1566,10 @@ final class Reader_Activation {
 			}
 		}
 
+		if ( ! empty( $metadata ) ) {
+			\update_user_meta( $user_id, 'np_registration_metadata', $metadata );
+		}
+
 		// Note the user's login method for later use.
 		if ( isset( $metadata['registration_method'] ) ) {
 			\update_user_meta( $user_id, self::REGISTRATION_METHOD, $metadata['registration_method'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes the `reader_registered` action to listen to WP's `user_register` action hook instead of the hook coming from `Reader_Activation:register_reader()`.

This allows for broader coverage of reader registrations, like from WC product purchases.

The original metadata coming from `Reader_Activation:register_reader()` is preserved by storing its entire value as a `np_registration_metadata` user meta.

Note: tests were initially failing because the `user_register` will trigger on mock users created during unit testing. This triggers a filter inside the GA4 connector that calls for `wp_get_current_user()`, which fails the `is_reader()` check. 47469878b56ab3416dac27d85e5c05dc4cf4aebd (with a fix at 999622040a36f72df7f3f1c0e339f3d3b1e51986) fixes that behavior by preventing GA4 connector logic to run when not configured. If we don't want to touch the GA4 logic I can look at how to prevent the error on the tests. cc @leogermani 

### How to test the changes in this Pull Request:

1. Make sure you have `define( 'NEWSPACK_EXPERIMENTAL_WEBHOOKS', true );`
2. Setup a webhook using https://webhook.site/ to get all incoming data events 
3. Purchase a product anonymously and confirm that the created account triggers a `reader_registered` event and it reaches the webhook
4. On a fresh session, register through a RAS prompt with a reader registration block
5. Confirm the event reaches the webhook with no regression on the metadata contents

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->