### PR TITLE
feat: disable deactivate and delete for Akismet

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -22,6 +22,7 @@ class Plugin_Manager {
 	 * @var array
 	 */
 	public static $required_plugins = [
+		'akismet',
 		'jetpack',
 		'pwa',
 		'google-site-kit',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds `akismet` to the list of "required" plugins for the Newspack platform. Coupled with the PR in the private Manager repository, it makes it difficult to deactivate or delete this plugin from the Plugins dashboard page.

### How to test the changes in this Pull Request:

Follow instructions in the private manager plugin repository.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->