### PR TITLE
fix(wp-6.3): rename Reusable Blokks to Patterns

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -18,7 +18,7 @@ class Patches {
 	 */
 	public static function init() {
 		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
-		add_action( 'admin_menu', [ __CLASS__, 'add_reusable_blocks_menu_link' ] );
+		add_action( 'admin_menu', [ __CLASS__, 'add_patterns_menu_link' ] );
 		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
 		add_filter( 'map_meta_cap', [ __CLASS__, 'prevent_accidental_page_deletion' ], 10, 4 );
 		add_action( 'pre_post_update', [ __CLASS__, 'prevent_unpublish_front_page' ], 10, 2 );
@@ -101,10 +101,10 @@ class Patches {
 	}
 
 	/**
-	 * Add a menu link in WP Admin to easily edit and manage reusable blocks.
+	 * Add a menu link in WP Admin to easily edit and manage patterns.
 	 */
-	public static function add_reusable_blocks_menu_link() {
-		add_submenu_page( 'edit.php', 'manage_reusable_blocks', __( 'Reusable Blocks' ), 'edit_posts', 'edit.php?post_type=wp_block', '', 2 );
+	public static function add_patterns_menu_link() {
+		add_submenu_page( 'edit.php', 'manage_patterns', __( 'Patterns' ), 'edit_posts', 'edit.php?post_type=wp_block', '', 2 );
 	}
 
 	/**

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -19,6 +19,9 @@ class Patches {
 	public static function init() {
 		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_patterns_menu_link' ] );
+		add_action( 'manage_edit-wp_block_columns', [ __CLASS__, 'add_custom_columns' ] );
+		add_action( 'manage_edit-wp_block_sortable_columns', [ __CLASS__, 'add_sortable_columns' ] );
+		add_action( 'manage_wp_block_posts_custom_column', [ __CLASS__, 'custom_column_content' ], 10, 2 );
 		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'http_ogurls' ] );
 		add_filter( 'map_meta_cap', [ __CLASS__, 'prevent_accidental_page_deletion' ], 10, 4 );
 		add_action( 'pre_post_update', [ __CLASS__, 'prevent_unpublish_front_page' ], 10, 2 );
@@ -105,6 +108,44 @@ class Patches {
 	 */
 	public static function add_patterns_menu_link() {
 		add_submenu_page( 'edit.php', 'manage_patterns', __( 'Patterns' ), 'edit_posts', 'edit.php?post_type=wp_block', '', 2 );
+	}
+
+	/**
+	 * Add a custom column to the patterns list table.
+	 *
+	 * @param array $columns An associative array of column headings.
+	 */
+	public static function add_custom_columns( $columns ) {
+		$columns['sync_status'] = __( 'Sync status', 'newspack' );
+		return $columns;
+	}
+
+	/**
+	 * Add a sortable custom column to the patterns list table.
+	 *
+	 * @param array $columns An associative array of column headings.
+	 */
+	public static function add_sortable_columns( $columns ) {
+		$columns['sync_status'] = __( 'Sync status', 'newspack' );
+		return $columns;
+	}
+
+	/**
+	 * Render sync status in the custom column content.
+	 *
+	 * @param string $column The column name.
+	 * @param int    $post_id The post ID.
+	 */
+	public static function custom_column_content( $column, $post_id ) {
+		switch ( $column ) {
+			case 'sync_status':
+				$sync_status = get_post_meta( $post_id, 'wp_pattern_sync_status', true );
+				printf(
+					'%s',
+					empty( $sync_status ) ? esc_html( __( 'synced', 'newspack' ) ) : esc_html( $sync_status )
+				);
+				break;
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Note: Not to be released until WP 6.3 gets released.

WP 6.3 renames "Reusable Blocks" to "Synced Patterns" and merges them in the admin with newly editable, unsynced block patterns. #949 added an admin menu item to manage Reusable Blocks outside of the block editor, so this updates the name to "Patterns." Luckily, the admin page lists both already, so this is in line with the merging of block patterns and reusable blocks.

Also adds a sortable column to the list of patterns stating the sync status ("sycned" or "unsynced") so you can differentiate between the two types.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Confirm there's a menu item "Patterns" under Posts.
3. Click it and confirm you see the a list of Patterns. Create a synced and an unsynced pattern and confirm you see the status rendering correctly in the column:

<img width="1487" alt="Screen Shot 2023-07-26 at 4 27 37 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/e17bed3b-24b6-401d-8b95-40649656b826">


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->