### PR TITLE
feat(woocommerce): add UTM parameters as order meta

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -39,6 +39,8 @@ class WooCommerce_Connection {
 	 * @codeCoverageIgnore
 	 */
 	public static function init() {
+		include_once __DIR__ . '/class-woocommerce-order-utm.php';
+
 		\add_action( 'admin_init', [ __CLASS__, 'disable_woocommerce_setup' ] );
 		\add_filter( 'option_woocommerce_subscriptions_allow_switching_nyp_price', [ __CLASS__, 'force_allow_switching_subscription_amount' ] );
 		\add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'send_customizable_receipt_email' ], 10, 3 );
@@ -169,9 +171,9 @@ class WooCommerce_Connection {
 
 	/**
 	 * Get the contact data from a WooCommerce customer user account.
-	 * 
+	 *
 	 * @param \WC_Customer|int $customer Customer or customer ID.
-	 * 
+	 *
 	 * @return array|false Contact data or false.
 	 */
 	public static function get_contact_from_customer( $customer ) {
@@ -180,7 +182,7 @@ class WooCommerce_Connection {
 		}
 
 		$metadata = [];
-		
+
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'account' ) ]           = $customer->get_id();
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_date' ) ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-order-utm.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-order-utm.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Add UTM parameters to WooCommerce orders.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Order UTM class.
+ */
+class WooCommerce_Order_UTM {
+
+	/**
+	 * UTM parameters.
+	 *
+	 * @var string[]
+	 */
+	private static $params = [
+		'source',
+		'medium',
+		'campaign',
+		'term',
+		'content',
+	];
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'woocommerce_checkout_after_customer_details', [ __CLASS__, 'render_utm_inputs' ] );
+		add_action( 'woocommerce_new_order', [ __CLASS__, 'set_utm_to_order' ] );
+		add_action( 'woocommerce_admin_order_data_after_billing_address', [ __CLASS__, 'display_utm_parameters' ] );
+	}
+
+	/**
+	 * Render UTM parameters as checkout form inputs.
+	 */
+	public static function render_utm_inputs() {
+		foreach ( self::$params as $param ) {
+			$query_arg = 'utm_' . $param;
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			if ( ! empty( $_GET[ $query_arg ] ) ) {
+				?>
+				<input type="hidden" name="<?php echo esc_attr( $query_arg ); ?>" value="<?php echo esc_attr( sanitize_text_field( wp_unslash( $_GET[ $query_arg ] ) ) ); ?>" />
+				<?php
+			}
+			// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		}
+	}
+
+	/**
+	 * Add UTM to order.
+	 *
+	 * @param int $order_id Order ID.
+	 *
+	 * @return void
+	 */
+	public static function set_utm_to_order( $order_id ) {
+		$order = wc_get_order( $order_id );
+		$utm   = self::get_utm();
+		if ( ! empty( $utm ) ) {
+			$order->update_meta_data( 'utm', $utm );
+			$order->save();
+		}
+	}
+
+	/**
+	 * Get UTM parameters.
+	 */
+	private static function get_utm() {
+		$utm = [];
+		foreach ( self::$params as $param ) {
+			$query_arg = 'utm_' . $param;
+			if ( ! empty( $_REQUEST[ $query_arg ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$utm[ $param ] = sanitize_text_field( wp_unslash( $_REQUEST[ $query_arg ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			}
+		}
+		return $utm;
+	}
+
+	/**
+	 * Display UTM parameters in order details.
+	 *
+	 * @param \WC_Order $order Order object.
+	 */
+	public static function display_utm_parameters( $order ) {
+		$utm = $order->get_meta( 'utm' );
+		if ( empty( $utm ) ) {
+			return;
+		}
+		echo '<h3>' . esc_html__( 'UTM Parameters', 'newspack-plugin' ) . '</h3>';
+		foreach ( $utm as $key => $value ) {
+			echo '<p><strong>' . esc_html( ucfirst( $key ) ) . ':</strong> ' . esc_html( $value ) . '</p>';
+		}
+	}
+}
+WooCommerce_Order_UTM::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds UTM parameters as order meta and render in the order details:

<img width="682" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/d2809488-c6e5-412d-86f8-ef29ec0d7b14">

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/1540
2. Visit a page that contains a Donate block with these parameters: `?utm_source=new+subscribers&utm_medium=email&utm_campaign=black+friday+sale&utm_content=first+cta+button&utm_term=test`
3. Make a donation and visit the order details at WooCommerce -> Orders
4. Confirm the UTM parameters are displayed like in the image above
5. Repeat the steps above but with a page that has a Checkout Button block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->