### PR TITLE
feat(auth): listen cookie changes for store state

### DIFF
--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -279,6 +279,24 @@ function setReferrer() {
 }
 
 /**
+ * Listen to cookie changes to detect authentication.
+ */
+function listenAuthCookie() {
+	// If the reader is already authenticated, bail.
+	if ( getCookie( 'np_auth_reader' ) ) {
+		return;
+	}
+	const interval = setInterval( () => {
+		const authCookie = getCookie( 'np_auth_reader' );
+		if ( authCookie ) {
+			setReaderEmail( authCookie );
+			setAuthenticated( true );
+			clearInterval( interval );
+		}
+	}, 1000 );
+}
+
+/**
  * Initialize store data.
  */
 function init() {
@@ -295,6 +313,7 @@ function init() {
 	}
 	emit( EVENTS.reader, reader );
 	fixClientID();
+	listenAuthCookie();
 	pushActivities();
 	setReferrer();
 }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -72,6 +72,7 @@ final class Reader_Activation {
 			\add_action( 'clear_auth_cookie', [ __CLASS__, 'clear_auth_reader_cookie' ] );
 			\add_action( 'set_auth_cookie', [ __CLASS__, 'clear_auth_intention_cookie' ] );
 			\add_filter( 'login_form_defaults', [ __CLASS__, 'add_auth_intention_to_login_form' ], 20 );
+			\add_action( 'wp_login', [ __CLASS__, 'login_set_reader_cookie' ], 10, 2 );
 			\add_action( 'resetpass_form', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'password_reset', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'password_reset', [ __CLASS__, 'set_reader_has_password' ] );
@@ -578,6 +579,18 @@ final class Reader_Activation {
 
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
 		setcookie( self::AUTH_READER_COOKIE, $user->user_email, time() + HOUR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, true );
+	}
+
+	/**
+	 * Set the reader cookie on wp login.
+	 *
+	 * @param string   $user_login User login.
+	 * @param \WP_User $user       User object.
+	 */
+	public static function login_set_reader_cookie( $user_login, $user ) {
+		if ( self::is_user_reader( $user ) ) {
+			self::set_auth_reader_cookie( $user );
+		}
 	}
 
 	/**
@@ -1468,7 +1481,6 @@ final class Reader_Activation {
 		\wp_clear_auth_cookie();
 		\wp_set_current_user( $user->ID );
 		\wp_set_auth_cookie( $user->ID, true );
-		self::set_auth_reader_cookie( $user );
 		\do_action( 'wp_login', $user->user_login, $user );
 		Logger::log( 'Logged in user ' . $user->ID );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1205103340481499

Implements a more generic approach for updating the reader state in the store. It should now listen for changes in the `np_auth_reader` cookie to set the authenticated state. This allows for XHR/Fetch requests that populate the cookie to automatically update the state of the "Sign In/My Account" button without having any extra JS handling.

The method that populates this cookie was also moved to the `wp_login` action, so if a reader account is created through WooCommerce checkout or other flows that may trigger `wp_login`, it'll also trigger the cookie change for the UI update.

### How to test the changes in this Pull Request:

1. Checkout this branch and make sure you have RAS setup
2. On a fresh session subscribe using the Newsletter Subscription Form block and confirm the button updates after submitting (it may have a 1s delay due to the interval)
3. Click "My Account" and confirm it redirects you to the page for account verification
4. On another fresh session, subscribe using an existing reader account email
5. Confirm the button also changes from "Sign In" to "My Account" but clicking on it opens up the Sign In modal in OTP state

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->