### PR TITLE
Feat/add media partners

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -113,6 +113,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/authors/class-authors-custom-fields.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-rss.php';
+		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-media-partners.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-provider.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-generated.php';
@@ -374,7 +375,6 @@ final class Newspack {
 			[],
 			NEWSPACK_PLUGIN_VERSION
 		);
-
 	}
 }
 Newspack::instance();

--- a/includes/optional-modules/class-media-partners.php
+++ b/includes/optional-modules/class-media-partners.php
@@ -26,7 +26,7 @@ class Media_Partners {
 			return;
 		}
 
-		add_filter( 'admin_init', [ __CLASS__, 'switch_from_standalone_plugin' ] );
+		add_action( 'admin_init', [ __CLASS__, 'switch_from_standalone_plugin' ] );
 		add_action( 'init', [ __CLASS__, 'register_taxonomies' ] );
 
 		add_action( 'partner_add_form_fields', [ __CLASS__, 'add_partner_meta_fields' ] );
@@ -35,7 +35,7 @@ class Media_Partners {
 		add_action( 'edited_partner', [ __CLASS__, 'save_partner_meta_fields' ] );
 		add_action( 'create_partner', [ __CLASS__, 'save_partner_meta_fields' ] );
 		add_action( 'init', [ __CLASS__, 'add_partners_shortcode' ] );
-		add_filter( 'admin_init', [ __CLASS__, 'handle_settings_update' ] );
+		add_action( 'admin_init', [ __CLASS__, 'handle_settings_update' ] );
 		add_filter( 'the_content', [ __CLASS__, 'add_content_partner_logo' ] );
 	}
 
@@ -47,7 +47,6 @@ class Media_Partners {
 			deactivate_plugins( 'newspack-media-partners/newspack-media-partners.php' );
 			Settings::activate_optional_module( 'media-partners' );
 		}
-		return true;
 	}
 
 	/**

--- a/includes/optional-modules/class-media-partners.php
+++ b/includes/optional-modules/class-media-partners.php
@@ -420,6 +420,11 @@ class Media_Partners {
 
 		$partner_settings = self::get_partner_settings( $partner );
 
+		// Skip partners in RSS feed.
+		if ( is_feed() ) {
+			return $content;
+		}
+
 		ob_start();
 		?>
 		<div class="wp-block-group alignright newspack-media-partners">

--- a/includes/optional-modules/class-media-partners.php
+++ b/includes/optional-modules/class-media-partners.php
@@ -126,9 +126,9 @@ class Media_Partners {
 	}
 
 	/**
-	 * Get default settings.
+	 * Get default config for a media partner.
 	 */
