### PR TITLE
fix: remove honeypot field if using reCAPTCHA

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -949,10 +949,16 @@ final class Reader_Activation {
 	 * Render a honeypot field to guard against bot form submissions. Note that
 	 * this field is named `email` to hopefully catch more bots who might be
 	 * looking for such fields, where as the "real" field is named "npe".
+	 * 
+	 * Not rendered if reCAPTCHA is enabled as it's a superior spam protection.
 	 *
 	 * @param string $placeholder Placeholder text to render in the field.
 	 */
 	public static function render_honeypot_field( $placeholder = '' ) {
+		if ( Recaptcha::can_use_captcha() ) {
+			return;
+		}
+
 		if ( empty( $placeholder ) ) {
 			$placeholder = __( 'Enter your email address', 'newspack-plugin' );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We've seen reports from readers that the honeypot field sometimes gets autofilled by Chrome's built-in password manager, despite the `autocomplete="off"` attribute. (Probably because Chrome [intentionally ignores this attribute](https://adamsilver.io/blog/stopping-chrome-from-ignoring-autocomplete-off/)). There's not much we can do to prevent this frustrating behavior, but since the honeypot is kind of redundant/unnecessary if protecting forms with reCAPTCHA, this PR proposes we only render the honeypot if reCAPTCHA is not on, as a sort of fallback security measure. Since most Newspack sites enable reCAPTCHA to protect their form inputs, this should sidestep the autocomplete issue for most readers.

See also https://github.com/Automattic/newspack-newsletters/pull/1301

### How to test the changes in this Pull Request:

1. Check out this branch.
2. With reCAPTCHA enabled in the Connections wizard, view the site on the front-end. Confirm that the Registration and auth modal forms don't contain a honeypot input field (with `name="email"` and `class="nphp"`). Confirm you can still register/login without error.
3. Disable reCAPTCHA in Connections and confirm that the Registration block and auth modal forms do render the honeypot field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->