### PR TITLE
feat: update analytics wizard

### DIFF
--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { withWizard } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { Plugins, CustomDimensions, CustomEvents } from './views';
+import { Plugins, NewspackCustomEvents } from './views';
 import './style.scss';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
@@ -27,12 +27,8 @@ const TABS = [
 		exact: true,
 	},
 	{
-		label: __( 'Custom Dimensions', 'newspack' ),
-		path: '/custom-dimensions',
-	},
-	{
-		label: __( 'Custom Events', 'newspack' ),
-		path: '/custom-events',
+		label: __( 'Newspack Custom Events', 'newspack' ),
+		path: '/newspack-custom-events',
 	},
 ];
 
@@ -55,14 +51,9 @@ class AnalyticsWizard extends Component {
 					<Switch>
 						{ pluginRequirements }
 						<Route
-							path="/custom-dimensions"
+							path="/newspack-custom-events"
 							exact
-							render={ () => <CustomDimensions { ...sharedProps } /> }
-						/>
-						<Route
-							path="/custom-events"
-							exact
-							render={ () => <CustomEvents { ...sharedProps } /> }
+							render={ () => <NewspackCustomEvents { ...sharedProps } /> }
 						/>
 						<Route path="/" exact render={ () => <Plugins { ...sharedProps } /> } />
 						<Redirect to="/" />

--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -40,7 +40,7 @@ class AnalyticsWizard extends Component {
 		const { pluginRequirements, wizardApiFetch, isLoading } = this.props;
 		const sharedProps = {
 			headerText: __( 'Analytics', 'newspack' ),
-			subHeaderText: __( 'Track traffic and activity', 'newspack' ),
+			subHeaderText: __( 'Manage Google Analytics Configuration', 'newspack' ),
 			tabbedNavigation: TABS,
 			wizardApiFetch,
 			isLoading,

--- a/assets/wizards/analytics/style.scss
+++ b/assets/wizards/analytics/style.scss
@@ -64,3 +64,7 @@
 		}
 	}
 }
+
+.newspack__analytics-newspack-custom-events__save-button {
+	margin-top: 15px;
+}

--- a/assets/wizards/analytics/views/index.js
+++ b/assets/wizards/analytics/views/index.js
@@ -1,3 +1,2 @@
 export { default as Plugins } from './plugins';
-export { default as CustomDimensions } from './custom-dimensions';
-export { default as CustomEvents } from './custom-events';
+export { default as NewspackCustomEvents } from './newspack-custom-events';

