### PR TITLE
Activate Akismet upon site creation

### DIFF
--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -191,6 +191,7 @@ class Setup_Wizard extends Wizard {
 	 */
 	public function api_initial_check() {
 		$required_plugins_slugs = [
+			'akismet',
 			'jetpack',
 			'pwa',
 			'wordpress-seo',


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As a natural follow-up to https://github.com/Automattic/newspack-plugin/pull/2593, this PR ensures that Akismet is activated and defaults to the "on" position upon site creation.

### How to test the changes in this Pull Request:

1. Create a new Newspack site.
2. Verify that Akismet, a symlinked plugin, is automatically activated.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->