### PR TITLE
fix: sync scripts for Stripe-to-Woo migrations

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -98,7 +98,8 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-magic-link.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/stripe/class-stripe-connection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/stripe/class-stripe-webhooks.php';
-		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-woocommerce-connection.php';
+		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/woocommerce/class-woocommerce-connection.php';
+		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/woocommerce/class-woocommerce-sync.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/stripe/class-stripe-sync.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/my-account/class-woocommerce-my-account.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-reader-revenue-emails.php';

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -14,6 +14,11 @@ defined( 'ABSPATH' ) || exit;
  */
 class Stripe_Sync {
 	/**
+	 * A flag to indicate that a Stripe subscription was migrated from Stripe to WooCommerce.
+	 */
+	const MIGRATION_CANCELLATION_FLAG = 'newspack_subscription_migrated_to_woo';
+
+	/**
 	 * The final results object.
 	 *
 	 * @var array
@@ -764,7 +769,14 @@ Running script to set next payment dates on migrated subscriptions...
 							sprintf( '    * Would cancel Stripe subscription %s.', $existing_subscription->id )
 						);
 					} else {
-						$stripe->subscriptions->cancel( $existing_subscription->id );
+						$stripe->subscriptions->cancel(
+							$existing_subscription->id,
+							[
+								'cancellation_details' => [
+									'comment' => self::MIGRATION_CANCELLATION_FLAG, // Add a flag so we know not to sync this subscription in the future.
+								],
+							]
+						);
 						\WP_CLI::success( sprintf( 'Cancelled old subscription: %s', $existing_subscription->id ) );
 					}
 				} catch ( \Throwable $e ) {

--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -575,7 +575,7 @@ Running script to set next payment dates on migrated subscriptions...
 	 * @param int $offset Offset to start at.
 	 * @return array Array of WC Subscriptions.
 	 */
-	protected static function get_migrated_subscriptions( $batch_size = 0, $offset = 0 ) {
+	public static function get_migrated_subscriptions( $batch_size = 0, $offset = 0 ) {
 		$args = [
 			'fields'         => 'ids',
 			'offset'         => $offset,

--- a/includes/reader-revenue/stripe/class-stripe-webhooks.php
+++ b/includes/reader-revenue/stripe/class-stripe-webhooks.php
@@ -255,6 +255,11 @@ class Stripe_Webhooks {
 			return;
 		}
 
+		// If the subscription was cancelled due to a migration to WooCommerce, don't attempt to sync this subscription.
+		if ( isset( $payload['cancellation_details']['comment'] ) && Stripe_Sync::MIGRATION_CANCELLATION_FLAG === $payload['cancellation_details']['comment'] ) {
+			return;
+		}
+
 		switch ( $request['type'] ) {
 			case 'charge.succeeded':
 				$payment  = $payload;

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -168,6 +168,33 @@ class WooCommerce_Connection {
 	}
 
 	/**
+	 * Get the contact data from a WooCommerce customer user account.
+	 * 
+	 * @param \WC_Customer|int $customer Customer or customer ID.
+	 * 
+	 * @return array|false Contact data or false.
+	 */
+	public static function get_contact_from_customer( $customer ) {
+		if ( is_integer( $customer ) ) {
+			$customer = new \WC_Customer( $customer );
+		}
+
+		$metadata = [];
+		
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'account' ) ]           = $customer->get_id();
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_date' ) ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
+
+		$first_name   = $customer->get_first_name();
+		$last_name    = $customer->get_last_name();
+		$display_name = $customer->get_display_name();
+		return [
+			'email'    => $customer->get_email(),
+			'name'     => $display_name ?? "$first_name $last_name",
+			'metadata' => $metadata,
+		];
+	}
+
+	/**
 	 * Get the contact data from a WooCommerce order.
 	 *
 	 * @param \WC_Order|int $order WooCommerce order or order ID.
@@ -308,7 +335,7 @@ class WooCommerce_Connection {
 			return;
 		}
 
-		\Newspack_Newsletters_Subscription::add_contact( $contact );
+		return \Newspack_Newsletters_Subscription::add_contact( $contact );
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-sync.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-sync.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * WP CLI scripts for managing WooCommerce Reader Revenue data.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stripe Syncs.
+ */
+class WooCommerce_Sync {
+	// User roles that a customer can have.
+	const CUSTOMER_ROLES = [ 'customer', 'subscriber' ];
+
+	/**
+	 * The final results object.
+	 *
+	 * @var array
+	 * @codeCoverageIgnore
+	 */
+	private static $results = [
+		'processed' => 0,
+	];
+
+		/**
+		 * Initialize.
+		 *
+		 * @codeCoverageIgnore
+		 */
+	public static function init() {
+		\add_action( 'init', [ __CLASS__, 'wp_cli' ] );
+	}
+
+		/**
+		 * Add CLI commands.
+		 */
+	public static function wp_cli() {
+		if ( ! defined( 'WP_CLI' ) ) {
+			return;
+		}
+
+		\WP_CLI::add_command(
+			'newspack woo resync',
+			[ __CLASS__, 'resync_woo_contacts' ],
+			[
+				'shortdesc' => __( 'Resync customer and transaction data to the connected ESP.', 'newspack' ),
+				'synopsis'  => [
+					[
+						'type'     => 'flag',
+						'name'     => 'dry-run',
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'migrated-subscriptions',
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'subscription-ids',
+						'default'  => false,
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'user-ids',
+						'default'  => false,
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'order-ids',
+						'default'  => false,
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'batch-size',
+						'default'  => 10,
+						'optional' => true,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * CLI command for resyncing contact data from WooCommerce customers to the connected ESP.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public static function resync_woo_contacts( $args, $assoc_args ) {
+		$is_dry_run       = ! empty( $assoc_args['dry-run'] );
+		$migrated_only    = ! empty( $assoc_args['migrated-subscriptions'] );
+		$subscription_ids = ! empty( $assoc_args['subscription-ids'] ) ? explode( ',', $assoc_args['subscription-ids'] ) : false;
+		$user_ids         = ! empty( $assoc_args['user-ids'] ) ? explode( ',', $assoc_args['user-ids'] ) : false;
+		$order_ids        = ! empty( $assoc_args['order-ids'] ) ? explode( ',', $assoc_args['order-ids'] ) : false;
+		$batch_size       = ! empty( $assoc_args['batch-size'] ) ? intval( $assoc_args['batch-size'] ) : 10;
+
+		\WP_CLI::log(
+			'
+
+Running WooCommerce-to-ESP contact resync...
+
+		'
+		);
+
+		// If resyncing only migrated subscriptions.
+		if ( $migrated_only ) {
+			$subscription_ids = Stripe_Sync::get_migrated_subscriptions( $batch_size );
+			$batches          = 0;
+		}
+
+		if ( ! empty( $subscription_ids ) ) {
+			\WP_CLI::log( __( 'Migrating by subscription ID...', 'newspack' ) );
+			while ( $subscription_ids ) {
+				$subscription_id = array_shift( $subscription_ids );
+				$subscription    = new \WC_Subscription( $subscription_id );
+
+				if ( \is_wp_error( $subscription ) ) {
+					\WP_CLI::log(
+						sprintf(
+							// Translators: %d is the subscription ID arg passed to the script.
+							__( 'No subscription with ID %d. Skipping.', 'newspack' ),
+							$subscription_id
+						)
+					);
+
+					continue;
+				}
+
+				self::resync_contact( $subscription->get_customer_id(), $is_dry_run );
+
+				// Get the next batch.
+				if ( $migrated_only && empty( $subscription_ids ) ) {
+					$batches ++;
+					$subscription_ids = Stripe_Sync::get_migrated_subscriptions( $batch_size, $batches * $batch_size );
+				}
+			}
+
+			return;
+		}
+
+		// If user-ids flag is passed, resync those users.
+		if ( ! empty( $user_ids ) ) {
+			\WP_CLI::log( __( 'Migrating by customers user ID...', 'newspack' ) );
+			foreach ( $user_ids as $user_id ) {
+				self::resync_contact( $user_id, $is_dry_run );
+			}
+		}
+
+		// If order-ids flag is passed, resync contacts for those orders.
+		if ( ! empty( $order_ids ) ) {
+			\WP_CLI::log( __( 'Migrating by order ID...', 'newspack' ) );
+			foreach ( $order_ids as $order_id ) {
+				$order = new \WC_Order( $order_id );
+
+				if ( \is_wp_error( $order ) ) {
+					\WP_CLI::log(
+						sprintf(
+							// Translators: %d is the order ID arg passed to the script.
+							__( 'No order with ID %d. Skipping.', 'newspack' ),
+							$order_id
+						)
+					);
+
+					continue;
+				}
+				
+				self::resync_contact( $order->get_customer_id(), $is_dry_run );
+			}
+		}
+
+		// Default behavior: resync all customers and subscribers.
+		if ( empty( $user_ids ) && empty( $order_ids ) && empty( $subscription_ids ) ) {
+			\WP_CLI::log( __( 'Migrating all customers...', 'newspack' ) );
+			$user_ids = self::get_batch_of_customers( $batch_size );
+			$batches  = 0;
+
+			while ( $user_ids ) {
+				$user_id = array_shift( $user_ids );
+
+				self::resync_contact( $user_id, $is_dry_run );
+
+				// Get the next batch.
+				if ( empty( $user_ids ) ) {
+					$batches ++;
+					$user_ids = self::get_batch_of_customers( $batch_size, $batches * $batch_size );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Given a WP user ID for a Woo customer, resync that customer's contact data in the connected ESP.
+	 * 
+	 * @param int  $user_id WP user ID for the customer.
+	 * @param bool $is_dry_run True if a dry run.
+	 */
+	public static function resync_contact( $user_id, $is_dry_run = false ) {
+		$result = false;
+		$user   = \get_userdata( $user_id );
+
+		if ( ! $user || empty( array_intersect( $user->roles, self::CUSTOMER_ROLES ) ) ) {
+			\WP_CLI::log(
+				sprintf(
+				// Translators: %d is the user ID arg passed to the script.
+					__( 'No customer user with ID %d. Skipping.', 'newspack' ),
+					$user_id
+				)
+			);
+
+			return $result;
+		}
+
+		$customer = new \WC_Customer( $user_id );
+		if ( ! $customer->get_id() ) {
+			\WP_CLI::log(
+				sprintf(
+				// Translators: %d is the user ID arg passed to the script.
+					__( 'Customer with ID %d does not exist. Skipping.', 'newspack' ),
+					$user_id
+				)
+			);
+
+			return $result;
+		}
+
+		if ( ! $customer->get_order_count() ) {
+			$contact = WooCommerce_Connection::get_contact_from_customer( $customer );
+			$result  = ! $dry_run ? \Newspack_Newsletters_Subscription::add_contact( $contact ) : true;
+		} else {
+			$result = ! $dry_run ? WooCommerce_Connection::sync_reader_from_order( $customer->get_last_order(), false ) : true;
+		}
+
+		if ( $result && ! \is_wp_error( $result ) ) {
+			\WP_CLI::log(
+				sprintf(
+					// Translators: %1$s is the resync status and %2$s is the contact's email address.
+					__( '%1$s contact data for %2$s.', 'newspack' ),
+					$is_dry_run ? __( 'Would resync', 'newspack' ) : __( 'Resynced', 'newspack' ),
+					$customer->get_email()
+				)
+			);
+			self::$results['processed'] ++;
+		}
+
+		if ( \is_wp_error( $result ) ) {
+			\WP_CLI::error(
+				sprintf(
+					// Translators: $1$s is the contact's email address. %2$s is the error message.
+					__( 'Error resyncing contact info for %1$s. %2$s' ),
+					$customer->get_email(),
+					$result->get_error_message()
+				)
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get a batch of customer IDs.
+	 * 
+	 * @param int $batch_size Number of customers to get.
+	 * @param int $offset     Number to skip.
+	 * 
+	 * @return array|false Array of customer IDs, or false if no more to fetch.
+	 */
+	public static function get_batch_of_customers( $batch_size, $offset = 0 ) {
+		$query = new \WP_User_Query(
+			[
+				'fields'   => 'ID',
+				'number'   => $batch_size,
+				'offset'   => $offset,
+				'order'    => 'DESC',
+				'orderby'  => 'registered',
+				'role__in' => self::CUSTOMER_ROLES,
+			]
+		);
+
+		$results = $query->get_results();
+
+		return ! empty( $results ) ? $results : false;
+	}
+}
+WooCommerce_Sync::init();

--- a/includes/reader-revenue/woocommerce/class-woocommerce-sync.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-sync.php
@@ -26,11 +26,11 @@ class WooCommerce_Sync {
 		'processed' => 0,
 	];
 
-		/**
-		 * Initialize.
-		 *
-		 * @codeCoverageIgnore
-		 */
+	/**
+	 * Initialize.
+	 *
+	 * @codeCoverageIgnore
+	 */
 	public static function init() {
 		\add_action( 'init', [ __CLASS__, 'wp_cli' ] );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes some lingering issues with the Stripe-to-Woo migration script. Also adds a new script that allows us to trigger a resync of contact data to the connected ESP, in case the ESP's synced data has diverged from the source of truth (WooCommerce).

### How to test the changes in this Pull Request:

#### Stripe-to-Woo migration script fix

1. On `master`, set your Reader Revenue platform to Stripe and make sure your wp-config.php doesn't have the `NEWSPACK_USE_WC_SUBSCRIPTIONS_WITH_STRIPE_PLATFORM` constant. Also make sure that RAS is enabled and that your connected ESP is either ActiveCampaign or Mailchimp (the ESPs to which we sync RAS data).
2. Make a recurring donation as a new reader. Confirm that the contact is synced to the connected ESP with our usual Newspack metadata. Take special note of the `NP_Membership Status` value: it should be something like "Monthly Donor", indicating your donor status and the recurrence period of the donation.
3. Run the `wp newspack stripe sync-stripe-subscriptions-to-wc` script. This will migrate the Stripe customer and their subscription to WooCommerce and cancel the Stripe subscription.
4. In the connected ESP, observe that the Stripe subscription cancellation has triggered a contact sync: the `NP_Membership Status` field will now say something like "Ex-Monthly donor", which isn't accurate because the subscription wasn't actually cancelled, it was just migrated to WooCommerce. Make note of this contact for testing the resync script, below.
5. Check out this branch and repeat steps 2-3 with a new customer email and subscription. This time, confirm that in the connected ESP, the contact has not been updated because their migrated subscription is still active in WooCommerce.
6. In WooCommerce > Subscriptions, find and edit the migrated subscription. In the Subscription Actions panel, process a manual renewal to trigger another charge on the subscription. In the connected ESP, confirm that the contact's metadata has been updated (e.g. the `NP_Total Paid` value has increased by the amount of the manual renewal), indicating that the WooCommerce subscription is now syncing to this contact in the ESP.

Note: in this test, the manual renewal will trigger a one-time donation transaction for the customer, which will change the `NP_Membership Status` of the contact in the ESP to "Donor" instead of e.g. "Monthly Donor". This won't happen for real automated subscription renewals.

#### Resync script

1. Run the `wp newspack woo resync` CLI script. You can run this script without flags, which will resync all customers in the site, or with the following options:
  - `--migrated-subscriptions`: will only resync customers attached to subscriptions that were migrated from Stripe. This takes precedence over any other args passed.
  - `--subscription-ids`: will resync customers attached to the given subscription IDs (comma-delimited list).
  - `--user-ids`: will resync customers with the given user IDs (comma-delimited list).
  - `--order-ids`: will resync customers attached to the given order IDs (comma-delimited list).

2. Look up the Stripe customer that was accidentally flagged as an "ex-" donor in step 3 above, and confirm that they were resynced with the proper active status (no "ex-" in their `NP_Membership Status` value).
3. Test the script with each flag (and no flags) and confirm that in every case, only the contacts you'd expect are resynced.
4. Confirm that when resyncing, only the contact data and metadata fields are updated, not the ESP list subscription status (so that if a contact was subscribed to any lists, they won't be unsubscribed by the resync, and vice versa).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->