### PR TITLE
Fix/donation events renewals

### DIFF
--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -78,17 +78,19 @@ When a reader updates their lists subscription from Newspack Newsletters.
 
 For when there's a new donation processed through WooCommerce.
 
-| Name            | Type     | Obs                                                    |
-| --------------- | -------- | ------------------------------------------------------ |
-| `user_id`       | `int`    |                                                        |
-| `email`         | `string` |                                                        |
-| `amount`        | `float`  |                                                        |
-| `currency`      | `string` |                                                        |
-| `recurrence`    | `string` |                                                        |
-| `platform`      | `string` | Always `wc` in this case                               |
-| `referer`       | `string` |                                                        |
-| `popup_id`      | `string` | If the donation was triggered by a popup, the popup ID |
-| `platform_data` | `array`  |                                                        |
+| Name             | Type     | Obs                                                    |
+| ---------------- | -------- | ------------------------------------------------------ |
+| `user_id`        | `int`    |                                                        |
+| `email`          | `string` |                                                        |
+| `amount`         | `float`  |                                                        |
+| `currency`       | `string` |                                                        |
+| `recurrence`     | `string` |                                                        |
+| `platform`       | `string` | Always `wc` in this case                               |
+| `referer`        | `string` |                                                        |
+| `popup_id`       | `string` | If the donation was triggered by a popup, the popup ID |
+| `is_renewal`     | `bool`   | If this is a subscription renewal (recurring payment)  |
+| `subscription_id`| `bool`   | The related subscription id (if any)                   |
+| `platform_data`  | `array`  |                                                        |
 
 ### `woocommerce_order_failed`
 
@@ -96,34 +98,38 @@ For when there's a new donation payment failed through WooCommerce.
 Known issue: If the user tries to pay again after a failed payment, and the payment fails for a second time,
 the order is already marked as failed so this hook will not trigger.
 
-| Name            | Type     | Obs                                                    |
-| --------------- | -------- | ------------------------------------------------------ |
-| `user_id`       | `int`    |                                                        |
-| `email`         | `string` |                                                        |
-| `amount`        | `float`  |                                                        |
-| `currency`      | `string` |                                                        |
-| `recurrence`    | `string` |                                                        |
-| `platform`      | `string` | Always `wc` in this case                               |
-| `referer`       | `string` |                                                        |
-| `popup_id`      | `string` | If the donation was triggered by a popup, the popup ID |
-| `platform_data` | `array`  |                                                        |
+| Name             | Type     | Obs                                                    |
+| ---------------- | -------- | ------------------------------------------------------ |
+| `user_id`        | `int`    |                                                        |
+| `email`          | `string` |                                                        |
+| `amount`         | `float`  |                                                        |
+| `currency`       | `string` |                                                        |
+| `recurrence`     | `string` |                                                        |
+| `platform`       | `string` | Always `wc` in this case                               |
+| `referer`        | `string` |                                                        |
+| `is_renewal`     | `bool`   | If this is a subscription renewal (recurring payment)  |
+| `subscription_id`| `bool`   | The related subscription id (if any)                   |
+| `popup_id`       | `string` | If the donation was triggered by a popup, the popup ID |
+| `platform_data`  | `array`  |                                                        |
 
 
 ### `donation_new`
 
 When there's a new donation, either through Stripe or Newspack (WooCommerce) platforms.
 
-| Name            | Type     | Obs                                                    |
-| --------------- | -------- | ------------------------------------------------------ |
-| `user_id`       | `int`    |                                                        |
-| `email`         | `string` |                                                        |
-| `amount`        | `float`  |                                                        |
-| `currency`      | `string` |                                                        |
-| `recurrence`    | `string` |                                                        |
-| `platform`      | `string` |                                                        |
-| `referer`       | `string` |                                                        |
-| `popup_id`      | `string` | If the donation was triggered by a popup, the popup ID |
-| `platform_data` | `array`  |                                                        |
+| Name             | Type     | Obs                                                    |
+| ---------------- | -------- | ------------------------------------------------------ |
+| `user_id`        | `int`    |                                                        |
+| `email`          | `string` |                                                        |
+| `amount`         | `float`  |                                                        |
+| `currency`       | `string` |                                                        |
+| `recurrence`     | `string` |                                                        |
+| `platform`       | `string` |                                                        |
+| `referer`        | `string` |                                                        |
+| `popup_id`       | `string` | If the donation was triggered by a popup, the popup ID |
+| `is_renewal`     | `bool`   | If this is a subscription renewal (recurring payment)  |
+| `subscription_id`| `bool`   | The related subscription id (if any)                   |
+| `platform_data`  | `array`  |                                                        |
 
 ### `donation_subscription_new`
 
