### PR TITLE
feat(reader-registration): custom checkbox state for lists

### DIFF
--- a/assets/blocks/reader-registration/block.json
+++ b/assets/blocks/reader-registration/block.json
@@ -53,6 +53,10 @@
 				"type": "string"
 			}
 		},
+		"listsCheckboxes": {
+			"type": "object",
+			"default": {}
+		},
 		"haveAccountLabel": {
 			"type": "string",
 			"default": "Already have an account?"

--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -32,6 +32,10 @@ import {
  */
 import './editor.scss';
 
+const getListCheckboxId = listId => {
+	return 'newspack-reader-registration-list-checkbox-' + listId;
+};
+
 const editedStateOptions = [
 	{ label: __( 'Initial', 'newspack' ), value: 'initial' },
 	{ label: __( 'Registration Success', 'newspack' ), value: 'registration' },
@@ -54,6 +58,7 @@ export default function ReaderRegistrationEdit( {
 		signInLabel,
 		signedInLabel,
 		lists,
+		listsCheckboxes,
 		className,
 	},
 } ) {
@@ -109,6 +114,15 @@ export default function ReaderRegistrationEdit( {
 
 	const shouldHideSubscribeInput = () => {
 		return lists.length === 1 && hideSubscriptionInput;
+	};
+
+	const isListSelected = listId => {
+		return ! listsCheckboxes.hasOwnProperty( listId ) || listsCheckboxes[ listId ];
+	};
+	const toggleListCheckbox = listId => () => {
+		const newListsCheckboxes = { ...listsCheckboxes };
+		newListsCheckboxes[ listId ] = ! isListSelected( listId );
+		setAttributes( { listsCheckboxes: newListsCheckboxes } );
 	};
 
 	return (
@@ -286,10 +300,18 @@ export default function ReaderRegistrationEdit( {
 											{ lists.map( listId => (
 												<li key={ listId }>
 													<span className="newspack-reader__lists__checkbox">
-														<input type="checkbox" checked readOnly />
+														<input
+															id={ getListCheckboxId( listId ) }
+															type="checkbox"
+															checked={ isListSelected( listId ) }
+															onChange={ toggleListCheckbox( listId ) }
+														/>
 													</span>
 													<span className="newspack-reader__lists__details">
-														<span className="newspack-reader__lists__label">
+														<label
+															htmlFor={ getListCheckboxId( listId ) }
+															className="newspack-reader__lists__label"
+														>
 															<span className="newspack-reader__lists__title">
 																{ lists.length === 1 ? (
 																	<RichText
@@ -309,7 +331,7 @@ export default function ReaderRegistrationEdit( {
 																	{ listConfig[ listId ]?.description }
 																</span>
 															) }
-														</span>
+														</label>
 													</span>
 												</li>
 											) ) }

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -182,6 +182,15 @@ function render_block( $attrs, $content ) {
 		$success_login_markup = '<p class="has-text-align-center">' . $attrs['signedInLabel'] . '</p>';
 	}
 
+	$checked = [];
+	if ( ! empty( $attrs['listsCheckboxes'] ) ) {
+		foreach ( $lists as $list_id => $list_name ) {
+			if ( ! isset( $attrs['listsCheckboxes'][ $list_id ] ) || false !== $attrs['listsCheckboxes'][ $list_id ] ) {
+				$checked[] = $list_id;
+			}
+		}
+	}
+
 	ob_start();
 	?>
 	<div class="newspack-registration <?php echo esc_attr( get_block_classes( $attrs ) ); ?>">
@@ -234,7 +243,7 @@ function render_block( $attrs, $content ) {
 						} else {
 							Reader_Activation::render_subscription_lists_inputs(
 								$lists,
-								array_keys( $lists ),
+								$checked,
 								[
 									'title'            => $attrs['newsletterTitle'],
 									'single_label'     => $attrs['newsletterLabel'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1205543124448992

Similar to https://github.com/Automattic/newspack-newsletters/pull/1313, support toggling and storing the checkbox state for defining the initial form state:

<img width="846" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/42258c98-4292-4b9b-8fd3-9e4794786ed2">

### How to test the changes in this Pull Request:

1. Draft a new page and add a Newsletter Subscription Form block
2. Enable multiple lists and toggle their checkbox state in the editor
3. Save, refresh, and confirm the selected state is preserved
4. Visit the page and confirm the selected state is also reflected on the page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->