### PR TITLE
chore: avoid warnings on php 8.1

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -717,7 +717,7 @@ class Donations {
 			$query_args['modal_checkout'] = 1;
 		}
 		foreach ( [ 'after_success_behavior', 'after_success_button_label', 'after_success_url' ] as $attribute_name ) {
-			$value = filter_input( INPUT_GET, $attribute_name, FILTER_SANITIZE_STRING );
+			$value = filter_input( INPUT_GET, $attribute_name, FILTER_SANITIZE_SPECIAL_CHARS );
 			if ( ! empty( $value ) ) {
 				$query_args[ $attribute_name ] = $value;
 			}

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -58,7 +58,7 @@ abstract class Wizard {
 	 */
 	public function add_page() {
 		add_submenu_page(
-			$this->hidden ? null : 'newspack',
+			$this->hidden ? 'hidden' : 'newspack',
 			$this->get_name(),
 			$this->get_name(),
 			$this->capability,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoid Warnings to be thrown when using php 8.1

### How to test the changes in this Pull Request:

1. Make sure you are running php 8.1
2. On `master` visit the admin dashboard
3. Confirm you see the following warnings:

```
[01-Dec-2023 14:00:37 UTC] PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/html/wp-includes/functions.php on line 7241
[01-Dec-2023 14:00:37 UTC] PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/html/wp-includes/functions.php on line 2187
```
4. Visit one of the hidden pages. Example: `/wp-admin/admin.php?page=newspack-components-demo`
5. Confirm you see the following warning:

```
PHP Deprecated:  strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/wp-admin/admin-header.php on line 36
```
6. Also notice that the Page title (on the browser title bar) doesnt have the current page name, only the site name
7. Checkout this branch
8. Confirm all warnings are gone
9. Confirm hidden pages are still hidden, but accessible
10. Verify that the page title now includes the current page title "Components Demo"

Also, make a purchase via a checkout button and make sure you don't see a Warning about the `FILTER_SANITIZE_STRING` constant

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->