### PR TITLE
fix(data-events): earlier priority for webhook registration

### DIFF
--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -52,8 +52,8 @@ final class Webhooks {
 	 * Initialize hooks.
 	 */
 	public static function init() {
-		\add_action( 'init', [ __CLASS__, 'register_request_post_type' ] );
-		\add_action( 'init', [ __CLASS__, 'register_endpoint_taxonomy' ] );
+		\add_action( 'init', [ __CLASS__, 'register_request_post_type' ], 1, 0 );
+		\add_action( 'init', [ __CLASS__, 'register_endpoint_taxonomy' ], 1, 0 );
 		\add_action( 'init', [ __CLASS__, 'register_cron_events' ] );
 		\add_action( 'newspack_deactivation', [ __CLASS__, 'clear_cron_events' ] );
 		\add_action( 'newspack_data_event_dispatch', [ __CLASS__, 'handle_dispatch' ], 10, 4 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Registers webhook hooks earlier for https://github.com/Automattic/newspack-newsletters/pull/1314

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->