### PR TITLE
fix: ensure not null in currency string

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -146,6 +146,8 @@ class Donations {
 
 	/**
 	 * Get the donation currency symbol.
+	 *
+	 * @return string Currency symbol.
 	 */
 	private static function get_currency_symbol() {
 		switch ( self::get_platform_slug() ) {
@@ -157,9 +159,8 @@ class Donations {
 			case 'stripe':
 				$currency = Stripe_Connection::get_stripe_data()['currency'];
 				return newspack_get_currency_symbol( $currency );
-			default:
-				return '$';
 		}
+		return '$';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Very minor fix :-D 
I didn't have the Woo plugin on my local install and I was getting a `Deprecated: html_entity_decode(): Passing null to parameter #1 ($string) of type string is deprecated in newspack-plugin/includes/class-donations.php on line 291`.

The switch didn't correctly handle cases where Woo is not installed and would install null in that case. This PR fixes that.

### How to test the changes in this Pull Request:

1. On a site with no Woo installed, go to `wp-admin/admin.php?page=newspack` and `WP_DEBUG_DISPLAY` set to true you should not see the deprecation notice (and you should without this patch).
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->