### PR TITLE
fix(mailchimp): prevent merge fields fetch throwing fatal error

### DIFF
--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -90,18 +90,18 @@ class Mailchimp {
 		);
 
 		// Get and match existing merge fields.
-		$merge_fields = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" );
-		if ( \is_wp_error( $merge_fields ) ) {
+		$merge_fields_res = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" );
+		if ( \is_wp_error( $merge_fields_res ) ) {
 			Logger::log(
 				sprintf(
 					// Translators: %1$s is the error message.
 					__( 'Error getting merge fields: %1$s', 'newspack-plugin' ),
-					$merge_fields->get_error_message()
+					$merge_fields_res->get_error_message()
 				)
 			);
 			return [];
 		}
-		$existing_fields = $merge_fields['merge_fields'];
+		$existing_fields = $merge_fields_res['merge_fields'];
 		usort(
 			$existing_fields,
 			function( $a, $b ) {

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -90,7 +90,18 @@ class Mailchimp {
 		);
 
 		// Get and match existing merge fields.
-		$existing_fields = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" )['merge_fields'];
+		$merge_fields = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" );
+		if ( \is_wp_error( $merge_fields ) ) {
+			Logger::log(
+				sprintf(
+					// Translators: %1$s is the error message.
+					__( 'Error getting merge fields: %1$s', 'newspack-plugin' ),
+					$merge_fields->get_error_message()
+				)
+			);
+			return [];
+		}
+		$existing_fields = $merge_fields['merge_fields'];
 		usort(
 			$existing_fields,
 			function( $a, $b ) {
@@ -108,7 +119,7 @@ class Mailchimp {
 				Logger::log(
 					sprintf(
 						// Translators: %1$s is the merge field name, %2$s is the field's unique tag.
-						__( 'Warning: Duplicate merge field %1$s found with tag %2$s.', 'newspack-newsletters' ),
+						__( 'Warning: Duplicate merge field %1$s found with tag %2$s.', 'newspack-plugin' ),
 						$field['name'],
 						$field['tag']
 					)
@@ -141,7 +152,7 @@ class Mailchimp {
 			Logger::log(
 				sprintf(
 					// Translators: %1$s is the merge field key, %2$s is the error message.
-					__( 'Created merge field %1$s.', 'newspack-newsletters' ),
+					__( 'Created merge field %1$s.', 'newspack-plugin' ),
 					$field_name
 				)
 			);
@@ -156,7 +167,7 @@ class Mailchimp {
 	 *
 	 * @param string $email Email address.
 	 * @param array  $data  Data to update.
-	 * 
+	 *
 	 * @return array|WP_Error response body or error.
 	 */
 	public static function put( $email, $data = [] ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fetch may fail if the audience does not exist in Mailchimp (Resource not found). This change prevents this error from throwing a fatal error and breaking the donation flow.

### How to test the changes in this Pull Request:

1. Make sure you have RAS enabled and Newspack Newsletters is connected Mailchimp
2. Confirm you have `define( 'NEWSPACK_LOG_LEVEL', 2 );`
3. While on the `release` branch confirm the error by adding `$audience_id = 'foo';` to line 53 of `includes/data-events/connectors/class-mailchimp.php`
4. Go through the donation flow and confirm the donation order goes through but you get an unhandled error in the UI
5. Check out this branch, apply the same `$audience_id = 'foo';` line, and got through the donation flow again
6. Confirm the donation succeeds and the logs shows: `[28441][NEWSPACK][Newspack\Data_Events\Connectors\Mailchimp::get_merge_fields]: Error getting merge fields: Resource Not Found`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->