### PR TITLE
fix(reader-data): `gettype` typo while checking newsletter subscription

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -345,7 +345,7 @@ final class Reader_Data {
 			return;
 		}
 		$is_newsletter_subscriber = self::get_data( $data['user_id'], 'is_newsletter_subscriber' );
-		if ( ! empty( $is_newsletter_subscriber ) && type( $is_newsletter_subscriber ) === 'string' ) {
+		if ( ! empty( $is_newsletter_subscriber ) && gettype( $is_newsletter_subscriber ) === 'string' ) {
 			$is_newsletter_subscriber = json_decode( $is_newsletter_subscriber );
 		}
 		// Bail if reader is already a newsletter subscriber.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a PHP typo.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->