### PR TITLE
fix(content-gate): close excerpt tags before inline gate

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -317,6 +317,9 @@ class Memberships {
 		}
 		$gate = \apply_filters( 'the_content', \get_the_content( null, null, $gate_post_id ) );
 
+		// Add clearfix to the gate.
+		$gate = '<div style=\'content:"";clear:both;display:table;\'></div>' . $gate;
+
 		// Apply inline fade.
 		if ( \get_post_meta( $gate_post_id, 'inline_fade', true ) ) {
 			$gate = '<div style="pointer-events: none; height: 10em; margin-top: -10em; width: 100%; position: absolute; background: linear-gradient(180deg, rgba(255,255,255,0) 14%, rgba(255,255,255,1) 76%);"></div>' . $gate;
@@ -391,7 +394,7 @@ class Memberships {
 				$content[ count( $content ) - 1 ] .= ' [&hellip;]';
 			}
 			// Rejoin the paragraphs into a single string again.
-			$content = wp_kses_post( implode( '</p>', $content ) . '</p>' );
+			$content = \force_balance_tags( \wp_kses_post( implode( '</p>', $content ) . '</p>' ) );
 		}
 		return $content;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements [`force_balance_tags()`](https://developer.wordpress.org/reference/functions/force_balance_tags/) to the generated excerpt so the inline gate is never caught inside a blockquote or other parent tags the final `<p />` may be in. Also adds a clearfix to clear from any floating elements it may encounter.

### How to test the changes in this Pull Request:

1. While on master setup memberships and a gate without metering (so the backend strategy is used for locking content)
2. Set the gate number of paragraphs to 2
3. Create an article that will be gated and add a paragraph block and a blockquote block second with sample content, e.g.:
```html
<!-- wp:paragraph -->
<p>First Paragraph</p>
<!-- /wp:paragraph -->
<!-- wp:quote {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"className":"is-style-default","fontSize":"large"} -->
<blockquote class="wp-block-quote is-style-default has-large-font-size" style="font-style:normal;font-weight:700"><!-- wp:paragraph -->
<p>Testing Quote</p>
<!-- /wp:paragraph --><cite>Mary</cite></blockquote>
<!-- /wp:quote -->
```
4. Publish, visit the post anonymously, and confirm the gate is inside the blockquote and inheriting its CSS
5. Check out this branch, build, and refresh
6. Confirm the gate is outside the blockquote and formatted as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->