### PR TITLE
fix: use Woo's cart fee for covering transaction fees

### DIFF
--- a/assets/other-scripts/wc-cover-fees/index.js
+++ b/assets/other-scripts/wc-cover-fees/index.js
@@ -1,0 +1,29 @@
+/* globals jQuery, newspack_wc_cover_fees */
+( function ( $ ) {
+	if ( ! $ ) {
+		return;
+	}
+	const $body = $( document.body );
+	$body.on( 'init_checkout', function () {
+		const form = document.querySelector( 'form.checkout' );
+		if ( ! form ) {
+			return;
+		}
+		let checked = document.getElementById( newspack_wc_cover_fees.custom_field_name )?.checked;
+		form.addEventListener( 'change', function () {
+			// Get element on every change because the DOM is replaced by AJAX.
+			const input = document.getElementById( newspack_wc_cover_fees.custom_field_name );
+			if ( ! input ) {
+				return;
+			}
+			if ( checked !== input.checked ) {
+				checked = input.checked;
+				$body.trigger( 'update_checkout', { update_shipping_method: false } );
+			}
+		} );
+		// Trigger checkout update on payment method change so it updates the fee.
+		$( document ).on( 'payment_method_selected', function () {
+			$body.trigger( 'update_checkout', { update_shipping_method: false } );
+		} );
+	} );
+} )( jQuery );

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -120,16 +120,7 @@ class WooCommerce_Cover_Fees {
 		if ( true !== boolval( get_option( 'newspack_donations_allow_covering_fees' ) ) ) {
 			return false;
 		}
-		if ( \Newspack_Blocks\Modal_Checkout::is_modal_checkout() ) {
-			return true;
-		}
-		if ( isset( $_POST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			parse_str( \sanitize_text_field( \wp_unslash( $_POST['post_data'] ) ), $post_data ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			if ( isset( $post_data['modal_checkout'] ) && 1 === intval( $post_data['modal_checkout'] ) ) {
-				return true;
-			}
-		}
-		return false;
+		return true;
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -13,18 +13,15 @@ defined( 'ABSPATH' ) || exit;
  * WooCommerce Order UTM class.
  */
 class WooCommerce_Cover_Fees {
-	const CUSTOM_FIELD_NAME  = 'newspack-wc-pay-fees';
-	const PRICE_ELEMENT_ID   = 'newspack-wc-price';
-	const WC_ORDER_META_NAME = 'newspack_donor_covers_fees';
+	const CUSTOM_FIELD_NAME = 'newspack-wc-pay-fees';
 
 	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
 		\add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'add_checkout_fields' ] );
-		\add_filter( 'woocommerce_checkout_create_order', [ __CLASS__, 'set_total_with_fees' ], 1, 2 );
 		\add_action( 'woocommerce_checkout_order_processed', [ __CLASS__, 'add_order_note' ], 1, 3 );
-		\add_filter( 'wc_price', [ __CLASS__, 'amend_price_markup' ], 1, 2 );
+		\add_action( 'woocommerce_cart_calculate_fees', [ __CLASS__, 'add_transaction_fee' ] );
 		\add_action( 'wc_stripe_payment_fields_stripe', [ __CLASS__, 'render_stripe_input' ] );
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'print_checkout_helper_script' ] );
 	}
@@ -47,22 +44,6 @@ class WooCommerce_Cover_Fees {
 			],
 		];
 		return $fields;
