### PR TITLE
Hotfix (perfmatters): force stylesheet exclusion in unused CSS feature

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -20,6 +20,7 @@ class Perfmatters {
 		add_filter( 'option_perfmatters_options', [ __CLASS__, 'set_defaults' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'admin_notice' ] );
 		add_filter( 'perfmatters_lazyload_youtube_thumbnail_resolution', [ __CLASS__, 'maybe_serve_high_res_youtube_thumbs' ] );
+		add_filter( 'perfmatters_rucss_excluded_stylesheets', [ __CLASS__, 'add_rucss_excluded_stylesheets' ] );
 	}
 
 	/**
@@ -285,6 +286,18 @@ class Perfmatters {
 
 		// Use high-res thumbnails on desktop devices.
 		return 'maxresdefault';
+	}
+
+	/**
+	 * Use the Perfmatters filter to always exclude Newspack stylesheets from the "Unused CSS" feature,
+	 * regardless of the settings value.
+	 *
+	 * This is a backup solution, in a edge case where a user overrides their settings.
+	 *
+	 * @param array $stylesheet_exclusions Existing stylesheet exclusions.
+	 */
+	public static function add_rucss_excluded_stylesheets( $stylesheet_exclusions ) {
+		return array_unique( array_merge( $stylesheet_exclusions, self::unused_css_excluded_stylesheets() ) );
 	}
 }
 Perfmatters::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an edge case encountered on live sites. Before some Perfmatters' defaults were applied, the plugin already had a chance to create the "used CSS" stylesheet and save it. Later, when CSS used by our software was updated, the out-of-date copy was still kept in Perfmatters' file. 

In practice, this has resulted in Newspack Campaigns' prompts not being displayed. 

This PR forces our unused CSS exclusion array regardless of the settings. After clearing unused CSS (`wp eval "\Perfmatters\CSS::clear_used_css();"`, this change should ensure this never happens again. 

### How to test the changes in this Pull Request:

1. On `release`
1. Set the `NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS` env. variable, so Perfmatters settings can be changed
2. Go to Settings -> Perfmatters -> Assets and remove all lines but one from the CSS -> Excluded Stylesheets list
3. Log the value of `$stylesheet_exclusions` variable (after the filter is applied) in `wp-content/plugins/perfmatters/inc/classes/CSS.php` file, `remove_unused_css` method. 
4. Observe the value is missing Newspack entries (when loading any page)
5. Switch to this branch, observe the value contains Newspack entries

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->