### PR TITLE
fix: correct thank you message text domain

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -1018,7 +1018,7 @@ class Donations {
 		if ( ! $product_id ) {
 			return $text;
 		}
-		return __( 'Thank you for your donation!', 'newspack-blocks' );
+		return __( 'Thank you for your donation!', 'newspack' );
 	}
 }
 Donations::init();

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -1,22 +1,23 @@
-# Copyright (C) 2020 Automattic
+# Copyright (C) 2023 Automattic
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Newspack 1.0.0-alpha.21\n"
+"Project-Id-Version: Newspack 2.3.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/newspack-plugin\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-12-21T12:58:44+00:00\n"
+"POT-Creation-Date: 2023-08-11T22:43:18+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.5.0-alpha-59d879d\n"
+"X-Generator: WP-CLI 2.8.1\n"
 "X-Domain: newspack\n"
 
 #. Plugin Name of the plugin
-#: includes/wizards/class-dashboard.php:138
-#: assets/wizards/readerRevenue/views/platform/index.js:64
+#: includes/class-plugin-manager.php:162
+#: includes/wizards/class-dashboard.php:141
+#: assets/wizards/readerRevenue/views/platform/index.js:32
 msgid "Newspack"
 msgstr ""
 
@@ -25,6 +26,15 @@ msgid "An advanced open-source publishing and revenue-generating platform for ne
 msgstr ""
 
 #. Author of the plugin
+#: includes/class-plugin-manager.php:44
+#: includes/class-plugin-manager.php:80
+#: includes/class-plugin-manager.php:105
+#: includes/class-plugin-manager.php:113
+#: includes/class-plugin-manager.php:121
+#: includes/class-plugin-manager.php:130
+#: includes/class-plugin-manager.php:138
+#: includes/class-plugin-manager.php:146
+#: includes/class-plugin-manager.php:154
 msgid "Automattic"
 msgstr ""
 
@@ -32,8 +42,100 @@ msgstr ""
 msgid "https://newspack.com/"
 msgstr ""
 
+#: assets/blocks/reader-registration/index.php:39
+msgid "Stacked"
+msgstr ""
+
+#: assets/blocks/reader-registration/index.php:47
+msgid "Columns (newsletter subscription)"
+msgstr ""
+
+#: assets/blocks/reader-registration/index.php:110
+#: assets/blocks/reader-registration/index.php:343
+#: includes/oauth/class-google-login.php:173
+#: includes/plugins/wc-memberships/block-patterns/registration-wall.php:31
+#: assets/blocks/reader-registration/edit.js:80
+msgid "Thank you for registering!"
+msgstr ""
+
+#. Translators: %s is a link to My Account.
+#: assets/blocks/reader-registration/index.php:115
+msgid "Please visit %s to verify and manage your account."
+msgstr ""
+
+#: assets/blocks/reader-registration/index.php:116
+#: includes/reader-activation/class-reader-activation.php:928
+#: includes/reader-revenue/class-woocommerce-connection.php:1113
+msgid "My Account"
+msgstr ""
+
+#: assets/blocks/reader-registration/index.php:123
+#: includes/reader-activation/class-reader-activation.php:1144
+#: assets/blocks/reader-registration/edit.js:326
+msgid "Sign up"
+msgstr ""
+
+#: assets/blocks/reader-registration/index.php:124
+#: includes/reader-activation/class-reader-activation.php:1220
+#: assets/blocks/reader-registration/edit.js:299
+msgid "Subscribe to our newsletter"
+msgstr ""
+
+#: assets/blocks/reader-registration/index.php:125
+#: includes/plugins/wc-memberships/block-patterns/donation-wall.php:40
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier-metering.php:62
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier.php:30
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:36
+#: includes/plugins/wc-memberships/block-patterns/registration-wall.php:23
+#: assets/blocks/reader-registration/edit.js:247
+msgid "Already have an account?"
+msgstr ""
+
+#: assets/blocks/reader-registration/index.php:126
+#: includes/reader-activation/class-reader-activation.php:1108
+#: includes/reader-activation/class-reader-activation.php:1121
+msgid "Sign in"
+msgstr ""
+
+#: assets/blocks/reader-registration/index.php:127
+msgid "An account was already registered with this email. Please check your inbox for an authentication link."
+msgstr ""
+
+#: assets/blocks/reader-registration/index.php:410
+#: includes/reader-activation/class-reader-activation.php:1383
+msgid "You must enter a valid email address."
+msgstr ""
+
+#: includes/analytics/class-analytics.php:113
+msgid "Newspack Reader Activation"
+msgstr ""
+
+#: includes/analytics/class-analytics.php:114
+msgid "Registration"
+msgstr ""
+
+#: includes/analytics/class-analytics.php:122
+msgid "Signed up for lists:"
+msgstr ""
+
+#: includes/analytics/class-analytics.php:142
+msgid "NTG account"
+msgstr ""
+
+#: includes/analytics/class-analytics.php:143
+msgid "registration"
+msgstr ""
+
+#: includes/analytics/class-analytics.php:183
+msgid "NTG newsletter"
+msgstr ""
+
+#: includes/analytics/class-analytics.php:184
+msgid "newsletter signup"
+msgstr ""
+
 #: includes/api/class-plugins-controller.php:392
-#: includes/api/class-wizards-controller.php:131
+#: includes/api/class-wizards-controller.php:130
 msgid "You cannot view this resource."
 msgstr ""
 
@@ -43,15 +145,23 @@ msgstr ""
 #: includes/api/class-plugins-controller.php:482
 #: includes/api/class-plugins-controller.php:502
 #: includes/api/class-plugins-controller.php:522
-#: includes/api/class-wizards-controller.php:151
-#: includes/class-profile.php:169
-#: includes/wizards/class-wizard.php:138
-#: includes/wizards/class-wizard.php:157
+#: includes/api/class-wizards-controller.php:150
+#: includes/class-profile.php:277
+#: includes/class-recaptcha.php:108
+#: includes/class-salesforce.php:185
+#: includes/data-events/class-api.php:101
+#: includes/emails/class-emails.php:532
+#: includes/oauth/class-fivetran-connection.php:197
+#: includes/oauth/class-google-login.php:80
+#: includes/oauth/class-google-oauth.php:90
+#: includes/reader-revenue/stripe/class-stripe-webhooks.php:164
+#: includes/wizards/class-wizard.php:165
+#: includes/wizards/class-wizard.php:184
 msgid "You cannot use this resource."
 msgstr ""
 
 #: includes/api/class-plugins-controller.php:543
-#: includes/api/class-wizards-controller.php:171
+#: includes/api/class-wizards-controller.php:170
 msgid "Resource does not exist."
 msgstr ""
 
@@ -103,296 +213,936 @@ msgstr ""
 msgid "The edit link of the plugin."
 msgstr ""
 
-#: includes/class-admin-plugins-screen.php:113
+#: includes/author-filter/class-author-filter.php:106
+msgid "All authors"
+msgstr ""
+
+#: includes/authors/class-authors-custom-fields.php:55
+msgid "Job Title"
+msgstr ""
+
+#: includes/authors/class-authors-custom-fields.php:59
+#: assets/wizards/analytics/views/custom-dimensions/index.js:92
+msgid "Role"
+msgstr ""
+
+#: includes/authors/class-authors-custom-fields.php:63
+msgid "Employer/Organization"
+msgstr ""
+
+#: includes/authors/class-authors-custom-fields.php:67
+msgid "Phone number"
+msgstr ""
+
+#: includes/authors/class-authors-custom-fields.php:81
+msgid "Additional user profile fields"
+msgstr ""
+
+#: includes/authors/class-authors-custom-fields.php:82
+msgid "These fields will be displayed by Newspack."
+msgstr ""
+
+#: includes/class-admin-plugins-screen.php:112
+#: assets/wizards/componentsDemo/index.js:376
+#: assets/wizards/componentsDemo/index.js:412
 msgid "Premium"
 msgstr ""
 
 #. translators: %s - plugin name
-#: includes/class-admin-plugins-screen.php:119
+#: includes/class-admin-plugins-screen.php:118
 msgid "Install %s"
 msgstr ""
 
-#: includes/class-admin-plugins-screen.php:121
+#: includes/class-admin-plugins-screen.php:120
+#: assets/components/src/plugin-installer/index.js:174
+#: assets/components/src/plugin-installer/index.js:213
+#: assets/wizards/componentsDemo/index.js:291
+#: assets/wizards/componentsDemo/index.js:318
+#: assets/wizards/componentsDemo/index.js:379
+#: assets/wizards/componentsDemo/index.js:415
 msgid "Install"
 msgstr ""
 
-#: includes/class-admin-plugins-screen.php:135
+#: includes/class-admin-plugins-screen.php:134
 msgid "Sorry, you are not allowed to install plugins."
 msgstr ""
 
-#: includes/class-admin-plugins-screen.php:140
-#: includes/class-admin-plugins-screen.php:146
-#: includes/class-plugin-manager.php:561
+#: includes/class-admin-plugins-screen.php:139
+#: includes/class-admin-plugins-screen.php:145
+#: includes/class-plugin-manager.php:469
 msgid "Invalid plugin."
 msgstr ""
 
-#: includes/class-admin-plugins-screen.php:173
+#: includes/class-admin-plugins-screen.php:172
 msgid "Plugin installed."
 msgstr ""
 
-#: includes/class-admin-plugins-screen.php:175
-#: includes/class-admin-plugins-screen.php:187
+#: includes/class-admin-plugins-screen.php:174
+#: includes/class-admin-plugins-screen.php:186
 msgid "Dismiss."
 msgstr ""
 
-#: includes/class-admin-plugins-screen.php:185
+#: includes/class-admin-plugins-screen.php:184
 msgid "Failed to install plugin:"
 msgstr ""
 
-#: includes/class-admin-plugins-screen.php:264
-msgid "The following plugins are required by Newspack but are not active: "
-msgstr ""
-
-#: includes/class-admin-plugins-screen.php:267
-msgid "The following plugins are not supported by Newspack: "
-msgstr ""
-
-#: includes/class-admin-plugins-screen.php:270
-msgid "The Newspack Theme is not currently active."
-msgstr ""
-
-#: includes/class-admin-plugins-screen.php:274
-msgid "You are using the Disqus comment system without the Newspack Disqus AMP plugin. The comments form will not display on AMP pages. Correct this "
-msgstr ""
-
-#: includes/class-donations.php:44
-msgid "The required plugins are not installed and activated. Install and/or activate them to access this feature."
-msgstr ""
-
-#: includes/class-donations.php:65
+#: includes/class-donations.php:67
 msgid "Donate"
 msgstr ""
 
+#: includes/class-donations.php:113
+msgid "The required plugins are not installed and activated. Install and/or activate them to access this feature."
+msgstr ""
+
+#: includes/class-donations.php:191
+msgid "Missing donation product. Save the donation settings to create it."
+msgstr ""
+
+#: includes/class-donations.php:199
+msgid "Misconfigured donation product. Save the donation settings to fix it."
+msgstr ""
+
+#: includes/class-donations.php:211
+msgid "Missing donation products. Save the donation settings to fix this."
+msgstr ""
+
+#: includes/class-donations.php:436
+msgid "One-Time Donation"
+msgstr ""
+
+#: includes/class-donations.php:438
+msgid "Monthly Donation"
+msgstr ""
+
+#: includes/class-donations.php:440
+msgid "Yearly Donation"
+msgstr ""
+
+#: includes/class-donations.php:442
+#: includes/class-donations.php:735
+#: assets/wizards/popups/views/segments/SingleSegment.js:254
+msgid "Donation"
+msgstr ""
+
 #. translators: %s: Product name
-#: includes/class-donations.php:213
-#: includes/class-donations.php:321
+#: includes/class-donations.php:482
+msgid "%s: One-Time"
+msgstr ""
+
+#. translators: %s: Product name
+#: includes/class-donations.php:485
 msgid "%s: Monthly"
 msgstr ""
 
 #. translators: %s: Product name
-#: includes/class-donations.php:233
-#: includes/class-donations.php:315
+#: includes/class-donations.php:489
 msgid "%s: Yearly"
 msgstr ""
 
-#. translators: %s: Product name
-#: includes/class-donations.php:253
-#: includes/class-donations.php:326
-msgid "%s: One-Time"
-msgstr ""
-
-#: includes/class-donations.php:454
+#: includes/class-donations.php:734
 msgid "With the support of readers like you, we provide thoughtfully researched articles for a more informed and connected community. This is your chance to support credible, community-based, public-service journalism. Please join us!"
 msgstr ""
 
-#: includes/class-donations.php:455
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:191
-msgid "Donation"
-msgstr ""
-
-#: includes/class-donations.php:456
+#: includes/class-donations.php:736
 msgid "Edit and add to this content to tell your publication's story and explain the benefits of becoming a member. This is a good place to mention any special member privileges, let people know that donations are tax-deductible, or provide any legal information."
 msgstr ""
 
-#: includes/class-donations.php:482
+#: includes/class-donations.php:762
+#: includes/wizards/class-setup-wizard.php:397
 msgid "Support our publication"
 msgstr ""
 
-#: includes/class-donations.php:484
+#: includes/class-donations.php:764
 msgid "Support quality journalism by joining us today!"
 msgstr ""
 
-#: includes/class-donations.php:503
+#: includes/class-donations.php:785
 msgid "Join"
 msgstr ""
 
-#: includes/class-handoff-banner.php:71
+#: includes/class-donations.php:1021
+msgid "Thank you for your donation!"
+msgstr ""
+
+#: includes/class-handoff-banner.php:64
+#: assets/wizards/handoff-banner/index.js:20
 msgid "Return to Newspack after completing configuration"
 msgstr ""
 
-#: includes/class-handoff-banner.php:72
+#: includes/class-handoff-banner.php:65
+#: assets/wizards/handoff-banner/index.js:21
 msgid "Back to Newspack"
 msgstr ""
 
-#: includes/class-plugin-manager.php:140
-#: tests/unit-tests/plugin-manager.php:58
+#: includes/class-magic-link.php:334
+#: includes/reader-activation/class-reader-activation.php:734
+#: includes/reader-activation/class-reader-activation.php:1476
+msgid "Invalid user."
+msgstr ""
+
+#: includes/class-magic-link.php:462
+#: includes/class-magic-link.php:532
+#: includes/class-magic-link.php:613
+#: includes/class-magic-link.php:833
+#: includes/class-magic-link.php:961
+msgid "User not found."
+msgstr ""
+
+#: includes/class-magic-link.php:464
+#: includes/class-magic-link.php:534
+msgid "Not allowed for this user"
+msgstr ""
+
+#: includes/class-magic-link.php:468
+#: includes/class-magic-link.php:498
+msgid "Invalid token."
+msgstr ""
+
+#: includes/class-magic-link.php:489
+msgid "Invalid client."
+msgstr ""
+
+#: includes/class-magic-link.php:536
+#: includes/class-magic-link.php:618
+msgid "OTP is not enabled."
+msgstr ""
+
+#: includes/class-magic-link.php:540
+#: includes/class-magic-link.php:570
+msgid "Invalid OTP."
+msgstr ""
+
+#: includes/class-magic-link.php:566
+msgid "Maximum OTP attempts reached."
+msgstr ""
+
+#: includes/class-magic-link.php:577
+msgid "Invalid hash."
+msgstr ""
+
+#: includes/class-magic-link.php:670
+msgid "We were not able to authenticate your account. Please try logging in again."
+msgstr ""
+
+#: includes/class-magic-link.php:728
+#: includes/class-magic-link.php:761
+msgid "Unsupported request method"
+msgstr ""
+
+#: includes/class-magic-link.php:765
+msgid "Missing required parameters"
+msgstr ""
+
+#: includes/class-magic-link.php:770
+msgid "Invalid user"
+msgstr ""
+
+#: includes/class-magic-link.php:780
+msgid "You've reached the maximum attempts for this code. Please try again."
+msgstr ""
+
+#: includes/class-magic-link.php:783
+msgid "The code does not match."
+msgstr ""
+
+#: includes/class-magic-link.php:788
+msgid "Unable to authenticated. Please try again."
+msgstr ""
+
+#: includes/class-magic-link.php:791
+#: includes/reader-activation/class-reader-activation.php:1176
+msgid "Login successful!"
+msgstr ""
+
+#. translators: %s is the email address of the user.
+#: includes/class-magic-link.php:843
+msgid "Email sent to %s."
+msgstr ""
+
+#: includes/class-magic-link.php:849
+msgid "Send a magic link to a reader."
+msgstr ""
+
+#: includes/class-magic-link.php:893
+msgid "Send authentication link"
+msgstr ""
+
+#: includes/class-magic-link.php:914
+msgid "Authentication link sent."
+msgstr ""
+
+#: includes/class-magic-link.php:917
+msgid "All authentication link tokens were removed."
+msgstr ""
+
+#: includes/class-magic-link.php:920
+msgid "Authentication links are now disabled."
+msgstr ""
+
+#: includes/class-magic-link.php:923
+msgid "Authentication links are now enabled."
+msgstr ""
+
+#: includes/class-magic-link.php:945
+#: includes/class-magic-link.php:949
+#: includes/reader-activation/class-reader-activation.php:1375
+#: includes/reader-activation/class-reader-activation.php:1379
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:261
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:281
+msgid "Invalid request."
+msgstr ""
+
+#: includes/class-magic-link.php:955
+msgid "You do not have permission to do that."
+msgstr ""
+
+#: includes/class-magic-link.php:1005
+msgid "Passwordless Authentication Management"
+msgstr ""
+
+#: includes/class-magic-link.php:1008
+msgid "Authentication Link Support"
+msgstr ""
+
+#. translators: %1$s: Disabled or enabled. %2$s: User's display name.
+#: includes/class-magic-link.php:1019
+msgid "Authentication links support is currently %1$s for %2$s."
+msgstr ""
+
+#: includes/class-magic-link.php:1020
+#: assets/blocks/reader-registration/edit.js:208
+msgid "disabled"
+msgstr ""
+
+#: includes/class-magic-link.php:1020
+#: assets/blocks/reader-registration/edit.js:207
+msgid "enabled"
+msgstr ""
+
+#: includes/class-magic-link.php:1029
+msgid "Send Authentication Link"
+msgstr ""
+
+#. translators: %1$s: User's display name. %2$d is the expiration period in minutes.
+#: includes/class-magic-link.php:1036
+msgid "Generate and send a new link to %1$s, which will authenticate them instantly. The link will be valid for %2$d minutes after its creation."
+msgstr ""
+
+#: includes/class-magic-link.php:1045
+msgid "Clear All Tokens"
+msgstr ""
+
+#. translators: %s: User's display name.
+#: includes/class-magic-link.php:1052
+msgid "Clear all existing authentication link tokens for %s."
+msgstr ""
+
+#: includes/class-newspack.php:213
+msgid "Starter content removed."
+msgstr ""
+
+#: includes/class-patches.php:119
+#: includes/class-patches.php:129
+msgid "Sync status"
+msgstr ""
+
+#: includes/class-patches.php:145
+msgid "synced"
+msgstr ""
+
+#: includes/class-plugin-manager.php:42
+msgid "Akismet Anti-Spam"
+msgstr ""
+
+#: includes/class-plugin-manager.php:43
+msgid "Used by millions, Akismet is quite possibly the best way in the world to protect your blog from spam. It keeps your site protected even while you sleep."
+msgstr ""
+
+#: includes/class-plugin-manager.php:50
+msgid "Co-Authors Plus"
+msgstr ""
+
+#: includes/class-plugin-manager.php:51
+msgid "Allows multiple authors and guest authors to be assigned to a post."
+msgstr ""
+
+#: includes/class-plugin-manager.php:52
+msgid "Mohammad Jangda, Daniel Bachhuber, Automattic, Weston Ruter"
+msgstr ""
+
+#: includes/class-plugin-manager.php:58
 #: assets/wizards/health-check/views/configuration/index.js:42
+msgid "Google Site Kit"
+msgstr ""
+
+#: includes/class-plugin-manager.php:59
+msgid "Site Kit is is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web."
+msgstr ""
+
+#: includes/class-plugin-manager.php:60
+#: assets/wizards/connections/views/main/google.js:153
+msgid "Google"
+msgstr ""
+
+#: includes/class-plugin-manager.php:71
+msgid "Gravity Forms"
+msgstr ""
+
+#: includes/class-plugin-manager.php:72
+msgid "Create custom web forms to capture leads, collect payments, automate your workflows, and build your business online."
+msgstr ""
+
+#: includes/class-plugin-manager.php:73
+msgid "Rocketgenius"
+msgstr ""
+
+#: includes/class-plugin-manager.php:78
+#: assets/wizards/health-check/views/configuration/index.js:31
 msgid "Jetpack"
 msgstr ""
 
-#: includes/class-plugin-manager.php:141
-#: tests/unit-tests/plugin-manager.php:59
+#: includes/class-plugin-manager.php:79
 msgid "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users."
 msgstr ""
 
-#: includes/class-plugin-manager.php:150
+#: includes/class-plugin-manager.php:88
 msgid "Connects WooCommerce to Mailchimp to sync your store data, send targeted campaigns to your customers, and sell more stuff."
 msgstr ""
 
-#: includes/class-plugin-manager.php:165
+#: includes/class-plugin-manager.php:89
+#: assets/wizards/connections/views/main/fivetran.js:23
+#: assets/wizards/engagement/components/mailchimp.js:38
+msgid "Mailchimp"
+msgstr ""
+
+#: includes/class-plugin-manager.php:95
+msgid "MC4WP: Mailchimp for WordPress"
+msgstr ""
+
+#: includes/class-plugin-manager.php:96
+msgid "Mailchimp for WordPress by ibericode. Adds various highly effective sign-up methods to your site."
+msgstr ""
+
+#: includes/class-plugin-manager.php:97
+msgid "ibericode"
+msgstr ""
+
+#: includes/class-plugin-manager.php:103
 msgid "Newspack Ads"
 msgstr ""
 
-#: includes/class-plugin-manager.php:166
+#: includes/class-plugin-manager.php:104
 msgid "Ads integration."
 msgstr ""
 
-#: includes/class-plugin-manager.php:173
+#: includes/class-plugin-manager.php:111
 msgid "Newspack Blocks"
 msgstr ""
 
-#: includes/class-plugin-manager.php:174
+#: includes/class-plugin-manager.php:112
 msgid "A collection of blocks for news publishers."
 msgstr ""
 
-#: includes/class-plugin-manager.php:181
+#: includes/class-plugin-manager.php:119
 msgid "Newspack Content Converter"
 msgstr ""
 
-#: includes/class-plugin-manager.php:182
+#: includes/class-plugin-manager.php:120
 msgid "Batch conversion of Classic->Gutenberg post conversion."
 msgstr ""
 
-#: includes/class-plugin-manager.php:337
-msgid "Super Cool Ad Inserter Plugin"
+#: includes/class-plugin-manager.php:128
+msgid "Newspack Newsletters"
 msgstr ""
 
-#: includes/class-plugin-manager.php:338
-msgid "This WordPress plugin gives site administrators a way to insert widgets such as ads, newsletter signups, or calls to action into posts at set intervals."
+#: includes/class-plugin-manager.php:129
+msgid "Newsletter authoring using the Gutenberg editor."
 msgstr ""
 
-#: includes/class-plugin-manager.php:362
+#: includes/class-plugin-manager.php:136
+msgid "Newspack Campaigns"
+msgstr ""
+
+#: includes/class-plugin-manager.php:137
+msgid "AMP-compatible overlay and inline Campaigns."
+msgstr ""
+
+#: includes/class-plugin-manager.php:144
+msgid "Newspack Sponsors"
+msgstr ""
+
+#: includes/class-plugin-manager.php:145
+msgid "Sponsored and underwritten content for Newspack sites."
+msgstr ""
+
+#: includes/class-plugin-manager.php:152
+msgid "Newspack Listings"
+msgstr ""
+
+#: includes/class-plugin-manager.php:153
+msgid "Create reusable content in list form using the Gutenberg editor."
+msgstr ""
+
+#: includes/class-plugin-manager.php:160
+msgid "Newspack Theme"
+msgstr ""
+
+#: includes/class-plugin-manager.php:161
+msgid "The Newspack theme."
+msgstr ""
+
+#: includes/class-plugin-manager.php:165
+msgid "Parse.ly"
+msgstr ""
+
+#: includes/class-plugin-manager.php:166
+msgid "This plugin makes it a snap to add Parse.ly tracking code to your WordPress blog."
+msgstr ""
+
+#: includes/class-plugin-manager.php:167
+msgid "Mike Sukmanowsky ( mike@parsely.com )"
+msgstr ""
+
+#: includes/class-plugin-manager.php:173
+msgid "Password Protected"
+msgstr ""
+
+#: includes/class-plugin-manager.php:174
+msgid "A very simple way to quickly password protect your WordPress site with a single password. Please note: This plugin does not restrict access to uploaded files and images and does not work with some caching setups."
+msgstr ""
+
+#: includes/class-plugin-manager.php:175
+msgid "Ben Huson"
+msgstr ""
+
+#: includes/class-plugin-manager.php:182
+msgid "Publish to Apple News"
+msgstr ""
+
+#: includes/class-plugin-manager.php:183
+msgid "Export and synchronize posts to Apple format"
+msgstr ""
+
+#: includes/class-plugin-manager.php:184
+msgid "Alley Interactive"
+msgstr ""
+
+#: includes/class-plugin-manager.php:195
+msgid "PWA"
+msgstr ""
+
+#: includes/class-plugin-manager.php:196
+msgid "Feature plugin to bring Progressive Web App (PWA) capabilities to Core."
+msgstr ""
+
+#: includes/class-plugin-manager.php:197
+msgid "PWA Plugin Contributors"
+msgstr ""
+
+#: includes/class-plugin-manager.php:203
+msgid "Redirection"
+msgstr ""
+
+#: includes/class-plugin-manager.php:204
+msgid "Manage all your 301 redirects and monitor 404 errors."
+msgstr ""
+
+#: includes/class-plugin-manager.php:205
+msgid "John Godley"
+msgstr ""
+
+#: includes/class-plugin-manager.php:211
+#: includes/class-plugin-manager.php:222
+#: includes/class-plugin-manager.php:238
 msgid "WooCommerce"
 msgstr ""
 
-#: includes/class-plugin-manager.php:363
-#: includes/class-plugin-manager.php:395
+#: includes/class-plugin-manager.php:212
 msgid "An eCommerce toolkit that helps you sell anything. Beautifully."
 msgstr ""
 
-#: includes/class-plugin-manager.php:371
+#: includes/class-plugin-manager.php:213
+msgid "WordPress.com VIP, XWP, Google, and contributors"
+msgstr ""
+
+#: includes/class-plugin-manager.php:220
 msgid "WooCommerce Stripe Gateway"
 msgstr ""
 
-#: includes/class-plugin-manager.php:372
+#: includes/class-plugin-manager.php:221
 msgid "Take credit card payments on your store using Stripe."
 msgstr ""
 
-#: includes/class-plugin-manager.php:380
+#: includes/class-plugin-manager.php:229
 msgid "WooCommerce Name Your Price"
 msgstr ""
 
-#: includes/class-plugin-manager.php:381
+#: includes/class-plugin-manager.php:230
 msgid "WooCommerce Name Your Price allows customers to set their own price for products or donations."
 msgstr ""
 
-#: includes/class-plugin-manager.php:387
-msgid "WooCommerce One Page Checkout"
+#: includes/class-plugin-manager.php:231
+msgid "Kathy Darling"
 msgstr ""
 
-#: includes/class-plugin-manager.php:388
-msgid "Super fast sales with WooCommerce. Add to cart, checkout & pay all on the one page!"
-msgstr ""
-
-#: includes/class-plugin-manager.php:394
+#: includes/class-plugin-manager.php:236
 msgid "WooCommerce Subscriptions"
 msgstr ""
 
-#: includes/class-plugin-manager.php:402
-msgid "Convert and retain customers with automated marketing that does the hard work for you."
+#: includes/class-plugin-manager.php:237
+msgid "Sell products and services with recurring payments in your WooCommerce Store."
 msgstr ""
 
-#: includes/class-plugin-manager.php:408
-msgid "AutomateWoo - Refer A Friend"
+#: includes/class-plugin-manager.php:243
+msgid "Yoast SEO"
 msgstr ""
 
-#: includes/class-plugin-manager.php:409
-msgid "Boost your organic sales by adding a customer referral program to your WooCommerce store."
+#: includes/class-plugin-manager.php:244
+msgid "The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more."
 msgstr ""
 
-#: includes/class-plugin-manager.php:437
+#: includes/class-plugin-manager.php:245
+msgid "Team Yoast"
+msgstr ""
+
+#: includes/class-plugin-manager.php:251
+msgid "Wordpress Commenting"
+msgstr ""
+
+#: includes/class-plugin-manager.php:256
+msgid "WP GDPR Cookie Notice"
+msgstr ""
+
+#: includes/class-plugin-manager.php:257
 msgid "Simple performant cookie consent notice that supports AMP, granular cookie control and live preview customization."
 msgstr ""
 
