### PR TITLE
fix(perfmatters): handling false values when applying defaults

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -246,6 +246,14 @@ class Perfmatters {
 
 		// Ensure our defaults remain the default, but can be overwritten.
 		if ( defined( 'NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS' ) && NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS ) {
+
+			// Ensure all keys from $defaults are present in $options.
+			// The $options will not contain keys set to false, so these would be otherwise overwritten by
+			// the array_merge call.
+			foreach ( array_keys( $defaults ) as $key ) {
+				$options[ $key ] = $options[ $key ] ?? false;
+			}
+
 			return array_merge( $defaults, $options );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with applying Perfmatters' defaults.

Closes 1200550061930446-as-1205578729475972

### How to test the changes in this Pull Request:

1. On `master`,
1. Start afresh by removing the `perfmatters_options` option
2. Ensure the `NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS` env. variable is **not** set
3. Visit the Perfmatters settings, observe the defaults are applied
4. Update one of the toggled off options (e.g. "Disable Embeds") to make sure the options are saved to the DB
5. Now set the `NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS` env. variable to `true`
6. Update the one of the _toggled on_ options (e.g. "Disable Emojis")
7. Observe the option can't be toggled off!
8. Switch to this branch, try to disable the toggled on option again, observe it now can be toggled off

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->