### PR TITLE
feat(donations): disable coupons for donation checkout

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -1046,10 +1046,14 @@ class Donations {
 	 * @return bool
 	 */
 	public static function disable_coupons( $enabled ) {
-		if ( self::is_donation_cart( \WC()->cart ) ) {
-			return false;
+		$cart = WC()->cart;
+		if ( ! $cart ) {
+			return $enabled;
 		}
-		return $enabled;
+		if ( ! self::is_donation_cart( $cart ) ) {
+			return $enabled;
+		}
+		return false;
 	}
 }
 Donations::init();

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -74,6 +74,7 @@ class Donations {
 			add_filter( 'amp_skip_post', [ __CLASS__, 'should_skip_amp' ], 10, 2 );
 			add_filter( 'newspack_blocks_donate_billing_fields_keys', [ __CLASS__, 'get_billing_fields' ] );
 			add_action( 'woocommerce_checkout_create_order_line_item', [ __CLASS__, 'checkout_create_order_line_item' ], 10, 4 );
+			add_action( 'woocommerce_coupons_enabled', [ __CLASS__, 'disable_coupons' ] );
 		}
 	}
 
@@ -1035,6 +1036,20 @@ class Donations {
 	public static function update_billing_fields( $billing_fields ) {
 		update_option( self::DONATION_BILLING_FIELDS_OPTION, $billing_fields );
 		return $billing_fields;
+	}
+
+	/**
+	 * Disable coupons for donation checkouts.
+	 *
+	 * @param bool $enabled Whether coupons are enabled.
+	 *
+	 * @return bool
+	 */
+	public static function disable_coupons( $enabled ) {
+		if ( self::is_donation_cart( \WC()->cart ) ) {
+			return false;
+		}
+		return $enabled;
 	}
 }
 Donations::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Coupons should never be rendered when donating. This change ensures coupons are disabled for donation carts.

### How to test the changes in this Pull Request:

1. Make sure you have coupons enabled
2. Start a donation checkout through the Donate block and confirm the coupon form doesn't render
3. Checkout a different product and confirm the coupon form renders

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->