### PR TITLE
fix(auth): render otp when registering with existing account

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -384,7 +384,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 							readerActivation
 								.authenticateOTP( body.get( 'otp_code' ) )
 								.then( data => {
-									form.endLoginFlow( data.message, 200, data, body.get( 'redirect' ) );
+									form.endLoginFlow(
+										data.message,
+										200,
+										data,
+										currentHash ? '' : body.get( 'redirect' )
+									);
 								} )
 								.catch( data => {
 									if ( data.expired ) {
@@ -405,16 +410,20 @@ window.newspackRAS.push( function ( readerActivation ) {
 									res
 										.json()
 										.then( ( { message, data } ) => {
+											let redirect = body.get( 'redirect' );
+											/** Redirect every registration to the account page for verification if not coming from a hash link */
+											if ( action === 'register' ) {
+												redirect = newspack_ras_config.account_url;
+											}
+											// Never redirect from hash links.
+											if ( currentHash ) {
+												redirect = '';
+											}
 											const otpHash = readerActivation.getOTPHash();
 											if ( otpHash ) {
 												setFormAction( 'otp' );
-												form.endLoginFlow( message, 400, data );
+												form.endLoginFlow( message, 400, data, redirect );
 											} else {
-												let redirect = body.get( 'redirect' );
-												/** Redirect every registration to the account page for verification if not coming from a hash link */
-												if ( action === 'register' && ! currentHash ) {
-													redirect = newspack_ras_config.account_url;
-												}
 												form.endLoginFlow( message, res.status, data, redirect );
 											}
 										} )

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -420,12 +420,10 @@ window.newspackRAS.push( function ( readerActivation ) {
 												redirect = '';
 											}
 											const otpHash = readerActivation.getOTPHash();
-											if ( otpHash ) {
+											if ( otpHash && [ 'register', 'link' ].includes( action ) ) {
 												setFormAction( 'otp' );
-												form.endLoginFlow( message, 400, data, redirect );
-											} else {
-												form.endLoginFlow( message, res.status, data, redirect );
 											}
+											form.endLoginFlow( message, res.status, data, redirect );
 										} )
 										.catch( () => {
 											form.endLoginFlow();

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -401,26 +401,26 @@ window.newspackRAS.push( function ( readerActivation ) {
 								body,
 							} )
 								.then( res => {
-									const otpHash = readerActivation.getOTPHash();
-									if ( 'link' === action && otpHash ) {
-										form.endLoginFlow( null, 0 );
-										setFormAction( 'otp' );
-									} else {
-										container.setAttribute( 'data-form-status', res.status );
-										res
-											.json()
-											.then( ( { message, data } ) => {
+									container.setAttribute( 'data-form-status', res.status );
+									res
+										.json()
+										.then( ( { message, data } ) => {
+											const otpHash = readerActivation.getOTPHash();
+											if ( otpHash ) {
+												setFormAction( 'otp' );
+												form.endLoginFlow( message, 400, data );
+											} else {
 												let redirect = body.get( 'redirect' );
 												/** Redirect every registration to the account page for verification if not coming from a hash link */
 												if ( action === 'register' && ! currentHash ) {
 													redirect = newspack_ras_config.account_url;
 												}
 												form.endLoginFlow( message, res.status, data, redirect );
-											} )
-											.catch( () => {
-												form.endLoginFlow();
-											} );
-									}
+											}
+										} )
+										.catch( () => {
+											form.endLoginFlow();
+										} );
 								} )
 								.catch( () => {
 									form.endLoginFlow();

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1014,6 +1014,19 @@ final class Reader_Activation {
 						<div class="<?php echo \esc_attr( $class( 'header' ) ); ?>">
 							<h2><?php _e( 'Sign In', 'newspack' ); ?></h2>
 						</div>
+						<div class="<?php echo \esc_attr( $class( 'response' ) ); ?>">
+							<span class="<?php echo \esc_attr( $class( 'response', 'icon' ) ); ?>" data-form-status="400">
+								<?php echo self::get_error_icon(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+							</span>
+							<span class="<?php echo \esc_attr( $class( 'response', 'icon' ) ); ?>" data-form-status="200">
+								<?php echo self::get_check_icon(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+							</span>
+							<div class="<?php echo \esc_attr( $class( 'response', 'content' ) ); ?>">
+								<?php if ( ! empty( $message ) ) : ?>
+									<p><?php echo \esc_html( $message ); ?></p>
+								<?php endif; ?>
+							</div>
+						</div>
 						<p data-has-auth-link>
 							<?php _e( "We've recently sent you an authentication link. Please, check your inbox!", 'newspack' ); ?>
 						</p>
@@ -1076,19 +1089,6 @@ final class Reader_Activation {
 						</div>
 						<div class="components-form__field" data-action="pwd">
 							<input name="password" type="password" placeholder="<?php \esc_attr_e( 'Enter your password', 'newspack' ); ?>" />
-						</div>
-						<div class="<?php echo \esc_attr( $class( 'response' ) ); ?>">
-							<span class="<?php echo \esc_attr( $class( 'response', 'icon' ) ); ?>" data-form-status="400">
-								<?php echo self::get_error_icon(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-							</span>
-							<span class="<?php echo \esc_attr( $class( 'response', 'icon' ) ); ?>" data-form-status="200">
-								<?php echo self::get_check_icon(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-							</span>
-							<div class="<?php echo \esc_attr( $class( 'response', 'content' ) ); ?>">
-								<?php if ( ! empty( $message ) ) : ?>
-									<p><?php echo \esc_html( $message ); ?></p>
-								<?php endif; ?>
-							</div>
 						</div>
 						<div class="<?php echo \esc_attr( $class( 'actions' ) ); ?>" data-action="pwd">
 							<div class="components-form__submit">
@@ -1407,7 +1407,7 @@ final class Reader_Activation {
 				}
 				$user_id = self::register_reader( $email, '', true, $metadata );
 				if ( false === $user_id ) {
-					return self::send_auth_form_response( $payload, __( 'An account was already registered with this email. Please check your inbox for an authentication link.', 'newspack' ), $redirect );
+					return self::send_auth_form_response( $payload, __( 'An account was already registered with this email.', 'newspack' ), $redirect );
 				}
 				if ( \is_wp_error( $user_id ) ) {
 					return self::send_auth_form_response(

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1407,7 +1407,9 @@ final class Reader_Activation {
 				}
 				$user_id = self::register_reader( $email, '', true, $metadata );
 				if ( false === $user_id ) {
-					return self::send_auth_form_response( $payload, __( 'An account was already registered with this email.', 'newspack' ), $redirect );
+					return self::send_auth_form_response(
+						new \WP_Error( 'unauthorized', __( 'An account was already registered with this email.', 'newspack' ) )
+					);
 				}
 				if ( \is_wp_error( $user_id ) ) {
 					return self::send_auth_form_response(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Improves the authentication flow when a reader attempts to register with an existing account. It's currently not working as expected but could also be improved to allow the OTP code to be entered directly.

| Current | Expected | Proposed |
| --- | --- | --- |
| <img width="565" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/e139e56e-90c3-4c7f-9a2d-55c0b159da59"> | <img width="564" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/a1a27279-b4ea-4df1-bc4e-71769afdbd21"> | <img width="578" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/eacf3f64-95a3-4d85-bce2-e7a244d39b98"> |

### How to test the changes in this Pull Request:

1. While on the master branch make sure you have RAS enabled and register a new reader account
2. Start a fresh session in click on the "Sign In" button
3. Click on "I don't have an account" and enter the existing reader email
4. Confirm you get a ✅ without any message
5. Check out this branch, restart the fresh session (to clear the OTP cookie), and go through steps 2-3
6. Confirm you get a warning message and the OTP input
7. Enter the received OTP code and confirm you are authenticated

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->