### PR TITLE
fix(ras): handle UTM metadata field keys with arbitrary suffixes

### DIFF
--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -170,7 +170,7 @@ class Newspack_Newsletters {
 						$normalized_metadata[ self::get_metadata_key( $meta_key ) ] = $meta_value; // If passed a raw key, map it to the prefixed key.
 					} elseif (
 						in_array( $meta_key, $prefixed_keys, true ) ||
-						false !== strpos( $meta_key, self::get_metadata_key( self::$metadata_keys['signup_page_utm'] ) ) && false !== strpos( $meta_key, self::get_metadata_key( self::$metadata_keys['payment_page_utm'] ) ) // UTM meta keys can have arbitrary suffixes.
+						( false !== strpos( $meta_key, self::get_metadata_key( 'signup_page_utm' ) ) || false !== strpos( $meta_key, self::get_metadata_key( 'payment_page_utm' ) ) ) // UTM meta keys can have arbitrary suffixes.
 					) {
 						$normalized_metadata[ $meta_key ] = $meta_value;
 					}

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -143,6 +143,9 @@ class Newspack_Newsletters {
 		// Parse full name into first + last for MC, which stores these as separate merge fields.
 		if ( method_exists( 'Newspack_Newsletters', 'service_provider' ) && 'mailchimp' === \Newspack_Newsletters::service_provider() ) {
 			if ( isset( $contact['name'] ) ) {
+				if ( ! isset( $contact['metadata'] ) ) {
+					$contact['metadata'] = [];
+				}
 				$name_fragments                    = explode( ' ', $contact['name'], 2 );
 				$contact['metadata']['First Name'] = $name_fragments[0];
 				if ( isset( $name_fragments[1] ) ) {
@@ -165,7 +168,10 @@ class Newspack_Newsletters {
 				if ( self::should_sync_ras_metadata() ) {
 					if ( in_array( $meta_key, $raw_keys, true ) ) {
 						$normalized_metadata[ self::get_metadata_key( $meta_key ) ] = $meta_value; // If passed a raw key, map it to the prefixed key.
-					} elseif ( in_array( $meta_key, $prefixed_keys, true ) ) {
+					} elseif (
+						in_array( $meta_key, $prefixed_keys, true ) ||
+						false !== strpos( $meta_key, self::get_metadata_key( self::$metadata_keys['signup_page_utm'] ) ) && false !== strpos( $meta_key, self::get_metadata_key( self::$metadata_keys['payment_page_utm'] ) ) // UTM meta keys can have arbitrary suffixes.
+					) {
 						$normalized_metadata[ $meta_key ] = $meta_value;
 					}
 				} else {

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -140,20 +140,6 @@ class Newspack_Newsletters {
 	 * @return array Normalized contact data.
 	 */
 	public static function normalize_contact_data( $contact ) {
-		// Parse full name into first + last for MC, which stores these as separate merge fields.
-		if ( method_exists( 'Newspack_Newsletters', 'service_provider' ) && 'mailchimp' === \Newspack_Newsletters::service_provider() ) {
-			if ( isset( $contact['name'] ) ) {
-				if ( ! isset( $contact['metadata'] ) ) {
-					$contact['metadata'] = [];
-				}
-				$name_fragments                    = explode( ' ', $contact['name'], 2 );
-				$contact['metadata']['First Name'] = $name_fragments[0];
-				if ( isset( $name_fragments[1] ) ) {
-					$contact['metadata']['Last Name'] = $name_fragments[1];
-				}
-			}
-		}
-
 		// If syncing for RAS, ensure that metadata keys are normalized with the correct RAS metadata keys.
 		if ( isset( $contact['metadata'] ) ) {
 			$normalized_metadata = [];
@@ -182,6 +168,20 @@ class Newspack_Newsletters {
 				}
 			}
 			$contact['metadata'] = $normalized_metadata;
+		}
+
+		// Parse full name into first + last for MC, which stores these as separate merge fields.
+		if ( method_exists( 'Newspack_Newsletters', 'service_provider' ) && 'mailchimp' === \Newspack_Newsletters::service_provider() ) {
+			if ( isset( $contact['name'] ) ) {
+				if ( ! isset( $contact['metadata'] ) ) {
+					$contact['metadata'] = [];
+				}
+				$name_fragments                    = explode( ' ', $contact['name'], 2 );
+				$contact['metadata']['First Name'] = $name_fragments[0];
+				if ( isset( $name_fragments[1] ) ) {
+					$contact['metadata']['Last Name'] = $name_fragments[1];
+				}
+			}
 		}
 
 		Logger::log( 'Normalizing contact data for reader ESP sync:' );

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -142,4 +142,85 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$this->assertFalse( Reader_Activation::is_user_reader( $user ) );
 		wp_delete_user( $reader_id ); // Clean up.
 	}
+
+	/**
+	 * Test contact data synced to ESP.
+	 */
+	public function test_sync_contact_data() {
+		// Set connected ESP to ActiveCampaign.
+		\update_option( 'newspack_newsletters_service_provider', 'active_campaign' );
+		$contact_data_with_raw_keys      = [
+			'email'    => 'test@email.com',
+			'name'     => 'Test Contact',
+			'metadata' => [
+				'account'           => 123,
+				'registration_date' => '2023-12-11',
+				'current_page_url'  => 'https://newspack.com/registration-page/',
+			],
+		];
+		$contact_data_with_prefixed_keys = [
+			'email'    => 'test@email.com',
+			'name'     => 'Test Contact',
+			'metadata' => [
+				'NP_Account'           => 123,
+				'NP_Registration'      => '2023-12-11',
+				'NP_Registration Page' => 'https://newspack.com/registration-page/',
+			],
+		];
+		$contact_data_with_custom_prefix = [
+			'email'    => 'test@email.com',
+			'name'     => 'Test Contact',
+			'metadata' => [
+				'CU_Account'           => 123,
+				'CU_Registration'      => '2023-12-11',
+				'CU_Registration Page' => 'https://newspack.com/registration-page/',
+			],
+		];
+
+		// Raw metadata keys should be converted to prefixed keys.
+		$this->assertEquals(
+			$contact_data_with_prefixed_keys,
+			Reader_Activation::normalize_contact_data( $contact_data_with_raw_keys )
+		);
+
+		\Newspack\Newspack_Newsletters::update_metadata_prefix( 'CU' );
+
+		// Metadata keys should be prefixed with the custom prefix, if set.
+		$this->assertEquals(
+			$contact_data_with_custom_prefix,
+			Reader_Activation::normalize_contact_data( $contact_data_with_raw_keys )
+		);
+
+		// Clear from last test.
+		\delete_option( \Newspack\Newspack_Newsletters::METADATA_PREFIX_OPTION );
+
+		// Most keys should be exact.
+		$contact_data_with_prefixed_keys['metadata']['NP_Invalid_Key'] = 'Invalid data';
+		$this->assertEquals(
+			array_diff( $contact_data_with_prefixed_keys, Reader_Activation::normalize_contact_data( $contact_data_with_raw_keys ) ),
+			[
+				'metadata' => [
+					'NP_Invalid_Key' => 'Invalid data',
+				],
+			]
+		);
+
+		// But UTM keys can have arbitrary suffixes.
+		$contact_data_with_prefixed_keys['metadata']['Signup UTM: foo'] = 'bar';
+		$this->assertEquals(
+			$contact_data_with_prefixed_keys,
+			Reader_Activation::normalize_contact_data( $contact_data_with_raw_keys )
+		);
+
+		// Set connected ESP to Mailchimp.
+		\update_option( 'newspack_newsletters_service_provider', 'mailchimp' );
+
+		// Mailchimp contact data should split the name into first/last name.
+		$contact_data_with_prefixed_keys['metadata']['First Name'] = 'Test';
+		$contact_data_with_prefixed_keys['metadata']['Last Name']  = 'Contact';
+		$this->assertEquals(
+			$contact_data_with_prefixed_keys,
+			Reader_Activation::normalize_contact_data( $contact_data_with_raw_keys )
+		);
+	}
 }

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -202,7 +202,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		);
 
 		// But UTM keys can have arbitrary suffixes.
-		$contact_data_with_prefixed_keys['metadata']['Signup UTM: foo'] = 'bar';
+		$contact_data_with_prefixed_keys['metadata']['NP_Signup UTM: foo'] = 'bar';
 		$this->assertEquals(
 			$contact_data_with_prefixed_keys,
 			\Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_raw_keys )

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -183,7 +183,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 			\Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_raw_keys )
 		);
 
-		\Newspack\Newspack_Newsletters::update_metadata_prefix( 'CU' );
+		\Newspack\Newspack_Newsletters::update_metadata_prefix( 'CU_' );
 
 		// Metadata keys should be prefixed with the custom prefix, if set.
 		$this->assertEquals(

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -180,7 +180,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		// Raw metadata keys should be converted to prefixed keys.
 		$this->assertEquals(
 			$contact_data_with_prefixed_keys,
-			Reader_Activation::normalize_contact_data( $contact_data_with_raw_keys )
+			\Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_raw_keys )
 		);
 
 		\Newspack\Newspack_Newsletters::update_metadata_prefix( 'CU' );
@@ -188,7 +188,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		// Metadata keys should be prefixed with the custom prefix, if set.
 		$this->assertEquals(
 			$contact_data_with_custom_prefix,
-			Reader_Activation::normalize_contact_data( $contact_data_with_raw_keys )
+			\Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_raw_keys )
 		);
 
 		// Clear from last test.
@@ -197,7 +197,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		// Most keys should be exact.
 		$contact_data_with_prefixed_keys['metadata']['NP_Invalid_Key'] = 'Invalid data';
 		$this->assertEquals(
-			array_diff( $contact_data_with_prefixed_keys, Reader_Activation::normalize_contact_data( $contact_data_with_raw_keys ) ),
+			array_diff( $contact_data_with_prefixed_keys, \Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_raw_keys ) ),
 			[
 				'metadata' => [
 					'NP_Invalid_Key' => 'Invalid data',
@@ -209,7 +209,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$contact_data_with_prefixed_keys['metadata']['Signup UTM: foo'] = 'bar';
 		$this->assertEquals(
 			$contact_data_with_prefixed_keys,
-			Reader_Activation::normalize_contact_data( $contact_data_with_raw_keys )
+			\Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_raw_keys )
 		);
 
 		// Set connected ESP to Mailchimp.
@@ -220,7 +220,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$contact_data_with_prefixed_keys['metadata']['Last Name']  = 'Contact';
 		$this->assertEquals(
 			$contact_data_with_prefixed_keys,
-			Reader_Activation::normalize_contact_data( $contact_data_with_raw_keys )
+			\Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_raw_keys )
 		);
 	}
 }

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -197,7 +197,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		// Most keys should be exact.
 		$contact_data_with_prefixed_keys['metadata']['NP_Invalid_Key'] = 'Invalid data';
 		$this->assertEquals(
-			array_diff( $contact_data_with_prefixed_keys, \Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_raw_keys ) ),
+			array_diff( $contact_data_with_prefixed_keys, \Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_prefixed_keys ) ),
 			[
 				'metadata' => [
 					'NP_Invalid_Key' => 'Invalid data',

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -197,12 +197,8 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		// Most keys should be exact.
 		$contact_data_with_prefixed_keys['metadata']['NP_Invalid_Key'] = 'Invalid data';
 		$this->assertEquals(
-			array_diff( $contact_data_with_prefixed_keys, \Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_prefixed_keys ) ),
-			[
-				'metadata' => [
-					'NP_Invalid_Key' => 'Invalid data',
-				],
-			]
+			array_diff( $contact_data_with_prefixed_keys['metadata'], \Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_prefixed_keys )['metadata'] ),
+			[ 'NP_Invalid_Key' => 'Invalid data' ]
 		);
 
 		// But UTM keys can have arbitrary suffixes.

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -163,7 +163,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 			'name'     => 'Test Contact',
 			'metadata' => [
 				'NP_Account'           => 123,
-				'NP_Registration'      => '2023-12-11',
+				'NP_Registration Date' => '2023-12-11',
 				'NP_Registration Page' => 'https://newspack.com/registration-page/',
 			],
 		];
