### PR TITLE
feat: force allow subscription switching

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -43,7 +43,10 @@ class WooCommerce_Connection {
 		include_once __DIR__ . '/class-woocommerce-cover-fees.php';
 
 		\add_action( 'admin_init', [ __CLASS__, 'disable_woocommerce_setup' ] );
-		\add_filter( 'option_woocommerce_subscriptions_allow_switching_nyp_price', [ __CLASS__, 'force_allow_switching_subscription_amount' ] );
+		\add_filter( 'option_woocommerce_subscriptions_allow_switching', [ __CLASS__, 'force_allow_subscription_switching' ], 10, 2 );
+		\add_filter( 'option_woocommerce_subscriptions_allow_switching_nyp_price', [ __CLASS__, 'force_allow_subscription_switching' ], 10, 2 );
+		\add_filter( 'default_option_woocommerce_subscriptions_allow_switching', [ __CLASS__, 'force_allow_subscription_switching' ], 10, 2 );
+		\add_filter( 'default_option_woocommerce_subscriptions_allow_switching_nyp_price', [ __CLASS__, 'force_allow_subscription_switching' ], 10, 2 );
 		\add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'send_customizable_receipt_email' ], 10, 3 );
 
 		// WooCommerce Subscriptions.
@@ -1118,14 +1121,30 @@ class WooCommerce_Connection {
 	}
 
 	/**
-	 * Force allow switching the subscription amount unless the NEWSPACK_PREVENT_WC_SUBS_ALLOW_SWITCHING_OVERRIDE constant is set
+	 * Force values for subscription switching options to ON unless the
+	 * NEWSPACK_PREVENT_WC_SUBS_ALLOW_SWITCHING_OVERRIDE constant is set.
+	 * This affects the following "Allow Switching" options:
+	 * 
+	 * - Between Subscription Variations 
+	 * - Between Grouped Subscriptions 
+	 * - Change Name Your Price subscription amount
 	 *
-	 * @param bool $can_switch Whether the subscription amount can be switched.
+	 * @param bool   $can_switch Whether the subscription amount can be switched.
+	 * @param string $option_name The name of the option.
+	 * 
+	 * @return string Option value.
 	 */
-	public static function force_allow_switching_subscription_amount( $can_switch ) {
+	public static function force_allow_subscription_switching( $can_switch, $option_name ) {
 		if ( defined( 'NEWSPACK_PREVENT_WC_SUBS_ALLOW_SWITCHING_OVERRIDE' ) && NEWSPACK_PREVENT_WC_SUBS_ALLOW_SWITCHING_OVERRIDE ) {
 			return $can_switch;
 		}
+
+		// Subscriptions' default switching options are combined into a single options row with possible values 'no', 'variable', 'grouped', or 'variable_grouped'.
+		if ( 'woocommerce_subscriptions_allow_switching' === $option_name ) {
+			return 'variable_grouped';
+		}
+
+		// Other options added by the woocommerce_subscriptions_allow_switching_options filter are either 'yes' or 'no'.
 		return 'yes';
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#2305 added a feature to force the "Subscription Switching" option for Name Your Price products to on unless a `NEWSPACK_PREVENT_FORCE_ALLOW_SWITCHING` constant is added to wp-config.php. However, this didn't quite go far enough. The filter used to force the value is only fired if the option exists, so if a publisher has never saved that page before, the option wouldn't exist and the feature wouldn't take effect. Also there are additional "Subscription Switching" options that remain off by default. 

This PR updates the feature so that all Subscription Switching feature are turned on unless the constant is present, and also adds filters for `default_option_{option_name}` so that the features are turned on even if the option hasn't ever been changed.

### How to test the changes in this Pull Request:

1. While on `master`, if your wp-config contains `define( 'NEWSPACK_PREVENT_WC_SUBS_ALLOW_SWITCHING_OVERRIDE', true );`, temporarily disable it for testing.
2. Using CLI, make sure you have no option value set for the NYP option: `wp option delete woocommerce_subscriptions_allow_switching_nyp_price`
3. Visit WP admin > WooCommerce > Settings > Subscriptions and observe that the "Change Name Your Price subscription amount" is not enabled, despite the filter to force it on. This is because the `option_woocommerce_subscriptions_allow_switching_nyp_price` filter hook runs only if the option exists in the DB.

<img width="627" alt="Screenshot 2023-12-01 at 5 16 29 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/29bbe6e5-d1a8-4505-825b-68a11e3b57ad">

4. Check out this branch.
5. Refresh the WCS settings page and confirm that all Subscription Switching options are now on:

<img width="683" alt="Screenshot 2023-12-01 at 5 18 12 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/2cee6054-0f76-4067-98fd-052b11aa0c4f">

6. Try to turn them off and "Save changes", and confirm that you can't.
7. As a reader, make a recurring donation and then purchase a non-donation, non-NYP variable subscription product as the same reader. (If you haven't created one, [create one](https://woo.com/document/subscriptions/store-manager-guide/#wistia_yiww9wlyjy))
8. Visit My Account and verify so you can manage your subscriptions, then go to Subscriptions.
9. Confirm that for the donation subscription, you're able to click "Change price" to change your subscription to any frequency (monthly or annual, because they're all part of the same grouped product) as well as change the price of the recurring subscription. Note that you'll have to add the new "upgrade" or "downgrade" item to the cart and then complete the standard, non-modal Woo checkout in order to do this.

<img width="1243" alt="Screenshot 2023-12-01 at 5 25 48 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/95e400c6-d6bc-42e1-86f5-b1d815dfb72f">

10. Confirm that for the variable subscription, you're able to click "Upgrade or downgrade" to switch between the different variations of that product, but you can't enter a price since it's not NYP-enabled. Again, you'll have to add the upgrade/downgrade to your cart and complete the transaction via standard Woo checkout.

<img width="986" alt="Screenshot 2023-12-01 at 5 25 20 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/0a6d20b9-c886-4077-a2fd-cc1c1e045a85">

11. Add the `define( 'NEWSPACK_PREVENT_WC_SUBS_ALLOW_SWITCHING_OVERRIDE', true );` constant to wp-config.php.
12. In WP admin > WooCommerce > Settings > Subscriptions confirm that all three options are off. Also confirm that you can turn them on and off and your changes persist after clicking "Save changes", and that while logged in as the reader, you can't switch subscriptions as in steps 9-10 if the options are off.

<img width="627" alt="Screenshot 2023-12-01 at 5 16 29 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/70cb9eb4-2e9a-4c59-a89f-4e7448c23a81">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->