### PR TITLE
fix: support temporary preview sessions for reader data store

### DIFF
--- a/assets/reader-activation/store.js
+++ b/assets/reader-activation/store.js
@@ -15,7 +15,7 @@ import { EVENTS, emit } from './events';
  */
 const config = {
 	storePrefix: newspack_reader_data?.store_prefix || 'np_reader_',
-	storage: window.localStorage,
+	storage: newspack_reader_data?.is_temporary ? window.sessionStorage : window.localStorage,
 	collections: {
 		maxItems: 1000,
 		maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days.
@@ -24,13 +24,14 @@ const config = {
 
 /**
  * Queue of keys to sync with the server every second.
+ * No need to sync data for temporary sessions.
  *
  * @type {string[]} Array of keys.
  */
 const syncQueue = [];
 
 setInterval( () => {
-	if ( ! syncQueue.length ) {
+	if ( ! syncQueue.length || newspack_reader_data?.is_temporary ) {
 		return;
 	}
 	const key = syncQueue.shift();
@@ -204,8 +205,8 @@ export default function Store() {
 		syncQueue.push( key );
 	}
 
-	// Rehydrate items from server.
-	if ( newspack_reader_data?.items ) {
+	// Rehydrate items from server. No need to rehydrate for temporary sessions.
+	if ( newspack_reader_data?.items && ! newspack_reader_data?.is_temporary ) {
 		const keys = Object.keys( newspack_reader_data.items );
 		for ( const key of keys ) {
 			// Do not overwrite items that were pending sync.

--- a/assets/wizards/popups/components/segmentation-preview/index.js
+++ b/assets/wizards/popups/components/segmentation-preview/index.js
@@ -6,6 +6,7 @@
 /**
  * WordPress dependencies
  */
+import { useEffect, useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -14,6 +15,9 @@ import { addQueryArgs } from '@wordpress/url';
 import { WebPreview } from '../../../../components/src';
 
 const SegmentationPreview = props => {
+	const [ decoratedUrl, setDecoratedUrl ] = useState( null );
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ sessionId, setSessionId ] = useState( Math.floor( Math.random() * 9999 ) ); // A random ID that can be used to tie together all pageviews in a single preview session.
 	const postPreviewLink = window?.newspack_popups_wizard_data?.preview_post;
 	const frontendUrl = window?.newspack_popups_wizard_data?.frontend_url || '/';
 
@@ -25,7 +29,13 @@ const SegmentationPreview = props => {
 		url = postPreviewLink || frontendUrl,
 	} = props;
 
-	const decorateURL = urlToDecorate => {
+	useEffect( () => {
+		if ( ! isOpen ) {
+			setDecoratedUrl( decorateUrl( url ) );
+		}
+	}, [ isOpen ] );
+
+	const decorateUrl = urlToDecorate => {
 		const view_as = segment.length ? [ `segment:${ segment }` ] : [ 'segment:everyone' ];
 
 		if ( showUnpublished ) {
@@ -39,6 +49,8 @@ const SegmentationPreview = props => {
 			view_as.push( 'all' );
 		}
 
+		view_as.push( 'session_id:' + sessionId );
+
 		return addQueryArgs( urlToDecorate, { view_as: view_as.join( ';' ) } );
 	};
 
@@ -47,14 +59,25 @@ const SegmentationPreview = props => {
 			[ ...iframeEl.contentWindow.document.querySelectorAll( 'a' ) ].forEach( anchor => {
 				const href = anchor.getAttribute( 'href' );
 				if ( href.indexOf( frontendUrl ) === 0 ) {
-					anchor.setAttribute( 'href', decorateURL( href ) );
+					anchor.setAttribute( 'href', decorateUrl( href ) );
 				}
 			} );
+			setIsOpen( true );
 			onLoad( iframeEl );
 		}
 	};
 
-	return <WebPreview { ...props } onLoad={ onWebPreviewLoad } url={ decorateURL( url ) } />;
+	return (
+		<WebPreview
+			{ ...props }
+			onLoad={ onWebPreviewLoad }
+			onClose={ () => {
+				setSessionId( Math.floor( Math.random() * 9999 ) ); // Reset session ID when the preview is closed.
+				setIsOpen( false );
+			} }
+			url={ decoratedUrl }
+		/>
+	);
 };
 
 export default SegmentationPreview;

--- a/assets/wizards/popups/components/settings-modal/index.js
+++ b/assets/wizards/popups/components/settings-modal/index.js
@@ -127,7 +127,6 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 							onChange={ tokens => setPromptConfig( { segments: tokens } ) }
 							label={ __( 'Segments', 'newspack' ) }
 							taxonomy="popup_segment"
-							hideLabelFromVision
 						/>
 						<CategoryAutocomplete
 							label={ __( 'Post categories', 'newspack ' ) }

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -53,8 +53,15 @@ final class Reader_Data {
 			sprintf( 'np_reader_%d_', \get_current_blog_id() )
 		);
 
+		/**
+		 * Allows for "temporary" reader data for things like previews.
+		 * If true, the store will use sessionStorage instead of localStorage.
+		 */
+		$is_temporary = apply_filters( 'newspack_reader_data_store_is_temp_session', false );
+
 		$config = [
 			'store_prefix'    => $store_prefix,
+			'is_temporary'    => $is_temporary,
 			'reader_activity' => self::$reader_activity,
 		];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a filter which lets us set a reader data store session as temporary. If set, reader data will be written to and read from `sessionStorage` intead of `localStorage`, and will not be synced to nor rehydrated from the server. This is to support preview sessions in https://github.com/Automattic/newspack-popups/pull/1178.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-popups/pull/1178.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->