### PR TITLE
Introduce the newspack_managed_plugins filter

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -341,7 +341,13 @@ class Plugin_Manager {
 			$managed_plugins[ $plugin_slug ]['HandoffLink'] = isset( $managed_plugins[ $plugin_slug ]['EditPath'] ) ? admin_url( $managed_plugins[ $plugin_slug ]['EditPath'] ) : null;
 			$managed_plugins[ $plugin_slug ]                = wp_parse_args( $managed_plugins[ $plugin_slug ], $default_info );
 		}
-		return $managed_plugins;
+
+		/**
+		 * Filter the list of managed plugins.
+		 *
+		 * @param array $args Full list of managed plugins.
+		 */
+		return apply_filters( 'newspack_managed_plugins', $managed_plugins );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a filter to allow for the modification of the managed plugins array. For example, some hosts may pre-install plugins in a way that Newspack isn't able to detect and so plugins that are active may not be recognised as such by Newspack, preventing users from using the features. This is the case on VIP where Jetpack is always active but doesn't appear in the normal plugins list.

Here's how the filter could be used on VIP to ensure wizards move past the Jetpack requirement:

```
/**
 * Make sure Newspack sees Jetpack as active.
 *
 * On VIP, Jetpack is always active but Newspack uses the core get_plugins()
 * function to determine if Jetpack is active, which won't show Jetpack. This
 * hook marks Jetpack as active on VIP.
 *
 * @param array $plugins Array of plugins.
 *
 * @return array Modified array of plugins.
 */
function mytheme_newspack_managed_plugins( $plugins ) {
	// Jetpack is always active on VIP.
	if ( defined( 'VIP_GO_ENV' ) && VIP_GO_ENV ) {
		$plugins['jetpack']['Status'] = 'active';
	}
	return $plugins;
}
add_filter( 'newspack_managed_plugins', 'mytheme_newspack_managed_plugins' );

```

### How to test the changes in this Pull Request:

Testing on VIP would be best if possible. Otherwise, filter the `get_plugins()` function to explicitly remove Jetpack even when active.

1. Try to access a wizard (e.g. Engagement) and observe you are asked to install/activate Jetpack
2. Apply this patch
3. Add a filter to the theme's functions.php, such as the example above.
4. Refresh the wizard screen and observe that it no longer asks you to activate Jetpack

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->