### PR TITLE
Adds ads.txt manager to plugin manager

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -292,7 +292,7 @@ class Plugin_Manager {
 				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/ad-refresh-control/' ),
 				'Download'    => 'wporg',
 			],
-			'ads-txt'     => [
+			'ads-txt'                       => [
 				'Name'        => esc_html__( 'Ads.txt Manager', 'newspack' ),
 				'Description' => esc_html__( 'Create, manage, and validate your ads.txt and app-ads.txt from within WordPress, just like any other content asset.', 'newspack' ),
 				'Author'      => esc_html__( '10up', 'newspack' ),
@@ -300,7 +300,7 @@ class Plugin_Manager {
 				'AuthorURI'   => esc_url( 'https://10up.com/' ),
 				'Download'    => 'wporg',
 				'EditPath'    => 'options-general.php?page=adstxt-settings',
-],
+			],
 			'publisher-media-kit'           => [
 				'Name'        => esc_html__( 'Publisher Media Kit', 'newspack' ),
 				'Description' => esc_html__( 'Quick and easy option for small to medium sized publishers to digitize their media kit.', 'newspack' ),

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -292,6 +292,15 @@ class Plugin_Manager {
 				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/ad-refresh-control/' ),
 				'Download'    => 'wporg',
 			],
+			'ads-txt'     => [
+				'Name'        => esc_html__( 'Ads.txt Manager', 'newspack' ),
+				'Description' => esc_html__( 'Create, manage, and validate your ads.txt and app-ads.txt from within WordPress, just like any other content asset.', 'newspack' ),
+				'Author'      => esc_html__( '10up', 'newspack' ),
+				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/ads-txt/' ),
+				'AuthorURI'   => esc_url( 'https://10up.com/' ),
+				'Download'    => 'wporg',
+				'EditPath'    => 'options-general.php?page=adstxt-settings',
+],
 			'publisher-media-kit'           => [
 				'Name'        => esc_html__( 'Publisher Media Kit', 'newspack' ),
 				'Description' => esc_html__( 'Quick and easy option for small to medium sized publishers to digitize their media kit.', 'newspack' ),


### PR DESCRIPTION
Adds 10up's Ads.txt Manager plugin to Newspack's list of approved/recommended/default plugins.

### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds 10up's [Ads.txt Manager](https://wordpress.org/plugins/ads-txt/) plugin to Newspack's list of approved/recommended/default plugins. See 1204015893379290-as-1204159745402806.

### How to test the changes in this Pull Request:

1. Navigate to `/wp-admin/plugins.php`
2. Note that Ads.txt Manager is among the default plugins listed with a hyphen prefix.
3. Install and activate the plugin.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->