@@ -173,7 +179,7 @@ When a WooCommerce Subscription status changes.
 
 ### `product_subscription_active`
 
-When a non-donation subscription is activated. 
+When a non-donation subscription is activated.
 
 | Name              | Type     |
 | ----------------- | -------- |
@@ -186,7 +192,7 @@ When a non-donation subscription is activated.
 
 ### `product_subscription_inactive`
 
-When a non-donation subscription is changed to any non-active status. 
+When a non-donation subscription is changed to any non-active status.
 
 | Name              | Type     |
 | ----------------- | -------- |

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -89,7 +89,7 @@ For when there's a new donation processed through WooCommerce.
 | `referer`        | `string` |                                                        |
 | `popup_id`       | `string` | If the donation was triggered by a popup, the popup ID |
 | `is_renewal`     | `bool`   | If this is a subscription renewal (recurring payment)  |
-| `subscription_id`| `bool`   | The related subscription id (if any)                   |
+| `subscription_id`| `int`    | The related subscription id (if any)                   |
 | `platform_data`  | `array`  |                                                        |
 
 ### `woocommerce_order_failed`
@@ -108,7 +108,7 @@ the order is already marked as failed so this hook will not trigger.
 | `platform`       | `string` | Always `wc` in this case                               |
 | `referer`        | `string` |                                                        |
 | `is_renewal`     | `bool`   | If this is a subscription renewal (recurring payment)  |
-| `subscription_id`| `bool`   | The related subscription id (if any)                   |
+| `subscription_id`| `int`    | The related subscription id (if any)                   |
 | `popup_id`       | `string` | If the donation was triggered by a popup, the popup ID |
 | `platform_data`  | `array`  |                                                        |
 
@@ -128,7 +128,7 @@ When there's a new donation, either through Stripe or Newspack (WooCommerce) pla
 | `referer`        | `string` |                                                        |
 | `popup_id`       | `string` | If the donation was triggered by a popup, the popup ID |
 | `is_renewal`     | `bool`   | If this is a subscription renewal (recurring payment)  |
-| `subscription_id`| `bool`   | The related subscription id (if any)                   |
+| `subscription_id`| `int`    | The related subscription id (if any)                   |
 | `platform_data`  | `array`  |                                                        |
 
 ### `donation_subscription_new`

