### PR TITLE
Removes MC4WP from managed plugins

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -92,14 +92,6 @@ class Plugin_Manager {
 				'PluginURI'   => esc_url( 'https://mailchimp.com/connect-your-store/' ),
 				'Download'    => 'wporg',
 			],
-			'mailchimp-for-wp'              => [
-				'Name'        => esc_html__( 'MC4WP: Mailchimp for WordPress', 'newspack' ),
-				'Description' => esc_html__( 'Mailchimp for WordPress by ibericode. Adds various highly effective sign-up methods to your site.', 'newspack' ),
-				'Author'      => esc_html__( 'ibericode', 'newspack' ),
-				'PluginURI'   => esc_url( 'https://mc4wp.com' ),
-				'AuthorURI'   => esc_url( 'https://ibericode.com' ),
-				'Download'    => 'wporg',
-			],
 			'newspack-ads'                  => [
 				'Name'        => esc_html__( 'Newspack Ads', 'newspack' ),
 				'Description' => esc_html__( 'Ads integration.', 'newspack' ),


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes MC4WP from our managed plugins, per Tracy in Slack:

> The campaigns refactor removed support for targeting readers via the MC4WP plugin so we should no longer recommend that for pubs. And we need to communicate to those using it that we are no longer supporting.

### How to test the changes in this Pull Request:

1. Switch to this branch.
2. Visit `/wp-admin/plugins.php`.
3. Note that "MC4WP: Mailchimp for WordPress" is no longer among the default plugins available.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->