### PR TITLE
feat(reader-data): set referrer

### DIFF
--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -237,6 +237,16 @@ function fixClientID() {
 }
 
 /**
+ * Store the referrer.
+ */
+function setReferrer() {
+	const referrer = document.referrer ? new URL( document.referrer ).hostname : '';
+	if ( referrer && referrer !== window.location.hostname ) {
+		store.set( 'referrer', referrer.replace( 'www.', '' ).trim().toLowerCase() );
+	}
+}
+
+/**
  * Initialize store data.
  */
 function init() {
@@ -253,6 +263,7 @@ function init() {
 	}
 	emit( EVENTS.reader, reader );
 	fixClientID();
+	setReferrer();
 }
 
 init();

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -229,5 +229,6 @@ final class Reader_Data {
 		self::delete_item( \get_current_user_id(), $key );
 		return new \WP_REST_Response( [ 'success' => true ] );
 	}
+
 }
 Reader_Data::init();

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -23,7 +23,8 @@ final class Reader_Data {
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'config_script' ] );
-		add_action( 'wp_head', [ __CLASS__, 'set_referrer' ] );
+
+		add_action( 'wp_footer', [ __CLASS__, 'set_referrer' ], 100 );
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -23,6 +23,7 @@ final class Reader_Data {
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'config_script' ] );
+		add_action( 'wp_head', [ __CLASS__, 'set_referrer' ] );
 	}
 
 	/**
@@ -230,5 +231,21 @@ final class Reader_Data {
 		return new \WP_REST_Response( [ 'success' => true ] );
 	}
 
+	/**
+	 * Set the referrer if it's not the same as the current domain.
+	 */
+	public static function set_referrer() {
+		?>
+		<script>
+			window.newspackRAS = window.newspackRAS || [];
+			window.newspackRAS.push( function( ras ) {
+				var referrer = document.referrer ? new URL( document.referrer ).hostname : '';
+				if ( referrer && referrer !== window.location.hostname ) {
+					ras.store.set( 'referrer', referrer.replace( 'www.', '' ).trim().toLowerCase() );
+				}
+			} );
+		</script>
+		<?php
+	}
 }
 Reader_Data::init();

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -23,8 +23,6 @@ final class Reader_Data {
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'config_script' ] );
-
-		add_action( 'wp_footer', [ __CLASS__, 'set_referrer' ], 100 );
 	}
 
 	/**
@@ -230,23 +228,6 @@ final class Reader_Data {
 		}
 		self::delete_item( \get_current_user_id(), $key );
 		return new \WP_REST_Response( [ 'success' => true ] );
-	}
-
-	/**
-	 * Set the referrer if it's not the same as the current domain.
-	 */
-	public static function set_referrer() {
-		?>
-		<script>
-			window.newspackRAS = window.newspackRAS || [];
-			window.newspackRAS.push( function( ras ) {
-				var referrer = document.referrer ? new URL( document.referrer ).hostname : '';
-				if ( referrer && referrer !== window.location.hostname ) {
-					ras.store.set( 'referrer', referrer.replace( 'www.', '' ).trim().toLowerCase() );
-				}
-			} );
-		</script>
-		<?php
 	}
 }
 Reader_Data::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Similar to #2520 and #2539, set the referrer store data item if coming from an external source.

### How to test the changes in this Pull Request:

1. Create a link to your instance from a different domain (use Google Drive, Gmail, or any code playground)
2. Click on the link to visit the site and confirm the referrer is stored (`newspackReaderActivation.store.get( 'referrer' )`)
3. Navigate on the site and confirm the referrer persists (not replaced by referring itself)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->