### PR TITLE
feat(ras): custom newsletter list selection on registration

### DIFF
--- a/assets/components/src/sortable-newsletter-list-control/index.js
+++ b/assets/components/src/sortable-newsletter-list-control/index.js
@@ -1,0 +1,110 @@
+/**
+ * WordPress dependencies
+ */
+import { Icon, chevronUp, chevronDown, trash } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import ActionCard from '../action-card';
+import Button from '../button';
+import './style.scss';
+
+export default function SortableNewsletterListControl( {
+	lists,
+	selected = [],
+	onChange = () => {},
+} ) {
+	const getList = id => lists.find( list => list.id === id );
+	const getAvailableLists = () => {
+		return lists.filter( list => list.active && ! selected.includes( list.id ) );
+	};
+	return (
+		<div className="newspack__newsletter-list-control">
+			<div className="newspack__newsletter-list-control__selected">
+				{ selected.map( listId => {
+					const list = getList( listId );
+					if ( ! list ) {
+						return null;
+					}
+					return (
+						<ActionCard
+							key={ `selected-${ listId }` }
+							title={ list.name }
+							description={ list.description }
+							isSmall
+							actionText={
+								<>
+									<Button
+										onClick={ () => onChange( selected.filter( id => id !== listId ) ) }
+										label={ __( 'Remove', 'newspack' ) }
+										icon={ trash }
+									/>
+								</>
+							}
+						>
+							{ selected.length > 1 && (
+								<span className="newspack__newsletter-list-control__sort-handle">
+									<button
+										onClick={ () => {
+											const index = selected.findIndex( item => item === listId );
+											if ( index === 0 ) {
+												return;
+											}
+											const newSelected = [ ...selected ];
+											newSelected.splice( index, 1 );
+											newSelected.splice( index - 1, 0, listId );
+											onChange( newSelected );
+										} }
+										className={
+											selected.findIndex( item => item === listId ) === 0 ? 'disabled' : ''
+										}
+									>
+										<Icon icon={ chevronUp } />
+									</button>
+									<button
+										onClick={ () => {
+											const index = selected.findIndex( item => item === listId );
+											const newSelected = [ ...selected ];
+											newSelected.splice( index, 1 );
+											newSelected.splice( index + 1, 0, listId );
+											onChange( newSelected );
+										} }
+										className={
+											selected.findIndex( item => item === listId ) === selected.length - 1
+												? 'disabled'
+												: ''
+										}
+									>
+										<Icon icon={ chevronDown } />
+									</button>
+								</span>
+							) }
+						</ActionCard>
+					);
+				} ) }
+			</div>
+			{ getAvailableLists().length > 0 && (
+				<p className="newspack__newsletter-list-control__lists">
+					{ selected.length > 0 ? (
+						<strong>{ __( 'Add more lists:', 'newspack' ) }</strong>
+					) : (
+						<strong>{ __( 'Select lists:', 'newspack' ) }</strong>
+					) }{ ' ' }
+					{ getAvailableLists().map( list => {
+						return (
+							<Button
+								key={ list.id }
+								variant="secondary"
+								onClick={ () => onChange( [ ...selected, list.id ] ) }
+							>
+								{ list.name }
+							</Button>
+						);
+					} ) }
+				</p>
+			) }
+		</div>
+	);
+}

