### PR TITLE
feat(reader-data): set newsletter subscriber status on form submission

### DIFF
--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -302,6 +302,27 @@ function attachAuthCookiesListener() {
 	}, 1000 );
 }
 
+/**
+ * Set the reader as newsletter subscriber once a newsletter form is submitted.
+ */
+function attachNewsletterFormListener() {
+	const forms = document.querySelectorAll( '.newspack-subscribe-form,.mc4wp-form' );
+	if ( ! forms.length ) {
+		return;
+	}
+	forms.forEach( form => {
+		if ( form.tagName !== 'FORM' ) {
+			form = form.querySelector( 'form' );
+		}
+		if ( ! form ) {
+			return;
+		}
+		form.addEventListener( 'submit', () => {
+			store.set( 'is_newsletter_subscriber', true );
+		} );
+	} );
+}
+
 const readerActivation = {
 	store,
 	on,
@@ -359,6 +380,7 @@ function init() {
 	fixClientID();
 	setupArticleViewsAggregates( readerActivation );
 	attachAuthCookiesListener();
+	attachNewsletterFormListener();
 	pushActivities();
 	setReferrer();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Restores the behavior from https://github.com/Automattic/newspack-popups/pull/836 by optimistically updating the reader's newsletter subscription status when a newsletter subscription form is submitted.

### How to test the changes in this Pull Request:

1. Checkout this branch and create a subscription form using the MC4WP plugin
2. Visit the page with the MC4WP form anonymously and subscribe
3. Confirm the value was updated by entering `newspackReaderActivation.store.get('is_newsletter_subscriber');` in the browser console
4. Test the `.newspack-subscribe-form` class by creating a generic contact form with Jetpack inside a Group block with the `newspack-subscribe-form` class
5. Visit the page anonymously (new session), submit, and confirm the store value is updated (step 3) 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->