--- a/assets/wizards/analytics/views/newspack-custom-events/index.js
+++ b/assets/wizards/analytics/views/newspack-custom-events/index.js
@@ -34,10 +34,10 @@ class NewspackCustomEvents extends Component {
 		wizardApiFetch( {
 			path: '/newspack/v1/wizard/analytics/ga4-credentials',
 			method: 'POST',
+			quiet: true,
 			data: {
 				measurement_id: this.state.ga4Credendials.measurement_id,
 				measurement_protocol_secret: this.state.ga4Credendials.measurement_protocol_secret,
-				quiet: true,
 			},
 		} )
 			.then( response => this.setState( { ga4Credendials: response, error: false } ) )

--- a/assets/wizards/analytics/views/newspack-custom-events/index.js
+++ b/assets/wizards/analytics/views/newspack-custom-events/index.js
@@ -1,0 +1,122 @@
+/* global newspack_analytics_wizard_data */
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	Button,
+	Grid,
+	Notice,
+	SectionHeader,
+	TextControl,
+	withWizardScreen,
+} from '../../../../components/src';
+
+/**
+ * Analytics Custom Events screen.
+ */
+class NewspackCustomEvents extends Component {
+	state = {
+		ga4Credendials: newspack_analytics_wizard_data.ga4_credentials,
+		error: false,
+	};
+
+	handleAPIError = ( { message: error } ) => this.setState( { error } );
+
+	updateGa4Credentials = () => {
+		const { wizardApiFetch } = this.props;
+		wizardApiFetch( {
+			path: '/newspack/v1/wizard/analytics/ga4-credentials',
+			method: 'POST',
+			data: {
+				measurement_id: this.state.ga4Credendials.measurement_id,
+				measurement_protocol_secret: this.state.ga4Credendials.measurement_protocol_secret,
+			},
+		} )
+			.then( response => this.setState( { ga4Credendials: response, error: false } ) )
+			.catch( this.handleAPIError );
+	};
+
+	render() {
+		const { error, ga4Credendials } = this.state;
+		const { isLoading } = this.props;
+
+		return (
+			<div className="newspack__analytics-configuration">
+				<div className="newspack__analytics-configuration__header">
+					<SectionHeader
+						title={ __( 'Additional Newspack Custom Events', 'newspack' ) }
+						description={ __(
+							'Adds support for back-end events tracking for Google Analytics 4',
+							'newspack'
+						) }
+						noMargin
+					/>
+					<p>
+						{ __(
+							'Newspack tracks some custom events to your configured Google Analytics account.',
+							'newspack'
+						) }
+						{ __(
+							"By adding the credentials below, you will enable additional events that are fired from your site's backend, like when a donation is confirmed or when a user subscribes to a Newsletter.",
+							'newspack'
+						) }
+					</p>
+				</div>
+
+				{ error && <Notice isError noticeText={ error } /> }
+				<Grid noMargin rowGap={ 16 }>
+					<TextControl
+						value={ ga4Credendials?.measurement_id }
+						label={ __( 'Measurement ID', 'newspack' ) }
+						help={ __(
+							'The same measurement ID you have configured in your GA plugin. Example: G-ABCD1234',
+							'newspack'
+						) }
+						onChange={ value =>
+							this.setState( {
+								...this.state,
+								ga4Credendials: { ...ga4Credendials, measurement_id: value },
+							} )
+						}
+						disabled={ isLoading }
+						autoComplete="off"
+					/>
+					<TextControl
+						type="password"
+						value={ ga4Credendials?.measurement_protocol_secret }
+						label={ __( 'Measurement Protocol API Secret', 'newspack' ) }
+						help={ __(
+							'You can grab your API Secret from your Google Analytics dashboard in Admin > Dat a Stream. Click in your data stream and then on Measurement Protocol API secrets',
+							'newspack'
+						) }
+						onChange={ value =>
+							this.setState( {
+								...this.state,
+								ga4Credendials: { ...ga4Credendials, measurement_protocol_secret: value },
+							} )
+						}
+						disabled={ isLoading }
+						autoComplete="off"
+					/>
+				</Grid>
+				<Button
+					className="newspack__analytics-newspack-custom-events__save-button"
+					variant="primary"
+					disabled={ isLoading }
+					onClick={ this.updateGa4Credentials }
+				>
+					{ __( 'Save', 'newspack' ) }
+				</Button>
+			</div>
+		);
+	}
+}
+
+export default withWizardScreen( NewspackCustomEvents );