@@ -172,7 +172,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 			'name'     => 'Test Contact',
 			'metadata' => [
 				'CU_Account'           => 123,
-				'CU_Registration'      => '2023-12-11',
+				'CU_Registration Date' => '2023-12-11',
 				'CU_Registration Page' => 'https://newspack.com/registration-page/',
 			],
 		];

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -202,6 +202,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		);
 
 		// But UTM keys can have arbitrary suffixes.
+		unset( $contact_data_with_prefixed_keys['metadata']['NP_Invalid_Key'] );
 		$contact_data_with_prefixed_keys['metadata']['NP_Signup UTM: foo'] = 'bar';
 		$this->assertEquals(
 			$contact_data_with_prefixed_keys,

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -205,7 +205,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$contact_data_with_prefixed_keys['metadata']['NP_Signup UTM: foo'] = 'bar';
 		$this->assertEquals(
 			$contact_data_with_prefixed_keys,
-			\Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_raw_keys )
+			\Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_prefixed_keys )
 		);
 
 		// Set connected ESP to Mailchimp.
@@ -216,7 +216,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$contact_data_with_prefixed_keys['metadata']['Last Name']  = 'Contact';
 		$this->assertEquals(
 			$contact_data_with_prefixed_keys,
-			\Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_raw_keys )
+			\Newspack\Newspack_Newsletters::normalize_contact_data( $contact_data_with_prefixed_keys )
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#2780 added a filter to normalize RAS contact data synced to the connected ESP. However, this filter didn't account for some meta keys being dynamic (namely all the UTM ones). This PR fixes that.

