### PR TITLE
feat(campaigns): newsletter subscription list criteria

### DIFF
--- a/assets/components/src/autocomplete-tokenfield/index.js
+++ b/assets/components/src/autocomplete-tokenfield/index.js
@@ -58,6 +58,26 @@ class AutocompleteTokenField extends Component {
 	}
 
 	/**
+	 * When the component updates, fetch information about the tokens so we can populate
+	 * the tokens with the correct labels.
+	 */
+	componentDidUpdate( prevProps ) {
+		const { tokens, fetchSavedInfo } = this.props;
+
+		if ( tokens !== prevProps.tokens && this.isFetchingInfoOnLoad() ) {
+			fetchSavedInfo( tokens ).then( results => {
+				const { validValues } = this.state;
+
+				results.forEach( suggestion => {
+					validValues[ suggestion.value ] = suggestion.label;
+				} );
+
+				this.setState( { validValues, loading: false } );
+			} );
+		}
+	}
+
+	/**
 	 * Clean up any unfinished autocomplete api call requests.
 	 */
 	componentWillUnmount() {
@@ -183,7 +203,7 @@ class AutocompleteTokenField extends Component {
 	 * Render.
 	 */
 	render() {
-		const { help, label = '', maxLength } = this.props;
+		const { help, label = '', placeholder = '', maxLength } = this.props;
 		const { suggestions, loading } = this.state;
 
 		return (
@@ -195,6 +215,7 @@ class AutocompleteTokenField extends Component {
 					onInputChange={ input => this.debouncedUpdateSuggestions( input ) }
 					label={ label }
 					maxLength={ maxLength }
+					placeholder={ placeholder }
 				/>
 				{ loading && <Spinner /> }
 				{ help && <p className="newspack-autocomplete-tokenfield__help">{ help }</p> }

--- a/assets/components/src/settings/style.scss
+++ b/assets/components/src/settings/style.scss
@@ -53,11 +53,12 @@
 					width: 100%;
 				}
 				.newspack-autocomplete-tokenfield {
+					display: block;
+					margin: 0;
+
 					label:empty {
 						display: none;
 					}
-					display: block;
-					margin: 0;
 				}
 				.newspack-text-control,
 				.newspack-checkbox-control {

--- a/assets/components/src/settings/style.scss
+++ b/assets/components/src/settings/style.scss
@@ -48,8 +48,16 @@
 						margin: 0;
 					}
 				}
+				.newspack-autocomplete-tokenfield,
 				.newspack-settings__min-max {
 					width: 100%;
+				}
+				.newspack-autocomplete-tokenfield {
+					label:empty {
+						display: none;
+					}
+					display: block;
+					margin: 0;
 				}
 				.newspack-text-control,
 				.newspack-checkbox-control {

--- a/assets/components/src/subscription-lists-control/index.js
+++ b/assets/components/src/subscription-lists-control/index.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import AutocompleteTokenField from '../autocomplete-tokenfield';
+
+export default function SubscriptionListsControl( { label, help, placeholder, value, onChange } ) {
+	return (
+		<AutocompleteTokenField
+			label={ label }
+			help={ help }
+			placeholder={ placeholder }
+			tokens={ value || [] }
+			fetchSuggestions={ async () => {
+				const lists = await apiFetch( {
+					path: '/newspack-newsletters/v1/lists_config',
+				} );
+				return Object.values( lists ).map( item => ( { value: item.id, label: item.title } ) );
+			} }
+			fetchSavedInfo={ async ids => {
+				const lists = await apiFetch( {
+					path: '/newspack-newsletters/v1/lists_config',
+				} );
+				return Object.values( lists )
+					.filter( item => ids.includes( item.id ) )
+					.map( item => ( { value: item.id, label: item.title } ) );
+			} }
+			onChange={ onChange }
+		/>
+	);
+}

--- a/assets/reader-activation/store.js
+++ b/assets/reader-activation/store.js
@@ -217,6 +217,13 @@ export default function Store() {
 		}
 	}
 
+	// Delete items that were deleted on the server.
+	if ( newspack_reader_data?.deleted_items ) {
+		for ( const key of newspack_reader_data.deleted_items ) {
+			config.storage.removeItem( getStoreItemKey( key ) );
+		}
+	}
+
 	return {
 		/**
 		 * Get a value from the store.

--- a/assets/reader-activation/store.js
+++ b/assets/reader-activation/store.js
@@ -217,13 +217,6 @@ export default function Store() {
 		}
 	}
 
-	// Delete items that were deleted on the server.
-	if ( newspack_reader_data?.deleted_items ) {
-		for ( const key of newspack_reader_data.deleted_items ) {
-			config.storage.removeItem( getStoreItemKey( key ) );
-		}
-	}
-
 	return {
 		/**
 		 * Get a value from the store.

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -270,7 +270,7 @@ const getNewsletterSubscriptionLists = memoize( async () => {
 	}
 } );
 
-const NewsletterSubscriptionListsNames = ( { ids } ) => {
+const NewsletterSubscriptionListsNames = ( { label, ids } ) => {
 	const [ lists, setLists ] = useState( [] );
 	useEffect( () => {
 		getNewsletterSubscriptionLists().then( setLists );
@@ -280,7 +280,7 @@ const NewsletterSubscriptionListsNames = ( { ids } ) => {
 	}
 	return (
 		<span>
-			{ __( 'Newsletter Subscribed Lists:', 'newspack' ) }{ ' ' }
+			{ label }{ ' ' }
 			{ lists.length
 				? lists
 						.filter( list => ids.includes( list.id ) )
@@ -295,11 +295,18 @@ addFilter(
 	'newspack.wizards.campaigns.segmentDescription.criteriaMessage',
 	'newspack.newsletterSubscribedLists',
 	( message, value, config, item ) => {
-		if ( 'newsletter_subscribed_lists' === config.id ) {
+		if ( [ 'subscribed_lists', 'not_subscribed_lists' ].includes( config.id ) ) {
 			if ( ! item.value?.length ) {
 				return null;
 			}
-			return <NewsletterSubscriptionListsNames ids={ item.value } />;
+			return (
+				<NewsletterSubscriptionListsNames
+					label={
+						config.id === 'subscribed_lists' ? __( 'Subscribed to:' ) : __( 'Not subscribed to:' )
+					}
+					ids={ item.value }
+				/>
+			);
 		}
 		return message;
 	}

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -287,7 +287,7 @@ addFilter(
 );
 
 /**
- * Adds a custom input for the newsletter_subscribed_lists criteria.
+ * Adds a custom input for the subscribed_lists and not_subscribed_lists criteria.
  */
 addFilter(
 	'newspack.criteria.input',

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -19,6 +19,7 @@ import {
 	TextControl,
 	hooks,
 } from '../../../../components/src';
+import SubscriptionListsControl from '../../../../components/src/subscription-lists-control';
 
 const { useHistory } = Router;
 const { SettingsCard, SettingsSection, MinMaxSetting } = Settings;
@@ -278,6 +279,26 @@ addFilter(
 					} }
 					label={ criteria.name }
 					hideLabelFromVision
+				/>
+			);
+		}
+		return element;
+	}
+);
+
+/**
+ * Adds a custom input for the newsletter_subscribed_lists criteria.
+ */
+addFilter(
+	'newspack.criteria.input',
+	'newspack.newsletterSubscribedLists',
+	function ( element, criteria, value, update ) {
+		if ( criteria.id === 'newsletter_subscribed_lists' ) {
+			return (
+				<SubscriptionListsControl
+					placeholder={ __( 'Start typing to search for lists…', 'newspack-plugin' ) }
+					value={ value }
+					onChange={ update }
 				/>
 			);
 		}

--- a/assets/wizards/popups/views/segments/SingleSegment.js
+++ b/assets/wizards/popups/views/segments/SingleSegment.js
@@ -293,7 +293,7 @@ addFilter(
 	'newspack.criteria.input',
 	'newspack.newsletterSubscribedLists',
 	function ( element, criteria, value, update ) {
-		if ( criteria.id === 'newsletter_subscribed_lists' ) {
+		if ( [ 'subscribed_lists', 'not_subscribed_lists' ].includes( criteria.id ) ) {
 			return (
 				<SubscriptionListsControl
 					placeholder={ __( 'Start typing to search for lists…', 'newspack-plugin' ) }

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -277,6 +277,7 @@ final class Reader_Data {
 	 */
 	public static function update_newsletter_subscribed_lists( $timestamp, $data ) {
 		if ( ! empty( $data['lists'] ) ) {
+			self::update_item( $data['user_id'], 'is_newsletter_subscriber', true );
 			self::update_item( $data['user_id'], 'newsletter_subscribed_lists', wp_json_encode( $data['lists'] ) );
 		}
 		if ( ! empty( $data['lists_added'] ) ) {
@@ -289,6 +290,7 @@ final class Reader_Data {
 			} else {
 				$newsletter_subscribed_lists = $data['lists_added'];
 			}
+			self::update_item( $data['user_id'], 'is_newsletter_subscriber', true );
 			self::update_item( $data['user_id'], 'newsletter_subscribed_lists', wp_json_encode( $newsletter_subscribed_lists ) );
 		}
 		if ( ! empty( $data['lists_removed'] ) ) {
@@ -299,10 +301,9 @@ final class Reader_Data {
 			if ( ! empty( $newsletter_subscribed_lists ) && is_array( $newsletter_subscribed_lists ) ) {
 				$newsletter_subscribed_lists = array_diff( $newsletter_subscribed_lists, $data['lists_removed'] );
 			}
+			self::update_item( $data['user_id'], 'is_newsletter_subscriber', ! empty( $newsletter_subscribed_lists ) );
 			self::update_item( $data['user_id'], 'newsletter_subscribed_lists', wp_json_encode( $newsletter_subscribed_lists ) );
 		}
-		// Deprecate 'is_newsletter_subscriber' item.
-		self::delete_item( $data['user_id'], 'is_newsletter_subscriber' );
 	}
 
 	/**
@@ -386,6 +387,7 @@ final class Reader_Data {
 		}
 		$subscribed_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $data['email'] );
 		if ( ! is_wp_error( $subscribed_lists ) && is_array( $subscribed_lists ) ) {
+			self::update_item( $data['user_id'], 'is_newsletter_subscriber', ! empty( $subscribed_lists ) );
 			self::update_item( $data['user_id'], 'newsletter_subscribed_lists', wp_json_encode( $subscribed_lists ) );
 		}
 	}

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -25,13 +25,6 @@ final class Reader_Data {
 	private static $reader_activity = [];
 
 	/**
-	 * List of deleted items to send to the front-end.
-	 *
-	 * @var string[]
-	 */
-	private static $deleted_items = [];
-
-	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -75,10 +68,9 @@ final class Reader_Data {
 		];
 
 		if ( \is_user_logged_in() ) {
-			$config['api_url']       = \get_rest_url( null, NEWSPACK_API_NAMESPACE . '/reader-data' );
-			$config['nonce']         = \wp_create_nonce( 'wp_rest' );
-			$config['items']         = self::get_data( \get_current_user_id() );
-			$config['deleted_items'] = self::$deleted_items;
+			$config['api_url'] = \get_rest_url( null, NEWSPACK_API_NAMESPACE . '/reader-data' );
+			$config['nonce']   = \wp_create_nonce( 'wp_rest' );
+			$config['items']   = self::get_data( \get_current_user_id() );
 		}
 
 		wp_localize_script( Reader_Activation::SCRIPT_HANDLE, 'newspack_reader_data', $config );
@@ -223,9 +215,6 @@ final class Reader_Data {
 			\update_user_meta( $user_id, 'newspack_reader_data_keys', $user_keys );
 		}
 		\delete_user_meta( $user_id, self::get_meta_key_name( $key ) );
-		if ( get_current_user_id() === $user_id ) {
-			self::$deleted_items[] = $key;
-		}
 		return true;
 	}
 

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -33,8 +33,8 @@ final class Reader_Data {
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'config_script' ] );
 
 		/* Update reader data items on event dispatches */
-		add_action( 'newspack_data_event_dispatch_newsletter_subscribed', [ __CLASS__, 'set_is_newsletter_subscriber' ], 10, 2 );
-		add_action( 'newspack_data_event_dispatch_newsletter_updated', [ __CLASS__, 'set_is_newsletter_subscriber' ], 10, 2 );
+		add_action( 'newspack_data_event_dispatch_newsletter_subscribed', [ __CLASS__, 'update_newsletter_subscribed_lists' ], 10, 2 );
+		add_action( 'newspack_data_event_dispatch_newsletter_updated', [ __CLASS__, 'update_newsletter_subscribed_lists' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_new', [ __CLASS__, 'set_is_donor' ], 10, 2 );
 		add_action( 'newspack_data_event_dispatch_donation_subscription_cancelled', [ __CLASS__, 'set_is_former_donor' ], 10, 2 );
 
@@ -264,8 +264,7 @@ final class Reader_Data {
 	 * @param int   $timestamp Timestamp.
 	 * @param array $data      Data.
 	 */
-	public static function set_is_newsletter_subscriber( $timestamp, $data ) {
-		self::update_item( $data['user_id'], 'is_newsletter_subscriber', true );
+	public static function update_newsletter_subscribed_lists( $timestamp, $data ) {
 		if ( ! empty( $data['lists'] ) ) {
 			self::update_item( $data['user_id'], 'newsletter_subscribed_lists', wp_json_encode( $data['lists'] ) );
 		}
@@ -291,6 +290,8 @@ final class Reader_Data {
 			}
 			self::update_item( $data['user_id'], 'newsletter_subscribed_lists', wp_json_encode( $newsletter_subscribed_lists ) );
 		}
+		// Deprecate 'is_newsletter_subscriber' item.
+		self::delete_item( $data['user_id'], 'is_newsletter_subscriber' );
 	}
 
 	/**
@@ -374,7 +375,6 @@ final class Reader_Data {
 		}
 		$subscribed_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $data['email'] );
 		if ( ! is_wp_error( $subscribed_lists ) && is_array( $subscribed_lists ) ) {
-			self::update_item( $data['user_id'], 'is_newsletter_subscriber', ! empty( $subscribed_lists ) );
 			self::update_item( $data['user_id'], 'newsletter_subscribed_lists', wp_json_encode( $subscribed_lists ) );
 		}
 	}

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -369,17 +369,12 @@ final class Reader_Data {
 		if ( empty( $data['user_id'] ) || empty( $data['email'] ) ) {
 			return;
 		}
-		$is_newsletter_subscriber = self::get_data( $data['user_id'], 'is_newsletter_subscriber' );
-		if ( ! empty( $is_newsletter_subscriber ) && gettype( $is_newsletter_subscriber ) === 'string' ) {
-			$is_newsletter_subscriber = json_decode( $is_newsletter_subscriber );
-		}
-		// Check if the user is subscribed to a newsletter.
 		if ( ! class_exists( '\Newspack_Newsletters' ) || ! class_exists( '\Newspack_Newsletters_Subscription' ) ) {
 			return;
 		}
 		$subscribed_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $data['email'] );
-		if ( ! is_wp_error( $subscribed_lists ) && ! empty( $subscribed_lists ) && is_array( $subscribed_lists ) ) {
-			self::update_item( $data['user_id'], 'is_newsletter_subscriber', true );
+		if ( ! is_wp_error( $subscribed_lists ) && is_array( $subscribed_lists ) ) {
+			self::update_item( $data['user_id'], 'is_newsletter_subscriber', ! empty( $subscribed_lists ) );
 			self::update_item( $data['user_id'], 'newsletter_subscribed_lists', wp_json_encode( $subscribed_lists ) );
 		}
 	}

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -25,6 +25,13 @@ final class Reader_Data {
 	private static $reader_activity = [];
 
 	/**
+	 * List of deleted items to send to the front-end.
+	 *
+	 * @var string[]
+	 */
+	private static $deleted_items = [];
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -68,9 +75,10 @@ final class Reader_Data {
 		];
 
 		if ( \is_user_logged_in() ) {
-			$config['api_url'] = \get_rest_url( null, NEWSPACK_API_NAMESPACE . '/reader-data' );
-			$config['nonce']   = \wp_create_nonce( 'wp_rest' );
-			$config['items']   = self::get_data( \get_current_user_id() );
+			$config['api_url']       = \get_rest_url( null, NEWSPACK_API_NAMESPACE . '/reader-data' );
+			$config['nonce']         = \wp_create_nonce( 'wp_rest' );
+			$config['items']         = self::get_data( \get_current_user_id() );
+			$config['deleted_items'] = self::$deleted_items;
 		}
 
 		wp_localize_script( Reader_Activation::SCRIPT_HANDLE, 'newspack_reader_data', $config );
@@ -215,6 +223,7 @@ final class Reader_Data {
 			\update_user_meta( $user_id, 'newspack_reader_data_keys', $user_keys );
 		}
 		\delete_user_meta( $user_id, self::get_meta_key_name( $key ) );
+		self::$deleted_items[] = $key;
 		return true;
 	}
 

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -223,7 +223,9 @@ final class Reader_Data {
 			\update_user_meta( $user_id, 'newspack_reader_data_keys', $user_keys );
 		}
 		\delete_user_meta( $user_id, self::get_meta_key_name( $key ) );
-		self::$deleted_items[] = $key;
+		if ( get_current_user_id() === $user_id ) {
+			self::$deleted_items[] = $key;
+		}
 		return true;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes required for https://github.com/Automattic/newspack-popups/pull/1218:

 - Implements a new `newsletter_subscribed_lists` store data item
 - Adds the necessary changes to the campaigns' wizard to support the new criteria
 - Creates a `SubscriptionListsControl` component to select newsletter subscription lists from the API using the `AutocompleteTokenField` component

### How to test the changes in this Pull Request:

1. Follow instructions at https://github.com/Automattic/newspack-popups/pull/1218
2. Make sure the `newsletter_subscribed_lists` data item updates on different occasions:
    1. subscribe a fresh account and confirm the selected lists are stored
    2. unsubscribe to a list from "My Account -> Newsletters" and confirm it updates the item
    3. subscribe to another list from "My Account -> Newsletters" and confirm it updates the item

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->