### PR TITLE
fix: allow for /* modifier in activeTabPaths prop

### DIFF
--- a/assets/components/src/tabbed-navigation/index.js
+++ b/assets/components/src/tabbed-navigation/index.js
@@ -25,7 +25,14 @@ const TabbedNavigation = ( { items, className, disableUpcoming, children = null 
 							to={ item.path }
 							isActive={ ( match, { pathname } ) => {
 								if ( item.activeTabPaths ) {
-									return item.activeTabPaths.includes( pathname );
+									return item.activeTabPaths.some( path => {
+										if ( path.includes( '/*' ) ) {
+											return path
+												.split( '/*' )
+												.every( part => '' === part || pathname.includes( part ) );
+										}
+										return path === pathname;
+									}, false );
 								}
 								return match;
 							} }

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -156,6 +156,7 @@ class AdvertisingWizard extends Component {
 				label: __( 'Providers', 'newspack' ),
 				path: '/',
 				exact: true,
+				activeTabPaths: [ '/', '/google_ad_manager/*' ],
 			},
 			{
 				label: __( 'Placements', 'newspack' ),
@@ -176,6 +177,7 @@ class AdvertisingWizard extends Component {
 			{
 				label: __( 'Marketplace', 'newspack' ),
 				path: '/marketplace',
+				activeTabPaths: [ '/marketplace/*' ],
 			},
 		];
 		return (

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -86,11 +86,7 @@ class EngagementWizard extends Component {
 				label: __( 'Reader Activation', 'newspack' ),
 				path: '/reader-activation',
 				exact: true,
-				activeTabPaths: [
-					'/reader-activation',
-					'/reader-activation/campaign',
-					'/reader-activation/complete',
-				],
+				activeTabPaths: [ '/reader-activation/*' ],
 			},
 			{
 				label: __( 'Newsletters', 'newspack' ),

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -42,6 +42,7 @@ const tabbedNavigation = [
 		label: __( 'Segments', 'newpack' ),
 		path: '/segments',
 		exact: true,
+		activeTabPaths: [ '/segments/*' ],
 	},
 	{
 		label: __( 'Analytics', 'newpack' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor pet peeve of mine in the tabbed Newspack wizard UI. Allows for a `/pathname/*` pattern to be included in the `activeTabPaths` prop used in the tabbed wizard navigation, so that a tab can be highlighted as long as the current route path contains the non-* parts of the pattern. This is so that we can highlight tabs even if the route path contains dynamic parts.

Branched off of #2628 because that PR introduces a whole new section that can make use of this new feature.

### How to test the changes in this Pull Request:

1.  View some wizard pages that use the `activeTabPaths` prop (Advertising > Providers, Advertising > Marketplace, Campaigns > Segments, Engagement > Reader Activation, and their subpages, including dynamic routes like editing an existing segment or GAM ad unit).
2. Confirm that the right tab is highlighted in the wizard navigation bar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->