### PR TITLE
feat(content-gate): support gate per plan

### DIFF
--- a/assets/memberships-gate/editor.js
+++ b/assets/memberships-gate/editor.js
@@ -52,6 +52,26 @@ function GateEdit() {
 			wrapper.removeAttribute( 'data-overlay-size' );
 		}
 	}, [ meta.style, meta.overlay_size ] );
+	const { createNotice } = useDispatch( 'core/notices' );
+	useEffect( () => {
+		if ( Object.keys( newspack_memberships_gate.gate_plans ).length ) {
+			createNotice(
+				'info',
+				sprintf(
+					// translators: %s is the list of plans.
+					__( "You're currently editing a gate for content restricted by: %s", 'newspack' ),
+					Object.values( newspack_memberships_gate.gate_plans ).join( ', ' )
+				)
+			);
+		}
+	}, [] );
+	const getPlansToEdit = () => {
+		const currentGatePlans = Object.keys( newspack_memberships_gate.gate_plans ) || [];
+		const plans = newspack_memberships_gate.plans.filter( plan => {
+			return ! currentGatePlans.includes( plan.id.toString() );
+		} );
+		return plans;
+	};
 	return (
 		<Fragment>
 			{ newspack_memberships_gate.has_campaigns && (
@@ -64,6 +84,65 @@ function GateEdit() {
 					</p>
 				</PluginPostStatusInfo>
 			) }
+			<PluginDocumentSettingPanel
+				name="memberships-gate-plans"
+				title={ __( 'WooCommerce Memberships', 'newspack' ) }
+			>
+				{ ! Object.keys( newspack_memberships_gate.gate_plans ).length ? (
+					<Fragment>
+						<p>
+							{ __(
+								'This gate will be rendered for all membership plans. Create a custom gate for when a content is locked behind a specific plan:',
+								'newspack'
+							) }
+						</p>
+					</Fragment>
+				) : (
+					<Fragment>
+						<p>
+							{ sprintf(
+								// translators: %s is the list of plans.
+								__(
+									'This gate will be rendered for the following membership plans: %s',
+									'newspack'
+								),
+								Object.values( newspack_memberships_gate.gate_plans ).join( ', ' )
+							) }
+						</p>
+						<hr />
+						<p
+							dangerouslySetInnerHTML={ {
+								__html: sprintf(
+									// translators: %s is the link to the primary gate.
+									__( 'Edit the <a href="%s">primary gate</a>, or:', 'newspack' ),
+									newspack_memberships_gate.edit_gate_url
+								),
+							} }
+						/>
+					</Fragment>
+				) }
+				<ul>
+					{ getPlansToEdit().map( plan => (
+						<li key={ plan.id }>
+							{ plan.name } (
+							{ plan.gate_id !== false && (
+								<Fragment>
+									<strong>
+										{ plan.gate_status === 'publish'
+											? __( 'published', 'newspack' )
+											: __( 'draft', 'newspack' ) }
+									</strong>{ ' ' }
+									-{ ' ' }
+								</Fragment>
+							) }
+							<a href={ newspack_memberships_gate.edit_gate_url + '&plan_id=' + plan.id }>
+								{ plan.gate_id ? __( 'edit gate', 'newspack' ) : __( 'create gate', 'newspack' ) }
+							</a>
+							)
+						</li>
+					) ) }
+				</ul>
+			</PluginDocumentSettingPanel>
 			<PluginDocumentSettingPanel
 				name="memberships-gate-styles-panel"
 				title={ __( 'Styles', 'newspack' ) }

--- a/assets/memberships-gate/editor.js
+++ b/assets/memberships-gate/editor.js
@@ -84,65 +84,67 @@ function GateEdit() {
 					</p>
 				</PluginPostStatusInfo>
 			) }
-			<PluginDocumentSettingPanel
-				name="memberships-gate-plans"
-				title={ __( 'WooCommerce Memberships', 'newspack' ) }
-			>
-				{ ! Object.keys( newspack_memberships_gate.gate_plans ).length ? (
-					<Fragment>
-						<p>
-							{ __(
-								'This gate will be rendered for all membership plans. Create a custom gate for when a content is locked behind a specific plan:',
-								'newspack'
-							) }
-						</p>
-					</Fragment>
-				) : (
-					<Fragment>
-						<p>
-							{ sprintf(
-								// translators: %s is the list of plans.
-								__(
-									'This gate will be rendered for the following membership plans: %s',
+			{ newspack_memberships_gate.plans.length > 1 && (
+				<PluginDocumentSettingPanel
+					name="memberships-gate-plans"
+					title={ __( 'WooCommerce Memberships', 'newspack' ) }
+				>
+					{ ! Object.keys( newspack_memberships_gate.gate_plans ).length ? (
+						<Fragment>
+							<p>
+								{ __(
+									'This gate will be rendered for all membership plans. Manage custom gates for when the content is locked behind a specific plan:',
 									'newspack'
-								),
-								Object.values( newspack_memberships_gate.gate_plans ).join( ', ' )
-							) }
-						</p>
-						<hr />
-						<p
-							dangerouslySetInnerHTML={ {
-								__html: sprintf(
-									// translators: %s is the link to the primary gate.
-									__( 'Edit the <a href="%s">primary gate</a>, or:', 'newspack' ),
-									newspack_memberships_gate.edit_gate_url
-								),
-							} }
-						/>
-					</Fragment>
-				) }
-				<ul>
-					{ getPlansToEdit().map( plan => (
-						<li key={ plan.id }>
-							{ plan.name } (
-							{ plan.gate_id !== false && (
-								<Fragment>
-									<strong>
-										{ plan.gate_status === 'publish'
-											? __( 'published', 'newspack' )
-											: __( 'draft', 'newspack' ) }
-									</strong>{ ' ' }
-									-{ ' ' }
-								</Fragment>
-							) }
-							<a href={ newspack_memberships_gate.edit_gate_url + '&plan_id=' + plan.id }>
-								{ plan.gate_id ? __( 'edit gate', 'newspack' ) : __( 'create gate', 'newspack' ) }
-							</a>
-							)
-						</li>
-					) ) }
-				</ul>
-			</PluginDocumentSettingPanel>
+								) }
+							</p>
+						</Fragment>
+					) : (
+						<Fragment>
+							<p>
+								{ sprintf(
+									// translators: %s is the list of plans.
+									__(
+										'This gate will be rendered for the following membership plans: %s',
+										'newspack'
+									),
+									Object.values( newspack_memberships_gate.gate_plans ).join( ', ' )
+								) }
+							</p>
+							<hr />
+							<p
+								dangerouslySetInnerHTML={ {
+									__html: sprintf(
+										// translators: %s is the link to the primary gate.
+										__( 'Edit the <a href="%s">primary gate</a>, or:', 'newspack' ),
+										newspack_memberships_gate.edit_gate_url
+									),
+								} }
+							/>
+						</Fragment>
+					) }
+					<ul>
+						{ getPlansToEdit().map( plan => (
+							<li key={ plan.id }>
+								{ plan.name } (
+								{ plan.gate_id !== false && (
+									<Fragment>
+										<strong>
+											{ plan.gate_status === 'publish'
+												? __( 'published', 'newspack' )
+												: __( 'draft', 'newspack' ) }
+										</strong>{ ' ' }
+										-{ ' ' }
+									</Fragment>
+								) }
+								<a href={ newspack_memberships_gate.edit_gate_url + '&plan_id=' + plan.id }>
+									{ plan.gate_id ? __( 'edit gate', 'newspack' ) : __( 'create gate', 'newspack' ) }
+								</a>
+								)
+							</li>
+						) ) }
+					</ul>
+				</PluginDocumentSettingPanel>
+			) }
 			<PluginDocumentSettingPanel
 				name="memberships-gate-styles-panel"
 				title={ __( 'Styles', 'newspack' ) }

--- a/assets/memberships-gate/metering.js
+++ b/assets/memberships-gate/metering.js
@@ -2,6 +2,8 @@
 
 const settings = newspack_metering_settings;
 
+const storeKey = 'metering-' + settings.gate_id || 0;
+
 function getCurrentExpiration() {
 	const date = new Date();
 	// Reset time to 00:00:00:000.
@@ -28,7 +30,7 @@ function getCurrentExpiration() {
 
 function getUserData( store ) {
 	const currentExpiration = getCurrentExpiration();
-	const data = store.get( 'metering' ) || {
+	const data = store.get( storeKey ) || {
 		content: [],
 		expiration: currentExpiration,
 	};
@@ -41,7 +43,7 @@ function getUserData( store ) {
 		// Reset expiration.
 		data.expiration = currentExpiration;
 	}
-	store.set( 'metering', data );
+	store.set( storeKey, data );
 	return data;
 }
 
@@ -93,7 +95,7 @@ function meter( store ) {
 	// Add current content to read content.
 	if ( ! locked && ! data.content.includes( settings.post_id ) ) {
 		data.content.push( settings.post_id );
-		store.set( 'metering', data );
+		store.set( storeKey, data );
 	}
 }
 

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -241,7 +241,7 @@ class Memberships {
 	 *
 	 * @return int|false Gate post ID or false if not found.
 	 */
-	public static function get_plan_gate_id( $plan_id ) {
+	private static function get_plan_gate_id( $plan_id ) {
 		$gates = get_posts(
 			[
 				'post_type'      => self::GATE_CPT,
@@ -329,7 +329,7 @@ class Memberships {
 	 *
 	 * @return int[] Array of plan IDs.
 	 */
-	public static function get_restricted_post_plans( $post_id ) {
+	private static function get_restricted_post_plans( $post_id ) {
 		if ( ! class_exists( 'WC_Memberships' ) ) {
 			return [];
 		}

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -300,6 +300,23 @@ class Memberships {
 	}
 
 	/**
+	 * Whether the current user is a member of the given plan.
+	 *
+	 * @param int $plan_id Plan ID.
+	 *
+	 * @return bool
+	 */
+	private static function current_user_has_plan( $plan_id ) {
+		if ( ! \is_user_logged_in() ) {
+			return false;
+		}
+		if ( ! function_exists( 'wc_memberships_is_user_active_or_delayed_member' ) ) {
+			return false;
+		}
+		return \wc_memberships_is_user_active_or_delayed_member( \get_current_user_id(), $plan_id );
+	}
+
+	/**
 	 * Get the plans that are currently restricting the given post.
 	 *
 	 * @param int $post_id Post ID.
@@ -313,9 +330,9 @@ class Memberships {
 		}
 		$plans = [];
 		foreach ( $rules as $rule ) {
-			$plan = $rule->get_membership_plan_id();
-			if ( ! empty( $plan ) ) {
-				$plans[] = $plan;
+			$plan_id = $rule->get_membership_plan_id();
+			if ( ! empty( $plan_id ) && ! self::current_user_has_plan( $plan_id ) ) {
+				$plans[] = $plan_id;
 			}
 		}
 		return $plans;

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -225,8 +225,10 @@ class Memberships {
 			$plans = self::get_restricted_post_plans( $post_id );
 			$gates = array_map( [ __CLASS__, 'get_plan_gate_id' ], $plans );
 			$gates = array_values( array_filter( $gates ) );
-			if ( ! empty( $gates ) ) {
-				return $gates[0];
+			foreach ( $gates as $gate_id ) {
+				if ( 'publish' === get_post_status( $gate_id ) ) {
+					return $gate_id;
+				}
 			}
 		}
 		return $gate_post_id ? $gate_post_id : false;

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -427,7 +427,7 @@ class Memberships {
 			}
 			$gate_post_id = \wp_insert_post(
 				[
-					'post_title'   => __( 'Memberships Gate', 'newspack' ),
+					'post_title'   => $post_title,
 					'post_type'    => self::GATE_CPT,
 					'post_status'  => 'draft',
 					'post_content' => '<!-- wp:paragraph --><p>' . __( 'This post is only available to members.', 'newspack' ) . '</p><!-- /wp:paragraph -->',

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -266,6 +266,9 @@ class Memberships {
 	 * @return string[] Plan names keyed by plan ID.
 	 */
 	private static function get_gate_plans( $gate_id ) {
+		if ( ! function_exists( 'wc_memberships_get_membership_plan' ) ) {
+			return [];
+		}
 		$ids = get_post_meta( $gate_id, 'plans', true );
 		if ( empty( $ids ) || ! is_array( $ids ) ) {
 			return [];
@@ -286,6 +289,9 @@ class Memberships {
 	 * @return array
 	 */
 	private static function get_plans() {
+		if ( ! function_exists( 'wc_memberships_get_membership_plans' ) ) {
+			return [];
+		}
 		$membership_plans = wc_memberships_get_membership_plans();
 		$plans            = [];
 		foreach ( $membership_plans as $plan ) {
@@ -324,6 +330,9 @@ class Memberships {
 	 * @return int[] Array of plan IDs.
 	 */
 	public static function get_restricted_post_plans( $post_id ) {
+		if ( ! class_exists( 'WC_Memberships' ) ) {
+			return [];
+		}
 		$rules = wc_memberships()->get_rules_instance()->get_post_content_restriction_rules( $post_id );
 		if ( ! $rules || empty( $rules ) ) {
 			return [];

--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -101,6 +101,7 @@ class Metering {
 				'use_more_tag'       => \get_post_meta( $gate_post_id, 'use_more_tag', true ),
 				'count'              => \get_post_meta( $gate_post_id, 'metering_anonymous_count', true ),
 				'period'             => \get_post_meta( $gate_post_id, 'metering_period', true ),
+				'gate_id'            => $gate_post_id,
 				'post_id'            => get_the_ID(),
 			]
 		);
@@ -215,8 +216,10 @@ class Metering {
 			return self::$logged_in_metering_cache[ $post_id ];
 		}
 
+		$user_meta_key = self::METERING_META_KEY . '_' . $gate_post_id;
+
 		$updated_user_data  = false;
-		$user_metering_data = \get_user_meta( get_current_user_id(), self::METERING_META_KEY, true );
+		$user_metering_data = \get_user_meta( get_current_user_id(), $user_meta_key, true );
 		if ( ! is_array( $user_metering_data ) ) {
 			$user_metering_data = [];
 		}
@@ -244,7 +247,7 @@ class Metering {
 		}
 
 		if ( $updated_user_data ) {
-			\update_user_meta( get_current_user_id(), self::METERING_META_KEY, $user_metering_data );
+			\update_user_meta( get_current_user_id(), $user_meta_key, $user_metering_data );
 		}
 
 		// Allowed if the content has been accessed or the metering limit has not been reached.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Support custom gates for content restricted behind a specific membership plan.

Primary gate:

<img width="1289" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/e456deb9-8fec-445b-accb-8dffbea0cf50">

Plan gate:

![image](https://github.com/Automattic/newspack-plugin/assets/820752/e765d8a1-9e17-46b7-9a9b-8081b80782e2)

### How to test the changes in this Pull Request:

1. Make sure you have at least 2 plans with WC Memberships. One targets a group of categories, and the other targets a specific category (not included in the prior plan).
2. Visit the Content Gate editor (Newspack -> Engagement -> Advanced Settings)
3. Confirm you see the WooCommerce Memberships panel in the sidebar of the editor (as the image above)
4. Create a gate that should target the group of categories and save
5. Click to create a gate for the plan that targets a specific category
6. Save the gate with different content
7. In a fresh session, navigate the site and confirm you see the gate for every content (outside the category) and the specific category gate for content inside the category targeted by the plan
8. Create a user and manually add that user as member to the generic plan
9. Navigate and confirm you can access the other content and the specific plan renders its gate
10. Configure metering to the generic gate
11. Navigate to an article in the gated category and confirm it still shows the gate
12. Confirm metering works with other articles
13. Manually add the user to the specific category plan
14. Navigate to an article in the category and confirm the content renders fully

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->