-#: includes/class-plugin-manager.php:581
+#: includes/class-plugin-manager.php:258
+msgid "Felix Arntz"
+msgstr ""
+
+#: includes/class-plugin-manager.php:264
+msgid "Simple Local Avatars"
+msgstr ""
+
+#: includes/class-plugin-manager.php:265
+msgid "Adds an avatar upload field to user profiles if the current user has media permissions. Generates requested sizes on demand just like Gravatar! Simple and lightweight."
+msgstr ""
+
+#: includes/class-plugin-manager.php:266
+msgid "Jake Goldman, 10up"
+msgstr ""
+
+#: includes/class-plugin-manager.php:272
+#: assets/wizards/syndication/views/intro/index.js:42
+msgid "Distributor"
+msgstr ""
+
+#: includes/class-plugin-manager.php:273
+msgid "Distributor is a WordPress plugin that makes it easy to syndicate and reuse content across your websites — whether in a single multisite or across the web."
+msgstr ""
+
+#: includes/class-plugin-manager.php:280
+msgid "Super Cool Ad Inserter Plugin"
+msgstr ""
+
+#: includes/class-plugin-manager.php:281
+msgid "Display ads within your article content."
+msgstr ""
+
+#: includes/class-plugin-manager.php:282
+msgid "INN Labs, Automattic"
+msgstr ""
+
+#: includes/class-plugin-manager.php:288
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:137
+msgid "Ad Refresh Control"
+msgstr ""
+
+#: includes/class-plugin-manager.php:289
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:138
+msgid "Enable Active View refresh for Google Ad Manager ads without needing to modify any code."
+msgstr ""
+
+#: includes/class-plugin-manager.php:290
+msgid "Gary Thayer, David Green, 10up"
+msgstr ""
+
+#: includes/class-plugin-manager.php:296
+msgid "Publisher Media Kit"
+msgstr ""
+
+#: includes/class-plugin-manager.php:297
+msgid "Quick and easy option for small to medium sized publishers to digitize their media kit."
+msgstr ""
+
+#: includes/class-plugin-manager.php:298
+msgid "10up"
+msgstr ""
+
+#: includes/class-plugin-manager.php:304
+msgid "Broadstreet"
+msgstr ""
+
+#: includes/class-plugin-manager.php:305
+msgid "Integrate Broadstreet’s business directory and ad-serving features into your site."
+msgstr ""
+
+#: includes/class-plugin-manager.php:489
 msgid "The plugin is already active."
 msgstr ""
 
-#: includes/class-plugin-manager.php:601
-#: includes/class-plugin-manager.php:715
+#: includes/class-plugin-manager.php:509
+#: includes/class-plugin-manager.php:630
 msgid "The plugin is not installed."
 msgstr ""
 
-#: includes/class-plugin-manager.php:611
+#: includes/class-plugin-manager.php:519
 msgid "The plugin is not active."
 msgstr ""
 
-#: includes/class-plugin-manager.php:616
+#: includes/class-plugin-manager.php:524
 msgid "Failed to deactivate plugin."
 msgstr ""
 
-#: includes/class-plugin-manager.php:692
+#: includes/class-plugin-manager.php:600
 msgid "Plugins cannot be installed."
 msgstr ""
 
-#: includes/class-plugin-manager.php:710
+#: includes/class-plugin-manager.php:618
 msgid "Plugins cannot be uninstalled."
 msgstr ""
 
-#: includes/class-plugin-manager.php:736
+#: includes/class-plugin-manager.php:654
 msgid "The plugin could not be uninstalled."
 msgstr ""
 
-#: includes/class-plugin-manager.php:749
+#: includes/class-plugin-manager.php:667
 msgid "The plugin directory already exists."
 msgstr ""
 
-#: includes/class-plugin-manager.php:756
+#: includes/class-plugin-manager.php:674
 msgid "Plugin not found."
 msgstr ""
 
-#: includes/class-plugin-manager.php:762
+#: includes/class-plugin-manager.php:680
 msgid "Newspack cannot install this plugin. You will need to get it from the plugin's site and install it manually."
 msgstr ""
 
 #. translators: %s: plugin URL
-#: includes/class-plugin-manager.php:765
+#: includes/class-plugin-manager.php:683
 msgid "Newspack cannot install this plugin. You will need to get it from <a href=\"%s\">the plugin's site</a> and install it manually."
 msgstr ""
 
-#: includes/class-pwa.php:35
+#: includes/class-profile.php:40
+#: assets/wizards/seo/views/settings/index.js:75
+msgid "Facebook Page"
+msgstr ""
+
+#: includes/class-profile.php:41
+#: assets/wizards/seo/views/settings/index.js:78
+msgid "https://facebook.com/page"
+msgstr ""
+
+#: includes/class-profile.php:45
+#: assets/wizards/seo/views/settings/index.js:81
+msgid "Twitter"
+msgstr ""
+
+#: includes/class-profile.php:46
+#: assets/wizards/seo/views/settings/index.js:84
+msgid "username"
+msgstr ""
+
+#: includes/class-profile.php:51
+#: assets/wizards/seo/views/settings/index.js:90
+msgid "https://instagram.com/user"
+msgstr ""
+
+#: includes/class-profile.php:56
+#: assets/wizards/seo/views/settings/index.js:96
+msgid "https://linkedin.com/user"
+msgstr ""
+
+#: includes/class-profile.php:61
+#: assets/wizards/seo/views/settings/index.js:102
+msgid "https://youtube.com/c/channel"
+msgstr ""
+
+#: includes/class-profile.php:66
+#: assets/wizards/seo/views/settings/index.js:108
+msgid "https://pinterest.com/user"
+msgstr ""
+
+#: includes/class-profile.php:215
+msgid "Social Links"
+msgstr ""
+
+#: includes/class-pwa.php:37
 msgid "Site is not served over https. Progressive web app features will not work."
 msgstr ""
 
-#: includes/class-pwa.php:39
+#: includes/class-pwa.php:41
 msgid "No site icon specified. Visitors will not be able to install the site as an app."
 msgstr ""
 
-#: includes/class-salesforce.php:369
-msgid "No sObject type given."
+#: includes/class-pwa.php:99
+msgid "There has been a problem connecting with the server. Please check your internet connection or try again later."
 msgstr ""
 
-#: includes/class-settings.php:64
-msgid "Setup Wizard"
+#: includes/class-recaptcha.php:256
+msgid "Missing or invalid captcha token."
 msgstr ""
 
-#: includes/class-settings.php:66
-msgid "Components Demo"
+#: includes/class-recaptcha.php:280
+msgid "Error validating captcha."
 msgstr ""
 
-#: includes/class-settings.php:90
-msgid "Debug Mode"
+#. Translators: error message for reCaptcha.
+#: includes/class-recaptcha.php:284
+msgid "reCaptcha error: %s"
 msgstr ""
 
-#: includes/class-settings.php:97
-msgid "Reset Newspack"
+#: includes/class-recaptcha.php:295
+msgid "User action failed captcha challenge."
 msgstr ""
 
-#: includes/class-settings.php:105
-msgid "Reset WordPress.com authentication"
+#: includes/class-rss-add-image.php:52
+msgid "RSS Image Sizes"
 msgstr ""
 
-#: includes/class-starter-content.php:245
+#: includes/class-rss-add-image.php:71
+msgid "RSS Image size"
+msgstr ""
+
+#: includes/class-rss-add-image.php:122
+msgid "Max Width"
+msgstr ""
+
+#: includes/class-rss-add-image.php:137
+msgid "Max Height"
+msgstr ""
+
+#: includes/class-salesforce.php:215
+msgid "Invalid webhook request."
+msgstr ""
+
+#: includes/class-salesforce.php:275
+msgid "Connected App Settings"
+msgstr ""
+
+#: includes/class-salesforce.php:276
+msgid "Settings for your Salesforce connected app."
+msgstr ""
+
+#: includes/class-salesforce.php:285
+msgid "Consumer Key"
+msgstr ""
+
+#: includes/class-salesforce.php:286
+msgid "The connected app’s Consumer Key."
+msgstr ""
+
+#: includes/class-salesforce.php:295
+msgid "Consumer Secret"
+msgstr ""
+
+#: includes/class-salesforce.php:296
+msgid "The connected app’s Consumer Secret."
+msgstr ""
+
+#: includes/class-salesforce.php:359
+msgid "Could not validate credentials with Salesforce. Please verify your consumer key and secret and try again."
+msgstr ""
+
+#: includes/class-salesforce.php:379
+msgid "Webhook is not configured. Please try resetting your Salesforce connection and reconnecting."
+msgstr ""
+
+#: includes/class-salesforce.php:395
+msgid "Invalid Consumer Key, Secret, or Refresh Token."
+msgstr ""
+
+#: includes/class-salesforce.php:419
+msgid "We couldn’t validate the connection with Salesforce. Please verify the status of the Connected App in Salesforce."
+msgstr ""
+
+#: includes/class-salesforce.php:487
+#: includes/class-salesforce.php:1212
+msgid "Invalid Consumer Key or Secret."
+msgstr ""
+
+#: includes/class-salesforce.php:514
+msgid "Could not verify the Salesforce connected app. Please check your Consumer Key and Secret and try connecting again."
+msgstr ""
+
+#: includes/class-salesforce.php:551
+#: includes/class-salesforce.php:1305
+msgid "Order successfully synced to Salesforce."
+msgstr ""
+
+#: includes/class-salesforce.php:589
+msgid "No valid WooCommerce order data."
+msgstr ""
+
+#: includes/class-salesforce.php:602
+msgid "No valid transaction or contact data."
+msgstr ""
+
+#: includes/class-salesforce.php:611
+msgid "No valid contact email address."
+msgstr ""
+
+#: includes/class-salesforce.php:622
+msgid "Could not communicate with Salesforce."
+msgstr ""
+
+#: includes/class-salesforce.php:638
+msgid "Error creating contact."
+msgstr ""
+
+#: includes/class-salesforce.php:650
+msgid "Could not create or update Salesforce data."
+msgstr ""
+
+#: includes/class-salesforce.php:676
+msgid "Error creating opportunity."
+msgstr ""
+
+#: includes/class-salesforce.php:902
+msgid "WooCommerce must be installed and active."
+msgstr ""
+
+#: includes/class-salesforce.php:932
+msgid "Valid Order ID required."
+msgstr ""
+
+#: includes/class-salesforce.php:1220
+msgid "Invalid refresh token."
+msgstr ""
+
+#: includes/class-salesforce.php:1266
+msgid "Salesforce sync status"
+msgstr ""
+
+#: includes/class-salesforce.php:1267
+msgid "Fetching…"
+msgstr ""
+
+#: includes/class-salesforce.php:1281
+msgid "Sync order to Salesforce"
+msgstr ""
+
+#: includes/class-starter-content.php:73
+msgid "Invalid starter content approach"
+msgstr ""
+
+#: includes/class-starter-content.php:99
+#: includes/class-starter-content.php:113
+msgid "Starter content is not initialized correctly"
+msgstr ""
+
+#: includes/class-starter-content.php:177
 msgid "Newspack Placeholder Logo"
 msgstr ""
 
@@ -408,31 +1158,11 @@ msgstr ""
 msgid "Newspack theme installation failed."
 msgstr ""
 
-#: includes/class-webhooks.php:62
-msgid "No valid WooCommerce order data."
-msgstr ""
-
-#: includes/class-webhooks.php:73
-msgid "No valid transaction or contact data."
-msgstr ""
-
-#: includes/class-webhooks.php:80
-msgid "No valid contact email address."
-msgstr ""
-
-#: includes/class-webhooks.php:89
-msgid "Could not communicate with Salesforce."
-msgstr ""
-
-#: includes/class-webhooks.php:113
-msgid "Could not create or update Salesforce data."
-msgstr ""
-
 #: includes/configuration_managers/class-configuration-manager.php:32
 msgid "The plugin is not managed by Newspack."
 msgstr ""
 
-#: includes/configuration_managers/class-configuration-managers.php:75
+#: includes/configuration_managers/class-configuration-managers.php:79
 msgid "No configuration manager exists for this plugin."
 msgstr ""
 
@@ -444,28 +1174,1445 @@ msgstr ""
 msgid "Sorry, something is wrong with your Jetpack connection."
 msgstr ""
 
-#: includes/configuration_managers/class-newspack-ads-configuration-manager.php:137
+#: includes/configuration_managers/class-newspack-ads-configuration-manager.php:175
 msgid "The Newspack Ads plugin is not installed and activated. Install and/or activate it to access this feature."
 msgstr ""
 
-#: includes/configuration_managers/class-newspack-popups-configuration-manager.php:185
+#: includes/configuration_managers/class-newspack-newsletters-configuration-manager.php:78
+#: includes/configuration_managers/class-newspack-newsletters-configuration-manager.php:98
+msgid "The Newspack Newsletters plugin is not installed and activated. Install and/or activate it to access this feature."
+msgstr ""
+
+#: includes/configuration_managers/class-newspack-popups-configuration-manager.php:352
 msgid "The Newspack Popups plugin is not installed and activated. Install and/or activate it to access this feature."
+msgstr ""
+
+#: includes/configuration_managers/class-parsely-configuration-manager.php:40
+msgid "Parse.ly plugin is not installed and activated. Install and/or activate it to access this feature."
 msgstr ""
 
 #: includes/configuration_managers/class-wordpress-seo-configuration-manager.php:80
 msgid "Yoast plugin is not installed and activated. Install and/or activate it to access this feature."
 msgstr ""
 
-#: includes/popups-analytics/class-popups-analytics-utils.php:160
+#: includes/data-events/class-api.php:162
+#: includes/data-events/class-api.php:240
+msgid "Invalid URL."
+msgstr ""
+
+#: includes/data-events/class-api.php:249
+msgid "You must select actions to trigger this endpoint. Set it to global if this endpoint is meant for all actions."
+msgstr ""
+
+#: includes/data-events/class-data-events.php:162
+msgid "Action already registered."
+msgstr ""
+
+#: includes/data-events/class-data-events.php:182
+#: includes/data-events/class-data-events.php:276
+msgid "Action not registered."
+msgstr ""
+
+#: includes/data-events/class-data-events.php:185
+msgid "Handler is not callable."
+msgstr ""
+
+#: includes/data-events/class-data-events.php:188
+msgid "Handler already registered."
+msgstr ""
+
+#: includes/data-events/class-webhooks.php:72
+msgid "Webhook Requests"
+msgstr ""
+
+#: includes/data-events/class-webhooks.php:73
+msgid "Webhook Request"
+msgstr ""
+
+#: includes/data-events/class-webhooks.php:99
+#: assets/wizards/connections/views/main/webhooks.js:265
+msgid "Webhook Endpoints"
+msgstr ""
+
+#: includes/data-events/class-webhooks.php:100
+#: assets/wizards/connections/views/main/webhooks.js:441
+msgid "Webhook Endpoint"
+msgstr ""
+
+#: includes/data-events/class-webhooks.php:275
+#: includes/data-events/class-webhooks.php:301
+#: includes/data-events/class-webhooks.php:316
+#: includes/data-events/class-webhooks.php:350
+#: includes/data-events/class-webhooks.php:379
+msgid "Webhook endpoint not found."
+msgstr ""
+
+#: includes/data-events/class-webhooks.php:406
+msgid "Webhook request not found."
+msgstr ""
+
+#: includes/data-events/class-webhooks.php:677
+msgid "Endpoint not found."
+msgstr ""
+
+#: includes/data-events/class-webhooks.php:682
+msgid "Endpoint is disabled."
+msgstr ""
+
+#: includes/data-events/class-webhooks.php:721
+msgid "Endpoint not registered"
+msgstr ""
+
+#: includes/data-events/class-webhooks.php:752
+msgid "Request failed"
+msgstr ""
+
+#: includes/emails/class-emails.php:66
+msgctxt "post type general name"
+msgid "Newspack Emails"
+msgstr ""
+
+#: includes/emails/class-emails.php:67
+msgctxt "post type singular name"
+msgid "Newspack Email"
+msgstr ""
+
+#: includes/emails/class-emails.php:68
+msgctxt "admin menu"
+msgid "Newspack Emails"
+msgstr ""
+
+#: includes/emails/class-emails.php:69
+msgctxt "add new on admin bar"
+msgid "Newspack Email"
+msgstr ""
+
+#: includes/emails/class-emails.php:70
+msgctxt "popup"
+msgid "Add New"
+msgstr ""
+
+#: includes/emails/class-emails.php:71
+msgid "Add New Newspack Email"
+msgstr ""
+
+#: includes/emails/class-emails.php:72
+msgid "New Newspack Email"
+msgstr ""
+
+#: includes/emails/class-emails.php:73
+msgid "Edit Newspack Email"
+msgstr ""
+
+#: includes/emails/class-emails.php:74
+msgid "View Newspack Email"
+msgstr ""
+
+#: includes/emails/class-emails.php:75
+msgid "All Newspack Emails"
+msgstr ""
+
+#: includes/emails/class-emails.php:76
+msgid "Search Newspack Emails"
+msgstr ""
+
+#: includes/emails/class-emails.php:77
+msgid "Parent Newspack Emails:"
+msgstr ""
+
+#: includes/emails/class-emails.php:78
+msgid "No Newspack Emails found."
+msgstr ""
+
+#: includes/emails/class-emails.php:79
+msgid "No Newspack Emails found in Trash."
+msgstr ""
+
+#: includes/emails/class-emails.php:80
+msgid "Newspack Emails list"
+msgstr ""
+
+#: includes/emails/class-emails.php:81
+msgid "Newspack Email published"
+msgstr ""
+
+#: includes/emails/class-emails.php:82
+msgid "Newspack Email published privately"
+msgstr ""
+
+#: includes/emails/class-emails.php:83
+msgid "Newspack Email reverted to draft"
+msgstr ""
+
+#: includes/emails/class-emails.php:84
+msgid "Newspack Email scheduled"
+msgstr ""
+
+#: includes/emails/class-emails.php:85
+msgid "Newspack Email updated"
+msgstr ""
+
+#: includes/emails/class-emails.php:491
+#: assets/other-scripts/emails/index.js:84
+msgid "Test email was not sent."
+msgstr ""
+
+#: includes/oauth/class-fivetran-connection.php:170
+msgid "Fivetran proxy error"
+msgstr ""
+
+#: includes/oauth/class-google-login.php:117
+#: includes/oauth/class-google-oauth.php:215
+#: includes/reader-revenue/templates/myaccount-delete-account.php:20
+msgid "Invalid nonce."
+msgstr ""
+
+#: includes/oauth/class-google-login.php:122
+#: includes/oauth/class-google-oauth.php:220
+msgid "Invalid request"
+msgstr ""
+
+#: includes/oauth/class-google-login.php:130
+#: includes/oauth/class-google-login.php:136
+msgid "Authentication failed."
+msgstr ""
+
+#: includes/oauth/class-google-login.php:184
+msgid "Thank you for signing in!"
+msgstr ""
+
+#: includes/oauth/class-google-login.php:201
+msgid "Failed to retrieve email address. Please try again."
+msgstr ""
+
+#: includes/oauth/class-google-oauth.php:113
+msgid "Session token mismatch."
+msgstr ""
+
+#: includes/oauth/class-google-oauth.php:123
+msgid "Missing data."
+msgstr ""
+
+#: includes/oauth/class-google-oauth.php:172
+#: includes/oauth/class-mailchimp-api.php:188
+msgid "Request failed."
+msgstr ""
+
+#: includes/oauth/class-google-oauth.php:245
+msgid "Could not save auth data for user."
+msgstr ""
+
+#: includes/oauth/class-google-oauth.php:255
+msgid "Successfully connected to Google account."
+msgstr ""
+
+#: includes/oauth/class-google-oauth.php:276
+msgid "Missing token for user."
+msgstr ""
+
+#: includes/oauth/class-google-oauth.php:288
+msgid "Could not revoke credentials."
+msgstr ""
+
+#: includes/oauth/class-google-oauth.php:348
+msgid "Newspack can’t access all necessary data because you haven’t granted all permissions requested during setup. Please reconnect your Google account."
+msgstr ""
+
+#: includes/oauth/class-google-oauth.php:364
+msgid "Invalid Google credentials. Please reconnect."
+msgstr ""
+
+#: includes/oauth/class-google-oauth.php:376
+msgid "Invalid or missing Google credentials."
+msgstr ""
+
+#: includes/oauth/class-google-services-connection.php:37
+#: includes/popups-analytics/class-popups-analytics-utils.php:184
+msgid "Connect Site Kit plugin to view Campaign Analytics."
+msgstr ""
+
+#: includes/oauth/class-mailchimp-api.php:95
+#: includes/oauth/class-mailchimp-api.php:165
+msgid "Invalid Mailchimp API Key."
+msgstr ""
+
+#: includes/plugins/class-gravityforms.php:202
+msgid "There is a mistake in the form!"
+msgstr ""
+
+#: includes/plugins/class-gravityforms.php:203
+msgid "Form successfully submitted."
+msgstr ""
+
+#: includes/plugins/class-gravityforms.php:204
+msgid "Submitting…"
+msgstr ""
+
+#: includes/plugins/class-gravityforms.php:205
+msgid "Something went wrong. Please try again later."
+msgstr ""
+
+#: includes/plugins/class-perfmatters.php:266
+msgid "Newspack plugin is overriding Perfmatters settings. You can use the <code>NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS</code> flag to disable that behavior."
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/donation-wall.php:34
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:30
+msgid "Choose an option to continue reading"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/donation-wall.php:41
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier-metering.php:63
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier.php:31
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:37
+#: includes/plugins/wc-memberships/block-patterns/registration-wall.php:24
+#: includes/reader-activation/class-reader-activation.php:929
+#: includes/reader-activation/class-reader-activation.php:981
+#: includes/reader-activation/class-reader-activation.php:1028
+#: assets/blocks/reader-registration/edit.js:254
+msgid "Sign In"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier-metering.php:18
+msgid "You've read all free articles for the week."
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier-metering.php:28
+msgid "Register now and get<br><strong>3 free articles every week.</strong>"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier-metering.php:37
+msgid "Register for free"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier-metering.php:50
+msgid "Unlimited access to our<br><strong>daily content and archives</strong>."
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier-metering.php:54
+msgid "Subscribe for $5/month!"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier.php:9
+msgid "Unlimited access to our content and archive"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier.php:10
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:10
+msgid "Puzzles and recipes"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-one-tier.php:11
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:16
+msgid "Exclusive podcasts and newsletters"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:9
+msgid "Unlimited access to our content"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:11
+msgid "Support quality journalism"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:15
+msgid "Everything Members get"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:17
+msgid "Our appreciation and love"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:48
+msgid "Member"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:53
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:76
+msgid "per month"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:63
+msgid "Become a Member"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:71
+msgid "Patron"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers.php:86
+msgid "Become a Patron"
+msgstr ""
+
+#: includes/plugins/wc-memberships/block-patterns/registration-wall.php:17
+msgid "Register to continue reading"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-block-patterns.php:50
+msgid "Registration Wall"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-block-patterns.php:51
+msgid "Donation Wall"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-block-patterns.php:52
+msgid "Pay Wall with One Tier"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-block-patterns.php:53
+msgid "Pay Wall with One Tier and Metering"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-block-patterns.php:54
+msgid "Pay Wall with Two Tiers"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-block-patterns.php:66
+msgid "Memberships"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-block-patterns.php:84
+msgctxt "Block pattern description"
+msgid "Invite your reader to become a member before continuing reading the article"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-memberships.php:101
+#: includes/plugins/wc-memberships/class-memberships.php:467
+msgid "Memberships Gate"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-memberships.php:103
+msgid "Memberships Gate published."
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-memberships.php:104
+msgid "Memberships Gate reverted to draft."
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-memberships.php:105
+msgid "Memberships Gate updated."
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-memberships.php:106
+msgid "New Memberships Gate"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-memberships.php:107
+msgid "Edit Memberships Gate"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-memberships.php:108
+msgid "View Memberships Gate"
+msgstr ""
+
+#. Translators: %s is the plan name.
+#: includes/plugins/wc-memberships/class-memberships.php:473
+msgid "%s Gate"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-memberships.php:483
+msgid "This post is only available to members."
+msgstr ""
+
+#: includes/popups-analytics/class-popups-analytics-utils.php:55
+msgid "Date"
+msgstr ""
+
+#: includes/popups-analytics/class-popups-analytics-utils.php:55
+msgid "Views"
+msgstr ""
+
+#: includes/popups-analytics/class-popups-analytics-utils.php:179
 msgid "Please authenticate with Google Analytics to view Campaign analytics."
 msgstr ""
 
-#: includes/popups-analytics/class-popups-analytics-utils.php:162
+#: includes/popups-analytics/class-popups-analytics-utils.php:181
 msgid "Google Analytics data fetching error."
 msgstr ""
 
