### PR TITLE
feat: add support for revisions to content gate CPT

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -120,7 +120,7 @@ class Memberships {
 				'show_ui'      => true,
 				'show_in_menu' => false,
 				'show_in_rest' => true,
-				'supports'     => [ 'editor', 'custom-fields' ],
+				'supports'     => [ 'editor', 'custom-fields', 'revisions' ],
 			]
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

To be consistent with https://github.com/Automattic/newspack-popups/pull/1250, this PR adds support for revisions to the `np_memberships_gate` custom post type (CPT).

### How to test the changes in this Pull Request:

1. Make a change to a content gate. Observe that there is no "Revisions" box in the post settings.
2. Switch to this branch.
3. Make a change to a content gate. Observe that there is a "Revisions" box in the post settings.
4. Confirm that the previous version of the content gate is visible in (and can be restored from) the revisions timeline.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->