### PR TITLE
feat: don’t send OTP via preauth flow when signing up for newsletter

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1612,8 +1612,11 @@ final class Reader_Activation {
 		$user_id = false;
 
 		if ( $existing_user ) {
-			Logger::log( "User with $email already exists. Sending magic link." );
-			Magic_Link::send_email( $existing_user );
+			// Don't send OTP email for newsletter signup.
+			if ( ! isset( $metadata['registration_method'] ) || false === strpos( $metadata['registration_method'], 'newsletters-subscription' ) ) {
+				Logger::log( "User with $email already exists. Sending magic link." );
+				Magic_Link::send_email( $existing_user );
+			}
 		} else {
 			/**
 			 * Create new reader.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A smallish tweak to the preauth flow in a specific user scenario.

Right now, it's possible to sign up for new newsletter lists via Newsletter Subscription Form blocks using an email address that's already been registered in the past, but while not logged into the account for that email address. 

We've gone back and forth on this in the past, but we've decided on a product strategy level that we should continue to allow this, for the time being.

However, when you do this, we currently send an OTP email to the email address to log into the account. This email feels unexpected because it's not part of the intent of the newsletter signup flow, which doesn't require an account login. We should not send the OTP email in this scenario.

Closes `1205865273809972/1205933702651178`.

### How to test the changes in this Pull Request:

1. On a site with RAS enabled, make sure your site has at least three newsletter lists enabled for signup.
2. On `master`, in a new browser session, sign up for one list and confirm that the email is subscribed to this list.
3. In another new browser session, sign up for the other list using the same email address (but without logging into the account registered in step 2) and that the email is subscribed to this list.
4. Observe that an OTP email is sent to the email address.
5. Check out this branch. In another new browser session, sign up for _another_ list and confirm that the OTP email is not sent, but that the email is subscribed to this list.
6. Smoke test the same flow but by signing up for new lists with the same email address via the Registration block and confirm that in this case an OTP email _is_ sent (because the Registration block includes a message that sets an expectation that it's sent in this scenario).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->