-#: includes/popups-analytics/class-popups-analytics-utils.php:165
-msgid "Connect Site Kit plugin to view Campaign Analytics."
+#: includes/reader-activation/class-reader-activation-emails.php:45
+msgid "Verification"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:46
+msgid "Email sent to the reader after they've registered."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:48
+msgid "This email will be sent to a reader after they've registered."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:51
+msgid "the verification link"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:58
+msgid "Login link"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:59
+msgid "Email with a login link."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:61
+msgid "This email will be sent to a reader when they request a login link."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:64
+#: includes/reader-activation/class-reader-activation-emails.php:77
+msgid "the one-time password"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:71
+msgid "Login one-time password"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:72
+msgid "Email with a one-time password and login link."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:74
+msgid "This email will be sent to a reader when they request a login link and a one-time password is available."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:81
+msgid "the login link"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:88
+msgid "Set a New Password"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:89
+msgid "Email with password reset link."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:91
+msgid "This email will be sent to a reader when they request a password creation or reset."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:94
+msgid "the password reset link"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:101
+#: includes/reader-revenue/templates/myaccount-delete-account.php:52
+#: includes/reader-revenue/templates/myaccount-edit-account.php:107
+msgid "Delete Account"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:102
+msgid "Email with account deletion link."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:104
+msgid "This email will be sent to a reader when they request an account deletion."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:107
+msgid "the account deletion link"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:148
+#: includes/reader-activation/class-reader-activation.php:1515
+msgid "Please enter a valid email address."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:149
+msgid "Please enter a password."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:150
+msgid "The popup has been blocked. Allow popups for the site and try again."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:173
+msgid "Subscribe to our newsletters:"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:260
+msgid "Newspack Campaigns plugin is required to activate Reader Activation features."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:376
+msgid "Legal Pages"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:379
+msgid "Privacy policies that tell users how you collect and use their data are essential for running a  trustworthy website. While rules and regulations can differ by country, certain legal pages might be required by law."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:382
+msgid "Legal Pages Disclaimer Text"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:386
+msgid "Legal Pages URL"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:396
+msgid "Email Service Provider (ESP)"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:397
+msgid "Connect to your ESP to register readers with their email addresses and send newsletters."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:398
+msgid "Connect to your email service provider (ESP) and enable at least one subscription list."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:405
+msgid "Transactional Emails"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:410
+msgid "Sender Name"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:414
+msgid "Sender Email Address"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:418
+msgid "Contact Email Address"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:425
+#: assets/wizards/connections/views/main/recaptcha.js:65
+msgid "reCAPTCHA v3"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:426
+msgid "Connecting to a Google reCAPTCHA v3 account enables enhanced anti-spam for all Newspack sign-up blocks."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:427
+msgid "Enable reCAPTCHA v3 and enter your account credentials."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:440
+#: includes/wizards/class-reader-revenue-wizard.php:40
+#: assets/wizards/readerRevenue/index.js:84
+#: assets/wizards/setup/views/services/index.js:27
+msgid "Reader Revenue"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:441
+msgid "Setting suggested donation amounts is required for enabling a streamlined donation experience."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:442
+msgid "Set platform to \"Newspack\" or \"News Revenue Hub\" and configure your default donation settings. If using News Revenue Hub, set an Organization ID and a Donor Landing Page in News Revenue Hub Settings."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:452
+msgid "Reader Activation Campaign"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:453
+msgid "Building a set of prompts with default segments and settings allows for an improved experience optimized for Reader Activation."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:457
+msgid "Reader Activation campaign"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:458
+msgid "Waiting for all settings to be ready"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:510
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:435
+#: includes/reader-revenue/templates/myaccount-edit-account.php:56
+msgid "Email address"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:684
+msgid "Thank you for verifying your account!"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:957
+#: includes/reader-activation/class-reader-activation.php:1097
+msgid "Enter your email address"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:982
+msgid "Sign Up"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1013
+msgid "Close Authentication Form"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1024
+msgid "I don't have an account"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1025
+msgid "I already have an account"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1044
+msgid "We've recently sent you an authentication link. Please, check your inbox!"
+msgstr ""
+
+#. Translators: %s is the link to sign in via magic link instead.
+#: includes/reader-activation/class-reader-activation.php:1051
+msgid "Sign in with a password below, or %s."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1052
+msgid "sign in using your email"
+msgstr ""
+
+#. Translators: %s is the link to sign in via password instead.
+#: includes/reader-activation/class-reader-activation.php:1062
+msgid "Get a code sent to your email to sign in, or %s."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1063
+#: includes/reader-activation/class-reader-activation.php:1074
+msgid "sign in using a password"
+msgstr ""
+
+#. Translators: %s is the link to sign in via password instead.
+#: includes/reader-activation/class-reader-activation.php:1073
+msgid "Enter the code you received via email to sign in, or %s."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1101
+msgid "6-digit code"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1104
+msgid "Enter your password"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1112
+msgid "Sign in with your email"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1115
+msgid "Lost your password?"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1125
+msgid "Try a different email"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1128
+msgid "Send another code"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1134
+msgid "Send authorization code"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1138
+msgid "Sign in with a password"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1303
+#: assets/blocks/reader-registration/edit.js:337
+msgid "OR"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1310
+#: assets/blocks/reader-registration/edit.js:344
+msgid "Sign in with Google"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1390
+msgid "We couldn't find a reader account registered to this email address. Please confirm that you entered the correct email, or sign up for a new account."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1401
+msgid "You must enter a valid password."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1405
+msgid "Invalid credentials."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1413
+msgid "We encountered an error sending an authentication link. Please try again."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1415
+msgid "Please check your inbox for an authentication link."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1424
+msgid "An account was already registered with this email."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1429
+msgid "Unable to register your account. Try a different email."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1505
+msgid "Registration is disabled."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1509
+msgid "Cannot register while logged in."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1630
+msgid "Please wait before requesting another verification email."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1736
+msgid "Please wait a moment before requesting another password reset email."
+msgstr ""
+
+#: includes/reader-activation/class-reader-data.php:181
+msgid "Too many items."
+msgstr ""
+
+#: includes/reader-activation/class-reader-data.php:223
+#: includes/reader-activation/class-reader-data.php:246
+#: includes/wizards/class-analytics-wizard.php:136
+msgid "Invalid parameters."
+msgstr ""
+
+#: includes/reader-activation/class-reader-data.php:227
+msgid "Invalid value."
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:58
+msgid "Receipt"
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:59
+msgid "Email sent to the donor after they've donated."
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:61
+msgid "This email will be sent to a reader after they contribute to your site."
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:65
+msgid "the payment amount"
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:69
+msgid "payment date"
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:73
+msgid "payment method (last four digits of the card used)"
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:77
+msgid "the contact email to your site (same as the \"From\" email address)"
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:84
+msgid "automatically-generated receipt link"
+msgstr ""
+
+#: includes/reader-revenue/class-woocommerce-connection.php:412
+msgid "Donor has opted-in to your newsletter."
+msgstr ""
+
+#: includes/reader-revenue/class-woocommerce-connection.php:479
+msgid "Stripe via Newspack"
+msgstr ""
+
+#: includes/reader-revenue/class-woocommerce-connection.php:515
+msgid "One-time Newspack donation."
+msgstr ""
+
+#. translators: %s - donation frequency
+#: includes/reader-revenue/class-woocommerce-connection.php:518
+msgid "Newspack donation with frequency: %s."
+msgstr ""
+
+#: includes/reader-revenue/class-woocommerce-connection.php:587
+msgid "Missing donation product."
+msgstr ""
+
+#: includes/reader-revenue/class-woocommerce-connection.php:696
+msgid "This subscription was created via Newspack."
+msgstr ""
+
+#. translators: %s - donation frequency
+#: includes/reader-revenue/class-woocommerce-connection.php:699
+msgid "Newspack subscription with frequency: %s. The recurring payment and the subscription will be handled in Stripe, so you'll see \"Manual renewal\" as the payment method in WooCommerce."
+msgstr ""
+
+#: includes/reader-revenue/class-woocommerce-connection.php:709
+#: includes/reader-revenue/stripe/class-stripe-webhooks.php:413
+#: assets/wizards/connections/views/main/fivetran.js:27
+#: assets/wizards/readerRevenue/views/platform/index.js:40
+msgid "Stripe"
+msgstr ""
+
+#. translators: %s: Product name
+#: includes/reader-revenue/class-woocommerce-connection.php:995
+msgid "Newspack %1$s (Order #%2$d, Subscription #%3$d)"
+msgstr ""
+
+#. translators: %s: Product name
+#: includes/reader-revenue/class-woocommerce-connection.php:1003
+msgid "Newspack %1$s (Order #%2$d)"
+msgstr ""
+
+#: includes/reader-revenue/class-woocommerce-connection.php:1109
+#: includes/reader-revenue/stripe/class-stripe-connection.php:455
+msgid "Card"
+msgstr ""
+
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:85
+msgid "Billing"
+msgstr ""
+
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:93
+msgid "Log out"
+msgstr ""
+
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:170
+msgid "Please check your email inbox for instructions on how to set a new password."
+msgstr ""
+
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:177
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:238
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:310
+#: assets/wizards/connections/views/main/fivetran.js:70
+#: assets/wizards/connections/views/main/google.js:30
+#: assets/wizards/connections/views/main/mailchimp.js:24
+#: assets/wizards/engagement/components/active-campaign.js:33
+#: assets/wizards/engagement/components/mailchimp.js:33
+#: assets/wizards/engagement/views/newsletters/index.js:163
+#: assets/wizards/engagement/views/newsletters/index.js:305
+#: assets/wizards/engagement/views/reader-activation/campaign.js:65
+#: assets/wizards/engagement/views/reader-activation/complete.js:144
+#: assets/wizards/engagement/views/reader-activation/index.js:172
+#: assets/wizards/readerRevenue/views/emails/index.js:101
+msgid "Something went wrong."
+msgstr ""
+
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:238
+msgid "Please check your email inbox for instructions on how to delete your account."
+msgstr ""
+
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:303
+msgid "Please check your email inbox for a link to verify your account."
+msgstr ""
+
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:434
+#: includes/reader-revenue/templates/myaccount-edit-account.php:51
+msgid "Display name"
+msgstr ""
+
+#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:521
+msgid "You have successfully logged out."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:139
+msgid "Could not fetch customer."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:153
+msgid "Could not fetch charge."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:183
+msgid "Invalid transaction type."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:194
+msgid "Could not fetch customer's charges."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:272
+msgid "Could not retrieve or create billing portal configuration."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:297
+msgid "Could not create billing portal session."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:323
+msgid "Invoice ID is missing."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:334
+msgid "Could not fetch invoice."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:353
+msgid "Could not fetch subscription."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:372
+msgid "Could not fetch subscriptions."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:401
+msgid "Could not cancel subscription."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:415
+msgid "Could not fetch balance transaction."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:621
+msgid "Newspack Monthly Donation"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:624
+msgid "Newspack Annual Donation"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:628
+msgid "Products retrieval failed."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:652
+msgid "Stripe secret key not provided."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:739
+msgid "Customer creation failed."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:858
+#: includes/reader-revenue/stripe/class-stripe-webhooks.php:412
+msgid "Newspack Donation"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:871
+msgid "Apple Pay (Stripe)"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:874
+msgid "Google Pay (Stripe)"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-connection.php:877
+msgid "Credit Card (Stripe)"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:54
+msgid "Error fetching customer invoices: "
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:61
+msgid "Missing charge ID on invoice "
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:66
+msgid "Error retrieving charge of "
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:94
+#: includes/reader-revenue/stripe/class-stripe-sync.php:190
+msgid "Error fetching customer charges: "
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:125
+msgid "Error processing customer"
+msgstr ""
+
+#. translators: Customer email, linked orders count.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:131
+msgid "Created WC Customer with email: %1$s and linked %2$d order(s) to them."
+msgstr ""
+
+#. translators: Order ID.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:154
+msgid "Updated WC order: %d."
+msgstr ""
+
+#. translators: Order ID.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:163
+msgid "Created WC order: %d."
+msgstr ""
+
+#. translators: Customer email address.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:255
+msgid "Added customer %s to ESP."
+msgstr ""
+
+#. translators: Customer email address.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:258
+msgid "Would have added customer %s to ESP."
+msgstr ""
+
+#. translators: Number of customers processed.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:279
+msgid "Processing a batch of %d Stripe customers."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:308
+msgid "Could not process all customers:"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:338
+msgid "This is a dry run, no changes will be made."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:343
+msgid "WC Stripe Gateway plugin has to be active."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:348
+msgid "WooCommerce plugin has to be active."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:355
+msgid "Newspack Newsletters has to be active."
+msgstr ""
+
+#. translators: Number of Stripe customers processed.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:367
+msgid "Processed %d Stripe customers."
+msgstr ""
+
+#. translators: Number of customers found.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:371
+msgid "Found %d WC customers linked to Stripe customers."
+msgstr ""
+
+#. translators: Number of customers created.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:373
+msgid "Created %d WC customers from Stripe customers."
+msgstr ""
+
+#. translators: Number of subscription charges processed.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:375
+msgid "Processed %d subscription-related Stripe charges."
+msgstr ""
+
+#. translators: Number of one-time charges processed.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:377
+msgid "Processed %d one-time Stripe charges."
+msgstr ""
+
+#. translators: Number of orders updated.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:379
+msgid "Updated %d WC orders linked to Stripe charges."
+msgstr ""
+
+#. translators: Number of orders created.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:381
+msgid "Created %d WC orders from Stripe charges."
+msgstr ""
+
+#. translators: Number of Stripe customers skipped.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:383
+msgid "Skipped %d Stripe customers."
+msgstr ""
+
+#. translators: %s is the Stripe subscription ID.
+#: includes/reader-revenue/stripe/class-stripe-sync.php:720
+msgid "This subscription has been migrated from Stripe. It will now be fully manageable in WooCommerce. You can find the cancelled Stripe subscription by ID %s"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:789
+msgid "Backfill WC Customers from Stripe database."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:797
+msgid "Migrate subscriptions from Stripe to WC"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:823
+msgid "Ensure that all migrated subscriptions have a next payment date."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-sync.php:844
+msgid "Migrate customers from Stripe Connect to Stripe"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-webhooks.php:82
+msgid "Could not fetch webhooks:"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-webhooks.php:186
+msgid "Could not update Stripe webhook:"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-webhooks.php:203
+msgid "Could not delete Stripe webhook."
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-webhooks.php:207
+msgid "Could not delete Stripe webhook:"
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-webhooks.php:586
+msgid "Webhook reset failed "
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-webhooks.php:615
+msgid "Webhook creation failed: "
+msgstr ""
+
+#: includes/reader-revenue/stripe/class-stripe-webhooks.php:659
+msgid "Webhook validation failed: "
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-after-delete-account.php:15
+msgid "Your account has been deleted."
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-after-delete-account.php:18
+msgid "We're sorry to see you go. But hope you'll continue to follow our coverage."
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-after-delete-account.php:21
+msgid "Return to home page"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-billing.php:23
+msgid "Visit Stripe to change your payment method, cancel recurring payments, and view billing history."
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-billing.php:25
+msgid "Manage billing information"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-delete-account.php:25
+#: includes/reader-revenue/templates/myaccount-delete-account.php:32
+msgid "Invalid token"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-delete-account.php:39
+msgid "Confirm to delete your account permanently."
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-delete-account.php:42
+#: includes/reader-revenue/templates/myaccount-edit-account.php:115
+msgid "Deleting your account will also cancel any newsletter subscriptions and recurring payments."
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-delete-account.php:45
+msgid "Caution, this action is irreversible!"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-edit-account.php:65
+msgid "Save changes"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-edit-account.php:80
+msgid "Create a Password"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-edit-account.php:82
+msgid "Reset Password"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-edit-account.php:89
+msgid "Email me a link to set my password"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-edit-account.php:91
+msgid "Email me a password reset link"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-edit-account.php:110
+msgid "Request account deletion"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-verify.php:56
+msgid "You must verify your account before you can manage account settings. Verify with a link or by setting a password."
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-verify.php:60
+msgid "Send me a link"
+msgstr ""
+
+#: includes/reader-revenue/templates/myaccount-verify.php:63
+#: includes/templates/reader-activation-emails/password-reset.php:11
+#: includes/templates/reader-activation-emails/password-reset.php:15
+#: includes/templates/reader-activation-emails/password-reset.php:24
+#: includes/templates/reader-activation-emails/password-reset.php:169
+msgid "Set a new password"
+msgstr ""
+
+#. translators: 1 and 2 are the opening and closing <a> tag with the link to restore revisions.
+#: includes/revisions-control/class-major-revisions.php:93
+msgid "Revisions marked as major were deleted from the database. %1$sRestore major revisions.%2$s"
+msgstr ""
+
+#: includes/revisions-control/class-major-revisions.php:180
+msgid "Saving..."
+msgstr ""
+
+#: includes/revisions-control/class-major-revisions.php:181
+msgid "Changes applied"
+msgstr ""
+
+#: includes/revisions-control/class-major-revisions.php:182
+msgid "Unmark as a major revision"
+msgstr ""
+
+#: includes/revisions-control/class-major-revisions.php:183
+msgid "Mark as a major revision"
+msgstr ""
+
+#: includes/revisions-control/class-major-revisions.php:184
+msgid "Major revision"
+msgstr ""
+
+#. translators: %d is the maximum number of revisions that will be kept.
+#: includes/revisions-control/class-revisions-control.php:151
+msgid "<strong>Newspack</strong> revisions control is active. This means that there is a limit of %d revisions that will be kept."
+msgstr ""
+
+#: includes/revisions-control/class-revisions-control.php:152
+msgid " Older revisions that exceed this number will be deleted, except:"
+msgstr ""
+
+#: includes/revisions-control/class-revisions-control.php:153
+msgid "Revisions less than one week old"
+msgstr ""
+
+#: includes/revisions-control/class-revisions-control.php:154
+msgid "Revisions marked as major. Use the button on the revision title bar to mark/unmark a revision as major"
+msgstr ""
+
+#. translators: %s - Site URL
+#: includes/starter_content/class-starter-content-wordpress.php:38
+#: includes/wizards/class-setup-wizard.php:250
+msgid "Invalid site URL: \"%s\"."
+msgstr ""
+
+#. translators: %s - Site URL
+#: includes/starter_content/class-starter-content-wordpress.php:62
+msgid "\"%s\" is a WordPress site but does not have the REST API enabled."
+msgstr ""
+
+#. translators: %s - Site URL
+#: includes/starter_content/class-starter-content-wordpress.php:72
+msgid "\"%s\" does not appear to be a WordPress site."
+msgstr ""
+
+#. translators: %s - Site URL
+#: includes/starter_content/class-starter-content-wordpress.php:85
+msgid "Unable to parse response from \"%s\"."
+msgstr ""
+
+#: includes/starter_content/class-starter-content-wordpress.php:193
+msgid "Featured"
+msgstr ""
+
+#: includes/starter_content/class-starter-content-wordpress.php:198
+msgid "Latest"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/delete-account.php:11
+msgid "Account deletion request"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/delete-account.php:15
+#: includes/templates/reader-activation-emails/delete-account.php:169
+msgid "Sad to see you go!"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/delete-account.php:19
+#: includes/templates/reader-activation-emails/delete-account.php:169
+msgid "Delete your account by clicking this button:"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/delete-account.php:24
+#: includes/templates/reader-activation-emails/delete-account.php:169
+msgid "Delete my account"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/delete-account.php:29
+#: includes/templates/reader-activation-emails/delete-account.php:169
+#: includes/templates/reader-activation-emails/magic-link.php:29
+#: includes/templates/reader-activation-emails/magic-link.php:169
+#: includes/templates/reader-activation-emails/otp.php:37
+#: includes/templates/reader-activation-emails/otp.php:197
+#: includes/templates/reader-activation-emails/password-reset.php:29
+#: includes/templates/reader-activation-emails/password-reset.php:169
+#: includes/templates/reader-activation-emails/verification.php:29
+#: includes/templates/reader-activation-emails/verification.php:173
+msgid "Or copy and paste the link in your browser:"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/magic-link.php:11
+msgid "Authentication link"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/magic-link.php:15
+#: includes/templates/reader-activation-emails/magic-link.php:169
+#: includes/templates/reader-activation-emails/otp.php:15
+#: includes/templates/reader-activation-emails/otp.php:197
+msgid "Welcome back!"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/magic-link.php:19
+#: includes/templates/reader-activation-emails/magic-link.php:169
+msgid "Log into your account by clicking this button:"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/magic-link.php:24
+#: includes/templates/reader-activation-emails/magic-link.php:169
+#: includes/templates/reader-activation-emails/otp.php:32
+msgid "Log in"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/otp.php:11
+msgid "Authorization code"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/otp.php:19
+#: includes/templates/reader-activation-emails/otp.php:197
+msgid "Use the following code to login to your account:"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/otp.php:27
+#: includes/templates/reader-activation-emails/otp.php:197
+msgid "You can also log into your account by clicking the following button:"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/password-reset.php:19
+#: includes/templates/reader-activation-emails/password-reset.php:169
+msgid "Set a new password for your account by clicking this button:"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/password-reset.php:169
+msgid "Set new password"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/verification.php:11
+msgid "Your verification link"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/verification.php:15
+#: includes/templates/reader-activation-emails/verification.php:173
+msgid "Hi there!"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/verification.php:19
+#: includes/templates/reader-activation-emails/verification.php:173
+msgid "To manage your account, please verify your email address by clicking the link below:"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/verification.php:24
+#: includes/templates/reader-activation-emails/verification.php:173
+msgid "Verify my email"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/verification.php:33
+#: includes/templates/reader-activation-emails/verification.php:173
+msgid "Once verified, you'll be able to edit your profile, set a password for easier access, and manage your newsletter subscriptions and billing information."
+msgstr ""
+
+#: includes/templates/reader-revenue-emails/receipt.php:9
+msgid "Thank you!"
+msgstr ""
+
+#: includes/util.php:46
+msgid "United Arab Emirates dirham"
 msgstr ""
 
 #: includes/util.php:47
@@ -477,27 +2624,27 @@ msgid "Albanian lek"
 msgstr ""
 
 #: includes/util.php:49
-msgid "Algerian dinar"
-msgstr ""
-
-#: includes/util.php:50
-msgid "Angolan kwanza"
-msgstr ""
-
-#: includes/util.php:51
-msgid "Argentine peso"
-msgstr ""
-
-#: includes/util.php:52
 msgid "Armenian dram"
 msgstr ""
 
+#: includes/util.php:50
+msgid "Netherlands Antillean guilder"
+msgstr ""
+
+#: includes/util.php:51
+msgid "Angolan kwanza"
+msgstr ""
+
+#: includes/util.php:52
+msgid "Argentine peso"
+msgstr ""
+
 #: includes/util.php:53
-msgid "Aruban florin"
+msgid "Australian dollar"
 msgstr ""
 
 #: includes/util.php:54
-msgid "Australian dollar"
+msgid "Aruban florin"
 msgstr ""
 
 #: includes/util.php:55
@@ -505,11 +2652,11 @@ msgid "Azerbaijani manat"
 msgstr ""
 
 #: includes/util.php:56
-msgid "Bahamian dollar"
+msgid "Bosnia and Herzegovina convertible mark"
 msgstr ""
 
 #: includes/util.php:57
-msgid "Bahraini dinar"
+msgid "Barbadian dollar"
 msgstr ""
 
 #: includes/util.php:58
@@ -517,43 +2664,43 @@ msgid "Bangladeshi taka"
 msgstr ""
 
 #: includes/util.php:59
-msgid "Barbadian dollar"
+msgid "Bulgarian lev"
 msgstr ""
 
 #: includes/util.php:60
-msgid "Belarusian ruble (old)"
+msgid "Bahraini dinar"
 msgstr ""
 
 #: includes/util.php:61
-msgid "Belarusian ruble"
+msgid "Burundian franc"
 msgstr ""
 
 #: includes/util.php:62
-msgid "Belize dollar"
-msgstr ""
-
-#: includes/util.php:63
 msgid "Bermudian dollar"
 msgstr ""
 
+#: includes/util.php:63
+msgid "Brunei dollar"
+msgstr ""
+
 #: includes/util.php:64
-msgid "Bhutanese ngultrum"
-msgstr ""
-
-#: includes/util.php:65
-msgid "Bitcoin"
-msgstr ""
-
-#: includes/util.php:66
-msgid "Bol&iacute;var soberano"
-msgstr ""
-
-#: includes/util.php:67
 msgid "Bolivian boliviano"
 msgstr ""
 
+#: includes/util.php:65
+msgid "Brazilian real"
+msgstr ""
+
+#: includes/util.php:66
+msgid "Bahamian dollar"
+msgstr ""
+
+#: includes/util.php:67
+msgid "Bitcoin"
+msgstr ""
+
 #: includes/util.php:68
-msgid "Bosnia and Herzegovina convertible mark"
+msgid "Bhutanese ngultrum"
 msgstr ""
 
 #: includes/util.php:69
@@ -561,227 +2708,227 @@ msgid "Botswana pula"
 msgstr ""
 
 #: includes/util.php:70
-msgid "Brazilian real"
+msgid "Belarusian ruble (old)"
 msgstr ""
 
 #: includes/util.php:71
-msgid "Brunei dollar"
+msgid "Belarusian ruble"
 msgstr ""
 
 #: includes/util.php:72
-msgid "Bulgarian lev"
+msgid "Belize dollar"
 msgstr ""
 
 #: includes/util.php:73
-msgid "Burmese kyat"
-msgstr ""
-
-#: includes/util.php:74
-msgid "Burundian franc"
-msgstr ""
-
-#: includes/util.php:75
-msgid "CFP franc"
-msgstr ""
-
-#: includes/util.php:76
-msgid "Cambodian riel"
-msgstr ""
-
-#: includes/util.php:77
 msgid "Canadian dollar"
 msgstr ""
 
-#: includes/util.php:78
-msgid "Cape Verdean escudo"
-msgstr ""
-
-#: includes/util.php:79
-msgid "Cayman Islands dollar"
-msgstr ""
-
-#: includes/util.php:80
-msgid "Central African CFA franc"
-msgstr ""
-
-#: includes/util.php:81
-msgid "Chilean peso"
-msgstr ""
-
-#: includes/util.php:82
-msgid "Chinese yuan"
-msgstr ""
-
-#: includes/util.php:83
-msgid "Colombian peso"
-msgstr ""
-
-#: includes/util.php:84
-msgid "Comorian franc"
-msgstr ""
-
-#: includes/util.php:85
+#: includes/util.php:74
 msgid "Congolese franc"
 msgstr ""
 
-#: includes/util.php:86
+#: includes/util.php:75
+msgid "Swiss franc"
+msgstr ""
+
+#: includes/util.php:76
+msgid "Chilean peso"
+msgstr ""
+
+#: includes/util.php:77
+msgid "Chinese yuan"
+msgstr ""
+
+#: includes/util.php:78
+msgid "Colombian peso"
+msgstr ""
+
+#: includes/util.php:79
 msgid "Costa Rican col&oacute;n"
 msgstr ""
 
-#: includes/util.php:87
-msgid "Croatian kuna"
-msgstr ""
-
-#: includes/util.php:88
+#: includes/util.php:80
 msgid "Cuban convertible peso"
 msgstr ""
 
-#: includes/util.php:89
+#: includes/util.php:81
 msgid "Cuban peso"
 msgstr ""
 
-#: includes/util.php:90
+#: includes/util.php:82
+msgid "Cape Verdean escudo"
+msgstr ""
+
+#: includes/util.php:83
 msgid "Czech koruna"
 msgstr ""
 
-#: includes/util.php:91
-msgid "Danish krone"
-msgstr ""
-
-#: includes/util.php:92
+#: includes/util.php:84
 msgid "Djiboutian franc"
 msgstr ""
 
-#: includes/util.php:93
+#: includes/util.php:85
+msgid "Danish krone"
+msgstr ""
+
+#: includes/util.php:86
 msgid "Dominican peso"
 msgstr ""
 
-#: includes/util.php:94
-msgid "East Caribbean dollar"
+#: includes/util.php:87
+msgid "Algerian dinar"
 msgstr ""
 
-#: includes/util.php:95
+#: includes/util.php:88
 msgid "Egyptian pound"
 msgstr ""
 
-#: includes/util.php:96
+#: includes/util.php:89
 msgid "Eritrean nakfa"
 msgstr ""
 
-#: includes/util.php:97
+#: includes/util.php:90
 msgid "Ethiopian birr"
 msgstr ""
 
-#: includes/util.php:98
+#: includes/util.php:91
 msgid "Euro"
 msgstr ""
 
-#: includes/util.php:99
-msgid "Falkland Islands pound"
-msgstr ""
-
-#: includes/util.php:100
+#: includes/util.php:92
 msgid "Fijian dollar"
 msgstr ""
 
-#: includes/util.php:101
-msgid "Gambian dalasi"
+#: includes/util.php:93
+msgid "Falkland Islands pound"
 msgstr ""
 
-#: includes/util.php:102
+#: includes/util.php:94
+msgid "Pound sterling"
+msgstr ""
+
+#: includes/util.php:95
 msgid "Georgian lari"
 msgstr ""
 
-#: includes/util.php:103
-msgid "Ghana cedi"
-msgstr ""
-
-#: includes/util.php:104
-msgid "Gibraltar pound"
-msgstr ""
-
-#: includes/util.php:105
-msgid "Guatemalan quetzal"
-msgstr ""
-
-#: includes/util.php:106
+#: includes/util.php:96
 msgid "Guernsey pound"
 msgstr ""
 
-#: includes/util.php:107
+#: includes/util.php:97
+msgid "Ghana cedi"
+msgstr ""
+
+#: includes/util.php:98
+msgid "Gibraltar pound"
+msgstr ""
+
+#: includes/util.php:99
+msgid "Gambian dalasi"
+msgstr ""
+
+#: includes/util.php:100
 msgid "Guinean franc"
 msgstr ""
 
-#: includes/util.php:108
+#: includes/util.php:101
+msgid "Guatemalan quetzal"
+msgstr ""
+
+#: includes/util.php:102
 msgid "Guyanese dollar"
 msgstr ""
 
-#: includes/util.php:109
-msgid "Haitian gourde"
-msgstr ""
-
-#: includes/util.php:110
-msgid "Honduran lempira"
-msgstr ""
-
-#: includes/util.php:111
+#: includes/util.php:103
 msgid "Hong Kong dollar"
 msgstr ""
 
-#: includes/util.php:112
+#: includes/util.php:104
+msgid "Honduran lempira"
+msgstr ""
+
+#: includes/util.php:105
+msgid "Croatian kuna"
+msgstr ""
+
+#: includes/util.php:106
+msgid "Haitian gourde"
+msgstr ""
+
+#: includes/util.php:107
 msgid "Hungarian forint"
 msgstr ""
 
-#: includes/util.php:113
-msgid "Icelandic kr&oacute;na"
-msgstr ""
-
-#: includes/util.php:114
-msgid "Indian rupee"
-msgstr ""
-
-#: includes/util.php:115
+#: includes/util.php:108
 msgid "Indonesian rupiah"
 msgstr ""
 
-#: includes/util.php:116
-msgid "Iranian rial"
-msgstr ""
-
-#: includes/util.php:117
-msgid "Iranian toman"
-msgstr ""
-
-#: includes/util.php:118
-msgid "Iraqi dinar"
-msgstr ""
-
-#: includes/util.php:119
+#: includes/util.php:109
 msgid "Israeli new shekel"
 msgstr ""
 
-#: includes/util.php:120
-msgid "Jamaican dollar"
+#: includes/util.php:110
+msgid "Manx pound"
 msgstr ""
 
-#: includes/util.php:121
-msgid "Japanese yen"
+#: includes/util.php:111
+msgid "Indian rupee"
 msgstr ""
 
-#: includes/util.php:122
+#: includes/util.php:112
+msgid "Iraqi dinar"
+msgstr ""
+
+#: includes/util.php:113
+msgid "Iranian rial"
+msgstr ""
+
+#: includes/util.php:114
+msgid "Iranian toman"
+msgstr ""
+
+#: includes/util.php:115
+msgid "Icelandic kr&oacute;na"
+msgstr ""
+
+#: includes/util.php:116
 msgid "Jersey pound"
 msgstr ""
 
-#: includes/util.php:123
+#: includes/util.php:117
+msgid "Jamaican dollar"
+msgstr ""
+
+#: includes/util.php:118
 msgid "Jordanian dinar"
 msgstr ""
 
+#: includes/util.php:119
+msgid "Japanese yen"
+msgstr ""
+
+#: includes/util.php:120
+msgid "Kenyan shilling"
+msgstr ""
+
+#: includes/util.php:121
+msgid "Kyrgyzstani som"
+msgstr ""
+
+#: includes/util.php:122
+msgid "Cambodian riel"
+msgstr ""
+
+#: includes/util.php:123
+msgid "Comorian franc"
+msgstr ""
+
 #: includes/util.php:124
-msgid "Kazakhstani tenge"
+msgid "North Korean won"
 msgstr ""
 
 #: includes/util.php:125
-msgid "Kenyan shilling"
+msgid "South Korean won"
 msgstr ""
 
 #: includes/util.php:126
@@ -789,151 +2936,151 @@ msgid "Kuwaiti dinar"
 msgstr ""
 
 #: includes/util.php:127
-msgid "Kyrgyzstani som"
+msgid "Cayman Islands dollar"
 msgstr ""
 
 #: includes/util.php:128
-msgid "Lao kip"
+msgid "Kazakhstani tenge"
 msgstr ""
 
 #: includes/util.php:129
-msgid "Lebanese pound"
+msgid "Lao kip"
 msgstr ""
 
 #: includes/util.php:130
-msgid "Lesotho loti"
+msgid "Lebanese pound"
 msgstr ""
 
 #: includes/util.php:131
-msgid "Liberian dollar"
+msgid "Sri Lankan rupee"
 msgstr ""
 
 #: includes/util.php:132
-msgid "Libyan dinar"
+msgid "Liberian dollar"
 msgstr ""
 
 #: includes/util.php:133
-msgid "Macanese pataca"
+msgid "Lesotho loti"
 msgstr ""
 
 #: includes/util.php:134
-msgid "Macedonian denar"
+msgid "Libyan dinar"
 msgstr ""
 
 #: includes/util.php:135
-msgid "Malagasy ariary"
-msgstr ""
-
-#: includes/util.php:136
-msgid "Malawian kwacha"
-msgstr ""
-
-#: includes/util.php:137
-msgid "Malaysian ringgit"
-msgstr ""
-
-#: includes/util.php:138
-msgid "Maldivian rufiyaa"
-msgstr ""
-
-#: includes/util.php:139
-msgid "Manx pound"
-msgstr ""
-
-#: includes/util.php:140
-msgid "Mauritanian ouguiya"
-msgstr ""
-
-#: includes/util.php:141
-msgid "Mauritian rupee"
-msgstr ""
-
-#: includes/util.php:142
-msgid "Mexican peso"
-msgstr ""
-
-#: includes/util.php:143
-msgid "Moldovan leu"
-msgstr ""
-
-#: includes/util.php:144
-msgid "Mongolian t&ouml;gr&ouml;g"
-msgstr ""
-
-#: includes/util.php:145
 msgid "Moroccan dirham"
 msgstr ""
 
