### PR TITLE
fix: newsletters Lists indentation

### DIFF
--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -343,7 +343,9 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 							toggleOnChange={ handleChange( index, 'active' ) }
 							toggleChecked={ list.active }
 							className={
-								'mailchimp-group' === list?.type ? 'newspack-newsletters-group-list-item' : ''
+								list?.id && list.id.startsWith( 'group' )
+									? 'newspack-newsletters-group-list-item'
+									: ''
 							}
 							actionText={
 								list?.edit_link ? (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression created by https://github.com/Automattic/newspack-newsletters/pull/1255 that broke changes introduced by https://github.com/Automattic/newspack-plugin/pull/2424. In the Newsletters PR, the group is no longer returned with `type=mailchimp-group`.

### How to test the changes in this Pull Request:

1. Make sure you have Mailchimp set up and there are some groups
2. Visit Newspack Engagement
3. See that the groups are indented under their Audiences

![image](https://github.com/Automattic/newspack-plugin/assets/971483/06f01d57-b13f-4593-a898-8e82a177f632)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->