### PR TITLE
fix: update support link to help site

### DIFF
--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -105,7 +105,7 @@ abstract class Wizard {
 			],
 			'homepage'       => get_edit_post_link( get_option( 'page_on_front', false ) ),
 			'site'           => get_site_url(),
-			'support'        => esc_url( 'https://newspack.com/support/' ),
+			'support'        => esc_url( 'https://help.newspack.com/' ),
 			'support_email'  => $support_email,
 		];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the last (hopefully) instance of a support link that hasn't been updated to the new URL.

### How to test the changes in this Pull Request:

1. Check out this branch, visit any Newspack wizard page in the admin.
2. Confirm that the "Documentation" link at the bottom of the page leads to help.newspack.com, not newspack.com/support.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->