--- a/assets/wizards/analytics/views/newspack-custom-events/index.js
+++ b/assets/wizards/analytics/views/newspack-custom-events/index.js
@@ -51,20 +51,16 @@ class NewspackCustomEvents extends Component {
 			<div className="newspack__analytics-configuration">
 				<div className="newspack__analytics-configuration__header">
 					<SectionHeader
-						title={ __( 'Additional Newspack Custom Events', 'newspack' ) }
+						title={ __( 'Activate Newspack Custom Events', 'newspack' ) }
 						description={ __(
-							'Adds support for back-end events tracking for Google Analytics 4',
+							'Allows Newspack to send enhanced custom event data to your Google Analytics.',
 							'newspack'
 						) }
 						noMargin
 					/>
 					<p>
 						{ __(
-							'Newspack tracks some custom events to your configured Google Analytics account.',
-							'newspack'
-						) }
-						{ __(
-							"By adding the credentials below, you will enable additional events that are fired from your site's backend, like when a donation is confirmed or when a user subscribes to a Newsletter.",
+							"Newspack already sends some custom event data to your GA account, but adding the credentials below enables enhanced events that are fired from your site's backend. For example, when a donation is confirmed or when a user successfully subscribes to a newsletter.",
 							'newspack'
 						) }
 					</p>
@@ -76,7 +72,7 @@ class NewspackCustomEvents extends Component {
 						value={ ga4Credendials?.measurement_id }
 						label={ __( 'Measurement ID', 'newspack' ) }
 						help={ __(
-							'The same measurement ID you have configured in your GA plugin. Example: G-ABCD1234',
+							'You can find this in Site Kit Settings, or in Google Analytics > Admin > Data Streams and clickng the data stream. Example: G-ABCD1234',
 							'newspack'
 						) }
 						onChange={ value =>
@@ -93,7 +89,7 @@ class NewspackCustomEvents extends Component {
 						value={ ga4Credendials?.measurement_protocol_secret }
 						label={ __( 'Measurement Protocol API Secret', 'newspack' ) }
 						help={ __(
-							'You can grab your API Secret from your Google Analytics dashboard in Admin > Dat a Stream. Click in your data stream and then on Measurement Protocol API secrets',
+							'Generate an API secret from your GA dashboard in Admin > Data Streams and opening your data stream. Select "Measurement Protocol API secrets" under the Events section. Create a new secret.',
 							'newspack'
 						) }
 						onChange={ value =>

--- a/assets/wizards/analytics/views/newspack-custom-events/index.js
+++ b/assets/wizards/analytics/views/newspack-custom-events/index.js
@@ -37,6 +37,7 @@ class NewspackCustomEvents extends Component {
 			data: {
 				measurement_id: this.state.ga4Credendials.measurement_id,
 				measurement_protocol_secret: this.state.ga4Credendials.measurement_protocol_secret,
+				quiet: true,
 			},
 		} )
 			.then( response => this.setState( { ga4Credendials: response, error: false } ) )

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -9,6 +9,7 @@ namespace Newspack\Data_Events\Connectors;
 
 require_once 'class-event.php';
 
+use Newspack\Analytics_Wizard;
 use Newspack\Data_Events;
 use Newspack\Data_Events\Connectors\GA4\Event;
 use Newspack\Data_Events\Popups as Popups_Events;
@@ -69,7 +70,7 @@ class GA4 {
 	 */
 	private static function get_ga4_properties() {
 		$properties = [
-			self::get_credentials(),
+			Analytics_Wizard::get_ga4_credentials(),
 		];
 
 		/**
@@ -386,18 +387,6 @@ class GA4 {
 	public static function get_sanitized_popup_params( $popup_id ) {
 		$popup_params = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		return Newspack_Popups_Data_Api::prepare_popup_params_for_ga( $popup_params );
-	}
-
-	/**
-	 * Gets the credentials for the GA4 API.
-	 *
-	 * @return array
-	 */
-	private static function get_credentials() {
-		// @TODO: add UI to set credentials or fetch it from Site Kit.
-		$measurement_protocol_secret = get_option( 'ga4_measurement_protocol_secret' );
-		$measurement_id              = get_option( 'ga4_measurement_id' );
-		return compact( 'measurement_protocol_secret', 'measurement_id' );
 	}
 
 	/**

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -115,8 +115,8 @@ class Analytics_Wizard extends Wizard {
 	 * @return array
 	 */
 	public static function get_ga4_credentials() {
-		$measurement_protocol_secret = get_option( 'ga4_measurement_protocol_secret' );
-		$measurement_id              = get_option( 'ga4_measurement_id' );
+		$measurement_protocol_secret = get_option( 'ga4_measurement_protocol_secret', '' );
+		$measurement_id              = get_option( 'ga4_measurement_id', '' );
 		return compact( 'measurement_protocol_secret', 'measurement_id' );
 	}
 

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -114,7 +114,7 @@ class Analytics_Wizard extends Wizard {
 	 *
 	 * @return array
 	 */
-	public function get_ga4_credentials() {
+	public static function get_ga4_credentials() {
 		$measurement_protocol_secret = get_option( 'ga4_measurement_protocol_secret' );
 		$measurement_id              = get_option( 'ga4_measurement_id' );
 		return compact( 'measurement_protocol_secret', 'measurement_id' );

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -79,121 +79,69 @@ class Analytics_Wizard extends Wizard {
 	 * Register the endpoints needed for the wizard screens.
 	 */
 	public function register_api_endpoints() {
-		// Create a custom dimension.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/analytics/custom-dimensions',
+			'/wizard/analytics/ga4-credentials',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'create_custom_dimension' ],
+				'callback'            => [ $this, 'api_set_ga4_credentials' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'name'  => [
+					'measurement_id'              => [
 						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ $this, 'validate_measurement_id' ],
 					],
-					'scope' => [
+					'measurement_protocol_secret' => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
 			]
 		);
+	}
 
-		// Set the custom dimensions.
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/analytics/custom-dimensions/(?P<id>[\w:]+)',
-			[
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_set_custom_dimensions' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'id'   => [
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'role' => [
-						'sanitize_callback' => 'sanitize_text_field',
-						'validate_callback' => [ __CLASS__, 'validate_custom_dimension_name' ],
-					],
-				],
-			]
-		);
+	/**
+	 * Validates the Measurement ID
+	 *
+	 * @param string $value The value to validate.
+	 * @return bool
+	 */
+	public function validate_measurement_id( $value ) {
+		return is_string( $value ) && strpos( $value, 'G-' ) === 0;
+	}
 
-		// Set custom events.
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/analytics/custom-events',
-			[
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'set_custom_events' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'events' => [
-						'type'     => 'array',
-						'required' => true,
-						'items'    => [
-							'type'       => 'object',
-							'properties' => [
-								'event_name'      => [
-									'type' => 'string',
-								],
-								'event_category'  => [
-									'type' => 'string',
-								],
-								'event_label'     => [
-									'type' => 'string',
-								],
-								'on'              => [
-									'type' => 'string',
-									'enum' => [ 'click', 'submit' ],
-								],
-								'element'         => [
-									'type' => 'string',
-								],
-								'amp_element'     => [
-									'type' => 'string',
-								],
-								'non_interaction' => [
-									'type' => 'boolean',
-								],
-								'is_active'       => [
-									'type' => 'boolean',
-								],
-							],
-							'required'   => [ 'event_name', 'event_category', 'on', 'element' ],
-						],
-					],
-				],
-			]
-		);
+	/**
+	 * Gets the credentials for the GA4 API.
+	 *
+	 * @return array
+	 */
+	public function get_ga4_credentials() {
+		$measurement_protocol_secret = get_option( 'ga4_measurement_protocol_secret' );
+		$measurement_id              = get_option( 'ga4_measurement_id' );
+		return compact( 'measurement_protocol_secret', 'measurement_id' );
+	}
 
-		// NTG Events.
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/analytics/ntg',
-			[
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'api_ntg_events_status' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-			]
-		);
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/analytics/ntg',
-			[
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_enable_ntg_events' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-			]
-		);
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/analytics/ntg',
-			[
-				'methods'             => \WP_REST_Server::DELETABLE,
-				'callback'            => [ $this, 'api_disable_ntg_events' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-			]
-		);
+	/**
+	 * Updates the GA4 crendetials
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function api_set_ga4_credentials( $request ) {
+		$measurement_id              = $request->get_param( 'measurement_id' );
+		$measurement_protocol_secret = $request->get_param( 'measurement_protocol_secret' );
+
+		if ( ! $measurement_id || ! $measurement_protocol_secret ) {
+			return new \WP_Error(
+				'newspack_analytics_wizard_invalid_params',
+				\esc_html__( 'Invalid parameters.', 'newspack' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		update_option( 'ga4_measurement_id', $measurement_id );
+		update_option( 'ga4_measurement_protocol_secret', $measurement_protocol_secret );
+
+		return rest_ensure_response( $this->get_ga4_credentials() );
 	}
 
 	/**
@@ -213,33 +161,12 @@ class Analytics_Wizard extends Wizard {
 			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
-		$custom_dimensions          = self::list_custom_dimensions();
-		$analytics_connection_error = null;
-		if ( is_wp_error( $custom_dimensions ) ) {
-			$analytics_connection_error = $custom_dimensions->get_error_message();
-		}
-		$custom_events = get_option( self::$custom_events_option_name, '[]' );
+
 		\wp_localize_script(
 			'newspack-analytics-wizard',
 			'newspack_analytics_wizard_data',
 			[
-				'customEvents'             => json_decode( $custom_events ),
-				'customDimensions'         => $custom_dimensions,
-				'analyticsConnectionError' => $analytics_connection_error,
-				'customDimensionsOptions'  => array_merge(
-					[
-						[
-							'value' => '',
-							'label' => __( 'none', 'newspack' ),
-						],
-					],
-					array_map(
-						function ( $item ) {
-							return $item['option'];
-						},
-						self::get_custom_dimensions_config()
-					)
-				),
+				'ga4_credentials' => $this->get_ga4_credentials(),
 			]
 		);
 
@@ -448,17 +375,6 @@ class Analytics_Wizard extends Wizard {
 	}
 
 	/**
-	 * Set custom dimension as the category-reporting dimension.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return Object|WP_Error Object on success, or WP_Error object on failure.
-	 */
-	public static function api_set_custom_dimensions( $request ) {
-		self::set_custom_dimension( $request['id'], self::get_custom_dimensions_option_name( $request['role'] ) );
-		return self::list_custom_dimensions();
-	}
-
-	/**
 	 * Set custom dimension option.
 	 *
 	 * @param string $dimension_id Dimension id.
@@ -512,19 +428,6 @@ class Analytics_Wizard extends Wizard {
 	}
 
 	/**
-	 * NTG events status.
-	 *
-	 * @return Object|WP_Error Object on success, or WP_Error object on failure.
-	 */
-	public static function api_ntg_events_status() {
-		return rest_ensure_response(
-			[
-				'enabled' => self::ntg_events_enabled(),
-			]
-		);
-	}
-
-	/**
 	 * Enable NTG events.
 	 *
 	 * @return Object|WP_Error Object on success, or WP_Error object on failure.
@@ -537,16 +440,4 @@ class Analytics_Wizard extends Wizard {
 		}
 	}
 
-	/**
-	 * Disable NTG events.
-	 *
-	 * @return Object|WP_Error Object on success, or WP_Error object on failure.
-	 */
-	public static function api_disable_ntg_events() {
-		if ( update_option( self::$ntg_events_option_name, 'disabled' ) ) {
-			return self::api_ntg_events_status();
-		} else {
-			return new WP_Error( 'newspack_analytics', __( 'Error when setting NTG events status.', 'newspack' ) );
-		}
-	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

![image](https://github.com/Automattic/newspack-plugin/assets/971483/c2631f7f-5006-45a1-9ae3-1f419db67387)

This PR updates the Analytics wizard by removing the tabs handling UA's custom dimensions and events and replacing with a tab where the users can add the credentials to enable GA4 back-end events tracking.

This PR does NOT deprecates or removes several back-end classes, hooks and methods that uses those custom dimensions and other UA plus AMP event tracking. I think there should be a dedicated effort for that.

### How to test the changes in this Pull Request:

1. Go to Newspack > Analytics
2. Confirm you see only one tab other than Plugins
3. Go to that tab
4. Check that you can save your credentials and they persist
5. Try to add a Measurement ID that don't start with "G-" and confirm you see an error
6. Perform a donation or newsletter subscription in your site
7. confirm you see a [corresponding event](https://github.com/Automattic/newspack-plugin/tree/master/includes/data-events/connectors/ga4) in your Real time dashboard (it can take up to two minutes for it to show up - make sure to browse your site to trigger the async jobs)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->