### PR TITLE
feat(donation): additional receipt email template variables

### DIFF
--- a/includes/reader-revenue/class-reader-revenue-emails.php
+++ b/includes/reader-revenue/class-reader-revenue-emails.php
@@ -55,37 +55,53 @@ class Reader_Revenue_Emails {
 	public static function add_email_configs( $configs ) {
 		$configs[ self::EMAIL_TYPES['RECEIPT'] ] = [
 			'name'                   => self::EMAIL_TYPES['RECEIPT'],
-			'label'                  => __( 'Receipt', 'newspack' ),
-			'description'            => __( "Email sent to the donor after they've donated.", 'newspack' ),
+			'label'                  => __( 'Receipt', 'newspack-plugin' ),
+			'description'            => __( "Email sent to the donor after they've donated.", 'newspack-plugin' ),
 			'template'               => dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-revenue-emails/receipt.php',
-			'editor_notice'          => __( 'This email will be sent to a reader after they contribute to your site.', 'newspack' ),
+			'editor_notice'          => __( 'This email will be sent to a reader after they contribute to your site.', 'newspack-plugin' ),
 			'from_email'             => self::get_from_email(),
 			'available_placeholders' => [
 				[
-					'label'    => __( 'the customer billing name', 'newspack' ),
+					'label'    => __( 'the customer billing name', 'newspack-plugin' ),
 					'template' => '*BILLING_NAME*',
 				],
 				[
-					'label'    => __( 'the payment amount', 'newspack' ),
+					'label'    => __( 'the customer billing first name', 'newspack-plugin' ),
+					'template' => '*BILLING_FIRST_NAME*',
+				],
+				[
+					'label'    => __( 'the customer billing last name', 'newspack-plugin' ),
+					'template' => '*BILLING_LAST_NAME*',
+				],
+				[
+					'label'    => __( 'the billing frequency (one-time, monthly or annual)', 'newspack-plugin' ),
+					'template' => '*BILLING_FREQUENCY*',
+				],
+				[
+					'label'    => __( 'the product name', 'newspack-plugin' ),
+					'template' => '*PRODUCT_NAME*',
+				],
+				[
+					'label'    => __( 'the payment amount', 'newspack-plugin' ),
 					'template' => '*AMOUNT*',
 				],
 				[
-					'label'    => __( 'payment date', 'newspack' ),
+					'label'    => __( 'payment date', 'newspack-plugin' ),
 					'template' => '*DATE*',
 				],
 				[
-					'label'    => __( 'payment method (last four digits of the card used)', 'newspack' ),
+					'label'    => __( 'payment method (last four digits of the card used)', 'newspack-plugin' ),
 					'template' => '*PAYMENT_METHOD*',
 				],
 				[
 					'label'    => __(
 						'the contact email to your site (same as the "From" email address)',
-						'newspack'
+						'newspack-plugin'
 					),
 					'template' => '*CONTACT_EMAIL*',
 				],
 				[
-					'label'    => __( 'automatically-generated receipt link', 'newspack' ),
+					'label'    => __( 'automatically-generated receipt link', 'newspack-plugin' ),
 					'template' => '*RECEIPT_URL*',
 				],
 			],

--- a/includes/reader-revenue/class-reader-revenue-emails.php
+++ b/includes/reader-revenue/class-reader-revenue-emails.php
@@ -106,6 +106,24 @@ class Reader_Revenue_Emails {
 				],
 			],
 		];
+
+		$platform = Donations::get_platform_slug();
+		// If using 'Stripe', remove unsupported placeholders.
+		$stripe_unsupported_placeholders = [
+			'*BILLING_FIRST_NAME*',
+			'*BILLING_LAST_NAME*',
+			'*BILLING_FREQUENCY*',
+			'*PRODUCT_NAME*',
+		];
+		if ( 'stripe' === $platform ) {
+			foreach ( $configs[ self::EMAIL_TYPES['RECEIPT'] ]['available_placeholders'] as $key => $placeholder ) {
+				if ( in_array( $placeholder['template'], $stripe_unsupported_placeholders ) ) {
+					unset( $configs[ self::EMAIL_TYPES['RECEIPT'] ]['available_placeholders'][ $key ] );
+				}
+			}
+			$configs[ self::EMAIL_TYPES['RECEIPT'] ]['available_placeholders'] = array_values( $configs[ self::EMAIL_TYPES['RECEIPT'] ]['available_placeholders'] );
+		}
+
 		return $configs;
 	}
 }

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -360,7 +360,7 @@ class WooCommerce_Connection {
 
 	/**
 	 * Upsert reader data to the ESP connected via Newspack Newsletters.
-	 * 
+	 *
 	 * @param array $contact Reader data to sync.
 	 * @return bool|WP_Error Contact data if it was added, WP_Error otherwise.
 	 */
@@ -480,7 +480,7 @@ class WooCommerce_Connection {
 		$order->set_billing_first_name( $order_data['name'] );
 
 		if ( isset( $order_data['subscribed'] ) && $order_data['subscribed'] ) {
-			$order->add_order_note( __( 'Donor has opted-in to your newsletter.', 'newspack' ) );
+			$order->add_order_note( __( 'Donor has opted-in to your newsletter.', 'newspack-plugin' ) );
 		}
 
 		if ( ! empty( $order_data['client_id'] ) ) {
@@ -547,7 +547,7 @@ class WooCommerce_Connection {
 		if ( isset( $metadata['payment_method_title'] ) ) {
 			$order->set_payment_method_title( $metadata['payment_method_title'] );
 		} else {
-			$order->set_payment_method_title( __( 'Stripe via Newspack', 'newspack' ) );
+			$order->set_payment_method_title( __( 'Stripe via Newspack', 'newspack-plugin' ) );
 		}
 		if ( isset( $metadata['stripe_customer_id'] ) ) {
 			$order->add_meta_data( '_stripe_customer_id', $metadata['stripe_customer_id'] );
@@ -583,10 +583,10 @@ class WooCommerce_Connection {
 
 		// Add notes to the order.
 		if ( 'once' === $frequency ) {
-			$order->add_order_note( __( 'One-time Newspack donation.', 'newspack' ) );
+			$order->add_order_note( __( 'One-time Newspack donation.', 'newspack-plugin' ) );
 		} else {
 			/* translators: %s - donation frequency */
-			$order->add_order_note( sprintf( __( 'Newspack donation with frequency: %s.', 'newspack' ), $frequency ) );
+			$order->add_order_note( sprintf( __( 'Newspack donation with frequency: %s.', 'newspack-plugin' ), $frequency ) );
 		}
 
 		$order->add_item( $item );
@@ -658,7 +658,7 @@ class WooCommerce_Connection {
 		// Match the Stripe product to WC product.
 		$item = self::get_order_item( $frequency, $order_data['amount'], $product_sku );
 		if ( false === $item ) {
-			return new \WP_Error( 'newspack_woocommerce', __( 'Missing product.', 'newspack' ) );
+			return new \WP_Error( 'newspack_woocommerce', __( 'Missing product.', 'newspack-plugin' ) );
 		}
 
 		$subscription_status = 'none';
@@ -767,10 +767,10 @@ class WooCommerce_Connection {
 					$subscription->add_item( $item );
 
 					if ( false === $stripe_subscription_id ) {
-						$subscription->add_order_note( __( 'This subscription was created via Newspack.', 'newspack' ) );
+						$subscription->add_order_note( __( 'This subscription was created via Newspack.', 'newspack-plugin' ) );
 					} else {
 						/* translators: %s - donation frequency */
-						$subscription->add_order_note( sprintf( __( 'Newspack subscription with frequency: %s. The recurring payment and the subscription will be handled in Stripe, so you\'ll see "Manual renewal" as the payment method in WooCommerce.', 'newspack' ), $frequency ) );
+						$subscription->add_order_note( sprintf( __( 'Newspack subscription with frequency: %s. The recurring payment and the subscription will be handled in Stripe, so you\'ll see "Manual renewal" as the payment method in WooCommerce.', 'newspack-plugin' ), $frequency ) );
 						$subscription->update_status( 'active' ); // Settings status via method (not in wcs_create_subscription), to make WCS recalculate dates.
 					}
 					$subscription->calculate_totals();
@@ -780,7 +780,7 @@ class WooCommerce_Connection {
 						if ( isset( $order_data['payment_method_title'] ) ) {
 							$subscription->set_payment_method_title( $order_data['payment_method_title'] );
 						} else {
-							$subscription->set_payment_method_title( __( 'Stripe', 'newspack' ) );
+							$subscription->set_payment_method_title( __( 'Stripe', 'newspack-plugin' ) );
 						}
 					} else {
 						update_post_meta( $subscription_id, self::SUBSCRIPTION_STRIPE_ID_META_KEY, $stripe_subscription_id );
@@ -1066,7 +1066,7 @@ class WooCommerce_Connection {
 		if ( $order_data['subscription_id'] ) {
 			return sprintf(
 				/* translators: %s: Product name */
-				__( 'Newspack %1$s (Order #%2$d, Subscription #%3$d)', 'newspack' ),
+				__( 'Newspack %1$s (Order #%2$d, Subscription #%3$d)', 'newspack-plugin' ),
 				Donations::get_donation_name_by_frequency( $frequency ),
 				$order_data['order_id'],
 				$order_data['subscription_id']
@@ -1074,7 +1074,7 @@ class WooCommerce_Connection {
 		} else {
 			return sprintf(
 				/* translators: %s: Product name */
-				__( 'Newspack %1$s (Order #%2$d)', 'newspack' ),
+				__( 'Newspack %1$s (Order #%2$d)', 'newspack-plugin' ),
 				Donations::get_donation_name_by_frequency( $frequency ),
 				$order_data['order_id']
 			);
@@ -1143,14 +1143,14 @@ class WooCommerce_Connection {
 	 * Force values for subscription switching options to ON unless the
 	 * NEWSPACK_PREVENT_WC_SUBS_ALLOW_SWITCHING_OVERRIDE constant is set.
 	 * This affects the following "Allow Switching" options:
-	 * 
-	 * - Between Subscription Variations 
-	 * - Between Grouped Subscriptions 
+	 *
+	 * - Between Subscription Variations
+	 * - Between Grouped Subscriptions
 	 * - Change Name Your Price subscription amount
 	 *
 	 * @param bool   $can_switch Whether the subscription amount can be switched.
 	 * @param string $option_name The name of the option.
-	 * 
+	 *
 	 * @return string Option value.
 	 */
 	public static function force_allow_subscription_switching( $can_switch, $option_name ) {
@@ -1182,10 +1182,19 @@ class WooCommerce_Connection {
 			return $enable;
 		}
 
-		$currency = $order->get_currency();
-		$symbol   = newspack_get_currency_symbol( $currency );
-		$total    = $order->get_total();
-		$created  = $order->get_date_created();
+		$frequencies = [
+			'month' => __( 'Monthly', 'newspack-plugin' ),
+			'year'  => __( 'Yearly', 'newspack-plugin' ),
+		];
+		$product_map = [];
+		foreach ( $frequencies as $frequency => $label ) {
+			$product_id = Donations::get_donation_product( $frequency );
+			if ( $product_id ) {
+				$product_map[ $product_id ] = $label;
+			}
+		}
+
+		$item = array_values( $order->get_items() )[0];
 
 		// Replace content placeholders.
 		$placeholders = [
@@ -1194,20 +1203,36 @@ class WooCommerce_Connection {
 				'value'    => trim( $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() ),
 			],
 			[
+				'template' => '*BILLING_FIRST_NAME*',
+				'value'    => $order->get_billing_first_name(),
+			],
+			[
+				'template' => '*BILLING_LAST_NAME*',
+				'value'    => $order->get_billing_last_name(),
+			],
+			[
+				'template' => '*BILLING_FREQUENCY*',
+				'value'    => $product_map[ $item->get_product_id() ] ?? __( 'One-time', 'newspack-plugin' ),
+			],
+			[
+				'template' => '*PRODUCT_NAME*',
+				'value'    => $item->get_name(),
+			],
+			[
 				'template' => '*AMOUNT*',
-				'value'    => 'USD' === $currency ? $symbol . $total : $total . $symbol,
+				'value'    => \wp_strip_all_tags( $order->get_formatted_order_total() ),
 			],
 			[
 				'template' => '*DATE*',
-				'value'    => $created->date_i18n(),
+				'value'    => $order->get_date_created()->date_i18n(),
 			],
 			[
 				'template' => '*PAYMENT_METHOD*',
-				'value'    => __( 'Card', 'newspack' ) . ' – ' . $order->get_payment_method(),
+				'value'    => __( 'Card', 'newspack-plugin' ) . ' – ' . $order->get_payment_method(),
 			],
 			[
 				'template' => '*RECEIPT_URL*',
-				'value'    => sprintf( '<a href="%s">%s</a>', $order->get_view_order_url(), __( 'My Account', 'newspack' ) ),
+				'value'    => sprintf( '<a href="%s">%s</a>', $order->get_view_order_url(), __( 'My Account', 'newspack-plugin' ) ),
 			],
 		];
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -1194,7 +1194,7 @@ class WooCommerce_Connection {
 			}
 		}
 
-		$item = array_values( $order->get_items() )[0];
+		$item = array_shift( $order->get_items() );
 
 		// Replace content placeholders.
 		$placeholders = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add support for the following new template variables to the RR receipt email:

- First name
- Last name
- Product name
- Billing frequency

<img width="1329" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/8431380e-13b6-4fb8-872d-5da53faf3a29">

This change should only impact the "Newspack" (WC) platform. Customers using Stripe should not support the new variables.

Along with the new values, the `*AMOUNT*` has changed so it uses a Woo function to determine the formatted value.

This PR also corrects the textdomain for the modified files so it uses `newspack-plugin` instead of `newspack`.

### How to test the changes in this Pull Request:

1. Checkout this branch and make sure you have Newspack as your RR platform
2. Edit the Receipt email (Newspack -> Reader Revenue -> Emails)
3. Confirm you see the new variables as above
4. Edit your content to include these variables (see example above)
5. Go through the donation flow for each type (one-time, monthly, and yearly)
6. Confirm all 3 emails include the new values
7. Edit your RR platform and set it to Stripe
8. Edit the receipt email and confirm the instructions do not include the new variables

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->