### PR TITLE
fix: check for the ga4 connector

### DIFF
--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -81,11 +81,13 @@ class GA4 {
 		 */
 		$properties = apply_filters( 'newspack_data_events_ga4_properties', $properties );
 
-		$properties = array_filter(
-			$properties,
-			function( $a ) {
-				return ! is_empty( $a );
-			} 
+		$properties = array_values(
+			array_filter(
+				$properties,
+				function( $a ) {
+					return ! empty( $a ) && ! empty( $a['measurement_id'] );
+				}
+			)
 		);
 
 		return $properties;

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -81,6 +81,13 @@ class GA4 {
 		 */
 		$properties = apply_filters( 'newspack_data_events_ga4_properties', $properties );
 
+		$properties = array_filter(
+			$properties,
+			function( $a ) {
+				return ! is_empty( $a );
+			} 
+		);
+
 		return $properties;
 	}
 

--- a/tests/unit-tests/ga4-connector.php
+++ b/tests/unit-tests/ga4-connector.php
@@ -411,7 +411,7 @@ class Newspack_Test_GA4_Connector extends WP_UnitTestCase {
 					'xxx' => 'local_secret',
 					'yyy' => 'local_id',
 				],
-				true,
+				false,
 			],
 		];
 	}
@@ -423,6 +423,7 @@ class Newspack_Test_GA4_Connector extends WP_UnitTestCase {
 	 * @param array $filter_creds The credentials that will be added via a filter.
 	 * @param bool  $expected The expected result.
 	 * @return void
+	 * @dataProvider can_use_ga4_data
 	 */
 	public function test_can_use_ga4( $local_creds, $filter_creds, $expected ) {
 

--- a/tests/unit-tests/ga4-connector.php
+++ b/tests/unit-tests/ga4-connector.php
@@ -365,4 +365,82 @@ class Newspack_Test_GA4_Connector extends WP_UnitTestCase {
 	public function test_get_donation_amount_range( $value, $expected ) {
 		$this->assertEquals( $expected, GA4::get_donation_amount_range( $value ) );
 	}
+
+	/**
+	 * Data provider for test_can_use_ga4
+	 *
+	 * @return array
+	 */
+	public function can_use_ga4_data() {
+		return [
+			'empty'          => [
+				[],
+				[],
+				false,
+			],
+			'local'          => [
+				[
+					'secret' => 'local_secret',
+					'id'     => 'local_id',
+				],
+				[],
+				true,
+			],
+			'filter'         => [
+				[],
+				[
+					'measurement_protocol_secret' => 'local_secret',
+					'measurement_id'              => 'local_id',
+				],
+				true,
+			],
+			'both'           => [
+				[
+					'secret' => 'local_secret',
+					'id'     => 'local_id',
+				],
+				[
+					'measurement_protocol_secret' => 'local_secret',
+					'measurement_id'              => 'local_id',
+				],
+				true,
+			],
+			'invalid_filter' => [
+				[],
+				[
+					'xxx' => 'local_secret',
+					'yyy' => 'local_id',
+				],
+				true,
+			],
+		];
+	}
+
+	/**
+	 * Tests the can_use_ga4 method
+	 *
+	 * @param array $local_creds The credentials present in the database.
+	 * @param array $filter_creds The credentials that will be added via a filter.
+	 * @param bool  $expected The expected result.
+	 * @return void
+	 */
+	public function test_can_use_ga4( $local_creds, $filter_creds, $expected ) {
+
+		if ( ! empty( $local_creds ) ) {
+			update_option( 'ga4_measurement_protocol_secret', $local_creds['secret'] );
+			update_option( 'ga4_measurement_id', $local_creds['id'] );
+		}
+
+		if ( ! empty( $filter_creds ) ) {
+			add_filter(
+				'newspack_data_events_ga4_properties',
+				function( $props ) use ( $filter_creds ) {
+					$props[] = $filter_creds;
+					return $props;
+				}
+			);
+		}
+
+		$this->assertSame( $expected, GA4::can_use_ga4() );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression that was preventing ga4 events to be sent

### How to test the changes in this Pull Request:

1. Check that events are sent when only the credentials added via filter (newspack manager) exist

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->