### PR TITLE
fix: preserve newsletters lists order on reg block

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -142,7 +142,13 @@ function render_block( $attrs, $content ) {
 	if ( $attrs['newsletterSubscription'] && method_exists( 'Newspack_Newsletters_Subscription', 'get_lists_config' ) ) {
 		$list_config = \Newspack_Newsletters_Subscription::get_lists_config();
 		if ( ! \is_wp_error( $list_config ) ) {
-			$lists = array_intersect_key( $list_config, array_flip( $attrs['lists'] ) );
+			// get existing lists preserving the order.
+			$lists = [];
+			foreach ( $attrs['lists'] as $list_id ) {
+				if ( isset( $list_config[ $list_id ] ) ) {
+					$lists[ $list_id ] = $list_config[ $list_id ];
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Preserves the order of the Newsletters Lists in the Registration block

### How to test the changes in this Pull Request:

1. While on the `release` branch, select different Newsletters lists on a "Reader Registration block block
2. Make sure to select a list on the bottom first, and another at the top
3. Confirm that the bottom list is rendered first in the editor
4. Visit the page and confirm it's not reflected on the page
5. Check out this branch, refresh, and confirm it's rendering in the expected order.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->