--- a/assets/components/src/sortable-newsletter-list-control/index.js
+++ b/assets/components/src/sortable-newsletter-list-control/index.js
@@ -18,26 +18,42 @@ export default function SortableNewsletterListControl( {
 } ) {
 	const getList = id => lists.find( list => list.id === id );
 	const getAvailableLists = () => {
-		return lists.filter( list => list.active && ! selected.includes( list.id ) );
+		return lists.filter( list => list.active && ! selected.find( ( { id } ) => id === list.id ) );
 	};
 	return (
 		<div className="newspack__newsletter-list-control">
 			<div className="newspack__newsletter-list-control__selected">
-				{ selected.map( listId => {
-					const list = getList( listId );
+				{ selected.map( selectedList => {
+					const list = getList( selectedList.id );
 					if ( ! list ) {
 						return null;
 					}
 					return (
 						<ActionCard
-							key={ `selected-${ listId }` }
+							key={ `selected-${ selectedList.id }` }
 							title={ list.name }
-							description={ list.description }
+							description={ () => (
+								<>
+									<input
+										type="checkbox"
+										checked={ selectedList.checked }
+										onChange={ () => {
+											const index = selected.findIndex( ( { id } ) => id === selectedList.id );
+											const newSelected = [ ...selected ];
+											newSelected[ index ].checked = ! newSelected[ index ].checked;
+											onChange( newSelected );
+										} }
+									/>
+									{ __( 'Checked by default', 'newspack' ) }
+								</>
+							) }
 							isSmall
 							actionText={
 								<>
 									<Button
-										onClick={ () => onChange( selected.filter( id => id !== listId ) ) }
+										onClick={ () =>
+											onChange( selected.filter( ( { id } ) => id !== selectedList.id ) )
+										}
 										label={ __( 'Remove', 'newspack' ) }
 										icon={ trash }
 									/>
@@ -48,31 +64,31 @@ export default function SortableNewsletterListControl( {
 								<span className="newspack__newsletter-list-control__sort-handle">
 									<button
 										onClick={ () => {
-											const index = selected.findIndex( item => item === listId );
+											const index = selected.findIndex( item => item === selectedList.id );
 											if ( index === 0 ) {
 												return;
 											}
 											const newSelected = [ ...selected ];
 											newSelected.splice( index, 1 );
-											newSelected.splice( index - 1, 0, listId );
+											newSelected.splice( index - 1, 0, selectedList.id );
 											onChange( newSelected );
 										} }
 										className={
-											selected.findIndex( item => item === listId ) === 0 ? 'disabled' : ''
+											selected.findIndex( item => item === selectedList.id ) === 0 ? 'disabled' : ''
 										}
 									>
 										<Icon icon={ chevronUp } />
 									</button>
 									<button
 										onClick={ () => {
-											const index = selected.findIndex( item => item === listId );
+											const index = selected.findIndex( item => item === selectedList.id );
 											const newSelected = [ ...selected ];
 											newSelected.splice( index, 1 );
-											newSelected.splice( index + 1, 0, listId );
+											newSelected.splice( index + 1, 0, selectedList.id );
 											onChange( newSelected );
 										} }
 										className={
-											selected.findIndex( item => item === listId ) === selected.length - 1
+											selected.findIndex( item => item === selectedList.id ) === selected.length - 1
 												? 'disabled'
 												: ''
 										}
@@ -97,7 +113,7 @@ export default function SortableNewsletterListControl( {
 							<Button
 								key={ list.id }
 								variant="secondary"
-								onClick={ () => onChange( [ ...selected, list.id ] ) }
+								onClick={ () => onChange( [ ...selected, { id: list.id, checked: true } ] ) }
 							>
 								{ list.name }
 							</Button>

--- a/assets/components/src/sortable-newsletter-list-control/index.js
+++ b/assets/components/src/sortable-newsletter-list-control/index.js
@@ -70,7 +70,7 @@ export default function SortableNewsletterListControl( {
 											}
 											const newSelected = [ ...selected ];
 											newSelected.splice( index, 1 );
-											newSelected.splice( index - 1, 0, selectedList.id );
+											newSelected.splice( index - 1, 0, selectedList );
 											onChange( newSelected );
 										} }
 										className={
@@ -86,7 +86,7 @@ export default function SortableNewsletterListControl( {
 											const index = selected.findIndex( ( { id } ) => id === selectedList.id );
 											const newSelected = [ ...selected ];
 											newSelected.splice( index, 1 );
-											newSelected.splice( index + 1, 0, selectedList.id );
+											newSelected.splice( index + 1, 0, selectedList );
 											onChange( newSelected );
 										} }
 										className={

--- a/assets/components/src/sortable-newsletter-list-control/index.js
+++ b/assets/components/src/sortable-newsletter-list-control/index.js
@@ -64,7 +64,7 @@ export default function SortableNewsletterListControl( {
 								<span className="newspack__newsletter-list-control__sort-handle">
 									<button
 										onClick={ () => {
-											const index = selected.findIndex( item => item === selectedList.id );
+											const index = selected.findIndex( ( { id } ) => id === selectedList.id );
 											if ( index === 0 ) {
 												return;
 											}
@@ -74,21 +74,24 @@ export default function SortableNewsletterListControl( {
 											onChange( newSelected );
 										} }
 										className={
-											selected.findIndex( item => item === selectedList.id ) === 0 ? 'disabled' : ''
+											selected.findIndex( ( { id } ) => id === selectedList.id ) === 0
+												? 'disabled'
+												: ''
 										}
 									>
 										<Icon icon={ chevronUp } />
 									</button>
 									<button
 										onClick={ () => {
-											const index = selected.findIndex( item => item === selectedList.id );
+											const index = selected.findIndex( ( { id } ) => id === selectedList.id );
 											const newSelected = [ ...selected ];
 											newSelected.splice( index, 1 );
 											newSelected.splice( index + 1, 0, selectedList.id );
 											onChange( newSelected );
 										} }
 										className={
-											selected.findIndex( item => item === selectedList.id ) === selected.length - 1
+											selected.findIndex( ( { id } ) => id === selectedList.id ) ===
+											selected.length - 1
 												? 'disabled'
 												: ''
 										}

--- a/assets/components/src/sortable-newsletter-list-control/style.scss
+++ b/assets/components/src/sortable-newsletter-list-control/style.scss
@@ -2,7 +2,6 @@
 	&__selected {
 		.newspack-card {
 			display: flex;
-			// flex-direction: column;
 			justify-content: center;
 			min-height: 40px;
 			flex-direction: row;

--- a/assets/components/src/sortable-newsletter-list-control/style.scss
+++ b/assets/components/src/sortable-newsletter-list-control/style.scss
@@ -1,0 +1,46 @@
+.newspack__newsletter-list-control {
+	&__selected {
+		.newspack-card {
+			display: flex;
+			// flex-direction: column;
+			justify-content: center;
+			min-height: 40px;
+			flex-direction: row;
+			.newspack-action-card__region {
+				align-items: center;
+				display: flex;
+				justify-content: space-between;
+				margin: 0;
+			}
+			.newspack-action-card__region-top {
+				flex: 1;
+				order: 2;
+			}
+			.newspack-action-card__region-children {
+				padding: 12px;
+			}
+		}
+	}
+	&__sort-handle {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		button {
+			background: transparent;
+			border: none;
+			margin: 0;
+			padding: 0;
+			height: 20px;
+			&.disabled {
+				cursor: default;
+				opacity: 0.3;
+			}
+		}
+	}
+	&__lists {
+		button {
+			margin-right: 0.5rem;
+		}
+	}
+}

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -278,6 +278,13 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 					) }
 
 					<SectionHeader
+						title={ __( 'Newsletter Subscription Lists', 'newspack' ) }
+						description={ __( 'Configure the newsletter subscription lists.', 'newspack' ) }
+					/>
+					<p>{ __( ' Available newsletter lists upon registration', 'newspack' ) }</p>
+					<hr />
+
+					<SectionHeader
 						title={ __( 'Email Service Provider (ESP) Advanced Settings', 'newspack' ) }
 						description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
 					/>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -25,6 +25,7 @@ import Prerequisite from '../../components/prerequisite';
 import ActiveCampaign from '../../components/active-campaign';
 import Mailchimp from '../../components/mailchimp';
 import { HANDOFF_KEY } from '../../../../components/src/consts';
+import SortableNewsletterListControl from '../../../../components/src/sortable-newsletter-list-control';
 
 export default withWizardScreen( ( { wizardApiFetch } ) => {
 	const [ inFlight, setInFlight ] = useState( false );
@@ -277,11 +278,24 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 						</>
 					) }
 
-					<SectionHeader
-						title={ __( 'Newsletter Subscription Lists', 'newspack' ) }
-						description={ __( 'Configure the newsletter subscription lists.', 'newspack' ) }
+					<SectionHeader title={ __( 'Newsletter Subscription Lists', 'newspack' ) } />
+					<ActionCard
+						title={ __( 'Custom newsletter lists on registration', 'newspack' ) }
+						description={ __(
+							"Choose which of the Newspack Newsletters's subscription lists should be available upon registration.",
+							'newspack'
+						) }
+						toggleChecked={ config.use_custom_lists }
+						toggleOnChange={ value => updateConfig( 'use_custom_lists', value ) }
 					/>
-					<p>{ __( ' Available newsletter lists upon registration', 'newspack' ) }</p>
+					{ config.use_custom_lists && (
+						<SortableNewsletterListControl
+							lists={ newspack_engagement_wizard.available_newsletter_lists }
+							selected={ config.newsletter_lists }
+							onChange={ selected => updateConfig( 'newsletter_lists', selected ) }
+						/>
+					) }
+
 					<hr />
 
 					<SectionHeader
@@ -338,6 +352,8 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 									mailchimp_audience_id: config.mailchimp_audience_id,
 									active_campaign_master_list: config.active_campaign_master_list,
 									memberships_require_all_plans: membershipsConfig.require_all_plans,
+									use_custom_lists: config.use_custom_lists,
+									newsletter_lists: config.newsletter_lists,
 								} );
 							} }
 							disabled={ inFlight }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -314,10 +314,14 @@ final class Reader_Activation {
 		if ( ! method_exists( 'Newspack_Newsletters_Subscription', 'get_lists' ) ) {
 			return [];
 		}
-		$lists           = self::get_setting( 'newsletter_lists' );
-		$available_lists = \Newspack_Newsletters_Subscription::get_lists_config();
-		if ( empty( $lists ) ) {
+		$use_custom_lists = self::get_setting( 'use_custom_lists' );
+		$available_lists  = \Newspack_Newsletters_Subscription::get_lists_config();
+		if ( ! $use_custom_lists ) {
 			return $available_lists;
+		}
+		$lists = self::get_setting( 'newsletter_lists' );
+		if ( empty( $lists ) ) {
+			return [];
 		}
 		$registration_lists = [];
 		foreach ( $lists as $list_id ) {

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -324,9 +324,10 @@ final class Reader_Activation {
 			return [];
 		}
 		$registration_lists = [];
-		foreach ( $lists as $list_id ) {
-			if ( isset( $available_lists[ $list_id ] ) ) {
-				$registration_lists[ $list_id ] = $available_lists[ $list_id ];
+		foreach ( $lists as $list ) {
+			if ( isset( $available_lists[ $list['id'] ] ) ) {
+				$registration_lists[ $list['id'] ]            = $available_lists[ $list['id'] ];
+				$registration_lists[ $list['id'] ]['checked'] = $list['checked'] ?? false;
 			}
 		}
 		return $registration_lists;
@@ -1120,7 +1121,14 @@ final class Reader_Activation {
 								<?php
 								self::render_subscription_lists_inputs(
 									$lists,
-									array_keys( $lists ),
+									array_keys(
+										array_filter(
+											$lists,
+											function( $list ) {
+												return $list['checked'] ?? false;
+											}
+										)
+									),
 									[
 										'single_label' => $newsletters_label,
 									]

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -411,6 +411,10 @@ class Engagement_Wizard extends Wizard {
 			$data['new_subscription_lists_url'] = \Newspack\Newsletters\Subscription_Lists::get_add_new_url();
 		}
 
+		if ( method_exists( 'Newspack_Newsletters_Subscription', 'get_lists' ) ) {
+			$data['available_newsletter_lists'] = \Newspack_Newsletters_Subscription::get_lists();
+		}
+
 		$newspack_popups = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
 		if ( $newspack_popups->is_configured() ) {
 			$data['preview_query_keys'] = $newspack_popups->preview_query_keys();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements a RAS advanced setting for selecting custom newsletter lists, their order and default `checked` state when rendering in the registration modal.

<img width="1146" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/eebf3ecd-dd4d-4d0f-8ad8-aa9316849501">

### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have RAS enabled and Newspack Newsletters connected with an ESP and enabled with subscription lists
2. Navigate to Newspack -> Engagement -> Reader Activation -> Advanced settings
3. Scroll to the "Newsletter Subscription Lists" section and toggle the "Custom newsletter lists on registration"
4. Confirm you can click on multiple available lists
5. Sort by clicking on the chevrons, make some checked by default and others not and save
6. Visit your site anonymously, click "Sign in" -> "I don't have an account" and confirm the configured lists and rendered in the defined order with the defined `checked` state

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->