+#: includes/util.php:136
+msgid "Moldovan leu"
+msgstr ""
+
+#: includes/util.php:137
+msgid "Malagasy ariary"
+msgstr ""
+
+#: includes/util.php:138
+msgid "Macedonian denar"
+msgstr ""
+
+#: includes/util.php:139
+msgid "Burmese kyat"
+msgstr ""
+
+#: includes/util.php:140
+msgid "Mongolian t&ouml;gr&ouml;g"
+msgstr ""
+
+#: includes/util.php:141
+msgid "Macanese pataca"
+msgstr ""
+
+#: includes/util.php:142
+msgid "Mauritanian ouguiya"
+msgstr ""
+
+#: includes/util.php:143
+msgid "Mauritian rupee"
+msgstr ""
+
+#: includes/util.php:144
+msgid "Maldivian rufiyaa"
+msgstr ""
+
+#: includes/util.php:145
+msgid "Malawian kwacha"
+msgstr ""
+
 #: includes/util.php:146
-msgid "Mozambican metical"
+msgid "Mexican peso"
 msgstr ""
 
 #: includes/util.php:147
-msgid "Namibian dollar"
+msgid "Malaysian ringgit"
 msgstr ""
 
 #: includes/util.php:148
-msgid "Nepalese rupee"
+msgid "Mozambican metical"
 msgstr ""
 
 #: includes/util.php:149
-msgid "Netherlands Antillean guilder"
+msgid "Namibian dollar"
 msgstr ""
 
 #: includes/util.php:150
-msgid "New Taiwan dollar"
-msgstr ""
-
-#: includes/util.php:151
-msgid "New Zealand dollar"
-msgstr ""
-
-#: includes/util.php:152
-msgid "Nicaraguan c&oacute;rdoba"
-msgstr ""
-
-#: includes/util.php:153
 msgid "Nigerian naira"
 msgstr ""
 
-#: includes/util.php:154
-msgid "North Korean won"
+#: includes/util.php:151
+msgid "Nicaraguan c&oacute;rdoba"
 msgstr ""
 
-#: includes/util.php:155
+#: includes/util.php:152
 msgid "Norwegian krone"
 msgstr ""
 
-#: includes/util.php:156
+#: includes/util.php:153
+msgid "Nepalese rupee"
+msgstr ""
+
+#: includes/util.php:154
+msgid "New Zealand dollar"
+msgstr ""
+
+#: includes/util.php:155
 msgid "Omani rial"
 msgstr ""
 
-#: includes/util.php:157
-msgid "Pakistani rupee"
-msgstr ""
-
-#: includes/util.php:158
+#: includes/util.php:156
 msgid "Panamanian balboa"
 msgstr ""
 
-#: includes/util.php:159
+#: includes/util.php:157
+msgid "Sol"
+msgstr ""
+
+#: includes/util.php:158
 msgid "Papua New Guinean kina"
 msgstr ""
 
-#: includes/util.php:160
-msgid "Paraguayan guaran&iacute;"
-msgstr ""
-
-#: includes/util.php:161
+#: includes/util.php:159
 msgid "Philippine peso"
 msgstr ""
 
-#: includes/util.php:162
+#: includes/util.php:160
+msgid "Pakistani rupee"
+msgstr ""
+
+#: includes/util.php:161
 msgid "Polish z&#x142;oty"
 msgstr ""
 
+#: includes/util.php:162
+msgid "Transnistrian ruble"
+msgstr ""
+
 #: includes/util.php:163
-msgid "Pound sterling"
+msgid "Paraguayan guaran&iacute;"
 msgstr ""
 
 #: includes/util.php:164
@@ -945,1281 +3092,1269 @@ msgid "Romanian leu"
 msgstr ""
 
 #: includes/util.php:166
-msgid "Russian ruble"
-msgstr ""
-
-#: includes/util.php:167
-msgid "Rwandan franc"
-msgstr ""
-
-#: includes/util.php:168
-msgid "S&atilde;o Tom&eacute; and Pr&iacute;ncipe dobra"
-msgstr ""
-
-#: includes/util.php:169
-msgid "Saint Helena pound"
-msgstr ""
-
-#: includes/util.php:170
-msgid "Samoan t&#x101;l&#x101;"
-msgstr ""
-
-#: includes/util.php:171
-msgid "Saudi riyal"
-msgstr ""
-
-#: includes/util.php:172
 msgid "Serbian dinar"
 msgstr ""
 
-#: includes/util.php:173
-msgid "Seychellois rupee"
+#: includes/util.php:167
+msgid "Russian ruble"
 msgstr ""
 
-#: includes/util.php:174
-msgid "Sierra Leonean leone"
+#: includes/util.php:168
+msgid "Rwandan franc"
 msgstr ""
 
-#: includes/util.php:175
-msgid "Singapore dollar"
+#: includes/util.php:169
+msgid "Saudi riyal"
 msgstr ""
 
-#: includes/util.php:176
-msgid "Sol"
-msgstr ""
-
-#: includes/util.php:177
+#: includes/util.php:170
 msgid "Solomon Islands dollar"
 msgstr ""
 
-#: includes/util.php:178
-msgid "Somali shilling"
+#: includes/util.php:171
+msgid "Seychellois rupee"
 msgstr ""
 
-#: includes/util.php:179
-msgid "South African rand"
-msgstr ""
-
-#: includes/util.php:180
-msgid "South Korean won"
-msgstr ""
-
-#: includes/util.php:181
-msgid "South Sudanese pound"
-msgstr ""
-
-#: includes/util.php:182
-msgid "Sri Lankan rupee"
-msgstr ""
-
-#: includes/util.php:183
+#: includes/util.php:172
 msgid "Sudanese pound"
 msgstr ""
 
-#: includes/util.php:184
-msgid "Surinamese dollar"
-msgstr ""
-
-#: includes/util.php:185
-msgid "Swazi lilangeni"
-msgstr ""
-
-#: includes/util.php:186
+#: includes/util.php:173
 msgid "Swedish krona"
 msgstr ""
 
-#: includes/util.php:187
-msgid "Swiss franc"
+#: includes/util.php:174
+msgid "Singapore dollar"
 msgstr ""
 
-#: includes/util.php:188
+#: includes/util.php:175
+msgid "Saint Helena pound"
+msgstr ""
+
+#: includes/util.php:176
+msgid "Sierra Leonean leone"
+msgstr ""
+
+#: includes/util.php:177
+msgid "Somali shilling"
+msgstr ""
+
+#: includes/util.php:178
+msgid "Surinamese dollar"
+msgstr ""
+
+#: includes/util.php:179
+msgid "South Sudanese pound"
+msgstr ""
+
+#: includes/util.php:180
+msgid "S&atilde;o Tom&eacute; and Pr&iacute;ncipe dobra"
+msgstr ""
+
+#: includes/util.php:181
 msgid "Syrian pound"
 msgstr ""
 
-#: includes/util.php:189
-msgid "Tajikistani somoni"
+#: includes/util.php:182
+msgid "Swazi lilangeni"
 msgstr ""
 
-#: includes/util.php:190
-msgid "Tanzanian shilling"
-msgstr ""
-
-#: includes/util.php:191
+#: includes/util.php:183
 msgid "Thai baht"
 msgstr ""
 
-#: includes/util.php:192
-msgid "Tongan pa&#x2bb;anga"
+#: includes/util.php:184
+msgid "Tajikistani somoni"
 msgstr ""
 
-#: includes/util.php:193
-msgid "Transnistrian ruble"
-msgstr ""
-
-#: includes/util.php:194
-msgid "Trinidad and Tobago dollar"
-msgstr ""
-
-#: includes/util.php:195
-msgid "Tunisian dinar"
-msgstr ""
-
-#: includes/util.php:196
-msgid "Turkish lira"
-msgstr ""
-
-#: includes/util.php:197
+#: includes/util.php:185
 msgid "Turkmenistan manat"
 msgstr ""
 
-#: includes/util.php:198
-msgid "Ugandan shilling"
+#: includes/util.php:186
+msgid "Tunisian dinar"
 msgstr ""
 
-#: includes/util.php:199
+#: includes/util.php:187
+msgid "Tongan pa&#x2bb;anga"
+msgstr ""
+
+#: includes/util.php:188
+msgid "Turkish lira"
+msgstr ""
+
+#: includes/util.php:189
+msgid "Trinidad and Tobago dollar"
+msgstr ""
+
+#: includes/util.php:190
+msgid "New Taiwan dollar"
+msgstr ""
+
+#: includes/util.php:191
+msgid "Tanzanian shilling"
+msgstr ""
+
+#: includes/util.php:192
 msgid "Ukrainian hryvnia"
 msgstr ""
 
-#: includes/util.php:200
-msgid "United Arab Emirates dirham"
+#: includes/util.php:193
+msgid "Ugandan shilling"
 msgstr ""
 
-#: includes/util.php:201
+#: includes/util.php:194
 msgid "United States (US) dollar"
 msgstr ""
 
-#: includes/util.php:202
+#: includes/util.php:195
 msgid "Uruguayan peso"
 msgstr ""
 
-#: includes/util.php:203
+#: includes/util.php:196
 msgid "Uzbekistani som"
 msgstr ""
 
-#: includes/util.php:204
-msgid "Vanuatu vatu"
-msgstr ""
-
-#: includes/util.php:205
+#: includes/util.php:197
 msgid "Venezuelan bol&iacute;var"
 msgstr ""
 
-#: includes/util.php:206
+#: includes/util.php:198
+msgid "Bol&iacute;var soberano"
+msgstr ""
+
+#: includes/util.php:199
 msgid "Vietnamese &#x111;&#x1ed3;ng"
 msgstr ""
 
-#: includes/util.php:207
+#: includes/util.php:200
+msgid "Vanuatu vatu"
+msgstr ""
+
+#: includes/util.php:201
+msgid "Samoan t&#x101;l&#x101;"
+msgstr ""
+
+#: includes/util.php:202
+msgid "Central African CFA franc"
+msgstr ""
+
+#: includes/util.php:203
+msgid "East Caribbean dollar"
+msgstr ""
+
+#: includes/util.php:204
 msgid "West African CFA franc"
 msgstr ""
 
-#: includes/util.php:208
+#: includes/util.php:205
+msgid "CFP franc"
+msgstr ""
+
+#: includes/util.php:206
 msgid "Yemeni rial"
 msgstr ""
 
-#: includes/util.php:209
+#: includes/util.php:207
+msgid "South African rand"
+msgstr ""
+
+#: includes/util.php:208
 msgid "Zambian kwacha"
 msgstr ""
 
-#: includes/util.php:221
-msgid "Afghanistan"
-msgstr ""
-
-#: includes/util.php:222
-msgid "&#197;land Islands"
-msgstr ""
-
-#: includes/util.php:223
-msgid "Albania"
-msgstr ""
-
-#: includes/util.php:224
-msgid "Algeria"
-msgstr ""
-
-#: includes/util.php:225
-msgid "American Samoa"
-msgstr ""
-
-#: includes/util.php:226
-msgid "Andorra"
-msgstr ""
-
-#: includes/util.php:227
-msgid "Angola"
-msgstr ""
-
-#: includes/util.php:228
-msgid "Anguilla"
-msgstr ""
-
-#: includes/util.php:229
-msgid "Antarctica"
-msgstr ""
-
-#: includes/util.php:230
-msgid "Antigua and Barbuda"
+#: includes/util.php:213
+#: includes/util.php:484
+#: assets/components/src/select-control/GroupedSelectControl.js:55
+msgid "-- Select --"
 msgstr ""
 
 #: includes/util.php:231
-msgid "Argentina"
+msgid "Afghanistan"
 msgstr ""
 
 #: includes/util.php:232
-msgid "Armenia"
+msgid "Åland Islands"
 msgstr ""
 
 #: includes/util.php:233
-msgid "Aruba"
+msgid "Albania"
 msgstr ""
 
 #: includes/util.php:234
-msgid "Australia"
+msgid "Algeria"
 msgstr ""
 
 #: includes/util.php:235
-msgid "Austria"
+msgid "American Samoa"
 msgstr ""
 
 #: includes/util.php:236
-msgid "Azerbaijan"
+msgid "Andorra"
 msgstr ""
 
 #: includes/util.php:237
-msgid "Bahamas"
+msgid "Angola"
 msgstr ""
 
 #: includes/util.php:238
-msgid "Bahrain"
+msgid "Anguilla"
 msgstr ""
 
 #: includes/util.php:239
-msgid "Bangladesh"
+msgid "Antarctica"
 msgstr ""
 
 #: includes/util.php:240
-msgid "Barbados"
+msgid "Antigua and Barbuda"
 msgstr ""
 
 #: includes/util.php:241
-msgid "Belarus"
+msgid "Argentina"
 msgstr ""
 
 #: includes/util.php:242
-msgid "Belgium"
+msgid "Armenia"
 msgstr ""
 
 #: includes/util.php:243
-msgid "Belau"
+msgid "Aruba"
 msgstr ""
 
 #: includes/util.php:244
-msgid "Belize"
+msgid "Australia"
 msgstr ""
 
 #: includes/util.php:245
-msgid "Benin"
+msgid "Austria"
 msgstr ""
 
 #: includes/util.php:246
-msgid "Bermuda"
+msgid "Azerbaijan"
 msgstr ""
 
 #: includes/util.php:247
-msgid "Bhutan"
+msgid "Bahamas"
 msgstr ""
 
 #: includes/util.php:248
-msgid "Bolivia"
+msgid "Bahrain"
 msgstr ""
 
 #: includes/util.php:249
-msgid "Bonaire, Saint Eustatius and Saba"
+msgid "Bangladesh"
 msgstr ""
 
 #: includes/util.php:250
-msgid "Bosnia and Herzegovina"
+msgid "Barbados"
 msgstr ""
 
 #: includes/util.php:251
-msgid "Botswana"
+msgid "Belarus"
 msgstr ""
 
 #: includes/util.php:252
-msgid "Bouvet Island"
+msgid "Belgium"
 msgstr ""
 
 #: includes/util.php:253
-msgid "Brazil"
+msgid "Belau"
 msgstr ""
 
 #: includes/util.php:254
-msgid "British Indian Ocean Territory"
+msgid "Belize"
 msgstr ""
 
 #: includes/util.php:255
-msgid "Brunei"
+msgid "Benin"
 msgstr ""
 
 #: includes/util.php:256
-msgid "Bulgaria"
+msgid "Bermuda"
 msgstr ""
 
 #: includes/util.php:257
-msgid "Burkina Faso"
+msgid "Bhutan"
 msgstr ""
 
 #: includes/util.php:258
-msgid "Burundi"
+msgid "Bolivia"
 msgstr ""
 
 #: includes/util.php:259
-msgid "Cambodia"
+msgid "Bonaire, Saint Eustatius and Saba"
 msgstr ""
 
 #: includes/util.php:260
-msgid "Cameroon"
+msgid "Bosnia and Herzegovina"
 msgstr ""
 
 #: includes/util.php:261
-msgid "Canada"
+msgid "Botswana"
 msgstr ""
 
 #: includes/util.php:262
-msgid "Cape Verde"
+msgid "Bouvet Island"
 msgstr ""
 
 #: includes/util.php:263
-msgid "Cayman Islands"
+msgid "Brazil"
 msgstr ""
 
 #: includes/util.php:264
-msgid "Central African Republic"
+msgid "British Indian Ocean Territory"
 msgstr ""
 
 #: includes/util.php:265
-msgid "Chad"
+msgid "Brunei"
 msgstr ""
 
 #: includes/util.php:266
-msgid "Chile"
+msgid "Bulgaria"
 msgstr ""
 
 #: includes/util.php:267
-msgid "China"
+msgid "Burkina Faso"
 msgstr ""
 
 #: includes/util.php:268
-msgid "Christmas Island"
+msgid "Burundi"
 msgstr ""
 
 #: includes/util.php:269
-msgid "Cocos (Keeling) Islands"
+msgid "Cambodia"
 msgstr ""
 
 #: includes/util.php:270
-msgid "Colombia"
+msgid "Cameroon"
 msgstr ""
 
 #: includes/util.php:271
-msgid "Comoros"
+msgid "Canada"
 msgstr ""
 
 #: includes/util.php:272
-msgid "Congo (Brazzaville)"
+msgid "Cape Verde"
 msgstr ""
 
 #: includes/util.php:273
-msgid "Congo (Kinshasa)"
+msgid "Cayman Islands"
 msgstr ""
 
 #: includes/util.php:274
-msgid "Cook Islands"
+msgid "Central African Republic"
 msgstr ""
 
 #: includes/util.php:275
-msgid "Costa Rica"
+msgid "Chad"
 msgstr ""
 
 #: includes/util.php:276
-msgid "Croatia"
+msgid "Chile"
 msgstr ""
 
 #: includes/util.php:277
-msgid "Cuba"
+msgid "China"
 msgstr ""
 
 #: includes/util.php:278
-msgid "Cura&ccedil;ao"
+msgid "Christmas Island"
 msgstr ""
 
 #: includes/util.php:279
-msgid "Cyprus"
+msgid "Cocos (Keeling) Islands"
 msgstr ""
 
 #: includes/util.php:280
-msgid "Czech Republic"
+msgid "Colombia"
 msgstr ""
 
 #: includes/util.php:281
-msgid "Denmark"
+msgid "Comoros"
 msgstr ""
 
 #: includes/util.php:282
-msgid "Djibouti"
+msgid "Congo (Brazzaville)"
 msgstr ""
 
 #: includes/util.php:283
-msgid "Dominica"
+msgid "Congo (Kinshasa)"
 msgstr ""
 
 #: includes/util.php:284
-msgid "Dominican Republic"
+msgid "Cook Islands"
 msgstr ""
 
 #: includes/util.php:285
-msgid "Ecuador"
+msgid "Costa Rica"
 msgstr ""
 
 #: includes/util.php:286
-msgid "Egypt"
+msgid "Croatia"
 msgstr ""
 
 #: includes/util.php:287
-msgid "El Salvador"
+msgid "Cuba"
 msgstr ""
 
 #: includes/util.php:288
-msgid "Equatorial Guinea"
+msgid "Cura&ccedil;ao"
 msgstr ""
 
 #: includes/util.php:289
-msgid "Eritrea"
+msgid "Cyprus"
 msgstr ""
 
 #: includes/util.php:290
-msgid "Estonia"
+msgid "Czech Republic"
 msgstr ""
 
 #: includes/util.php:291
-msgid "Ethiopia"
+msgid "Denmark"
 msgstr ""
 
 #: includes/util.php:292
-msgid "Falkland Islands"
+msgid "Djibouti"
 msgstr ""
 
 #: includes/util.php:293
-msgid "Faroe Islands"
+msgid "Dominica"
 msgstr ""
 
 #: includes/util.php:294
-msgid "Fiji"
+msgid "Dominican Republic"
 msgstr ""
 
 #: includes/util.php:295
-msgid "Finland"
+msgid "Ecuador"
 msgstr ""
 
 #: includes/util.php:296
-msgid "France"
+msgid "Egypt"
 msgstr ""
 
 #: includes/util.php:297
-msgid "French Guiana"
+msgid "El Salvador"
 msgstr ""
 
 #: includes/util.php:298
-msgid "French Polynesia"
+msgid "Equatorial Guinea"
 msgstr ""
 
 #: includes/util.php:299
-msgid "French Southern Territories"
+msgid "Eritrea"
 msgstr ""
 
 #: includes/util.php:300
-msgid "Gabon"
+msgid "Estonia"
 msgstr ""
 
 #: includes/util.php:301
-msgid "Gambia"
+msgid "Ethiopia"
 msgstr ""
 
 #: includes/util.php:302
-msgid "Georgia"
+msgid "Falkland Islands"
 msgstr ""
 
 #: includes/util.php:303
-msgid "Germany"
+msgid "Faroe Islands"
 msgstr ""
 
 #: includes/util.php:304
-msgid "Ghana"
+msgid "Fiji"
 msgstr ""
 
 #: includes/util.php:305
-msgid "Gibraltar"
+msgid "Finland"
 msgstr ""
 
 #: includes/util.php:306
-msgid "Greece"
+msgid "France"
 msgstr ""
 
 #: includes/util.php:307
-msgid "Greenland"
+msgid "French Guiana"
 msgstr ""
 
 #: includes/util.php:308
-msgid "Grenada"
+msgid "French Polynesia"
 msgstr ""
 
 #: includes/util.php:309
-msgid "Guadeloupe"
+msgid "French Southern Territories"
 msgstr ""
 
 #: includes/util.php:310
-msgid "Guam"
+msgid "Gabon"
 msgstr ""
 
 #: includes/util.php:311
-msgid "Guatemala"
+msgid "Gambia"
 msgstr ""
 
 #: includes/util.php:312
-msgid "Guernsey"
+msgid "Georgia"
 msgstr ""
 
 #: includes/util.php:313
-msgid "Guinea"
+msgid "Germany"
 msgstr ""
 
 #: includes/util.php:314
-msgid "Guinea-Bissau"
+msgid "Ghana"
 msgstr ""
 
 #: includes/util.php:315
-msgid "Guyana"
+msgid "Gibraltar"
 msgstr ""
 
 #: includes/util.php:316
-msgid "Haiti"
+msgid "Greece"
 msgstr ""
 
 #: includes/util.php:317
-msgid "Heard Island and McDonald Islands"
+msgid "Greenland"
 msgstr ""
 
 #: includes/util.php:318
-msgid "Honduras"
+msgid "Grenada"
 msgstr ""
 
 #: includes/util.php:319
-msgid "Hong Kong"
+msgid "Guadeloupe"
 msgstr ""
 
 #: includes/util.php:320
-msgid "Hungary"
+msgid "Guam"
 msgstr ""
 
 #: includes/util.php:321
-msgid "Iceland"
+msgid "Guatemala"
 msgstr ""
 
 #: includes/util.php:322
-msgid "India"
+msgid "Guernsey"
 msgstr ""
 
 #: includes/util.php:323
-msgid "Indonesia"
+msgid "Guinea"
 msgstr ""
 
 #: includes/util.php:324
-msgid "Iran"
+msgid "Guinea-Bissau"
 msgstr ""
 
 #: includes/util.php:325
-msgid "Iraq"
+msgid "Guyana"
 msgstr ""
 
 #: includes/util.php:326
-msgid "Ireland"
+msgid "Haiti"
 msgstr ""
 
 #: includes/util.php:327
-msgid "Isle of Man"
+msgid "Heard Island and McDonald Islands"
 msgstr ""
 
 #: includes/util.php:328
-msgid "Israel"
+msgid "Honduras"
 msgstr ""
 
 #: includes/util.php:329
-msgid "Italy"
+msgid "Hong Kong"
 msgstr ""
 
 #: includes/util.php:330
-msgid "Ivory Coast"
+msgid "Hungary"
 msgstr ""
 
 #: includes/util.php:331
-msgid "Jamaica"
+msgid "Iceland"
 msgstr ""
 
 #: includes/util.php:332
-msgid "Japan"
+msgid "India"
 msgstr ""
 
 #: includes/util.php:333
-msgid "Jersey"
+msgid "Indonesia"
 msgstr ""
 
 #: includes/util.php:334
-msgid "Jordan"
+msgid "Iran"
 msgstr ""
 
 #: includes/util.php:335
-msgid "Kazakhstan"
+msgid "Iraq"
 msgstr ""
 
 #: includes/util.php:336
-msgid "Kenya"
+msgid "Ireland"
 msgstr ""
 
 #: includes/util.php:337
-msgid "Kiribati"
+msgid "Isle of Man"
 msgstr ""
 
 #: includes/util.php:338
-msgid "Kuwait"
+msgid "Israel"
 msgstr ""
 
 #: includes/util.php:339
-msgid "Kyrgyzstan"
+msgid "Italy"
 msgstr ""
 
 #: includes/util.php:340
-msgid "Laos"
+msgid "Ivory Coast"
 msgstr ""
 
 #: includes/util.php:341
-msgid "Latvia"
+msgid "Jamaica"
 msgstr ""
 
 #: includes/util.php:342
-msgid "Lebanon"
+msgid "Japan"
 msgstr ""
 
 #: includes/util.php:343
-msgid "Lesotho"
+msgid "Jersey"
 msgstr ""
 
 #: includes/util.php:344
-msgid "Liberia"
+msgid "Jordan"
 msgstr ""
 
 #: includes/util.php:345
-msgid "Libya"
+msgid "Kazakhstan"
 msgstr ""
 
 #: includes/util.php:346
-msgid "Liechtenstein"
+msgid "Kenya"
 msgstr ""
 
 #: includes/util.php:347
-msgid "Lithuania"
+msgid "Kiribati"
 msgstr ""
 
 #: includes/util.php:348
-msgid "Luxembourg"
+msgid "Kuwait"
 msgstr ""
 
 #: includes/util.php:349
-msgid "Macao S.A.R., China"
+msgid "Kyrgyzstan"
 msgstr ""
 
 #: includes/util.php:350
-msgid "North Macedonia"
+msgid "Laos"
 msgstr ""
 
 #: includes/util.php:351
-msgid "Madagascar"
+msgid "Latvia"
 msgstr ""
 
 #: includes/util.php:352
-msgid "Malawi"
+msgid "Lebanon"
 msgstr ""
 
 #: includes/util.php:353
-msgid "Malaysia"
+msgid "Lesotho"
 msgstr ""
 
 #: includes/util.php:354
-msgid "Maldives"
+msgid "Liberia"
 msgstr ""
 
 #: includes/util.php:355
-msgid "Mali"
+msgid "Libya"
 msgstr ""
 
 #: includes/util.php:356
-msgid "Malta"
+msgid "Liechtenstein"
 msgstr ""
 
 #: includes/util.php:357
-msgid "Marshall Islands"
+msgid "Lithuania"
 msgstr ""
 
 #: includes/util.php:358
-msgid "Martinique"
+msgid "Luxembourg"
 msgstr ""
 
 #: includes/util.php:359
-msgid "Mauritania"
+msgid "Macao"
 msgstr ""
 
 #: includes/util.php:360
-msgid "Mauritius"
+msgid "North Macedonia"
 msgstr ""
 
 #: includes/util.php:361
-msgid "Mayotte"
+msgid "Madagascar"
 msgstr ""
 
 #: includes/util.php:362
-msgid "Mexico"
+msgid "Malawi"
 msgstr ""
 
 #: includes/util.php:363
-msgid "Micronesia"
+msgid "Malaysia"
 msgstr ""
 
 #: includes/util.php:364
-msgid "Moldova"
+msgid "Maldives"
 msgstr ""
 
 #: includes/util.php:365
-msgid "Monaco"
+msgid "Mali"
 msgstr ""
 
 #: includes/util.php:366
-msgid "Mongolia"
+msgid "Malta"
 msgstr ""
 
 #: includes/util.php:367
-msgid "Montenegro"
+msgid "Marshall Islands"
 msgstr ""
 
 #: includes/util.php:368
-msgid "Montserrat"
+msgid "Martinique"
 msgstr ""
 
 #: includes/util.php:369
-msgid "Morocco"
+msgid "Mauritania"
 msgstr ""
 
 #: includes/util.php:370
-msgid "Mozambique"
+msgid "Mauritius"
 msgstr ""
 
 #: includes/util.php:371
-msgid "Myanmar"
+msgid "Mayotte"
 msgstr ""
 
 #: includes/util.php:372
-msgid "Namibia"
+msgid "Mexico"
 msgstr ""
 
 #: includes/util.php:373
-msgid "Nauru"
+msgid "Micronesia"
 msgstr ""
 
 #: includes/util.php:374
-msgid "Nepal"
+msgid "Moldova"
 msgstr ""
 
 #: includes/util.php:375
-msgid "Netherlands"
+msgid "Monaco"
 msgstr ""
 
 #: includes/util.php:376
-msgid "New Caledonia"
+msgid "Mongolia"
 msgstr ""
 
 #: includes/util.php:377
-msgid "New Zealand"
+msgid "Montenegro"
 msgstr ""
 
 #: includes/util.php:378
-msgid "Nicaragua"
+msgid "Montserrat"
 msgstr ""
 
 #: includes/util.php:379
-msgid "Niger"
+msgid "Morocco"
 msgstr ""
 
 #: includes/util.php:380
-msgid "Nigeria"
+msgid "Mozambique"
 msgstr ""
 
 #: includes/util.php:381
-msgid "Niue"
+msgid "Myanmar"
 msgstr ""
 
 #: includes/util.php:382
-msgid "Norfolk Island"
+msgid "Namibia"
 msgstr ""
 
 #: includes/util.php:383
-msgid "Northern Mariana Islands"
+msgid "Nauru"
 msgstr ""
 
 #: includes/util.php:384
-msgid "North Korea"
+msgid "Nepal"
 msgstr ""
 
 #: includes/util.php:385
-msgid "Norway"
+msgid "Netherlands"
 msgstr ""
 
 #: includes/util.php:386
-msgid "Oman"
+msgid "New Caledonia"
 msgstr ""
 
 #: includes/util.php:387
-msgid "Pakistan"
+msgid "New Zealand"
 msgstr ""
 
 #: includes/util.php:388
-msgid "Palestinian Territory"
+msgid "Nicaragua"
 msgstr ""
 
 #: includes/util.php:389
-msgid "Panama"
+msgid "Niger"
 msgstr ""
 
 #: includes/util.php:390
-msgid "Papua New Guinea"
+msgid "Nigeria"
 msgstr ""
 
 #: includes/util.php:391
-msgid "Paraguay"
+msgid "Niue"
 msgstr ""
 
 #: includes/util.php:392
-msgid "Peru"
+msgid "Norfolk Island"
 msgstr ""
 
 #: includes/util.php:393
-msgid "Philippines"
+msgid "Northern Mariana Islands"
 msgstr ""
 
 #: includes/util.php:394
