### PR TITLE
fix: restore audience selector for mailchimp data sync

### DIFF
--- a/assets/wizards/engagement/components/mailchimp.js
+++ b/assets/wizards/engagement/components/mailchimp.js
@@ -20,7 +20,7 @@ export default function Mailchimp( { value, onChange } ) {
 		apiFetch( {
 			path: '/newspack-newsletters/v1/lists',
 		} )
-			.then( res => setLists( res.filter( list => ! list.type ) ) )
+			.then( res => setLists( res.filter( list => list.type_label === 'Mailchimp Audience' ) ) )
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
 	};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

https://github.com/Automattic/newspack-newsletters/pull/1255 introduced a change in the Newsletters' subscription lists schema which caused a regression in Mailchimp's audience selector for RAS' data sync settings wizard.

This PR restores the selector options.

<img width="1123" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/e4dc6c6f-b260-44e5-8d36-b08874ee517e">

### How to test the changes in this Pull Request:

1. While in the `release` branch, make sure you have RAS and Mailchimp as your ESP
2. Visit "Engagement -> Reader Activation -> Show Advanced Settings" and scroll down to "Mailchimp"
3. Confirm "Audience ID" is "None" and there are no options available
4. Check out this branch, build, refresh the page, and confirm you're now presented with the available audiences
5. Select an audience, save, refresh, and confirm the audience persists

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->