### PR TITLE
fix(data-events): no longer use ActionScheduler for dispatches

### DIFF
--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -43,26 +43,8 @@ final class Data_Events {
 	public static function init() {
 		\add_action( 'wp_ajax_' . self::ACTION, [ __CLASS__, 'maybe_handle' ] );
 		\add_action( 'wp_ajax_nopriv_' . self::ACTION, [ __CLASS__, 'maybe_handle' ] );
-		\add_action( 'newspack_data_events_as_dispatch', [ __CLASS__, 'handle' ], 10, 4 );
 	}
 
-	/**
-	 * Whether to use Action Scheduler if available.
-	 *
-	 * @return bool
-	 */
-	public static function use_action_scheduler() {
-		$use_action_scheduler = false;
-		if ( function_exists( 'as_enqueue_async_action' ) ) {
-			$use_action_scheduler = true;
-		}
-		/**
-		 * Filters whether to use the Action Scheduler if available.
-		 *
-		 * @param bool $use_action_scheduler
-		 */
-		return \apply_filters( 'newspack_data_events_use_action_scheduler', $use_action_scheduler );
-	}
 
 	/**
 	 * Maybe handle an event.
@@ -330,39 +312,29 @@ final class Data_Events {
 			return $body;
 		}
 
-		if ( self::use_action_scheduler() ) {
-			Logger::log(
-				sprintf( 'Dispatching action "%s" via Action Scheduler.', $action_name ),
-				self::LOGGER_HEADER
-			);
+		Logger::log(
+			sprintf( 'Dispatching action "%s".', $action_name ),
+			self::LOGGER_HEADER
+		);
 
-			\as_enqueue_async_action( 'newspack_data_events_as_dispatch', array_values( $body ), 'newspack-data-events' );
+		$url = \add_query_arg(
+			[
+				'action' => self::ACTION,
+				'nonce'  => \wp_create_nonce( self::ACTION ),
+			],
+			\admin_url( 'admin-ajax.php' )
+		);
 
-		} else {
-			Logger::log(
-				sprintf( 'Dispatching action "%s" via HTTP request.', $action_name ),
-				self::LOGGER_HEADER
-			);
-
-			$url = \add_query_arg(
-				[
-					'action' => self::ACTION,
-					'nonce'  => \wp_create_nonce( self::ACTION ),
-				],
-				\admin_url( 'admin-ajax.php' )
-			);
-
-			return \wp_remote_post(
-				$url,
-				[
-					'timeout'   => 0.01,
-					'blocking'  => false,
-					'body'      => $body,
-					'cookies'   => $_COOKIE, // phpcs:ignore
-					'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
-				]
-			);
-		}
+		return \wp_remote_post(
+			$url,
+			[
+				'timeout'   => 0.01,
+				'blocking'  => false,
+				'body'      => $body,
+				'cookies'   => $_COOKIE, // phpcs:ignore
+				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
+			]
+		);
 	}
 }
 Data_Events::init();

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -223,6 +223,10 @@ class GA4 {
 			$order_id = $body['data']['interaction_data']['donation_order_id'] ?? false;
 		}
 
+		if ( ! function_exists( 'wc_get_order' ) ) {
+			return $body;
+		}
+
 		$order = wc_get_order( $order_id );
 		if ( $order ) {
 			$ga_client_id = $order->get_meta( '_newspack_ga_client_id' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the use of ActionScheduler for dispatching data events. It should use the fallback strategy in place for when AS is not available, which is to send an unblocking HTTP request.

The reason for this change is that the amount of data events we dispatch drastically increased, especially with Newspack Newsletters' tracking functionality. This can be too much for AS' queue to handle.

This change shouldn't impact the processing or reliability of data events, since this is already the strategy in place for sites without AS available (without WooCommerce installed).

Update: 30ff7642fb84d141b43efb53b9fd6147eee28fdd adds a check for a WC function on the GA4 connector so it doesn't fatal if WC is not installed.

### How to test the changes in this Pull Request:

1. Checkout this branch, make sure you have GA4 connected and `define( 'NEWSPACK_LOG_LEVEL', 2 );`
2. Make sure you also have a global webhook configured in Newspack -> Connections. Make sure you have `define( 'NEWSPACK_EXPERIMENTAL_WEBHOOKS', true );`. You can use https://webhook.site/ to register a test endpoint
3. Go through the RAS registration flow and confirm the dispatches are logged, e.g.: `Dispatching action "reader_logged_in".`
4. Confirm you see the events also reaching GA4 through GA's real-time report page.
5. Confirm the request also reached the webhook endpoint

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->