### PR TITLE
fix: don’t sync empty contact fields to ESP

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -325,11 +325,12 @@ class WooCommerce_Connection {
 
 		$first_name = $order->get_billing_first_name();
 		$last_name  = $order->get_billing_last_name();
-		return [
+		$contact    = [
 			'email'    => $order->get_billing_email(),
-			'name'     => "$first_name $last_name",
-			'metadata' => $metadata,
+			'name'     => trim( "$first_name $last_name" ),
+			'metadata' => array_filter( $metadata ),
 		];
+		return array_filter( $contact );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Don't try to sync contact fields if we don't have any reader data for those fields to sync. Some publishers who have imported reader accounts to Woo have preexisting reader data in their ESP that is getting overwritten if the corresponding Woo reader has less data than the ESP.

### How to test the changes in this Pull Request:

1. In Newspack > Reader Revenue > Donations, disable all billing fields except for email.
2. On `master`, make a new donation as a new reader.
3. Find the reader's corresponding contact in your ESP (I tested with ActiveCampaign). Manually add some values to certain fields such as First/Last Name, NP_Current Subscription End Date, etc. and save in the ESP
4. In a new session, log in as the user created in step 2 to trigger a reader data sync. Observe in the ESP that the preexisting values in the fields you manually entered in step 3 have been overwritten with empty values.
5. Check out this branch, repeat steps 3-4, and this time confirm that the preexisting manually-entered values are not overwritten.
6. Reenable all billing fields and smoke test a new donation/reader to confirm that all fields are synced if they contain data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->