### PR TITLE
feat: new options for Stripe fees

### DIFF
--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -31,27 +31,33 @@ const { SettingsCard } = Settings;
 
 const StripeFeeSettings = ( { data, changeHandler } ) => (
 	<SettingsCard
-		title={ __( 'Fee', 'newspack' ) }
+		title={ __( 'Transaction Fees', 'newspack-plugin' ) }
 		description={ __(
 			'If you have a non-default or negotiated fee with Stripe, update its parameters here.',
-			'newspack'
+			'newspack-plugin'
 		) }
 		columns={ 1 }
 		noBorder
 	>
+		<TextControl
+			value={ data.allow_covering_fees_label }
+			label={ __( 'Fee message', 'newspack-plugin' ) }
+			placeholder={ __( 'A message to explain the transaction fee option.', 'newspack-plugin' ) }
+			onChange={ changeHandler( 'allow_covering_fees_label' ) }
+		/>
 		<Grid noMargin rowGap={ 16 }>
 			<TextControl
 				type="number"
 				step="0.1"
 				value={ data.fee_multiplier }
-				label={ __( 'Fee multiplier', 'newspack' ) }
+				label={ __( 'Fee multiplier', 'newspack-plugin' ) }
 				onChange={ changeHandler( 'fee_multiplier' ) }
 			/>
 			<TextControl
 				type="number"
 				step="0.1"
 				value={ data.fee_static }
-				label={ __( 'Fee static portion', 'newspack' ) }
+				label={ __( 'Fee static portion', 'newspack-plugin' ) }
 				onChange={ changeHandler( 'fee_static' ) }
 			/>
 		</Grid>
@@ -80,19 +86,19 @@ export const StripeKeysSettings = () => {
 		<Grid columns={ 1 } gutter={ 16 }>
 			<Grid columns={ 1 } gutter={ 16 }>
 				<p className="newspack-payment-setup-screen__api-keys-instruction">
-					{ __( 'Configure Stripe and enter your API keys', 'newspack' ) }
+					{ __( 'Configure Stripe and enter your API keys', 'newspack-plugin' ) }
 					{ ' – ' }
 					<ExternalLink href="https://stripe.com/docs/keys#api-keys">
 						{ __( 'learn how' ) }
 					</ExternalLink>
 				</p>
 				<CheckboxControl
-					label={ __( 'Use Stripe in test mode', 'newspack' ) }
+					label={ __( 'Use Stripe in test mode', 'newspack-plugin' ) }
 					checked={ testMode }
 					onChange={ changeHandler( 'testMode' ) }
 					help={ __(
 						'Test mode will not capture real payments. Use it for testing your purchase flow.',
-						'newspack'
+						'newspack-plugin'
 					) }
 				/>
 			</Grid>
@@ -102,13 +108,13 @@ export const StripeKeysSettings = () => {
 						<TextControl
 							type="password"
 							value={ testPublishableKey }
-							label={ __( 'Test Publishable Key', 'newspack' ) }
+							label={ __( 'Test Publishable Key', 'newspack-plugin' ) }
 							onChange={ changeHandler( 'testPublishableKey' ) }
 						/>
 						<TextControl
 							type="password"
 							value={ testSecretKey }
-							label={ __( 'Test Secret Key', 'newspack' ) }
+							label={ __( 'Test Secret Key', 'newspack-plugin' ) }
 							onChange={ changeHandler( 'testSecretKey' ) }
 						/>
 					</>
@@ -117,13 +123,13 @@ export const StripeKeysSettings = () => {
 						<TextControl
 							type="password"
 							value={ publishableKey }
-							label={ __( 'Publishable Key', 'newspack' ) }
+							label={ __( 'Publishable Key', 'newspack-plugin' ) }
 							onChange={ changeHandler( 'publishableKey' ) }
 						/>
 						<TextControl
 							type="password"
 							value={ secretKey }
-							label={ __( 'Secret Key', 'newspack' ) }
+							label={ __( 'Secret Key', 'newspack-plugin' ) }
 							onChange={ changeHandler( 'secretKey' ) }
 						/>
 					</>
@@ -174,7 +180,7 @@ const StripeSetup = () => {
 						<a href="https://stripe.com/docs/security/guide">
 							{ __(
 								'This site does not use SSL. The page hosting the Stipe integration should be secured with SSL.',
-								'newspack'
+								'newspack-plugin'
 							) }
 						</a>
 					}
@@ -185,26 +191,31 @@ const StripeSetup = () => {
 					{ ! isEmpty( data.connection_error ) && (
 						<Notice isError noticeText={ data.connection_error } />
 					) }
-					<SettingsCard title={ __( 'Settings', 'newspack' ) } columns={ 1 } gutter={ 16 } noBorder>
+					<SettingsCard
+						title={ __( 'Settings', 'newspack-plugin' ) }
+						columns={ 1 }
+						gutter={ 16 }
+						noBorder
+					>
 						{ data.can_use_stripe_platform === false && (
 							<Notice
 								isError
 								noticeText={ __(
 									'The Stripe platform will not work properly on this site.',
-									'newspack'
+									'newspack-plugin'
 								) }
 							/>
 						) }
 						<StripeKeysSettings />
 						<Grid rowGap={ 16 }>
 							<SelectControl
-								label={ __( 'Country', 'newspack' ) }
+								label={ __( 'Country', 'newspack-plugin' ) }
 								value={ data.location_code }
 								options={ country_state_fields }
 								onChange={ changeHandler( 'location_code' ) }
 							/>
 							<SelectControl
-								label={ __( 'Currency', 'newspack' ) }
+								label={ __( 'Currency', 'newspack-plugin' ) }
 								value={ data.currency }
 								options={ currency_fields }
 								onChange={ changeHandler( 'currency' ) }
@@ -212,10 +223,10 @@ const StripeSetup = () => {
 						</Grid>
 					</SettingsCard>
 					<SettingsCard
-						title={ __( 'Newsletters', 'newspack' ) }
+						title={ __( 'Newsletters', 'newspack-plugin' ) }
 						description={ __(
 							'Allow donors to sign up to your newsletter when donating.',
-							'newspack'
+							'newspack-plugin'
 						) }
 						columns={ 1 }
 						gutter={ 16 }
@@ -232,7 +243,7 @@ const StripeSetup = () => {
 				<>
 					<Grid>
 						<ToggleControl
-							label={ __( 'Enable Stripe', 'newspack' ) }
+							label={ __( 'Enable Stripe', 'newspack-plugin' ) }
 							checked={ data.enabled }
 							onChange={ changeHandler( 'enabled' ) }
 						/>
@@ -241,22 +252,33 @@ const StripeSetup = () => {
 						<>
 							<StripeKeysSettings />
 							<StripeFeeSettings data={ data } changeHandler={ changeHandler } />
-							<CheckboxControl
-								label={ __( 'Allow donors to cover transaction fees', 'newspack' ) }
-								checked={ data.allow_covering_fees }
-								onChange={ changeHandler( 'allow_covering_fees' ) }
-								help={ __(
-									"If checked, the donors will be able to cover Stripe's transaction fees.",
-									'newspack'
-								) }
-							/>
+							<Grid columns={ 2 }>
+								<CheckboxControl
+									label={ __( 'Allow donors to cover transaction fees', 'newspack-plugin' ) }
+									checked={ data.allow_covering_fees }
+									onChange={ changeHandler( 'allow_covering_fees' ) }
+									help={ __(
+										"If checked, the donors will be able to cover Stripe's transaction fees.",
+										'newspack-plugin'
+									) }
+								/>
+								<CheckboxControl
+									label={ __( 'Enable covering fees by default', 'newspack-plugin' ) }
+									checked={ data.allow_covering_fees_default }
+									onChange={ changeHandler( 'allow_covering_fees_default' ) }
+									help={ __(
+										'If checked, the option to cover transaction fees will be checked by default.',
+										'newspack-plugin'
+									) }
+								/>
+							</Grid>
 						</>
 					) : (
 						<Grid>
 							<p className="newspack-payment-setup-screen__info">
-								{ __( 'Other gateways can be enabled and set up in the ', 'newspack' ) }
+								{ __( 'Other gateways can be enabled and set up in the ', 'newspack-plugin' ) }
 								<ExternalLink href="/wp-admin/admin.php?page=wc-settings&tab=checkout">
-									{ __( 'WooCommerce payment gateway settings', 'newspack' ) }
+									{ __( 'WooCommerce payment gateway settings', 'newspack-plugin' ) }
 								</ExternalLink>
 							</p>
 						</Grid>
@@ -265,19 +287,19 @@ const StripeSetup = () => {
 			) }
 			<div className="newspack-buttons-card">
 				<Button isPrimary onClick={ onSave }>
-					{ __( 'Save Settings', 'newspack' ) }
+					{ __( 'Save Settings', 'newspack-plugin' ) }
 				</Button>
 			</div>
 			{ displayStripeSettingsOnly && (
 				<ActionCard
-					title={ __( 'Webhooks', 'newspack' ) }
+					title={ __( 'Webhooks', 'newspack-plugin' ) }
 					titleLink="#/stripe-webhooks"
 					href="#/stripe-webhooks"
 					description={ __(
 						'Manage the webhooks Stripe uses to communicate with your site.',
-						'newspack'
+						'newspack-plugin'
 					) }
-					actionText={ __( 'Edit', 'newspack' ) }
+					actionText={ __( 'Edit', 'newspack-plugin' ) }
 				/>
 			) }
 		</>

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -265,16 +265,16 @@ const StripeSetup = () => {
 										'newspack-plugin'
 									) }
 								/>
-								<TextControl
-									value={ data.allow_covering_fees_label }
-									label={ __( 'Custom message', 'newspack-plugin' ) }
-									placeholder={ __(
-										'A message to explain the transaction fee option (optional).',
-										'newspack-plugin'
-									) }
-									onChange={ changeHandler( 'allow_covering_fees_label' ) }
-								/>
 							</Grid>
+							<TextControl
+								value={ data.allow_covering_fees_label }
+								label={ __( 'Custom message', 'newspack-plugin' ) }
+								placeholder={ __(
+									'A message to explain the transaction fee option (optional).',
+									'newspack-plugin'
+								) }
+								onChange={ changeHandler( 'allow_covering_fees_label' ) }
+							/>
 						</>
 					) : (
 						<Grid>

--- a/assets/wizards/readerRevenue/views/stripe-setup/index.js
+++ b/assets/wizards/readerRevenue/views/stripe-setup/index.js
@@ -39,12 +39,6 @@ const StripeFeeSettings = ( { data, changeHandler } ) => (
 		columns={ 1 }
 		noBorder
 	>
-		<TextControl
-			value={ data.allow_covering_fees_label }
-			label={ __( 'Fee message', 'newspack-plugin' ) }
-			placeholder={ __( 'A message to explain the transaction fee option.', 'newspack-plugin' ) }
-			onChange={ changeHandler( 'allow_covering_fees_label' ) }
-		/>
 		<Grid noMargin rowGap={ 16 }>
 			<TextControl
 				type="number"
@@ -270,6 +264,15 @@ const StripeSetup = () => {
 										'If checked, the option to cover transaction fees will be checked by default.',
 										'newspack-plugin'
 									) }
+								/>
+								<TextControl
+									value={ data.allow_covering_fees_label }
+									label={ __( 'Custom message', 'newspack-plugin' ) }
+									placeholder={ __(
+										'A message to explain the transaction fee option (optional).',
+										'newspack-plugin'
+									) }
+									onChange={ changeHandler( 'allow_covering_fees_label' ) }
 								/>
 							</Grid>
 						</>

--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -112,15 +112,7 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 		if ( ! isset( $gateways['stripe'] ) ) {
 			return $defaults;
 		}
-		$stripe = $gateways['stripe'];
-
-		$default_message = sprintf(
-			// Translators: %s is the transaction fee, as percentage with static portion (e.g. 2% + $0.3), %s is the site title.
-			__( 'Cover Stripe’s %1$s transaction fee, so that %2$s receives 100%% of your payment.', 'newspack-plugin' ),
-			WooCommerce_Cover_Fees::get_fee_human_readable_value(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			get_option( 'blogname' )
-		);
-
+		$stripe      = $gateways['stripe'];
 		$stripe_data = [
 			'enabled'                     => 'yes' === $stripe->get_option( 'enabled', false ) ? true : false,
 			'testMode'                    => 'yes' === $stripe->get_option( 'testmode', false ) ? true : false,
@@ -130,7 +122,7 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 			'testSecretKey'               => $stripe->get_option( 'test_secret_key', '' ),
 			'allow_covering_fees'         => get_option( 'newspack_donations_allow_covering_fees', true ),
 			'allow_covering_fees_default' => get_option( 'newspack_donations_allow_covering_fees_default', false ),
-			'allow_covering_fees_label'   => get_option( 'newspack_donations_allow_covering_fees_label', $default_message ),
+			'allow_covering_fees_label'   => get_option( 'newspack_donations_allow_covering_fees_label', '' ),
 		];
 		return \wp_parse_args( $stripe_data, $defaults );
 	}

--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -112,15 +112,25 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 		if ( ! isset( $gateways['stripe'] ) ) {
 			return $defaults;
 		}
-		$stripe      = $gateways['stripe'];
+		$stripe = $gateways['stripe'];
+
+		$default_message = sprintf(
+			// Translators: %s is the transaction fee, as percentage with static portion (e.g. 2% + $0.3), %s is the site title.
+			__( 'Cover Stripe’s %1$s transaction fee, so that %2$s receives 100%% of your payment.', 'newspack-plugin' ),
+			WooCommerce_Cover_Fees::get_fee_human_readable_value(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			get_option( 'blogname' )
+		);
+
 		$stripe_data = [
-			'enabled'             => 'yes' === $stripe->get_option( 'enabled', false ) ? true : false,
-			'testMode'            => 'yes' === $stripe->get_option( 'testmode', false ) ? true : false,
-			'publishableKey'      => $stripe->get_option( 'publishable_key', '' ),
-			'secretKey'           => $stripe->get_option( 'secret_key', '' ),
-			'testPublishableKey'  => $stripe->get_option( 'test_publishable_key', '' ),
-			'testSecretKey'       => $stripe->get_option( 'test_secret_key', '' ),
-			'allow_covering_fees' => get_option( 'newspack_donations_allow_covering_fees', true ),
+			'enabled'                     => 'yes' === $stripe->get_option( 'enabled', false ) ? true : false,
+			'testMode'                    => 'yes' === $stripe->get_option( 'testmode', false ) ? true : false,
+			'publishableKey'              => $stripe->get_option( 'publishable_key', '' ),
+			'secretKey'                   => $stripe->get_option( 'secret_key', '' ),
+			'testPublishableKey'          => $stripe->get_option( 'test_publishable_key', '' ),
+			'testSecretKey'               => $stripe->get_option( 'test_secret_key', '' ),
+			'allow_covering_fees'         => get_option( 'newspack_donations_allow_covering_fees', true ),
+			'allow_covering_fees_default' => get_option( 'newspack_donations_allow_covering_fees_default', false ),
+			'allow_covering_fees_label'   => get_option( 'newspack_donations_allow_covering_fees_label', $default_message ),
 		];
 		return \wp_parse_args( $stripe_data, $defaults );
 	}

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -138,21 +138,38 @@ class WooCommerce_Cover_Fees {
 					<?php endif; ?>
 				>
 				<label for=<?php echo esc_attr( self::CUSTOM_FIELD_NAME ); ?> style="display:inline;">
-					<b><?php echo esc_html( __( 'Cover transaction fees?', 'newspack-plugin' ) ); ?></b><br/>
+					<b><?php echo esc_html( __( 'Cover transaction fee?', 'newspack-plugin' ) ); ?></b><br/>
 					<?php
+					$custom_message = get_option( 'newspack_donations_allow_covering_fees_label', '' );
+					if ( ! empty( $custom_message ) ) {
+						echo esc_html( $custom_message );
+					} else {
 						printf(
-							// Translators: %s is the transaction fee, as percentage with static portion (e.g. 2% + $0.3), %s is the site title.
-							esc_html__( 'Cover Stripe’s %1$s transaction fee, so that %2$s receives 100%% of your payment.', 'newspack-plugin' ),
-							self::get_fee_display_value(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							esc_html( get_option( 'blogname' ) )
+							// Translators: %s is the possessive form of the site name.
+							esc_html__(
+								'I’d like to cover the %1$s transaction fee to ensure my full donation goes towards %2$s mission.',
+								'newspack-plugin' 
+							),
+							esc_html( self::get_fee_display_value() ),
+							esc_html( self::get_possessive( get_option( 'blogname' ) ) )
 						);
+					}
 					?>
-
 				</label>
 			</p>
 		<?php
 		$desc .= ob_get_clean();
 		return $desc;
+	}
+
+	/**
+	 * Get possessive form of the given string. Proper nouns ending in S should not have a trailing S.
+	 * 
+	 * @param string $string String to modify.
+	 * @return string Modified string.
+	 */
+	private static function get_possessive( $string ) {
+		return $string . '’' . ( 's' !== $string[ strlen( $string ) - 1 ] ? 's' : '' );
 	}
 
 	/**
@@ -227,7 +244,7 @@ class WooCommerce_Cover_Fees {
 	/**
 	 * Get the fee display value.
 	 */
-	private static function get_fee_display_value() {
+	public static function get_fee_display_value() {
 		$price = floatval( WC()->cart->total );
 		$total = self::get_total_with_fee( $price );
 		// Just one decimal place, please.

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -42,7 +42,8 @@ class WooCommerce_Cover_Fees {
 		}
 		$fields['newspack'] = [
 			self::CUSTOM_FIELD_NAME => [
-				'type' => 'checkbox',
+				'type'    => 'checkbox',
+				'default' => intval( get_option( 'newspack_donations_allow_covering_fees_default', false ) ),
 			],
 		];
 		return $fields;
@@ -132,6 +133,9 @@ class WooCommerce_Cover_Fees {
 					value="true"
 					style="margin-right: 10px;"
 					onchange="newspackHandleCoverFees(this)"
+					<?php if ( get_option( 'newspack_donations_allow_covering_fees_default', false ) ) : ?>
+						checked
+					<?php endif; ?>
 				>
 				<label for=<?php echo esc_attr( self::CUSTOM_FIELD_NAME ); ?> style="display:inline;">
 					<b><?php echo esc_html( __( 'Cover transaction fees?', 'newspack-plugin' ) ); ?></b><br/>
@@ -223,7 +227,7 @@ class WooCommerce_Cover_Fees {
 	/**
 	 * Get the fee human-redable value.
 	 */
-	private static function get_fee_human_readable_value() {
+	public static function get_fee_human_readable_value() {
 		return self::get_stripe_fee_multiplier_value() . '% + ' . wc_price( self::get_stripe_fee_static_value() );
 	}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -138,7 +138,6 @@ class WooCommerce_Cover_Fees {
 					<?php endif; ?>
 				>
 				<label for=<?php echo esc_attr( self::CUSTOM_FIELD_NAME ); ?> style="display:inline;">
-					<b><?php echo esc_html( __( 'Cover transaction fee?', 'newspack-plugin' ) ); ?></b><br/>
 					<?php
 					$custom_message = get_option( 'newspack_donations_allow_covering_fees_label', '' );
 					if ( ! empty( $custom_message ) ) {

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -379,9 +379,8 @@ class Reader_Revenue_Wizard extends Wizard {
 			if ( isset( $args['allow_covering_fees_default'] ) ) {
 				update_option( 'newspack_donations_allow_covering_fees_default', $args['allow_covering_fees_default'] );
 			}
-			if ( ! empty( $args['allow_covering_fees_label'] ) ) {
-				update_option( 'newspack_donations_allow_covering_fees_label', $args['allow_covering_fees_label'] );
-			}
+
+			update_option( 'newspack_donations_allow_covering_fees_label', $args['allow_covering_fees_label'] );
 		}
 
 		Stripe_Connection::update_stripe_data( $args );

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -380,7 +380,9 @@ class Reader_Revenue_Wizard extends Wizard {
 				update_option( 'newspack_donations_allow_covering_fees_default', $args['allow_covering_fees_default'] );
 			}
 
-			update_option( 'newspack_donations_allow_covering_fees_label', $args['allow_covering_fees_label'] );
+			if ( isset( $args['allow_covering_fees_label'] ) ) {
+				update_option( 'newspack_donations_allow_covering_fees_label', $args['allow_covering_fees_label'] );
+			}
 		}
 
 		Stripe_Connection::update_stripe_data( $args );

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -155,28 +155,28 @@ class Reader_Revenue_Wizard extends Wizard {
 				'callback'            => [ $this, 'api_update_stripe_settings' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'enabled'             => [
+					'enabled'                     => [
 						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
 					],
-					'testMode'            => [
+					'testMode'                    => [
 						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
 					],
-					'publishableKey'      => [
+					'publishableKey'              => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
-					'secretKey'           => [
+					'secretKey'                   => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
-					'testPublishableKey'  => [
+					'testPublishableKey'          => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
-					'testSecretKey'       => [
+					'testSecretKey'               => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
-					'newsletter_list_id'  => [
+					'newsletter_list_id'          => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
-					'fee_multiplier'      => [
+					'fee_multiplier'              => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 						'validate_callback' => function ( $value ) {
 							if ( (float) $value > 10 ) {
@@ -188,13 +188,19 @@ class Reader_Revenue_Wizard extends Wizard {
 							return true;
 						},
 					],
-					'fee_static'          => [
+					'fee_static'                  => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
-					'allow_covering_fees' => [
+					'allow_covering_fees'         => [
 						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
 					],
-					'location_code'       => [
+					'allow_covering_fees_default' => [
+						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
+					],
+					'allow_covering_fees_label'   => [
+						'sanitize_callback' => 'Newspack\newspack_clean',
+					],
+					'location_code'               => [
 						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
 				],
@@ -204,7 +210,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		// Update Donations settings.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/donations/',
+			' / wizard / ' . $this->slug . ' / donations / ',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_donation_settings' ],
@@ -231,7 +237,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		// Save Salesforce settings.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/salesforce/',
+			' / wizard / ' . $this->slug . ' / salesforce / ',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_salesforce_settings' ],
@@ -255,7 +261,7 @@ class Reader_Revenue_Wizard extends Wizard {
 
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/donations/',
+			' / wizard / ' . $this->slug . ' / donations / ',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_donation_settings' ],
@@ -289,12 +295,12 @@ class Reader_Revenue_Wizard extends Wizard {
 			NRH::update_settings( $params );
 		}
 
-		// Ensure that any Reader Revenue settings changed while the platform wasn't WC are persisted to WC products.
+		// Ensure that any Reader Revenue settings changed while the platform wasn't WC are persisted to WC products .
 		if ( Donations::is_platform_wc() ) {
 			Donations::update_donation_product( Donations::get_donation_settings() );
 		}
 
-		return \rest_ensure_response( $this->fetch_all_data() );
+					return \rest_ensure_response( $this->fetch_all_data() );
 	}
 
 	/**
@@ -369,6 +375,12 @@ class Reader_Revenue_Wizard extends Wizard {
 			}
 			if ( isset( $args['allow_covering_fees'] ) ) {
 				update_option( 'newspack_donations_allow_covering_fees', $args['allow_covering_fees'] );
+			}
+			if ( isset( $args['allow_covering_fees_default'] ) ) {
+				update_option( 'newspack_donations_allow_covering_fees_default', $args['allow_covering_fees_default'] );
+			}
+			if ( ! empty( $args['allow_covering_fees_label'] ) ) {
+				update_option( 'newspack_donations_allow_covering_fees_label', $args['allow_covering_fees_label'] );
 			}
 		}
 

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -237,7 +237,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		// Save Salesforce settings.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			' / wizard / ' . $this->slug . ' / salesforce / ',
+			'/wizard/' . $this->slug . '/salesforce/',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_salesforce_settings' ],
@@ -261,7 +261,7 @@ class Reader_Revenue_Wizard extends Wizard {
 
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			' / wizard / ' . $this->slug . ' / donations / ',
+			'/wizard/' . $this->slug . '/donations/',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_donation_settings' ],
@@ -300,7 +300,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			Donations::update_donation_product( Donations::get_donation_settings() );
 		}
 
-					return \rest_ensure_response( $this->fetch_all_data() );
+		return \rest_ensure_response( $this->fetch_all_data() );
 	}
 
 	/**

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -210,7 +210,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		// Update Donations settings.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			' / wizard / ' . $this->slug . ' / donations / ',
+			'/wizard/' . $this->slug . '/donations/',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_donation_settings' ],


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds two new configuration options for the "Stripe fees" option introduced in https://github.com/Automattic/newspack-plugin/pull/2695:

- Make the checkbox checked by default (opt-out instead of opt-in): This is configurable by publisher because some sites want it to be opt-out, but others must follow regulations to make such options opt-in.
- Custom fee message. Also tweaks the default message to the slightly more reader-friendly:

> I’d like to cover the [fee percentage] transaction fee to ensure my full donation goes towards [site name]'s mission.

Also integrates the flat percentage fee display from #2746 for better readability in the default messaging.

Closes `1205451924709234/1205912365838338`.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Visit Newspack > Reader Revenue > Stripe Gateway (make sure platform is "Newspack")
3. Confirm the new options here (both should be empty/unchecked by default):

<img width="1063" alt="Screenshot 2023-11-10 at 4 30 00 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/4efcb74e-cb97-442e-814c-846b8be03060">

4. Without changing any settings, smoke test a donation and confirm that the checkout modal shows defaults:

<img width="546" alt="Screenshot 2023-11-10 at 4 51 53 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/5f860dd9-02c6-464a-8f4a-90bec0fc39c7">

5. Update the settings and confirm with a new donation that they take effect (the checkbox should be checked by default, and the custom message should appear below the label):

<img width="551" alt="Screenshot 2023-11-10 at 4 53 07 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/42d9c1cb-a69d-4ecf-99d1-34fced9a0183">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->