### PR TITLE
fix(recaptcha): refresh token on checkout error

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -323,7 +323,7 @@ final class Recaptcha {
 		<script>
 			grecaptcha.ready( function() {
 				var field;
-				setInterval( function() {
+				function update() {
 					grecaptcha.execute(
 						'<?php echo \esc_attr( $site_key ); ?>',
 						{ action: 'checkout' }
@@ -332,7 +332,13 @@ final class Recaptcha {
 							field.value = token;
 						}
 					} );
-				}, 30000 );
+				}
+				setInterval( update, 30000 );
+				( function( $ ) {
+					if ( ! $ ) { return; }
+					$( document ).on( 'updated_checkout', update );
+					$( document.body ).on( 'checkout_error', update );
+				} )( jQuery );
 				grecaptcha.execute(
 					'<?php echo \esc_attr( $site_key ); ?>',
 					{ action: 'checkout' }

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -323,7 +323,7 @@ final class Recaptcha {
 		<script>
 			grecaptcha.ready( function() {
 				var field;
-				function update() {
+				function refreshToken() {
 					grecaptcha.execute(
 						'<?php echo \esc_attr( $site_key ); ?>',
 						{ action: 'checkout' }
@@ -333,11 +333,11 @@ final class Recaptcha {
 						}
 					} );
 				}
-				setInterval( update, 30000 );
+				setInterval( refreshToken, 30000 );
 				( function( $ ) {
 					if ( ! $ ) { return; }
-					$( document ).on( 'updated_checkout', update );
-					$( document.body ).on( 'checkout_error', update );
+					$( document ).on( 'updated_checkout', refreshToken );
+					$( document.body ).on( 'checkout_error', refreshToken );
 				} )( jQuery );
 				grecaptcha.execute(
 					'<?php echo \esc_attr( $site_key ); ?>',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When going through checkout and the submission fails, the next attempt might send the same token, which is not allowed by reCAPTCHA.

This change ensures the captcha token is regenerated on checkout updates and errors to prevent duplicate tokens while placing the order.

### How to test the changes in this Pull Request:

1. While on the master branch, add an item to cart and visit the regular WC checkout page (/checkout/)
2. Place order without entering the required billing fields and confirm you get a regular WC error
3. Place the order again and confirm you get a `reCaptcha error: timeout-or-duplicate` along with the other validation errors
4. Check out this branch, repeat steps 2 and 3 and confirm you only get the validation errors
5. Without refreshing, fill the required fields and confirm you are able to place the order

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->