### PR TITLE
feat(ras-acc): support shipping, custom fields, and order notes in modal checkout

### DIFF
--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies.
  */
 import { useDispatch } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { ToggleControl, CheckboxControl } from '@wordpress/components';
 
 /**

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -453,12 +453,17 @@ class Reader_Revenue_Wizard extends Wizard {
 		$stripe_data                            = Stripe_Connection::get_stripe_data();
 		$stripe_data['can_use_stripe_platform'] = Donations::can_use_stripe_platform();
 
-		$billing_fields = [];
+		$billing_fields    = null;
+		$order_notes_field = [];
 		if ( $wc_installed && Donations::is_platform_wc() ) {
-			$checkout = new \WC_Checkout();
-			$fields   = $checkout->get_checkout_fields();
+			$checkout        = new \WC_Checkout();
+			$fields          = $checkout->get_checkout_fields();
+			$checkout_fields = $fields;
 			if ( ! empty( $fields['billing'] ) ) {
 				$billing_fields = $fields['billing'];
+			}
+			if ( ! empty( $fields['order']['order_comments'] ) ) {
+				$order_notes_field = $fields['order']['order_comments'];
 			}
 		}
 
@@ -470,6 +475,7 @@ class Reader_Revenue_Wizard extends Wizard {
 			'donation_data'            => Donations::get_donation_settings(),
 			'donation_page'            => Donations::get_donation_page_info(),
 			'available_billing_fields' => $billing_fields,
+			'order_notes_field'        => $order_notes_field,
 			'salesforce_settings'      => [],
 			'platform_data'            => [
 				'platform' => $platform,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for a new option to show different billing fields for donations vs. non-donation transactions, and to show order notes in either case. Also adds support for shipping methods and fields as implemented in https://github.com/Automattic/newspack-blocks/pull/1626.

### How to test the changes in this Pull Request:

Check out this branch and https://github.com/Automattic/newspack-blocks/pull/1626.

#### Order notes

1. Visit **Newspack > Reader Revenue > Donations**. Scroll down to the "Donation Billing Fields" section and confirm there's slightly different copy and styles, as well as a `*` indicator next to fields that are required for checkout when shown.

<img width="1052" alt="Screenshot 2023-12-08 at 6 53 58 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/399cffaf-75e7-4d64-9f6d-9450caa9d346">

2. Confirm there's a new checkbox option for "Order notes", disabled by default.
3. Check it and save.
4. As a reader, start a new donation and confirm you see the "Order notes" field on the first modal checkout screen:

<img width="771" alt="Screenshot 2023-12-08 at 6 41 34 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/ae1ce8ab-74f2-47b2-8a1d-3e3a973cc656">

5. Fill out the Order Notes field and complete the transaction. In the admin, find the order and confirm that your note is attached to the order:

<img width="1252" alt="Screenshot 2023-12-08 at 6 42 29 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/fcf333e5-c358-4651-a4a2-883ac5f57f6a">

#### Customized billing fields

1. Install and activate the the [Checkout Field Editor plugin](https://woo.com/products/woocommerce-checkout-field-editor/) (let me know if you need the package as it's a premium plugin).
2. In WP admin, visit **WooCommerce > Checkout Fields**. Make some customizations to the core billing fields, such as changing the labels and placeholders, as well as the "required" validation status for some fields (it will only let you make certain fields optional, such as Phone). Also add some of your own custom fields with various options. Save.

<img width="1334" alt="Screenshot 2023-12-08 at 6 51 35 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/cd59bdec-0715-4a4d-9edb-21f7733a1d41">

3. Visit **Newspack > Reader Revenue > Donations**. Confirm that the available fields for both the Donation and Non-donation Billing Fields sections now reflect your customizations from step 2: core field labels will be as configured in the Checkout Fields plugin, and your custom fields will appear as additional fields that can be enabled or disabled like the other fields.
4. Enable the customized core fields and the new custom fields for both Donation and Non-donation Billing Fields and save.
5. As a reader, complete both a donation and a non-donation transaction and confirm that your customizations and custom fields are presented during checkout, and that you can complete both transactions as expected.

<img width="659" alt="Screenshot 2023-12-08 at 6 52 26 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/3c9308bc-7599-4ab5-9d3c-57ad9ade0449">

### Other information:


* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205855958320407