### PR TITLE
fix(woocommerce): check method exists before syncing reader

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -336,7 +336,9 @@ class WooCommerce_Connection {
 		if ( ! $contact ) {
 			return;
 		}
-
+		if ( ! method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ) ) {
+			return;
+		}
 		return \Newspack_Newsletters_Subscription::add_contact( $contact );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Check if the Newspack Newsletters method is available before syncing the reader on WooCommerce orders.

### How to test the changes in this Pull Request:

1. While on the master branch, make sure you have RAS configured and deactivate the Newspack Newsletters plugin
2. Donate using the donate block and confirm you get a fatal error
3. Checkout this branch, donate again, and confirm it works without errors
4. Activate Newspack Newsletters and donate again
5. Confirm the contact syncs to the ESP

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->