### PR TITLE
fix: avoid deepMapKeys NPM package

### DIFF
--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -26,15 +26,19 @@ const Main = () => {
 			<SectionHeader title={ __( 'Plugins', 'newspack' ) } />
 			<Plugins />
 			<SectionHeader title={ __( 'APIs', 'newspack' ) } />
-			{ newspack_connections_data.can_connect_google && <GoogleAuth setError={ setError } /> }
-			<Mailchimp setError={ setError } />
+			{ newspack_connections_data.can_connect_google && (
+				<GoogleAuth setError={ err => setError( __( 'Google: ', 'newspack-plugin' ) + err ) } />
+			) }
+			<Mailchimp setError={ err => setError( __( 'Mailchimp: ', 'newspack-plugin' ) + err ) } />
 			{ newspack_connections_data.can_connect_fivetran && (
 				<>
 					<SectionHeader title="Fivetran" />
-					<FivetranConnection setError={ setError } />
+					<FivetranConnection
+						setError={ err => setError( __( 'FiveTran: ', 'newspack-plugin' ) + err ) }
+					/>
 				</>
 			) }
-			<Recaptcha setError={ setError } />
+			<Recaptcha setError={ err => setError( __( 'reCAPTCHA: ', 'newspack-plugin' ) + err ) } />
 			<Webhooks />
 		</>
 	);

--- a/assets/wizards/seo/index.js
+++ b/assets/wizards/seo/index.js
@@ -20,11 +20,40 @@ import { Settings } from './views';
 /**
  * External dependencies.
  */
-import deepMapKeys from 'deep-map-keys';
 import camelCase from 'lodash/camelCase';
 import snakeCase from 'lodash/snakeCase';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
+
+/**
+ * Check whether the given object is a pure object with key/value pairs.
+ *
+ * @param {*} obj Object to check.
+ * @return {boolean} True if an object, otherwise false.
+ */
+const isObj = obj =>
+	null !== obj && typeof obj === 'object' && Object.getPrototypeOf( obj ).isPrototypeOf( Object );
+
+/**
+ * Recursively run the given `callback` on all keys of `obj`, and all keys of values of `obj`.
+ *
+ * @param {*}        obj
+ * @param {Function} callback
+ * @return {*} Transformed obj.
+ */
+const deepMapKeys = ( obj, callback ) => {
+	if ( ! isObj( obj ) ) {
+		return obj;
+	}
+	const result = {};
+	for ( const key in obj ) {
+		if ( obj.hasOwnProperty( key ) ) {
+			result[ callback( key ) ] = deepMapKeys( obj[ key ], callback );
+		}
+	}
+
+	return result;
+};
 
 class SEOWizard extends Component {
 	state = {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The `deep-map-keys` NPM package is throwing a lodash dependency error. Since this package hasn't received an update in 5+ years, let's not rely on it anymore.

### How to test the changes in this Pull Request:

1. On `release`, visit Newspack > SEO and observe a JS error: 

![image__16_](https://github.com/Automattic/newspack-plugin/assets/2230142/f86d3e76-0582-434b-a2ff-56e0bc1e17e8)

2. Check out this branch, refresh, confirm no error.
3. Update values for each setting, save, refresh, confirm all values are persisted.

#### Bonus: Better error messaging in Connections wizard

1. Go to Newspack > Connections
2. Force an error in any of the third-party connection components (Google, Mailchimp, Fivetran, reCAPTCHA) by adding a `setError( 'TEST' );` call in the component render function
3. Confirm that the error message is prefixed with the name of the service:

<img width="992" alt="Screenshot 2023-10-02 at 4 00 35 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/519836c8-0e55-425a-aff2-2424297fea00">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->