### PR TITLE
feat(reader-data): add newsletter subscription and donation

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -26,6 +26,7 @@ final class Reader_Data {
 
 		/* Update reader data items on event dispatches */
 		add_action( 'newspack_data_event_dispatch_newsletter_subscribed', [ __CLASS__, 'set_is_newsletter_subscriber' ], 10, 2 );
+		add_action( 'newspack_data_event_dispatch_newsletter_updated', [ __CLASS__, 'set_is_newsletter_subscriber' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_new', [ __CLASS__, 'set_is_donor' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_subscription_new', [ __CLASS__, 'set_is_donor' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_subscription_cancelled', [ __CLASS__, 'set_is_former_donor' ], 10, 2 );

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -23,6 +23,12 @@ final class Reader_Data {
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'config_script' ] );
+
+		/* Update reader data items on event dispatches */
+		add_action( 'newspack_data_event_dispatch_newsletter_subscribed', [ __CLASS__, 'set_is_newsletter_subscriber' ] );
+		add_action( 'newspack_data_event_dispatch_donation_new', [ __CLASS__, 'set_is_donor' ] );
+		add_action( 'newspack_data_event_dispatch_donation_subscription_new', [ __CLASS__, 'set_is_donor' ], 10, 2 );
+		add_action( 'newspack_data_event_dispatch_donation_subscription_cancelled', [ __CLASS__, 'set_is_former_donor' ], 10, 2 );
 	}
 
 	/**
@@ -149,6 +155,10 @@ final class Reader_Data {
 			$user_keys = [];
 		}
 
+		if ( ! is_string( $value ) ) {
+			$value = wp_json_encode( $value );
+		}
+
 		/**
 		 * Filter the maximum number of items per user.
 		 *
@@ -228,6 +238,35 @@ final class Reader_Data {
 		}
 		self::delete_item( \get_current_user_id(), $key );
 		return new \WP_REST_Response( [ 'success' => true ] );
+	}
+
+	/**
+	 * Set the user as a newsletter subscriber.
+	 */
+	public static function set_is_newsletter_subscriber() {
+		self::update_item( \get_current_user_id(), 'is_newsletter_subscriber', 'true' );
+	}
+
+	/**
+	 * Set the user as a donor.
+	 *
+	 * @param int   $timestamp Timestamp.
+	 * @param array $data      Data.
+	 */
+	public static function set_is_donor( $timestamp, $data ) {
+		self::update_item( $data['user_id'], 'is_donor', 'true' );
+		self::update_item( $data['user_id'], 'is_former_donor', 'false' );
+	}
+
+	/**
+	 * Set the user as a former donor.
+	 *
+	 * @param int   $timestamp Timestamp.
+	 * @param array $data      Data.
+	 */
+	public static function set_is_former_donor( $timestamp, $data ) {
+		self::update_item( $data['user_id'], 'is_donor', 'false' );
+		self::update_item( $data['user_id'], 'is_former_donor', 'true' );
 	}
 
 }

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -247,7 +247,7 @@ final class Reader_Data {
 	 * @param array $data      Data.
 	 */
 	public static function set_is_newsletter_subscriber( $timestamp, $data ) {
-		self::update_item( $data['user_id'] ?? \get_current_user_id(), 'is_newsletter_subscriber', 'true' );
+		self::update_item( $data['user_id'] ?? \get_current_user_id(), 'is_newsletter_subscriber', true );
 	}
 
 	/**
@@ -257,8 +257,8 @@ final class Reader_Data {
 	 * @param array $data      Data.
 	 */
 	public static function set_is_donor( $timestamp, $data ) {
-		self::update_item( $data['user_id'], 'is_donor', 'true' );
-		self::update_item( $data['user_id'], 'is_former_donor', 'false' );
+		self::update_item( $data['user_id'], 'is_donor', true );
+		self::update_item( $data['user_id'], 'is_former_donor', false );
 	}
 
 	/**
@@ -268,8 +268,8 @@ final class Reader_Data {
 	 * @param array $data      Data.
 	 */
 	public static function set_is_former_donor( $timestamp, $data ) {
-		self::update_item( $data['user_id'], 'is_donor', 'false' );
-		self::update_item( $data['user_id'], 'is_former_donor', 'true' );
+		self::update_item( $data['user_id'], 'is_donor', false );
+		self::update_item( $data['user_id'], 'is_former_donor', true );
 	}
 
 }

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -25,8 +25,8 @@ final class Reader_Data {
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'config_script' ] );
 
 		/* Update reader data items on event dispatches */
-		add_action( 'newspack_data_event_dispatch_newsletter_subscribed', [ __CLASS__, 'set_is_newsletter_subscriber' ] );
-		add_action( 'newspack_data_event_dispatch_donation_new', [ __CLASS__, 'set_is_donor' ] );
+		add_action( 'newspack_data_event_dispatch_newsletter_subscribed', [ __CLASS__, 'set_is_newsletter_subscriber' ], 10, 2 );
+		add_action( 'newspack_data_event_dispatch_donation_new', [ __CLASS__, 'set_is_donor' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_subscription_new', [ __CLASS__, 'set_is_donor' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_subscription_cancelled', [ __CLASS__, 'set_is_former_donor' ], 10, 2 );
 	}
@@ -242,9 +242,12 @@ final class Reader_Data {
 
 	/**
 	 * Set the user as a newsletter subscriber.
+	 *
+	 * @param int   $timestamp Timestamp.
+	 * @param array $data      Data.
 	 */
-	public static function set_is_newsletter_subscriber() {
-		self::update_item( \get_current_user_id(), 'is_newsletter_subscriber', 'true' );
+	public static function set_is_newsletter_subscriber( $timestamp, $data ) {
+		self::update_item( $data['user_id'] ?? \get_current_user_id(), 'is_newsletter_subscriber', 'true' );
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -36,7 +36,6 @@ final class Reader_Data {
 		add_action( 'newspack_data_event_dispatch_newsletter_subscribed', [ __CLASS__, 'set_is_newsletter_subscriber' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_newsletter_updated', [ __CLASS__, 'set_is_newsletter_subscriber' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_new', [ __CLASS__, 'set_is_donor' ], 10, 2 );
-		add_action( 'newspack_data_event_dispatch_donation_subscription_new', [ __CLASS__, 'set_is_donor' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_subscription_cancelled', [ __CLASS__, 'set_is_former_donor' ], 10, 2 );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements the following common reader data:
 - `is_newsletter_subscriber`
 - `is_donor`
 - `is_former_donor`

### How to test the changes in this Pull Request:

1. Check out this branch and subscribe to a newsletter in a fresh session (either through Newsletter Subscription Form block or Reader Registration block)
2. Confirm the next page render have the `is_newsletter_subscriber` store item set as true either by running `newspackReaderActivation.store.get('is_newsletter_subscriber')` on the frontend or checking the localStorage items in devtools
3. Do a one-time donation through the Donate block
4. Confirm the next page render has the `is_donor` set as true and `is_former_donor` set as false
5. Subscribe to a recurring donation
6. Cancel the subscription through "My Account" (it'll be set as pending and not canceled just yet)
7. Expedite the cancellation on the dashboard (WooCommerce -> Subscriptions -> Click Cancel Now on the order item)
8. Refresh the page on the reader session and confirm `is_donor` is false and `is_former_donor` is true

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->