### PR TITLE
fix(wp-6.3): destructured lodash module import error

### DIFF
--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { intersection } from 'lodash';
+import intersection from 'lodash/intersection';
 
 /**
  * WordPress dependencies

--- a/assets/components/src/autocomplete-tokenfield/index.js
+++ b/assets/components/src/autocomplete-tokenfield/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 /**
  * WordPress dependencies

--- a/assets/components/src/category-autocomplete/index.js
+++ b/assets/components/src/category-autocomplete/index.js
@@ -19,7 +19,9 @@ import './style.scss';
 /**
  * External dependencies
  */
-import { debounce, find, filter } from 'lodash';
+import debounce from 'lodash/debounce';
+import find from 'lodash/find';
+import filter from 'lodash/filter';
 import classnames from 'classnames';
 
 /**

--- a/assets/components/src/handoff/index.js
+++ b/assets/components/src/handoff/index.js
@@ -17,7 +17,7 @@ import { Button, Card, Modal, Waiting } from '../';
 /**
  * External dependencies.
  */
-import { assign } from 'lodash';
+import assign from 'lodash/assign';
 import classnames from 'classnames';
 
 class Handoff extends Component {

--- a/assets/components/src/hooks/useObjectState.js
+++ b/assets/components/src/hooks/useObjectState.js
@@ -3,7 +3,8 @@
  */
 import { useState } from '@wordpress/element';
 
-import { mergeWith, isArray } from 'lodash';
+import isArray from 'lodash/isArray';
+import mergeWith from 'lodash/mergeWith';
 
 const mergeCustomizer = ( objValue, srcValue ) => {
 	if ( isArray( objValue ) ) {

--- a/assets/components/src/select-control/GroupedSelectControl.js
+++ b/assets/components/src/select-control/GroupedSelectControl.js
@@ -9,7 +9,8 @@ import { Icon, chevronDown } from '@wordpress/icons';
  * External dependencies
  */
 import classnames from 'classnames';
-import { find, some } from 'lodash';
+import find from 'lodash/find';
+import some from 'lodash/some';
 
 /**
  * Internal dependencies

--- a/assets/components/src/tabbed-navigation/index.js
+++ b/assets/components/src/tabbed-navigation/index.js
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import classnames from 'classnames';
-import { findIndex } from 'lodash';
+import findIndex from 'lodash/findIndex';
 import Router from '../proxied-imports/router';
 
 /**

--- a/assets/components/src/wizard/store/index.js
+++ b/assets/components/src/wizard/store/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies.
  */
-import { set, get, isEmpty } from 'lodash';
+import set from 'lodash/set';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * WordPress dependencies.

--- a/assets/shared/js/button-props.js
+++ b/assets/shared/js/button-props.js
@@ -1,7 +1,9 @@
 /**
  * Internal dependencies
  */
-import { isFunction, isString, isObject } from 'lodash';
+import isFunction from 'lodash/isFunction';
+import isObject from 'lodash/isObject';
+import isString from 'lodash/isString';
 
 /**
  * Creates button props based on an action

--- a/assets/wizards/advertising/components/ad-unit-size-control/index.js
+++ b/assets/wizards/advertising/components/ad-unit-size-control/index.js
@@ -7,7 +7,7 @@
 /**
  * External dependencies.
  */
-import { startCase } from 'lodash';
+import startCase from 'lodash/startCase';
 
 /**
  * WordPress dependencies.

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -6,7 +6,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { set } from 'lodash/fp';
+import set from 'lodash/set';
 
 /**
  * WordPress dependencies

--- a/assets/wizards/analytics/views/custom-events/index.js
+++ b/assets/wizards/analytics/views/custom-events/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 /**
  * WordPress dependencies

--- a/assets/wizards/connections/views/main/fivetran.js
+++ b/assets/wizards/connections/views/main/fivetran.js
@@ -15,7 +15,7 @@ import { ActionCard } from '../../../../components/src';
  * External dependencies
  */
 import classnames from 'classnames';
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 const CONNECTORS = [
 	{

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -2,7 +2,11 @@
 /**
  * Internal dependencies
  */
-import { values, mapValues, property, isEmpty, once } from 'lodash';
+import values from 'lodash/values';
+import mapValues from 'lodash/mapValues';
+import property from 'lodash/property';
+import isEmpty from 'lodash/isEmpty';
+import once from 'lodash/once';
 
 /**
  * WordPress dependencies

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -9,7 +9,7 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * External dependencies.
  */
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize';
 import { format, parse } from 'date-fns';
 
 /**

--- a/assets/wizards/popups/views/analytics/Info.js
+++ b/assets/wizards/popups/views/analytics/Info.js
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import classnames from 'classnames';
-import { unescape } from 'lodash';
+import unescape from 'lodash/unescape';
 import humanNumber from 'human-number';
 
 /**

--- a/assets/wizards/popups/views/analytics/utils.js
+++ b/assets/wizards/popups/views/analytics/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { uniqBy } from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 import { subDays } from 'date-fns';
 
 /**

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -32,7 +32,7 @@ import './style.scss';
  * External dependencies
  */
 import classnames from 'classnames';
-import { find } from 'lodash';
+import find from 'lodash/find';
 
 const { useHistory } = Router;
 

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -5,7 +5,8 @@ import { ToggleControl } from '@wordpress/components';
 import { useMemo, useEffect, useState, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { find, debounce } from 'lodash';
+import debounce from 'lodash/debounce';
+import find from 'lodash/find';
 
 /**
  * Internal dependencies.

--- a/assets/wizards/readerRevenue/index.js
+++ b/assets/wizards/readerRevenue/index.js
@@ -3,7 +3,7 @@ import '../../shared/js/public-path';
 /**
  * External dependencies.
  */
-import { values } from 'lodash';
+import values from 'lodash/values';
 
 /**
  * WordPress dependencies.

--- a/assets/wizards/readerRevenue/views/emails/index.js
+++ b/assets/wizards/readerRevenue/views/emails/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { values } from 'lodash';
+import values from 'lodash/values';
 
 /**
  * Internal dependencies

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -8,7 +8,7 @@ import { useDispatch } from '@wordpress/data';
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * Internal dependencies

--- a/assets/wizards/seo/index.js
+++ b/assets/wizards/seo/index.js
@@ -21,7 +21,8 @@ import { Settings } from './views';
  * External dependencies.
  */
 import deepMapKeys from 'deep-map-keys';
-import { camelCase, snakeCase } from 'lodash';
+import camelCase from 'lodash/camelCase';
+import snakeCase from 'lodash/snakeCase';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 

--- a/assets/wizards/setup/views/services/ReaderRevenue.js
+++ b/assets/wizards/setup/views/services/ReaderRevenue.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * WordPress dependencies.

--- a/assets/wizards/setup/views/services/index.js
+++ b/assets/wizards/setup/views/services/index.js
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { values, keys, mapValues, property } from 'lodash';
+import values from 'lodash/values';
+import keys from 'lodash/keys';
+import mapValues from 'lodash/mapValues';
+import property from 'lodash/property';
 
 /**
  * WordPress dependencies

--- a/assets/wizards/setup/views/welcome/index.js
+++ b/assets/wizards/setup/views/welcome/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies.
  */
-import { omit, times } from 'lodash';
+import omit from 'lodash/omit';
+import times from 'lodash/times';
 
 /**
  * WordPress dependencies

--- a/assets/wizards/site-design/views/main/index.js
+++ b/assets/wizards/site-design/views/main/index.js
@@ -9,7 +9,7 @@ import { TextareaControl, ToggleControl } from '@wordpress/components';
 /**
  * External dependencies
  */
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 
 /**
  * Internal dependencies

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -83,7 +83,7 @@ class Google_OAuth {
 	 * @return bool|WP_Error
 	 */
 	public static function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'manage_options' ) || ! self::is_oauth_configured() ) {
 			Logger::error( 'Fail: user failed permissions check or OAuth is not configured.' );
 			return new \WP_Error(
 				'newspack_rest_forbidden',

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -83,7 +83,7 @@ class Google_OAuth {
 	 * @return bool|WP_Error
 	 */
 	public static function permissions_check() {
-		if ( ! current_user_can( 'manage_options' ) || ! self::is_oauth_configured() ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
 			Logger::error( 'Fail: user failed permissions check or OAuth is not configured.' );
 			return new \WP_Error(
 				'newspack_rest_forbidden',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal error that prevents Newspack admin dashboard screens from rendering. For some reason, WP 6.3 does not like our use of destructured module imports from the main `lodash` NPM package. This also only seems to affect the main plugin and not our other repos.

### How to test the changes in this Pull Request:

1. On a site running `release` and WP [6.3-RC1](https://wordpress.org/news/2023/07/wordpress-6-3-release-candidate-1/), visit any of the Newspack wizard screens and observe a JS error that prevents the UI from rendering:

```
Uncaught TypeError: __webpack_require__.nmd is not a function
```

2. Check out this branch and confirm that all Newspack wizard screens load without errors. Also check that the block editor works with Newspack blocks (Registration, Subscribe, Donate, Homepage Posts, Carousel, etc.)
3. Gut check a test site running WP 6.2.2 and confirm that this build also works for that version.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->