### PR TITLE
Feat/design settings improvements

### DIFF
--- a/assets/wizards/site-design/index.js
+++ b/assets/wizards/site-design/index.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { withWizard } from '../../components/src';
+import { withWizard, utils } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
 import { ThemeSettings, Main } from './views';
 
@@ -36,6 +36,24 @@ class SiteDesignWizard extends Component {
 	updateThemeMods = () => {
 		const { setError, wizardApiFetch } = this.props;
 		const { themeMods } = this.state;
+
+		// Warn user before overwriting existing posts.
+		if (
+			themeMods.featured_image_all_posts !== 'none' ||
+			themeMods.post_template_all_posts !== 'none'
+		) {
+			if (
+				! utils.confirmAction(
+					__(
+						'Saving will overwrite existing posts, this cannot be undone. Are you sure you want to proceed?',
+						'newspack'
+					)
+				)
+			) {
+				return;
+			}
+		}
+
 		const params = {
 			path: '/newspack/v1/wizard/newspack-setup-wizard/theme/',
 			method: 'POST',

--- a/assets/wizards/site-design/index.js
+++ b/assets/wizards/site-design/index.js
@@ -26,7 +26,9 @@ class SiteDesignWizard extends Component {
 			method: 'GET',
 		};
 		wizardApiFetch( params )
-			.then( response => this.setState( { themeSettings: response.theme_mods } ) )
+			.then( response =>
+				this.setState( { themeSettings: { ...response.theme_mods, ...response.etc } } )
+			)
 			.catch( setError );
 	};
 

--- a/assets/wizards/site-design/index.js
+++ b/assets/wizards/site-design/index.js
@@ -26,27 +26,27 @@ class SiteDesignWizard extends Component {
 			method: 'GET',
 		};
 		wizardApiFetch( params )
-			.then( response => this.setState( { themeMods: response.theme_mods } ) )
+			.then( response => this.setState( { themeSettings: response.theme_mods } ) )
 			.catch( setError );
 	};
 
 	setThemeMods = themeModUpdates =>
-		this.setState( { themeMods: { ...this.state.themeMods, ...themeModUpdates } } );
+		this.setState( { themeSettings: { ...this.state.themeSettings, ...themeModUpdates } } );
 
 	updateThemeMods = () => {
 		const { setError, wizardApiFetch } = this.props;
-		const { themeMods } = this.state;
+		const { themeSettings } = this.state;
 
 		// Warn user before overwriting existing posts.
 		if (
-			themeMods.featured_image_all_posts !== 'none' ||
-			themeMods.post_template_all_posts !== 'none'
+			themeSettings.featured_image_all_posts !== 'none' ||
+			themeSettings.post_template_all_posts !== 'none'
 		) {
 			if (
 				! utils.confirmAction(
 					__(
 						'Saving will overwrite existing posts, this cannot be undone. Are you sure you want to proceed?',
-						'newspack'
+						'newspack-plugin'
 					)
 				)
 			) {
@@ -57,13 +57,13 @@ class SiteDesignWizard extends Component {
 		const params = {
 			path: '/newspack/v1/wizard/newspack-setup-wizard/theme/',
 			method: 'POST',
-			data: { theme_mods: themeMods },
+			data: { theme_mods: themeSettings },
 			quiet: true,
 		};
 		wizardApiFetch( params )
 			.then( response => {
 				const { theme, theme_mods } = response;
-				this.setState( { theme, themeMods: theme_mods } );
+				this.setState( { theme, themeSettings: theme_mods } );
 			} )
 			.catch( error => {
 				console.log( '[Theme Update Error]', error );
@@ -101,8 +101,11 @@ class SiteDesignWizard extends Component {
 							render={ () => {
 								return (
 									<Main
-										headerText={ __( 'Site Design', 'newspack' ) }
-										subHeaderText={ __( 'Customize the look and feel of your site', 'newspack' ) }
+										headerText={ __( 'Site Design', 'newspack-plugin' ) }
+										subHeaderText={ __(
+											'Customize the look and feel of your site',
+											'newspack-plugin'
+										) }
 										tabbedNavigation={ tabbedNavigation }
 										wizardApiFetch={ wizardApiFetch }
 										setError={ setError }
@@ -115,17 +118,17 @@ class SiteDesignWizard extends Component {
 							path="/settings"
 							exact
 							render={ () => {
-								const { themeMods } = this.state;
+								const { themeSettings } = this.state;
 								return (
 									<ThemeSettings
-										headerText={ __( 'Site Design', 'newspack' ) }
-										subHeaderText={ __( 'Configure your Newspack theme', 'newspack' ) }
+										headerText={ __( 'Site Design', 'newspack-plugin' ) }
+										subHeaderText={ __( 'Configure your Newspack theme', 'newspack-plugin' ) }
 										tabbedNavigation={ tabbedNavigation }
-										themeMods={ themeMods }
+										themeSettings={ themeSettings }
 										setThemeMods={ this.setThemeMods }
-										buttonText={ __( 'Save', 'newspack' ) }
+										buttonText={ __( 'Save', 'newspack-plugin' ) }
 										buttonAction={ this.updateThemeMods }
-										secondaryButtonText={ __( 'Advanced Settings', 'newspack' ) }
+										secondaryButtonText={ __( 'Advanced Settings', 'newspack-plugin' ) }
 										secondaryButtonAction="/wp-admin/customize.php"
 									/>
 								);

--- a/assets/wizards/site-design/index.js
+++ b/assets/wizards/site-design/index.js
@@ -33,7 +33,7 @@ class SiteDesignWizard extends Component {
 	setThemeMods = themeModUpdates =>
 		this.setState( { themeSettings: { ...this.state.themeSettings, ...themeModUpdates } } );
 
-	updateThemeMods = () => {
+	updateThemeSettings = () => {
 		const { setError, wizardApiFetch } = this.props;
 		const { themeSettings } = this.state;
 
@@ -127,7 +127,7 @@ class SiteDesignWizard extends Component {
 										themeSettings={ themeSettings }
 										setThemeMods={ this.setThemeMods }
 										buttonText={ __( 'Save', 'newspack-plugin' ) }
-										buttonAction={ this.updateThemeMods }
+										buttonAction={ this.updateThemeSettings }
 										secondaryButtonText={ __( 'Advanced Settings', 'newspack-plugin' ) }
 										secondaryButtonAction="/wp-admin/customize.php"
 									/>

--- a/assets/wizards/site-design/index.js
+++ b/assets/wizards/site-design/index.js
@@ -41,8 +41,9 @@ class SiteDesignWizard extends Component {
 
 		// Warn user before overwriting existing posts.
 		if (
-			themeSettings.featured_image_all_posts !== 'none' ||
-			themeSettings.post_template_all_posts !== 'none'
+			( themeSettings.featured_image_all_posts &&
+				themeSettings.featured_image_all_posts !== 'none' ) ||
+			( themeSettings.post_template_all_posts && themeSettings.post_template_all_posts !== 'none' )
 		) {
 			if (
 				! utils.confirmAction(

--- a/assets/wizards/site-design/views/theme-settings/index.js
+++ b/assets/wizards/site-design/views/theme-settings/index.js
@@ -22,7 +22,7 @@ import './style.scss';
  */
 const ThemeSettings = props => {
 	const [ imageThumbnail, setImageThumbnail ] = useState( null );
-	const { themeMods, setThemeMods } = props;
+	const { themeSettings, setThemeMods } = props;
 
 	const {
 		show_author_bio: authorBio = true,
@@ -35,7 +35,7 @@ const ThemeSettings = props => {
 		newspack_image_credits_placeholder_url: imageCreditsPlaceholderUrl,
 		newspack_image_credits_class_name: imageCreditsClassName = '',
 		newspack_image_credits_prefix_label: imageCreditsPrefix = '',
-	} = themeMods;
+	} = themeSettings;
 
 	useEffect( () => {
 		if ( imageCreditsPlaceholderUrl ) {
@@ -46,21 +46,24 @@ const ThemeSettings = props => {
 	return (
 		<Fragment>
 			<SectionHeader
-				title={ __( 'Author Bio', 'newspack' ) }
-				description={ __( 'Control how author bios are displayed on posts.', 'newspack' ) }
+				title={ __( 'Author Bio', 'newspack-plugin' ) }
+				description={ __( 'Control how author bios are displayed on posts.', 'newspack-plugin' ) }
 			/>
 			<Grid gutter={ 32 }>
 				<Grid columns={ 1 } gutter={ 16 }>
 					<ToggleControl
-						label={ __( 'Author Bio', 'newspack' ) }
-						help={ __( 'Display an author bio under individual posts.', 'newspack' ) }
+						label={ __( 'Author Bio', 'newspack-plugin' ) }
+						help={ __( 'Display an author bio under individual posts.', 'newspack-plugin' ) }
 						checked={ authorBio }
 						onChange={ value => setThemeMods( { show_author_bio: value } ) }
 					/>
 					{ authorBio && (
 						<ToggleControl
-							label={ __( 'Author Email', 'newspack' ) }
-							help={ __( 'Display the author email with bio on individual posts.', 'newspack' ) }
+							label={ __( 'Author Email', 'newspack-plugin' ) }
+							help={ __(
+								'Display the author email with bio on individual posts.',
+								'newspack-plugin'
+							) }
 							checked={ authorEmail }
 							onChange={ value => setThemeMods( { show_author_email: value } ) }
 						/>
@@ -69,10 +72,10 @@ const ThemeSettings = props => {
 				<Grid columns={ 1 } gutter={ 16 }>
 					{ authorBio && (
 						<TextControl
-							label={ __( 'Length', 'newspack' ) }
+							label={ __( 'Length', 'newspack-plugin' ) }
 							help={ __(
 								'Truncates the author bio on single posts to this approximate character length, but without breaking a word. The full bio appears on the author archive page.',
-								'newspack'
+								'newspack-plugin'
 							) }
 							type="number"
 							value={ authorBioLength }
@@ -83,58 +86,58 @@ const ThemeSettings = props => {
 			</Grid>
 
 			<SectionHeader
-				title={ __( 'Default Featured Image Position And Post Template', 'newspack' ) }
+				title={ __( 'Default Featured Image Position And Post Template', 'newspack-plugin' ) }
 				description={ __(
 					'Modify how the featured image and post template settings are applied to new posts.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			/>
 			<Grid gutter={ 32 }>
 				<SelectControl
-					label={ __( 'Default featured image position for new posts', 'newspack' ) }
-					help={ __( 'Set a default featured image position for new posts.', 'newspack' ) }
+					label={ __( 'Default featured image position for new posts', 'newspack-plugin' ) }
+					help={ __( 'Set a default featured image position for new posts.', 'newspack-plugin' ) }
 					value={ featuredImageDefault }
 					options={ [
-						{ label: __( 'Large', 'newspack' ), value: 'large' },
-						{ label: __( 'Small', 'newspack' ), value: 'small' },
-						{ label: __( 'Behind article title', 'newspack' ), value: 'behind' },
-						{ label: __( 'Beside article title', 'newspack' ), value: 'beside' },
-						{ label: __( 'Hidden', 'newspack' ), value: 'hidden' },
+						{ label: __( 'Large', 'newspack-plugin' ), value: 'large' },
+						{ label: __( 'Small', 'newspack-plugin' ), value: 'small' },
+						{ label: __( 'Behind article title', 'newspack-plugin' ), value: 'behind' },
+						{ label: __( 'Beside article title', 'newspack-plugin' ), value: 'beside' },
+						{ label: __( 'Hidden', 'newspack-plugin' ), value: 'hidden' },
 					] }
 					onChange={ value => setThemeMods( { featured_image_default: value } ) }
 				/>
 				<SelectControl
-					label={ __( 'Default template for new posts', 'newspack' ) }
-					help={ __( 'Set a default template for new posts.', 'newspack' ) }
+					label={ __( 'Default template for new posts', 'newspack-plugin' ) }
+					help={ __( 'Set a default template for new posts.', 'newspack-plugin' ) }
 					value={ postTemplateDefault }
 					options={ [
-						{ label: __( 'Default', 'newspack' ), value: 'default' },
-						{ label: __( 'One Column', 'newspack' ), value: 'single-feature.php' },
-						{ label: __( 'One Column Wide', 'newspack' ), value: 'single-wide.php' },
+						{ label: __( 'Default', 'newspack-plugin' ), value: 'default' },
+						{ label: __( 'One Column', 'newspack-plugin' ), value: 'single-feature.php' },
+						{ label: __( 'One Column Wide', 'newspack-plugin' ), value: 'single-wide.php' },
 					] }
 					onChange={ value => setThemeMods( { post_template_default: value } ) }
 				/>
 			</Grid>
 			<SectionHeader
-				title={ __( 'Featured Image Position And Post Template For All Posts', 'newspack' ) }
+				title={ __( 'Featured Image Position And Post Template For All Posts', 'newspack-plugin' ) }
 				description={ __(
 					'Modify how the featured image and post template settings are applied to existing posts. Warning: saving these options will override all posts.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			/>
 			<Grid gutter={ 32 }>
 				<div>
 					<SelectControl
-						label={ __( 'Featured image position for all posts', 'newspack' ) }
-						help={ __( 'Set a featured image position for all posts.', 'newspack' ) }
+						label={ __( 'Featured image position for all posts', 'newspack-plugin' ) }
+						help={ __( 'Set a featured image position for all posts.', 'newspack-plugin' ) }
 						value={ featuredImageAllPosts }
 						options={ [
-							{ label: __( 'Select to change all posts', 'newspack' ), value: 'none' },
-							{ label: __( 'Large', 'newspack' ), value: 'large' },
-							{ label: __( 'Small', 'newspack' ), value: 'small' },
-							{ label: __( 'Behind article title', 'newspack' ), value: 'behind' },
-							{ label: __( 'Beside article title', 'newspack' ), value: 'beside' },
-							{ label: __( 'Hidden', 'newspack' ), value: 'hidden' },
+							{ label: __( 'Select to change all posts', 'newspack-plugin' ), value: 'none' },
+							{ label: __( 'Large', 'newspack-plugin' ), value: 'large' },
+							{ label: __( 'Small', 'newspack-plugin' ), value: 'small' },
+							{ label: __( 'Behind article title', 'newspack-plugin' ), value: 'behind' },
+							{ label: __( 'Beside article title', 'newspack-plugin' ), value: 'beside' },
+							{ label: __( 'Hidden', 'newspack-plugin' ), value: 'hidden' },
 						] }
 						onChange={ value => setThemeMods( { featured_image_all_posts: value } ) }
 					/>
@@ -150,14 +153,14 @@ const ThemeSettings = props => {
 
 				<div>
 					<SelectControl
-						label={ __( 'Template for all posts', 'newspack' ) }
-						help={ __( 'Set a template for all posts.', 'newspack' ) }
+						label={ __( 'Template for all posts', 'newspack-plugin' ) }
+						help={ __( 'Set a template for all posts.', 'newspack-plugin' ) }
 						value={ postTemplateAllPosts }
 						options={ [
-							{ label: __( 'Select to change all posts', 'newspack' ), value: 'none' },
-							{ label: __( 'Default', 'newspack' ), value: 'default' },
-							{ label: __( 'One Column', 'newspack' ), value: 'single-feature.php' },
-							{ label: __( 'One Column Wide', 'newspack' ), value: 'single-wide.php' },
+							{ label: __( 'Select to change all posts', 'newspack-plugin' ), value: 'none' },
+							{ label: __( 'Default', 'newspack-plugin' ), value: 'default' },
+							{ label: __( 'One Column', 'newspack-plugin' ), value: 'single-feature.php' },
+							{ label: __( 'One Column Wide', 'newspack-plugin' ), value: 'single-wide.php' },
 						] }
 						onChange={ value => setThemeMods( { post_template_all_posts: value } ) }
 					/>
@@ -173,28 +176,28 @@ const ThemeSettings = props => {
 			</Grid>
 
 			<SectionHeader
-				title={ __( 'Media Credits', 'newspack' ) }
+				title={ __( 'Media Credits', 'newspack-plugin' ) }
 				description={ __(
 					'Control how credits are displayed alongside media attachments.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			/>
 			<Grid gutter={ 32 }>
 				<Grid columns={ 1 } gutter={ 16 }>
 					<TextControl
-						label={ __( 'Credit Class Name', 'newspack' ) }
+						label={ __( 'Credit Class Name', 'newspack-plugin' ) }
 						help={ __(
 							'A CSS class name to be applied to all image credit elements. Leave blank to display no class name.',
-							'newspack'
+							'newspack-plugin'
 						) }
 						value={ imageCreditsClassName }
 						onChange={ value => setThemeMods( { newspack_image_credits_class_name: value } ) }
 					/>
 					<TextControl
-						label={ __( 'Credit Label', 'newspack' ) }
+						label={ __( 'Credit Label', 'newspack-plugin' ) }
 						help={ __(
 							'A label to prefix all media credits. Leave blank to display no prefix.',
-							'newspack'
+							'newspack-plugin'
 						) }
 						value={ imageCreditsPrefix }
 						onChange={ value => setThemeMods( { newspack_image_credits_prefix_label: value } ) }
@@ -203,15 +206,15 @@ const ThemeSettings = props => {
 				<Grid columns={ 1 } gutter={ 16 }>
 					<ImageUpload
 						image={ imageThumbnail ? { url: imageThumbnail } : null }
-						label={ __( 'Placeholder Image', 'newspack' ) }
-						buttonLabel={ __( 'Select', 'newspack' ) }
+						label={ __( 'Placeholder Image', 'newspack-plugin' ) }
+						buttonLabel={ __( 'Select', 'newspack-plugin' ) }
 						onChange={ image => {
 							setImageThumbnail( image?.url || null );
 							setThemeMods( { newspack_image_credits_placeholder: image?.id || null } );
 						} }
 						help={ __(
 							'A placeholder image to be displayed in place of images without credits. If none is chosen, the image will be displayed normally whether or not it has a credit.',
-							'newspack'
+							'newspack-plugin'
 						) }
 					/>
 				</Grid>
@@ -221,7 +224,7 @@ const ThemeSettings = props => {
 };
 
 ThemeSettings.defaultProps = {
-	themeMods: {},
+	themeSettings: {},
 	setThemeMods: () => null,
 };
 

--- a/assets/wizards/site-design/views/theme-settings/index.js
+++ b/assets/wizards/site-design/views/theme-settings/index.js
@@ -111,7 +111,7 @@ const ThemeSettings = props => {
 					help={ __( 'Set a default template for new posts.', 'newspack-plugin' ) }
 					value={ postTemplateDefault }
 					options={ [
-						{ label: __( 'Default', 'newspack-plugin' ), value: 'default' },
+						{ label: __( 'With sidebar', 'newspack-plugin' ), value: 'default' },
 						{ label: __( 'One Column', 'newspack-plugin' ), value: 'single-feature.php' },
 						{ label: __( 'One Column Wide', 'newspack-plugin' ), value: 'single-wide.php' },
 					] }
@@ -158,7 +158,7 @@ const ThemeSettings = props => {
 						value={ postTemplateAllPosts }
 						options={ [
 							{ label: __( 'Select to change all posts', 'newspack-plugin' ), value: 'none' },
-							{ label: __( 'Default', 'newspack-plugin' ), value: 'default' },
+							{ label: __( 'With sidebar', 'newspack-plugin' ), value: 'default' },
 							{ label: __( 'One Column', 'newspack-plugin' ), value: 'single-feature.php' },
 							{ label: __( 'One Column Wide', 'newspack-plugin' ), value: 'single-wide.php' },
 						] }

--- a/assets/wizards/site-design/views/theme-settings/index.js
+++ b/assets/wizards/site-design/views/theme-settings/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Fragment, useEffect, useState } from '@wordpress/element';
-import { RadioControl, ToggleControl } from '@wordpress/components';
+import { SelectControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -28,7 +28,8 @@ const ThemeSettings = props => {
 		show_author_bio: authorBio = true,
 		show_author_email: authorEmail = false,
 		author_bio_length: authorBioLength = 200,
-		featured_image_default: featuredImageDefault,
+		featured_image_default: featuredImageDefault = 'large',
+		post_template_default: postTemplateDefault = 'default',
 		newspack_image_credits_placeholder_url: imageCreditsPlaceholderUrl,
 		newspack_image_credits_class_name: imageCreditsClassName = '',
 		newspack_image_credits_prefix_label: imageCreditsPrefix = '',
@@ -80,22 +81,38 @@ const ThemeSettings = props => {
 			</Grid>
 
 			<SectionHeader
-				title={ __( 'Featured Image', 'newspack' ) }
-				description={ __( 'Set a default featured image position for new posts.', 'newspack' ) }
+				title={ __( 'Default Featured Image Position And Post Template', 'newspack' ) }
+				description={ __(
+					'Modify how the featured image and post template settings are applied to new posts.',
+					'newspack'
+				) }
 			/>
-			<RadioControl
-				label={ __( 'Default Position', 'newspack' ) }
-				hideLabelFromVision
-				selected={ featuredImageDefault || 'large' }
-				options={ [
-					{ label: __( 'Large', 'newspack' ), value: 'large' },
-					{ label: __( 'Small', 'newspack' ), value: 'small' },
-					{ label: __( 'Behind article title', 'newspack' ), value: 'behind' },
-					{ label: __( 'Beside article title', 'newspack' ), value: 'beside' },
-					{ label: __( 'Hidden', 'newspack' ), value: 'hidden' },
-				] }
-				onChange={ value => setThemeMods( { featured_image_default: value } ) }
-			/>
+			<Grid gutter={ 32 }>
+				<SelectControl
+					label={ __( 'Default featured image position for new posts', 'newspack' ) }
+					help={ __( 'Set a default featured image position for new posts.', 'newspack' ) }
+					value={ featuredImageDefault }
+					options={ [
+						{ label: __( 'Large', 'newspack' ), value: 'large' },
+						{ label: __( 'Small', 'newspack' ), value: 'small' },
+						{ label: __( 'Behind article title', 'newspack' ), value: 'behind' },
+						{ label: __( 'Beside article title', 'newspack' ), value: 'beside' },
+						{ label: __( 'Hidden', 'newspack' ), value: 'hidden' },
+					] }
+					onChange={ value => setThemeMods( { featured_image_default: value } ) }
+				/>
+				<SelectControl
+					label={ __( 'Default template for new posts', 'newspack' ) }
+					help={ __( 'Set a default template for new posts.', 'newspack' ) }
+					value={ postTemplateDefault }
+					options={ [
+						{ label: __( 'Default', 'newspack' ), value: 'default' },
+						{ label: __( 'One Column', 'newspack' ), value: 'single-feature.php' },
+						{ label: __( 'One Column Wide', 'newspack' ), value: 'single-wide.php' },
+					] }
+					onChange={ value => setThemeMods( { post_template_default: value } ) }
+				/>
+			</Grid>
 
 			<SectionHeader
 				title={ __( 'Media Credits', 'newspack' ) }

--- a/assets/wizards/site-design/views/theme-settings/index.js
+++ b/assets/wizards/site-design/views/theme-settings/index.js
@@ -141,8 +141,8 @@ const ThemeSettings = props => {
 					{ featuredImageAllPosts !== 'none' && (
 						<Notice isDismissible={ false } status="warning" className="ma0 mt2">
 							{ __(
-								'After saving the settings with this option selected, all post will be updated. This cannot be undone.',
-								'newspack-newsletters'
+								'After saving the settings with this option selected, all posts will be updated. This cannot be undone.',
+								'newspack-plugin'
 							) }
 						</Notice>
 					) }
@@ -164,8 +164,8 @@ const ThemeSettings = props => {
 					{ postTemplateAllPosts !== 'none' && (
 						<Notice isDismissible={ false } status="warning" className="ma0 mt2">
 							{ __(
-								'After saving the settings with this option selected, all post will be updated. This cannot be undone.',
-								'newspack-newsletters'
+								'After saving the settings with this option selected, all posts will be updated. This cannot be undone.',
+								'newspack-plugin'
 							) }
 						</Notice>
 					) }

--- a/assets/wizards/site-design/views/theme-settings/index.js
+++ b/assets/wizards/site-design/views/theme-settings/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Fragment, useEffect, useState } from '@wordpress/element';
-import { SelectControl, ToggleControl } from '@wordpress/components';
+import { SelectControl, Notice, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -30,6 +30,8 @@ const ThemeSettings = props => {
 		author_bio_length: authorBioLength = 200,
 		featured_image_default: featuredImageDefault = 'large',
 		post_template_default: postTemplateDefault = 'default',
+		featured_image_all_posts: featuredImageAllPosts = 'none',
+		post_template_all_posts: postTemplateAllPosts = 'none',
 		newspack_image_credits_placeholder_url: imageCreditsPlaceholderUrl,
 		newspack_image_credits_class_name: imageCreditsClassName = '',
 		newspack_image_credits_prefix_label: imageCreditsPrefix = '',
@@ -112,6 +114,62 @@ const ThemeSettings = props => {
 					] }
 					onChange={ value => setThemeMods( { post_template_default: value } ) }
 				/>
+			</Grid>
+			<SectionHeader
+				title={ __( 'Featured Image Position And Post Template For All Posts', 'newspack' ) }
+				description={ __(
+					'Modify how the featured image and post template settings are applied to existing posts. Warning: saving these options will override all posts.',
+					'newspack'
+				) }
+			/>
+			<Grid gutter={ 32 }>
+				<div>
+					<SelectControl
+						label={ __( 'Featured image position for all posts', 'newspack' ) }
+						help={ __( 'Set a featured image position for all posts.', 'newspack' ) }
+						value={ featuredImageAllPosts }
+						options={ [
+							{ label: __( 'Select to change all posts', 'newspack' ), value: 'none' },
+							{ label: __( 'Large', 'newspack' ), value: 'large' },
+							{ label: __( 'Small', 'newspack' ), value: 'small' },
+							{ label: __( 'Behind article title', 'newspack' ), value: 'behind' },
+							{ label: __( 'Beside article title', 'newspack' ), value: 'beside' },
+							{ label: __( 'Hidden', 'newspack' ), value: 'hidden' },
+						] }
+						onChange={ value => setThemeMods( { featured_image_all_posts: value } ) }
+					/>
+					{ featuredImageAllPosts !== 'none' && (
+						<Notice isDismissible={ false } status="warning" className="ma0 mt2">
+							{ __(
+								'After saving the settings with this option selected, all post will be updated. This cannot be undone.',
+								'newspack-newsletters'
+							) }
+						</Notice>
+					) }
+				</div>
+
+				<div>
+					<SelectControl
+						label={ __( 'Template for all posts', 'newspack' ) }
+						help={ __( 'Set a template for all posts.', 'newspack' ) }
+						value={ postTemplateAllPosts }
+						options={ [
+							{ label: __( 'Select to change all posts', 'newspack' ), value: 'none' },
+							{ label: __( 'Default', 'newspack' ), value: 'default' },
+							{ label: __( 'One Column', 'newspack' ), value: 'single-feature.php' },
+							{ label: __( 'One Column Wide', 'newspack' ), value: 'single-wide.php' },
+						] }
+						onChange={ value => setThemeMods( { post_template_all_posts: value } ) }
+					/>
+					{ postTemplateAllPosts !== 'none' && (
+						<Notice isDismissible={ false } status="warning" className="ma0 mt2">
+							{ __(
+								'After saving the settings with this option selected, all post will be updated. This cannot be undone.',
+								'newspack-newsletters'
+							) }
+						</Notice>
+					) }
+				</div>
 			</Grid>
 
 			<SectionHeader

--- a/assets/wizards/site-design/views/theme-settings/index.js
+++ b/assets/wizards/site-design/views/theme-settings/index.js
@@ -128,7 +128,7 @@ const ThemeSettings = props => {
 			{ themeSettings.post_count > 1000 && (
 				<Notice isDismissible={ false } status="warning" className="ma0 mb2">
 					{ __(
-						'You have more than 1000 posts. Applying this settings might take a moment.',
+						'You have more than 1000 posts. Applying these settings might take a moment.',
 						'newspack-plugin'
 					) }
 				</Notice>

--- a/assets/wizards/site-design/views/theme-settings/index.js
+++ b/assets/wizards/site-design/views/theme-settings/index.js
@@ -125,6 +125,14 @@ const ThemeSettings = props => {
 					'newspack-plugin'
 				) }
 			/>
+			{ themeSettings.post_count > 1000 && (
+				<Notice isDismissible={ false } status="warning" className="ma0 mb2">
+					{ __(
+						'You have more than 1000 posts. Applying this settings might take a moment.',
+						'newspack-plugin'
+					) }
+				</Notice>
+			) }
 			<Grid gutter={ 32 }>
 				<div>
 					<SelectControl

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -373,6 +373,9 @@ class Setup_Wizard extends Wizard {
 				'theme'             => Starter_Content::get_theme(),
 				'theme_mods'        => $theme_mods,
 				'homepage_patterns' => $this->get_homepage_patterns(),
+				'etc'               => [
+					'post_count' => wp_count_posts()->publish,
+				],
 			]
 		);
 	}

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -504,6 +504,35 @@ class Setup_Wizard extends Wizard {
 				continue;
 			}
 
+			if ( substr_compare( $key, '_all_posts', -strlen( '_all_posts' ) ) === 0 ) {
+				$post_ids = get_posts(
+					[
+						'posts_per_page' => -1,
+						'post_type'      => 'post',
+						'fields'         => 'ids',
+					]
+				);
+				// Update the featured image position on all posts.
+				if ( 'featured_image_all_posts' === $key ) {
+					foreach ( $post_ids as $post_id ) {
+						update_post_meta( $post_id, 'newspack_featured_image_position', $value );
+						Logger::log(
+							sprintf( 'Updated featured image position to "%s" on post #%s.', $value, $post_id )
+						);
+					}
+				}
+				// Update the template on all posts.
+				if ( 'post_template_all_posts' === $key ) {
+					foreach ( $post_ids as $post_id ) {
+						update_post_meta( $post_id, '_wp_page_template', $value );
+						Logger::log(
+							sprintf( 'Updated template to "%s" on post #%s.', $value, $post_id )
+						);
+					}
+				}
+				continue;
+			}
+
 			if ( null !== $value && in_array( $key, $this->media_theme_mods ) ) {
 				$value = $value['id'];
 			}

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -504,49 +504,15 @@ class Setup_Wizard extends Wizard {
 				continue;
 			}
 
+			// All-posts updates: featured image and post template.
 			if ( substr_compare( $key, '_all_posts', -strlen( '_all_posts' ) ) === 0 ) {
-				$meta_key = null;
 				switch ( $key ) {
 					case 'featured_image_all_posts':
-						$meta_key = 'newspack_featured_image_position';
+						self::update_meta_key_in_batches( $key, 'newspack_featured_image_position', $value );
 						break;
 					case 'post_template_all_posts':
-						$meta_key = '_wp_page_template';
+						self::update_meta_key_in_batches( $key, '_wp_page_template', $value );
 						break;
-				}
-				if ( null !== $meta_key ) {
-					$post_ids = get_posts(
-						[
-							'posts_per_page' => -1,
-							'post_type'      => 'post',
-							'fields'         => 'ids',
-							'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-								[
-									'key'     => $meta_key,
-									'value'   => $value,
-									'compare' => '!=',
-								],
-							],
-						]
-					);
-					// Update the featured image position on all posts.
-					if ( 'featured_image_all_posts' === $key ) {
-						Logger::log(
-							sprintf( 'Will update featured image position to "%s" on %s posts.', $value, count( $post_ids ) )
-						);
-						foreach ( $post_ids as $post_id ) {
-							update_post_meta( $post_id, 'newspack_featured_image_position', $value );
-						}
-					}
-					// Update the template on all posts.
-					if ( 'post_template_all_posts' === $key ) {
-						Logger::log(
-							sprintf( 'Will update template to "%s" on %s posts.', $value, count( $post_ids ) )
-						);
-						foreach ( $post_ids as $post_id ) {
-							update_post_meta( $post_id, '_wp_page_template', $value );
-						}
-					}
 				}
 				continue;
 			}
@@ -557,6 +523,41 @@ class Setup_Wizard extends Wizard {
 			set_theme_mod( $key, $value );
 		}
 		return self::api_retrieve_theme_and_set_defaults();
+	}
+
+	/**
+	 * Change a meta value on a batch of posts.
+	 *
+	 * @param string $key The key of the theme mod.
+	 * @param string $meta_key The meta key to update.
+	 * @param string $value The value to update.
+	 * @param int    $page The page of posts to update.
+	 */
+	private static function update_meta_key_in_batches( $key, $meta_key, $value, $page = 0 ) {
+		$args            = [
+			'posts_per_page' => 100,
+			'post_type'      => 'post',
+			'fields'         => 'ids',
+			'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				[
+					'key'     => $meta_key,
+					'value'   => $value,
+					'compare' => '!=',
+				],
+			],
+		];
+		$results         = new \WP_Query( $args );
+		$number_of_pages = $results->max_num_pages;
+
+		Logger::log(
+			sprintf( 'Updating %s to "%s" on %s posts (batch %d/%d).', $meta_key, $value, count( $results->posts ), $page + 1, $number_of_pages + $page )
+		);
+		foreach ( $results->posts as $post ) {
+			update_post_meta( $post, $meta_key, $value );
+		}
+		if ( 1 < $number_of_pages ) {
+			self::update_meta_key_in_batches( $key, $meta_key, $value, $page + 1 );
+		}
 	}
 
 	/**

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -511,10 +511,10 @@ class Setup_Wizard extends Wizard {
 			if ( substr_compare( $key, '_all_posts', -strlen( '_all_posts' ) ) === 0 ) {
 				switch ( $key ) {
 					case 'featured_image_all_posts':
-						self::update_meta_key_in_batches( $key, 'newspack_featured_image_position', $value );
+						self::update_meta_key_in_batches( 'newspack_featured_image_position', $value );
 						break;
 					case 'post_template_all_posts':
-						self::update_meta_key_in_batches( $key, '_wp_page_template', $value );
+						self::update_meta_key_in_batches( '_wp_page_template', $value );
 						break;
 				}
 				continue;
@@ -531,12 +531,11 @@ class Setup_Wizard extends Wizard {
 	/**
 	 * Change a meta value on a batch of posts.
 	 *
-	 * @param string $key The key of the theme mod.
 	 * @param string $meta_key The meta key to update.
 	 * @param string $value The value to update.
 	 * @param int    $page The page of posts to update.
 	 */
-	private static function update_meta_key_in_batches( $key, $meta_key, $value, $page = 0 ) {
+	private static function update_meta_key_in_batches( $meta_key, $value, $page = 0 ) {
 		$args            = [
 			'posts_per_page' => 100,
 			'post_type'      => 'post',
@@ -559,7 +558,7 @@ class Setup_Wizard extends Wizard {
 			update_post_meta( $post, $meta_key, $value );
 		}
 		if ( 1 < $number_of_pages ) {
-			self::update_meta_key_in_batches( $key, $meta_key, $value, $page + 1 );
+			self::update_meta_key_in_batches( $meta_key, $value, $page + 1 );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks the Site Design -> Settings section UI and ads a couple of features.

Before:

<img width="805" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/66d02917-782f-41f9-b620-da5819e2f389">

After:

<img width="804" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/33d778e7-aeeb-4ad1-97b4-41e541ddea7a">

The new "Featured Image Position And Post Template For All Posts" section will allow for bulk-update of featured image and post template. This action is undoable, so there are two levels of warnings added.

### How to test the changes in this Pull Request:

1. Switch to this branch, open Site Design wizard, Settings tab
2. Modify the "DEFAULT FEATURED IMAGE POSITION FOR NEW POSTS" and "DEFAULT TEMPLATE FOR NEW POSTS" settings, save, and verify they are applied by creating a new post and by checking if the values match in the Customizer (Template Settings -> Post Settings section)
3. Modify the "FEATURED IMAGE POSITION FOR ALL POSTS" and "TEMPLATE FOR ALL POSTS" settings and observe warnings being displayed below the selections:

<img width="805" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/4b00e2f5-d300-40ab-a542-b646024b7f0b">

4. Click the "Save" button, observe a native browser confirmation dialog kindly ensures if you want to proceed:

<img width="436" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/800c3347-8ac7-459e-90a2-8d7f2576a578">

5. Click "Cancel" on the confirmation dialog and verify that posts (just pick one) were not updated 
6. Click "Save" again and confirm. Verify posts were updated accordingly 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->