### PR TITLE
refactor: unify ESP data sync strategy

### DIFF
--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -55,15 +55,12 @@ class ActiveCampaign {
 	 */
 	private static function put( $email, $metadata ) {
 		$master_list_id = Reader_Activation::get_setting( 'active_campaign_master_list' );
-		if ( ! $master_list_id ) {
-			return;
-		}
 		\Newspack_Newsletters_Subscription::add_contact(
 			[
 				'email'    => $email,
 				'metadata' => $metadata,
 			],
-			$master_list_id
+			! empty( $master_list_id ) ? $master_list_id : false
 		);
 	}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -134,14 +134,6 @@ class WooCommerce_Connection {
 			return;
 		}
 
-		if ( self::can_sync_customers() ) {
-			$order = new \WC_Order( $order_id );
-			if ( ! $order->get_customer_id() ) {
-				return;
-			}
-			self::sync_reader_from_order( $order );
-		}
-
 		/**
 		 * Fires when a donation order is processed.
 		 *
@@ -149,6 +141,18 @@ class WooCommerce_Connection {
 		 * @param int $product_id Donation product post ID.
 		 */
 		\do_action( 'newspack_donation_order_processed', $order_id, $product_id );
+	}
+
+	/**
+	 * Get last donation order from customer
+	 *
+	 * @param \WC_Customer $customer Customer object.
+	 *
+	 * @return \WC_Order|false Order object or false.
+	 */
+	public static function get_customer_last_donation_order( $customer ) {
+		/** TODO */
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Related to #2758.

Unify the ESP data sync strategy to no longer use `WooCommerce_Connection::sync_reader_from_order` or Newspack Newsletters' `add_contact()` method. This sync should be performed by data event handlers

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->