-	private static function get_default_settings() {
+	private static function get_default_media_partner_config() {
 		return [
 			'attribution_message' => __( 'This story also appeared in', 'newspack-plugin' ),
 		];
@@ -178,7 +178,7 @@ class Media_Partners {
 		</div>
 
 		<?php
-		$defaults = self::get_default_settings();
+		$defaults = self::get_default_media_partner_config();
 		self::render_settings_field( 'partner_url', __( 'Partner URL', 'newspack-plugin' ) );
 		self::render_settings_field( 'attribution_message', __( 'Attribution message', 'newspack-plugin' ), $defaults );
 	}
@@ -218,18 +218,18 @@ class Media_Partners {
 		</tr>
 
 		<?php
-		$partner = self::get_partner_settings( $term );
+		$partner = self::get_partner_config( $term );
 		self::render_settings_field( 'partner_url', __( 'Partner URL', 'newspack-plugin' ), $partner, 'edit_partner' );
 		self::render_settings_field( 'attribution_message', __( 'Attribution message', 'newspack-plugin' ), $partner, 'edit_partner' );
 	}
 
 	/**
-	 * Get partner settings.
+	 * Get partner config.
 	 *
 	 * @param WP_Term $partner The partner term.
 	 */
-	private static function get_partner_settings( $partner ) {
-		$defaults         = self::get_default_settings();
+	private static function get_partner_config( $partner ) {
+		$defaults         = self::get_default_media_partner_config();
 		$partner_settings = [
 			'partner_url'         => esc_url( get_term_meta( $partner->term_id, 'partner_homepage_url', true ) ),
 			'attribution_message' => get_term_meta( $partner->term_id, 'attribution_message', true ),
@@ -420,7 +420,7 @@ class Media_Partners {
 			$partner_names[] = $partner_name;
 		}
 
-		$partner_settings = self::get_partner_settings( $partner );
+		$partner_settings = self::get_partner_config( $partner );
 
 		// Skip partners in RSS feed.
 		$settings = self::get_settings();
@@ -484,7 +484,7 @@ class Media_Partners {
 						</label>
 					</div>
 					<p class="submit">
-						<input type="submit" name="submit" id="submit" class="button button-primary" value="<?php echo esc_html__( 'Save', 'newspack-plugin' ); ?>">
+						<input type="submit" name="submit" id="submit" class="button button-primary" value="<?php echo esc_attr__( 'Save', 'newspack-plugin' ); ?>">
 					</p>
 				</form>
 			</div>

--- a/includes/optional-modules/class-media-partners.php
+++ b/includes/optional-modules/class-media-partners.php
@@ -94,7 +94,7 @@ class Media_Partners {
 		ob_start();
 		if ( 'textarea' === $tag ) {
 			?>
-				<textarea name="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $value ); ?></textarea>
+				<textarea name="<?php echo esc_attr( $key ); ?>" rows="2" cols="40"><?php echo esc_html( $value ); ?></textarea>
 			<?php
 		} else {
 			?>
@@ -178,7 +178,7 @@ class Media_Partners {
 		<?php
 		$defaults = self::get_default_settings();
 		self::render_settings_field( 'partner_url', __( 'Partner URL', 'newspack-plugin' ) );
-		self::render_settings_field( 'attribution_message', __( 'Attribution message', 'newspack-plugin' ), $defaults, 'edit_partner' );
+		self::render_settings_field( 'attribution_message', __( 'Attribution message', 'newspack-plugin' ), $defaults );
 	}
 
 	/**

--- a/includes/optional-modules/class-media-partners.php
+++ b/includes/optional-modules/class-media-partners.php
@@ -133,6 +133,35 @@ class Media_Partners {
 	}
 
 	/**
+	 * Get partner logo upload setting JS script.
+	 */
+	private static function get_logo_upload_script() {
+		ob_start()
+		?>
+		<script>
+		jQuery( document ).ready( function() {
+			const removeBtn = jQuery( '#remove_partner_logo' );
+			jQuery( '#add_partner_logo' ).click( function() {
+				wp.media.editor.send.attachment = function( props, attachment ) {
+					jQuery( '#partner_logo' ).val( attachment.id );
+					jQuery( '#partner_logo_preview' ).attr( 'src', attachment.url );
+					removeBtn[0].classList.remove('hidden')
+				}
+				wp.media.editor.open( this );
+				return false;
+			} );
+			removeBtn.click( function() {
+				jQuery( '#partner_logo' ).val( '' );
+				jQuery( '#partner_logo_preview' ).attr( 'src', '' );
+				removeBtn[0].classList.add('hidden')
+			} );
+		} );
+		</script>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
 	 * Add custom meta to the Add New Partner screen.
 	 */
 	public static function add_partner_meta_fields() {
@@ -141,19 +170,9 @@ class Media_Partners {
 			<label for="partner_logo"><?php esc_html_e( 'Partner Logo:', 'newspack-plugin' ); ?></label>
 			<input type="hidden" name="partner_logo" id="partner_logo" value="" />
 			<input class="upload_image_button button" name="add_partner_logo" id="add_partner_logo" type="button" value="<?php esc_attr_e( 'Select/Upload Image', 'newspack-plugin' ); ?>" />
+			<input class="button button-link-delete hidden" name="remove_partner_logo" id="remove_partner_logo" type="button" value="<?php esc_attr_e( 'Remove Image', 'newspack-plugin' ); ?>" />
 			<img src='' id='partner_logo_preview' style='max-width: 250px; width: 100%; height: auto' />
-			<script>
-				jQuery( document ).ready( function() {
-					jQuery( '#add_partner_logo' ).click( function() {
-						wp.media.editor.send.attachment = function( props, attachment ) {
-							jQuery( '#partner_logo' ).val( attachment.id );
-							jQuery( '#partner_logo_preview' ).attr( 'src', attachment.url );
-						}
-						wp.media.editor.open( this );
-						return false;
-					} );
-				} );
-			</script>
+			<?php echo self::get_logo_upload_script(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</div>
 
 		<?php
@@ -183,6 +202,7 @@ class Media_Partners {
 			<td>
 				<input type="hidden" name="partner_logo" id="partner_logo" value="<?php echo esc_attr( $logo_id ); ?>" />
 				<input class="upload_image_button button" name="add_partner_logo" id="add_partner_logo" type="button" value="<?php esc_attr_e( 'Select/Upload Image', 'newspack-plugin' ); ?>" />
+				<input class="button button-link-delete <?php echo empty( $logo ) ? 'hidden' : ''; ?>" name="remove_partner_logo" id="remove_partner_logo" type="button" value="<?php esc_attr_e( 'Remove Image', 'newspack-plugin' ); ?>" />
 			</td>
 		</tr>
 		<tr class="form-field">
@@ -191,19 +211,7 @@ class Media_Partners {
 				<div class="img-preview">
 					<img src='<?php echo esc_url( $logo ); ?>' id='partner_logo_preview' style='max-width: 250px; width: 100%; height: auto' />
 				</div>
-
-				<script>
-					jQuery( document ).ready( function() {
-						jQuery( '#add_partner_logo' ).click( function() {
-							wp.media.editor.send.attachment = function( props, attachment ) {
-								jQuery( '#partner_logo' ).val( attachment.id );
-								jQuery( '#partner_logo_preview' ).attr( 'src', attachment.url );
-							}
-							wp.media.editor.open( this );
-							return false;
-						} );
-					} );
-				</script>
+				<?php echo self::get_logo_upload_script(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</td>
 		</tr>
 
@@ -243,6 +251,8 @@ class Media_Partners {
 		$partner_logo = filter_input( INPUT_POST, 'partner_logo', FILTER_SANITIZE_NUMBER_INT );
 		if ( $partner_logo ) {
 			update_term_meta( $term_id, 'logo', (int) $partner_logo );
+		} else {
+			delete_term_meta( $term_id, 'logo' );
 		}
 
 		$partner_url = filter_input( INPUT_POST, 'partner_url', FILTER_SANITIZE_STRING );

--- a/includes/optional-modules/class-media-partners.php
+++ b/includes/optional-modules/class-media-partners.php
@@ -47,6 +47,7 @@ class Media_Partners {
 			deactivate_plugins( 'newspack-media-partners/newspack-media-partners.php' );
 			Settings::activate_optional_module( 'media-partners' );
 		}
+		return true;
 	}
 
 	/**

--- a/includes/optional-modules/class-media-partners.php
+++ b/includes/optional-modules/class-media-partners.php
@@ -1,0 +1,367 @@
+<?php
+/**
+ * Media Partners.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Media partners.
+ */
+class Media_Partners {
+
+	/**
+	 * Initialize everything.
+	 */
+	public static function init() {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		// If the standalone plugin is active, deactivate it and activate as a module.
+		if ( is_plugin_active( 'newspack-media-partners/newspack-media-partners.php' ) ) {
+			deactivate_plugins( 'newspack-media-partners/newspack-media-partners.php' );
+			Settings::activate_optional_module( 'media-partners' );
+		}
+
+		if ( ! Settings::is_optional_module_active( 'media-partners' ) ) {
+			return;
+		}
+
+		add_action( 'init', [ __CLASS__, 'register_taxonomies' ] );
+
+		add_action( 'partner_add_form_fields', [ __CLASS__, 'add_partner_meta_fields' ] );
+		add_action( 'partner_edit_form_fields', [ __CLASS__, 'edit_partner_meta_fields' ] );
+		add_action( 'edited_partner', [ __CLASS__, 'save_partner_meta_fields' ] );
+		add_action( 'create_partner', [ __CLASS__, 'save_partner_meta_fields' ] );
+		add_action( 'init', [ __CLASS__, 'add_partners_shortcode' ] );
+
+		add_filter( 'the_content', [ __CLASS__, 'add_content_partner_logo' ] );
+	}
+
+	/**
+	 * Register Partner taxonomy.
+	 */
+	public static function register_taxonomies() {
+		register_taxonomy(
+			'partner',
+			'post',
+			[
+				'hierarchical'      => true,
+				'labels'            => [
+					'name'              => esc_html_x( 'Media Partners', 'taxonomy general name', 'newspack-plugin' ),
+					'singular_name'     => esc_html_x( 'Media Partner', 'taxonomy singular name', 'newspack-plugin' ),
+					'search_items'      => esc_html__( 'Search Media Partners', 'newspack-plugin' ),
+					'all_items'         => esc_html__( 'All Media Partners', 'newspack-plugin' ),
+					'parent_item'       => esc_html__( 'Parent Media Partner', 'newspack-plugin' ),
+					'parent_item_colon' => esc_html__( 'Parent Media Partner:', 'newspack-plugin' ),
+					'edit_item'         => esc_html__( 'Edit Media Partner', 'newspack-plugin' ),
+					'view_item'         => esc_html__( 'View Media Partner', 'newspack-plugin' ),
+					'update_item'       => esc_html__( 'Update Media Partner', 'newspack-plugin' ),
+					'add_new_item'      => esc_html__( 'Add New Media Partner', 'newspack-plugin' ),
+					'new_item_name'     => esc_html__( 'New Media Partner Name', 'newspack-plugin' ),
+					'menu_name'         => esc_html__( 'Media Partners' ),
+				],
+				'public'            => true,
+				'show_admin_column' => true,
+				'show_in_nav_menus' => true,
+				'query_var'         => true,
+				'rewrite'           => [ 'slug' => 'partners' ],
+				'show_in_rest'      => true,
+			]
+		);
+	}
+
+	/**
+	 * Add custom meta to the Add New Partner screen.
+	 */
+	public static function add_partner_meta_fields() {
+		?>
+		<div class="form-field">
+			<label for="partner_logo"><?php esc_html_e( 'Partner Logo:', 'newspack-plugin' ); ?></label>
+			<input type="hidden" name="partner_logo" id="partner_logo" value="" />
+			<input class="upload_image_button button" name="add_partner_logo" id="add_partner_logo" type="button" value="<?php esc_attr_e( 'Select/Upload Image', 'newspack-plugin' ); ?>" />
+			<img src='' id='partner_logo_preview' style='max-width: 250px; width: 100%; height: auto' />
+			<script>
+				jQuery( document ).ready( function() {
+					jQuery( '#add_partner_logo' ).click( function() {
+						wp.media.editor.send.attachment = function( props, attachment ) {
+							jQuery( '#partner_logo' ).val( attachment.id );
+							jQuery( '#partner_logo_preview' ).attr( 'src', attachment.url );
+						}
+						wp.media.editor.open( this );
+						return false;
+					} );
+				} );
+			</script>
+		</div>
+
+		<div class="form-field">
+			<label for="partner_logo"><?php esc_html_e( 'Partner URL:', 'newspack-media-partners' ); ?></label>
+			<input type="text" name="partner_url" value="" />
+		</div>
+		<?php
+	}
+
+	/**
+	 * Add custom meta to the Edit Partner screen.
+	 *
+	 * @param WP_Term $term Current term object.
+	 */
+	public static function edit_partner_meta_fields( $term ) {
+		$logo_id = (int) get_term_meta( $term->term_id, 'logo', true );
+		$logo    = '';
+		if ( $logo_id ) {
+			$logo_atts = wp_get_attachment_image_src( $logo_id );
+			if ( $logo_atts ) {
+				$logo = $logo_atts[0];
+			}
+		}
+
+		$partner_url = esc_url( get_term_meta( $term->term_id, 'partner_homepage_url', true ) );
+
+		?>
+		<tr class="form-field">
+			<th scope="row" valign="top"><label for="add_partner_logo"><?php esc_html_e( 'Partner Logo', 'newspack-plugin' ); ?></label></th>
+			<td>
+				<input type="hidden" name="partner_logo" id="partner_logo" value="<?php echo esc_attr( $logo_id ); ?>" />
+				<input class="upload_image_button button" name="add_partner_logo" id="add_partner_logo" type="button" value="<?php esc_attr_e( 'Select/Upload Image', 'newspack-plugin' ); ?>" />
+			</td>
+		</tr>
+		<tr class="form-field">
+			<th scope="row" valign="top"></th>
+			<td>
+				<div class="img-preview">
+					<img src='<?php echo esc_url( $logo ); ?>' id='partner_logo_preview' style='max-width: 250px; width: 100%; height: auto' />
+				</div>
+
+				<script>
+					jQuery( document ).ready( function() {
+						jQuery( '#add_partner_logo' ).click( function() {
+							wp.media.editor.send.attachment = function( props, attachment ) {
+								jQuery( '#partner_logo' ).val( attachment.id );
+								jQuery( '#partner_logo_preview' ).attr( 'src', attachment.url );
+							}
+							wp.media.editor.open( this );
+							return false;
+						} );
+					} );
+				</script>
+			</td>
+		</tr>
+
+		<tr class="form-field">
+			<th scope="row" valign="top"><label for="partner_url"><?php esc_html_e( 'Partner URL', 'newspack-media-partners' ); ?></label></th>
+			<td>
+				<input type="text" name="partner_url" value="<?php echo esc_attr( $partner_url ); ?>" />
+			</td>
+		</tr>
+		<?php
+	}
+
+	/**
+	 * Save the meta fields for the Partner taxonomy.
+	 *
+	 * @param int $term_id Term ID.
+	 */
+	public static function save_partner_meta_fields( $term_id ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
+		$partner_logo = filter_input( INPUT_POST, 'partner_logo', FILTER_SANITIZE_NUMBER_INT );
+		if ( $partner_logo ) {
+			update_term_meta( $term_id, 'logo', (int) $partner_logo );
+		}
+
+		$partner_url = filter_input( INPUT_POST, 'partner_url', FILTER_SANITIZE_STRING );
+		if ( $partner_url ) {
+			update_term_meta( $term_id, 'partner_homepage_url', esc_url( $partner_url ) );
+		}
+	}
+
+	/**
+	 * Register the 'partners' shortcode.
+	 * Can be inserted into a post or page to display a list of partners.
+	 */
+	public static function add_partners_shortcode() {
+		add_shortcode( 'partners', [ __CLASS__, 'render_partners_shortcode' ] );
+	}
+
+	/**
+	 * Render the 'partners' shortcode.
+	 */
+	public static function render_partners_shortcode() {
+		$partners = get_terms(
+			[
+				'taxonomy'   => 'partner',
+				'hide_empty' => false,
+			]
+		);
+
+		ob_start();
+
+		?>
+		<style>
+			.wp-block-image.media-partner img {
+				max-height: 200px;
+			}
+		</style>
+		<?php
+
+		$elements = [];
+		foreach ( $partners as $partner ) {
+			$partner_html = '';
+			$partner_logo = get_term_meta( $partner->term_id, 'logo', true );
+			$partner_url  = get_term_meta( $partner->term_id, 'partner_homepage_url', true );
+
+			if ( $partner_logo ) {
+				$logo_html = '';
+				$logo_atts = wp_get_attachment_image_src( $partner_logo, 'full' );
+				$logo_alt  = $partner->name;
+
+				if ( $partner_url ) {
+					$logo_alt = sprintf(
+						/* translators: replaced with the name of the Media Partner */
+						__( 'Website for %s', 'newspack-plugin' ),
+						$partner->name
+					);
+				}
+
+				if ( $logo_atts ) {
+					$logo_html = '<figure class="wp-block-image newspack-media-partners media-partner"><img class="aligncenter" src="' . esc_url( $logo_atts[0] ) . '" alt="' . esc_attr( $logo_alt ) . '" /></figure>';
+				}
+
+				if ( $logo_html && $partner_url ) {
+					$logo_html = '<a href="' . esc_url( $partner_url ) . '">' . $logo_html . '</a>';
+				}
+
+				$partner_html .= $logo_html;
+			}
+
+			$partner_name = $partner->name;
+			if ( $partner_url ) {
+				$partner_name = '<a href="' . esc_url( $partner_url ) . '">' . $partner_name . '</a>';
+			}
+			$partner_html .= '<p class="has-text-align-center">' . $partner_name . '</p>';
+
+			$elements[] = $partner_html;
+		}
+
+		$num_columns      = 3;
+		$current          = 0;
+		$container_closed = true;
+		foreach ( $elements as $element ) {
+			if ( 0 == $current ) {
+				echo '<div class="wp-block-columns is-style-borders">';
+				$container_closed = false;
+			}
+
+			echo '<div class="wp-block-column">';
+			echo wp_kses_post( $element );
+			echo '</div>';
+
+			++$current;
+
+			if ( $num_columns == $current ) {
+				echo '</div><hr class="wp-block-separator is-style-wide">';
+				$current          = 0;
+				$container_closed = true;
+			}
+		}
+
+		// Close last div if needed.
+		if ( ! $container_closed ) {
+			echo '</div><hr class="wp-block-separator is-style-wide">';
+		}
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Filter in a partner logo on posts that have partners.
+	 *
+	 * @param string $content The post content.
+	 * @return string Modified $content.
+	 */
+	public static function add_content_partner_logo( $content ) {
+		$id       = get_the_ID();
+		$partners = get_the_terms( $id, 'partner' );
+		if ( ! $partners ) {
+			return $content;
+		}
+
+		$partner_images = [];
+		$partner_names  = [];
+		foreach ( $partners as $partner ) {
+			$partner_image_id = get_term_meta( $partner->term_id, 'logo', true );
+			$partner_url      = esc_url( get_term_meta( $partner->term_id, 'partner_homepage_url', true ) );
+			$image            = '';
+			$image_alt        = $partner->name;
+
+			if ( $partner_url ) {
+				$image_alt = sprintf(
+					/* translators: replaced with the name of the Media Partner */
+					__( 'Website for %s', 'newspack-plugin' ),
+					$partner->name
+				);
+			}
+
+			if ( $partner_image_id ) {
+				$image = wp_get_attachment_image( $partner_image_id, [ 200, 999 ], false, [ 'alt' => esc_attr( $image_alt ) ] );
+				if ( $image && $partner_url ) {
+					$image = '<a href="' . $partner_url . '" target="_blank">' . $image . '</a>';
+				}
+			}
+
+			$partner_images[] = $image;
+
+			$partner_name = $partner->name;
+			if ( $partner_url ) {
+				$partner_name = '<a href="' . $partner_url . '" target="_blank">' . $partner_name . '</a>';
+			}
+			$partner_names[] = $partner_name;
+		}
+
+		ob_start();
+		?>
+		<div class="wp-block-group alignright newspack-media-partners">
+			<div class="wp-block-group__inner-container">
+				<figure class="wp-block-image size-full is-resized">
+					<?php echo implode( '<br/>', $partner_images ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<figcaption>
+						<?php
+						echo wp_kses_post(
+							sprintf(
+								/* translators: replaced with the name of the Media Partner, linked */
+								__( 'This story also appeared in %s', 'newspack-plugin' ),
+								implode( esc_html__( ' and ', 'newspack-plugin' ), $partner_names )
+							)
+						);
+						?>
+					</figcaption>
+				</figure>
+			</div>
+		</div>
+
+		<?php
+		$partner_html = ob_get_clean();
+
+		// Inject logo in between 2 paragraph elements.
+		$content_halves = preg_split( '#<\/p>\s*<p>#', $content, 2 );
+
+		// Just append it to the top if a good injection spot can't be found..
+		if ( 1 === count( $content_halves ) ) {
+			$content = $partner_html . $content;
+		} else {
+			$content = $content_halves[0] . '</p>' . $partner_html . '<p>' . $content_halves[1];
+		}
+
+		return $content;
+	}
+}
+Media_Partners::init();

--- a/includes/wizards/class-settings.php
+++ b/includes/wizards/class-settings.php
@@ -47,9 +47,10 @@ class Settings extends Wizard {
 	 */
 	private static function get_settings() {
 		$default_settings = [
-			self::MODULE_ENABLED_PREFIX . 'rss' => false,
+			self::MODULE_ENABLED_PREFIX . 'rss'            => false,
+			self::MODULE_ENABLED_PREFIX . 'media-partners' => false,
 		];
-		return get_option( self::SETTINGS_OPTION_NAME, $default_settings );
+		return wp_parse_args( get_option( self::SETTINGS_OPTION_NAME ), $default_settings );
 	}
 
 	/**

--- a/tests/unit-tests/settings.php
+++ b/tests/unit-tests/settings.php
@@ -24,7 +24,10 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 	public function test_settings_defaults() {
 		self::assertEquals(
 			Settings::api_get_settings(),
-			[ 'module_enabled_rss' => false ],
+			[
+				'module_enabled_rss'            => false,
+				'module_enabled_media-partners' => false,
+			],
 			'Default settings are as expected.'
 		);
 	}
@@ -38,7 +41,10 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 		Settings::api_update_settings( $request );
 		self::assertEquals(
 			Settings::api_get_settings(),
-			[ 'module_enabled_rss' => true ],
+			[
+				'module_enabled_rss'            => true,
+				'module_enabled_media-partners' => false,
+			],
 			'Settings is updated.'
 		);
 
@@ -46,7 +52,10 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 		Settings::api_update_settings( $request );
 		self::assertEquals(
 			Settings::api_get_settings(),
-			[ 'module_enabled_rss' => true ],
+			[
+				'module_enabled_rss'            => true,
+				'module_enabled_media-partners' => false,
+			],
 			'A non-existent setting is not saved.'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the https://github.com/Automattic/newspack-media-partners plugin as an optional module. Similar to the RSS Enhancements plugin story (https://github.com/Automattic/newspack-plugin/pull/1688), the module will replace the plugin if the plugin is active. 

This also adds few new features to the Media Partners taxonomy (see 1200133283036252-as-1205658718219681):

1.  Ability to remove the media partner logo
2. Ability to modify the "This story also appeared in" text
3. Ability to skip the media partner markup in RSS feeds (a global setting) 

Note: https://github.com/Automattic/newspack-media-partners should be archived after this is released

### How to test the changes in this Pull Request:

1. Install and activate the [`newspack-media-partners` plugin](https://github.com/Automattic/newspack-media-partners) 
5. Load the admin page, go to Posts -> Media Partners 
6. Observe that the plugin has been deactivated
7. Create a media partner with an image and assign it to a post (it's a taxonomy)
8. Visit the post – observe the attribution message close to the beginning of the post 
9. Edit the media partner, remove the image and change the attribution message 
10. Verify this is updated in the post
11. Visit your site's `/feed` and observe the media partner markup is there
12. Toggle the "Skip in RSS feeds" setting, observe that now the markup does not appear in the feed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->