### PR TITLE
feat: new option to require all membership plans for restricted content

### DIFF
--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -76,7 +76,7 @@ class EngagementWizard extends Component {
 	 * Render
 	 */
 	render() {
-		const { pluginRequirements } = this.props;
+		const { pluginRequirements, wizardApiFetch } = this.props;
 		const { relatedPostsEnabled, relatedPostsError, relatedPostsMaxAge, relatedPostsUpdated } =
 			this.state;
 
@@ -114,6 +114,7 @@ class EngagementWizard extends Component {
 		const props = {
 			headerText: __( 'Engagement', 'newspack' ),
 			tabbedNavigation: tabbed_navigation,
+			wizardApiFetch,
 		};
 		return (
 			<Fragment>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -26,7 +26,7 @@ import ActiveCampaign from '../../components/active-campaign';
 import Mailchimp from '../../components/mailchimp';
 import { HANDOFF_KEY } from '../../../../components/src/consts';
 
-export default withWizardScreen( () => {
+export default withWizardScreen( ( { wizardApiFetch } ) => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ config, setConfig ] = useState( {} );
 	const [ membershipsConfig, setMembershipsConfig ] = useState( {} );
@@ -57,9 +57,10 @@ export default withWizardScreen( () => {
 	const saveConfig = data => {
 		setError( false );
 		setInFlight( true );
-		apiFetch( {
+		wizardApiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
 			method: 'post',
+			quiet: true,
 			data,
 		} )
 			.then( ( { config: fetchedConfig, prerequisites_status, memberships } ) => {
@@ -238,6 +239,19 @@ export default withWizardScreen( () => {
 								description={ getContentGateDescription() }
 								actionText={ __( 'Configure', 'newspack' ) }
 							/>
+							{ membershipsConfig?.plans && 1 < membershipsConfig.plans.length && (
+								<ActionCard
+									title={ __( 'Require membership in all plans', 'newspack' ) }
+									description={ __(
+										'When enabled, readers must belong to all membership plans that apply to a restricted content item before they are granted access. Otherwise, they will be able to unlock access to that item with membership in any single plan that applies to it.',
+										'newspack'
+									) }
+									toggleOnChange={ value =>
+										setMembershipsConfig( { ...membershipsConfig, require_all_plans: value } )
+									}
+									toggleChecked={ membershipsConfig.require_all_plans }
+								/>
+							) }
 							<hr />
 						</>
 					) : null }
@@ -316,6 +330,7 @@ export default withWizardScreen( () => {
 									metadata_prefix: config.metadata_prefix,
 									mailchimp_audience_id: config.mailchimp_audience_id,
 									active_campaign_master_list: config.active_campaign_master_list,
+									memberships_require_all_plans: membershipsConfig.require_all_plans,
 								} );
 							} }
 							disabled={ inFlight }

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -42,6 +42,7 @@ class Memberships {
 		add_action( 'wp_footer', [ __CLASS__, 'render_js' ] );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
+		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -688,6 +689,108 @@ class Memberships {
 			return false;
 		}
 		return $activity;
+	}
+
+	/**
+	 * Check if the passed in caps contain a positive 'manage_woocommerce' capability.
+	 * Copied from the WooCommerce Memberships plugin.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $caps Capabilities.
+	 * @return bool
+	 */
+	private static function can_manage_woocommerce( $caps ) {
+		return isset( $caps['manage_woocommerce'] ) && $caps['manage_woocommerce'];
+	}
+
+	/**
+	 * Checks if a user has a certain capability.
+	 * Overrides behvavior from the WooCommerce Memberships plugin to decide whether to show restricted content.
+	 *
+	 * @internal
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $all_caps All capabilities.
+	 * @param array $caps Capabilities.
+	 * @param array $args Capability arguments.
+	 * @return array Filtered capabilities.
+	 */
+	public static function user_has_cap( $all_caps, $caps, $args ) {
+		// Bail if Woo Memberships is not active.
+		if ( ! class_exists( 'WC_Memberships' ) || ! function_exists( 'wc_memberships' ) ) {
+			return $all_caps;
+		}
+
+		if ( ! empty( $caps ) ) {
+			foreach ( $caps as $cap ) {
+				if ( 'wc_memberships_view_restricted_post_content' === $cap ) {
+					if ( self::can_manage_woocommerce( $all_caps ) ) {
+						$all_caps[ $cap ] = true;
+						break;
+					}
+
+					$user_id = (int) $args[1];
+					$post_id = (int) $args[2];
+
+					if ( wc_memberships()->get_restrictions_instance()->is_post_public( $post_id ) ) {
+						$all_caps[ $cap ] = true;
+						break;
+					}
+
+					$rules            = wc_memberships()->get_rules_instance()->get_post_content_restriction_rules( $post_id );
+					$all_caps[ $cap ] = self::user_has_content_access_from_rules( $user_id, $rules, $post_id );
+
+					break;
+				}           
+			}
+		}
+
+		return $all_caps;
+	}
+
+	/**
+	 * Checks if a user has content access from rules.
+	 * Overrides behvavior from the WooCommerce Memberships plugin to decide whether to show restricted content.
+	 * Default behavior matches the WooCommerce Memberships plugin: if a user matches ANY applicable membership
+	 * plan rule, they are granted access to the content.
+	 * 
+	 * Custom behavior: If the "Check all rules" option is enabled in the Engagement wizard, then a user must 
+	 * match ALL applicable membership plan rules before being granted access to the content.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @param int                                    $user_id WP_User ID.
+	 * @param \WC_Memberships_Membership_Plan_Rule[] $rules array of rules to search access from.
+	 * @param int                                    $object_id Optional object ID to check access for (defaults to null).
+	 * @return bool returns true if there are no rules at all (users always have access).
+	 */
+	private static function user_has_content_access_from_rules( $user_id, array $rules, $object_id = null ) {
+		// Return true if there are no rules at all (users always have access).
+		if ( empty( $rules ) ) {
+			return true;
+		}
+
+		$has_access = false;
+
+		foreach ( $rules as $rule ) {
+
+			// If no object ID is provided, then we are looking at rules that apply to whole post types or taxonomies.
+			// In this case, rules that apply to specific objects should be skipped.
+			if ( empty( $object_id ) && $rule->has_objects() ) {
+				continue;
+			}
+
+			if ( wc_memberships_is_user_active_or_delayed_member( $user_id, $rule->get_membership_plan_id() ) ) {
+				$has_access = true;
+			} else {
+				$has_access = false;
+				break;
+			}
+		}
+
+		return $has_access;
 	}
 }
 Memberships::init();

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -204,8 +204,10 @@ class Engagement_Wizard extends Wizard {
 	 */
 	private static function get_memberships_settings() {
 		return [
-			'edit_gate_url' => Memberships::get_edit_gate_url(),
-			'gate_status'   => get_post_status( Memberships::get_gate_post_id() ),
+			'edit_gate_url'     => Memberships::get_edit_gate_url(),
+			'gate_status'       => get_post_status( Memberships::get_gate_post_id() ),
+			'plans'             => Memberships::get_plans(),
+			'require_all_plans' => Memberships::get_require_all_plans_setting(),
 		];
 	}
 
@@ -236,6 +238,12 @@ class Engagement_Wizard extends Wizard {
 		foreach ( $args as $key => $value ) {
 			Reader_Activation::update_setting( $key, $value );
 		}
+
+		// Update Memberships options.
+		if ( isset( $args['memberships_require_all_plans'] ) ) {
+			Memberships::set_require_all_plans_setting( (bool) $args['memberships_require_all_plans'] );
+		}
+
 		return rest_ensure_response(
 			[
 				'config'               => Reader_Activation::get_settings(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some publishers want to gate most articles behind a metered reg wall, but gate some smaller subset of those articles (e.g. those with a "Premium" category) behind a hard paywall. Free registrants should get access to most articles, but not to paywalled articles until they purchase the necessary membership. This is a common content gating strategy used by many large-scale publishing sites but which we currently can't support without the proposed change.

We do have the ability to show different paywalls for these two "tiers" of restricted content. This is done by creating two membership plans: Plan 1 restricts all posts with a metered reg wall. Plan 2 restricts Premium articles with a paywall.

However, the way WooCommerce Memberships works, if multiple different membership plans have different rules restricting the same content (as in the above example—Premium articles are a subset of all articles) it will grant access to the restricted content as long as the reader is a member of ANY applicable membership plan. So this defeats the purpose of the paywall in the above scenario: as soon as you register a free account, you get access to all articles, which includes the Premium articles.

This PR introduces a new option in the Reader Activation wizard where we already show other Content Gate settings. This option lets us implement a "stricter" evaluation of membership rules when deciding whether or not to grant access to restricted content. 

<img width="1053" alt="Screenshot 2023-08-31 at 2 03 31 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/bbf82ac3-5c23-4adc-8fcf-c5f823ced1d7">

The default (disabled) behavior introduces no changes to the current behavior, as some publishers have content gating strategies that require this behavior. When enabled, the behavior changes such that if multiple membership plans are restricting access to the same content, a reader must be a member of ALL plans in order to get access to the content, not just one of them.

Closes `1200550061930446/1205368936341187`.

### How to test the changes in this Pull Request:

1. On `master`, set up two membership plans.
  - Plan 1: Should grant access upon "user account registration" and should restrict access to all posts of post type "Post".
  - Plan 2: Should grant access upon product "product(s) purchase", tied to a paid subscription product, and should restrict access to a specific category or categories of posts.

2. Go to **Newspack > Engagement > Reader Activation** and open the advanced settings panel. Edit and publish your primary content gate and insert a Registration wall pattern. Turn on metering and set it to an easily testable value like `2`.
3. From the WooCommerce Memberships sidebar panel in this editor, create or edit the content gate tied to the subscription-based Plan 2 above. Add a paywall pattern tied to the subscription product with no metering and publish.
4. On the front-end, start a new reader session and immediately visit a post in the premium category. Confirm that the post is blocked by the paywall gate right away.
5. Visit 3 other non-premium posts. Confirm that you're able to see the first two, but that the third is blocked with the reg wall gate.
6. Register for a free account from the reg wall and confirm that you gain access as expected.
7. Visit any premium post and observe that you also now have access to these posts, despite not owning the required subscription/membership.
8. Check out this branch and go back to **Newspack > Engagement > Reader Activation**. Confirm you see the new option right under the content gate and that it's off by default (note that you will only see the new option if your site has more than one active membership plan):

<img width="1053" alt="Screenshot 2023-08-31 at 2 03 31 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/bbf82ac3-5c23-4adc-8fcf-c5f823ced1d7">

9. Leave it off and do a smoke test by repeating steps 4–7. The behavior should be exactly the same as before.
10. Toggle on the new option and save. Refresh the admin page and confirm your setting persists.
11. Repeat steps 4–7 again, but this time confirm that at step 7 after registering for a free account, you have access to non-premium posts while premium posts are still blocked by the paywall gate.
12. Purchase a subscription product via the paywall gate and confirm that you now have access to all premium posts as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->