### PR TITLE
fix: avoid webhooks to break with json encoded data

### DIFF
--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -534,7 +534,10 @@ final class Webhooks {
 		 */
 		$body = apply_filters( 'newspack_webhooks_request_body', $body, $endpoint_id );
 
-		\update_post_meta( $request_id, 'body', \wp_json_encode( $body ) );
+		// addslashes prevents JSON from breaking if the data contains quotes or another json encoded string inside it.
+		$body_value = addslashes( \wp_json_encode( $body ) );
+
+		\update_post_meta( $request_id, 'body', $body_value );
 		\update_post_meta( $request_id, 'action_name', $action_name );
 		\update_post_meta( $request_id, 'client_id', $action_name );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-popups/issues/1164 .

### How to test the changes in this Pull Request:

1. Set up a webhook in https://webhook.site
2. In Newspack > Connections, create a new webhook with the endpoint created above
3. Select only the `prompt_interaction` event for this webhook
4. Make a donation via a campaign prompt
5. on `master` confirm that the json received is broken
6. Checkout this branch and repeat the process, confirm the json looks ok

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->