### PR TITLE
feat(emails): support billing name on receipt email

### DIFF
--- a/includes/reader-revenue/class-reader-revenue-emails.php
+++ b/includes/reader-revenue/class-reader-revenue-emails.php
@@ -62,6 +62,10 @@ class Reader_Revenue_Emails {
 			'from_email'             => self::get_from_email(),
 			'available_placeholders' => [
 				[
+					'label'    => __( 'the customer billing name', 'newspack' ),
+					'template' => '*BILLING_NAME*',
+				],
+				[
 					'label'    => __( 'the payment amount', 'newspack' ),
 					'template' => '*AMOUNT*',
 				],

--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -447,6 +447,10 @@ class Stripe_Connection {
 		// Replace content placeholders.
 		$placeholders = [
 			[
+				'template' => '*BILLING_NAME*',
+				'value'    => $customer['name'],
+			],
+			[
 				'template' => '*AMOUNT*',
 				'value'    => self::format_amount( $amount_normalised, $payment['currency'] ),
 			],

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -100,11 +100,11 @@ class WooCommerce_Connection {
 
 	/**
 	 * Get a WC_Order_Item related to the product with the given SKU, or a Newspack donation product based on frequency.
-	 * 
+	 *
 	 * @param string      $frequency Frequency of the order's recurrence.
 	 * @param number      $amount Donation amount.
 	 * @param null|string $product_sku Product's SKU string, or null to get a Newspack donation product.
-	 * 
+	 *
 	 * @return boolean|WC_Order_Item_Product Order item product, or false if there's no product with matching SKU.
 	 */
 	public static function get_order_item( $frequency = 'once', $amount = 0, $product_sku = null ) {
@@ -1114,6 +1114,10 @@ class WooCommerce_Connection {
 		// Replace content placeholders.
 		$placeholders = [
 			[
+				'template' => '*BILLING_NAME*',
+				'value'    => trim( $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() ),
+			],
+			[
 				'template' => '*AMOUNT*',
 				'value'    => 'USD' === $currency ? $symbol . $total : $total . $symbol,
 			],
@@ -1142,7 +1146,7 @@ class WooCommerce_Connection {
 
 	/**
 	 * Get an array of product IDs associated with the given subscription ID.
-	 * 
+	 *
 	 * @param int     $subscription_id Subscription ID.
 	 * @param boolean $include_donations If true, include donation products, otherwise omit them.
 	 * @return array Array of product IDs associated with this subscription.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1205661051657369

Implements support for displaying the customer's billing name in reader revenue's receipt email.

### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have "Newspack" as your RR platform
2. Edit the Receipt email in "Newspack -> Reader Revenue -> Emails" and confirm you see the new `*BILLING_NAME*` placeholder option
3. Add the `*BILLING_NAME*` to the email body and save
4. Donate using the donate block and confirm the sent email includes the customer's billing name
5. Switch your RR platform to Stripe and donate again
6. Confirm the email body includes the customer name from Stripe

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->