### PR TITLE
Replaces WP GDPR cookie consent plugin with Complianz

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -252,13 +252,14 @@ class Plugin_Manager {
 				'WPCore'   => true,
 				'EditPath' => 'options-discussion.php',
 			],
-			'wp-gdpr-cookie-notice'         => [
-				'Name'        => esc_html__( 'WP GDPR Cookie Notice', 'newspack' ),
-				'Description' => esc_html__( 'Simple performant cookie consent notice that supports AMP, granular cookie control and live preview customization.', 'newspack' ),
-				'Author'      => esc_html__( 'Felix Arntz', 'newspack' ),
-				'AuthorURI'   => esc_url( 'https://felix-arntz.me/' ),
-				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/wp-gdpr-cookie-notice/' ),
+			'complianz-gdpr'         => [
+				'Name'        => esc_html__( 'Complianz – GDPR/CCPA Cookie Consent', 'newspack' ),
+				'Description' => esc_html__( 'Complianz Privacy Suite for GDPR, CaCPA, DSVGO, AVG with a conditional cookie warning and customized cookie policy.', 'newspack' ),
+				'Author'      => esc_html__( 'Really Simple Plugins', 'newspack' ),
+				'AuthorURI'   => esc_url( 'https://www.complianz.io/' ),
+				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/complianz-gdpr/' ),
 				'Download'    => 'wporg',
+				'EditPath'    => 'admin.php?page=complianz',
 			],
 			'simple-local-avatars'          => [
 				'Name'        => esc_html__( 'Simple Local Avatars', 'newspack' ),


### PR DESCRIPTION
Replaces `wp-gdpr-compliance` with `complianz-gdpr`.

### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We've had multiple reports of the [WP GDPR plugin](https://wordpress.org/plugins/wp-gdpr-compliance/) that we recommend being non-compliant with EU laws, as it doesn't allow site owners to set the cookie opt-out as the default. We are pivoting to the freemium plugin [Complianz](https://wordpress.org/plugins/complianz-gdpr/) instead.

More details in Asana: 1200024937525366-as-1201693786874162

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Navigate to `/wp-admin/plugins.php`
2. Observe that Felix Arntz's WP GDPR Cookie Notice plugin is no longer listed (unless already installed).
3. Observe that Complianz | GDPR/CCPA Cookie Consent by Really Simple Plugins is listed.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->