### PR TITLE
feat(modal-checkout): display flat percentage fee when offering to cover stripe fees

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -227,9 +227,7 @@ class WooCommerce_Cover_Fees {
 		$price = floatval( WC()->cart->total );
 		$total = self::get_total_with_fee( $price );
 		// Just one decimal place, please.
-		$flat_percentage = number_format( ( ( $total - $price ) * 100 ) / $price, 1 );
-		// Remove trailing zero.
-		$flat_percentage = preg_replace( '/[.,]0+$/', '', $flat_percentage );
+		$flat_percentage = (float) number_format( ( ( $total - $price ) * 100 ) / $price, 1 );
 		return $flat_percentage . '%';
 	}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -139,7 +139,7 @@ class WooCommerce_Cover_Fees {
 						printf(
 							// Translators: %s is the transaction fee, as percentage with static portion (e.g. 2% + $0.3), %s is the site title.
 							esc_html__( 'Cover Stripe’s %1$s transaction fee, so that %2$s receives 100%% of your payment.', 'newspack-plugin' ),
-							self::get_fee_human_readable_value(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							self::get_fee_display_value(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 							esc_html( get_option( 'blogname' ) )
 						);
 					?>
@@ -221,10 +221,16 @@ class WooCommerce_Cover_Fees {
 	}
 
 	/**
-	 * Get the fee human-redable value.
+	 * Get the fee display value.
 	 */
-	private static function get_fee_human_readable_value() {
-		return self::get_stripe_fee_multiplier_value() . '% + ' . wc_price( self::get_stripe_fee_static_value() );
+	private static function get_fee_display_value() {
+		$price = floatval( WC()->cart->total );
+		$total = self::get_total_with_fee( $price );
+		// Just one decimal place, please.
+		$flat_percentage = number_format( ( ( $total - $price ) * 100 ) / $price, 1 );
+		// Remove trailing zero.
+		$flat_percentage = preg_replace( '/[.,]0+$/', '', $flat_percentage );
+		return $flat_percentage . '%';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Replaces the lengthy `2.9% + $0.3` with a flat percentage, e.g. `3%`:

<img width="491" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/92045ca1-00f1-4f2c-8863-6bdd58d625b8">

### How to test the changes in this Pull Request:

1. Initiate a donate with the modal checkout
2. Observe the transaction fee in the "Cover transaction fees?" is expressed as percentage only
3. Try with different amounts, you can verify the calculation by checking the option (so the total amount is updated in the UI and computing the percentage of the initial amount)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->