### PR TITLE
feat: campaigns analytics placeholder

### DIFF
--- a/assets/wizards/popups/views/analytics/index.js
+++ b/assets/wizards/popups/views/analytics/index.js
@@ -1,92 +1,42 @@
 /**
- * External dependencies.
- */
-import { stringify } from 'qs';
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies.
  */
-import { useEffect, useState } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
  */
-import { withWizardScreen, Notice } from '../../../../components/src';
-import Filters from './Filters';
-import Chart from './Chart';
-import Info from './Info';
+import { Button, Card, withWizardScreen } from '../../../../components/src';
 import './style.scss';
-import { useFiltersState, useAnalyticsState } from './utils';
 
 /**
  * Popups Analytics screen.
  */
-const PopupAnalytics = ( { setError } ) => {
-	const [ filtersState, dispatchFilter ] = useFiltersState();
-	const [ siteKitWarningText, setSiteKitWarningText ] = useState();
-	const [ isLoading, setIsLoading ] = useState( false );
-	const [ state, updateState ] = useAnalyticsState();
-	const { report, labels, actions, key_metrics, post_edit_link } = state;
-
-	useEffect( () => {
-		setIsLoading( true );
-		apiFetch( { path: `/newspack/v1/popups-analytics/report/?${ stringify( filtersState ) }` } )
-			.then( response => {
-				updateState( { type: 'UPDATE_ALL', payload: response } );
-				setIsLoading( false );
-			} )
-			.catch( error => {
-				if (
-					error.code === 'newspack_campaign_analytics_sitekit_disconnected' ||
-					error.code === 'newspack_campaign_analytics_sitekit_auth'
-				) {
-					setSiteKitWarningText( error.message );
-					setIsLoading( false );
-				} else {
-					setError( error );
-				}
-			} );
-	}, [ filtersState ] );
-
-	const handleFilterChange = type => payload => dispatchFilter( { type, payload } );
-
-	if ( siteKitWarningText ) {
-		return (
-			<Notice
-				rawHTML
-				isWarning
-				noticeText={ `<a href="/wp-admin/admin.php?page=googlesitekit-splash">${ siteKitWarningText }</a>` }
-			/>
-		);
-	}
-
-	return (
-		<div
-			className={ classnames( 'newspack-campaigns-wizard-analytics__wrapper', {
-				'newspack-campaigns-wizard-analytics__wrapper--loading': isLoading,
-			} ) }
-		>
-			<Filters
-				disabled={ isLoading }
-				labelFilters={ labels }
-				eventActionFilters={ actions }
-				filtersState={ filtersState }
-				onChange={ handleFilterChange }
-			/>
-			{ report && <Chart data={ report } isLoading={ isLoading } /> }
-			{ key_metrics && (
-				<Info
-					keyMetrics={ key_metrics }
-					filtersState={ filtersState }
-					labelFilters={ labels }
-					isLoading={ isLoading }
-					postEditLink={ post_edit_link }
-				/>
-			) }
-		</div>
-	);
-};
+const PopupAnalytics = () => (
+	<div className="newspack-campaigns-wizard-analytics__wrapper">
+		<Card isNarrow>
+			<h2>{ __( 'Coming soon', 'newspack' ) }</h2>
+			<p>
+				{ [
+					<>
+						{ __(
+							'We’re currently redesigning this dashboard to accommodate GA4 and give you deeper insights into Campaign performance. In the meantime, you can find Campaign event data within your GA account. Review this ',
+							'newspack'
+						) }
+					</>,
+					<>
+						<a href="https://help.newspack.com/analytics/">{ __( 'help page', 'newspack' ) }</a>
+					</>,
+					<>{ __( ' to see how Campaign data is being recorded in GA.', 'newspack' ) }</>,
+				] }
+			</p>
+			<Card buttonsCard noBorder>
+				<Button href="https://help.newspack.com/analytics/" isPrimary>
+					{ __( 'View the help page', 'newspack' ) }
+				</Button>
+			</Card>
+		</Card>
+	</div>
+);
 
 export default withWizardScreen( PopupAnalytics );

--- a/assets/wizards/popups/views/analytics/index.js
+++ b/assets/wizards/popups/views/analytics/index.js
@@ -25,13 +25,24 @@ const PopupAnalytics = () => (
 						) }
 					</>,
 					<>
-						<a href="https://help.newspack.com/analytics/">{ __( 'help page', 'newspack' ) }</a>
+						<a
+							target="_blank"
+							rel="noopener noreferrer"
+							href="https://help.newspack.com/analytics/"
+						>
+							{ __( 'help page', 'newspack' ) }
+						</a>
 					</>,
 					<>{ __( ' to see how Campaign data is being recorded in GA.', 'newspack' ) }</>,
 				] }
 			</p>
 			<Card buttonsCard noBorder>
-				<Button href="https://help.newspack.com/analytics/" isPrimary>
+				<Button
+					target="_blank"
+					rel="noopener noreferrer"
+					href="https://help.newspack.com/analytics/"
+					isPrimary
+				>
 					{ __( 'View the help page', 'newspack' ) }
 				</Button>
 			</Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Deprecates the UA-driven Campaigns Analytics dashboard and replaces it with a temporary placeholder message. I didn't remove the other views or components from the codebase in case we want to re-use those in the future to show GA4 data.

### How to test the changes in this Pull Request:

1. Check out this branch, visit **Newspack > Campaigns > Analytics**. Check that the links lead to the [right page](https://help.newspack.com/analytics/).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->