### PR TITLE
fix: ensure generated id always have given length

### DIFF
--- a/assets/reader-activation/utils.js
+++ b/assets/reader-activation/utils.js
@@ -37,5 +37,11 @@ export function setCookie( name, value, expirationDays = 365 ) {
  * @return {string} Random ID.
  */
 export function generateID( length = 9 ) {
-	return Math.random().toString( 36 ).substr( 2, length );
+	let randomString = '';
+	const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+	for ( let i = 0; i < length; i++ ) {
+		const randomIndex = Math.floor( Math.random() * chars.length );
+		randomString += chars.charAt( randomIndex );
+	}
+	return randomString;
 }

--- a/assets/reader-activation/utils.test.js
+++ b/assets/reader-activation/utils.test.js
@@ -9,4 +9,14 @@ describe( 'generateID', () => {
 		const id = generateID( 10 );
 		expect( id ).toHaveLength( 10 );
 	} );
+	it( 'should always generate a random ID of the given length', () => {
+		let failedIds = 0;
+		for ( let i = 0; i < 1000; i++ ) {
+			const id = generateID( 10 );
+			if ( id.length !== 10 ) {
+				failedIds++;
+			}
+		}
+		expect( failedIds ).toEqual( 0 );
+	} );
 } );

--- a/assets/reader-activation/utils.test.js
+++ b/assets/reader-activation/utils.test.js
@@ -19,4 +19,11 @@ describe( 'generateID', () => {
 		}
 		expect( failedIds ).toEqual( 0 );
 	} );
+	it( 'should be unique among 10000 generated IDs', () => {
+		const ids = [];
+		for ( let i = 0; i < 10000; i++ ) {
+			ids[ generateID() ] = true;
+		}
+		expect( Object.keys( ids ) ).toHaveLength( 10000 );
+	} );
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Using the `Math.random()` strategy there's a small chance the result does not have enough length to fetch using substring.

This PR changes the ID generation strategy to ensure its length.

### How to test the changes in this Pull Request:

1. Confirm 82b7d4f21287b091466a9d467356bdf4dfd8b45d, which introduces a new test, fails
2. Confirm the test passes with 14571aa19326c2c15c59bd01eb6f867280b2178f
3. Confirm the entropy test introduced by 3b9bb585014a499214ad567894eff430763d26f2 also passes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->