### PR TITLE
fix(reader-data): ensure author on 'article_view' push

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -291,6 +291,7 @@ final class Reader_Data {
 		 * Article view activity.
 		 */
 		if ( is_singular( 'post' ) ) {
+			global $post;
 			$activity = [
 				'action' => 'article_view',
 				'data'   => [
@@ -298,7 +299,7 @@ final class Reader_Data {
 					'permalink'  => get_permalink(),
 					'categories' => wp_get_post_categories( get_the_ID(), [ 'fields' => 'ids' ] ),
 					'tags'       => wp_get_post_tags( get_the_ID(), [ 'fields' => 'ids' ] ),
-					'author'     => get_the_author(),
+					'author'     => $post->post_author,
 				],
 			];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `activity_view` data setup runs before the `get_the_author()` function is able to return the author's display name. The function uses the global `$authordata`, which for single posts is only registered when `setup_postdata()` is called.

This changes the author property to use the post's `post_author` directly.

### How to test the changes in this Pull Request:

1. While on the master branch, navigate to an article and confirm the pushed `article_view` has author empty
2. Checkout this branch, refresh and confirm the new push contains the author ID

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->