### PR TITLE
feat(my-account): support edit address

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -717,7 +717,7 @@ class Donations {
 			$query_args['modal_checkout'] = 1;
 		}
 		foreach ( [ 'after_success_behavior', 'after_success_button_label', 'after_success_url' ] as $attribute_name ) {
-			$value = filter_input( INPUT_GET, $attribute_name, FILTER_SANITIZE_STRING );
+			$value = filter_input( INPUT_GET, $attribute_name, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! empty( $value ) ) {
 				$query_args[ $attribute_name ] = $value;
 			}

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -123,9 +123,16 @@ class WooCommerce_My_Account {
 				}
 			}
 			if ( class_exists( 'WC_Customer' ) ) {
+				$ignored_fields   = [ 'first_name', 'last_name', 'email' ];
 				$customer         = new \WC_Customer( $customer_id );
 				$billing_address  = $customer->get_billing();
 				$shipping_address = $customer->get_shipping();
+
+				// We only want to show the Addresses menu item if the reader has address info (not first/last name or email).
+				foreach ( $ignored_fields as $ignored_field ) {
+					unset( $billing_address[ $ignored_field ] );
+					unset( $shipping_address[ $ignored_field ] );
+				}
 
 				if ( empty( array_filter( $billing_address ) ) && empty( array_filter( $billing_address ) ) ) {
 					$default_disabled_items[] = 'edit-address';

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -105,7 +105,7 @@ class WooCommerce_My_Account {
 				return $items;
 			}
 
-			$default_disabled_items = array_merge( $default_disabled_items, [ 'dashboard', 'members-area', 'edit-address' ] );
+			$default_disabled_items = array_merge( $default_disabled_items, [ 'dashboard', 'members-area' ] );
 			$customer_id            = \get_current_user_id();
 			if ( function_exists( 'wcs_user_has_subscription' ) && function_exists( 'wcs_get_subscriptions' ) ) {
 				$user_subscriptions             = wcs_get_subscriptions( [ 'customer_id' => $customer_id ] );
@@ -120,6 +120,15 @@ class WooCommerce_My_Account {
 				// The Stripe-tied subscriptions will be available for management in the "Billing" section.
 				if ( ! $has_non_newspack_subscriptions ) {
 					$default_disabled_items[] = 'subscriptions';
+				}
+			}
+			if ( class_exists( 'WC_Customer' ) ) {
+				$customer         = new \WC_Customer( $customer_id );
+				$billing_address  = $customer->get_billing();
+				$shipping_address = $customer->get_shipping();
+
+				if ( empty( array_filter( $billing_address ) ) && empty( array_filter( $billing_address ) ) ) {
+					$default_disabled_items[] = 'edit-address';
 				}
 			}
 			if ( function_exists( 'wc_get_orders' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for seeing and editing billing and shipping addresses in My Account, if the user account has any address info.

### How to test the changes in this Pull Request:

1. Enable address fields in Reader Revenue > Donations.
2. As a new reader, make a purchase and input address info.
3. Go to My Account and confirm that there's an "Addresses" menu item and that clicking on it allows you to see/edit the billing address you entered during checkout.
4. Confirm you can update the billing address and that it's pre-populated when you make new purchases while logged in.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->