### PR TITLE
feat(ras): overlay management for content gate refresh

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -191,6 +191,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 			} else {
 				emailInput.focus();
 			}
+			container.overlayId = readerActivation.overlays.add();
 		}
 
 		containers.forEach( container => {
@@ -227,6 +228,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 							document.title,
 							window.location.pathname + window.location.search
 						);
+					}
+					if ( container.overlayId ) {
+						readerActivation.overlays.remove( container.overlayId );
 					}
 				} );
 			}

--- a/assets/reader-activation/events.js
+++ b/assets/reader-activation/events.js
@@ -4,6 +4,7 @@ export const EVENTS = {
 	reader: 'reader' /* This event can soon be depecrated to use only 'data'. */,
 	data: 'data',
 	activity: 'activity',
+	overlay: 'overlay',
 };
 
 const eventList = Object.values( EVENTS );

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -4,6 +4,7 @@ window.newspack_ras_config = window.newspack_ras_config || {};
 import Store from './store.js';
 import { EVENTS, on, off, emit } from './events.js';
 import { getCookie, setCookie, generateID } from './utils.js';
+import overlays from './overlays.js';
 
 import setupArticleViewsAggregates from './article-view.js';
 
@@ -325,6 +326,7 @@ function attachNewsletterFormListener() {
 
 const readerActivation = {
 	store,
+	overlays,
 	on,
 	off,
 	dispatchActivity,

--- a/assets/reader-activation/overlays.js
+++ b/assets/reader-activation/overlays.js
@@ -1,0 +1,54 @@
+import { EVENTS, emit } from './events';
+import { generateID } from './utils';
+
+const overlays = [];
+
+/**
+ * Get all overlays.
+ *
+ * @return {Array} Overlays.
+ */
+function get() {
+	return overlays || [];
+}
+
+/**
+ * Add an overlay.
+ *
+ * @param {string} overlayId Overlay ID.
+ *
+ * @return {string} Overlay ID.
+ */
+function add( overlayId = '' ) {
+	if ( ! overlayId ) {
+		overlayId = generateID();
+	}
+	overlays.push( overlayId );
+	emit( EVENTS.overlay, { overlays } );
+	return overlayId;
+}
+
+/**
+ * Remove an overlay.
+ *
+ * @param {string} overlayId Overlay ID.
+ *
+ * @return {Array} Overlays.
+ */
+function remove( overlayId ) {
+	if ( ! overlayId ) {
+		return overlays;
+	}
+	const index = overlays.indexOf( overlayId );
+	if ( index > -1 ) {
+		overlays.splice( index, 1 );
+	}
+	emit( EVENTS.overlay, { overlays } );
+	return overlays;
+}
+
+export default {
+	get,
+	add,
+	remove,
+};

--- a/assets/reader-activation/overlays.test.js
+++ b/assets/reader-activation/overlays.test.js
@@ -1,0 +1,23 @@
+import { on } from './events';
+import overlays from './overlays';
+
+describe( 'overlays', () => {
+	it( 'should return an array', () => {
+		expect( Array.isArray( overlays.get() ) ).toBe( true );
+	} );
+	it( 'should add an overlay and emit the overlay event', () => {
+		const callback = jest.fn();
+		on( 'overlay', callback );
+		const overlayId = overlays.add();
+		expect( overlays.get() ).toEqual( [ overlayId ] );
+		expect( callback ).toHaveBeenCalled();
+	} );
+	it( 'should remove an overlay and emit the overlay event', () => {
+		const callback = jest.fn();
+		on( 'overlay', callback );
+		const overlayId = overlays.add();
+		overlays.remove( overlayId );
+		expect( overlays.get() ).toEqual( [] );
+		expect( callback ).toHaveBeenCalled();
+	} );
+} );

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -351,7 +351,7 @@ class Memberships {
 
 	/**
 	 * Get the current setting of the "Require memberships in all plans" option.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public static function get_require_all_plans_setting() {
@@ -360,10 +360,10 @@ class Memberships {
 
 	/**
 	 * Set the "Require memberships in all plans" option.
-	 * 
+	 *
 	 * @param boolean $require False to require membership in any plan restricting content (default)
 	 *                         or true to require membership in all plans restricting content.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public static function set_require_all_plans_setting( $require = false ) {
@@ -673,9 +673,17 @@ class Memberships {
 			window.newspackRAS.push( function( ras ) {
 				ras.on( 'reader', function( ev ) {
 					if ( ev.detail.authenticated ) {
-						setTimeout( function() {
-							window.location.reload();
-						}, 2000 );
+						if ( ras.overlays.get().length ) {
+							ras.on( 'overlay', function( ev ) {
+								if ( ! ev.detail.overlays.length ) {
+									window.location.reload();
+								}
+							} );
+						} else {
+							setTimeout( function() {
+								window.location.reload();
+							}, 2000 );
+						}
 					}
 				} );
 			} );
@@ -766,7 +774,7 @@ class Memberships {
 					$all_caps[ $cap ] = self::user_has_content_access_from_rules( $user_id, $rules, $post_id );
 
 					break;
-				}           
+				}
 			}
 		}
 
@@ -778,7 +786,7 @@ class Memberships {
 	 * Overrides behvavior from the WooCommerce Memberships plugin to decide whether to show restricted content.
 	 * Default behavior matches the WooCommerce Memberships plugin: if a user matches ANY applicable membership
 	 * plan rules, they are granted access to the content.
-	 * 
+	 *
 	 * Custom behavior: If the "Require membership in all plans" option is enabled in the Engagement wizard,
 	 * then a user must match ALL applicable membership plan rules before being granted access to the content.
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements centralized overlay management in RAS to allow side effects on overlay state changes. The content gate should now wait until the overlay is closed in order to refresh and unlock the content.

Adding or removing an overlay emits an `overlay` event that includes an array with all the opened overlays in its payload. 

### How to test the changes in this Pull Request:

1. Written tests should pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->