### PR TITLE
fix: only redirect to setup if not completed already

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -335,6 +335,9 @@ final class Newspack {
 			return;
 		}
 		delete_transient( NEWSPACK_ACTIVATION_TRANSIENT );
+		if ( \get_option( NEWSPACK_SETUP_COMPLETE, false ) ) {
+			return false;
+		}
 		wp_safe_redirect( admin_url( 'admin.php?page=newspack-setup-wizard' ) );
 		exit;
 	}

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -336,7 +336,7 @@ final class Newspack {
 		}
 		delete_transient( NEWSPACK_ACTIVATION_TRANSIENT );
 		if ( \get_option( NEWSPACK_SETUP_COMPLETE, false ) ) {
-			return false;
+			return;
 		}
 		wp_safe_redirect( admin_url( 'admin.php?page=newspack-setup-wizard' ) );
 		exit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor pet peeve which should mainly affect only devs and Newspack team members. The redirect to the setup wizard upon plugin activation should only happen if setup hasn't already been completed.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. On a fresh site, install and activate this plugin. Confirm that on the next visit to any page within WP admin, you're redirected to the Newspack setup wizard.
3. On a site that has already completed the setup wizard, deactivate and reactivate this plugin. Confirm that you're NOT redirected to the setup wizard when visiting WP admin.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->