### PR TITLE
fix(ads): stick to top toggle

### DIFF
--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -210,7 +210,7 @@ const Placements = () => {
 							checked={ !! placement.data?.stick_to_top }
 							onChange={ value => {
 								setPlacements(
-									set( [ editingPlacement, 'data', 'stick_to_top' ], value, placements )
+									set( { ...placements }, [ editingPlacement, 'data', 'stick_to_top' ], value )
 								);
 							} }
 						/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the "Stick to top" toggle when editing the "Sidebar" ad placement.

#2578 [accidentally removed](https://github.com/Automattic/newspack-plugin/pull/2578/files#diff-47fb0b82e6a1f192e1bddc4a8c5402e2d94367b906c71cc7b0422ecfae456b13) the `set()` we were using (from fp to the regular `set()`). This fix changes to no longer use the fp approach.

### How to test the changes in this Pull Request:

1. While on the `release` branch, visit Newspack -> Advertising -> Placements
2. Enable and edit the Sidebar placement and toggle "Stick to top"
3. Confirm the placement data breaks and the UI appears broken
4. Check out this branch, refresh the page, and try again
5. Confirm you are able to toggle and save the setting

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->