-	}
-
-	/**
-	 * Set order total, taking the fee into account.
-	 *
-	 * @param \WC_Order $order Order object.
-	 * @param array     $data  Posted data.
-	 *
-	 * @return \WC_Order
-	 */
-	public static function set_total_with_fees( $order, $data ) {
-		if ( isset( $data[ self::CUSTOM_FIELD_NAME ] ) && 1 === $data[ self::CUSTOM_FIELD_NAME ] ) {
-			$order->add_meta_data( self::WC_ORDER_META_NAME, 1 );
-			$order->set_total( self::get_total_with_fee( $order->get_total() ) );
-		}
-		return $order;
 	}
 
 	/**
@@ -100,7 +81,7 @@ class WooCommerce_Cover_Fees {
 		if ( true !== boolval( get_option( 'newspack_donations_allow_covering_fees' ) ) ) {
 			return false;
 		}
-		if ( \Newspack_Blocks\Modal_Checkout::is_modal_checkout() ) {  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( \Newspack_Blocks\Modal_Checkout::is_modal_checkout() ) {
 			return true;
 		}
 		if ( isset( $_POST['post_data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
@@ -126,9 +107,7 @@ class WooCommerce_Cover_Fees {
 					id=<?php echo esc_attr( self::CUSTOM_FIELD_NAME ); ?>
 					name=<?php echo esc_attr( self::CUSTOM_FIELD_NAME ); ?>
 					type="checkbox"
-					value="true"
 					style="margin-right: 8px;"
-					onchange="newspackHandleCoverFees(this)"
 					<?php if ( get_option( 'newspack_donations_allow_covering_fees_default', false ) ) : ?>
 						checked
 					<?php endif; ?>
@@ -167,19 +146,6 @@ class WooCommerce_Cover_Fees {
 	}
 
 	/**
-	 * Amend the price markup so it's possible to manipulate it via JS.
-	 *
-	 * @param string $html  Price HTML.
-	 * @param string $price Price.
-	 */
-	public static function amend_price_markup( $html, $price ) {
-		if ( ! self::should_allow_covering_fees() ) {
-			return $html;
-		}
-		return str_replace( $price, '<span id="' . self::PRICE_ELEMENT_ID . '">' . $price . '</span>', $html );
-	}
-
-	/**
 	 * Print the checkout helper JS script.
 	 */
 	public static function print_checkout_helper_script() {
@@ -189,36 +155,21 @@ class WooCommerce_Cover_Fees {
 		$handler = 'newspack-wc-modal-checkout-helper';
 		wp_register_script( $handler, '', [], false, [ 'in_footer' => true ] ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
 		wp_enqueue_script( $handler );
-		$original_price          = WC()->cart->total;
-		$price_with_fee          = number_format( self::get_total_with_fee( $original_price ), 2 );
-		$has_coupons_available   = WC()->cart->get_coupon_discount_totals();
-		$coupons_handling_script = '';
-		if ( \wc_coupons_enabled() ) {
-			// Handle an edge case where the price was updated in the UI, and then a coupon was applied.
-			// In this case, the price has to be reverted to the original value, since covering fees
-			// is not supported with coupons.
-			$coupons_handling_script = 'setInterval(function(){
-				if(document.querySelector(".woocommerce-remove-coupon")){
-					document.getElementById( "' . self::PRICE_ELEMENT_ID . '" ).textContent =  "' . $original_price . '";
+		ob_start();
+		?>
+		( function( $ ) {
+			$(document.body).on('init_checkout', function() {
+				var inputEl = document.getElementById( "<?php echo esc_attr( self::CUSTOM_FIELD_NAME ); ?>" );
+				if ( inputEl ) {
+					inputEl.addEventListener( 'change', function( e ) {
+						$( document.body ).trigger( 'update_checkout', { update_shipping_method: false } );
+					} );
 				}
-			}, 1000);';
-		}
-		wp_add_inline_script(
-			$handler,
-			'const form = document.querySelector(\'form[name="checkout"]\');
-			if ( form ) {
-				form.addEventListener(\'change\', function( e ){
-					const inputEl = document.getElementById( "' . self::CUSTOM_FIELD_NAME . '" );
-					if( e.target.name === "payment_method" && e.target.value !== "stripe" && inputEl.checked ){
-						inputEl.checked = false;
-						newspackHandleCoverFees(inputEl);
-					}
-				});
-			}
-			function newspackHandleCoverFees(inputEl) {
-				document.getElementById( "' . self::PRICE_ELEMENT_ID . '" ).textContent = inputEl.checked ? "' . $price_with_fee . '" : "' . $original_price . '";
-			};' . $coupons_handling_script
-		);
+			});
+		} )( jQuery );
+		<?php
+		$output = ob_get_clean();
+		wp_add_inline_script( $handler, $output );
 	}
 
 	/**
@@ -239,25 +190,53 @@ class WooCommerce_Cover_Fees {
 	 * Get the fee display value.
 	 */
 	public static function get_fee_display_value() {
-		$price = floatval( WC()->cart->total );
-		$total = self::get_total_with_fee( $price );
+		$subtotal = WC()->cart->get_subtotal();
+		$total    = self::get_total_with_fee();
 		// Just one decimal place, please.
-		$flat_percentage = (float) number_format( ( ( $total - $price ) * 100 ) / $price, 1 );
+		$flat_percentage = (float) number_format( ( ( $total - $subtotal ) * 100 ) / $subtotal, 1 );
 		return $flat_percentage . '%';
+	}
+
+	/**
+	 * Add fee.
+	 *
+	 * @param \WC_Cart $cart Cart object.
+	 */
+	public static function add_transaction_fee( $cart ) {
+		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
+			return;
+		}
+		if ( ! self::should_allow_covering_fees() ) {
+			return;
+		}
+		$cart->add_fee(
+			sprintf(
+				// Translators: %s is the fee percentage.
+				__( 'Transaction fees (%s)', 'newspack-plugin' ),
+				self::get_fee_display_value()
+			),
+			self::get_fee_value()
+		);
+	}
+
+	/**
+	 * Get the fee value.
+	 */
+	public static function get_fee_value() {
+		$fee_multiplier = self::get_stripe_fee_multiplier_value();
+		$fee_static     = self::get_stripe_fee_static_value();
+		$subtotal       = WC()->cart->get_subtotal();
+		$fee            = ( ( ( $subtotal + $fee_static ) / ( 100 - $fee_multiplier ) ) * 100 - $subtotal );
+		return $fee;
 	}
 
 	/**
 	 * Calculate the adjusted total, taking the fee into account.
 	 *
-	 * @param float $total Total amount.
-	 *
 	 * @return float
 	 */
