### PR TITLE
fix(content-gate): use custom filter for gate content

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -43,6 +43,17 @@ class Memberships {
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 
+		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
+		add_filter( 'newspack_gate_content', 'do_blocks', 9 );
+		add_filter( 'newspack_gate_content', 'wptexturize' );
+		add_filter( 'newspack_gate_content', 'convert_smilies', 20 );
+		add_filter( 'newspack_gate_content', 'wpautop' );
+		add_filter( 'newspack_gate_content', 'shortcode_unautop' );
+		add_filter( 'newspack_gate_content', 'prepend_attachment' );
+		add_filter( 'newspack_gate_content', 'wp_filter_content_tags' );
+		add_filter( 'newspack_gate_content', 'wp_replace_insecure_home_url' );
+		add_filter( 'newspack_gate_content', 'do_shortcode', 11 );
+
 		include __DIR__ . '/class-block-patterns.php';
 		include __DIR__ . '/class-metering.php';
 	}
@@ -316,7 +327,7 @@ class Memberships {
 		if ( 'inline' !== $style ) {
 			return '';
 		}
-		$gate = \apply_filters( 'the_content', \get_the_content( null, null, $gate_post_id ) );
+		$gate = \apply_filters( 'newspack_gate_content', \get_the_content( null, null, $gate_post_id ), $gate_post_id );
 
 		// Add clearfix to the gate.
 		$gate = '<div style=\'content:"";clear:both;display:table;\'></div>' . $gate;
@@ -430,7 +441,7 @@ class Memberships {
 		<div class="newspack-memberships__gate newspack-memberships__overlay-gate" style="display:none;" data-position="<?php echo \esc_attr( $position ); ?>" data-size="<?php echo \esc_attr( $size ); ?>">
 			<div class="newspack-memberships__overlay-gate__container">
 				<div class="newspack-memberships__overlay-gate__content">
-					<?php echo \apply_filters( 'the_content', \get_the_content( null, null, $gate_post_id ) );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<?php echo \apply_filters( 'newspack_gate_content', \get_the_content( null, null, $gate_post_id ) );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using `the_content` to parse the gate contents it may pick up additional markup meant to be rendered in the article. This implements a new `newspack_gate_content` filter, which allows better control of [which filters](https://github.com/WordPress/WordPress/blob/fe75c1b12f94fdb1deb37dd6ba1f29f639357a35/wp-includes/default-filters.php#L192-L199) should be applied.

### How to test the changes in this Pull Request:

1. Make sure you have WC Memberships with content gate
2. Add all block patterns from the category "Memberships" to the content gate to test their rendering
3. Visit a gated article and confirm all blocks render as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->