### PR TITLE
fix(campaigns): move try/catch while fetching fav cat names

### DIFF
--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -11,6 +11,7 @@ import { useEffect, useState, Fragment } from '@wordpress/element';
  * External dependencies.
  */
 import memoize from 'lodash/memoize';
+import compact from 'lodash/compact';
 import { format, parse } from 'date-fns';
 
 const allCriteria = window.newspack_popups_wizard_data?.criteria || [];
@@ -221,7 +222,7 @@ const getFavoriteCategoryNamesFn = async favoriteCategories => {
 			}
 		} )
 	);
-	return favoriteCategoryNames;
+	return compact( favoriteCategoryNames );
 };
 const getFavoriteCategoryNames = memoize( getFavoriteCategoryNamesFn );
 

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -206,24 +206,22 @@ export const segmentDescription = segment => {
 };
 
 const getFavoriteCategoryNamesFn = async favoriteCategories => {
-	try {
-		const favoriteCategoryNames = await Promise.all(
-			favoriteCategories.map( async categoryId => {
+	const favoriteCategoryNames = await Promise.all(
+		favoriteCategories.map( async categoryId => {
+			try {
 				const category = await apiFetch( {
 					path: addQueryArgs( '/wp/v2/categories/' + categoryId, {
 						_fields: 'name',
 					} ),
 				} );
-
 				return category.name;
-			} )
-		);
-
-		return favoriteCategoryNames;
-	} catch ( e ) {
-		console.error( e );
-		return [];
-	}
+			} catch ( e ) {
+				console.warn( e );
+				return '';
+			}
+		} )
+	);
+	return favoriteCategoryNames;
 };
 const getFavoriteCategoryNames = memoize( getFavoriteCategoryNamesFn );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves the try/catch so other favorite categories that might be part of the segment render their names if one fails.

### How to test the changes in this Pull Request:

1. Checkout https://github.com/Automattic/newspack-plugin/tree/epic/campaigns-rearchitecture, https://github.com/Automattic/newspack-popups/tree/epic/rearchitecture and https://github.com/Automattic/newspack-blocks/tree/epic/campaigns-rearchitecture
2. Create a segment that matches 2 favorite categories
3. Delete one of the categories
4. Visit the "Segments" wizard and confirm the "Favorite Categories: " description shows empty
5. Check out this branch, refresh, and confirm it shows the remaining category

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->