### PR TITLE
feat: modal checkout redesign tweaks

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -74,6 +74,7 @@ class Donations {
 		add_filter( 'amp_skip_post', [ __CLASS__, 'should_skip_amp' ], 10, 2 );
 		add_filter( 'newspack_blocks_donate_billing_fields_keys', [ __CLASS__, 'get_billing_fields' ] );
 		add_action( 'woocommerce_checkout_create_order_line_item', [ __CLASS__, 'checkout_create_order_line_item' ], 10, 4 );
+		add_filter( 'woocommerce_coupons_enabled', [ __CLASS__, 'disable_coupons' ] );
 		add_filter( 'wcs_place_subscription_order_text', [ __CLASS__, 'order_button_text' ], 9 );
 		add_filter( 'woocommerce_order_button_text', [ __CLASS__, 'order_button_text' ], 9 );
 		add_filter( 'option_woocommerce_subscriptions_order_button_text', [ __CLASS__, 'order_button_text' ], 9 );

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -1069,7 +1069,7 @@ class Donations {
 	 */
 	public static function order_button_text( $text ) {
 		if ( self::is_donation_cart() ) {
-			return __( 'Donate now', 'newspack-blocks' );
+			return __( 'Donate now', 'newspack-plugin' );
 		}
 		return $text;
 	}

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -65,17 +65,18 @@ class Donations {
 	 */
 	public static function init() {
 		self::$donation_product_name = __( 'Donate', 'newspack' );
-		if ( ! is_admin() ) {
-			add_action( 'wp_loaded', [ __CLASS__, 'process_donation_form' ], 99 );
-			add_action( 'woocommerce_checkout_update_order_meta', [ __CLASS__, 'woocommerce_checkout_update_order_meta' ] );
-			add_filter( 'woocommerce_billing_fields', [ __CLASS__, 'woocommerce_billing_fields' ] );
-			add_filter( 'pre_option_woocommerce_enable_guest_checkout', [ __CLASS__, 'disable_guest_checkout' ] );
-			add_action( 'woocommerce_check_cart_items', [ __CLASS__, 'handle_cart' ] );
-			add_filter( 'amp_skip_post', [ __CLASS__, 'should_skip_amp' ], 10, 2 );
-			add_filter( 'newspack_blocks_donate_billing_fields_keys', [ __CLASS__, 'get_billing_fields' ] );
-			add_action( 'woocommerce_checkout_create_order_line_item', [ __CLASS__, 'checkout_create_order_line_item' ], 10, 4 );
-			add_action( 'woocommerce_coupons_enabled', [ __CLASS__, 'disable_coupons' ] );
-		}
+
+		add_action( 'wp_loaded', [ __CLASS__, 'process_donation_form' ], 99 );
+		add_action( 'woocommerce_checkout_update_order_meta', [ __CLASS__, 'woocommerce_checkout_update_order_meta' ] );
+		add_filter( 'woocommerce_billing_fields', [ __CLASS__, 'woocommerce_billing_fields' ] );
+		add_filter( 'pre_option_woocommerce_enable_guest_checkout', [ __CLASS__, 'disable_guest_checkout' ] );
+		add_action( 'woocommerce_check_cart_items', [ __CLASS__, 'handle_cart' ] );
+		add_filter( 'amp_skip_post', [ __CLASS__, 'should_skip_amp' ], 10, 2 );
+		add_filter( 'newspack_blocks_donate_billing_fields_keys', [ __CLASS__, 'get_billing_fields' ] );
+		add_action( 'woocommerce_checkout_create_order_line_item', [ __CLASS__, 'checkout_create_order_line_item' ], 10, 4 );
+		add_filter( 'wcs_place_subscription_order_text', [ __CLASS__, 'order_button_text' ], 9 );
+		add_filter( 'woocommerce_order_button_text', [ __CLASS__, 'order_button_text' ], 9 );
+		add_filter( 'option_woocommerce_subscriptions_order_button_text', [ __CLASS__, 'order_button_text' ], 9 );
 	}
 
 	/**
@@ -614,6 +615,10 @@ class Donations {
 	 * Handle submission of the donation form.
 	 */
 	public static function process_donation_form() {
+		if ( is_admin() ) {
+			return;
+		}
+
 		$is_wc = self::is_platform_wc();
 
 		$donation_form_submitted = filter_input( INPUT_GET, 'newspack_donate', FILTER_SANITIZE_NUMBER_INT );
@@ -1054,6 +1059,18 @@ class Donations {
 			return $enabled;
 		}
 		return false;
+	}
+
+	/**
+	 * Set the "Place order" button text.
+	 *
+	 * @param string $text The button text.
+	 */
+	public static function order_button_text( $text ) {
+		if ( self::is_donation_cart() ) {
+			return __( 'Donate now', 'newspack-blocks' );
+		}
+		return $text;
 	}
 }
 Donations::init();

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -1052,6 +1052,9 @@ class Donations {
 	 * @return bool
 	 */
 	public static function disable_coupons( $enabled ) {
+		if ( is_admin() ) {
+			return $enabled;
+		}
 		$cart = WC()->cart;
 		if ( ! $cart ) {
 			return $enabled;

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -366,6 +366,10 @@ final class Recaptcha {
 		if ( ! $should_verify_captcha ) {
 			return;
 		}
+		// Bail if validating form.
+		if ( isset( $_POST['woocommerce_checkout_update_totals'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			return;
+		}
 		$token = isset( $_POST['g-recaptcha-response'] ) ? sanitize_text_field( wp_unslash( $_POST['g-recaptcha-response'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$check = self::verify_captcha( $token );
 		if ( \is_wp_error( $check ) ) {

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -208,7 +208,7 @@ class WooCommerce_Cover_Fees {
 		}
 		wp_add_inline_script(
 			$handler,
-			'var form = document.querySelector(\'form[name="checkout"]\');
+			'const form = document.querySelector(\'form[name="checkout"]\');
 			if ( form ) {
 				form.addEventListener(\'change\', function( e ){
 					var inputEl = document.getElementById( "' . self::CUSTOM_FIELD_NAME . '" );

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -208,7 +208,7 @@ class WooCommerce_Cover_Fees {
 		}
 		wp_add_inline_script(
 			$handler,
-			'const form = document.querySelector(\'form[name="checkout"]\');
+			'var form = document.querySelector(\'form[name="checkout"]\');
 			if ( form ) {
 				form.addEventListener(\'change\', function( e ){
 					var inputEl = document.getElementById( "' . self::CUSTOM_FIELD_NAME . '" );

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -13,9 +13,9 @@ defined( 'ABSPATH' ) || exit;
  * WooCommerce Order UTM class.
  */
 class WooCommerce_Cover_Fees {
-	const CUSTOM_FIELD_NAME  = 'newspack-wc-pay-fees';
-	const PRICE_ELEMENT_ID   = 'newspack-wc-price';
-	const WC_ORDER_META_NAME = 'newspack_donor_covers_fees';
+	const CUSTOM_FIELD_NAME        = 'newspack-wc-pay-fees';
+	const PRICE_ELEMENT_CLASS_NAME = 'newspack-wc-price';
+	const WC_ORDER_META_NAME       = 'newspack_donor_covers_fees';
 
 	/**
 	 * Initialize hooks.
@@ -176,7 +176,7 @@ class WooCommerce_Cover_Fees {
 		if ( ! self::should_allow_covering_fees() ) {
 			return $html;
 		}
-		return str_replace( $price, '<span id="' . self::PRICE_ELEMENT_ID . '">' . $price . '</span>', $html );
+		return str_replace( $price, '<span class="' . self::PRICE_ELEMENT_CLASS_NAME . '">' . $price . '</span>', $html );
 	}
 
 	/**
@@ -199,7 +199,10 @@ class WooCommerce_Cover_Fees {
 			// is not supported with coupons.
 			$coupons_handling_script = 'setInterval(function(){
 				if(document.querySelector(".woocommerce-remove-coupon")){
-					document.getElementById( "' . self::PRICE_ELEMENT_ID . '" ).textContent =  "' . $original_price . '";
+					var prices = document.querySelectorAll(".' . self::PRICE_ELEMENT_CLASS_NAME . '");
+					for (var i = 0; i < prices.length; i++) {
+						prices[i].textContent = "' . $original_price . '";
+					}
 				}
 			}, 1000);';
 		}
@@ -208,15 +211,18 @@ class WooCommerce_Cover_Fees {
 			'const form = document.querySelector(\'form[name="checkout"]\');
 			if ( form ) {
 				form.addEventListener(\'change\', function( e ){
-					const inputEl = document.getElementById( "' . self::CUSTOM_FIELD_NAME . '" );
-					if( e.target.name === "payment_method" && e.target.value !== "stripe" && inputEl.checked ){
+					var inputEl = document.getElementById( "' . self::CUSTOM_FIELD_NAME . '" );
+					if( inputEl && e.target.name === "payment_method" && e.target.value !== "stripe" && inputEl.checked ){
 						inputEl.checked = false;
 						newspackHandleCoverFees(inputEl);
 					}
 				});
 			}
 			function newspackHandleCoverFees(inputEl) {
-				document.getElementById( "' . self::PRICE_ELEMENT_ID . '" ).textContent = inputEl.checked ? "' . $price_with_fee . '" : "' . $original_price . '";
+				var prices = document.querySelectorAll(".' . self::PRICE_ELEMENT_CLASS_NAME . '");
+				for (var i = 0; i < prices.length; i++) {
+					prices[i].textContent = inputEl.checked ? "' . $price_with_fee . '" : "' . $original_price . '";
+				}
 			};' . $coupons_handling_script
 		);
 	}

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -13,9 +13,9 @@ defined( 'ABSPATH' ) || exit;
  * WooCommerce Order UTM class.
  */
 class WooCommerce_Cover_Fees {
-	const CUSTOM_FIELD_NAME        = 'newspack-wc-pay-fees';
-	const PRICE_ELEMENT_CLASS_NAME = 'newspack-wc-price';
-	const WC_ORDER_META_NAME       = 'newspack_donor_covers_fees';
+	const CUSTOM_FIELD_NAME  = 'newspack-wc-pay-fees';
+	const PRICE_ELEMENT_ID   = 'newspack-wc-price';
+	const WC_ORDER_META_NAME = 'newspack_donor_covers_fees';
 
 	/**
 	 * Initialize hooks.
@@ -176,7 +176,7 @@ class WooCommerce_Cover_Fees {
 		if ( ! self::should_allow_covering_fees() ) {
 			return $html;
 		}
-		return str_replace( $price, '<span class="' . self::PRICE_ELEMENT_CLASS_NAME . '">' . $price . '</span>', $html );
+		return str_replace( $price, '<span id="' . self::PRICE_ELEMENT_ID . '">' . $price . '</span>', $html );
 	}
 
 	/**
@@ -199,10 +199,7 @@ class WooCommerce_Cover_Fees {
 			// is not supported with coupons.
 			$coupons_handling_script = 'setInterval(function(){
 				if(document.querySelector(".woocommerce-remove-coupon")){
-					var prices = document.querySelectorAll(".' . self::PRICE_ELEMENT_CLASS_NAME . '");
-					for (var i = 0; i < prices.length; i++) {
-						prices[i].textContent = "' . $original_price . '";
-					}
+					document.getElementById( "' . self::PRICE_ELEMENT_ID . '" ).textContent =  "' . $original_price . '";
 				}
 			}, 1000);';
 		}
@@ -211,18 +208,15 @@ class WooCommerce_Cover_Fees {
 			'const form = document.querySelector(\'form[name="checkout"]\');
 			if ( form ) {
 				form.addEventListener(\'change\', function( e ){
-					var inputEl = document.getElementById( "' . self::CUSTOM_FIELD_NAME . '" );
-					if( inputEl && e.target.name === "payment_method" && e.target.value !== "stripe" && inputEl.checked ){
+					const inputEl = document.getElementById( "' . self::CUSTOM_FIELD_NAME . '" );
+					if( e.target.name === "payment_method" && e.target.value !== "stripe" && inputEl.checked ){
 						inputEl.checked = false;
 						newspackHandleCoverFees(inputEl);
 					}
 				});
 			}
 			function newspackHandleCoverFees(inputEl) {
-				var prices = document.querySelectorAll(".' . self::PRICE_ELEMENT_CLASS_NAME . '");
-				for (var i = 0; i < prices.length; i++) {
-					prices[i].textContent = inputEl.checked ? "' . $price_with_fee . '" : "' . $original_price . '";
-				}
+				document.getElementById( "' . self::PRICE_ELEMENT_ID . '" ).textContent = inputEl.checked ? "' . $price_with_fee . '" : "' . $original_price . '";
 			};' . $coupons_handling_script
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Combines #2794 and #2771 for https://github.com/Automattic/newspack-blocks/pull/1602.

2aaa84ade9633864be5e2a65540ff80d191cd875 skips reCAPTCHA when only performing form validation. There's no need for the extra API request if it's already performed while placing the order.

29ca89219c1fdeec12aef57142e6c40c63e9b8a0 moves the custom text for the order button to the main plugin's donation feature. It's best if the modal checkout, where it currently is, doesn't handle donation-specific tweaks.

Also changes how the initializer method registers hooks. I noticed all the hooks are registered inside a ! is_admin() condition, which doesn't seem like good practice. The origin of this is here https://github.com/Automattic/newspack-plugin/pull/225 and the intention is to prevent the process_donation_form, hooked to wp_loaded from running in the admin. This check was moved to inside the process_donation_form, which is more appropriate for that purpose.

### How to test the changes in this Pull Request:

Instructions at https://github.com/Automattic/newspack-blocks/pull/1602

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->