### PR TITLE
fix(perfmatters): add TEC CSS to excluded stylesheets

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -87,6 +87,8 @@ class Perfmatters {
 			'plugins/jetpack/modules/sharedaddy', // Jetpack's share buttons.
 			'plugins/jetpack/_inc/social-logos', // Jetpack's social logos CSS.
 			'plugins/jetpack/css/jetpack.css', // Jetpack's main CSS.
+			'plugins/the-events-calendar', // The Events Calendar.
+			'plugins/events-calendar-pro', // The Events Calendar Pro.
 			'/themes/newspack-', // Any Newspack theme stylesheet.
 			'cache/perfmatters', //	Perfmatters' cache.
 			'wp-includes',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds The Event Calendar and The Event Calendar Pro plugins to the list of excluded stylesheets in default Perfmatters settings. Otherwise, the search, filter, and subscribe UIs are not visible on the calendar page.

Closes `1200550061930446/1205011966811759`.

### How to test the changes in this Pull Request:

1. Install `the-events-calendar` and view your calendar page.
2. On `master` or `release`, observe that parts of the UI are missing:

<img width="1239" alt="Screen Shot 2023-07-11 at 5 46 33 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/a27060d5-70d2-461e-9f36-6d0392e28c10">

3. Check out this branch. You may have to go to Settings > Perfmatters > Assets and click the "Clear Used CSS" at this point, too.
4. Refresh the calendar page and confirm that the full UI is visible:

<img width="1173" alt="Screen Shot 2023-07-11 at 5 59 36 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/8029ef45-abfd-440a-ad78-b35b7245fb8f">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->