### PR TITLE
fix(reader-data): format of activity push array

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -321,9 +321,6 @@ final class Reader_Data {
 		 * @param array $reader_activity Reader activity.
 		 */
 		self::$reader_activity = apply_filters( 'newspack_reader_activity', self::$reader_activity );
-		foreach ( self::$reader_activity as $i => $activity ) {
-			self::$reader_activity[ $i ] = array_values( $activity );
-		}
 	}
 }
 Reader_Data::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

At some point during revisions of #2520 the strategy to push activities in the front-end changed from `newspackRAS.push( [ action, data ] );` to `ras.dispatchActivity( { action, data } );` but the activity setup didn't account for that change.

This PR changes the setup to create an array of objects with `action` and `data` properties instead of an array with the values.

### How to test the changes in this Pull Request:

Same instructions as in #2520 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->