### PR TITLE
fix: don't sync non-donation purchases to the ESP

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -272,11 +272,10 @@ class Donations {
 	/**
 	 * Whether the order is a donation.
 	 *
-	 * @param int $order_id Order ID.
+	 * @param \WC_Order $order Order object.
 	 * @return boolean True if a donation, false if not.
 	 */
-	public static function is_donation_order( $order_id ) {
-		$order = new \WC_Order( $order_id );
+	public static function is_donation_order( $order ) {
 		foreach ( $order->get_items() as $item ) {
 			if ( self::is_donation_product( $item->get_product_id() ) ) {
 				return true;

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -260,13 +260,29 @@ class Donations {
 
 	/**
 	 * Check whether the given product ID is a donation product.
-	 * 
+	 *
 	 * @param int $product_id Product ID to check.
 	 * @return boolean True if a donation product, false if not.
 	 */
 	public static function is_donation_product( $product_id ) {
 		$donation_product_ids = array_values( self::get_donation_product_child_products_ids() );
 		return in_array( $product_id, $donation_product_ids, true );
+	}
+
+	/**
+	 * Whether the order is a donation.
+	 *
+	 * @param int $order_id Order ID.
+	 * @return boolean True if a donation, false if not.
+	 */
+	public static function is_donation_order( $order_id ) {
+		$order = new \WC_Order( $order_id );
+		foreach ( $order->get_items() as $item ) {
+			if ( self::is_donation_product( $item->get_product_id() ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The current schema for syncing WC data to the ESP contact expects only donation products. There are 2 sync calls that push data from any order or subscription update, which causes the ESP contact data to be misleading.

This hotfix PR ensures the order is from a donation before syncing and is part of a 3-step approach in order to fully support multiple products' data sync through data events:

1. Hotfix to prevent the sync in which non-donation product orders are being pushed to the ESP from `WooCommerce_Connection::sync_reader_on_customer_login` and `WooCommerce_Connection::sync_reader_on_subscription_update`
2. Unify the syncing strategy to use the existing data events connectors and no longer the `WooCommerce_Connection::sync_reader_from_order` for better maintainability and to avoid confusion.
3. Discuss/decide how we'd like the schema and implement support for non-donation product data sync.

Related to https://github.com/Automattic/newspack-plugin/pull/2754

### How to test the changes in this Pull Request:

1. Change your ESP to manual so we can disconnect and test the sync on authentication (sync_reader_on_customer_login)
2. With a new reader account, purchase a subscription product that is not a recurring donation and log out
3. Change your ESP to ActiveCampaign, log the reader in, and confirm the order data is not pushed to the ESP
4. Change your ESP to manual again, now purchase a recurring donation with the reader and log out
5. Change your ESP back to ActiveCampaign, log the reader in, and confirm the order data is pushed to the ESP
6. Now edit the non-donation subscription, change its status to "Cancelled" and confirm nothing is pushed to the ESP
7. Edit the donation subscription, change its status to "Cancelled" and confirm the contact has its membership status as "Ex-Monthly/Yearly Donor"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->