-msgid "Pitcairn"
+msgid "North Korea"
 msgstr ""
 
 #: includes/util.php:395
-msgid "Poland"
+msgid "Norway"
 msgstr ""
 
 #: includes/util.php:396
-msgid "Portugal"
+msgid "Oman"
 msgstr ""
 
 #: includes/util.php:397
-msgid "Puerto Rico"
+msgid "Pakistan"
 msgstr ""
 
 #: includes/util.php:398
-msgid "Qatar"
+msgid "Palestinian Territory"
 msgstr ""
 
 #: includes/util.php:399
-msgid "Reunion"
+msgid "Panama"
 msgstr ""
 
 #: includes/util.php:400
-msgid "Romania"
+msgid "Papua New Guinea"
 msgstr ""
 
 #: includes/util.php:401
-msgid "Russia"
+msgid "Paraguay"
 msgstr ""
 
 #: includes/util.php:402
-msgid "Rwanda"
+msgid "Peru"
 msgstr ""
 
 #: includes/util.php:403
-msgid "Saint Barth&eacute;lemy"
+msgid "Philippines"
 msgstr ""
 
 #: includes/util.php:404
-msgid "Saint Helena"
+msgid "Pitcairn"
 msgstr ""
 
 #: includes/util.php:405
-msgid "Saint Kitts and Nevis"
+msgid "Poland"
 msgstr ""
 
 #: includes/util.php:406
-msgid "Saint Lucia"
+msgid "Portugal"
 msgstr ""
 
 #: includes/util.php:407
-msgid "Saint Martin (French part)"
+msgid "Puerto Rico"
 msgstr ""
 
 #: includes/util.php:408
-msgid "Saint Martin (Dutch part)"
+msgid "Qatar"
 msgstr ""
 
 #: includes/util.php:409
-msgid "Saint Pierre and Miquelon"
+msgid "Reunion"
 msgstr ""
 
 #: includes/util.php:410
-msgid "Saint Vincent and the Grenadines"
+msgid "Romania"
 msgstr ""
 
 #: includes/util.php:411
-msgid "San Marino"
+msgid "Russia"
 msgstr ""
 
 #: includes/util.php:412
-msgid "S&atilde;o Tom&eacute; and Pr&iacute;ncipe"
+msgid "Rwanda"
 msgstr ""
 
 #: includes/util.php:413
-msgid "Saudi Arabia"
+msgid "Saint Barth&eacute;lemy"
 msgstr ""
 
 #: includes/util.php:414
-msgid "Senegal"
+msgid "Saint Helena"
 msgstr ""
 
 #: includes/util.php:415
-msgid "Serbia"
+msgid "Saint Kitts and Nevis"
 msgstr ""
 
 #: includes/util.php:416
-msgid "Seychelles"
+msgid "Saint Lucia"
 msgstr ""
 
 #: includes/util.php:417
-msgid "Sierra Leone"
+msgid "Saint Martin (French part)"
 msgstr ""
 
 #: includes/util.php:418
-msgid "Singapore"
+msgid "Saint Martin (Dutch part)"
 msgstr ""
 
 #: includes/util.php:419
-msgid "Slovakia"
+msgid "Saint Pierre and Miquelon"
 msgstr ""
 
 #: includes/util.php:420
-msgid "Slovenia"
+msgid "Saint Vincent and the Grenadines"
 msgstr ""
 
 #: includes/util.php:421
-msgid "Solomon Islands"
+msgid "San Marino"
 msgstr ""
 
 #: includes/util.php:422
-msgid "Somalia"
+msgid "S&atilde;o Tom&eacute; and Pr&iacute;ncipe"
 msgstr ""
 
 #: includes/util.php:423
-msgid "South Africa"
+msgid "Saudi Arabia"
 msgstr ""
 
 #: includes/util.php:424
-msgid "South Georgia/Sandwich Islands"
+msgid "Senegal"
 msgstr ""
 
 #: includes/util.php:425
-msgid "South Korea"
+msgid "Serbia"
 msgstr ""
 
 #: includes/util.php:426
-msgid "South Sudan"
+msgid "Seychelles"
 msgstr ""
 
 #: includes/util.php:427
-msgid "Spain"
+msgid "Sierra Leone"
 msgstr ""
 
 #: includes/util.php:428
-msgid "Sri Lanka"
+msgid "Singapore"
 msgstr ""
 
 #: includes/util.php:429
-msgid "Sudan"
+msgid "Slovakia"
 msgstr ""
 
 #: includes/util.php:430
-msgid "Suriname"
+msgid "Slovenia"
 msgstr ""
 
 #: includes/util.php:431
-msgid "Svalbard and Jan Mayen"
+msgid "Solomon Islands"
 msgstr ""
 
 #: includes/util.php:432
-msgid "Swaziland"
+msgid "Somalia"
 msgstr ""
 
 #: includes/util.php:433
-msgid "Sweden"
+msgid "South Africa"
 msgstr ""
 
 #: includes/util.php:434
-msgid "Switzerland"
+msgid "South Georgia/Sandwich Islands"
 msgstr ""
 
 #: includes/util.php:435
-msgid "Syria"
+msgid "South Korea"
 msgstr ""
 
 #: includes/util.php:436
-msgid "Taiwan"
+msgid "South Sudan"
 msgstr ""
 
 #: includes/util.php:437
-msgid "Tajikistan"
+msgid "Spain"
 msgstr ""
 
 #: includes/util.php:438
-msgid "Tanzania"
+msgid "Sri Lanka"
 msgstr ""
 
 #: includes/util.php:439
-msgid "Thailand"
+msgid "Sudan"
 msgstr ""
 
 #: includes/util.php:440
-msgid "Timor-Leste"
+msgid "Suriname"
 msgstr ""
 
 #: includes/util.php:441
-msgid "Togo"
+msgid "Svalbard and Jan Mayen"
 msgstr ""
 
 #: includes/util.php:442
-msgid "Tokelau"
+msgid "Swaziland"
 msgstr ""
 
 #: includes/util.php:443
-msgid "Tonga"
+msgid "Sweden"
 msgstr ""
 
 #: includes/util.php:444
-msgid "Trinidad and Tobago"
+msgid "Switzerland"
 msgstr ""
 
 #: includes/util.php:445
-msgid "Tunisia"
+msgid "Syria"
 msgstr ""
 
 #: includes/util.php:446
-msgid "Turkey"
+msgid "Taiwan"
 msgstr ""
 
 #: includes/util.php:447
-msgid "Turkmenistan"
+msgid "Tajikistan"
 msgstr ""
 
 #: includes/util.php:448
-msgid "Turks and Caicos Islands"
+msgid "Tanzania"
 msgstr ""
 
 #: includes/util.php:449
-msgid "Tuvalu"
+msgid "Thailand"
 msgstr ""
 
 #: includes/util.php:450
-msgid "Uganda"
+msgid "Timor-Leste"
 msgstr ""
 
 #: includes/util.php:451
-msgid "Ukraine"
+msgid "Togo"
 msgstr ""
 
 #: includes/util.php:452
-msgid "United Arab Emirates"
+msgid "Tokelau"
 msgstr ""
 
 #: includes/util.php:453
-msgid "United Kingdom (UK)"
+msgid "Tonga"
 msgstr ""
 
 #: includes/util.php:454
-msgid "United States (US)"
+msgid "Trinidad and Tobago"
 msgstr ""
 
 #: includes/util.php:455
-msgid "United States (US) Minor Outlying Islands"
+msgid "Tunisia"
 msgstr ""
 
 #: includes/util.php:456
-msgid "Uruguay"
+msgid "Turkey"
 msgstr ""
 
 #: includes/util.php:457
-msgid "Uzbekistan"
+msgid "Turkmenistan"
 msgstr ""
 
 #: includes/util.php:458
-msgid "Vanuatu"
+msgid "Turks and Caicos Islands"
 msgstr ""
 
 #: includes/util.php:459
-msgid "Vatican"
+msgid "Tuvalu"
 msgstr ""
 
 #: includes/util.php:460
-msgid "Venezuela"
+msgid "Uganda"
 msgstr ""
 
 #: includes/util.php:461
-msgid "Vietnam"
+msgid "Ukraine"
 msgstr ""
 
 #: includes/util.php:462
-msgid "Virgin Islands (British)"
+msgid "United Arab Emirates"
 msgstr ""
 
 #: includes/util.php:463
-msgid "Virgin Islands (US)"
+msgid "United Kingdom (UK)"
 msgstr ""
 
 #: includes/util.php:464
-msgid "Wallis and Futuna"
+msgid "United States (US)"
 msgstr ""
 
 #: includes/util.php:465
-msgid "Western Sahara"
+msgid "United States (US) Minor Outlying Islands"
 msgstr ""
 
 #: includes/util.php:466
-msgid "Samoa"
+msgid "Uruguay"
 msgstr ""
 
 #: includes/util.php:467
-msgid "Yemen"
+msgid "Uzbekistan"
 msgstr ""
 
 #: includes/util.php:468
-msgid "Zambia"
+msgid "Vanuatu"
 msgstr ""
 
 #: includes/util.php:469
+msgid "Vatican"
+msgstr ""
+
+#: includes/util.php:470
+msgid "Venezuela"
+msgstr ""
+
+#: includes/util.php:471
+msgid "Vietnam"
+msgstr ""
+
+#: includes/util.php:472
+msgid "Virgin Islands (British)"
+msgstr ""
+
+#: includes/util.php:473
+msgid "Virgin Islands (US)"
+msgstr ""
+
+#: includes/util.php:474
+msgid "Wallis and Futuna"
+msgstr ""
+
+#: includes/util.php:475
+msgid "Western Sahara"
+msgstr ""
+
+#: includes/util.php:476
+msgid "Samoa"
+msgstr ""
+
+#: includes/util.php:477
+msgid "Yemen"
+msgstr ""
+
+#: includes/util.php:478
+msgid "Zambia"
+msgstr ""
+
+#: includes/util.php:479
 msgid "Zimbabwe"
 msgstr ""
 
-#: includes/wizards/class-advertising-wizard.php:80
+#: includes/wizards/class-advertising-wizard.php:72
+#: assets/wizards/advertising/index.js:191
+#: assets/wizards/advertising/index.js:204
+#: assets/wizards/advertising/index.js:291
+#: assets/wizards/advertising/index.js:306
 msgid "Advertising"
 msgstr ""
 
-#: includes/wizards/class-advertising-wizard.php:89
-msgid "Monetize your content through ads"
+#: includes/wizards/class-advertising-wizard.php:414
+msgid "Ad Units failed to fetch."
 msgstr ""
 
-#: includes/wizards/class-advertising-wizard.php:98
-#: includes/wizards/class-analytics-wizard.php:91
-#: includes/wizards/class-engagement-wizard.php:75
-#: includes/wizards/class-health-check-wizard.php:68
-#: includes/wizards/class-popups-wizard.php:68
-#: includes/wizards/class-reader-revenue-wizard.php:58
-#: includes/wizards/class-seo-wizard.php:68
-#: includes/wizards/class-setup-wizard.php:76
-#: includes/wizards/class-syndication-wizard.php:67
-msgid "10 minutes"
-msgstr ""
-
-#: includes/wizards/class-analytics-wizard.php:73
-#: assets/wizards/analytics/index.js:46
+#: includes/wizards/class-analytics-wizard.php:75
+#: assets/wizards/analytics/index.js:42
 msgid "Analytics"
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:82
-#: assets/wizards/analytics/index.js:47
-msgid "Track traffic and activity"
-msgstr ""
-
-#: includes/wizards/class-analytics-wizard.php:220
-msgid "none"
-msgstr ""
-
-#: includes/wizards/class-analytics-wizard.php:264
+#: includes/wizards/class-analytics-wizard.php:204
+#: assets/wizards/analytics/views/custom-events/index.js:174
+#: assets/wizards/analytics/views/custom-events/index.js:234
 msgid "Category"
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:271
+#: includes/wizards/class-analytics-wizard.php:211
 msgid "Author"
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:278
+#: includes/wizards/class-analytics-wizard.php:218
 msgid "Word count"
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:285
+#: includes/wizards/class-analytics-wizard.php:225
 msgid "Publish date"
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:318
+#: includes/wizards/class-analytics-wizard.php:254
 msgid "Please authenticate with the Site Kit plugin."
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:327
+#: includes/wizards/class-analytics-wizard.php:263
 msgid "Please re-authorize"
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:329
+#: includes/wizards/class-analytics-wizard.php:265
 msgid "Site Kit plugin"
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:331
+#: includes/wizards/class-analytics-wizard.php:267
 msgid "to allow updating Google Analytics settings."
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:342
+#: includes/wizards/class-analytics-wizard.php:278
 msgid "Please connect Analytics in the Site Kit plugin."
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:345
-msgid "Please install the Site Kit plugin."
-msgstr ""
-
-#: includes/wizards/class-analytics-wizard.php:364
-#: includes/wizards/class-analytics-wizard.php:382
+#: includes/wizards/class-analytics-wizard.php:298
+#: includes/wizards/class-analytics-wizard.php:316
 msgid "Error retrieving custom dimensions."
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:439
+#: includes/wizards/class-analytics-wizard.php:373
 msgid "Error when creating custom dimension."
 msgstr ""
 
-#: includes/wizards/class-analytics-wizard.php:494
+#: includes/wizards/class-analytics-wizard.php:417
 msgid "Error when setting custom events."
+msgstr ""
+
+#: includes/wizards/class-analytics-wizard.php:439
+msgid "Error when setting NTG events status."
 msgstr ""
 
 #: includes/wizards/class-components-demo.php:53
 msgid "Components demo"
 msgstr ""
 
-#: includes/wizards/class-components-demo.php:62
-msgid "A temporary demo of components used to build Newspack"
-msgstr ""
-
-#: includes/wizards/class-components-demo.php:71
-msgid "2 minutes"
+#: includes/wizards/class-connections-wizard.php:41
+#: assets/wizards/connections/index.js:24
+msgid "Connections"
 msgstr ""
 
 #: includes/wizards/class-dashboard.php:61
+#: assets/wizards/componentsDemo/index.js:599
+#: assets/wizards/setup/index.js:41
+#: assets/wizards/site-design/index.js:87
 msgid "Customize the look and feel of your site"
 msgstr ""
 
 #: includes/wizards/class-dashboard.php:67
+#: assets/wizards/readerRevenue/index.js:85
 msgid "Generate revenue from your customers"
 msgstr ""
 
@@ -2228,6 +4363,7 @@ msgid "Monetize your content through ads"
 msgstr ""
 
 #: includes/wizards/class-dashboard.php:79
+#: assets/wizards/syndication/index.js:22
 msgid "Distribute your content across multiple websites"
 msgstr ""
 
@@ -2236,694 +4372,4006 @@ msgid "Track traffic and activity"
 msgstr ""
 
 #: includes/wizards/class-dashboard.php:91
+#: assets/wizards/seo/index.js:87
 msgid "Configure basic SEO settings"
 msgstr ""
 
 #: includes/wizards/class-dashboard.php:97
+#: assets/wizards/health-check/index.js:89
+#: assets/wizards/health-check/index.js:107
 msgid "Verify and correct site health issues"
 msgstr ""
 
-#: includes/wizards/class-dashboard.php:147
-msgid "The Newspack hub"
-msgstr ""
-
-#: includes/wizards/class-dashboard.php:156
-msgid "1 day"
-msgstr ""
-
-#: includes/wizards/class-dashboard.php:173
-msgid "Dashboard"
-msgstr ""
-
-#: includes/wizards/class-dashboard.php:173
-#: includes/wizards/class-setup-wizard.php:60
-msgid "Setup"
-msgstr ""
-
-#: includes/wizards/class-engagement-wizard.php:57
-msgid "Engagement"
-msgstr ""
-
-#: includes/wizards/class-engagement-wizard.php:66
+#: includes/wizards/class-dashboard.php:103
 msgid "Newsletters, commenting, social, recirculation"
 msgstr ""
 
-#: includes/wizards/class-engagement-wizard.php:147
+#: includes/wizards/class-dashboard.php:109
+#: assets/wizards/popups/index.js:33
+msgid "Reach your readers with configurable campaigns"
+msgstr ""
+
+#: includes/wizards/class-dashboard.php:115
+#: assets/wizards/connections/index.js:25
+msgid "Connections to third-party services"
+msgstr ""
+
+#: includes/wizards/class-dashboard.php:158
+msgid "Dashboard"
+msgstr ""
+
+#: includes/wizards/class-dashboard.php:158
+#: includes/wizards/class-setup-wizard.php:73
+msgid "Setup"
+msgstr ""
+
+#: includes/wizards/class-engagement-wizard.php:58
+#: assets/wizards/engagement/index.js:115
+msgid "Engagement"
+msgstr ""
+
+#: includes/wizards/class-engagement-wizard.php:332
 msgid "Invalid argument: max age must be a number greater than zero."
 msgstr ""
 
 #: includes/wizards/class-health-check-wizard.php:50
+#: assets/wizards/health-check/index.js:88
+#: assets/wizards/health-check/index.js:106
 msgid "Health Check"
 msgstr ""
 
-#: includes/wizards/class-health-check-wizard.php:59
-msgid "Verify and improve the health of the site."
-msgstr ""
-
 #: includes/wizards/class-popups-wizard.php:50
+#: assets/wizards/popups/components/settings-modal/index.js:51
+#: assets/wizards/popups/components/settings-modal/index.js:64
+#: assets/wizards/popups/index.js:32
+#: assets/wizards/popups/views/campaigns/index.js:180
+#: assets/wizards/popups/views/campaigns/index.js:211
 msgid "Campaigns"
 msgstr ""
 
-#: includes/wizards/class-popups-wizard.php:59
-msgid "Reach your readers with configurable campaigns"
+#: includes/wizards/class-popups-wizard.php:853
+msgid "Could not activate campaigns."
 msgstr ""
 
-#: includes/wizards/class-reader-revenue-wizard.php:40
-msgid "Reader Revenue"
+#: includes/wizards/class-popups-wizard.php:885
+msgid "Could not deactivate campaigns."
 msgstr ""
 
-#: includes/wizards/class-reader-revenue-wizard.php:49
-msgid "Generate revenue from your customers."
+#: includes/wizards/class-reader-revenue-wizard.php:185
+msgid "Fee multiplier must be smaller than 10."
 msgstr ""
 
-#: includes/wizards/class-reader-revenue-wizard.php:383
+#: includes/wizards/class-reader-revenue-wizard.php:351
 msgid "Test Publishable Key and Test Secret Key are required to use Stripe in test mode."
 msgstr ""
 
-#: includes/wizards/class-reader-revenue-wizard.php:392
+#: includes/wizards/class-reader-revenue-wizard.php:360
 msgid "Publishable Key and Secret Key are required to use Stripe."
 msgstr ""
 
-#: includes/wizards/class-reader-revenue-wizard.php:635
+#: includes/wizards/class-reader-revenue-wizard.php:528
 msgid "The WooCommerce plugin is not installed and activated. Install and/or activate it to access this feature."
 msgstr ""
 
 #: includes/wizards/class-seo-wizard.php:50
+#: assets/wizards/seo/index.js:86
 msgid "SEO"
 msgstr ""
 
-#: includes/wizards/class-seo-wizard.php:59
-msgid "Configure basic SEO settings."
+#: includes/wizards/class-settings.php:166
+#: assets/memberships-gate/editor.js:201
+#: assets/other-scripts/emails/index.js:112
+#: assets/wizards/advertising/index.js:156
+#: assets/wizards/popups/components/settings-modal/index.js:71
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:159
+#: assets/wizards/setup/index.js:28
+msgid "Settings"
 msgstr ""
 
-#: includes/wizards/class-setup-wizard.php:68
-msgid "Setup Newspack."
+#: includes/wizards/class-settings.php:175
+msgid "Configure settings."
+msgstr ""
+
+#: includes/wizards/class-settings.php:184
+msgid "10 minutes"
+msgstr ""
+
+#: includes/wizards/class-setup-wizard.php:239
+msgid "Missing starter content initialization info"
+msgstr ""
+
+#: includes/wizards/class-setup-wizard.php:418
+msgid "Subscribe"
 msgstr ""
 
 #: includes/wizards/class-site-design-wizard.php:41
+#: assets/wizards/componentsDemo/index.js:598
+#: assets/wizards/site-design/index.js:86
+#: assets/wizards/site-design/index.js:103
 msgid "Site Design"
 msgstr ""
 
-#: includes/wizards/class-site-design-wizard.php:50
-msgid "Customize the look and feel of your site."
-msgstr ""
-
-#: includes/wizards/class-site-design-wizard.php:59
-msgid "5 minutes"
-msgstr ""
-
 #: includes/wizards/class-syndication-wizard.php:49
-#: assets/wizards/syndication/index.js:38
+#: assets/wizards/syndication/index.js:21
 msgid "Syndication"
 msgstr ""
 
-#: includes/wizards/class-syndication-wizard.php:58
-msgid "Distribute your content."
+#: assets/blocks/reader-registration/edit.js:36
+msgid "Initial"
 msgstr ""
 
-#: assets/components/src/action-card-sections/index.js:13
-msgid "All"
+#: assets/blocks/reader-registration/edit.js:37
+msgid "Registration Success"
 msgstr ""
 
-#: assets/components/src/action-card-sections/index.js:41
-msgid "Filter:"
+#: assets/blocks/reader-registration/edit.js:38
+msgid "Login Success"
 msgstr ""
 
-#: assets/components/src/preview-box/index.js:13
-#: assets/wizards/popups/views/preview/index.js:81
-msgid "Preview"
+#: assets/blocks/reader-registration/edit.js:117
+msgid "Form settings"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:119
+msgid "Input placeholder"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:126
+msgid "Newsletter Subscription"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:128
+msgid "Enable newsletter subscription"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:157
+msgid "Hide newsletter selection and always subscribe"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:172
+msgid "Lists"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:201
+msgid "Spam protection"
+msgstr ""
+
+#. translators: %s is either 'enabled' or 'disabled'.
+#: assets/blocks/reader-registration/edit.js:205
+msgid "reCAPTCHA v3 is currently %s."
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:213
+msgid "It's highly recommended that you enable reCAPTCHA v3 protection to prevent spambots from using this form!"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:221
+msgid "Configure your reCAPTCHA settings."
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:228
+msgid "Edited State"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:263
+msgid "Add title"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:270
+msgid "Add description"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:280
+msgid "Newsletters title…"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:353
+msgid "Terms & Conditions statement…"
+msgstr ""
+
+#: assets/blocks/reader-registration/edit.js:375
+msgid "Logged in message…"
+msgstr ""
+
+#: assets/components/src/autocomplete-with-suggestions/index.js:20
+msgid "Begin typing search term, click autocomplete result to select."
+msgstr ""
+
+#: assets/components/src/autocomplete-with-suggestions/index.js:22
+msgid "Search"
+msgstr ""
+
+#: assets/components/src/autocomplete-with-suggestions/index.js:28
+msgid "item"
+msgstr ""
+
+#: assets/components/src/autocomplete-with-suggestions/index.js:29
+msgid "items"
+msgstr ""
+
+#: assets/components/src/autocomplete-with-suggestions/index.js:99
+#: assets/components/src/autocomplete-with-suggestions/index.js:133
+#: assets/wizards/popups/components/prompt-action-card/index.js:128
+msgid "(no title)"
+msgstr ""
+
+#. Translators: %1: the length of selections. %2: the selection leabel.
+#: assets/components/src/autocomplete-with-suggestions/index.js:180
+msgid "%1$s %2$s selected"
+msgstr ""
+
+#. Translators: %s: The label for the selection.
+#: assets/components/src/autocomplete-with-suggestions/index.js:185
+msgid "Selected %s"
+msgstr ""
+
+#: assets/components/src/autocomplete-with-suggestions/index.js:191
+msgctxt "separator character"
+msgid " – "
+msgstr ""
+
+#: assets/components/src/autocomplete-with-suggestions/index.js:194
+msgid "Clear all"
+msgstr ""
+
+#. Translators: %s: The name of the type.
+#: assets/components/src/autocomplete-with-suggestions/index.js:222
+msgid "%s type"
+msgstr ""
+
+#. Translators: %s: the name of a post type.
+#: assets/components/src/autocomplete-with-suggestions/index.js:290
+msgid "Or, select a recent %s:"
+msgstr ""
+
+#: assets/components/src/autocomplete-with-suggestions/index.js:304
+#: assets/components/src/plugin-toggle/index.js:165
+#: assets/components/src/web-preview/index.js:115
+#: assets/wizards/connections/views/main/google.js:139
+#: assets/wizards/connections/views/main/mailchimp.js:89
+#: assets/wizards/connections/views/main/plugins.js:73
+msgid "Loading…"
+msgstr ""
+
+#: assets/components/src/autocomplete-with-suggestions/index.js:304
+msgid "Load more"
+msgstr ""
+
+#: assets/components/src/footer/index.js:35
+msgid "About"
+msgstr ""
+
+#: assets/components/src/footer/index.js:40
+msgid "Documentation"
+msgstr ""
+
+#: assets/components/src/footer/index.js:47
+#: assets/wizards/componentsDemo/index.js:93
+msgid "Components Demo"
+msgstr ""
+
+#: assets/components/src/footer/index.js:53
+msgid "Setup Wizard"
+msgstr ""
+
+#: assets/components/src/footer/index.js:59
+msgid "Reset Newspack"
+msgstr ""
+
+#: assets/components/src/footer/index.js:65
+msgid "Remove Starter Content"
+msgstr ""
+
+#: assets/components/src/footer/index.js:71
+msgid "Contact Support"
+msgstr ""
+
+#: assets/components/src/handoff/index.js:55
+#: assets/components/src/handoff/index.js:56
+#: assets/components/src/handoff/index.js:57
+msgid "Manage"
+msgstr ""
+
+#: assets/components/src/handoff/index.js:58
+#: assets/wizards/componentsDemo/index.js:240
+#: assets/wizards/handoff-banner/index.js:22
+msgid "Dismiss"
+msgstr ""
+
+#: assets/components/src/handoff/index.js:118
+msgid " not installed"
+msgstr ""
+
+#: assets/components/src/handoff/index.js:129
+msgid "Retrieving Plugin Info"
+msgstr ""
+
+#: assets/components/src/image-upload/index.js:105
+msgid "Image preview"
+msgstr ""
+
+#: assets/components/src/image-upload/index.js:109
+msgid "Replace"
+msgstr ""
+
+#: assets/components/src/image-upload/index.js:118
+#: assets/wizards/connections/views/main/webhooks.js:109
+msgid "Remove"
+msgstr ""
+
+#: assets/components/src/image-upload/index.js:124
+msgid "Upload"
+msgstr ""
+
+#: assets/components/src/notice/index.js:65
+msgid "Debug Mode"
+msgstr ""
+
+#: assets/components/src/patrons-logo/index.js:24
+msgid "A project of WordPress.com and the Google News Initiative"
+msgstr ""
+
+#: assets/components/src/plugin-installer/index.js:173
+#: assets/components/src/plugin-installer/index.js:220
+#: assets/wizards/popups/components/prompt-popovers/primary.js:79
+msgid "Activate"
+msgstr ""
+
+#: assets/components/src/plugin-installer/index.js:205
+msgid "Contact Newspack support to install"
+msgstr ""
+
+#: assets/components/src/plugin-installer/index.js:206
+msgid "Plugin must be installed manually"
+msgstr ""
+
+#: assets/components/src/plugin-installer/index.js:227
+msgid "Installed"
+msgstr ""
+
+#: assets/components/src/plugin-settings/index.js:208
+msgid "General Settings"
+msgstr ""
+
+#: assets/components/src/plugin-settings/SettingsSection.js:111
+#: assets/wizards/connections/views/main/recaptcha.js:90
+#: assets/wizards/engagement/index.js:196
+#: assets/wizards/engagement/views/newsletters/index.js:168
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:252
+#: assets/wizards/seo/index.js:88
+msgid "Save Settings"
+msgstr ""
+
+#: assets/components/src/plugin-toggle/index.js:70
+msgid "There was an error managing this plugin."
+msgstr ""
+
+#: assets/components/src/plugin-toggle/index.js:151
+#: assets/wizards/componentsDemo/index.js:312
+#: assets/wizards/setup/views/welcome/index.js:196
+msgid "Installing…"
+msgstr ""
+
+#: assets/components/src/plugin-toggle/index.js:158
+msgid "Deactivating…"
+msgstr ""
+
+#: assets/components/src/plugin-toggle/index.js:174
+#: assets/wizards/advertising/components/add-ons/index.js:21
+#: assets/wizards/advertising/components/add-ons/index.js:25
+#: assets/wizards/componentsDemo/index.js:358
+#: assets/wizards/componentsDemo/index.js:368
+#: assets/wizards/componentsDemo/index.js:396
+#: assets/wizards/componentsDemo/index.js:423
+#: assets/wizards/componentsDemo/index.js:432
+#: assets/wizards/engagement/views/reader-activation/index.js:239
+msgid "Configure"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:35
+msgid "Top"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:40
+#: assets/components/src/position-control/index.js:72
+msgid "Center"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:45
+msgid "Bottom"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:52
+msgid "Top Left"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:57
+msgid "Top Center"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:62
+msgid "Top Right"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:67
+msgid "Center Left"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:77
+msgid "Center Right"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:82
+msgid "Bottom Left"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:87
+msgid "Bottom Center"
+msgstr ""
+
+#. translators: Overlay Position
+#: assets/components/src/position-control/index.js:92
+msgid "Bottom Right"
+msgstr ""
+
+#: assets/components/src/position-control/index.js:98
+msgid "Select Position"
+msgstr ""
+
+#: assets/components/src/settings/MinMaxSetting.js:26
+msgid "Min"
+msgstr ""
+
+#: assets/components/src/settings/MinMaxSetting.js:40
+msgid "Max"
+msgstr ""
+
+#: assets/components/src/style-card/index.js:41
+msgid "Thumbnail"
+msgstr ""
+
+#: assets/components/src/style-card/index.js:46
+msgid "Selected"
+msgstr ""
+
+#: assets/components/src/style-card/index.js:52
+#: assets/components/src/style-card/index.js:55
+#: assets/wizards/site-design/views/theme-settings/index.js:132
+msgid "Select"
+msgstr ""
+
+#: assets/components/src/style-card/index.js:59
+msgid "View Demo"
 msgstr ""
 
 #: assets/components/src/text-control/index.js:31
 msgid "(required)"
 msgstr ""
 
