### PR TITLE
fix(password-reset): redirect non-readers to WP login

### DIFF
--- a/includes/reader-activation/class-reader-activation-emails.php
+++ b/includes/reader-activation/class-reader-activation-emails.php
@@ -32,6 +32,7 @@ class Reader_Activation_Emails {
 		// Disable the default WC password reset email and replace it with ours.
 		add_filter( 'woocommerce_email_enabled_customer_reset_password', '__return_false' );
 		add_action( 'woocommerce_reset_password_notification', [ __CLASS__, 'send_reset_password_email' ], 10, 2 );
+		add_action( 'woocommerce_customer_reset_password', [ __CLASS__, 'redirect_non_reader' ] );
 	}
 
 	/**
@@ -110,6 +111,18 @@ class Reader_Activation_Emails {
 			],
 		];
 		return $configs;
+	}
+
+	/**
+	 * Redirect non reader to default wp-login.php.
+	 *
+	 * @param \WP_User $user User object.
+	 */
+	public static function redirect_non_reader( $user ) {
+		if ( ! \Newspack\Reader_Activation::is_user_reader( $user ) ) {
+			wp_safe_redirect( wp_login_url() );
+			exit;
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The default password reset flow with WooCommerce redirects the user to the `my-account` page. Because we replace the authentication form on that page with a flow that is restricted to reader accounts only, non-readers get stuck in a form they can't use after a password reset.

This PR redirects non-readers to the regular `wp-login.php` page after a password reset.

### How to test the changes in this Pull Request:

1. Check out this branch and go through password reset for an admin account
2. Reset the password and confirm you're redirected to `wp-login.php`
3. Do the same but with a reader account
4. Reset the password and confirm you're redirect to `my-account`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->