### PR TITLE
fix: restore method used by migration scripts

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -169,6 +169,33 @@ class WooCommerce_Connection {
 	}
 
 	/**
+	 * Get the contact data from a WooCommerce customer user account.
+	 *
+	 * @param \WC_Customer|int $customer Customer or customer ID.
+	 *
+	 * @return array|false Contact data or false.
+	 */
+	public static function get_contact_from_customer( $customer ) {
+		if ( is_integer( $customer ) ) {
+			$customer = new \WC_Customer( $customer );
+		}
+
+		$metadata = [];
+
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'account' ) ]           = $customer->get_id();
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_date' ) ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
+
+		$first_name   = $customer->get_first_name();
+		$last_name    = $customer->get_last_name();
+		$display_name = $customer->get_display_name();
+		return [
+			'email'    => $customer->get_email(),
+			'name'     => $display_name ?? "$first_name $last_name",
+			'metadata' => $metadata,
+		];
+	}
+
+	/**
 	 * Get the contact data from a WooCommerce order.
 	 *
 	 * @param \WC_Order|int $order WooCommerce order or order ID.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Restores a method that was accidentally removed in #2663. This method is needed for migration scripts.

### How to test the changes in this Pull Request:

Confirm that the method is restored exactly as it was when it was [first added](https://github.com/Automattic/newspack-plugin/pull/2632/files#diff-b1dbb7bb086f4afe9581e4edecca68795028891e7d380656342dc169973ad5a5R170). You can test with WP shell:

```
> $customer = new WC_Customer( 42 ) // ID for a WC customer account
> Newspack\WooCommerce_Connection::get_contact_from_customer( $customer )
= [
    "email" => "donor@test.co",
    "name" => "Test Donor",
    "metadata" => [
      "NP_Account" => 42,
      "NP_Registration Date" => "2023-11-03",
    ],
  ]
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->