### PR TITLE
feat(ads): display parent ad unit path on ad unit editor

### DIFF
--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -66,12 +66,21 @@ class AdUnit extends Component {
 	 */
 	render() {
 		const { adUnit, service, onSave, onCancel } = this.props;
-		const { id, code, fluid = false, name = '' } = adUnit;
+		const { id, code, fluid = false, name = '', path = [] } = adUnit;
 		const isLegacy = adUnit.is_legacy;
 		const isExistingAdUnit = id !== 0;
 		const sizes = adUnit.sizes && Array.isArray( adUnit.sizes ) ? adUnit.sizes : [];
 		const isInvalidSize = ! fluid && sizes.length === 0;
 		const sizeOptions = this.getSizeOptions();
+		const getCodeValue = () => {
+			if ( isLegacy ) {
+				return code;
+			}
+			if ( ! path.length ) {
+				return code;
+			}
+			return `${ path.map( parent => parent.code ).join( '/' ) }/${ code }`;
+		};
 		return (
 			<>
 				<Card headerActions noBorder>
@@ -87,7 +96,7 @@ class AdUnit extends Component {
 					{ ( isExistingAdUnit || isLegacy ) && (
 						<TextControl
 							label={ __( 'Code', 'newspack' ) }
-							value={ code || '' }
+							value={ getCodeValue() }
 							className="code"
 							help={
 								isLegacy


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Details and instructions at https://github.com/Automattic/newspack-ads/pull/701

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->