### PR TITLE
feat: trigger reader_registered for Woo checkout

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -85,6 +85,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-popups.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/connectors/ga4/class-ga4.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/connectors/class-mailchimp.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-woo-user-registration.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-api.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-profile.php';
 		include_once NEWSPACK_ABSPATH . 'includes/analytics/class-analytics.php';

--- a/includes/data-events/class-woo-user-registration.php
+++ b/includes/data-events/class-woo-user-registration.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Newspack Data Events Woo Registration hooks.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Data_Events;
+
+/**
+ * Class that triggers a registration event with Newspack metadata for users registered during the Woocommerce checkout process.
+ */
+final class Woo_User_Registration {
+
+	/**
+	 * Whether the current request is processing a checkout.
+	 *
+	 * @var boolean
+	 */
+	private static $processing_checkout = false;
+
+	/**
+	 * Metadata to send with the registration event.
+	 *
+	 * @var array
+	 */
+	private static $metadata = [];
+
+	/**
+	 * Initialize the class.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		// is processing checkout?
+		add_action( 'woocommerce_checkout_process', [ __CLASS__, 'checkout_process' ] );
+
+		// created a user?
+		add_action( 'woocommerce_created_customer', [ __CLASS__, 'created_customer' ], 1 );
+	}
+
+	/**
+	 * During the checkout process, set the processing_checkout flag and store metadata.
+	 *
+	 * @return void
+	 */
+	public static function checkout_process() {
+
+		// If a user is created later on the request by woocommerce_created_customer(), it will at least have this data.
+		self::$metadata['registration_method'] = 'woocommerce';
+
+		/**
+		 * On Newspack\Donations::process_donation_form(), we add these values to the cart.
+		 *
+		 * Later, we add them to the order (Newspack\Donations::checkout_create_order_line_item()) and use it to send the metadata to Newspack on donation events.
+		 *
+		 * Here, we are going to read the same information from the cart and use it to send the metadata to Newspack on registration events.
+		 */
+		foreach ( \WC()->cart->get_cart() as $cart_item_key => $values ) {
+			if ( ! empty( $values['newspack_popup_id'] ) ) {
+				self::$metadata['newspack_popup_id'] = $values['newspack_popup_id'];
+			}
+			if ( ! empty( $values['referer'] ) ) {
+				self::$metadata['referer'] = $values['referer'];
+			}
+		}
+
+		self::$processing_checkout = true;
+	}
+
+	/**
+	 * If a user was created during the checkout by Woo, fire an event.
+	 *
+	 * @param int $user_id The ID of the created user.
+	 * @return void
+	 */
+	public static function created_customer( $user_id ) {
+		if ( ! self::$processing_checkout ) {
+			return;
+		}
+
+		$user = get_user_by( 'id', $user_id );
+
+		if ( ! $user ) {
+			return;
+		}
+
+		/**
+		 * Action after registering and authenticating a reader via Woocommerce checkout.
+		 *
+		 * @param string         $email         Email address.
+		 * @param false|int      $user_id       The created user id.
+		 * @param array          $metadata      Metadata.
+		 */
+		\do_action( 'newspack_registered_reader_via_woo', $user->user_email, $user_id, self::$metadata );
+	}
+}
+
+Woo_User_Registration::init();

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -15,18 +15,31 @@ use Newspack\Donations;
  * For when a reader registers.
  */
 Data_Events::register_listener(
-	'user_register',
+	'newspack_registered_reader',
 	'reader_registered',
-	function( $user_id, $userdata ) {
-		$user = \get_user_by( 'id', $user_id );
-		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+	function( $email, $authenticate, $user_id, $existing_user, $metadata ) {
+		if ( $existing_user ) {
 			return null;
 		}
-		$metadata = \get_user_meta( $user_id, 'np_registration_metadata', true );
 		return [
 			'user_id'  => $user_id,
-			'email'    => $userdata['user_email'],
-			'metadata' => $metadata ? $metadata : [],
+			'email'    => $email,
+			'metadata' => $metadata,
+		];
+	}
+);
+
+/**
+ * For when a reader registers via Woo.
+ */
+Data_Events::register_listener(
+	'newspack_registered_reader_via_woo',
+	'reader_registered',
+	function( $email, $user_id, $metadata ) {
+		return [
+			'user_id'  => $user_id,
+			'email'    => $email,
+			'metadata' => $metadata,
 		];
 	}
 );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1566,10 +1566,6 @@ final class Reader_Activation {
 			}
 		}
 
-		if ( ! empty( $metadata ) ) {
-			\update_user_meta( $user_id, 'np_registration_metadata', $metadata );
-		}
-
 		// Note the user's login method for later use.
 		if ( isset( $metadata['registration_method'] ) ) {
 			\update_user_meta( $user_id, self::REGISTRATION_METHOD, $metadata['registration_method'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-plugin/pull/2526 didn't actually work well. The metadata was being added after the user was registered, so the event was never sending any metadata.

This PR reverts the event to listen to the `newspack_registered_reader` hook and creates a new hook specifically for the readers registered during a Woocommerce checkout.

### How to test the changes in this Pull Request:

1. Setup a webhook using https://webhook.site/ to get all incoming data events 
2. Purchase a product anonymously and confirm that the created account triggers a `reader_registered` event and it reaches the webhook
3. On a fresh session, register through a RAS prompt with a reader registration block
4. Confirm the event reaches the webhook with no regression on the metadata contents
5. Test purchasing products and making donations via different entry points and check the metadata includes what's expected, see list below. (Important: be sure to not be logged in before making the donations/purchases)

A registration triggered by a donation in a campaign prompt should include:
* registration_method = woocommerce
* referer
* newspack_popup_id

A registration triggered by a donation outside a campaign prompt should include:
* registration_method = woocommerce
* referer

A registration triggered by any other Woocommerce checkout should include
* registration_method = woocommerce

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->