### PR TITLE
feat: add Perfmatters to managed plugins

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -179,6 +179,13 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'options-general.php?page=password-protected',
 			],
+			'perfmatters'            => [
+				'Name'        => esc_html__( 'Perfmatters', 'newspack' ),
+				'Description' => esc_html__( 'Perfmatters is a lightweight performance plugin developed to speed up your WordPress site.', 'newspack' ),
+				'Author'      => esc_html__( 'forgemedia', 'newspack' ),
+				'AuthorURI'   => esc_url( 'https://forgemedia.io/' ),
+				'PluginURI'   => esc_url( 'https://perfmatters.io/' ),
+			],
 			'publish-to-apple-news'         => [
 				'Name'        => esc_html__( 'Publish to Apple News', 'newspack' ),
 				'Description' => esc_html__( 'Export and synchronize posts to Apple format', 'newspack' ),
@@ -398,11 +405,8 @@ class Plugin_Manager {
 			'gravityformspolls',
 			'gravityformsmailchimp',
 			'gravityformsstripe',
-			'perfmatters',
 			'onesignal-free-web-push-notifications',
-			'super-cool-ad-inserter-plugin',
 			'web-stories',
-			'ads-txt',
 			'woocommerce-memberships',
 		];
 	}

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -179,7 +179,7 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'options-general.php?page=password-protected',
 			],
-			'perfmatters'            => [
+			'perfmatters'                   => [
 				'Name'        => esc_html__( 'Perfmatters', 'newspack' ),
 				'Description' => esc_html__( 'Perfmatters is a lightweight performance plugin developed to speed up your WordPress site.', 'newspack' ),
 				'Author'      => esc_html__( 'forgemedia', 'newspack' ),


### PR DESCRIPTION
Adds Perfmatters to our list of managed plugins.

### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds Perfmatters to our list of managed plugins.

Also deletes Perfmatters, Super Cool Ad Inserter Plugin, and Ads.txt Manager from our list of "supported, but not managed" plugins, since they are in fact managed (SCAIP as of https://github.com/Automattic/newspack-plugin/pull/246 and Ads.txt Manager as of https://github.com/Automattic/newspack-plugin/pull/2639).

### How to test the changes in this Pull Request:

1. Switch to this branch.
2. Ensure the Newspack plugin is active.
3. Visit `/wp-admin/plugins.php`
4. Verify that Perfmatters, whether or not it's installed, is nested under "Newspack" and prefixed with a hyphen.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->