-#: assets/components/src/with-wizard-screen/index.js:48
-msgid "Newspack is in debug mode."
+#: assets/components/src/web-preview/index.js:84
+msgid "Preview Desktop Size"
 msgstr ""
 
-#: assets/wizards/advertising/views/ad-unit/index.js:97
-msgid "Add Size"
+#: assets/components/src/web-preview/index.js:90
+msgid "Preview Tablet Size"
 msgstr ""
 
-#: assets/wizards/advertising/views/header-code/index.js:41
-msgid "Google Ad Manager Network Code"
+#: assets/components/src/web-preview/index.js:96
+msgid "Preview Phone Size"
+msgstr ""
+
+#: assets/components/src/web-preview/index.js:107
+msgid "Close Preview"
+msgstr ""
+
+#: assets/components/src/web-preview/index.js:169
+#: assets/wizards/popups/components/prompt-popovers/primary.js:61
+#: assets/wizards/site-design/views/main/index.js:381
+msgid "Preview"
+msgstr ""
+
+#: assets/components/src/with-wizard-screen/index.js:69
+#: assets/components/src/with-wizard/index.js:108
+#: assets/components/src/with-wizard/index.js:222
+#: assets/components/src/wizard/components/WizardError.js:44
+#: assets/components/src/wizard/index.js:93
+#: assets/wizards/componentsDemo/index.js:85
+msgid "Return to Dashboard"
+msgstr ""
+
+#: assets/components/src/with-wizard/index.js:232
+#: assets/components/src/wizard/index.js:60
+msgid "Required plugins"
+msgstr ""
+
+#: assets/components/src/with-wizard/index.js:233
+#: assets/components/src/wizard/index.js:61
+msgid "Required plugin"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:19
+#: assets/wizards/popups/components/segment-group/index.js:184
+#: assets/wizards/popups/utils.js:58
+msgid "Inline"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:20
+msgid "Overlay"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:24
+msgid "center"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:25
+msgid "bottom"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:29
+msgid "Extra Small"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:30
+#: assets/wizards/componentsDemo/index.js:505
+#: assets/wizards/componentsDemo/index.js:575
+#: assets/wizards/site-design/views/theme-settings/index.js:92
+msgid "Small"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:31
+msgid "Medium"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:32
+#: assets/wizards/site-design/views/theme-settings/index.js:91
+msgid "Large"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:33
+msgid "Full Width"
+msgstr ""
+
+#. translators: %s is the list of plans.
+#: assets/memberships-gate/editor.js:62
+msgid "You're currently editing a gate for content restricted by: %s"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:80
+msgid "Newspack Campaign prompts won't be displayed when rendering gated content."
+msgstr ""
+
+#: assets/memberships-gate/editor.js:90
+msgid "WooCommerce Memberships"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:95
+msgid "This gate will be rendered for all membership plans. Manage custom gates for when the content is locked behind a specific plan:"
+msgstr ""
+
+#. translators: %s is the list of plans.
+#: assets/memberships-gate/editor.js:106
+msgid "This gate will be rendered for the following membership plans: %s"
+msgstr ""
+
+#. translators: %s is the link to the primary gate.
+#: assets/memberships-gate/editor.js:118
+msgid "Edit the <a href=\"%s\">primary gate</a>, or:"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:133
+msgid "published"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:134
+msgid "draft"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:140
+msgid "edit gate"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:140
+msgid "create gate"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:150
+msgid "Styles"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:167
+msgid "Apply fade to last paragraph"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:170
+msgid "Whether to apply a gradient fade effect before rendering the gate."
+msgstr ""
+
+#: assets/memberships-gate/editor.js:179
+#: assets/wizards/advertising/components/ad-unit-size-control/index.js:73
+#: assets/wizards/advertising/views/ad-unit/index.js:133
+#: assets/wizards/site-design/views/main/index.js:265
+msgid "Size"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:185
+msgid "Position"
+msgstr ""
+
+#. translators: %s is the placement of the gate.
+#: assets/memberships-gate/editor.js:192
+msgid "The gate will be displayed at the %s of the screen."
+msgstr ""
+
+#: assets/memberships-gate/editor.js:207
+msgid "Default paragraph count"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:209
+msgid "Number of paragraphs that readers can see above the content gate."
+msgstr ""
+
+#: assets/memberships-gate/editor.js:216
+msgid "Use “More” tag to manually place content gate"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:219
+msgid "Override the default paragraph count on pages where a “More” block has been placed."
+msgstr ""
+
+#: assets/memberships-gate/editor.js:227
+msgid "Metering"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:230
+msgid "Enable metering"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:233
+msgid "Implement metering to configure access to restricted content before showing the gate."
+msgstr ""
+
+#: assets/memberships-gate/editor.js:244
+msgid "Available views for anonymous readers"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:246
+msgid "Number of times an anonymous reader can view gated content. If set to 0, anonymous readers will always render the gate."
+msgstr ""
+
+#: assets/memberships-gate/editor.js:255
+msgid "Available views for registered readers"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:257
+msgid "Number of times a registered reader can view gated content. If set to 0, registered readers without membership plan will always render the gate."
+msgstr ""
+
+#: assets/memberships-gate/editor.js:263
+msgid "Time period"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:266
+msgid "Day"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:267
+msgid "Week"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:268
+msgid "Month"
+msgstr ""
+
+#: assets/memberships-gate/editor.js:271
+msgid "The time period during which the metering views will be counted. For example, if the metering period is set to a week, the metering views will be reset every week."
+msgstr ""
+
+#. translators: 1: "From" email address 2: "From" email name
+#: assets/other-scripts/emails/index.js:59
+msgid "This email will be sent from %1$s <%2$s>."
+msgstr ""
+
+#: assets/other-scripts/emails/index.js:81
+msgid "Test email sent!"
+msgstr ""
+
+#: assets/other-scripts/emails/index.js:95
+msgid "Instructions"
+msgstr ""
+
+#: assets/other-scripts/emails/index.js:97
+msgid "Use the following placeholders to insert dynamic content in the email:"
+msgstr ""
+
+#: assets/other-scripts/emails/index.js:115
+msgid "Subject"
+msgstr ""
+
+#: assets/other-scripts/emails/index.js:120
+msgid "Testing"
+msgstr ""
+
+#: assets/other-scripts/emails/index.js:122
+msgid "Send to"
+msgstr ""
+
+#: assets/other-scripts/emails/index.js:129
+msgid "Sending…"
+msgstr ""
+
+#: assets/other-scripts/emails/index.js:129
+msgid "Send"
+msgstr ""
+
+#: assets/other-scripts/salesforce/index.js:28
+msgid "Not synced"
+msgstr ""
+
+#: assets/other-scripts/salesforce/index.js:35
+msgid "Synced"
+msgstr ""
+
+#: assets/other-scripts/salesforce/index.js:39
+#: assets/other-scripts/salesforce/index.js:44
+msgid "Error fetching status"
+msgstr ""
+
+#: assets/plugins-screen/plugins-screen.js:50
+#: dist/plugins-screen.js:1
+msgid "Plugin review required"
+msgstr ""
+
+#: assets/plugins-screen/plugins-screen.js:51
+#: dist/plugins-screen.js:1
+msgid "Please submit a plugin for review by the Newspack Team before installing it on your website. If you plan to install an approved plugin, feel free to close this message."
+msgstr ""
+
+#: assets/plugins-screen/plugins-screen.js:60
+#: dist/plugins-screen.js:1
+msgid "Plugin Review Form"
+msgstr ""
+
+#: assets/plugins-screen/plugins-screen.js:65
+#: dist/plugins-screen.js:1
+msgid "Approved Plugins List"
+msgstr ""
+
+#: assets/plugins-screen/plugins-screen.js:68
+#: dist/plugins-screen.js:1
+msgid "Close this message"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:21
+msgid "Viewability Threshold"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:22
+msgid "The percentage of the ad slot which must be visible in the viewport in order to be considered eligible for being refreshed. It's recommended you do not lower this below 50 or you risk third-party viewability tracking platforms flagging your ad impressions as not having been viewed before refreshing."
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:30
+msgid "Refresh Interval"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:31
+msgid "The number of seconds that must pass between an ad crossing the viewability threshold and the the ad refreshing. The plugin enforces a minimum of 30 in order to avoid your site being flagged for abusing ad refreshes by advertisers. This value may however be overridden via the avc_refresh_interval_value filter hook."
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:39
+msgid "Maximum Refreshes"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:40
+msgid "The number of times each ad slot is allowed to be refreshed. If this is set to 4 then an ad slot could have a total of 5 impressions by combining the initial loading of the ad with the 4 times it can refresh."
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:48
+msgid "Excluded Advertiser IDs"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:49
+msgid "Prevent ad refreshes for specific advertiser IDs in the format of a comma separated list (e.g., 125,594,293). If an ad slot ever displays an ad creative from one of the listed advertiser IDs then that ad slot will stop refreshing for the remainder of the page view. AdSense does not allow their ads to be auto-refreshed. When Newspack detects that AdSense is the advertiser for any given impression, a refresh will not take place."
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:57
+msgid "Line Items IDs to Exclude"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:58
+msgid "Prevent ad refreshs for specific line item IDs. (Comma Seperated List)"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:66
+msgid "Sizes to Exclude"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:67
+msgid "Prevent ad refreshs for specific sizes. Accepts string (fluid) or array (300x250). Example: fluid, 300x250."
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:75
+msgid "Slot IDs to Exclude"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-refresh-control/index.js:76
+msgid "Prevent ad refreshs for specific slot IDs e.g. div-gpt-ad-grid-1. (Comma Seperated List)."
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-unit-size-control/index.js:80
+#: assets/wizards/site-design/views/main/index.js:43
+msgid "Custom"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-unit-size-control/index.js:91
+msgid "Fluid is a native ad size that allows more flexibility when styling your ad. It automatically sizes the ad by filling the width of the enclosing column and adjusting the height as appropriate."
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-unit-size-control/index.js:99
+#: assets/wizards/advertising/views/ad-unit/index.js:134
+msgid "Width"
+msgstr ""
+
+#: assets/wizards/advertising/components/ad-unit-size-control/index.js:107
+#: assets/wizards/advertising/views/ad-unit/index.js:135
+msgid "Height"
+msgstr ""
+
+#: assets/wizards/advertising/components/add-ons/index.js:30
+msgid "Edit Media Kit"
+msgstr ""
+
+#: assets/wizards/advertising/components/onboarding/index.js:60
+msgid "Authenticate with Google in order to connect your Google Ad Manager account:"
+msgstr ""
+
+#: assets/wizards/advertising/components/onboarding/index.js:72
+msgid "We're all set here!"
+msgstr ""
+
+#: assets/wizards/advertising/components/onboarding/index.js:76
+msgid "Enter your Google Ad Manager network code and service account credentials for a full integration:"
+msgstr ""
+
+#: assets/wizards/advertising/components/onboarding/index.js:85
+msgid "Network code"
+msgstr ""
+
+#: assets/wizards/advertising/components/onboarding/index.js:92
+msgid "Upload credentials"
+msgstr ""
+
+#: assets/wizards/advertising/components/onboarding/index.js:94
+msgid "Upload your Service Account credentials file to connect your GAM account."
+msgstr ""
+
+#: assets/wizards/advertising/components/onboarding/index.js:108
+msgid "How to get a service account user for API access"
+msgstr ""
+
+#: assets/wizards/advertising/components/placement-control/index.js:25
+msgid "Select a provider"
+msgstr ""
+
+#: assets/wizards/advertising/components/placement-control/index.js:49
+msgid "Select an Ad Unit"
+msgstr ""
+
+#: assets/wizards/advertising/components/placement-control/index.js:77
+#: assets/wizards/advertising/views/placements/index.js:197
+msgid "Ad Unit"
+msgstr ""
+
+#. Translators: Ad bidder name.
+#: assets/wizards/advertising/components/placement-control/index.js:102
+msgid "%s does not support the selected ad unit sizes."
+msgstr ""
+
+#: assets/wizards/advertising/components/placement-control/index.js:111
+#: assets/wizards/advertising/views/placements/index.js:135
+msgid "There is no provider available."
+msgstr ""
+
+#: assets/wizards/advertising/components/placement-control/index.js:118
+msgid "Provider"
+msgstr ""
+
+#. Translators: Bidder name.
+#: assets/wizards/advertising/components/placement-control/index.js:142
+msgid "%s Placement ID"
+msgstr ""
+
+#: assets/wizards/advertising/components/utils/index.js:21
+msgid "Invalid JSON file"
+msgstr ""
+
+#: assets/wizards/advertising/components/utils/index.js:26
+msgid "Unable to read file"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:120
+msgid "Are you sure you want to archive this ad unit?"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:147
+msgid "Providers"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:152
+msgid "Placements"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:160
+msgid "Suppression"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:164
+msgid "Add-Ons"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:179
+msgid "Manage ad providers and their settings."
+msgstr ""
+
+#: assets/wizards/advertising/index.js:192
+msgid "Define global advertising placements to serve ad units on your site"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:205
+msgid "Configure display and advanced settings for your ads"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:219
+msgid "Monetize your content through Google Ad Manager"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:238
+#: assets/wizards/advertising/views/ad-units/index.js:159
+msgid "Add New Ad Unit"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:239
+#: assets/wizards/advertising/index.js:272
+msgid "Allows you to place ads on your site"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:271
+msgid "Edit Ad Unit"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:292
+msgid "Allows you to manage site-wide ad suppression"
+msgstr ""
+
+#: assets/wizards/advertising/index.js:307
+msgid "Add-ons for enhanced advertising"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:78
+msgid "Ad Unit Details"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:83
+#: assets/wizards/analytics/views/custom-dimensions/index.js:90
+#: assets/wizards/analytics/views/custom-dimensions/index.js:123
+msgid "Name"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:89
+msgid "Code"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:95
+msgid "Identifies the ad unit in the associated ad tag. Once you've created the ad unit, you can't change the code."
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:109
+msgid "Ad Unit Sizes"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:110
+msgid "Ad Unit Size"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:118
+msgid "Add New Size"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:125
+msgid "The ad unit must have at least one valid size or fluid size enabled."
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:136
+#: assets/wizards/analytics/views/custom-events/index.js:173
+#: assets/wizards/analytics/views/custom-events/index.js:227
+#: assets/wizards/connections/views/main/webhooks.js:387
+msgid "Action"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:171
+#: assets/wizards/analytics/views/custom-events/index.js:290
+#: assets/wizards/componentsDemo/index.js:300
+#: assets/wizards/componentsDemo/index.js:349
+#: assets/wizards/popups/components/campaign-management-popover/index.js:108
+#: assets/wizards/popups/components/prompt-popovers/primary.js:82
+#: assets/wizards/popups/views/segments/SegmentsList.js:215
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:74
+msgid "Delete"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:183
+#: assets/wizards/advertising/views/ad-units/index.js:139
+#: assets/wizards/advertising/views/placements/index.js:236
+#: assets/wizards/advertising/views/providers/index.js:134
+#: assets/wizards/advertising/views/suppression/index.js:158
+#: assets/wizards/analytics/views/custom-dimensions/index.js:138
+#: assets/wizards/analytics/views/custom-events/index.js:298
+#: assets/wizards/analytics/views/newspack-custom-events/index.js:112
+#: assets/wizards/connections/views/main/webhooks.js:561
+#: assets/wizards/popups/components/settings-modal/index.js:230
+#: assets/wizards/popups/views/segments/SingleSegment.js:359
+#: assets/wizards/site-design/index.js:108
+#: assets/wizards/site-design/views/main/index.js:399
+msgid "Save"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-unit/index.js:186
+#: assets/wizards/advertising/views/placements/index.js:226
+#: assets/wizards/advertising/views/providers/index.js:127
+#: assets/wizards/connections/views/main/mailchimp.js:152
+#: assets/wizards/connections/views/main/webhooks.js:124
+#: assets/wizards/popups/components/prompt-action-card/index.js:252
+#: assets/wizards/popups/components/settings-modal/index.js:227
+#: assets/wizards/popups/views/campaigns/index.js:304
+#: assets/wizards/popups/views/segments/SingleSegment.js:362
+msgid "Cancel"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:43
+msgid "Google Ad Manager Error"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:84
+#: assets/wizards/engagement/views/reader-activation/campaign.js:94
+#: assets/wizards/engagement/views/reader-activation/complete.js:158
+msgid "Back"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:90
+msgid "Connected GAM network code"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:101
+msgid "Your GAM network code is different than the network code the site was configured with. Legacy ad units are likely to not load."
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:127
+msgid "Currently operating in legacy mode."
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:132
+msgid "Network Code"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:146
+msgid "Set up multiple ad units to use on your homepage, articles and other places throughout your site."
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:151
+msgid "You can place ads through our Newspack Ad Block in the Editor, Newspack Ad widget, and using the global placements."
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:181
+msgid "Code:"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:187
+msgid "Sizes:"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:191
+msgid "Fluid"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:197
+msgid "Legacy ad unit."
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:203
+msgid "Default ad unit."
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/index.js:209
+msgid "Disconnected from GAM."
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/options-popover.js:28
+#: assets/wizards/popups/components/prompt-action-card/index.js:153
+#: assets/wizards/popups/views/segments/SegmentsList.js:192
+msgid "More options"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/options-popover.js:38
+#: assets/wizards/popups/components/campaign-management-popover/index.js:36
+#: assets/wizards/popups/components/prompt-popovers/primary.js:41
+#: assets/wizards/popups/views/segments/SegmentsList.js:203
+msgid "Close Popover"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/options-popover.js:41
+#: assets/wizards/analytics/views/custom-events/index.js:177
+#: assets/wizards/analytics/views/custom-events/index.js:204
+#: assets/wizards/componentsDemo/index.js:299
+#: assets/wizards/connections/views/main/webhooks.js:104
+#: assets/wizards/engagement/views/reader-activation/index.js:258
+#: assets/wizards/popups/components/prompt-action-card/index.js:221
+#: assets/wizards/popups/components/prompt-popovers/primary.js:64
+#: assets/wizards/popups/views/segments/SegmentsList.js:209
+#: assets/wizards/readerRevenue/views/emails/index.js:86
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:264
+msgid "Edit"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/options-popover.js:44
+#: assets/wizards/popups/components/campaign-management-popover/index.js:87
+msgid "Archive"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/service-account-connection.js:41
+msgid "Service Account connection"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/service-account-connection.js:47
+msgid "Update Service Account credentials"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/service-account-connection.js:54
+msgid "Remove Service Account credentials"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/service-account-connection.js:61
+msgid "Connect your Google Ad Manager account"
+msgstr ""
+
+#: assets/wizards/advertising/views/ad-units/service-account-connection.js:63
+msgid "Upload your Service Account credentials file to connect your GAM account with Newspack Ads."
+msgstr ""
+
+#: assets/wizards/advertising/views/placements/index.js:159
+msgid "Placement settings"
+msgstr ""
+
+#. translators: %s is the name of the placement
+#: assets/wizards/advertising/views/placements/index.js:172
+msgid "%s placement settings"
+msgstr ""
+
+#: assets/wizards/advertising/views/placements/index.js:209
+msgid "Stick to Top"
+msgstr ""
+
+#: assets/wizards/advertising/views/providers/index.js:74
+msgid "Click here to connect your account."
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:72
+msgid "Post Types"
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:73
+msgid "Suppress ads on specific post types."
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:94
+msgid "Tags"
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:95
+msgid "Suppress ads on specific tags and their archive pages."
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:114
+msgid "All tag archive pages"
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:117
+msgid "Categories"
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:118
+msgid "Suppress ads on specific categories and their archive pages."
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:139
+msgid "All category archive pages"
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:142
+msgid "Author Archive Pages"
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:143
+msgid "Suppress ads on automatically generated pages displaying a list of posts by an author."
+msgstr ""
+
+#: assets/wizards/advertising/views/suppression/index.js:154
+msgid "Suppress ads on author archive pages"
 msgstr ""
 
 #: assets/wizards/analytics/index.js:25
+#: assets/wizards/connections/views/main/index.js:26
+#: assets/wizards/health-check/index.js:70
 msgid "Plugins"
 msgstr ""
 
 #: assets/wizards/analytics/index.js:30
-msgid "Custom Dimensions"
+msgid "Newspack Custom Events"
 msgstr ""
 
-#: assets/wizards/analytics/index.js:34
-msgid "Custom Events"
+#: assets/wizards/analytics/index.js:43
+msgid "Manage Google Analytics Configuration"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-dimensions/index.js:23
+msgid "Hit"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-dimensions/index.js:24
+msgid "Session"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-dimensions/index.js:25
+msgid "User"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-dimensions/index.js:26
+msgid "Product"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-dimensions/index.js:76
+msgid "User-defined custom dimensions"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-dimensions/index.js:77
+msgid "Collect and analyze data that Google Analytics doesn't automatically track"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-dimensions/index.js:91
+msgid "ID"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-dimensions/index.js:117
+msgid "Create new custom dimension"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-dimensions/index.js:128
+msgid "Scope"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:44
+msgid "Click"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:45
+msgid "Submit"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:145
+msgid "User-defined custom events"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:146
+msgid "Collect and analyze specific user interactions"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:150
+#: assets/wizards/analytics/views/custom-events/index.js:216
+msgid "Add New Custom Event"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:156
+msgid "This is an advanced feature, read more about it on our"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:159
+msgid "support page"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:172
+#: assets/wizards/analytics/views/custom-events/index.js:277
+#: assets/wizards/componentsDemo/index.js:343
+#: assets/wizards/componentsDemo/index.js:348
+msgid "Active"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:175
+#: assets/wizards/analytics/views/custom-events/index.js:241
+msgid "Label"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:176
+#: assets/wizards/analytics/views/custom-events/index.js:247
+msgid "Trigger"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:217
+msgid "Editing Custom Event"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:255
+msgid "Selector"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:263
+msgid "AMP Selector"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:271
+msgid "Non-interaction event"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:298
+msgid "Update"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:308
+msgid "News Tagging Guide custom events"
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:311
+msgid "Free tool that helps you make the most of Google Analytics by capturing better data."
+msgstr ""
+
+#: assets/wizards/analytics/views/custom-events/index.js:319
+msgid "More info"
+msgstr ""
+
+#: assets/wizards/analytics/views/newspack-custom-events/index.js:55
+msgid "Activate Newspack Custom Events"
+msgstr ""
+
+#: assets/wizards/analytics/views/newspack-custom-events/index.js:56
+msgid "Allows Newspack to send enhanced custom event data to your Google Analytics."
+msgstr ""
+
+#: assets/wizards/analytics/views/newspack-custom-events/index.js:63
+msgid "Newspack already sends some custom event data to your GA account, but adding the credentials below enables enhanced events that are fired from your site's backend. For example, when a donation is confirmed or when a user successfully subscribes to a newsletter."
+msgstr ""
+
+#: assets/wizards/analytics/views/newspack-custom-events/index.js:74
+msgid "Measurement ID"
+msgstr ""
+
+#: assets/wizards/analytics/views/newspack-custom-events/index.js:75
+msgid "You can find this in Site Kit Settings, or in Google Analytics > Admin > Data Streams and clickng the data stream. Example: G-ABCD1234"
+msgstr ""
+
+#: assets/wizards/analytics/views/newspack-custom-events/index.js:91
+msgid "Measurement Protocol API Secret"
+msgstr ""
+
+#: assets/wizards/analytics/views/newspack-custom-events/index.js:92
+msgid "Generate an API secret from your GA dashboard in Admin > Data Streams and opening your data stream. Select \"Measurement Protocol API secrets\" under the Events section. Create a new secret."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:95
+msgid "Simple components used for composing the UI of Newspack"
 msgstr ""
 
 #: assets/wizards/componentsDemo/index.js:103
-#: assets/wizards/componentsDemo/index.js:110
+msgid "Autocomplete with Suggestions (single-select)"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:105
+msgid "Search for a post"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:106
+#: assets/wizards/componentsDemo/index.js:123
+msgid "Begin typing post title, click autocomplete result to select."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:118
+msgid "Autocomplete with Suggestions (multi-select)"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:122
+msgid "Search widgets"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:140
+msgid "Plugin toggles"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:154
+msgid "Web Previews"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:158
+#: assets/wizards/componentsDemo/index.js:165
 msgid "Preview Newspack Blog"
 msgstr ""
 
-#: assets/wizards/engagement/views/commenting/index.js:17
-msgid "WordPress comments"
+#: assets/wizards/componentsDemo/index.js:172
+msgid "Waiting"
 msgstr ""
 
-#: assets/wizards/engagement/views/commenting/index.js:25
-#: assets/wizards/engagement/views/commenting/index.js:28
-msgid "Disqus"
+#: assets/wizards/componentsDemo/index.js:178
+msgid "Spinner on the left"
 msgstr ""
 
-#: assets/wizards/engagement/views/commenting/index.js:41
-#: assets/wizards/engagement/views/commenting/index.js:44
-msgid "The Coral Project"
+#: assets/wizards/componentsDemo/index.js:182
+msgid "Spinner on the right"
 msgstr ""
 
-#: assets/wizards/engagement/views/related-content/index.js:31
-msgid "Recirculation Settings"
+#: assets/wizards/componentsDemo/index.js:189
+msgid "Color picker"
 msgstr ""
 
-#: assets/wizards/engagement/views/related-content/index.js:36
-msgid "These extra settings apply to Related Posts shown by Jetpack."
+#: assets/wizards/componentsDemo/index.js:191
+msgid "Color Picker"
 msgstr ""
 
-#: assets/wizards/engagement/views/related-content/index.js:39
-msgid "Configure Related Posts in Jetpack"
+#: assets/wizards/componentsDemo/index.js:197
+msgid "Handoff Buttons"
 msgstr ""
 
-#: assets/wizards/engagement/views/related-content/index.js:47
-msgid "If set, posts will be shown as related content only if published within the past number of months. If 0, any published post can be shown, regardless of publish date."
+#: assets/wizards/componentsDemo/index.js:200
+msgid "Manage AMP"
 msgstr ""
 
-#: assets/wizards/engagement/views/related-content/index.js:51
-msgid "Maximum age of related content, in months"
+#: assets/wizards/componentsDemo/index.js:201
+msgid "Click to go to the AMP dashboard. There will be a notification bar at the top with a link to return to Newspack."
 msgstr ""
 
-#: assets/wizards/health-check/views/configuration/index.js:45
-msgid "Jetpack is connected."
+#: assets/wizards/componentsDemo/index.js:216
+msgid "Specific Yoast Page"
 msgstr ""
 
-#: assets/wizards/health-check/views/configuration/index.js:46
-msgid "Jetpack is not connected. "
+#: assets/wizards/componentsDemo/index.js:221
+msgid "Modal"
 msgstr ""
 
