### PR TITLE
feat: give editors permission for restricted content

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -778,8 +778,8 @@ class Memberships {
 							break;
 						}
 
-						// Allow editors.
-						if ( isset( $all_caps['editor'] ) && true === $all_caps['editor'] ) {
+						// Allow ueser who can edit posts (by default: editors, authors, contributors).
+						if ( isset( $all_caps['edit_posts'] ) && true === $all_caps['edit_posts'] ) {
 							$all_caps[ $cap ] = true;
 							break;
 						}
@@ -810,8 +810,8 @@ class Memberships {
 					case 'wc_memberships_view_delayed_taxonomy_term':
 					case 'wc_memberships_view_delayed_post_content':
 					case 'wc_memberships_view_delayed_product':
-						// Allow editors.
-						if ( isset( $all_caps['editor'] ) && true === $all_caps['editor'] ) {
+						// Allow ueser who can edit posts (by default: editors, authors, contributors).
+						if ( isset( $all_caps['edit_posts'] ) && true === $all_caps['edit_posts'] ) {
 							$all_caps[ $cap ] = true;
 							break;
 						}

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -778,7 +778,7 @@ class Memberships {
 							break;
 						}
 
-						// Allow ueser who can edit posts (by default: editors, authors, contributors).
+						// Allow user who can edit posts (by default: editors, authors, contributors).
 						if ( isset( $all_caps['edit_posts'] ) && true === $all_caps['edit_posts'] ) {
 							$all_caps[ $cap ] = true;
 							break;

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -770,24 +770,52 @@ class Memberships {
 
 		if ( ! empty( $caps ) ) {
 			foreach ( $caps as $cap ) {
-				if ( 'wc_memberships_view_restricted_post_content' === $cap ) {
-					if ( self::can_manage_woocommerce( $all_caps ) ) {
-						$all_caps[ $cap ] = true;
+
+				switch ( $cap ) {
+					case 'wc_memberships_view_restricted_post_content':
+						if ( self::can_manage_woocommerce( $all_caps ) ) {
+							$all_caps[ $cap ] = true;
+							break;
+						}
+
+						// Allow editors.
+						if ( true === $all_caps['editor'] ) {
+							$all_caps[ $cap ] = true;
+							break;
+						}
+
+						$user_id = (int) $args[1];
+						$post_id = (int) $args[2];
+
+						if ( wc_memberships()->get_restrictions_instance()->is_post_public( $post_id ) ) {
+							$all_caps[ $cap ] = true;
+							break;
+						}
+
+						$rules            = wc_memberships()->get_rules_instance()->get_post_content_restriction_rules( $post_id );
+						$all_caps[ $cap ] = self::user_has_content_access_from_rules( $user_id, $rules, $post_id );
+
 						break;
-					}
 
-					$user_id = (int) $args[1];
-					$post_id = (int) $args[2];
-
-					if ( wc_memberships()->get_restrictions_instance()->is_post_public( $post_id ) ) {
-						$all_caps[ $cap ] = true;
+					case 'wc_memberships_access_all_restricted_content':
+					case 'wc_memberships_view_restricted_product':
+					case 'wc_memberships_purchase_restricted_product':
+					case 'wc_memberships_view_restricted_product_taxonomy_term':
+					case 'wc_memberships_view_delayed_product_taxonomy_term':
+					case 'wc_memberships_view_restricted_taxonomy_term':
+					case 'wc_memberships_view_restricted_taxonomy':
+					case 'wc_memberships_view_restricted_post_type':
+					case 'wc_memberships_view_delayed_post_type':
+					case 'wc_memberships_view_delayed_taxonomy':
+					case 'wc_memberships_view_delayed_taxonomy_term':
+					case 'wc_memberships_view_delayed_post_content':
+					case 'wc_memberships_view_delayed_product':
+						// Allow editors.
+						if ( true === $all_caps['editor'] ) {
+							$all_caps[ $cap ] = true;
+							break;
+						}
 						break;
-					}
-
-					$rules            = wc_memberships()->get_rules_instance()->get_post_content_restriction_rules( $post_id );
-					$all_caps[ $cap ] = self::user_has_content_access_from_rules( $user_id, $rules, $post_id );
-
-					break;
 				}
 			}
 		}

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -779,7 +779,7 @@ class Memberships {
 						}
 
 						// Allow editors.
-						if ( true === $all_caps['editor'] ) {
+						if ( isset( $all_caps['editor'] ) && true === $all_caps['editor'] ) {
 							$all_caps[ $cap ] = true;
 							break;
 						}
@@ -811,7 +811,7 @@ class Memberships {
 					case 'wc_memberships_view_delayed_post_content':
 					case 'wc_memberships_view_delayed_product':
 						// Allow editors.
-						if ( true === $all_caps['editor'] ) {
+						if ( isset( $all_caps['editor'] ) && true === $all_caps['editor'] ) {
 							$all_caps[ $cap ] = true;
 							break;
 						}

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -810,7 +810,7 @@ class Memberships {
 					case 'wc_memberships_view_delayed_taxonomy_term':
 					case 'wc_memberships_view_delayed_post_content':
 					case 'wc_memberships_view_delayed_product':
-						// Allow ueser who can edit posts (by default: editors, authors, contributors).
+						// Allow user who can edit posts (by default: editors, authors, contributors).
 						if ( isset( $all_caps['edit_posts'] ) && true === $all_caps['edit_posts'] ) {
 							$all_caps[ $cap ] = true;
 							break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allow editors to see content locked behind a membership

### How to test the changes in this Pull Request:

1. Create a user with the `editor` role and make sure they don't have any memberships
2. Set up a content gate
3. Visit the site anonymously and confirm the content is restricted
4. on `master`, log in as the editor and confirm the content is still restricted
5. Checkout this branch and confirm the content is allowed for the Editor, but still restricted for other logged in users in other roles (except admins)

Dev notes:

I just want to clarify something that may show up during review.

As you'll see, I changed the `if` statement with a `select`, so I could catch many other capabilities all at once.

The original code had a `break;` at the end of the `if`, meaning that the `foreach` was not continuing in case `$caps[0]` was the cap we are looking for. (in many examples in the internet for the `user_has_cap` filter you'll see that people only check for `$caps[0]`, which is not totally correct. So this `foreach` approach here is better)

But what I wanted to say that is now, all the `break`s we have are breaking out of the `switch` clause and not out of the `foreach` - and that's fine, it's not an oversight. It doens't really matter. If it happens that we receive more than one cap in the checks, the code will still work the same. And we usually only get more than one cap there when checking for meta caps, which is not the case.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205902823686548