### PR TITLE
fix: more fixes for Mailchimp RAS data sync

### DIFF
--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -7,6 +7,7 @@
 
 namespace Newspack\Data_Events\Connectors;
 
+use \Newspack\Logger;
 use \Newspack\Data_Events;
 use \Newspack\Mailchimp_API;
 use \Newspack\Newspack_Newsletters;
@@ -78,8 +79,7 @@ class Mailchimp {
 	 * @return array Merge fields.
 	 */
 	private static function get_merge_fields( $audience_id, $data ) {
-		$merge_fields       = [];
-		$fields_option_name = sprintf( 'newspack_data_mailchimp_%s_fields', $audience_id );
+		$merge_fields = [];
 
 		// Strip arrays.
 		$data = array_filter(
@@ -90,21 +90,36 @@ class Mailchimp {
 		);
 
 		// Get and match existing merge fields.
-		$fields_ids      = \get_option( $fields_option_name, [] );
-		$existing_fields = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" );
-		foreach ( $existing_fields['merge_fields'] as $field ) {
-			$field_name = '';
-			if ( isset( $fields_ids[ $field['merge_id'] ] ) ) {
-				// Match locally stored merge field ID.
-				$field_name = $fields_ids[ $field['merge_id'] ];
-			} elseif ( isset( $data[ $field['name'] ] ) ) {
-				// Match by merge field name.
-				$field_name                       = $field['name'];
-				$fields_ids[ $field['merge_id'] ] = $field_name;
+		$existing_fields = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" )['merge_fields'];
+		usort(
+			$existing_fields,
+			function( $a, $b ) {
+				return $a['merge_id'] - $b['merge_id'];
 			}
-			// If field name is found, add it to the payload.
-			if ( ! empty( $field_name ) && isset( $data[ $field_name ] ) ) {
-				$merge_fields[ $field['tag'] ] = $data[ $field_name ];
+		);
+
+		$list_merge_fields = [];
+
+		// Handle duplicate fields.
+		foreach ( $existing_fields as $field ) {
+			if ( ! isset( $list_merge_fields[ $field['name'] ] ) ) {
+				$list_merge_fields[ $field['name'] ] = $field['tag'];
+			} else {
+				Mailchimp_API::delete( "lists/$audience_id/merge-fields/" . $field['merge_id'] );
+				Logger::log(
+					sprintf(
+						// Translators: %1$s is the merge field key, %2$s is the error message.
+						__( 'Duplicate merge field %1$s found and deleted.', 'newspack-newsletters' ),
+						$field['name']
+					)
+				);
+			}
+		}
+
+		foreach ( $data as $field_name => $field_value ) {
+			// If field already exists, add it to the payload.
+			if ( isset( $list_merge_fields[ $field_name ] ) ) {
+				$merge_fields[ $list_merge_fields[ $field_name ] ] = $data[ $field_name ];
 				unset( $data[ $field_name ] );
 			}
 		}
@@ -123,12 +138,16 @@ class Mailchimp {
 			if ( is_wp_error( $created_field ) ) {
 				continue;
 			}
-			$merge_fields[ $created_field['tag'] ]    = $data[ $field_name ];
-			$fields_ids[ $created_field['merge_id'] ] = $field_name;
+			Logger::log(
+				sprintf(
+					// Translators: %1$s is the merge field key, %2$s is the error message.
+					__( 'Created merge field %1$s.', 'newspack-newsletters' ),
+					$field_name
+				)
+			);
+			$merge_fields[ $created_field['tag'] ] = $data[ $field_name ];
 		}
 
-		// Store fields IDs for future use.
-		\update_option( $fields_option_name, $fields_ids );
 		return $merge_fields;
 	}
 
@@ -137,8 +156,10 @@ class Mailchimp {
 	 *
 	 * @param string $email Email address.
 	 * @param array  $data  Data to update.
+	 * 
+	 * @return array|WP_Error response body or error.
 	 */
-	private static function put( $email, $data = [] ) {
+	public static function put( $email, $data = [] ) {
 		$audience_id = self::get_audience_id();
 		if ( ! $audience_id ) {
 			return;
@@ -154,8 +175,13 @@ class Mailchimp {
 			$payload['merge_fields'] = $merge_fields;
 		}
 
+		Logger::log(
+			'Syncing contact with metadata key(s): ' . implode( ', ', array_keys( $data ) ) . '.',
+			Data_Events::LOGGER_HEADER
+		);
+
 		// Upsert the contact.
-		Mailchimp_API::put(
+		return Mailchimp_API::put(
 			"lists/$audience_id/members/$hash",
 			$payload
 		);

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -105,12 +105,12 @@ class Mailchimp {
 			if ( ! isset( $list_merge_fields[ $field['name'] ] ) ) {
 				$list_merge_fields[ $field['name'] ] = $field['tag'];
 			} else {
-				Mailchimp_API::delete( "lists/$audience_id/merge-fields/" . $field['merge_id'] );
 				Logger::log(
 					sprintf(
-						// Translators: %1$s is the merge field key, %2$s is the error message.
-						__( 'Duplicate merge field %1$s found and deleted.', 'newspack-newsletters' ),
-						$field['name']
+						// Translators: %1$s is the merge field name, %2$s is the field's unique tag.
+						__( 'Warning: Duplicate merge field %1$s found with tag %2$s.', 'newspack-newsletters' ),
+						$field['name'],
+						$field['tag']
 					)
 				);
 			}

--- a/includes/oauth/class-mailchimp-api.php
+++ b/includes/oauth/class-mailchimp-api.php
@@ -182,7 +182,7 @@ class Mailchimp_API {
 			return $response;
 		}
 		$parsed_response = json_decode( $response['body'], true );
-		if ( 200 !== \wp_remote_retrieve_response_code( $response ) ) {
+		if ( $parsed_response && 200 !== \wp_remote_retrieve_response_code( $response ) ) {
 			return new \WP_Error(
 				'newspack_mailchimp_api',
 				array_key_exists( 'title', $parsed_response ) ? $parsed_response['title'] : __( 'Request failed.', 'newspack' )
@@ -224,6 +224,18 @@ class Mailchimp_API {
 	 */
 	public static function post( $path = '', $data = [] ) {
 		return self::request( 'POST', $path, $data );
+	}
+
+	/**
+	 * Perform a DELETE request to Mailchimp's API
+	 *
+	 * @param string $path API path.
+	 * @param array  $data Data to send.
+	 *
+	 * @return array|WP_Error API response or error.
+	 */
+	public static function delete( $path = '', $data = [] ) {
+		return self::request( 'DELETE', $path, $data );
 	}
 }
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1468,6 +1468,10 @@ final class Reader_Activation {
 				if ( ! empty( $lists ) ) {
 					$metadata['lists'] = $lists;
 				}
+				$metadata['referer']             = \wp_get_raw_referer(); // wp_get_referer() will return false because it's a POST request to the same page.
+				$metadata['current_page_url']    = \home_url( \add_query_arg( array(), $metadata['referer'] ) );
+				$metadata['registration_method'] = 'auth-form';
+
 				$user_id = self::register_reader( $email, '', true, $metadata );
 				if ( false === $user_id ) {
 					return self::send_auth_form_response(

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1042,6 +1042,8 @@ final class Reader_Activation {
 		$terms_url       = self::get_setting( 'terms_url' );
 		$is_account_page = function_exists( '\wc_get_page_id' ) ? \get_the_ID() === \wc_get_page_id( 'myaccount' ) : false;
 		$redirect        = $is_account_page ? \wc_get_account_endpoint_url( 'dashboard' ) : '';
+		$referer         = \wp_parse_url( \wp_get_referer() );
+		global $wp;
 		?>
 		<div class="<?php echo \esc_attr( implode( ' ', $classnames ) ); ?>" data-labels="<?php echo \esc_attr( htmlspecialchars( \wp_json_encode( $labels ), ENT_QUOTES, 'UTF-8' ) ); ?>">
 			<div class="<?php echo \esc_attr( $class( 'wrapper' ) ); ?>">
@@ -1055,6 +1057,9 @@ final class Reader_Activation {
 				<div class="<?php echo \esc_attr( $class( 'content' ) ); ?>">
 					<form method="post" target="_top">
 						<input type="hidden" name="<?php echo \esc_attr( self::AUTH_FORM_ACTION ); ?>" value="1" />
+						<?php if ( ! empty( $referer['path'] ) ) : ?>
+							<input type="hidden" name="referer" value="<?php echo \esc_url( $referer['path'] ); ?>" />
+						<?php endif; ?>
 						<input type="hidden" name="action" value="pwd" />
 						<div class="<?php echo \esc_attr( $class( 'have-account' ) ); ?>">
 							<a href="#" data-action="pwd link" data-set-action="register"><?php \esc_html_e( "I don't have an account", 'newspack-plugin' ); ?></a>
@@ -1394,13 +1399,15 @@ final class Reader_Activation {
 		if ( ! isset( $_POST[ self::AUTH_FORM_ACTION ] ) ) {
 			return;
 		}
-		$action        = isset( $_POST['action'] ) ? \sanitize_text_field( $_POST['action'] ) : '';
-		$email         = isset( $_POST['npe'] ) ? \sanitize_email( $_POST['npe'] ) : '';
-		$password      = isset( $_POST['password'] ) ? \sanitize_text_field( $_POST['password'] ) : '';
-		$redirect      = isset( $_POST['redirect'] ) ? \esc_url_raw( $_POST['redirect'] ) : '';
-		$lists         = isset( $_POST['lists'] ) ? array_map( 'sanitize_text_field', $_POST['lists'] ) : [];
-		$honeypot      = isset( $_POST['email'] ) ? \sanitize_text_field( $_POST['email'] ) : '';
-		$captcha_token = isset( $_POST['captcha_token'] ) ? \sanitize_text_field( $_POST['captcha_token'] ) : '';
+		$action           = isset( $_POST['action'] ) ? \sanitize_text_field( $_POST['action'] ) : '';
+		$referer          = isset( $_POST['referer'] ) ? \sanitize_text_field( $_POST['referer'] ) : '';
+		$current_page_url = \wp_parse_url( \wp_get_raw_referer() ); // Referer is the current page URL because the form is submitted via AJAX.
+		$email            = isset( $_POST['npe'] ) ? \sanitize_email( $_POST['npe'] ) : '';
+		$password         = isset( $_POST['password'] ) ? \sanitize_text_field( $_POST['password'] ) : '';
+		$redirect         = isset( $_POST['redirect'] ) ? \esc_url_raw( $_POST['redirect'] ) : '';
+		$lists            = isset( $_POST['lists'] ) ? array_map( 'sanitize_text_field', $_POST['lists'] ) : [];
+		$honeypot         = isset( $_POST['email'] ) ? \sanitize_text_field( $_POST['email'] ) : '';
+		$captcha_token    = isset( $_POST['captcha_token'] ) ? \sanitize_text_field( $_POST['captcha_token'] ) : '';
 		// phpcs:enable
 
 		// Honeypot trap.
@@ -1464,14 +1471,16 @@ final class Reader_Activation {
 				}
 				return self::send_auth_form_response( $payload, __( 'Please check your inbox for an authentication link.', 'newspack-plugin' ), $redirect );
 			case 'register':
-				$metadata = [];
+				$metadata = [ 'registration_method' => 'auth-form' ];
 				if ( ! empty( $lists ) ) {
 					$metadata['lists'] = $lists;
 				}
-				$metadata['referer']             = \wp_get_raw_referer(); // wp_get_referer() will return false because it's a POST request to the same page.
-				$metadata['current_page_url']    = \home_url( \add_query_arg( array(), $metadata['referer'] ) );
-				$metadata['registration_method'] = 'auth-form';
-
+				if ( ! empty( $referer ) ) {
+					$metadata['referer'] = \esc_url( $referer );
+				}
+				if ( ! empty( $current_page_url['path'] ) ) {
+					$metadata['current_page_url'] = \esc_url( \home_url( $current_page_url['path'] ) );
+				}
 				$user_id = self::register_reader( $email, '', true, $metadata );
 				if ( false === $user_id ) {
 					return self::send_auth_form_response(

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -220,9 +220,6 @@ class WooCommerce_Connection {
 		}
 
 		$customer = new \WC_Customer( $user_id );
-		$metadata = [
-			'registration_method' => 'woocommerce-order',
-		];
 
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'account' ) ]           = $order->get_customer_id();
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_date' ) ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
@@ -353,6 +350,28 @@ class WooCommerce_Connection {
 		if ( ! $contact ) {
 			return;
 		}
+
+		return self::sync_contact_to_esp( $contact );
+	}
+
+	/**
+	 * Upsert reader data to the ESP connected via Newspack Newsletters.
+	 * 
+	 * @param array $contact Reader data to sync.
+	 * @return bool|WP_Error Contact data if it was added, WP_Error otherwise.
+	 */
+	public static function sync_contact_to_esp( $contact ) {
+		if ( ! method_exists( 'Newspack_Newsletters', 'service_provider' ) ) {
+			return;
+		}
+
+		// If syncing to Mailchimp, we need to use its special method to add contacts which handles transactional contacts.
+		if ( 'mailchimp' === \Newspack_Newsletters::service_provider() ) {
+			// Normalize contact data, since this won't be passed through \Newspack_Newsletters_Subscription::add_contact().
+			$contact = \Newspack\Newspack_Newsletters::normalize_contact_data( $contact );
+			return \Newspack\Data_Events\Connectors\Mailchimp::put( $contact['email'], $contact['metadata'] );
+		}
+
 		if ( ! method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ) ) {
 			return;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds `Registration Method` and `Registration Page` metadata to `reader_registered` data events fired by the auth form. Currently new registrations via this method aren't capturing this info.

### How to test the changes in this Pull Request:

1. On `master`, visit any page in a new session and click the "Sign In" button in the header, then "I don't have an account". Register a new account via this form.
2. In the connected ESP, observe that the synced contact doesn't have any `NP_Registration Page` or `NP_Registration Method` values.
3. Check out this branch and https://github.com/Automattic/newspack-newsletters/pull/1370, repeat with a different email address, and confirm that the synced contact has a `NP_Registration Page` with the URL of the page you were viewing when you clicked "Sign In", and a `NP_Registration Method` of `auth-form`.

This PR now also contains an alternative solution for the issue described in https://github.com/Automattic/newspack-newsletters/pull/1365. Please follow testing instructions there to test this solution.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->