+#: assets/wizards/componentsDemo/index.js:224
+msgid "Open modal"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:229
+msgid "This is the modal title"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:233
+msgid "Based on industry research, we advise to test the modal component, and continuing this sentence so we can see how the text wraps is one good way of doing that."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:243
+msgid "Also dismiss"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:250
+msgid "Notice"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:251
+msgid "This is an info notice."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:252
+msgid "This is an error notice."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:253
+msgid "This is a help notice."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:254
+msgid "This is a success notice."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:255
+msgid "This is a warning notice."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:258
+msgid "Plugin installer"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:273
+msgid "Plugin installer (small)"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:289
+msgid "Example One"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:290
+msgid "Has an action button."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:297
+msgid "Example Two"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:298
+msgid "Has action button and secondary button."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:310
+msgid "Example Three"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:311
+msgid "Waiting/in-progress state, no action button."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:316
+msgid "Example Four"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:317
+msgid "Error notification"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:330
+msgid "Example Five"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:331
+msgid "Warning notification, action button"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:341
+msgid "Example Six"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:342
+msgid "Static text, no button"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:346
+msgid "Example Seven"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:347
+msgid "Static text, secondary action button."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:356
+msgid "Example Eight"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:357
+msgid "Image with link and action button."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:366
+msgid "Example Nine"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:367
+msgid "Action Card with Toggle Control."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:377
+msgid "Example Ten"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:378
+msgid "An example of an action card with a badge."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:386
+msgid "Example Eleven"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:387
+msgid "An example of a small action card."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:388
+msgid "Installing"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:394
+msgid "Example Twelve"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:395
+msgid "Action card with an unchecked checkbox."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:403
+msgid "Example Thirteen"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:404
+msgid "Action card with a checked checkbox."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:405
+#: assets/wizards/connections/views/main/google.js:163
+#: assets/wizards/connections/views/main/mailchimp.js:121
+msgid "Disconnect"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:412
+msgid "Archived"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:413
+msgid "Example Fourteen"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:414
+msgid "An example of an action card with two badges."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:421
+#: assets/wizards/componentsDemo/index.js:427
+msgid "Handoff"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:422
+msgid "An example of an action card with Handoff."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:428
+msgid " An example of an action card with Handoff and EditLink."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:438
+msgid "Expandable"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:439
+msgid " An example of an action card with expandable inner content."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:444
+msgid "Some inner content to display when the card is expanded."
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:447
+msgid "Image Uploader"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:458
+msgid "Progress bar"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:460
+#: assets/wizards/componentsDemo/index.js:465
+msgid "Progress made"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:470
+msgid "Select dropdowns"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:473
+msgid "Label for Select with a preselection"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:476
+#: assets/wizards/componentsDemo/index.js:487
+#: assets/wizards/componentsDemo/index.js:498
+#: assets/wizards/componentsDemo/index.js:509
+msgid "- Select -"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:477
+#: assets/wizards/componentsDemo/index.js:488
+#: assets/wizards/componentsDemo/index.js:499
+#: assets/wizards/componentsDemo/index.js:510
+#: assets/wizards/componentsDemo/index.js:521
+msgid "First"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:478
+#: assets/wizards/componentsDemo/index.js:489
+#: assets/wizards/componentsDemo/index.js:500
+#: assets/wizards/componentsDemo/index.js:511
+#: assets/wizards/componentsDemo/index.js:522
+msgid "Second"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:479
+#: assets/wizards/componentsDemo/index.js:490
+#: assets/wizards/componentsDemo/index.js:501
+#: assets/wizards/componentsDemo/index.js:512
+#: assets/wizards/componentsDemo/index.js:523
+msgid "Third"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:484
+msgid "Label for Select with no preselection"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:495
+msgid "Label for disabled Select"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:518
+msgid "Multi-select"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:524
+msgid "Fourth"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:525
+msgid "Fifth"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:526
+msgid "Sixth"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:527
+msgid "Seventh"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:534
+msgid "Selected:"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:537
+msgid "none"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:544
+msgid "Buttons"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:547
+#: assets/wizards/site-design/views/main/index.js:42
+msgid "Default"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:557
+msgid "Disabled"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:605
+#: assets/wizards/setup/views/welcome/index.js:333
+msgid "Start a new site"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:606
+#: assets/wizards/setup/views/welcome/index.js:334
+msgid "You don't have content to import"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:613
+msgid "Migrate an existing site"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:614
+#: assets/wizards/setup/views/welcome/index.js:344
+msgid "You have content to import"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:621
+msgid "Add a new Podcast"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:630
+msgid "Add a new Font"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:640
+msgid "Plugin Settings Section"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:643
+msgid "Example plugin settings"
+msgstr ""
+
+#: assets/wizards/componentsDemo/index.js:644
+msgid "Example plugin settings description"
+msgstr ""
+
+#: assets/wizards/connections/views/main/fivetran.js:31
+#: assets/wizards/setup/views/services/index.js:45
+msgid "Google Ad Manager"
+msgstr ""
+
+#: assets/wizards/connections/views/main/fivetran.js:35
+msgid "Facebook Pages"
+msgstr ""
+
+#: assets/wizards/connections/views/main/fivetran.js:50
+msgid "Sync is in progress – please check back in a while."
+msgstr ""
+
+#: assets/wizards/connections/views/main/fivetran.js:56
+#: assets/wizards/connections/views/main/google.js:148
+#: assets/wizards/connections/views/main/mailchimp.js:95
+#: assets/wizards/connections/views/main/plugins.js:76
+msgid "Not connected"
+msgstr ""
+
+#: assets/wizards/connections/views/main/fivetran.js:102
+msgid "In order to use the this features, you must read and accept"
+msgstr ""
+
+#: assets/wizards/connections/views/main/fivetran.js:104
+msgid "Newspack Terms of Service"
+msgstr ""
+
+#: assets/wizards/connections/views/main/fivetran.js:122
+msgid "I've read and accept Newspack Terms of Service"
+msgstr ""
+
+#: assets/wizards/connections/views/main/fivetran.js:130
+#: assets/wizards/connections/views/main/google.js:154
+#: assets/wizards/connections/views/main/mailchimp.js:112
+#: assets/wizards/connections/views/main/plugins.js:84
+msgid "Status:"
+msgstr ""
+
+#: assets/wizards/connections/views/main/fivetran.js:135
+msgid "Re-connect"
+msgstr ""
+
+#: assets/wizards/connections/views/main/fivetran.js:136
+#: assets/wizards/connections/views/main/google.js:163
+#: assets/wizards/connections/views/main/mailchimp.js:105
+#: assets/wizards/connections/views/main/mailchimp.js:121
+#: assets/wizards/connections/views/main/plugins.js:38
+#: assets/wizards/connections/views/main/plugins.js:45
+#: assets/wizards/health-check/views/configuration/index.js:37
 #: assets/wizards/health-check/views/configuration/index.js:48
-#: assets/wizards/health-check/views/configuration/index.js:59
 msgid "Connect"
 msgstr ""
 
-#: assets/wizards/health-check/views/configuration/index.js:53
-msgid "Google Site Kit"
+#: assets/wizards/connections/views/main/google.js:42
+msgid "Missing Google refresh token. Please"
 msgstr ""
 
-#: assets/wizards/health-check/views/configuration/index.js:56
+#: assets/wizards/connections/views/main/google.js:50
+msgid "revoke credentials"
+msgstr ""
+
+#: assets/wizards/connections/views/main/google.js:53
+msgid "and authorise the site again."
+msgstr ""
+
+#. Translators: connected user's email address.
+#. Translators: user connection status message.
+#: assets/wizards/connections/views/main/google.js:144
+#: assets/wizards/connections/views/main/mailchimp.js:93
+msgid "Connected as %s"
+msgstr ""
+
+#: assets/wizards/connections/views/main/index.js:28
+msgid "APIs"
+msgstr ""
+
+#: assets/wizards/connections/views/main/mailchimp.js:65
+msgid "Something went wrong during verification of your Mailchimp API key."
+msgstr ""
+
+#: assets/wizards/connections/views/main/mailchimp.js:100
+msgid "Connecting…"
+msgstr ""
+
+#: assets/wizards/connections/views/main/mailchimp.js:103
+#: assets/wizards/connections/views/main/plugins.js:78
+msgid "Connected"
+msgstr ""
+
+#: assets/wizards/connections/views/main/mailchimp.js:127
+msgid "Add Mailchimp API Key"
+msgstr ""
+
+#: assets/wizards/connections/views/main/mailchimp.js:132
+msgid "Mailchimp API Key"
+msgstr ""
+
+#: assets/wizards/connections/views/main/mailchimp.js:145
+msgid "Find or generate your API key"
+msgstr ""
+
+#: assets/wizards/connections/views/main/plugins.js:26
+msgid "Site Kit by Google"
+msgstr ""
+
+#: assets/wizards/connections/views/main/plugins.js:51
+msgid "Jetpack connection required"
+msgstr ""
+
+#: assets/wizards/connections/views/main/recaptcha.js:36
+msgid "Error fetching settings."
+msgstr ""
+
+#: assets/wizards/connections/views/main/recaptcha.js:57
+msgid "Error updating settings."
+msgstr ""
+
+#: assets/wizards/connections/views/main/recaptcha.js:68
+msgid "Enable reCAPTCHA v3"
+msgstr ""
+
+#: assets/wizards/connections/views/main/recaptcha.js:71
+msgid "Enabling reCAPTCHA v3 can help protect your site against bot attacks and credit card testing."
+msgstr ""
+
+#: assets/wizards/connections/views/main/recaptcha.js:101
+msgid "You must enter a valid site key and secret to use reCAPTCHA."
+msgstr ""
+
+#: assets/wizards/connections/views/main/recaptcha.js:110
+msgid "Site Key"
+msgstr ""
+
+#: assets/wizards/connections/views/main/recaptcha.js:120
+msgid "Site Secret"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:87
+msgid "Endpoint Actions"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:97
+msgid "Close Endpoint Actions"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:100
+msgid "View Requests"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:127
+msgid "Confirm"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:266
+msgid "Register webhook endpoints to integrate reader activity data to third-party services or private APIs"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:277
+msgid "Add New Endpoint"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:295
+msgid "This endpoint is disabled due excessive request errors: "
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:301
+msgid "Actions:"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:304
+msgid "global"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:330
+msgid "Remove Endpoint"
+msgstr ""
+
+#. translators: %s: endpoint title
+#: assets/wizards/connections/views/main/webhooks.js:333
+msgid "Are you sure you want to remove the endpoint %s?"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:345
+msgid "Enable Endpoint"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:346
+msgid "Disable Endpoint"
+msgstr ""
+
+#. translators: %s: endpoint title
+#: assets/wizards/connections/views/main/webhooks.js:352
+msgid "Are you sure you want to enable the endpoint %s?"
+msgstr ""
+
+#. translators: %s: endpoint title
+#: assets/wizards/connections/views/main/webhooks.js:357
+msgid "Are you sure you want to disable the endpoint %s?"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:369
+msgid "Latest Requests"
+msgstr ""
+
+#. translators: %s is the endpoint title (shortened URL).
+#: assets/wizards/connections/views/main/webhooks.js:375
+msgid "Most recent requests for %s"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:389
+msgid "Error"
+msgstr ""
+
+#. translators: %s is a human-readable time difference.
+#: assets/wizards/connections/views/main/webhooks.js:402
+msgid "sending in %s"
+msgstr ""
+
+#. translators: %s is a human-readable time difference.
+#: assets/wizards/connections/views/main/webhooks.js:407
+msgid "processed %s"
+msgstr ""
+
+#. translators: %s is the number of errors.
+#: assets/wizards/connections/views/main/webhooks.js:422
+msgid "Attempt #%s"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:434
+msgid "This endpoint didn't received any requests yet."
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:450
+msgid "This webhook endpoint is currently disabled."
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:457
+msgid "Request Error: "
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:464
+msgid "Test Error: "
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:470
+#: assets/wizards/setup/views/welcome/index.js:354
+msgid "URL"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:471
+msgid "The URL to send requests to. It's required for the URL to be under a valid TLS/SSL certificate. You can use the test button below to verify the endpoint response."
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:496
+msgid "Send a test request"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:502
+msgid "Label (optional)"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:503
+msgid "A label to help you identify this endpoint. It will not be sent to the endpoint."
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:512
+#: assets/wizards/popups/views/campaigns/index.js:235
+msgid "Actions"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:516
+msgid "Global"
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:517
+msgid "Leave this checked if you want this endpoint to receive data from all actions."
+msgstr ""
+
+#: assets/wizards/connections/views/main/webhooks.js:526
+msgid "If this endpoint is not global, select which actions should trigger this endpoint:"
+msgstr ""
+
+#: assets/wizards/engagement/components/active-campaign.js:38
+msgid "ActiveCampaign"
+msgstr ""
+
+#: assets/wizards/engagement/components/active-campaign.js:39
+msgid "Settings for the ActiveCampaign integration."
+msgstr ""
+
+#: assets/wizards/engagement/components/active-campaign.js:42
+msgid "Master List"
+msgstr ""
+
+#: assets/wizards/engagement/components/active-campaign.js:43
+msgid "Choose a list to which all registered readers will be added."
+msgstr ""
+
+#: assets/wizards/engagement/components/active-campaign.js:48
+#: assets/wizards/engagement/components/mailchimp.js:48
+msgid "None"
+msgstr ""
+
+#: assets/wizards/engagement/components/mailchimp.js:39
+msgid "Settings for the Mailchimp integration."
+msgstr ""
+
+#: assets/wizards/engagement/components/mailchimp.js:42
+msgid "Audience ID"
+msgstr ""
+
+#: assets/wizards/engagement/components/mailchimp.js:43
+msgid "Choose an audience to receive reader activity data."
+msgstr ""
+
+#: assets/wizards/engagement/index.js:70
+msgid "There was an error saving settings. Please try again."
+msgstr ""
+
+#: assets/wizards/engagement/index.js:86
+#: assets/wizards/engagement/views/reader-activation/index.js:157
+msgid "Reader Activation"
+msgstr ""
+
+#: assets/wizards/engagement/index.js:96
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:186
+#: assets/wizards/setup/views/services/index.js:36
+msgid "Newsletters"
+msgstr ""
+
+#: assets/wizards/engagement/index.js:101
+msgid "Commenting"
+msgstr ""
+
+#: assets/wizards/engagement/index.js:105
+msgid "Social"
+msgstr ""
+
+#: assets/wizards/engagement/index.js:110
+msgid "Recirculation"
+msgstr ""
+
+#: assets/wizards/engagement/index.js:128
+msgid "Configure your reader activation settings"
+msgstr ""
+
+#: assets/wizards/engagement/index.js:137
+#: assets/wizards/engagement/index.js:149
+msgid "Preview and customize the reader activation prompts"
+msgstr ""
+
+#: assets/wizards/engagement/index.js:161
+msgid "Configure your newsletter settings"
+msgstr ""
+
+#: assets/wizards/engagement/index.js:171
+msgid "Share your content to social media"
+msgstr ""
+
+#: assets/wizards/engagement/index.js:181
+msgid "Set up the commenting system for your site"
+msgstr ""
+
+#: assets/wizards/engagement/index.js:192
+msgid "Engage visitors with related content"
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:158
+msgid "Email Service Provider"
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:159
+msgid "Connect an email service provider (ESP) to author and send newsletters."
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:176
+msgid "Authorize Application"
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:185
+msgid "Authorize"
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:300
+msgid "Subscription Lists"
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:301
+msgid "Manage the lists available to readers for subscription."
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:307
+msgid "Please save your ESP settings before changing your subscription lists."
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:323
+msgid "Add New"
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:327
+msgid "Save Subscription Lists"
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:359
+msgid "List title"
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:365
+msgid "List description"
+msgstr ""
+
+#: assets/wizards/engagement/views/newsletters/index.js:401
+msgid "WooCommerce integration"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/campaign.js:57
+msgid "Set Up Reader Activation Campaign"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/campaign.js:58
+msgid "Preview and customize the prompts, or use our suggested defaults."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/campaign.js:72
+msgid "Retrieving prompts…"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/campaign.js:91
+#: assets/wizards/setup/views/welcome/index.js:385
+msgid "Continue"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:25
+msgid "Your <strong>current segments and prompts</strong> will be deactivated and archived."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:29
+msgid "<strong>Reader registration</strong> will be activated to enable better targeting for driving engagement and conversations."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:33
+msgid "The <strong>Reader Activation campaign</strong> will be activated with default segments and settings."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:40
+msgid "Setting up new segments…"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:41
+msgid "Activating reader registration…"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:42
+msgid "Activating Reader Activation Campaign…"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:80
+msgid "Done!"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:108
+msgid "Enable Reader Activation"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:111
+msgid "An easy way to let your readers register for your site, sign up for newsletters, or become donors and paid members. "
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:135
+msgid "You're all set to enable Reader Activation!"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/complete.js:136
+msgid "This is what will happen next:"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:139
+msgid "Configure the gate rendered on content with restricted access."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:144
+msgid "The gate is currently published."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:149
+msgid "The gate is currently a draft."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:160
+msgid "Newspack’s Reader Activation system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. "
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:177
+msgid "The following plugins are required."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:181
+msgid "Complete these settings to enable Reader Activation."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:186
+msgid "Reader Activation is enabled."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:191
+msgid "Retrieving status…"
+msgstr ""
+
+#. Translators: Show or Hide advanced settings.
+#: assets/wizards/engagement/views/reader-activation/index.js:220
+msgid "%s Advanced Settings"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:221
+#: assets/wizards/popups/components/settings-modal/index.js:179
+msgid "Hide"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:221
+#: assets/wizards/popups/components/settings-modal/index.js:179
+msgid "Show"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:231
+msgid "Memberships Integration"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:232
+msgid "Improve the reader experience on content gating."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:235
+msgid "Content Gate"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:248
+msgid "Transactional Email Content"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:249
+msgid "Customize the content of transactional emails."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:267
+msgid "Email Service Provider (ESP) Advanced Settings"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:268
+msgid "Settings for Newspack Newsletters integration."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:271
+msgid "Newsletter subscription text on registration"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:272
+msgid "The text to display while subscribing to newsletters from the sign-in modal."
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:281
+msgid "Metadata field prefix"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:282
+msgid "A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_"
+msgstr ""
+
+#: assets/wizards/engagement/views/reader-activation/index.js:323
+msgid "Save advanced settings"
+msgstr ""
+
+#: assets/wizards/engagement/views/related-content/index.js:38
+msgid "Related Posts"
+msgstr ""
+
+#: assets/wizards/engagement/views/related-content/index.js:40
+msgid "Automatically add related content at the bottom of each post."
+msgstr ""
+
+#: assets/wizards/engagement/views/related-content/index.js:53
+msgid "If set, posts will be shown as related content only if published within the past number of months. If 0, any published post can be shown, regardless of publish date."
+msgstr ""
+
+#: assets/wizards/engagement/views/related-content/index.js:57
+msgid "Maximum age of related content, in months"
+msgstr ""
+
+#: assets/wizards/engagement/views/social/meta-pixel.js:14
+msgid "Meta Pixel"
+msgstr ""
+
+#: assets/wizards/engagement/views/social/meta-pixel.js:17
+msgid "Add the Meta pixel (formely known as Facebook pixel) to your site."
+msgstr ""
+
+#: assets/wizards/engagement/views/social/meta-pixel.js:21
+#: assets/wizards/engagement/views/social/twitter-pixel.js:18
+msgid "Pixel ID"
+msgstr ""
+
+#: assets/wizards/engagement/views/social/meta-pixel.js:23
+msgid "The Meta Pixel ID. You only need to add the number, not the full code. Example: 123456789123456789. You can get this information <linkToFb>here</linkToFb>."
+msgstr ""
+
+#: assets/wizards/engagement/views/social/twitter-pixel.js:14
+msgid "Twitter Pixel"
+msgstr ""
+
+#: assets/wizards/engagement/views/social/twitter-pixel.js:16
+msgid "Add the Twitter pixel to your site."
+msgstr ""
+
+#: assets/wizards/engagement/views/social/twitter-pixel.js:20
+msgid "The Twitter Pixel ID. You only need to add the ID, not the full code. Example: ny3ad. You can read more about it <link>here</link>."
+msgstr ""
+
+#: assets/wizards/health-check/views/configuration/index.js:34
+msgid "Jetpack is connected."
+msgstr ""
+
+#: assets/wizards/health-check/views/configuration/index.js:35
+msgid "Jetpack is not connected. "
+msgstr ""
+
+#: assets/wizards/health-check/views/configuration/index.js:45
 msgid "Site Kit is connected."
 msgstr ""
 
-#: assets/wizards/health-check/views/configuration/index.js:57
+#: assets/wizards/health-check/views/configuration/index.js:46
 msgid "Site Kit is not connected. "
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/consts.js:7
-msgid "Last 7 days"
+#: assets/wizards/health-check/views/plugins/index.js:36
+msgid "These plugins shoud be active:"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/consts.js:8
-msgid "Last 14 days"
+#: assets/wizards/health-check/views/plugins/index.js:43
+msgid "Newspack does not support these plugins:"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/consts.js:9
-msgid "Last 28 days"
+#: assets/wizards/health-check/views/plugins/index.js:56
+msgid "Deactivate All"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/consts.js:10
-msgid "Last 90 days"
+#: assets/wizards/health-check/views/plugins/index.js:61
+msgid "No unsupported plugins found."
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/Filters.js:14
-msgid "All Prompts"
+#: assets/wizards/popups/components/campaign-management-popover/index.js:47
+msgid "Activate all prompts"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/Filters.js:21
-msgid "All Events"
+#: assets/wizards/popups/components/campaign-management-popover/index.js:58
+msgid "Deactivate all prompts"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/Info.js:30
-msgid "n/a"
+#: assets/wizards/popups/components/campaign-management-popover/index.js:68
+#: assets/wizards/popups/components/prompt-action-card/index.js:262
+#: assets/wizards/popups/components/prompt-popovers/primary.js:70
+#: assets/wizards/popups/views/campaigns/index.js:57
+msgid "Duplicate"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/Info.js:35
-msgid "All:"
+#: assets/wizards/popups/components/campaign-management-popover/index.js:77
+#: assets/wizards/popups/views/campaigns/index.js:55
+msgid "Rename"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/Info.js:45
-msgid "Seen"
+#: assets/wizards/popups/components/campaign-management-popover/index.js:98
+msgid "Unarchive"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/Info.js:47
-msgid "Conversion Rate"
+#: assets/wizards/popups/components/prompt-action-card/index.js:44
+msgid "Could not fetch Analytics data"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/Info.js:51
-msgid "Form Submissions"
+#: assets/wizards/popups/components/prompt-action-card/index.js:60
+msgid "No Analytics data"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/Info.js:56
-msgid "Click-through Rate"
+#: assets/wizards/popups/components/prompt-action-card/index.js:66
+msgid "viewability"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/Info.js:60
-msgid "Link Clicks"
+#: assets/wizards/popups/components/prompt-action-card/index.js:74
+msgid "conversion rate"
 msgstr ""
 
-#: assets/wizards/popups/views/analytics/Info.js:83
-msgid "These are aggregated metrics for multiple campaigns. Some of them might not have links or forms, which can skew the displayed rates."
+#: assets/wizards/popups/components/prompt-action-card/index.js:146
+msgid "Prompt settings"
 msgstr ""
 
-#: assets/wizards/popups/views/preview/index.js:54
-msgid "View your site as a reader in a selected segment, or with campaigns in selected groups. Choose a reader segment and/or one or more groups, then click the \"Preview\" button to view your site as a reader in that segment. Only the campaigns that match the selected segment and group(s) will be shown."
+#. Translators: %s: The title of the item.
+#: assets/wizards/popups/components/prompt-action-card/index.js:182
+msgid "Duplicate “%s”"
 msgstr ""
 
-#: assets/wizards/popups/views/preview/index.js:61
-msgid "Default (no segment)"
+#. Translators: %s: The title of the item.
+#: assets/wizards/popups/components/prompt-action-card/index.js:196
+msgid "Duplicate of “%s” created as a draft."
 msgstr ""
 
-#: assets/wizards/popups/views/preview/index.js:66
+#: assets/wizards/popups/components/prompt-action-card/index.js:203
+msgid "This prompt is currently not assigned to any campaign."
+msgstr ""
+
+#: assets/wizards/popups/components/prompt-action-card/index.js:218
+msgid "Close"
+msgstr ""
+
+#: assets/wizards/popups/components/prompt-action-card/index.js:230
+msgid "This prompt will not be assigned to any campaign."
+msgstr ""
+
+#: assets/wizards/popups/components/prompt-action-card/index.js:238
+#: assets/wizards/popups/views/segments/SingleSegment.js:140
+msgid "Title"
+msgstr ""
+
+#: assets/wizards/popups/components/prompt-popovers/primary.js:46
+msgid "Restore"
+msgstr ""
+
+#: assets/wizards/popups/components/prompt-popovers/primary.js:49
+msgid "Delete permanently"
+msgstr ""
+
+#: assets/wizards/popups/components/prompt-popovers/primary.js:79
+msgid "Deactivate"
+msgstr ""
+
+#: assets/wizards/popups/components/prompt-popovers/primary.js:87
+msgid "ID:"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:88
+msgid "No unassigned prompts in this segment."
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:91
+msgid "No prompts in this segment for"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:93
+msgid "No active prompts in this segment."
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:103
+msgid "Edit Segment "
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:108
+msgid "Segment: "
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:118
+msgid "All readers, regardless of segment"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:142
+msgid "Preview Segment"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:153
+#: assets/wizards/popups/components/segment-group/index.js:157
+msgid "Add New Prompt"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:166
+#: assets/wizards/popups/utils.js:52
+msgid "Center Overlay"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:167
+msgid "Fixed at the center of the screen"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:172
+#: assets/wizards/popups/utils.js:49
+msgid "Top Overlay"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:173
+msgid "Fixed at the top of the screen"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:178
+#: assets/wizards/popups/utils.js:55
+msgid "Bottom Overlay"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:179
+msgid "Fixed at the bottom of the screen"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:185
+msgid "Embedded in content"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:190
+msgid "In Archive Pages"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:191
+msgid "Embedded once or many times in archive pages"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:196
+#: assets/wizards/popups/utils.js:60
+msgid "Above Header"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:197
+msgid "Embedded at the very top of the page"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:202
+#: assets/wizards/popups/utils.js:67
+msgid "Custom Placement"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:203
+msgid "Only appears when placed in content"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:208
+#: assets/wizards/popups/utils.js:61
+msgid "Manual Only"
+msgstr ""
+
+#: assets/wizards/popups/components/segment-group/index.js:209
+msgid "Only appears where Single Prompt block is inserted"
+msgstr ""
+
+#: assets/wizards/popups/components/settings-modal/index.js:47
+msgid "Close Modal"
+msgstr ""
+
+#: assets/wizards/popups/components/settings-modal/index.js:52
+msgid "Assign a prompt to one or more campaigns for easier management"
+msgstr ""
+
+#: assets/wizards/popups/components/settings-modal/index.js:72
+msgid "When and how should the prompt be displayed"
+msgstr ""
+
+#: assets/wizards/popups/components/settings-modal/index.js:79
+msgid "Frequency"
+msgstr ""
+
+#: assets/wizards/popups/components/settings-modal/index.js:110
+msgid "Targeting"
+msgstr ""
+
+#: assets/wizards/popups/components/settings-modal/index.js:113
+msgid "Under which conditions should the prompt be displayed"
+msgstr ""
+
+#: assets/wizards/popups/components/settings-modal/index.js:115
+msgid "If multiple conditions are set, all will have to be satisfied in order to display the prompt"
+msgstr ""
+
+#: assets/wizards/popups/components/settings-modal/index.js:128
 msgid "Segment"
 msgstr ""
 
-#: assets/wizards/popups/views/preview/index.js:74
-msgid "Groups"
+#: assets/wizards/popups/components/settings-modal/index.js:145
+msgid "Prompt will only appear to reader belonging to the specified segments."
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SegmentsList.js:26
-msgid "Add new"
+#: assets/wizards/popups/components/settings-modal/index.js:156
+msgid "Prompt will only appear on posts with the specified categories."
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SegmentsList.js:39
-msgid "Created on"
+#: assets/wizards/popups/components/settings-modal/index.js:168
+msgid "Prompt will only appear on posts with the specified tags."
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SegmentsList.js:45
-msgid "More options"
+#: assets/wizards/popups/components/settings-modal/index.js:197
+msgid "Prompt will not appear on posts with the specified categories."
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SegmentsList.js:64
-msgid "Edit"
+#: assets/wizards/popups/components/settings-modal/index.js:215
+msgid "Prompt will not appear on posts with the specified tags."
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SegmentsList.js:71
-msgid "Delete"
+#: assets/wizards/popups/index.js:204
+msgid "Error duplicating prompt. Please try again later."
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SegmentsList.js:110
-msgid "You have no saved audience segments."
+#: assets/wizards/popups/utils.js:50
+msgid "Top Left Overlay"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SegmentsList.js:112
-msgid "Create audience segments to target visitors by engagement, activity, and more."
+#: assets/wizards/popups/utils.js:51
+msgid "Top Right Overlay"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:108
-msgid "Untitled Segment"
+#: assets/wizards/popups/utils.js:53
+msgid "Center Left Overlay"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:114
-msgid "Articles read"
+#: assets/wizards/popups/utils.js:54
+msgid "Center Right Overlay"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:115
-msgid "Number of articles read in the last 30 day period."
+#: assets/wizards/popups/utils.js:56
+msgid "Bottom Left Overlay"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:121
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:155
-msgid "Min."
+#: assets/wizards/popups/utils.js:57
+msgid "Bottom Right Overlay"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:124
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:158
-msgid "Min. posts"
+#: assets/wizards/popups/utils.js:59
+msgid "In archive pages"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:134
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:168
-msgid "Max."
+#: assets/wizards/popups/utils.js:96
+msgid "Once a month"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:137
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:171
-msgid "Max. posts"
+#: assets/wizards/popups/utils.js:97
+msgid "Once a week"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:145
-msgid "Articles read in session"
+#: assets/wizards/popups/utils.js:98
+msgid "Once a day"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:146
-msgid "Number of articles read in the current session (45 minutes)."
+#: assets/wizards/popups/utils.js:99
+msgid "Every pageview"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:178
-msgid "Newsletter"
+#: assets/wizards/popups/utils.js:100
+msgid "Custom frequency (edit prompt to manage)"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:182
-msgid "Is subscribed to newsletter"
+#: assets/wizards/popups/utils.js:125
+msgid "Campaign: "
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:187
-msgid "Is not subscribed to newsletter"
+#: assets/wizards/popups/utils.js:126
+msgid "Campaigns: "
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:192
-msgid "(if using WooCommerce checkout)"
+#: assets/wizards/popups/utils.js:131
+msgid "Categories: "
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:197
+#: assets/wizards/popups/utils.js:136
+msgid "Tags: "
+msgstr ""
+
+#: assets/wizards/popups/utils.js:140
+msgid "Pending review"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:143
+msgid "Scheduled"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:145
+msgid "Frequency: "
+msgstr ""
+
+#: assets/wizards/popups/utils.js:194
+msgid "Segment disabled"
+msgstr ""
+
+#. Translators: %1: The minimum number of articles. %2: The maximum number of articles.
+#: assets/wizards/popups/utils.js:202
+msgid "Articles read (past 30 days): %1$s %2$s"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:203
+#: assets/wizards/popups/utils.js:213
+msgid "min "
+msgstr ""
+
+#: assets/wizards/popups/utils.js:204
+#: assets/wizards/popups/utils.js:214
+msgid "max "
+msgstr ""
+
+#. Translators: %1: The minimum number of articles. %2: The maximum number of articles.
+#: assets/wizards/popups/utils.js:212
+msgid "Articles read (session): %1$s %2$s"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:221
 msgid "Has donated"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:202
