### PR TITLE
feat(campaigns): mark duplicate segments

### DIFF
--- a/assets/wizards/popups/views/segments/segments-list.js
+++ b/assets/wizards/popups/views/segments/segments-list.js
@@ -174,6 +174,9 @@ const SegmentActionCard = ( {
 						description={ segmentDescription( segment ) }
 						toggleChecked={ ! segment.configuration.is_disabled }
 						toggleOnChange={ () => toggleSegmentStatus( segment ) }
+						badge={
+							segment.is_criteria_duplicated ? __( 'Duplicate', 'newspack-plugin' ) : undefined
+						}
 						actionText={
 							<>
 								<Button


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds "DUPLICATE" badge if a segment is duplicated. 

See 1200133283036252-as-1205733927102145

### How to test the changes in this Pull Request:

_Follow instructions in https://github.com/Automattic/newspack-popups/pull/1244_ 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->