### PR TITLE
fix(auth): prevent registration redirect from hash link

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -408,8 +408,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 											.json()
 											.then( ( { message, data } ) => {
 												let redirect = body.get( 'redirect' );
-												/** Redirect every registration to the account page for verification */
-												if ( action === 'register' ) {
+												/** Redirect every registration to the account page for verification if not coming from a hash link */
+												if ( action === 'register' && ! currentHash ) {
 													redirect = newspack_reader_activation_data.account_url;
 												}
 												form.endLoginFlow( message, res.status, data, redirect );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The authentication modal is redirecting all registration flows to the "My Account" page in order to indicate the reader to verify their account. We want to prevent that when the registration comes from custom flows like the reg. wall, where the page should just refresh to allow the reader to continue reading after registering.

This prevents the redirection to occur if the source of the auth modal is a hash link.

### How to test the changes in this Pull Request:

1. Check out this branch, confirm you have RAS enabled and configured and edit a page to include a link to `#register_modal`
2. In an anonymous session, visit the page and click on the link
3. Register a new account and confirm you are not redirected to the "My Account" page
4. Start another fresh session and go through the same registration flow but from the "Sign In" button located in the header
5. Confirm you are redirected to the "My Account" page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->