### PR TITLE
feat(stripe-migration): support mapping of products by SKU

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -99,7 +99,7 @@ class WooCommerce_Connection {
 	}
 
 	/**
-	 * Get WC's Order Item related to a given SKU.
+	 * Get a WC_Order_Item related to the product with the given SKU, or a Newspack donation product based on frequency.
 	 * 
 	 * @param string      $frequency Frequency of the order's recurrence.
 	 * @param number      $amount Donation amount.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a method to migrate a subscription from Stripe to Woo using a specific Woo product by SKU.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. In WP admin, go to Products and create a new subscription-type product. Set the SKU to some string, e.g. `TEST-PRODUCT-SKU`.
3. SSH into your test site and run `wp shell`.
4. Create some fake order data. You can use this to test:

```php
$order_data = [ 'status' => 'completed', 'subscription_status' => 'created', 'wc_subscription_status' => 'active', 'email' => 'test@email.com', 'name' => 'Test Customer Name', 'date' => 1698796940, 'amount' => 100, 'frequency' => 'year', 'currency' => 'USD', 'client_id' => '', 'user_id' => '' ];
```

5. Create a transaction using the SKU you created in step 2:

```php
\Newspack\WooCommerce_Connection::create_transaction( $order_data, 'TEST-PRODUCT-SKU' );
```

6. Confirm that a new subscription and parent order were created, mapped to the product with matching SKU instead of to a Newspack donation product.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->