### PR TITLE
feat: Remove GA Fivetran connection

### DIFF
--- a/assets/wizards/connections/views/main/fivetran.js
+++ b/assets/wizards/connections/views/main/fivetran.js
@@ -19,10 +19,6 @@ import { get } from 'lodash';
 
 const CONNECTORS = [
 	{
-		service: 'google_analytics',
-		label: __( 'Google Analytics', 'newspack' ),
-	},
-	{
 		service: 'mailchimp',
 		label: __( 'Mailchimp', 'newspack' ),
 	},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Since GA3 is gone, we are removing the Fivetran connection for it

### How to test the changes in this Pull Request:

1. Go to Newspack Connections
2. Make sure there's no longer an item to connect Google Analytics


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->