### PR TITLE
fix(auth-modal): handle very long newsletter lists list

### DIFF
--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -401,6 +401,8 @@
 		border-radius: 2px;
 		padding: 0.5em;
 		box-sizing: border-box;
+		max-height: 21vh;
+		overflow-y: scroll;
 		h3 {
 			display: none;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Handle very long lists of newsletter lists. 

See 1200133283036252-as-1205829529414334

### How to test the changes in this Pull Request:

1. On `master`, go to Engagement -> Newsletters -> Subscription Lists and edit a list description to something super long. Can be your favourite book, for example. 
2. Visit the site, click on the "My Account" in top-right corner, then "I don't have an account"
3. Observe the lists are making the modal assume the window height, with the CTAs pushed below the fold
4. Switch to this branch, observe the newsletters lists list is scrollable

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->