### PR TITLE
Feat: add an image size control for the RSS images

### DIFF
--- a/includes/class-rss-add-image.php
+++ b/includes/class-rss-add-image.php
@@ -11,12 +11,156 @@ namespace Newspack;
  * RSS_Add_Image class.
  */
 class RSS_Add_Image {
+
+	/**
+	 * Option key for the RSS image width setting.
+	 *
+	 * @var string
+	 */
+	const OPTION_RSS_IMAGE_WIDTH = 'newspack_rss_image_size_width';
+
+	/**
+	 * Option key for the RSS image height setting.
+	 *
+	 * @var string
+	 */
+	const OPTION_RSS_IMAGE_HEIGHT = 'newspack_rss_image_size_height';
+
 	/**
 	 * Hook actions and filters.
 	 */
 	public static function init() {
+		add_action( 'admin_init', [ __CLASS__, 'add_rss_image_size_section' ] );
+		add_action( 'after_setup_theme', [ __CLASS__, 'rss_image_size' ] );
 		add_filter( 'the_excerpt_rss', [ __CLASS__, 'thumbnails_in_rss' ] );
 		add_filter( 'the_content_feed', [ __CLASS__, 'thumbnails_in_rss' ] );
+	}
+
+	/**
+	 * Add RSS image size.
+	 */
+	public static function rss_image_size() {
+		add_image_size( 'rss-image-size', self::get_rss_image_width(), self::get_rss_image_height() );
+	}
+
+	/**
+	 * Register the settings.
+	 */
+	public static function add_rss_image_size_section() {
+		add_settings_section(
+			'rss_image_sizes',
+			esc_html__( 'RSS Image Sizes', 'newspack' ),
+			[ __CLASS__, 'add_image_size_fields' ],
+			'media'
+		);
+
+		register_setting(
+			'rss_image_sizes',
+			self::OPTION_RSS_IMAGE_WIDTH,
+			[ __CLASS__, 'sanitize_rss_image_size_value' ]
+		);
+
+		register_setting(
+			'rss_image_sizes',
+			self::OPTION_RSS_IMAGE_HEIGHT,
+			[ __CLASS__, 'sanitize_rss_image_size_value' ]
+		);
+
+		add_settings_field(
+			self::OPTION_RSS_IMAGE_WIDTH,
+			__( 'RSS Image size', 'newspack' ),
+			[ __CLASS__, 'render_rss_image_width' ],
+			'media',
+			'rss_image_sizes'
+		);
+
+		add_settings_field(
+			self::OPTION_RSS_IMAGE_HEIGHT,
+			__( '', 'newspack' ),
+			[ __CLASS__, 'render_rss_image_height' ],
+			'media',
+			'rss_image_sizes'
+		);
+	}
+
+	/**
+	 * Get the image width setting.
+	 *
+	 * @return int The image width.
+	 */
+	public static function get_rss_image_width() {
+		$rss_image_width = get_option( self::OPTION_RSS_IMAGE_WIDTH, '1024' );
+		if ( empty( $rss_image_width ) ) {
+			return '';
+		}
+
+		return absint( $rss_image_width );
+	}
+
+	/**
+	 * Get the image height setting.
+	 *
+	 * @return int The image height.
+	 */
+	public static function get_rss_image_height() {
+		$rss_image_height = get_option( self::OPTION_RSS_IMAGE_HEIGHT, '1024' );
+		if ( empty( $rss_image_height ) ) {
+			return '';
+		}
+
+		return absint( $rss_image_height );
+	}
+
+	/**
+	 * Render the width control.
+	 */
+	public static function render_rss_image_width() {
+		$saved_width = self::get_rss_image_width();
+		?>
+		<fieldset>
+			<label for="<?php echo esc_attr( self::OPTION_RSS_IMAGE_WIDTH ); ?>">
+				<?php esc_html_e( 'Max Width', 'newspack' ); ?>
+			</label>
+			<input name="<?php echo esc_attr( self::OPTION_RSS_IMAGE_WIDTH ); ?>" type="number" step="1" min="0" id="<?php echo esc_attr( self::OPTION_RSS_IMAGE_WIDTH ); ?>" value="<?php echo esc_attr( $saved_width ); ?>" class="small-text" />
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Render the height control.
+	 */
+	public static function render_rss_image_height() {
+		$saved_height = self::get_rss_image_height();
+		?>
+		<fieldset>
+			<label for="<?php echo esc_attr( self::OPTION_RSS_IMAGE_HEIGHT ); ?>">
+				<?php esc_html_e( 'Max Height', 'newspack' ); ?>
+			</label>
+			<input name="<?php echo esc_attr( self::OPTION_RSS_IMAGE_HEIGHT ); ?>" type="number" step="1" min="0" id="<?php echo esc_attr( self::OPTION_RSS_IMAGE_HEIGHT ); ?>" value="<?php echo esc_attr( $saved_height ); ?>" class="small-text" />
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Render the size fields on the media settings page.
+	 */
+	public static function add_image_size_fields() {
+		settings_fields( 'rss_image_sizes' );
+		do_settings_sections( 'newspack-rss-image-settings' );
+	}
+
+	/**
+	 * Sanitize the size values.
+	 *
+	 * @param int $input Raw input from the setting field.
+	 * @return int Sanitized input.
+	 */
+	public function sanitize_rss_image_size_value( $input ) {
+		if ( empty( $input ) ) {
+			return '';
+		}
+
+		return absint( $input );
 	}
 
 	/**
@@ -27,7 +171,7 @@ class RSS_Add_Image {
 	public static function thumbnails_in_rss( $content ) {
 		global $post;
 		if ( has_post_thumbnail( $post->ID ) ) {
-			$content = '<figure>' . get_the_post_thumbnail( $post->ID, 'large' ) . '</figure>' . $content;
+			$content = '<figure>' . get_the_post_thumbnail( $post->ID, 'rss-image-size' ) . '</figure>' . $content;
 		}
 		return $content;
 	}

--- a/includes/class-rss-add-image.php
+++ b/includes/class-rss-add-image.php
@@ -76,7 +76,7 @@ class RSS_Add_Image {
 
 		add_settings_field(
 			self::OPTION_RSS_IMAGE_HEIGHT,
-			__( '', 'newspack' ),
+			'', // Empty to avoid a duplicate label.
 			[ __CLASS__, 'render_rss_image_height' ],
 			'media',
 			'rss_image_sizes'

--- a/includes/class-rss-add-image.php
+++ b/includes/class-rss-add-image.php
@@ -117,7 +117,7 @@ class RSS_Add_Image {
 	public static function render_rss_image_width() {
 		$saved_width = self::get_rss_image_width();
 		?>
-		<fieldset>
+		<fieldset style="margin-bottom: -40px;">
 			<label for="<?php echo esc_attr( self::OPTION_RSS_IMAGE_WIDTH ); ?>">
 				<?php esc_html_e( 'Max Width', 'newspack' ); ?>
 			</label>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We recently switched the RSS feed to use the large image rather than the medium image size. Unfortunately, this has caused email layout issues on sites using Active Campaign -- the email layouts look bad, and there isn't an option in Active Campaign itself to scale the image down. As a compromise between the two, this PR adds an RSS image size control to the Media Settings page. It still defaults to the standard WordPress large size (1024), but can be changed from there.

Note: this will be a breaking change for any publications with non-standard large image sizes; we may at least want to make a more noticeable announcement when this goes out.

See: 1200550061930446-as-1204959665169392

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Create and publish a new post with a featured image that's newly uploaded to your Media Library (alternatively, you can regenerate your site's thumbnails, but new images can be nice for comparing). 
3. View your RSS feed to confirm your new post's image uses maximum image width and height of 1024 -- for vertical images, this means the maximum width is 1024, and the height will reflect the image's aspect ratio. You can test this by subscribing to the RSS feed in an RSS reader, or you can _kind of_ see it in action by visiting [yourtestsite.com]/feed in Chrome and looking at the image size in the code. 
4. Next we'll change the image settings -- navigate to Settings > Media Settings.
5. Confirm you have an option to set an RSS Image size at the bottom, and that it's set to a maximum width of 1024, and a maximum height of 1024.
6. Change the height or width values, or both. I recommend changing to a smaller size since that matches our actual use case, being able to make these images smaller for Active Campaign.
7. Repeat step two (creating a new post with a newly uploaded image).
8. Revisit your feed in an RSS reader, and confirm that the new post is using your new maximum height or width. 

Note: the fields for the RSS Image aren't 1:1 with the fields for the other images -- I used the standard `do_settings_sections` output, which doesn't group them the same way, and places them in separate table cells with are spaced pretty far apart. I "worked around" this with some inline styles because it seemed like the most straight-forward approach, but I'm definitely open to other suggestions!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->