Also fixes the order in which we split out the full name into First/Last Names for Mailchimp. These meta fields were getting stripped because they weren't passing the validation check. Moving this to after validation ensures the names aren't dropped.

### How to test the changes in this Pull Request:

1. On `master` or `release` with `NEWSPACK_LOG_LEVEL` at `2` or more: As a new reader, visit a post or page containing a Donate or Checkout Button block. Add UTM params to the URL, e.g. `?utm_source=marketinglist&utm_medium=email&utm_campaign=2023-Newspack-Campaign` and complete a transaction.
2. Confirm that the order created in Woo has the UTM params:

<img width="1232" alt="Screenshot 2023-12-11 at 5 35 25 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/108912ea-e61f-435a-b958-913ccd8b5054">

3. However, in your debug.log observe that the normalized data drops the UTM-related metadata. Also find the synced contact in the connected ESP and observe that it didn't get the UTM metadata.
4. Check out this branch and repeat steps 1-3, and confirm that the UTM meta is all synced.

<img width="911" alt="Screenshot 2023-12-11 at 5 39 36 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/50821c1e-95f3-4c7a-96d4-dc6259175854">

#### Mailchimp first/last name split

1. Set your connected ESP to Mailchimp and ensure there's an audience selected in Newspack > Engagement > Reader Activation > Advanced Settings.
2. As a new reader, complete a donation without signing up for newsletters. Make sure to enter names during checkout.
3. Find the synced contact in Mailchimp and confirm that the contact's First and Last Name fields are both populated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->