### PR TITLE
fix(metering): restrict comments on gated content

### DIFF
--- a/assets/memberships-gate/metering.js
+++ b/assets/memberships-gate/metering.js
@@ -57,23 +57,12 @@ function lockContent() {
 	prompts.forEach( prompt => {
 		prompt.parentNode.removeChild( prompt );
 	} );
-	const visibleParagraphs = settings.visible_paragraphs;
-	const articleElements = document.querySelectorAll( '.entry-content > *' );
-	const moreIndex = content.innerHTML.indexOf( '<!--more-->' );
+	// Replace content.
+	content.innerHTML = settings.excerpt;
+	// Remove comments.
+	document.getElementById( 'comments' ).remove();
+	// Append inline gate, if any.
 	const inlineGate = document.querySelector( '.newspack-memberships__inline-gate' );
-	if ( moreIndex > -1 && settings.use_more_tag ) {
-		content.innerHTML = content.innerHTML.substring( 0, moreIndex );
-	} else {
-		let paragraphIndex = 0;
-		articleElements.forEach( element => {
-			if ( element.tagName === 'P' ) {
-				paragraphIndex++;
-			}
-			if ( paragraphIndex > visibleParagraphs ) {
-				content.removeChild( element );
-			}
-		} );
-	}
 	if ( inlineGate ) {
 		content.appendChild( inlineGate );
 	}

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -28,7 +28,7 @@ class Memberships {
 	/**
 	 * Membership statuses that should grant access to restricted content.
 	 * See: https://woocommerce.com/document/woocommerce-memberships-user-memberships/#section-4
-	 * 
+	 *
 	 * @var array
 	 */
 	public static $active_statuses = [ 'active', 'complimentary', 'free-trial', 'pending' ];
@@ -598,6 +598,17 @@ class Memberships {
 		if ( get_queried_object_id() !== $post->ID ) {
 			return $excerpt;
 		}
+		return self::get_restricted_post_excerpt( $post );
+	}
+
+	/**
+	 * Get the post excerpt to be displayed in the gate.
+	 *
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return string
+	 */
+	public static function get_restricted_post_excerpt( $post ) {
 		$gate_post_id = self::get_gate_post_id();
 
 		$content = $post->post_content;

--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -112,6 +112,7 @@ class Metering {
 				'gate_id'            => $gate_post_id,
 				'post_id'            => get_the_ID(),
 				'article_view'       => self::$article_view,
+				'excerpt'            => Memberships::get_restricted_post_excerpt( get_post() ),
 			]
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WC Memberships restricts comments when a post is restricted. Our custom content restriction strategy to handle metering is not handling comments, so you'll get a gated article with comments being rendered below the gate.

This PR ensures that content gated through the front-end metering strategy also removes the comments from the page.

It also changes how metering renders the gated content excerpt. Instead of duplicating the truncation logic in javascript, the backend sends the formatted excerpt from `\Newspack\Membershis::get_restricted_post_excerpt()`. This ensures that gating an article through the backend or the frontend always produces the same excerpt.

### How to test the changes in this Pull Request:

1. While on the master branch, make sure you have WC Memberships configured with a plan restricting posts
2. Edit your content gate and make sure you have anonymous metering set to 1 and the style set to "inline"
3. On an anonymous session, visit 2 articles and confirm the gate and the comments section render
4. Check out this branch, refresh, and confirm the excerpt renders and the comments are removed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->