### PR TITLE
feat(amp-deprecation): Remove AMP from supported list

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -400,6 +400,7 @@ class Plugin_Manager {
 			'gravityformsstripe',
 			'perfmatters',
 			'onesignal-free-web-push-notifications',
+			'super-cool-ad-inserter-plugin',
 			'web-stories',
 			'ads-txt',
 			'woocommerce-memberships',

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -390,7 +390,6 @@ class Plugin_Manager {
 	 */
 	private static function get_supported_plugins_slugs() {
 		return [
-			'amp',
 			'gutenberg',
 			'classic-widgets',
 			'republication-tracker-tool',


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Newspack Plugin maintains a list of plugins that will not be added to the WP Admin plugins screen, but installing them will not raise any issues in Newspack > Health Check.

Historically, this list has included AMP, which has been retired from our platform (and will likely soon be blocked entirely). This PR removes AMP from that list.

Adds `super-cool-ad-inserter-plugin` to the allowed list, while we're at it!

### How to test the changes in this Pull Request:

1. Navigate to `/wp-admin/plugin-install.php`
2. Search for, install, and activate [AMP](https://wordpress.org/plugins/amp/).
3. Visit `/wp-admin/admin.php?page=newspack-health-check-wizard#/` and confirm that AMP is listed as an unsupported plugin.

### Other information:

* [Z] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->