--- a/includes/data-events/class-popups.php
+++ b/includes/data-events/class-popups.php
@@ -222,7 +222,7 @@ final class Popups {
 	 */
 	public static function donation_submission_success( $timestamp, $data ) {
 		$popup_id = $data['popup_id'] ?? false;
-		if ( ! $popup_id ) {
+		if ( ! $popup_id || $data['is_renewal'] ) {
 			return;
 		}
 		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
@@ -310,7 +310,7 @@ final class Popups {
 	 */
 	public static function donation_submission_woocommerce( $timestamp, $data ) {
 		$popup_id = $data['popup_id'] ?? false;
-		if ( ! $popup_id ) {
+		if ( ! $popup_id || $data['is_renewal'] ) {
 			return;
 		}
 		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
@@ -340,7 +340,7 @@ final class Popups {
 	 */
 	public static function donation_submission_woocommerce_error( $timestamp, $data ) {
 		$popup_id = $data['popup_id'] ?? false;
-		if ( ! $popup_id ) {
+		if ( ! $popup_id || $data['is_renewal'] ) {
 			return;
 		}
 		$popup_data = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );

--- a/includes/data-events/connectors/ga4/README.md
+++ b/includes/data-events/connectors/ga4/README.md
@@ -57,9 +57,10 @@ Additional parameters:
 * `recurrence`
 * `platform`
 * `referer`
+* `is_renewal`: If this is a subscription renewal (recurring payment).
+* `subscription_id`: The related subscription id (if any).
 * `popup_id`: If the action was triggered from inside a popup, the popup id.
 * `range`: The range of the donation amount: `under-20`, `20-50`, `51-100`, `101-200`, `201-500` or `over-500`.
-
 
 ### donation_subscription_cancelled
 
@@ -74,8 +75,6 @@ Additional parameters:
 * `range`: The range of the donation amount: `under-20`, `20-50`, `51-100`, `101-200`, `201-500` or `over-500`.
 
 ### newsletter_subscribed
-
-
 
 Additional parameters:
 

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -287,13 +287,15 @@ class GA4 {
 	 * @return array $params The final version of the GA4 event params that will be sent to GA.
 	 */
 	public static function handle_donation_new( $params, $data ) {
-		$params['amount']     = $data['amount'];
-		$params['currency']   = $data['currency'];
-		$params['recurrence'] = $data['recurrence'];
-		$params['platform']   = $data['platform'];
-		$params['referer']    = $data['referer'] ?? '';
-		$params['popup_id']   = $data['popup_id'] ?? '';
-		$params['range']      = self::get_donation_amount_range( $data['amount'] );
+		$params['amount']          = $data['amount'];
+		$params['currency']        = $data['currency'];
+		$params['recurrence']      = $data['recurrence'];
+		$params['platform']        = $data['platform'];
+		$params['referer']         = $data['referer'] ?? '';
+		$params['popup_id']        = $data['popup_id'] ?? '';
+		$params['is_renewal']      = $data['is_renewal'] ? 'yes' : 'no';
+		$params['subscription_id'] = $data['subscription_id'] ?? '';
+		$params['range']           = self::get_donation_amount_range( $data['amount'] );
 		return $params;
 	}
 
@@ -465,6 +467,7 @@ class GA4 {
 			);
 
 			self::log( sprintf( 'Event sent to %s - %s - Client ID: %s', $property['measurement_id'], $event->get_name(), $client_id ) );
+			self::log( sprintf( 'Event payload: %s', wp_json_encode( $payload ) ) );
 		}
 
 	}

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -138,17 +138,26 @@ Data_Events::register_listener(
 		if ( ! $order ) {
 			return;
 		}
-		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
+		$recurrence      = get_post_meta( $product_id, '_subscription_period', true );
+		$is_renewal      = function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order );
+		$subscription_id = null;
+		if ( function_exists( 'wcs_get_subscriptions_for_renewal_order' ) ) {
+			$subscriptions   = array_values( wcs_get_subscriptions_for_renewal_order( $order ) );
+			$subscription_id = is_array( $subscriptions ) && ! empty( $subscriptions ) && is_a( $subscriptions[0], 'WC_Subscription' ) ? $subscriptions[0]->get_id() : null;
+		}
+
 		return [
-			'user_id'       => $order->get_customer_id(),
-			'email'         => $order->get_billing_email(),
-			'amount'        => (float) $order->get_total(),
-			'currency'      => $order->get_currency(),
-			'recurrence'    => empty( $recurrence ) ? 'once' : $recurrence,
-			'platform'      => 'wc',
-			'referer'       => $order->get_meta( '_newspack_referer' ),
-			'popup_id'      => $order->get_meta( '_newspack_popup_id' ),
-			'platform_data' => [
+			'user_id'         => $order->get_customer_id(),
+			'email'           => $order->get_billing_email(),
+			'amount'          => (float) $order->get_total(),
+			'currency'        => $order->get_currency(),
+			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
+			'platform'        => 'wc',
+			'referer'         => $order->get_meta( '_newspack_referer' ),
+			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),
+			'is_renewal'      => $is_renewal,
+			'subscription_id' => $subscription_id,
+			'platform_data'   => [
 				'order_id'   => $order_id,
 				'product_id' => $product_id,
 			],
@@ -170,18 +179,26 @@ Data_Events::register_listener(
 		if ( ! $product_id ) {
 			return;
 		}
-		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
+		$recurrence      = get_post_meta( $product_id, '_subscription_period', true );
+		$is_renewal      = function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order );
+		$subscription_id = null;
+		if ( function_exists( 'wcs_get_subscriptions_for_renewal_order' ) ) {
+			$subscriptions   = array_values( wcs_get_subscriptions_for_renewal_order( $order ) );
+			$subscription_id = is_array( $subscriptions ) && ! empty( $subscriptions ) && is_a( $subscriptions[0], 'WC_Subscription' ) ? $subscriptions[0]->get_id() : null;
+		}
 
 		return [
-			'user_id'       => $order->get_customer_id(),
-			'email'         => $order->get_billing_email(),
-			'amount'        => (float) $order->get_total(),
-			'currency'      => $order->get_currency(),
-			'recurrence'    => empty( $recurrence ) ? 'once' : $recurrence,
-			'platform'      => Donations::get_platform_slug(),
-			'referer'       => $order->get_meta( '_newspack_referer' ),
-			'popup_id'      => $order->get_meta( '_newspack_popup_id' ),
-			'platform_data' => [
+			'user_id'         => $order->get_customer_id(),
+			'email'           => $order->get_billing_email(),
+			'amount'          => (float) $order->get_total(),
+			'currency'        => $order->get_currency(),
+			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
+			'platform'        => Donations::get_platform_slug(),
+			'referer'         => $order->get_meta( '_newspack_referer' ),
+			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),
+			'is_renewal'      => $is_renewal,
+			'subscription_id' => $subscription_id,
+			'platform_data'   => [
 				'order_id'   => $order_id,
 				'product_id' => $product_id,
 				'client_id'  => $order->get_meta( NEWSPACK_CLIENT_ID_COOKIE_NAME ),
@@ -230,18 +247,26 @@ Data_Events::register_listener(
 		if ( ! $product_id ) {
 			return;
 		}
-		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
+		$recurrence      = get_post_meta( $product_id, '_subscription_period', true );
+		$is_renewal      = function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order );
+		$subscription_id = null;
+		if ( function_exists( 'wcs_get_subscriptions_for_renewal_order' ) ) {
+			$subscriptions   = array_values( wcs_get_subscriptions_for_renewal_order( $order ) );
+			$subscription_id = is_array( $subscriptions ) && ! empty( $subscriptions ) && is_a( $subscriptions[0], 'WC_Subscription' ) ? $subscriptions[0]->get_id() : null;
+		}
 
 		return [
-			'user_id'       => $order->get_customer_id(),
-			'email'         => $order->get_billing_email(),
-			'amount'        => (float) $order->get_total(),
-			'currency'      => $order->get_currency(),
-			'recurrence'    => empty( $recurrence ) ? 'once' : $recurrence,
-			'platform'      => Donations::get_platform_slug(),
-			'referer'       => $order->get_meta( '_newspack_referer' ),
-			'popup_id'      => $order->get_meta( '_newspack_popup_id' ),
-			'platform_data' => [
+			'user_id'         => $order->get_customer_id(),
+			'email'           => $order->get_billing_email(),
+			'amount'          => (float) $order->get_total(),
+			'currency'        => $order->get_currency(),
+			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
+			'platform'        => Donations::get_platform_slug(),
+			'referer'         => $order->get_meta( '_newspack_referer' ),
+			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),
+			'is_renewal'      => $is_renewal,
+			'subscription_id' => $subscription_id,
+			'platform_data'   => [
 				'order_id'   => $order_id,
 				'product_id' => $product_id,
 				'client_id'  => $order->get_meta( NEWSPACK_CLIENT_ID_COOKIE_NAME ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR does two things:

* Fix a bug in which `prompt_interaction` events were being triggered by renewal orders
* adds `is_renewal` and `subscription_id` params to woocommerce events and to the `donation_new` GA4 event.

### How to test the changes in this Pull Request:

1. Set up a Campaign prompt with a Donation block
2. Make a recurring donation
3. Confirm you see the woo events dispatched
4. Confirm you see the GA4 `donation_new` event dispatched with `is_renewal=no` and a `subscription_id` 
5. Confirm you see the `prompt_interaction` events being triggered
6. As an admin, go to the Dashboard and force a renewal for this subscription
7. Confirm that the correct events are triggered and that `prompt_interaction` events are not triggered
8. Confirm the GA4 `donation_new` event is sent with `is_renewal=yes`
9. Make a non recurring donation and a donation from a landing page (not a prompt) and confirm the events are still ok

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->