### PR TITLE
feat: segments criteria ui

### DIFF
--- a/__mocks__/@wordpress/api-fetch.js
+++ b/__mocks__/@wordpress/api-fetch.js
@@ -1,8 +1,5 @@
 const apiFetch = ( { path } ) =>
 	new Promise( resolve => {
-		if ( path.indexOf( '/newspack/v1/wizard/newspack-popups-wizard/segmentation-reach' ) === 0 ) {
-			resolve( { total: 10, in_segment: 10 } );
-		}
 		resolve();
 	} );
 

--- a/assets/components/src/settings/MinMaxSetting.js
+++ b/assets/components/src/settings/MinMaxSetting.js
@@ -16,9 +16,10 @@ const MinMaxSetting = ( {
 	onChangeMax,
 	minPlaceholder,
 	maxPlaceholder,
+	...props
 } ) => {
 	return (
-		<>
+		<div { ...props }>
 			<div className="newspack-settings__min-max">
 				<CheckboxControl
 					checked={ min > 0 }
@@ -26,27 +27,28 @@ const MinMaxSetting = ( {
 					label={ __( 'Min', 'newspack' ) }
 				/>
 				<TextControl
-					data-testid="min-articles-input"
+					data-testid="min"
 					type="number"
 					value={ min }
 					placeholder={ minPlaceholder }
 					onChange={ value => onChangeMin( value > 0 ? value : 0 ) }
 				/>
 			</div>
-			<div className="newspack-settings__min-max">
+			<div className="newspack-settings__min-max" data-testid="max">
 				<CheckboxControl
 					checked={ max > 0 }
 					onChange={ value => onChangeMax( value ? min || 1 : 0 ) }
 					label={ __( 'Max', 'newspack' ) }
 				/>
 				<TextControl
+					data-testid="max"
 					type="number"
 					value={ max }
 					placeholder={ maxPlaceholder }
 					onChange={ value => onChangeMax( value > 0 ? value : 0 ) }
 				/>
 			</div>
-		</>
+		</div>
 	);
 };
 export default MinMaxSetting;

--- a/assets/components/src/settings/style.scss
+++ b/assets/components/src/settings/style.scss
@@ -37,7 +37,8 @@
 				}
 			}
 			&__content {
-				> div {
+				> div,
+				.newspack-settings__min-max {
 					margin: 0;
 					display: flex;
 					align-items: center;
@@ -46,6 +47,9 @@
 					> *:not( [class*='help'], [class*='label'] ) {
 						margin: 0;
 					}
+				}
+				.newspack-settings__min-max {
+					width: 100%;
 				}
 				.newspack-text-control,
 				.newspack-checkbox-control {

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -2,8 +2,6 @@
  * Segment group component.
  */
 
-import cookies from 'js-cookie';
-
 /**
  * WordPress dependencies.
  */
@@ -47,23 +45,6 @@ const addNewURL = ( placement, campaignId, segmentId ) => {
 		params.push( `segment=${ segmentId }` );
 	}
 	return base + params.join( '&' );
-};
-
-const removeCIDCookie = () => {
-	if ( newspack_aux_data.popups_cookie_name ) {
-		// Remove cookies for all possible domains.
-		window.location.host
-			.split( '.' )
-			.reduce( ( acc, _, i, arr ) => {
-				acc.push( arr.slice( -( i + 1 ) ).join( '.' ) );
-				return acc;
-			}, [] )
-			.map( domain =>
-				cookies.remove( newspack_aux_data.popups_cookie_name, {
-					domain: `.${ domain }`,
-				} )
-			);
-	}
 };
 
 const SegmentGroup = props => {
@@ -123,22 +104,8 @@ const SegmentGroup = props => {
 						campaign={ campaignId ? campaignToPreview : false }
 						segment={ id }
 						showUnpublished={ !! campaignId } // Only if previewing a specific campaign/group.
-						onClose={ removeCIDCookie }
 						renderButton={ ( { showPreview } ) => (
-							<Button
-								isSmall
-								variant="tertiary"
-								onClick={ () => {
-									removeCIDCookie();
-									if ( newspack_aux_data.popups_cookie_name ) {
-										cookies.set( newspack_aux_data.popups_cookie_name, `preview-${ Date.now() }`, {
-											domain: '.' + window.location.host,
-										} );
-									}
-
-									showPreview();
-								} }
-							>
+							<Button isSmall variant="tertiary" onClick={ () => showPreview() }>
 								{ __( 'Preview Segment', 'newspack' ) }
 							</Button>
 						) }

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -17,7 +17,7 @@ import SegmentationPreview from '../segmentation-preview';
 import PromptActionCard from '../prompt-action-card';
 import {
 	descriptionForPopup,
-	descriptionForSegment,
+	segmentDescription,
 	getCardClassName,
 	getFavoriteCategoryNames,
 	warningForPopup,
@@ -95,7 +95,7 @@ const SegmentGroup = props => {
 					</h3>
 					<span className="newspack-campaigns__segment-group__description">
 						{ id
-							? descriptionForSegment( segment, categories )
+							? segmentDescription( segment, categories )
 							: __( 'All readers, regardless of segment', 'newspack' ) }
 					</span>
 				</div>

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -16,7 +16,7 @@ import { Button, ButtonCard, Card, Grid, Modal } from '../../../../components/sr
 import SegmentationPreview from '../segmentation-preview';
 import PromptActionCard from '../prompt-action-card';
 import {
-	descriptionForPopup,
+	promptDescription,
 	segmentDescription,
 	getCardClassName,
 	getFavoriteCategoryNames,
@@ -190,7 +190,7 @@ const SegmentGroup = props => {
 				{ prompts.map( item => (
 					<PromptActionCard
 						className={ getCardClassName( item.status, segment.configuration.is_disabled ) }
-						description={ descriptionForPopup( item ) }
+						description={ promptDescription( item ) }
 						warning={ warningForPopup( prompts, item ) }
 						key={ item.id }
 						prompt={ item }

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState, Fragment } from '@wordpress/element';
+import { useState, Fragment } from '@wordpress/element';
 import { header, layout } from '@wordpress/icons';
 
 /**
@@ -19,7 +19,6 @@ import {
 	promptDescription,
 	segmentDescription,
 	getCardClassName,
-	getFavoriteCategoryNames,
 	warningForPopup,
 } from '../../utils';
 import {
@@ -50,19 +49,8 @@ const addNewURL = ( placement, campaignId, segmentId ) => {
 const SegmentGroup = props => {
 	const { campaignData, campaignId, segment } = props;
 	const [ modalVisible, setModalVisible ] = useState( false );
-	const [ categories, setCategories ] = useState( [] );
 	const { label, id, prompts } = segment;
 	const campaignToPreview = 'unassigned' !== campaignId ? parseInt( campaignId ) : -1;
-
-	useEffect( () => {
-		updateCategories();
-	}, [ segment ] );
-
-	const updateCategories = async () => {
-		if ( 0 < segment.configuration?.favorite_categories?.length ) {
-			setCategories( await getFavoriteCategoryNames( segment.configuration.favorite_categories ) );
-		}
-	};
 
 	let emptySegmentText;
 	if ( 'unassigned' === campaignId ) {
@@ -73,6 +61,8 @@ const SegmentGroup = props => {
 	} else {
 		emptySegmentText = __( 'No active prompts in this segment.', 'newspack' );
 	}
+
+	const description = segmentDescription( segment );
 	return (
 		<Card isSmall className="newspack-campaigns__segment-group__card">
 			<div className="newspack-campaigns__segment-group__card__segment">
@@ -94,9 +84,7 @@ const SegmentGroup = props => {
 						) }
 					</h3>
 					<span className="newspack-campaigns__segment-group__description">
-						{ id
-							? segmentDescription( segment, categories )
-							: __( 'All readers, regardless of segment', 'newspack' ) }
+						{ id ? description() : __( 'All readers, regardless of segment', 'newspack' ) }
 					</span>
 				</div>
 				<div className="newspack-campaigns__segment-group__card__segment-actions">

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -191,11 +191,16 @@ export const segmentDescription = segment => {
 						value = option.label;
 					}
 				}
-				if ( item.value.min || item.value.max ) {
-					value = sprintf( '%1$s - %2$s', value.min, value.max );
-				}
 				if ( Array.isArray( value ) ) {
 					value = value.join( ', ' );
+				} else if ( typeof value === 'object' ) {
+					const values = [];
+					for ( const key in value ) {
+						if ( value[ key ] ) {
+							values.push( `${ key }: ${ value[ key ] }` );
+						}
+					}
+					value = values.join( ', ' );
 				}
 				const message = applyFilters(
 					'newspack.wizards.campaigns.segmentDescription.criteriaMessage',

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -117,7 +117,7 @@ export const getCardClassName = ( status, forceDisabled = false ) => {
 	return 'newspack-card__is-supported';
 };
 
-export const descriptionForPopup = prompt => {
+export const promptDescription = prompt => {
 	const { categories, tags, campaign_groups: campaigns, status } = prompt;
 	const descriptionMessages = [];
 	if ( campaigns.length > 0 ) {

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -84,10 +84,11 @@ const filterByCampaign = ( prompts, campaignId ) => {
 const groupBySegment = ( segments, prompts ) => {
 	const grouped = [];
 	grouped.push(
-		...segments.map( ( { name: label, id, configuration } ) => ( {
+		...segments.map( ( { name: label, id, configuration, criteria } ) => ( {
 			label,
 			id,
 			configuration,
+			criteria,
 			prompts: prompts.filter( ( { options: { selected_segment_id: _segments } } ) => {
 				return _segments ? -1 < _segments.split( ',' ).indexOf( id ) : false;
 			} ),

--- a/assets/wizards/popups/views/segments/SegmentsList.js
+++ b/assets/wizards/popups/views/segments/SegmentsList.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { useEffect, useRef, useState, Fragment } from '@wordpress/element';
+import { useRef, useState, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Draggable, MenuItem } from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -11,7 +11,7 @@ import { Icon, chevronDown, chevronUp, dragHandle, moreVertical } from '@wordpre
  * Internal dependencies.
  */
 import { ActionCard, Button, Card, Notice, Popover, Router } from '../../../../components/src';
-import { segmentDescription, getFavoriteCategoryNames } from '../../utils';
+import { segmentDescription } from '../../utils';
 
 const { NavLink, useHistory } = Router;
 
@@ -35,18 +35,7 @@ const SegmentActionCard = ( {
 	toggleSegmentStatus,
 } ) => {
 	const [ popoverVisibility, setPopoverVisibility ] = useState( false );
-	const [ categories, setCategories ] = useState( [] );
 	const [ isDragging, setIsDragging ] = useState( false );
-
-	useEffect( () => {
-		updateCategories();
-	}, [ segment ] );
-
-	const updateCategories = async () => {
-		if ( 0 < segment.configuration?.favorite_categories?.length ) {
-			setCategories( await getFavoriteCategoryNames( segment.configuration.favorite_categories ) );
-		}
-	};
 
 	const onFocusOutside = () => setPopoverVisibility( false );
 	const history = useHistory();
@@ -182,7 +171,7 @@ const SegmentActionCard = ( {
 						isSmall
 						title={ segment.name }
 						titleLink={ `#/segments/${ segment.id }` }
-						description={ segmentDescription( segment, categories ) }
+						description={ segmentDescription( segment ) }
 						toggleChecked={ ! segment.configuration.is_disabled }
 						toggleOnChange={ () => toggleSegmentStatus( segment ) }
 						actionText={

--- a/assets/wizards/popups/views/segments/SegmentsList.js
+++ b/assets/wizards/popups/views/segments/SegmentsList.js
@@ -269,6 +269,7 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 					...segment.configuration,
 					is_disabled: ! segment.configuration.is_disabled,
 				},
+				criteria: segment.criteria,
 			},
 		} )
 			.then( _segments => {

--- a/assets/wizards/popups/views/segments/SegmentsList.js
+++ b/assets/wizards/popups/views/segments/SegmentsList.js
@@ -11,7 +11,7 @@ import { Icon, chevronDown, chevronUp, dragHandle, moreVertical } from '@wordpre
  * Internal dependencies.
  */
 import { ActionCard, Button, Card, Notice, Popover, Router } from '../../../../components/src';
-import { descriptionForSegment, getFavoriteCategoryNames } from '../../utils';
+import { segmentDescription, getFavoriteCategoryNames } from '../../utils';
 
 const { NavLink, useHistory } = Router;
 
@@ -182,7 +182,7 @@ const SegmentActionCard = ( {
 						isSmall
 						title={ segment.name }
 						titleLink={ `#/segments/${ segment.id }` }
-						description={ descriptionForSegment( segment, categories ) }
+						description={ segmentDescription( segment, categories ) }
 						toggleChecked={ ! segment.configuration.is_disabled }
 						toggleOnChange={ () => toggleSegmentStatus( segment ) }
 						actionText={

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -48,7 +48,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	};
 
 	const isDirty =
-		JSON.stringify( segmentCriteriaInitially ) !== JSON.stringify( segmentCriteria ) ||
+		segmentCriteriaInitially !== JSON.stringify( segmentCriteria ) ||
 		nameInitially !== name ||
 		JSON.stringify( segmentInitially.is_disabled ) !== JSON.stringify( segmentConfig.is_disabled );
 
@@ -74,7 +74,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					setName( foundSegment.name );
 					setNameInitially( foundSegment.name );
 					setSegmentCriteria( [ ...foundSegment.criteria ] );
-					setSegmentCriteriaInitially( [ ...foundSegment.criteria ] );
+					setSegmentCriteriaInitially( JSON.stringify( foundSegment.criteria ) );
 				}
 			} );
 		}

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -1,4 +1,3 @@
-/* globals newspack_popups_wizard_data */
 /**
  * WordPress dependencies.
  */
@@ -24,13 +23,13 @@ import {
 const { useHistory } = Router;
 const { SettingsCard, SettingsSection, MinMaxSetting } = Settings;
 
-const allCriteria = newspack_popups_wizard_data.criteria;
-
 const DEFAULT_CONFIG = {
 	is_disabled: false,
 };
 
 const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
+	const allCriteria = window.newspack_popups_wizard_data?.criteria || [];
+
 	const [ segmentConfig, updateSegmentConfig ] = hooks.useObjectState( DEFAULT_CONFIG );
 	const [ name, setName ] = useState( '' );
 	const [ segmentCriteria, setSegmentCriteria ] = useState( [] );

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -127,6 +127,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 			if ( criteria.matching_function === 'range' ) {
 				return (
 					<MinMaxSetting
+						data-testid={ `newspack-criteria-${ criteria.id }` }
 						min={ value?.min }
 						max={ value?.max }
 						onChangeMin={ min => update( { min } ) }
@@ -137,8 +138,8 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 			if ( criteria.options?.length ) {
 				return (
 					<SelectControl
+						data-testid={ `newspack-criteria-${ criteria.id }` }
 						isWide
-						data-testid="subscriber-select"
 						onChange={ update }
 						value={ value }
 						options={ criteria.options }
@@ -147,6 +148,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 			}
 			return (
 				<TextControl
+					data-testid={ `newspack-criteria-${ criteria.id }` }
 					isWide
 					placeholder={ criteria.placeholder }
 					help={ criteria.help }

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -141,10 +141,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 						data-testid="subscriber-select"
 						onChange={ update }
 						value={ value }
-						options={ criteria.options.map( option => ( {
-							value: option.value,
-							label: option.name,
-						} ) ) }
+						options={ criteria.options }
 					/>
 				);
 			}

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -1,11 +1,12 @@
+/* globals newspack_popups_wizard_data */
 /**
  * WordPress dependencies.
  */
 import { ToggleControl } from '@wordpress/components';
-import { useMemo, useEffect, useState, Fragment } from '@wordpress/element';
+import { useEffect, useState, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
-import { find, debounce } from 'lodash';
+import { find } from 'lodash';
+import { applyFilters, addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies.
@@ -13,7 +14,6 @@ import { find, debounce } from 'lodash';
 import {
 	Button,
 	CategoryAutocomplete,
-	Notice,
 	Router,
 	SelectControl,
 	Settings,
@@ -24,45 +24,30 @@ import {
 const { useHistory } = Router;
 const { SettingsCard, SettingsSection, MinMaxSetting } = Settings;
 
+const allCriteria = newspack_popups_wizard_data.criteria;
+
 const DEFAULT_CONFIG = {
-	min_posts: 0,
-	max_posts: 0,
-	min_session_posts: 0,
-	max_session_posts: 0,
-	is_subscribed: false,
-	is_not_subscribed: false,
-	is_donor: false,
-	is_not_donor: false,
-	is_former_donor: false,
-	is_logged_in: false,
-	is_not_logged_in: false,
-	favorite_categories: [],
-	referrers: '',
-	referrers_not: '',
 	is_disabled: false,
 };
 
 const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	const [ segmentConfig, updateSegmentConfig ] = hooks.useObjectState( DEFAULT_CONFIG );
 	const [ name, setName ] = useState( '' );
+	const [ segmentCriteria, setSegmentCriteria ] = useState( [] );
 	const [ nameInitially, setNameInitially ] = useState( '' );
-	const [ isFetchingReach, setIsFetchingReach ] = useState( false );
-	const [ reach, setReach ] = useState( { total: 0, in_segment: 0 } );
 	const history = useHistory();
 
-	const [ segmentInitially, setSegmentInitially ] = useState( null );
+	const [ segmentInitially, setSegmentInitially ] = useState( '[]' );
 
 	const isSegmentValid = () => {
 		const _segmentConfig = { ...segmentConfig };
 		const _defaultConfig = { ...DEFAULT_CONFIG };
 		delete _segmentConfig.is_disabled;
 		delete _defaultConfig.is_disabled;
-		return name.length > 0 && JSON.stringify( _segmentConfig ) !== JSON.stringify( _defaultConfig ); // Segment has a name. // Segment differs from the default config with the exception of the is_disabled flag.
+		return name.length > 0 && segmentCriteria.length; // Segment has a name. // Segment has criteria.
 	};
 
-	const isDirty =
-		JSON.stringify( segmentInitially ) !== JSON.stringify( segmentConfig ) ||
-		nameInitially !== name;
+	const isDirty = segmentInitially !== JSON.stringify( segmentCriteria ) || nameInitially !== name;
 
 	const unblock = hooks.usePrompt(
 		isDirty,
@@ -82,35 +67,14 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 						...foundSegment.configuration,
 					};
 					updateSegmentConfig( segmentConfigurationWithDefaults );
-					setSegmentInitially( segmentConfigurationWithDefaults );
+					setSegmentInitially( JSON.stringify( foundSegment.criteria ) );
 					setName( foundSegment.name );
 					setNameInitially( foundSegment.name );
+					setSegmentCriteria( [ ...foundSegment.criteria ] );
 				}
 			} );
 		}
 	}, [ isNew ] );
-
-	const updateReach = useMemo( () => {
-		return debounce(
-			config => {
-				setIsFetchingReach( true );
-				apiFetch( {
-					path: `/newspack/v1/wizard/newspack-popups-wizard/segmentation-reach?config=${ JSON.stringify(
-						config
-					) }`,
-				} ).then( res => {
-					setReach( res );
-					setIsFetchingReach( false );
-				} );
-			},
-			500,
-			{ leading: true }
-		);
-	}, [] );
-
-	useEffect( () => {
-		updateReach( segmentConfig );
-	}, [ JSON.stringify( segmentConfig ) ] );
 
 	const saveSegment = () => {
 		unblock();
@@ -123,11 +87,78 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 			method: 'POST',
 			data: {
 				name,
+				criteria: segmentCriteria,
 				configuration: segmentConfig,
 			},
 		} )
 			.then( setSegments )
 			.then( history.push( '/segments' ) );
+	};
+
+	const getCriteriaValue = id => {
+		const item = segmentCriteria.find( c => c.criteria_id === id );
+		if ( ! item ) {
+			return null;
+		}
+		return item.value;
+	};
+
+	const updateCriteria = id => value => {
+		const config = [ ...segmentCriteria ];
+		const item = config.find( c => c.criteria_id === id );
+		if ( item ) {
+			if ( ! value ) {
+				config.splice( config.indexOf( item ), 1 );
+			} else if ( ! Array.isArray( value ) && typeof value === 'object' ) {
+				item.value = { ...item.value, ...value };
+			} else {
+				item.value = value;
+			}
+		} else if ( value ) {
+			config.push( { criteria_id: id, value } );
+		}
+		setSegmentCriteria( config );
+	};
+
+	const getCriteriaInput = criteria => {
+		const value = getCriteriaValue( criteria.id );
+		const update = updateCriteria( criteria.id );
+		const getInput = () => {
+			if ( criteria.matching_function === 'range' ) {
+				return (
+					<MinMaxSetting
+						min={ value?.min }
+						max={ value?.max }
+						onChangeMin={ min => update( { min } ) }
+						onChangeMax={ max => update( { max } ) }
+					/>
+				);
+			}
+			if ( criteria.options?.length ) {
+				return (
+					<SelectControl
+						isWide
+						data-testid="subscriber-select"
+						onChange={ update }
+						value={ value }
+						options={ criteria.options.map( option => ( {
+							value: option.value,
+							label: option.name,
+						} ) ) }
+					/>
+				);
+			}
+			return (
+				<TextControl
+					isWide
+					placeholder={ criteria.placeholder }
+					help={ criteria.help }
+					value={ value }
+					onChange={ update }
+				/>
+			);
+		};
+		return applyFilters( 'newspack.criteria.input', getInput(), criteria, value, update );
 	};
 
 	return (
@@ -139,19 +170,6 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 				label={ __( 'Title', 'newspack' ) }
 				className={ 'newspack-campaigns-wizard-segments__title' }
 			/>
-
-			{ reach.total > 0 && (
-				<Notice
-					isInfo
-					className="newspack-campaigns-wizard-segments__recorded-visitors"
-					style={ { opacity: isFetchingReach ? 0.5 : 1 } }
-					noticeText={
-						__( 'This segment would reach approximately ', 'newspack' ) +
-						Math.round( ( reach.in_segment * 100 ) / reach.total ) +
-						__( '% of recorded visitors.', 'newspack' )
-					}
-				/>
-			) }
 
 			<SettingsCard
 				title={ __( 'Segment Status', 'newspack' ) }
@@ -173,48 +191,17 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 				description={ __( 'Target readers based on their browsing behavior', 'newspack' ) }
 				noBorder
 			>
-				<SettingsSection
-					title={ __( 'Articles read', 'newspack' ) }
-					description={ __( 'Number of articles read in the last 30 day period.', 'newspack' ) }
-				>
-					<MinMaxSetting
-						min={ segmentConfig.min_posts }
-						max={ segmentConfig.max_posts }
-						onChangeMin={ updateSegmentConfig( 'min_posts' ) }
-						onChangeMax={ updateSegmentConfig( 'max_posts' ) }
-						minPlaceholder={ __( 'Min posts', 'newspack' ) }
-						maxPlaceholder={ __( 'Max posts', 'newspack' ) }
-					/>
-				</SettingsSection>
-				<SettingsSection
-					title={ __( 'Articles read in session', 'newspack' ) }
-					description={ __(
-						'Number of articles read in the current session (45 minutes).',
-						'newspack'
-					) }
-				>
-					<MinMaxSetting
-						min={ segmentConfig.min_session_posts }
-						max={ segmentConfig.max_session_posts }
-						onChangeMin={ updateSegmentConfig( 'min_session_posts' ) }
-						onChangeMax={ updateSegmentConfig( 'max_session_posts' ) }
-						minPlaceholder={ __( 'Min posts in session', 'newspack' ) }
-						maxPlaceholder={ __( 'Max posts in session', 'newspack' ) }
-					/>
-				</SettingsSection>
-				<SettingsSection
-					title={ __( 'Favorite Categories', 'newspack' ) }
-					description={ __( 'Most-read categories of reader.', 'newspack' ) }
-				>
-					<CategoryAutocomplete
-						value={ segmentConfig.favorite_categories.map( v => parseInt( v ) ) }
-						onChange={ selected => {
-							updateSegmentConfig( 'favorite_categories' )( selected.map( item => item.id ) );
-						} }
-						label={ __( 'Favorite Categories', 'newspack ' ) }
-						hideLabelFromVision
-					/>
-				</SettingsSection>
+				{ allCriteria
+					.filter( criteria => criteria.category === 'reader_engagement' )
+					.map( criteria => (
+						<SettingsSection
+							key={ criteria.id }
+							title={ criteria.name }
+							description={ criteria.description }
+						>
+							{ getCriteriaInput( criteria ) }
+						</SettingsSection>
+					) ) }
 			</SettingsCard>
 			<SettingsCard
 				title={ __( 'Reader Activity', 'newspack' ) }
@@ -222,93 +209,17 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 				columns={ 3 }
 				noBorder
 			>
-				<SettingsSection title={ __( 'Newsletter', 'newspack' ) }>
-					<SelectControl
-						isWide
-						data-testid="subscriber-select"
-						onChange={ value => {
-							value = parseInt( value );
-							if ( value === 0 ) {
-								updateSegmentConfig( {
-									is_subscribed: false,
-									is_not_subscribed: false,
-								} );
-							} else {
-								updateSegmentConfig( {
-									is_subscribed: value === 1,
-									is_not_subscribed: value === 2,
-								} );
-							}
-						} }
-						// eslint-disable-next-line no-nested-ternary
-						value={ segmentConfig.is_subscribed ? 1 : segmentConfig.is_not_subscribed ? 2 : 0 }
-						options={ [
-							{ value: 0, label: __( 'Subscribers and non-subscribers', 'newspack' ) },
-							{ value: 1, label: __( 'Subscribers', 'newspack' ) },
-							{ value: 2, label: __( 'Non-subscribers', 'newspack' ) },
-						] }
-					/>
-				</SettingsSection>
-				<SettingsSection
-					title={ __( 'Donation', 'newspack' ) }
-					description={ __( '(if the checkout happens on-site)', 'newspack' ) }
-				>
-					<SelectControl
-						isWide
-						onChange={ value => {
-							value = parseInt( value );
-							updateSegmentConfig( {
-								is_donor: value === 1,
-								is_not_donor: value === 2,
-								is_former_donor: value === 3,
-							} );
-						} }
-						value={ [
-							false,
-							segmentConfig.is_donor,
-							segmentConfig.is_not_donor,
-							segmentConfig.is_former_donor,
-						].reduce(
-							( defaultValue, configValue, index ) => ( configValue ? index : defaultValue ),
-							0
-						) }
-						options={ [
-							{ value: 0, label: __( 'Donors and non-donors', 'newspack' ) },
-							{ value: 1, label: __( 'Donors', 'newspack' ) },
-							{ value: 2, label: __( 'Non-donors', 'newspack' ) },
-							{
-								value: 3,
-								label: __( 'Former donors (who cancelled a recurring donation)', 'newspack' ),
-							},
-						] }
-					/>
-				</SettingsSection>
-				<SettingsSection title={ __( 'User Account', 'newspack' ) }>
-					<SelectControl
-						isWide
-						onChange={ value => {
-							value = parseInt( value );
-							if ( value === 0 ) {
-								updateSegmentConfig( {
-									is_logged_in: false,
-									is_not_logged_in: false,
-								} );
-							} else {
-								updateSegmentConfig( {
-									is_logged_in: value === 1,
-									is_not_logged_in: value === 2,
-								} );
-							}
-						} }
-						// eslint-disable-next-line no-nested-ternary
-						value={ segmentConfig.is_logged_in ? 1 : segmentConfig.is_not_logged_in ? 2 : 0 }
-						options={ [
-							{ value: 0, label: __( 'All users', 'newspack' ) },
-							{ value: 1, label: __( 'Has user account', 'newspack' ) },
-							{ value: 2, label: __( 'Does not have user account', 'newspack' ) },
-						] }
-					/>
-				</SettingsSection>
+				{ allCriteria
+					.filter( criteria => criteria.category === 'reader_activity' )
+					.map( criteria => (
+						<SettingsSection
+							key={ criteria.id }
+							title={ criteria.name }
+							description={ criteria.description }
+						>
+							{ getCriteriaInput( criteria ) }
+						</SettingsSection>
+					) ) }
 			</SettingsCard>
 			<SettingsCard
 				title={ __( 'Referrer Sources', 'newspack' ) }
@@ -320,34 +231,17 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 				columns={ 2 }
 				noBorder
 			>
-				<SettingsSection
-					title={ __( 'Sources to match', 'newspack' ) }
-					description={ __( 'Segment based on traffic source.', 'newspack' ) }
-				>
-					<TextControl
-						isWide
-						data-testid="referrers-input"
-						placeholder={ __( 'google.com, facebook.com', 'newspack' ) }
-						help={ __( 'A comma-separated list of domains.', 'newspack' ) }
-						value={ segmentConfig.referrers }
-						onChange={ updateSegmentConfig( 'referrers' ) }
-					/>
-				</SettingsSection>
-				<SettingsSection
-					title={ __( 'Sources to exclude', 'newspack' ) }
-					description={ __(
-						'Segment based on traffic source - hide campaigns for visitors coming from specific sources.',
-						'newspack'
-					) }
-				>
-					<TextControl
-						isWide
-						placeholder={ __( 'twitter.com, instagram.com', 'newspack' ) }
-						help={ __( 'A comma-separated list of domains.', 'newspack' ) }
-						value={ segmentConfig.referrers_not }
-						onChange={ updateSegmentConfig( 'referrers_not' ) }
-					/>
-				</SettingsSection>
+				{ allCriteria
+					.filter( criteria => criteria.category === 'referrer_sources' )
+					.map( criteria => (
+						<SettingsSection
+							key={ criteria.id }
+							title={ criteria.name }
+							description={ criteria.description }
+						>
+							{ getCriteriaInput( criteria ) }
+						</SettingsSection>
+					) ) }
 			</SettingsCard>
 			<div className="newspack-buttons-card">
 				<Button
@@ -364,5 +258,28 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 		</Fragment>
 	);
 };
+
+/**
+ * Adds a custom input for the favorite_categories criteria.
+ */
+addFilter(
+	'newspack.criteria.input',
+	'newspack.favoriteCategories',
+	function ( element, criteria, value, update ) {
+		if ( criteria.id === 'favorite_categories' ) {
+			return (
+				<CategoryAutocomplete
+					value={ value || [] }
+					onChange={ selected => {
+						update( selected.map( item => item.id ) );
+					} }
+					label={ criteria.name }
+					hideLabelFromVision
+				/>
+			);
+		}
+		return element;
+	}
+);
 
 export default SingleSegment;

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -33,6 +33,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	const [ segmentConfig, updateSegmentConfig ] = hooks.useObjectState( DEFAULT_CONFIG );
 	const [ name, setName ] = useState( '' );
 	const [ segmentCriteria, setSegmentCriteria ] = useState( [] );
+	const [ segmentCriteriaInitially, setSegmentCriteriaInitially ] = useState( [] );
 	const [ nameInitially, setNameInitially ] = useState( '' );
 	const history = useHistory();
 
@@ -46,7 +47,10 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 		return name.length > 0 && segmentCriteria.length; // Segment has a name. // Segment has criteria.
 	};
 
-	const isDirty = segmentInitially !== JSON.stringify( segmentCriteria ) || nameInitially !== name;
+	const isDirty =
+		JSON.stringify( segmentCriteriaInitially ) !== JSON.stringify( segmentCriteria ) ||
+		nameInitially !== name ||
+		JSON.stringify( segmentInitially.is_disabled ) !== JSON.stringify( segmentConfig.is_disabled );
 
 	const unblock = hooks.usePrompt(
 		isDirty,
@@ -66,10 +70,11 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 						...foundSegment.configuration,
 					};
 					updateSegmentConfig( segmentConfigurationWithDefaults );
-					setSegmentInitially( JSON.stringify( foundSegment.criteria ) );
+					setSegmentInitially( segmentConfigurationWithDefaults );
 					setName( foundSegment.name );
 					setNameInitially( foundSegment.name );
 					setSegmentCriteria( [ ...foundSegment.criteria ] );
+					setSegmentCriteriaInitially( [ ...foundSegment.criteria ] );
 				}
 			} );
 		}

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -127,8 +127,8 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 				return (
 					<MinMaxSetting
 						data-testid={ `newspack-criteria-${ criteria.id }` }
-						min={ value?.min }
-						max={ value?.max }
+						min={ value?.min || '' }
+						max={ value?.max || '' }
 						onChangeMin={ min => update( { min } ) }
 						onChangeMax={ max => update( { max } ) }
 					/>
@@ -140,7 +140,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 						data-testid={ `newspack-criteria-${ criteria.id }` }
 						isWide
 						onChange={ update }
-						value={ value }
+						value={ value || '' }
 						options={ criteria.options }
 					/>
 				);
@@ -151,7 +151,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					isWide
 					placeholder={ criteria.placeholder }
 					help={ criteria.help }
-					value={ value }
+					value={ value || '' }
 					onChange={ update }
 				/>
 			);

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -102,7 +102,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	const getCriteriaValue = id => {
 		const item = segmentCriteria.find( c => c.criteria_id === id );
 		if ( ! item ) {
-			return null;
+			return '';
 		}
 		return item.value;
 	};
@@ -132,8 +132,8 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 				return (
 					<MinMaxSetting
 						data-testid={ `newspack-criteria-${ criteria.id }` }
-						min={ value?.min || '' }
-						max={ value?.max || '' }
+						min={ value?.min }
+						max={ value?.max }
 						onChangeMin={ min => update( { min } ) }
 						onChangeMax={ max => update( { max } ) }
 					/>
@@ -145,7 +145,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 						data-testid={ `newspack-criteria-${ criteria.id }` }
 						isWide
 						onChange={ update }
-						value={ value || '' }
+						value={ value }
 						options={ criteria.options }
 					/>
 				);
@@ -156,7 +156,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					isWide
 					placeholder={ criteria.placeholder }
 					help={ criteria.help }
-					value={ value || '' }
+					value={ value }
 					onChange={ update }
 				/>
 			);

--- a/assets/wizards/popups/views/segments/SingleSegment.test.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.test.js
@@ -65,7 +65,7 @@ describe( 'A new segment creation', () => {
 	};
 
 	beforeEach( () => {
-		window.newspack_popups_wizard_data.criteria = criteria;
+		window.newspack_popups_wizard_data = { criteria };
 		render(
 			<MemoryRouter>
 				<SingleSegment { ...mockProps } />
@@ -113,6 +113,9 @@ describe( 'A new segment creation', () => {
 			...SEGMENTS,
 			{
 				name: 'Big time readers that subscribed and came from Google or Twitter',
+				configuration: {
+					is_disabled: false,
+				},
 				criteria: [
 					{
 						criteria_id: 'articles_read',

--- a/includes/configuration_managers/class-newspack-popups-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-popups-configuration-manager.php
@@ -171,17 +171,6 @@ class Newspack_Popups_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
-	 * Get segment's potential reach.
-	 *
-	 * @param object $config Segment configuration.
-	 */
-	public function get_segment_reach( $config ) {
-		return $this->is_configured() ?
-			\Newspack_Popups_Segmentation::get_segment_reach( $config ) :
-			$this->unconfigured_error();
-	}
-
-	/**
 	 * Sort all segments.
 	 *
 	 * @param object $segment_ids Sorted array of segment IDs.

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -239,21 +239,6 @@ class Popups_Wizard extends Wizard {
 
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/segmentation-reach',
-			[
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'api_get_segment_reach' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'config' => [
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-				],
-			]
-		);
-
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/segmentation-sort',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
@@ -817,18 +802,6 @@ class Popups_Wizard extends Wizard {
 	public function api_delete_segment( $request ) {
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
 		$response                              = $newspack_popups_configuration_manager->delete_segment( $request['id'] );
-		return $response;
-	}
-
-	/**
-	 * Get a specific segment's potential reach.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function api_get_segment_reach( $request ) {
-		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
-		$response                              = $newspack_popups_configuration_manager->get_segment_reach( json_decode( $request['config'] ) );
 		return $response;
 	}
 

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -452,6 +452,11 @@ class Popups_Wizard extends Wizard {
 			$preview_archive = \Newspack_Popups::preview_archive_permalink();
 		}
 
+		$criteria = [];
+		if ( method_exists( 'Newspack_Popups_Criteria', 'get_registered_criteria' ) ) {
+			$criteria = \Newspack_Popups_Criteria::get_registered_criteria();
+		}
+
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
 		$custom_placements                     = $newspack_popups_configuration_manager->get_custom_placements();
 		$overlay_placements                    = $newspack_popups_configuration_manager->get_overlay_placements();
@@ -470,6 +475,7 @@ class Popups_Wizard extends Wizard {
 				'overlay_sizes'      => $overlay_sizes,
 				'preview_query_keys' => $preview_query_keys,
 				'experimental'       => Reader_Activation::is_enabled(),
+				'criteria'           => $criteria,
 			]
 		);
 
@@ -776,6 +782,7 @@ class Popups_Wizard extends Wizard {
 		$response                              = $newspack_popups_configuration_manager->create_segment(
 			[
 				'name'          => $request['name'],
+				'criteria'      => $request['criteria'],
 				'configuration' => $request['configuration'],
 			]
 		);
@@ -794,6 +801,7 @@ class Popups_Wizard extends Wizard {
 			[
 				'id'            => $request['id'],
 				'name'          => $request['name'],
+				'criteria'      => $request['criteria'],
 				'configuration' => $request['configuration'],
 			]
 		);

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -143,10 +143,6 @@ abstract class Wizard {
 			'is_atomic'           => defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID,
 		];
 
-		if ( class_exists( 'Newspack_Popups_Segmentation' ) ) {
-			$aux_data['popups_cookie_name'] = \Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME;
-		}
-
 		wp_localize_script( 'newspack_data', 'newspack_urls', $urls );
 		wp_localize_script( 'newspack_data', 'newspack_aux_data', $aux_data );
 		wp_enqueue_script( 'newspack_data' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1204189396255901-as-1204857763418497

Changes the Segments UI to use the new criteria system and updated schema.

### How to test the changes in this Pull Request:

Confirm updated tests are passing and have appropriate coverage.

1. Checkout this branch and https://github.com/Automattic/newspack-popups/tree/epic/rearchitecture
2. Create, edit and delete segments and confirm everything works as expected
3. Create a segment using all available criteria
4. Visit the "Segments" home and confirm the description renders correctly for every item
5. Visit the "Campaigns" home and confirm the same description also renders correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->