### PR TITLE
fix: let set-next-payment-dates-for-migrated-subscriptions reset past dates

### DIFF
--- a/includes/reader-revenue/stripe/class-stripe-sync.php
+++ b/includes/reader-revenue/stripe/class-stripe-sync.php
@@ -504,9 +504,10 @@ Running script to set next payment dates on migrated subscriptions...
 
 				// Get the next payment date.
 				$next_payment_date = $subscription->get_date( 'next_payment' );
+				$is_in_past        = $next_payment_date && strtotime( $next_payment_date ) < time();
 
 				// If there's no next payment, set it.
-				if ( ! $next_payment_date ) {
+				if ( ! $next_payment_date || $is_in_past ) {
 					$next_payment_date = $subscription->calculate_date( 'next_payment' );
 					\WP_CLI::log( sprintf( 'No next payment date set. Setting to %s.', $next_payment_date ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The `wp newspack stripe set-next-payment-dates-for-migrated-subscriptions` script sets next payment dates for active migrated subscriptions that lack them, but it didn't account for migrated subscriptions that have next payment dates in the _past_. This fixes that.

### How to test the changes in this Pull Request:

1. On a WC subscription, set the next payment date to a date in the past. The UI doesn't let you do this, so you'll need to do it via code: e.g. `update_post_meta( 341, '_schedule_next_payment', '2022-12-04 14:44:30' );`
2. Run the `wp newspack stripe set-next-payment-dates-for-migrated-subscriptions` CLI script. Observe that it skips the subscription with the past date.
3. Check out this branch and repeat step 2. Confirm that it resets the next payment date for the subscription to the next future date based on the period and start date of the subscription (e.g. 1 month after the last payment date).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->