### PR TITLE
Sync order to ESP *after* payment goes through

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -60,8 +60,7 @@ class WooCommerce_Connection {
 		// WooCommerce Memberships.
 		\add_action( 'wc_memberships_user_membership_created', [ __CLASS__, 'wc_membership_created' ], 10, 2 );
 
-		// WC Subscriptions hooks in and creates subscription at priority 100, so use priority 101.
-		\add_action( 'woocommerce_checkout_order_processed', [ __CLASS__, 'order_processed' ], 101 );
+		\add_action( 'woocommerce_payment_complete', [ __CLASS__, 'order_paid' ], 101 );
 		\add_action( 'option_woocommerce_subscriptions_failed_scheduled_actions', [ __CLASS__, 'filter_subscription_scheduled_actions_errors' ] );
 
 		\add_action( 'wp_login', [ __CLASS__, 'sync_reader_on_customer_login' ], 10, 2 );
@@ -123,7 +122,7 @@ class WooCommerce_Connection {
 	 *
 	 * @param int $order_id Order ID.
 	 */
-	public static function order_processed( $order_id ) {
+	public static function order_paid( $order_id ) {
 		$product_id = Donations::get_order_donation_product_id( $order_id );
 
 		/** Bail if not a donation order. */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note**: this is a hotfix since the issue is affecting client ActiveCampaign automations.

This PR fixes an issue discovered by a client earlier this week. On new orders the "Last Payment Date" field is not getting synced. This is because: 
1. That field uses `$order->get_date_paid()`
2. We were hooked into `woocommerce_checkout_order_processed`
3. [The payment happens immediately **after** that hook](https://github.com/woocommerce/woocommerce/blob/6b44a969d0855702bd685a2b988d9f2825a59878/plugins/woocommerce/includes/class-wc-checkout.php#L1272-L1284), so `$order->get_date_paid()` would always return `NULL` because the order hadn't been paid yet.

This PR updates the hook to one that fires immediately after the order has been paid, so the payment date will be available.

### How to test the changes in this Pull Request:

1. Set up a site with RAS connected to ActiveCampaign.
2. Before applying this PR, make a one-time donation. In AC observe the Last Payment Date field is not there:

<img width="620" alt="Screenshot 2023-11-02 at 11 47 59 AM" src="https://github.com/Automattic/newspack-plugin/assets/7317227/2843bc95-dd2a-49a3-876e-ce11be02b66b">

3. Apply this PR. Make a one-time donation. In AC observe the Last Payment Date field is there:

<img width="499" alt="Screenshot 2023-11-02 at 11 56 41 AM" src="https://github.com/Automattic/newspack-plugin/assets/7317227/adb5ecd3-8e7b-4891-81c3-8dcaca2c4bee">

5. Just to be safe, test with a recurring donation too:

<img width="520" alt="Screenshot 2023-11-02 at 11 56 59 AM" src="https://github.com/Automattic/newspack-plugin/assets/7317227/dcfb85ad-aeb2-4b7e-a5b6-4e17a54ae7bc">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->