### PR TITLE
fix: tweak content gate styles for mobile

### DIFF
--- a/assets/memberships-gate/block-patterns.scss
+++ b/assets/memberships-gate/block-patterns.scss
@@ -90,4 +90,13 @@
 			padding-right: 1em;
 		}
 	}
+
+	/**
+	 * Columns block tweaks.
+	 */
+	 @media only screen and ( max-width: 781px ) {
+		.wp-block-column:empty {
+			display: none;
+		}
+	}
 }

--- a/includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier-metering.php
+++ b/includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier-metering.php
@@ -10,17 +10,17 @@
 <hr class="wp-block-separator has-alpha-channel-opacity is-style-dots"/>
 <!-- /wp:separator -->
 
-<!-- wp:group { "style":{ "spacing":{"padding":{"top":"var:preset|spacing|70","right":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|70"}} },"className":"is-style-border newspack-content-gate","layout":{"type":"constrained"} } -->
+<!-- wp:group { "style":{ "spacing":{ "padding":{ "top":"var:preset|spacing|70","right":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|70" } } },"className":"is-style-border newspack-content-gate","layout":{ "type":"constrained" } } -->
 <div class="wp-block-group is-style-border newspack-content-gate" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)">
 
-	<!-- wp:paragraph {"align":"center","textColor":"secondary","fontSize":"normal"} -->
-	<p class="has-text-align-center has-secondary-color has-text-color has-normal-font-size">
+	<!-- wp:paragraph {"align":"center","fontSize":"normal"} -->
+	<p class="has-text-align-center has-normal-font-size">
 		<?php esc_html_e( "You've read all free articles for the week.", 'newspack' ); ?>
 	</p>
 	<!-- /wp:paragraph -->
 
-	<!-- wp:columns {"backgroundColor":"light-gray","className":"is-style-borders"} -->
-	<div class="wp-block-columns is-style-borders has-light-gray-background-color has-background">
+	<!-- wp:columns { "style":{ "spacing":{ "padding":{ "top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60" } } },"backgroundColor":"light-gray","className":"is-style-borders" } -->
+	<div class="wp-block-columns is-style-borders has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
@@ -28,6 +28,7 @@
 				<?php echo wp_kses( __( 'Register now and get<br><strong>3 free articles every week.</strong>', 'newspack' ), 'post' ); ?>
 			</p>
 			<!-- /wp:paragraph -->
+
 			<!-- wp:buttons -->
 			<div class="wp-block-buttons">
 				<!-- wp:button {"backgroundColor":"secondary-variation","width":100} -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR, along with https://github.com/Automattic/newspack-theme/pull/2157, aim to improve how the content gate patterns look on mobile. The specific changes I made for this were:

* Hiding empty columns in the gate on smaller screen sizes -- this reduces some vertical spacing.
* Applying padding to a columns block instead of letting it fallback to the default padding that's added when the block has a background -- the latter doesn't change for smaller screen sizes, but thanks to https://github.com/Automattic/newspack-theme/pull/2157, the former will.

I also removed the secondary colour from a paragraph in the Paywall One Tier Metering pattern -- there isn't a way to make sure the contrast is sufficient for this colour in all cases, so it seems safer to leave it out. 

Lastly, I had to add some spacing to the block comments to get past one of the VIP checks. 

See 1200550061930446-as-1204946804697768

### How to test the changes in this Pull Request:

1. Apply this PR and https://github.com/Automattic/newspack-theme/pull/2157, and run `npm run build` for both the plugin and theme (the theme PR isn't necessary, but having it will help see what the two pieces look like together, and will remove distracting padding). 
2. Set up a content gate.
3. Cycle through each of the content gating patterns under "Memberships", and confirm that they don't look too crowded on mobile, and that there aren't any errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->