### PR TITLE
fix(pwa): improve "server offline" message

### DIFF
--- a/includes/class-pwa.php
+++ b/includes/class-pwa.php
@@ -24,6 +24,7 @@ class PWA {
 		add_filter( 'pre_option_offline_browsing', '__return_true' );
 
 		add_filter( 'wp_service_worker_navigation_caching', [ __CLASS__, 'increase_network_timeout' ] );
+		add_filter( 'wp_service_worker_error_messages', [ __CLASS__, 'error_messages' ] );
 	}
 
 	/**
@@ -74,7 +75,7 @@ class PWA {
 	}
 
 	/**
-	 * By default, PWA serves the offline-cached page if a request takes longer than 2 seconds. 
+	 * By default, PWA serves the offline-cached page if a request takes longer than 2 seconds.
 	 * This is too short, especially for homepages with a lot of posts blocks.
 	 * 44 seconds is right before the 45-second PHP process timeout.
 	 *
@@ -84,6 +85,20 @@ class PWA {
 	public static function increase_network_timeout( $config ) {
 		$config['network_timeout_seconds'] = 44;
 		return $config;
+	}
+
+	/**
+	 * Modify error messages.
+	 *
+	 * @param array $messages Error messages.
+	 *
+	 * @return array Modified error messages.
+	 */
+	public static function error_messages( $messages ) {
+		if ( ! empty( $messages['serverOffline'] ) ) {
+			$messages['serverOffline'] = __( 'There has been a problem connecting with the server. Please check your internet connection or try again later.', 'newspack' );
+		}
+		return $messages;
 	}
 }
 PWA::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Tweaks the "offline server" message from PWA to be more vague. Failing to fetch the server shouldn't immediately suggest that the server is down.

Before: The server appears to be down, or your connection isn't working as expected. Please try again later.
After: There has been a problem connecting with the server. Please check your internet connection or try again later.

### How to test the changes in this Pull Request:

1. Check out this branch and visit your website (make sure the PWA plugin is enabled)
2. Make your website offline (via /etc/hosts or shutting down nginx/apache)
3. Refresh and confirm it shows: "There has been a problem connecting with the server. Please check your internet connection or try again later."

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->