### PR TITLE
feat(reader-data): check newsletter subscription on login

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -37,6 +37,8 @@ final class Reader_Data {
 		add_action( 'newspack_data_event_dispatch_newsletter_updated', [ __CLASS__, 'set_is_newsletter_subscriber' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_new', [ __CLASS__, 'set_is_donor' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_subscription_cancelled', [ __CLASS__, 'set_is_former_donor' ], 10, 2 );
+
+		Data_Events::register_handler( [ __CLASS__, 'check_newsletter_subscription' ], 'reader_logged_in' );
 	}
 
 	/**
@@ -329,6 +331,35 @@ final class Reader_Data {
 		 * @param array $reader_activity Reader activity.
 		 */
 		self::$reader_activity = apply_filters( 'newspack_reader_activity', self::$reader_activity );
+	}
+
+	/**
+	 * Data event handler to check if the user is subscribed to a newsletter and
+	 * set the data item.
+	 *
+	 * @param int   $timestamp Timestamp.
+	 * @param array $data      Data.
+	 */
+	public static function check_newsletter_subscription( $timestamp, $data ) {
+		if ( empty( $data['user_id'] ) || empty( $data['email'] ) ) {
+			return;
+		}
+		$is_newsletter_subscriber = self::get_data( $data['user_id'], 'is_newsletter_subscriber' );
+		if ( ! empty( $is_newsletter_subscriber ) && type( $is_newsletter_subscriber ) === 'string' ) {
+			$is_newsletter_subscriber = json_decode( $is_newsletter_subscriber );
+		}
+		// Bail if reader is already a newsletter subscriber.
+		if ( $is_newsletter_subscriber ) {
+			return;
+		}
+		// Check if the user is subscribed to a newsletter.
+		if ( ! class_exists( '\Newspack_Newsletters' ) || ! class_exists( '\Newspack_Newsletters_Subscription' ) ) {
+			return;
+		}
+		$subscribed_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $email_address );
+		if ( ! is_wp_error( $subscribed_lists ) && ! empty( $subscribed_lists ) && is_array( $subscribed_lists ) ) {
+			self::update_item( $data['user_id'], 'is_newsletter_subscriber', true );
+		}
 	}
 }
 Reader_Data::init();

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -356,7 +356,7 @@ final class Reader_Data {
 		if ( ! class_exists( '\Newspack_Newsletters' ) || ! class_exists( '\Newspack_Newsletters_Subscription' ) ) {
 			return;
 		}
-		$subscribed_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $email_address );
+		$subscribed_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $data['email'] );
 		if ( ! is_wp_error( $subscribed_lists ) && ! empty( $subscribed_lists ) && is_array( $subscribed_lists ) ) {
 			self::update_item( $data['user_id'], 'is_newsletter_subscriber', true );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If a contact is already signed up for a list in the ESP, then somehow registers for the site with the same email address, they are not segmented as a newsletter subscriber until they update their subscriptions (by either signing up for a new list or unsubscribing from one in My Account).

TL;DR the segmentation update isn't triggered until you edit subscriptions on the site

Closes `1200550061930446/1205326345667208`.

### How to test the changes in this Pull Request:

1. Check out `master`.
2. Either turn off RAS temporarily on your site and sign up for a newsletter, or manually add a contact to a list directly in the connected ESP.
3. On the Newspack site, register for an account using the same email address. without signing up for newsletters. This can be done via a Registration block if multiple lists are available and you deselect them all when registering, or by making a donation.
4. Navigate around the site and observe you are not segmented as a newsletter subscriber, despite being subscribed in the ESP.
5. Go to My Account and verify if needed. Observe you can see the newsletter list signup status despite still not being segmented properly.
6. Update your subscriptions by signing up for a new list, or unsubscribing from a list and then resubscribing.
7. Continue navigating around the site and observe you're now segmented properly. 
8. Check out this branch. Repeat steps 2-3, but this time confirm that you're segmented properly as a newsletter subscriber immediately after registering for or logging into an account.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->