-msgid "Hasn't donated"
+#: assets/wizards/popups/utils.js:224
+msgid "Has not donated"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:206
-msgid "Referrer"
+#: assets/wizards/popups/utils.js:227
+msgid "Has cancelled a recurring donation"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:207
+#: assets/wizards/popups/utils.js:230
+msgid "Has subscribed"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:233
+msgid "Has not subscribed"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:236
+#: assets/wizards/popups/views/segments/SingleSegment.js:308
+msgid "Has user account"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:239
+#: assets/wizards/popups/views/segments/SingleSegment.js:309
+msgid "Does not have user account"
+msgstr ""
+
+#. Translators: %1: 'categories' or 'category' depending on number of categories. %2: a list of favorite categories.
+#: assets/wizards/popups/utils.js:256
+msgid "Favorite %1$s: %2$s"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:257
+msgid "categories"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:257
+msgid "category"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:262
+msgid "Has favorite categories"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:289
+#: assets/wizards/popups/utils.js:303
+msgid " uncategorized"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:291
+msgid "above-header prompts"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:292
+msgid "overlays"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:293
+#: assets/wizards/popups/utils.js:304
+msgid " and category filtering"
+msgstr ""
+
+#. Translators: %s: 'Conflicts' or 'Conflict' depending on number of conflicts.
+#: assets/wizards/popups/utils.js:356
+msgid "%s detected:"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:358
+msgid "Conflicts"
+msgstr ""
+
+#: assets/wizards/popups/utils.js:359
+msgid "Conflict"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Filters.js:35
+msgid "to"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Filters.js:42
+msgid "Choose a date range"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Filters.js:64
+#: assets/wizards/popups/views/campaigns/index.js:162
+msgid "All Prompts"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Filters.js:72
+msgid "All Events"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Info.js:34
+msgid "Choose \"All Events\" filter to see key metrics."
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Info.js:38
+msgid "n/a"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Info.js:44
+msgid "All:"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Info.js:55
+msgid "Seen"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Info.js:60
+msgid "Conversion Rate"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Info.js:64
+msgid "Form Submissions"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Info.js:69
+msgid "Click-through Rate"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Info.js:73
+msgid "Link Clicks"
+msgstr ""
+
+#: assets/wizards/popups/views/analytics/Info.js:96
+msgid "These are aggregated metrics for multiple campaigns. Some of them might not have links or forms, which can skew the displayed rates."
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:46
+msgid "Rename Campaign"
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:48
+msgid "Duplicate Campaign"
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:50
+#: assets/wizards/popups/views/campaigns/index.js:273
+msgid "Add New Campaign"
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:59
+msgid "Add"
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:97
+msgid "Everyone"
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:158
+msgid "Active Prompts"
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:166
+msgid "Trash"
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:172
+msgid "Unassigned Prompts"
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:194
+msgid "Archived Campaigns"
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:201
+msgid "(archived)"
+msgstr ""
+
+#: assets/wizards/popups/views/campaigns/index.js:284
+#: assets/wizards/popups/views/campaigns/index.js:286
+msgid "Campaign Name"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SegmentsList.js:20
+msgid "Add New Segment"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SegmentsList.js:236
+msgid "Move segment position up"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SegmentsList.js:242
+msgid "Move segment position down"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SegmentsList.js:334
+msgid "Audience segments"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SegmentsList.js:362
+msgid "You have no saved audience segments."
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SegmentsList.js:366
+msgid "Create audience segments to target visitors by engagement, activity, and more."
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:70
+msgid "There are unsaved changes to this segment. Discard changes?"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:137
+msgid "Untitled Segment"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:150
+msgid "This segment would reach approximately "
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:152
+msgid "% of recorded visitors."
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:158
+msgid "Segment Status"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:159
+msgid "If not enabled, the segment will be ignored for reader segmentation."
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:166
+msgid "Segment enabled"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:173
+msgid "Reader Engagement"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:174
+msgid "Target readers based on their browsing behavior"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:178
+msgid "Articles read"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:179
+msgid "Number of articles read in the last 30 day period."
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:186
+msgid "Min posts"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:187
+msgid "Max posts"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:191
+msgid "Articles read in session"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:192
+msgid "Number of articles read in the current session (45 minutes)."
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:202
+msgid "Min posts in session"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:203
+msgid "Max posts in session"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:207
+msgid "Favorite Categories"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:208
+msgid "Most-read categories of reader."
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:221
+msgid "Reader Activity"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:222
+msgid "Target readers based on their actions"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:226
+msgid "Newsletter"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:247
+msgid "Subscribers and non-subscribers"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:248
+msgid "Subscribers"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:249
+msgid "Non-subscribers"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:255
+msgid "(if the checkout happens on-site)"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:277
+msgid "Donors and non-donors"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:278
+msgid "Donors"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:279
+msgid "Non-donors"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:282
+msgid "Former donors (who cancelled a recurring donation)"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:287
+msgid "User Account"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:307
+msgid "All users"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:315
+msgid "Referrer Sources"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:316
+msgid "Target readers based on where they’re coming from"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:317
+msgid "Segments using these options will apply only to the first page visited after coming from an external source."
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:325
+msgid "Sources to match"
+msgstr ""
+
+#: assets/wizards/popups/views/segments/SingleSegment.js:326
 msgid "Segment based on traffic source."
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:211
+#: assets/wizards/popups/views/segments/SingleSegment.js:331
 msgid "google.com, facebook.com"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:212
+#: assets/wizards/popups/views/segments/SingleSegment.js:332
+#: assets/wizards/popups/views/segments/SingleSegment.js:347
 msgid "A comma-separated list of domains."
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:218
-msgid "Category Affinity"
+#: assets/wizards/popups/views/segments/SingleSegment.js:338
+msgid "Sources to exclude"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:219
-msgid "Most read categories of reader."
+#: assets/wizards/popups/views/segments/SingleSegment.js:339
+msgid "Segment based on traffic source - hide campaigns for visitors coming from specific sources."
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:233
-msgid "This segment would reach"
+#: assets/wizards/popups/views/segments/SingleSegment.js:346
+msgid "twitter.com, instagram.com"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:238
-msgid "of recorded visitors. "
+#: assets/wizards/readerRevenue/index.js:25
+msgid "Platform"
 msgstr ""
 
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:245
-msgid "Cancel"
-msgstr ""
-
-#: assets/wizards/popups/views/segmentation/SingleSegment.js:248
-msgid "Save"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/nrh-settings/index.js:29
-msgid "NRH Organization ID"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/nrh-settings/index.js:36
-msgid "NRH Salesforce Campaign ID"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/platform/index.js:59
-msgid "Select Reader Revenue Platform"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/platform/index.js:62
-msgid "-- Select Your Platform --"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/platform/index.js:68
-msgid "News Revenue Hub"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:110
-msgid "We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again."
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:125
-msgid "We couldn’t validate the connection with Salesforce. Please verify the status of the Connected App in Salesforce."
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:155
-msgid "Connected App settings"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:161
-msgid "Your site is connected to Salesforce."
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:169
-msgid "To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to paste the the full URL for this page into the “Callback URL” field in the Connected App’s settings. "
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:174
-msgid "Learn how to create a Connected App"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:179
-msgid "Enter your Consumer Key and Secret below, then click “Connect” to authorize access to your Salesforce account."
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:189
-msgid "To reconnect your site in case of issues, or to connect to a different Salesforce account, click “Reset\" below. You will need to re-enter your Consumer Key and Secret before you can re-connect to Salesforce."
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:198
-msgid "We couldn’t connect to Salesforce. Please verify that you entered the correct Consumer Key and Secret and try again. If you just created your Connected App or edited the Callback URL settings, it may take up to an hour before we can establish a connection."
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:209
-#: assets/wizards/readerRevenue/views/salesforce/index.js:223
-msgid "Your"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:209
-#: assets/wizards/readerRevenue/views/salesforce/index.js:223
-msgid "Enter your"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:210
-msgid " Salesforce Consumer Key"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/salesforce/index.js:224
-msgid " Salesforce Consumer Secret"
-msgstr ""
-
-#: assets/wizards/readerRevenue/views/services/index.js:27
+#: assets/wizards/readerRevenue/index.js:31
 msgid "Donations"
 msgstr ""
 
-#: assets/wizards/readerRevenue/views/services/index.js:28
-msgid "Set up a donations page and accept one-time or recurring payments from your readers."
+#: assets/wizards/readerRevenue/index.js:39
+msgid "Stripe Gateway"
 msgstr ""
 
-#: assets/wizards/readerRevenue/views/services/index.js:32
-#: assets/wizards/readerRevenue/views/services/index.js:41
-msgid "Configure"
+#: assets/wizards/readerRevenue/index.js:40
+msgid "Stripe Settings"
 msgstr ""
 
-#: assets/wizards/readerRevenue/views/services/index.js:36
+#: assets/wizards/readerRevenue/index.js:47
+msgid "Stripe Webhooks"
+msgstr ""
+
+#: assets/wizards/readerRevenue/index.js:54
+msgid "Emails"
+msgstr ""
+
+#: assets/wizards/readerRevenue/index.js:60
+#: assets/wizards/readerRevenue/views/location-setup/index.js:36
+msgid "Address"
+msgstr ""
+
+#: assets/wizards/readerRevenue/index.js:66
 msgid "Salesforce"
 msgstr ""
 
-#: assets/wizards/readerRevenue/views/services/index.js:37
-msgid "Integrate Salesforce to capture contact information when readers donate to your organization."
+#: assets/wizards/readerRevenue/index.js:72
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:51
+msgid "News Revenue Hub Settings"
 msgstr ""
 
-#: assets/wizards/seo/views/environment/index.js:25
-msgid "Environment"
+#: assets/wizards/readerRevenue/views/emails/index.js:55
+msgid "Newspack uses Newspack Newsletters to handle editing email-type content. Please activate this plugin to proceed."
 msgstr ""
 
-#: assets/wizards/seo/views/environment/index.js:28
-msgid "Site under construction"
+#: assets/wizards/readerRevenue/views/emails/index.js:61
+msgid "Until this feature is configured, default receipts will be used."
 msgstr ""
 
-#: assets/wizards/seo/views/environment/index.js:31
-msgid "Site is under construction and should not be indexed."
+#: assets/wizards/readerRevenue/views/emails/index.js:92
+msgid "This email is not active. The default receipt will be used."
 msgstr ""
 
-#: assets/wizards/seo/views/social/index.js:26
-msgid "Social profiles"
+#: assets/wizards/readerRevenue/views/location-setup/index.js:41
+msgid "Address line 2"
 msgstr ""
 
-#: assets/wizards/seo/views/social/index.js:28
-msgid "To let search engines know which social profiles are associated to this site, enter your site social profiles data below."
+#: assets/wizards/readerRevenue/views/location-setup/index.js:48
+msgid "City"
 msgstr ""
 
-#: assets/wizards/seo/views/social/index.js:35
-msgid "Facebook page URL"
+#: assets/wizards/readerRevenue/views/location-setup/index.js:53
+msgid "Postcode / Zip"
 msgstr ""
 
-#: assets/wizards/seo/views/social/index.js:40
-msgid "Twitter"
+#: assets/wizards/readerRevenue/views/location-setup/index.js:58
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:172
+#: assets/wizards/setup/views/settings/index.js:110
+msgid "Country"
 msgstr ""
 
-#: assets/wizards/seo/views/social/index.js:45
-msgid "Instagram URL"
+#: assets/wizards/readerRevenue/views/location-setup/index.js:64
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:178
+msgid "Currency"
 msgstr ""
 
-#: assets/wizards/seo/views/social/index.js:50
-msgid "LinkedIn URL"
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:52
+msgid "Configure your site’s connection to News Revenue Hub."
 msgstr ""
 
-#: assets/wizards/seo/views/social/index.js:55
-msgid "YouTube URL"
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:62
+msgid "Organization ID"
 msgstr ""
 
-#: assets/wizards/seo/views/social/index.js:60
-msgid "Pinterest URL"
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:68
+msgid "Custom domain (optional)"
 msgstr ""
 
-#: assets/wizards/seo/views/tools/index.js:25
-msgid "Webmaster tools verification"
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:75
+msgid "Salesforce Campaign ID (optional)"
 msgstr ""
 
-#: assets/wizards/seo/views/tools/index.js:27
-msgid "You can use the boxes below to verify with the different Webmaster Tools. This feature will add a verification meta tag on your home page. Follow the links to the different Webmaster Tools and look for instructions for the meta tag verification method to get the verification code."
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:85
+msgid "Donor Landing Page"
 msgstr ""
 
-#: assets/wizards/seo/views/tools/index.js:33
-msgid "Google"
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:87
+msgid "Set a page on your site as a donor landing page. Once a reader donates and lands on this page, they will be considered a donor."
 msgstr ""
 
-#. translators: hyperlink to Google Search Console
-#: assets/wizards/seo/views/tools/index.js:39
-msgid "Get your Google verification code in <a href=\"%s\">Google Search Console</a>."
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:93
+msgid "Search for a New Donor Landing Page"
 msgstr ""
 
-#: assets/wizards/seo/views/tools/index.js:50
-msgid "Bing"
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:94
+msgid "Begin typing page title, click autocomplete result to select."
 msgstr ""
 
-#. translators: hyperlink to Bing Webmaster Tools
-#: assets/wizards/seo/views/tools/index.js:56
-msgid "Get your Bing verification code in <a href=\"%s\">Bing Webmaster Tool</a>."
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:108
+msgid "page"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:39
+#: assets/wizards/readerRevenue/views/nrh-settings/index.js:109
+msgid "pages"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/platform/index.js:24
+msgid "Select Reader Revenue Platform"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/platform/index.js:28
+msgid "Other"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/platform/index.js:36
+msgid "News Revenue Hub"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/salesforce/index.js:74
+msgid "We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again."
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/salesforce/index.js:146
+msgid "Salesforce Settings"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/salesforce/index.js:153
+msgid "Your site is connected to Salesforce."
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/salesforce/index.js:158
+msgid "Establish a connection to sync WooCommerce order data to Salesforce. To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to paste the full URL for this page ("
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/salesforce/index.js:170
+msgid "copied to clipboard!"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/salesforce/index.js:171
+msgid "copy to clipboard"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/salesforce/index.js:174
+msgid ") into the “Callback URL” field in the Connected App’s settings. "
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/salesforce/index.js:180
+msgid "Learn how to create a Connected App"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:54
+msgid "Configure Stripe and enter your API keys"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:61
+msgid "Use Stripe in test mode"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:64
+msgid "Test mode will not capture real payments. Use it for testing your purchase flow."
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:76
+msgid "Test Publishable Key"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:82
+msgid "Test Secret Key"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:91
+msgid "Publishable Key"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:97
+msgid "Secret Key"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:146
+msgid "This site does not use SSL. The page hosting the Stipe integration should be secured with SSL."
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:163
+msgid "The Stripe platform will not work properly on this site."
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:187
+msgid "Allow donors to sign up to your newsletter when donating."
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:201
+msgid "Fee"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:202
+msgid "If you have a non-default or negotiated fee with Stripe, update its parameters here."
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:214
+msgid "Fee multiplier"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:221
+msgid "Fee static portion"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:231
+msgid "Enable Stripe"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:241
+msgid "Other gateways can be enabled and set up in the "
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:243
+msgid "WooCommerce payment gateway settings"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:257
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:143
+msgid "Webhooks"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/index.js:260
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:145
+msgid "Manage the webhooks Stripe uses to communicate with your site."
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/newsletter-settings.js:38
+msgid "You can configure Newsletters in the"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/newsletter-settings.js:40
+msgid "Engagement Wizard"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/newsletter-settings.js:48
+msgid "Chosen list"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/newsletter-settings.js:50
+msgid "-- Choose a list --"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:67
+msgid "Are you sure you want to remove this webhook?"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:130
+msgid "There are too many webhoooks for this site. Please delete or disable the extra ones."
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:139
+msgid "There are no active webhoooks for this site."
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:155
+msgid "Webhooks connected to this site"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:162
+msgid "Are you sure you want to reset all webhooks connected to this site?"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:172
+msgid "Reset"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:180
+msgid "Webhooks not connected to this site"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:186
+msgid "Back to Stripe Settings"
+msgstr ""
+
+#: assets/wizards/readerRevenue/views/stripe-setup/webhooks-settings.js:189
+msgid "Stripe Dashboard"
+msgstr ""
+
+#: assets/wizards/seo/index.js:89
+#: assets/wizards/site-design/index.js:110
+msgid "Advanced Settings"
+msgstr ""
+
+#: assets/wizards/seo/views/settings/index.js:34
+msgid "Webmaster Tools"
+msgstr ""
+
+#: assets/wizards/seo/views/settings/index.js:35
+msgid "Add verification meta tags to your site"
+msgstr ""
+
+#: assets/wizards/seo/views/settings/index.js:44
+#: assets/wizards/seo/views/settings/index.js:57
+msgid "Get your verification code in"
+msgstr ""
+
+#: assets/wizards/seo/views/settings/index.js:46
+msgid "Google Search Console"
+msgstr ""
+
+#: assets/wizards/seo/views/settings/index.js:59
+msgid "Bing Webmaster Tool"
+msgstr ""
+
+#: assets/wizards/seo/views/settings/index.js:66
+#: assets/wizards/setup/views/settings/index.js:116
+msgid "Social Accounts"
+msgstr ""
+
+#: assets/wizards/seo/views/settings/index.js:67
+msgid "Let search engines know which social profiles are associated to your site"
+msgstr ""
+
+#: assets/wizards/seo/views/settings/index.js:113
+msgid "Under construction"
+msgstr ""
+
+#: assets/wizards/seo/views/settings/index.js:114
+msgid "Discourage search engines from indexing this site."
+msgstr ""
+
+#: assets/wizards/setup/index.js:22
+msgid "Welcome"
+msgstr ""
+
+#: assets/wizards/setup/index.js:29
+msgid "Share a few details so we can start setting up your site"
+msgstr ""
+
+#: assets/wizards/setup/index.js:34
+msgid "Services"
+msgstr ""
+
+#: assets/wizards/setup/index.js:35
+msgid "Activate and configure the services that you need"
+msgstr ""
+
+#: assets/wizards/setup/index.js:40
+msgid "Design"
+msgstr ""
+
+#: assets/wizards/setup/index.js:46
+msgid "Completed"
+msgstr ""
+
+#: assets/wizards/setup/index.js:57
+msgid "Heads up! The setup has already been completed. No need to run it again."
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:39
+msgid "You’re ready to go!"
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:40
+msgid "While you’re off to a great start, there’s plenty more you can do:"
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:53
+msgid "Configure Newspack"
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:54
+msgid "Go in-depth with our various options to set up Newspack to meet your needs."
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:62
+msgid "Go to the Dashboard"
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:68
+msgid "Explore our documentation"
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:69
+msgid "Read about the different tools, plugins, and themes that make up Newspack."
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:77
+msgid "Read Documentation"
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:83
+msgid "Update your homepage"
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:84
+msgid "We’ve created the basics, now it’s time to update the content."
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:92
+msgid "Edit Homepage"
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:98
+msgid "View your site"
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:99
+msgid "Preview what you’ve created so far. It looks great!"
+msgstr ""
+
+#: assets/wizards/setup/views/completed/index.js:104
+msgid "Visit Site"
+msgstr ""
+
+#: assets/wizards/setup/views/services/index.js:28
+msgid "Encourage site visitors to contribute to your publishing through donations"
+msgstr ""
+
+#: assets/wizards/setup/views/services/index.js:37
+msgid "Create email newsletters and send them to your mail lists, all without leaving your website"
+msgstr ""
+
+#: assets/wizards/setup/views/services/index.js:46
+msgid "An advanced ad inventory creation and management platform, allowing you to be specific about ad placements"
+msgstr ""
+
+#: assets/wizards/setup/views/services/ReaderRevenue.js:25
+msgid "Looks like this Newspack instance is already configured to use News Revenue Hub as the Reader Revenue platform. To edit these settings, visit the Reader Revenue section from the Newspack dashboard."
+msgstr ""
+
+#: assets/wizards/setup/views/services/ReaderRevenue.js:33
+msgid "Payment gateway"
+msgstr ""
+
+#: assets/wizards/setup/views/settings/index.js:93
+msgid "Site Profile"
+msgstr ""
+
+#: assets/wizards/setup/views/settings/index.js:94
+msgid "Add and manage the basic information"
+msgstr ""
+
+#: assets/wizards/setup/views/settings/index.js:99
+msgid "Site Icon"
+msgstr ""
+
+#: assets/wizards/setup/views/settings/index.js:103
+msgid "Site Title"
+msgstr ""
+
+#: assets/wizards/setup/views/settings/index.js:104
+msgid "Tagline"
+msgstr ""
+
+#: assets/wizards/setup/views/settings/index.js:117
+msgid "Allow visitors to quickly access your social profiles"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:42
+msgid "Installation"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:43
+msgid "Starter content"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:112
+msgid "Failed to install"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:136
+msgid "Failed to create a post."
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:148
+msgid "Failed to create the homepage."
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:158
+msgid "Failed to activate the theme."
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:191
+msgid "Installation error"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:194
+msgid "Installation complete"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:201
+msgid "There has been an error during the installation. Please retry or manually install required plugins to continue with the configuration of your site."
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:207
+msgid "We will help you get set up by installing the most relevant plugins first before requiring a few details from you in order to build your site."
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:213
+msgid "Click the button below to start configuring your site."
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:216
+msgid "We are now installing core plugins and pre-populating your site with categories and placeholder stories to help you pre-configure it. All placeholder content can be deleted later."
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:221
+msgid "We are now installing core plugins."
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:242
+msgid "Retry"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:244
+msgid "Skip"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:270
+msgid "Welcome to Newspack,"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:272
+msgid "the platform for news"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:306
+msgid "Automatic redirection in"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:307
+msgid "seconds…"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:316
+msgid "This site does not use HTTPS. Newspack can't be installed."
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:343
+msgid "Migrate an existing WordPress site"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:357
+msgid "We will import the last 50 articles from your existing site to help you with the set up and customization."
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:370
+msgid "Install starter content"
+msgstr ""
+
+#: assets/wizards/setup/views/welcome/index.js:380
+msgid "Get Started"
+msgstr ""
+
+#: assets/wizards/site-design/index.js:104
+msgid "Configure your Newspack theme"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:103
+#: assets/wizards/site-design/views/main/index.js:208
+msgid "Headings"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:103
+#: assets/wizards/site-design/views/main/index.js:220
+msgid "Body"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:107
+msgid "Font provider import code or URL"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:120
+msgid "Font name"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:125
+msgid "Font fallback stack"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:127
+#: assets/wizards/site-design/views/main/utils.js:104
+msgid "Serif"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:128
+#: assets/wizards/site-design/views/main/utils.js:109
+msgid "Sans Serif"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:129
+#: assets/wizards/site-design/views/main/utils.js:114
+msgid "Display"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:130
+#: assets/wizards/site-design/views/main/utils.js:119
+msgid "Monospace"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:144
+msgid "Theme"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:145
+msgid "Select the theme for your site"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:153
+msgid "Homepage"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:154
+msgid "Select a homepage layout"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:165
+msgid "Activate Layout"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:172
+msgid "Colors"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:173
+msgid "Pick your primary and secondary colors"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:193
+msgid "Typography"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:194
+msgid "Define the font pairing to use throughout your site"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:198
+msgid "Typography Options"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:242
+msgid "Use all-caps for accent text"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:246
 msgid "Header"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:42
-msgid "Solid background"
+#: assets/wizards/site-design/views/main/index.js:247
+msgid "Update the header and add your logo"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:43
-msgid "Use the primary color as the header background."
+#: assets/wizards/site-design/views/main/index.js:255
+msgid "Style"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:49
-msgid "Center logo"
+#: assets/wizards/site-design/views/main/index.js:277
+msgid "Apply a background color to the header"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:50
-msgid "Center the logo in the header."
+#: assets/wizards/site-design/views/main/index.js:297
+msgid "Logo"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:56
-msgid "Short header"
+#: assets/wizards/site-design/views/main/index.js:310
+msgid "Logo Size"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:57
-msgid "Display the header as a shorter, simpler version"
+#: assets/wizards/site-design/views/main/index.js:319
+msgid "Footer"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:62
-#: assets/wizards/site-design/views/theme-mods/index.js:64
-msgid "Author bio"
+#: assets/wizards/site-design/views/main/index.js:320
+msgid "Personalize the footer of your site"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:65
+#: assets/wizards/site-design/views/main/index.js:327
+msgid "Copyright information"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:335
+msgid "Apply a background color to the footer"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:348
+msgid "Alternative Logo"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:349
+msgid "Optional alternative logo to be displayed in the footer."
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:361
+msgid "Alternative logo - Size"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:382
+msgid "See how your site looks like"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/index.js:395
+msgid "Finish"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/utils.js:137
+msgid "XS"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/utils.js:138
+msgid "S"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/utils.js:139
+msgid "M"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/utils.js:140
+msgid "L"
+msgstr ""
+
+#: assets/wizards/site-design/views/main/utils.js:141
+msgid "XL"
+msgstr ""
+
+#: assets/wizards/site-design/views/theme-settings/index.js:46
+#: assets/wizards/site-design/views/theme-settings/index.js:52
+msgid "Author Bio"
+msgstr ""
+
+#: assets/wizards/site-design/views/theme-settings/index.js:47
+msgid "Control how author bios are displayed on posts."
+msgstr ""
+
+#: assets/wizards/site-design/views/theme-settings/index.js:53
 msgid "Display an author bio under individual posts."
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:71
-msgid "Author email"
+#: assets/wizards/site-design/views/theme-settings/index.js:59
+msgid "Author Email"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:72
+#: assets/wizards/site-design/views/theme-settings/index.js:60
 msgid "Display the author email with bio on individual posts."
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:77
+#: assets/wizards/site-design/views/theme-settings/index.js:69
 msgid "Length"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:78
+#: assets/wizards/site-design/views/theme-settings/index.js:70
 msgid "Truncates the author bio on single posts to this approximate character length, but without breaking a word. The full bio appears on the author archive page."
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:88
+#: assets/wizards/site-design/views/theme-settings/index.js:83
 msgid "Featured Image"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:90
-msgid "Default position"
+#: assets/wizards/site-design/views/theme-settings/index.js:84
+msgid "Set a default featured image position for new posts."
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:93
-msgid "Large"
+#: assets/wizards/site-design/views/theme-settings/index.js:87
+msgid "Default Position"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:94
-msgid "Small"
-msgstr ""
-
-#: assets/wizards/site-design/views/theme-mods/index.js:95
+#: assets/wizards/site-design/views/theme-settings/index.js:93
 msgid "Behind article title"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:96
+#: assets/wizards/site-design/views/theme-settings/index.js:94
 msgid "Beside article title"
 msgstr ""
 
-#: assets/wizards/site-design/views/theme-mods/index.js:97
+#: assets/wizards/site-design/views/theme-settings/index.js:95
 msgid "Hidden"
 msgstr ""
 
-#: assets/wizards/support/views/loading/index.js:21
-msgid "Loading..."
+#: assets/wizards/site-design/views/theme-settings/index.js:101
+msgid "Media Credits"
 msgstr ""
 
-#: assets/wizards/updates/index.js:36
-msgid "Updates to the Newspack plugins and theme"
+#: assets/wizards/site-design/views/theme-settings/index.js:102
+msgid "Control how credits are displayed alongside media attachments."
 msgstr ""
 
-#: assets/wizards/updates/views/devInfo/index.js:64
-msgid "Something went wrong when fetching"
+#: assets/wizards/site-design/views/theme-settings/index.js:110
+msgid "Credit Class Name"
 msgstr ""
 
-#: assets/wizards/updates/views/devInfo/index.js:64
-msgid "data."
+#: assets/wizards/site-design/views/theme-settings/index.js:111
+msgid "A CSS class name to be applied to all image credit elements. Leave blank to display no class name."
 msgstr ""
 
-#: assets/wizards/updates/views/devInfo/index.js:88
-msgid "fixing"
+#: assets/wizards/site-design/views/theme-settings/index.js:119
+msgid "Credit Label"
 msgstr ""
 
-#: assets/wizards/updates/views/devInfo/index.js:89
-msgid "adding"
+#: assets/wizards/site-design/views/theme-settings/index.js:120
+msgid "A label to prefix all media credits. Leave blank to display no prefix."
 msgstr ""
 
-#: assets/wizards/updates/views/devInfo/index.js:99
-msgid "was released"
+#: assets/wizards/site-design/views/theme-settings/index.js:131
+msgid "Placeholder Image"
 msgstr ""
 
-#: assets/wizards/updates/views/devInfo/index.js:101
-msgid " and "
+#: assets/wizards/site-design/views/theme-settings/index.js:137
+msgid "A placeholder image to be displayed in place of images without credits. If none is chosen, the image will be displayed normally whether or not it has a credit."
+msgstr ""
+
+#: assets/wizards/syndication/index.js:25
+msgid "Main"
+msgstr ""
+
+#: assets/wizards/syndication/views/intro/index.js:18
+msgid "RSS Enhancements"
+msgstr ""
+
+#: assets/wizards/syndication/views/intro/index.js:19
+msgid "Create and manage customized RSS feeds for syndication partners"
+msgstr ""
+
+#: assets/wizards/syndication/views/intro/index.js:39
+msgid "Apple News"
+msgstr ""
+
+#: assets/blocks/reader-registration/block.json
+msgctxt "block title"
+msgid "Reader Registration"
+msgstr ""
+
+#: assets/blocks/reader-registration/block.json
+msgctxt "block description"
+msgid "Register a reader with their email."
 msgstr ""


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR corrects the text domain in a 'thank you' donation string, and adds a long-overdue update to the plugin's POT file. 

See 1200550061930446-as-1204849686104010

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Confirm that the text domain for the "Thank you for your donation!" string is now for this plugin, and not the blocks.
3. Confirm the POT file is up to date (the plugin doesn't have any translations bundled with it, so there isn't much to test!). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->