### PR TITLE
feat(authentication): rate limit magic links and OTP generation

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -384,7 +384,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 						if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 							return form.endFlow( newspack_reader_auth_labels.invalid_email, 400 );
 						}
-						readerActivation.setReaderEmail( body.get( 'npe' ) );
 						if ( 'otp' === action ) {
 							readerActivation
 								.authenticateOTP( body.get( 'otp_code' ) )
@@ -425,9 +424,14 @@ window.newspackRAS.push( function ( readerActivation ) {
 											if ( currentHash ) {
 												redirect = '';
 											}
+											if ( status === 200 ) {
+												readerActivation.setReaderEmail( body.get( 'npe' ) );
+											}
 											const otpHash = readerActivation.getOTPHash();
 											if ( otpHash && [ 'register', 'link' ].includes( action ) ) {
-												setFormAction( 'otp' );
+												if ( status === 200 ) {
+													setFormAction( 'otp' );
+												}
 												/** If action is link, suppress message and status so the OTP handles it. */
 												if ( status === 200 && action === 'link' ) {
 													status = null;

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -546,7 +546,7 @@ final class Magic_Link {
 			$tokens = \get_user_meta( $user->ID, self::TOKENS_META, true );
 			if ( empty( $tokens ) || empty( $hash ) ) {
 				$errors->add( 'invalid_hash', __( 'Invalid hash.', 'newspack' ) );
-			} elseif ( empty( $otp ) ) {
+			} elseif ( empty( $code ) ) {
 				$errors->add( 'invalid_otp', __( 'Invalid OTP.', 'newspack' ) );
 			}
 		}

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -342,22 +342,20 @@ final class Magic_Link {
 		$tokens = \get_user_meta( $user->ID, self::TOKENS_META, true );
 		if ( empty( $tokens ) ) {
 			$tokens = [];
-		} else {
-			// Rate limit token generation.
-			$last_token = end( $tokens );
-			if ( $last_token['time'] + self::RATE_INTERVAL > $now ) {
-				return new \WP_Error( 'rate_limit_exceeded', __( 'You must wait before you can issue another authorization code.', 'newspack' ) );
-			}
 		}
 
 		$expire = $now - self::get_token_expiration_period();
 		if ( ! empty( $tokens ) ) {
 			/** Limit maximum tokens to 5. */
 			$tokens = array_slice( $tokens, -4, 4 );
-			/** Clear expired tokens. */
 			foreach ( $tokens as $index => $token_data ) {
+				/** Clear expired tokens. */
 				if ( $token_data['time'] < $expire ) {
 					unset( $tokens[ $index ] );
+				}
+				/** Rate limit token generation. */
+				if ( $token_data['time'] + self::RATE_INTERVAL > $now ) {
+					return new \WP_Error( 'rate_limit_exceeded', __( 'You must wait before you can issue another authorization code.', 'newspack' ) );
 				}
 			}
 			$tokens = array_values( $tokens );

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -28,6 +28,8 @@ final class Magic_Link {
 	const AUTH_ACTION_RESULT = 'np_auth_link_result';
 	const COOKIE             = 'np_auth_link';
 
+	const RATE_INTERVAL = 60; // Interval in seconds to rate limit token generation.
+
 	const OTP_LENGTH       = 6;
 	const OTP_MAX_ATTEMPTS = 5;
 	const OTP_AUTH_ACTION  = 'np_otp_auth';
@@ -340,6 +342,12 @@ final class Magic_Link {
 		$tokens = \get_user_meta( $user->ID, self::TOKENS_META, true );
 		if ( empty( $tokens ) ) {
 			$tokens = [];
+		} else {
+			// Rate limit token generation.
+			$last_token = end( $tokens );
+			if ( $last_token['time'] + self::RATE_INTERVAL > $now ) {
+				return new \WP_Error( 'newspack_magic_link_rate_limit', __( 'You must wait before you can issue another authorization code.', 'newspack' ) );
+			}
 		}
 
 		$expire = $now - self::get_token_expiration_period();

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -355,7 +355,7 @@ final class Magic_Link {
 				}
 				/** Rate limit token generation. */
 				if ( $token_data['time'] + self::RATE_INTERVAL > $now ) {
-					return new \WP_Error( 'rate_limit_exceeded', __( 'You must wait before you can issue another authorization code.', 'newspack' ) );
+					return new \WP_Error( 'rate_limit_exceeded', __( 'Please wait a minute before requesting another authorization code.', 'newspack' ) );
 				}
 			}
 			$tokens = array_values( $tokens );

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -544,7 +544,9 @@ final class Magic_Link {
 			$errors->add( 'invalid_otp', __( 'OTP is not enabled.', 'newspack' ) );
 		} else {
 			$tokens = \get_user_meta( $user->ID, self::TOKENS_META, true );
-			if ( empty( $tokens ) || empty( $hash ) || empty( $code ) ) {
+			if ( empty( $tokens ) || empty( $hash ) ) {
+				$errors->add( 'invalid_hash', __( 'Invalid hash.', 'newspack' ) );
+			} elseif ( empty( $otp ) ) {
 				$errors->add( 'invalid_otp', __( 'Invalid OTP.', 'newspack' ) );
 			}
 		}

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -346,7 +346,7 @@ final class Magic_Link {
 			// Rate limit token generation.
 			$last_token = end( $tokens );
 			if ( $last_token['time'] + self::RATE_INTERVAL > $now ) {
-				return new \WP_Error( 'newspack_magic_link_rate_limit', __( 'You must wait before you can issue another authorization code.', 'newspack' ) );
+				return new \WP_Error( 'rate_limit_exceeded', __( 'You must wait before you can issue another authorization code.', 'newspack' ) );
 			}
 		}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1460,7 +1460,7 @@ final class Reader_Activation {
 			case 'link':
 				$sent = Magic_Link::send_email( $user );
 				if ( true !== $sent ) {
-					return self::send_auth_form_response( new \WP_Error( 'unauthorized', __( 'We encountered an error sending an authentication link. Please try again.', 'newspack-plugin' ) ) );
+					return self::send_auth_form_response( new \WP_Error( 'unauthorized', \is_wp_error( $sent ) ? $sent->get_error_message() : __( 'We encountered an error sending an authentication link. Please try again.', 'newspack-plugin' ) ) );
 				}
 				return self::send_auth_form_response( $payload, __( 'Please check your inbox for an authentication link.', 'newspack-plugin' ), $redirect );
 			case 'register':

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -228,7 +228,7 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
 		$otp        = $token_data['otp'];
 
-		for ( $i = 0; $i <= Magic_Link::OTP_MAX_ATTEMPTS; $i++ ) {
+		for ( $i = 0; $i < Magic_Link::OTP_MAX_ATTEMPTS; $i++ ) {
 			$validation = Magic_Link::validate_otp( self::$user_id, $otp['hash'], 12345 );
 			$this->assertTrue( is_wp_error( $validation ) );
 			$this->assertEquals( 'invalid_otp', $validation->get_error_code() );

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -57,6 +57,8 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 				]
 			);
 		}
+		// Remove tokens.
+		delete_user_meta( self::$user_id, Magic_Link::TOKEN_META );
 
 		// Create sample admin.
 		if ( empty( self::$admin_id ) ) {
@@ -69,6 +71,8 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 				]
 			);
 		}
+		// Remove tokens.
+		delete_user_meta( self::$admin_id, Magic_Link::TOKEN_META );
 	}
 
 	/**
@@ -265,5 +269,19 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 		$validation = Magic_Link::validate_token( self::$user_id, $token_data['client'], $token_data['token'] );
 		$this->assertTrue( is_wp_error( $validation ) );
 		$this->assertEquals( 'invalid_token', $validation->get_error_code() );
+	}
+
+	/**
+	 * Test rate limiting of token generation.
+	 */
+	public function test_rate_limit() {
+		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$validation = Magic_Link::validate_token( self::$user_id, $token_data['client'], $token_data['token'] );
+		$this->assertTokenIsValid( $validation );
+
+		// Second immediate generation should error with "rate_limit_exceeded".
+		$new_token = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$this->assertTrue( is_wp_error( $new_token ) );
+		$this->assertEquals( 'rate_limit_exceeded', $new_token->get_error_code() );
 	}
 }

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -58,7 +58,7 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 			);
 		}
 		// Remove tokens.
-		delete_user_meta( self::$user_id, Magic_Link::TOKEN_META );
+		delete_user_meta( self::$user_id, Magic_Link::TOKENS_META );
 
 		// Create sample admin.
 		if ( empty( self::$admin_id ) ) {
@@ -72,7 +72,7 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 			);
 		}
 		// Remove tokens.
-		delete_user_meta( self::$admin_id, Magic_Link::TOKEN_META );
+		delete_user_meta( self::$admin_id, Magic_Link::TOKENS_META );
 	}
 
 	/**

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -104,6 +104,20 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test rate limiting of token generation.
+	 */
+	public function test_rate_limit() {
+		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$validation = Magic_Link::validate_token( self::$user_id, $token_data['client'], $token_data['token'] );
+		$this->assertTokenIsValid( $validation );
+
+		// Second immediate generation should error with "rate_limit_exceeded".
+		$new_token = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$this->assertTrue( is_wp_error( $new_token ) );
+		$this->assertEquals( 'rate_limit_exceeded', $new_token->get_error_code() );
+	}
+
+	/**
 	 * Test simple token validation.
 	 */
 	public function test_validate_token() {
@@ -269,19 +283,5 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 		$validation = Magic_Link::validate_token( self::$user_id, $token_data['client'], $token_data['token'] );
 		$this->assertTrue( is_wp_error( $validation ) );
 		$this->assertEquals( 'invalid_token', $validation->get_error_code() );
-	}
-
-	/**
-	 * Test rate limiting of token generation.
-	 */
-	public function test_rate_limit() {
-		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
-		$validation = Magic_Link::validate_token( self::$user_id, $token_data['client'], $token_data['token'] );
-		$this->assertTokenIsValid( $validation );
-
-		// Second immediate generation should error with "rate_limit_exceeded".
-		$new_token = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
-		$this->assertTrue( is_wp_error( $new_token ) );
-		$this->assertEquals( 'rate_limit_exceeded', $new_token->get_error_code() );
 	}
 }

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -108,11 +108,7 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 	 */
 	public function test_rate_limit() {
 		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
-		$validation = Magic_Link::validate_token( self::$user_id, $token_data['client'], $token_data['token'] );
-		$this->assertTokenIsValid( $validation );
-
-		// Second immediate generation should error with "rate_limit_exceeded".
-		$new_token = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		$new_token  = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
 		$this->assertTrue( is_wp_error( $new_token ) );
 		$this->assertEquals( 'rate_limit_exceeded', $new_token->get_error_code() );
 	}
@@ -232,7 +228,7 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 		$token_data = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
 		$otp        = $token_data['otp'];
 
-		for ( $i = 0; $i < Magic_Link::OTP_MAX_ATTEMPTS; $i++ ) {
+		for ( $i = 0; $i <= Magic_Link::OTP_MAX_ATTEMPTS; $i++ ) {
 			$validation = Magic_Link::validate_otp( self::$user_id, $otp['hash'], 12345 );
 			$this->assertTrue( is_wp_error( $validation ) );
 			$this->assertEquals( 'invalid_otp', $validation->get_error_code() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implement a 60-second interval for rate-limiting the generation of magic links and OTPs.

<img width="587" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/de3aad6c-0c7c-4f2e-ba15-9017be502008">

87144f4c3899bab8644f007e5111018a1217430c changes the validation check so that it can return `invalid_hash` and `invalid_otp` early. The tests started to fail because it is now cleaning all tokens per test, meaning there are no tokens when testing OTP expiration. This change allows the expected `invalid_hash` to return.

### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have RAS enabled
2. On a fresh session, click the "Sign In" button on the header
3. Enter an existing reader account's email
4. Click "Try a different email" and proceed to send to the same email
5. Confirm you get the following error: "You must wait before you can issue another authorization code."

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->