### PR TITLE
Filter for Stripe connection

### DIFF
--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -554,7 +554,7 @@ class Stripe_Connection {
 	 */
 	private static function get_stripe_secret_key() {
 		$stripe_data = self::get_saved_stripe_data();
-		return $stripe_data['usedSecretKey'];
+		return apply_filters( 'newspack_stripe_connection_secret_key', $stripe_data['usedSecretKey'] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a small filter for changing the active Stripe key. This is very useful for subscription migrations:
- It allows us to run scripts from our local environment that use a publisher's Stripe key without having to connect our local environment to a publisher's Stripe.
- It allows us to run scripts using a live Stripe key while a staging site has Stripe test mode on.

### How to test the changes in this Pull Request:

1. Create a new script:
```
add_filter( 'newspack_stripe_connection_secret_key', function( $secret_key ) {
    return 'sk_live...'; // Use some different Stripe key than what you have "officially" set up on the site.
}

$stripe = Stripe_Connection::get_stripe_client();
$response = $stripe->customers->all( [ 'limit' => 5 ] );
var_dump( $response );
```
2. Run script with `wp eval-file`. Observe that the customers are from the Stripe account in the filter, not the connected Stripe account.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->