### PR TITLE
fix(recaptcha): prevent token timeout on WC

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -322,6 +322,17 @@ final class Recaptcha {
 		<script src="<?php echo \esc_url( self::get_script_url() ); ?>"></script>
 		<script>
 			grecaptcha.ready( function() {
+				setInterval( function() {
+					grecaptcha.execute(
+						'<?php echo \esc_attr( $site_key ); ?>',
+						{ action: 'checkout' }
+					).then( function( token ) {
+						var field = document.querySelector('input[name="g-recaptcha-response"]');
+						if ( field ) {
+							field.value = token;
+						}
+					} );
+				}, 30000 );
 				grecaptcha.execute(
 					'<?php echo \esc_attr( $site_key ); ?>',
 					{ action: 'checkout' }

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -322,12 +322,12 @@ final class Recaptcha {
 		<script src="<?php echo \esc_url( self::get_script_url() ); ?>"></script>
 		<script>
 			grecaptcha.ready( function() {
+				var field;
 				setInterval( function() {
 					grecaptcha.execute(
 						'<?php echo \esc_attr( $site_key ); ?>',
 						{ action: 'checkout' }
 					).then( function( token ) {
-						var field = document.querySelector('input[name="g-recaptcha-response"]');
 						if ( field ) {
 							field.value = token;
 						}
@@ -337,7 +337,7 @@ final class Recaptcha {
 					'<?php echo \esc_attr( $site_key ); ?>',
 					{ action: 'checkout' }
 				).then( function( token ) {
-					var field   = document.createElement('input');
+					field       = document.createElement('input');
 					field.type  = 'hidden';
 					field.name  = 'g-recaptcha-response';
 					field.value = token;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Regenerates the reCAPTCHA token every 30 seconds to make sure it's valid when an order is placed.

### How to test the changes in this Pull Request:

1. While on `release`,  go through the donate block flow and wait a little bit over 2 minutes before clicking "Place order"
2. Confirm you get captcha error
3. Check out this branch, repeat step 1, and confirm the order is placed without errors

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->