-	private static function get_total_with_fee( $total ) {
-		$fee_multiplier = self::get_stripe_fee_multiplier_value();
-		$fee_static     = self::get_stripe_fee_static_value();
-		$fee            = ( ( ( $total + $fee_static ) / ( 100 - $fee_multiplier ) ) * 100 - $total );
-		return $total + $fee;
+	private static function get_total_with_fee() {
+		return WC()->cart->get_subtotal() + self::get_fee_value();
 	}
 }
 WooCommerce_Cover_Fees::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Refactors the "cover fee" strategy to use  `WC()->cart->add_fee()` instead of modifying the order total directly.

This PR also changes the UI to show the fee through the order review table and and no longer modify the top summary value. This consolidates how we handle additional values added to the order (coupons, fees, and taxes excluded from the total).

<img width="612" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/457971e8-de0f-4fb8-af89-f787e577e7f9">

<img width="1219" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/adb33381-d965-4f30-a700-84abbfcc2ae2">

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/1633
2. Through the Donate block, start a one-time donation flow and confirm you can toggle the "I’d like to cover the {percentage}% transaction fee to ensure my full donation goes towards {site name}'s mission." checkbox
3. Confirm toggling the checkbox updates the fee as shown in the image above
4. Confirm you can place the order
5. Visit the order details in the dashboard and confirm you can see the fee as shown in the image above
6. Confirm the note "The donor opted to cover Stripe’s transaction fee." is also added to the order
7. Back to the Donate block, start a recurring donation flow, and also check the fee checkbox
8. Confirm the order review table also shows the fee added to the "Recurring totals"
9. Place the order and confirm in the dashboard that the fee has been added
10. Go to the subscription dashboard in WooCommerce -> Subscriptions
11. In the "Subscription actions" metabox, select "Process renewal"
12. Confirm the renewal order also includes the fee

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->