### PR TITLE
fix(auth): restore sign-in otp ui

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -424,7 +424,13 @@ window.newspackRAS.push( function ( readerActivation ) {
 											if ( otpHash && [ 'register', 'link' ].includes( action ) ) {
 												setFormAction( 'otp' );
 											}
-											form.endLoginFlow( message, res.status, data, redirect );
+											let status = res.status;
+											/** If action is link, suppress message and status so the OTP handles it. */
+											if ( action === 'link' ) {
+												status = null;
+												message = null;
+											}
+											form.endLoginFlow( message, status, data, redirect );
 										} )
 										.catch( () => {
 											form.endLoginFlow();

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -411,6 +411,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 									res
 										.json()
 										.then( ( { message, data } ) => {
+											let status = res.status;
 											let redirect = body.get( 'redirect' );
 											/** Redirect every registration to the account page for verification if not coming from a hash link */
 											if ( action === 'register' ) {
@@ -423,12 +424,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 											const otpHash = readerActivation.getOTPHash();
 											if ( otpHash && [ 'register', 'link' ].includes( action ) ) {
 												setFormAction( 'otp' );
-											}
-											let status = res.status;
-											/** If action is link, suppress message and status so the OTP handles it. */
-											if ( status === 200 && action === 'link' ) {
-												status = null;
-												message = null;
+												/** If action is link, suppress message and status so the OTP handles it. */
+												if ( status === 200 && action === 'link' ) {
+													status = null;
+													message = null;
+												}
 											}
 											form.endLoginFlow( message, status, data, redirect );
 										} )

--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -426,7 +426,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 											}
 											let status = res.status;
 											/** If action is link, suppress message and status so the OTP handles it. */
-											if ( action === 'link' ) {
+											if ( status === 200 && action === 'link' ) {
 												status = null;
 												message = null;
 											}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a regression introduced by #2542.

The OTP UI is no longer rendering when attempting to sign in. This is because the form handler interprets the status `200` as a form resolution and clears the UI.

### How to test the changes in this Pull Request:

1. While on the `release` branch, click to Sign In using email and confirm the form shows empty on submit
2. Check out this branch, Sign In and confirm OTP renders and works as expected
3. Start the auth flow again, click "I don't have an account", enter an existing reader email and confirm the OTP input also renders

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->