### PR TITLE
fix(ras): consolidate RAS <> ESP data syncs in data event connectors

### DIFF
--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -140,7 +140,6 @@ When any WooCommerce order is completed with a successful payment.
 | `email`           | `string` |                                                        |
 | `amount`          | `float`  |                                                        |
 | `currency`        | `string` |                                                        |
-| `recurrence`      | `string` |                                                        |
 | `platform`        | `string` |                                                        |
 | `referer`         | `string` |                                                        |
 | `popup_id`        | `string` | If the order was triggered by a popup, the popup ID    |

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -130,6 +130,24 @@ When there's a new donation, either through Stripe or Newspack (WooCommerce) pla
 | `subscription_id` | `int`    | The related subscription id (if any)                   |
 | `platform_data`   | `array`  |                                                        |
 
+### `order_completed`
+
+When any WooCommerce order is completed with a successful payment.
+
+| Name              | Type     | Obs                                                    |
+| ----------------- | -------- | ------------------------------------------------------ |
+| `user_id`         | `int`    |                                                        |
+| `email`           | `string` |                                                        |
+| `amount`          | `float`  |                                                        |
+| `currency`        | `string` |                                                        |
+| `recurrence`      | `string` |                                                        |
+| `platform`        | `string` |                                                        |
+| `referer`         | `string` |                                                        |
+| `popup_id`        | `string` | If the order was triggered by a popup, the popup ID    |
+| `is_renewal`      | `bool`   | If this is a subscription renewal (recurring payment)  |
+| `subscription_id` | `int`    | The related subscription id (if any)                   |
+| `platform_data`   | `array`  |                                                        |
+
 ### `donation_subscription_new`
 
 When there's a new WooCommerce Subscription. This action does not replace the `donation_new` that create the subscription.
@@ -176,22 +194,9 @@ When a WooCommerce Subscription status changes.
 | `recurrence`      | `string` |
 | `platform`        | `string` |
 
-### `product_subscription_active`
+### `product_subscription_changed`
 
-When a non-donation subscription is activated.
-
-| Name              | Type     |
-| ----------------- | -------- |
-| `user_id`         | `int`    |
-| `email`           | `string` |
-| `subscription_id` | `int`    |
-| `amount`          | `float`  |
-| `currency`        | `string` |
-| `recurrence`      | `string` |
-
-### `product_subscription_inactive`
-
-When a non-donation subscription is changed to any non-active status.
+When a non-donation subscription status changes.
 
 | Name              | Type     |
 | ----------------- | -------- |

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -313,7 +313,7 @@ final class Data_Events {
 		}
 
 		Logger::log(
-			sprintf( 'Dispatching action "%s".', $action_name ),
+			sprintf( 'Dispatching action "%s" with data:' . "\n" . \wp_json_encode( $data, JSON_PRETTY_PRINT ), $action_name ),
 			self::LOGGER_HEADER
 		);
 

--- a/includes/data-events/class-woo-user-registration.php
+++ b/includes/data-events/class-woo-user-registration.php
@@ -46,9 +46,6 @@ final class Woo_User_Registration {
 	 */
 	public static function checkout_process() {
 
-		// If a user is created later on the request by woocommerce_created_customer(), it will at least have this data.
-		self::$metadata['registration_method'] = 'woocommerce';
-
 		/**
 		 * On Newspack\Donations::process_donation_form(), we add these values to the cart.
 		 *
@@ -83,6 +80,14 @@ final class Woo_User_Registration {
 
 		if ( ! $user ) {
 			return;
+		}
+
+		// If a user is created later on the request by woocommerce_created_customer(), it will at least have this data.
+		self::$metadata['registration_method'] = 'woocommerce';
+
+		// For modal checkout, the referer is actually what we want to capture as the registration page.
+		if ( ! empty( self::$metadata['referer'] ) && method_exists( 'Newspack_Blocks\Modal_Checkout', 'is_modal_checkout' ) && \Newspack_Blocks\Modal_Checkout::is_modal_checkout() ) {
+			self::$metadata['current_page_url'] = self::$metadata['referer'];
 		}
 
 		/**

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -30,41 +30,37 @@ class ActiveCampaign {
 	 * Register handlers.
 	 */
 	public static function register_handlers() {
-		if ( ! method_exists( 'Newspack_Newsletters', 'get_service_provider' ) ) {
+		if ( ! method_exists( 'Newspack_Newsletters', 'service_provider' ) ) {
 			return;
 		}
-		$provider = \Newspack_Newsletters::get_service_provider();
 		if (
 			Reader_Activation::is_enabled() &&
 			true === Reader_Activation::get_setting( 'sync_esp' ) &&
-			$provider && 'active_campaign' === $provider->service
+			'active_campaign' === \Newspack_Newsletters::service_provider()
 		) {
 			Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
-			Data_Events::register_handler( [ __CLASS__, 'donation_new' ], 'donation_new' );
-			Data_Events::register_handler( [ __CLASS__, 'donation_subscription_new' ], 'donation_subscription_new' );
-			Data_Events::register_handler( [ __CLASS__, 'newsletter_updated' ], 'newsletter_updated' );
-			Data_Events::register_handler( [ __CLASS__, 'newsletter_subscribed' ], 'newsletter_updated' );
+			Data_Events::register_handler( [ __CLASS__, 'reader_logged_in' ], 'reader_logged_in' );
+			Data_Events::register_handler( [ __CLASS__, 'order_new' ], 'donation_new' );
+			Data_Events::register_handler( [ __CLASS__, 'order_new' ], 'product_order_new' );
+			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'donation_subscription_changed' );
+			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'product_subscription_active' );
+			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'product_subscription_inactive' );
+			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'newsletter_updated' );
+			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'newsletter_subscribed' );
 		}
 	}
 
 	/**
 	 * Upsert the contact.
 	 *
-	 * @param string $email    Email address.
-	 * @param array  $metadata Metadata to add to the contact.
+	 * @param array $contact Contact info to sync to ESP.
 	 */
-	private static function put( $email, $metadata ) {
+	private static function put( $contact ) {
 		$master_list_id = Reader_Activation::get_setting( 'active_campaign_master_list' );
 		if ( ! $master_list_id ) {
 			return;
 		}
-		\Newspack_Newsletters_Subscription::add_contact(
-			[
-				'email'    => $email,
-				'metadata' => $metadata,
-			],
-			$master_list_id
-		);
+		\Newspack_Newsletters_Subscription::add_contact( $contact, $master_list_id );
 	}
 
 	/**
@@ -75,7 +71,6 @@ class ActiveCampaign {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function reader_registered( $timestamp, $data, $client_id ) {
-		$prefix                = Newspack_Newsletters::get_metadata_prefix();
 		$account_key           = Newspack_Newsletters::get_metadata_key( 'account' );
 		$registration_date_key = Newspack_Newsletters::get_metadata_key( 'registration_date' );
 		$metadata              = [
@@ -83,76 +78,86 @@ class ActiveCampaign {
 			$registration_date_key => gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $timestamp ),
 		];
 		if ( isset( $data['metadata']['current_page_url'] ) ) {
-			$metadata[ $prefix . 'Registration Page' ] = $data['metadata']['current_page_url'];
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_page' ) ] = $data['metadata']['current_page_url'];
 		}
 		if ( isset( $data['metadata']['registration_method'] ) ) {
-			$metadata[ $prefix . 'Registration Method' ] = $data['metadata']['registration_method'];
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_method' ) ] = $data['metadata']['registration_method'];
 		}
-		self::put( $data['email'], $metadata );
+		$contact = [
+			'email'    => $data['email'],
+			'metadata' => $metadata,
+		];
+		self::put( $contact );
 	}
 
 	/**
-	 * Handle a donation being made.
+	 * Sync reader data on login.
 	 *
 	 * @param int   $timestamp Timestamp of the event.
 	 * @param array $data      Data associated with the event.
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
-	public static function donation_new( $timestamp, $data, $client_id ) {
+	public static function reader_logged_in( $timestamp, $data, $client_id ) {
+		if ( empty( $data['email'] ) || empty( $data['user_id'] ) ) {
+			return;
+		}
+
+		$customer = new \WC_Customer( $data['user_id'] );
+
+		// If user is not a Woo customer, don't need to sync them.
+		if ( ! $customer->get_order_count() ) {
+			return;
+		}
+
+		$last_order = $customer->get_last_order();
+		$contact    = WooCommerce_Connection::get_contact_from_order( $last_order );
+
+		self::put( $contact );
+	}
+
+	/**
+	 * Handle new order being.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 */
+	public static function order_new( $timestamp, $data, $client_id ) {
 		if ( ! isset( $data['platform_data']['order_id'] ) ) {
 			return;
 		}
 
 		$order_id = $data['platform_data']['order_id'];
-		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id );
+		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, false, true );
 
 		if ( ! $contact ) {
 			return;
 		}
 
-		$email         = $contact['email'];
-		$metadata      = $contact['metadata'];
-		$keys          = Newspack_Newsletters::$metadata_keys;
-		$prefixed_keys = array_map(
-			function( $key ) {
-				return Newspack_Newsletters::get_metadata_key( $key );
-			},
-			array_values( array_flip( $keys ) )
-		);
-
-		// Only use metadata defined in 'Newspack_Newsletters'.
-		$metadata = array_intersect_key( $metadata, array_flip( $prefixed_keys ) );
-
-		// Remove "product name" from metadata, we'll use
-		// 'donation_subscription_new' action for this data.
-		unset( $metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] );
-
-		self::put( $email, $metadata );
+		self::put( $contact );
 	}
 
 	/**
-	 * Handle a new subscription.
+	 * Handle a change in subscription status.
 	 *
 	 * @param int   $timestamp Timestamp of the event.
 	 * @param array $data      Data associated with the event.
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
-	public static function donation_subscription_new( $timestamp, $data, $client_id ) {
-		if ( empty( $data['platform_data']['order_id'] ) ) {
+	public static function subscription_updated( $timestamp, $data, $client_id ) {
+		if ( ! isset( $data['subscription_id'] ) ) {
 			return;
 		}
-		$account_key  = Newspack_Newsletters::get_metadata_key( 'account' );
-		$metadata     = [
-			$account_key => $data['user_id'],
-		];
-		$order_id     = $data['platform_data']['order_id'];
-		$product_id   = Donations::get_order_donation_product_id( $order_id );
-		$product_name = get_the_title( $product_id );
 
-		$key              = Newspack_Newsletters::get_metadata_key( 'product_name' );
-		$metadata[ $key ] = $product_name;
+		$subscription = \wcs_get_subscription( $data['subscription_id'] );
+		$order        = $subscription->get_last_order( 'all' );
+		$contact      = WooCommerce_Connection::get_contact_from_order( $order );
 
-		self::put( $data['email'], $metadata );
+		if ( ! $contact ) {
+			return;
+		}
+
+		self::put( $contact );
 	}
 
 	/**
@@ -192,7 +197,11 @@ class ActiveCampaign {
 			$account_key              => $data['user_id'],
 			$newsletter_selection_key => implode( ', ', $lists_names ),
 		];
-		self::put( $data['email'], $metadata );
+		$contact  = [
+			'email'    => $data['email'],
+			'metadata' => $metadata,
+		];
+		self::put( $contact );
 	}
 }
 new ActiveCampaign();

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -116,7 +116,7 @@ class ActiveCampaign {
 	}
 
 	/**
-	 * Handle new order being.
+	 * Handle a new order.
 	 *
 	 * @param int   $timestamp Timestamp of the event.
 	 * @param array $data      Data associated with the event.

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -181,13 +181,15 @@ class Mailchimp {
 			'status_if_new' => 'transactional',
 		];
 
-		$merge_fields = self::get_merge_fields( $audience_id, $data );
+		// Normalize contact metadata.
+		$contact      = Newspack_Newsletters::normalize_contact_data( [ 'metadata' => $data ] );
+		$merge_fields = self::get_merge_fields( $audience_id, $contact['metadata'] );
 		if ( ! empty( $merge_fields ) ) {
 			$payload['merge_fields'] = $merge_fields;
 		}
 
 		Logger::log(
-			'Syncing contact with metadata key(s): ' . implode( ', ', array_keys( $data ) ) . '.',
+			'Syncing contact with metadata key(s): ' . implode( ', ', array_keys( $contact['metadata'] ) ) . '.',
 			Data_Events::LOGGER_HEADER
 		);
 

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -32,10 +32,18 @@ class Mailchimp {
 	 * Register handlers.
 	 */
 	public static function register_handlers() {
-		if ( Reader_Activation::is_enabled() && true === Reader_Activation::get_setting( 'sync_esp' ) ) {
+		if ( ! method_exists( 'Newspack_Newsletters', 'service_provider' ) ) {
+			return;
+		}
+		if (
+			Reader_Activation::is_enabled() &&
+			true === Reader_Activation::get_setting( 'sync_esp' ) &&
+			'mailchimp' === \Newspack_Newsletters::service_provider()
+		) {
 			Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
-			Data_Events::register_handler( [ __CLASS__, 'donation_new' ], 'donation_new' );
-			Data_Events::register_handler( [ __CLASS__, 'donation_subscription_new' ], 'donation_subscription_new' );
+			Data_Events::register_handler( [ __CLASS__, 'reader_logged_in' ], 'reader_logged_in' );
+			Data_Events::register_handler( [ __CLASS__, 'order_new' ], 'donation_new' );
+			Data_Events::register_handler( [ __CLASS__, 'order_new' ], 'product_order_new' );
 		}
 	}
 
@@ -165,27 +173,28 @@ class Mailchimp {
 	/**
 	 * Update a Mailchimp contact
 	 *
-	 * @param string $email Email address.
-	 * @param array  $data  Data to update.
+	 * @param array $contact Contact info to sync to ESP without lists.
 	 *
 	 * @return array|WP_Error response body or error.
 	 */
-	public static function put( $email, $data = [] ) {
+	public static function put( $contact ) {
 		$audience_id = self::get_audience_id();
 		if ( ! $audience_id ) {
 			return;
 		}
-		$hash    = md5( strtolower( $email ) );
+		$hash    = md5( strtolower( $contact['email'] ) );
 		$payload = [
-			'email_address' => $email,
+			'email_address' => $contact['email'],
 			'status_if_new' => 'transactional',
 		];
 
 		// Normalize contact metadata.
-		$contact      = Newspack_Newsletters::normalize_contact_data( [ 'metadata' => $data ] );
-		$merge_fields = self::get_merge_fields( $audience_id, $contact['metadata'] );
-		if ( ! empty( $merge_fields ) ) {
-			$payload['merge_fields'] = $merge_fields;
+		$contact = Newspack_Newsletters::normalize_contact_data( $contact );
+		if ( ! empty( $contact['metadata'] ) ) {
+			$merge_fields = self::get_merge_fields( $audience_id, $contact['metadata'] );
+			if ( ! empty( $merge_fields ) ) {
+				$payload['merge_fields'] = $merge_fields;
+			}
 		}
 
 		Logger::log(
@@ -208,7 +217,6 @@ class Mailchimp {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function reader_registered( $timestamp, $data, $client_id ) {
-		$prefix                = Newspack_Newsletters::get_metadata_prefix();
 		$account_key           = Newspack_Newsletters::get_metadata_key( 'account' );
 		$registration_date_key = Newspack_Newsletters::get_metadata_key( 'registration_date' );
 		$metadata              = [
@@ -216,76 +224,63 @@ class Mailchimp {
 			$registration_date_key => gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $timestamp ),
 		];
 		if ( isset( $data['metadata']['current_page_url'] ) ) {
-			$metadata[ $prefix . 'Registration Page' ] = $data['metadata']['current_page_url'];
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_page' ) ] = $data['metadata']['current_page_url'];
 		}
 		if ( isset( $data['metadata']['registration_method'] ) ) {
-			$metadata[ $prefix . 'Registration Method' ] = $data['metadata']['registration_method'];
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_method' ) ] = $data['metadata']['registration_method'];
 		}
-		self::put( $data['email'], $metadata );
+		$contact = [
+			'email'    => $data['email'],
+			'metadata' => $metadata,
+		];
+		self::put( $contact );
 	}
 
 	/**
-	 * Handle a donation being made.
+	 * Sync reader data on login.
 	 *
 	 * @param int   $timestamp Timestamp of the event.
 	 * @param array $data      Data associated with the event.
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
-	public static function donation_new( $timestamp, $data, $client_id ) {
+	public static function reader_logged_in( $timestamp, $data, $client_id ) {
+		if ( empty( $data['email'] ) || empty( $data['user_id'] ) ) {
+			return;
+		}
+
+		$customer = new \WC_Customer( $data['user_id'] );
+
+		// If user is not a Woo customer, don't need to sync them.
+		if ( ! $customer->get_order_count() ) {
+			return;
+		}
+
+		$last_order = $customer->get_last_order();
+		$contact    = WooCommerce_Connection::get_contact_from_order( $last_order );
+
+		self::put( $contact );
+	}
+
+	/**
+	 * Handle a new order.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 */
+	public static function order_new( $timestamp, $data, $client_id ) {
 		if ( ! isset( $data['platform_data']['order_id'] ) ) {
 			return;
 		}
 
 		$order_id = $data['platform_data']['order_id'];
-		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id );
+		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, false, true );
 
 		if ( ! $contact ) {
 			return;
 		}
 
-		$email         = $contact['email'];
-		$metadata      = $contact['metadata'];
-		$keys          = Newspack_Newsletters::$metadata_keys;
-		$prefixed_keys = array_map(
-			function( $key ) {
-				return Newspack_Newsletters::get_metadata_key( $key );
-			},
-			array_values( array_flip( $keys ) )
-		);
-
-		// Only use metadata defined in 'Newspack_Newsletters'.
-		$metadata = array_intersect_key( $metadata, array_flip( $prefixed_keys ) );
-
-		// Remove "product name" from metadata, we'll use
-		// 'donation_subscription_new' action for this data.
-		unset( $metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] );
-
-		self::put( $email, $metadata );
-	}
-
-	/**
-	 * Handle a new subscription.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 * @param int   $client_id ID of the client that triggered the event.
-	 */
-	public static function donation_subscription_new( $timestamp, $data, $client_id ) {
-		if ( empty( $data['platform_data']['order_id'] ) ) {
-			return;
-		}
-		$account_key  = Newspack_Newsletters::get_metadata_key( 'account' );
-		$metadata     = [
-			$account_key => $data['user_id'],
-		];
-		$order_id     = $data['platform_data']['order_id'];
-		$product_id   = Donations::get_order_donation_product_id( $order_id );
-		$product_name = get_the_title( $product_id );
-
-		$key              = Newspack_Newsletters::get_metadata_key( 'product_name' );
-		$metadata[ $key ] = $product_name;
-
-		self::put( $data['email'], $metadata );
+		self::put( $contact );
 	}
 }
 new Mailchimp();

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -42,8 +42,9 @@ class Mailchimp {
 		) {
 			Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
 			Data_Events::register_handler( [ __CLASS__, 'reader_logged_in' ], 'reader_logged_in' );
-			Data_Events::register_handler( [ __CLASS__, 'order_new' ], 'donation_new' );
-			Data_Events::register_handler( [ __CLASS__, 'order_new' ], 'product_order_new' );
+			Data_Events::register_handler( [ __CLASS__, 'order_completed' ], 'order_completed' );
+			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'donation_subscription_changed' );
+			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'product_subscription_changed' );
 		}
 	}
 
@@ -262,19 +263,52 @@ class Mailchimp {
 	}
 
 	/**
-	 * Handle a new order.
+	 * Handle a completed order of any type.
 	 *
 	 * @param int   $timestamp Timestamp of the event.
 	 * @param array $data      Data associated with the event.
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
-	public static function order_new( $timestamp, $data, $client_id ) {
+	public static function order_completed( $timestamp, $data, $client_id ) {
 		if ( ! isset( $data['platform_data']['order_id'] ) ) {
 			return;
 		}
 
 		$order_id = $data['platform_data']['order_id'];
 		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, false, true );
+
+		if ( ! $contact ) {
+			return;
+		}
+
+		self::put( $contact );
+	}
+
+	/**
+	 * Handle a change in subscription status.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 */
+	public static function subscription_updated( $timestamp, $data, $client_id ) {
+		if ( empty( $data['subscription_id'] ) || empty( $data['status_before'] ) || empty( $data['status_after'] ) ) {
+			return;
+		}
+
+		/*
+		 * If the subscription is being activated after a successful first or renewal payment,
+		 * the contact will be synced when that order is completed, so no need to sync again.
+		 */
+		if (
+			( 'pending' === $data['status_before'] || 'on-hold' === $data['status_before'] ) &&
+			'active' === $data['status_after'] ) {
+			return;
+		}
+
+		$subscription = \wcs_get_subscription( $data['subscription_id'] );
+		$order        = $subscription->get_last_order( 'all' );
+		$contact      = WooCommerce_Connection::get_contact_from_order( $order );
 
 		if ( ! $contact ) {
 			return;

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -304,6 +304,9 @@ Data_Events::register_listener(
 		$subscriptions    = $wcs_is_available ? array_values( \wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] ) ) : null;
 		$is_renewal       = $wcs_is_available && \wcs_order_contains_renewal( $order );
 		$subscription_id  = ! empty( $subscriptions ) ? $subscriptions[0]->get_id() : null;
+		if ( $subscription_id ) {
+			$recurrence = $subscriptions[0]->get_billing_period();
+		}
 
 		return [
 			'user_id'         => $order->get_customer_id(),

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -292,20 +292,16 @@ Data_Events::register_listener(
 			return;
 		}
 
-		$recurrence       = is_numeric( $product_id ) ? \get_post_meta( $product_id, '_subscription_period', 'once' ) : 'once'; // Only donation products will have this meta.
 		$wcs_is_available = function_exists( 'wcs_get_subscriptions_for_order' ) && function_exists( 'wcs_order_contains_renewal' );
 		$subscriptions    = $wcs_is_available ? array_values( \wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] ) ) : null;
 		$is_renewal       = $wcs_is_available && \wcs_order_contains_renewal( $order );
 		$subscription_id  = ! empty( $subscriptions ) ? $subscriptions[0]->get_id() : null;
-		if ( 'once' === $recurrence && $subscription_id ) {
-			$recurrence = $subscriptions[0]->get_billing_period();
-		}
+
 		return [
 			'user_id'         => $order->get_customer_id(),
 			'email'           => $order->get_billing_email(),
 			'amount'          => (float) $order->get_total(),
 			'currency'        => $order->get_currency(),
-			'recurrence'      => $recurrence,
 			'referer'         => $order->get_meta( '_newspack_referer' ),
 			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),
 			'is_renewal'      => $is_renewal,

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -253,7 +253,7 @@ Data_Events::register_listener(
 		if ( ! $product_id ) {
 			return;
 		}
-		$recurrence       = \get_post_meta( $product_id, '_subscription_period', 'once' );
+		$recurrence       = \get_post_meta( $product_id, '_subscription_period', true );
 		$wcs_is_available = function_exists( 'wcs_is_subscription' ) && function_exists( 'wcs_get_subscriptions_for_order' ) && function_exists( 'wcs_order_contains_renewal' );
 		$subscriptions    = $wcs_is_available ? array_values( \wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] ) ) : null;
 		$is_renewal       = $wcs_is_available && \wcs_order_contains_renewal( $order );
@@ -264,7 +264,7 @@ Data_Events::register_listener(
 			'email'           => $order->get_billing_email(),
 			'amount'          => (float) $order->get_total(),
 			'currency'        => $order->get_currency(),
-			'recurrence'      => $recurrence,
+			'recurrence'      => ! empty( $recurrence ) ? $recurrence : 'once',
 			'platform'        => Donations::get_platform_slug(),
 			'referer'         => $order->get_meta( '_newspack_referer' ),
 			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -280,34 +280,26 @@ Data_Events::register_listener(
 );
 
 /**
- * For non-donation purchases.
+ * For any completed purchase. This data event triggers a contact sync to the connected ESP.
  */
 Data_Events::register_listener(
 	'woocommerce_order_status_completed',
-	'product_order_new',
+	'order_completed',
 	function( $order_id, $order ) {
-		// We only want to fire this for non-donation products.
-		$product_ids = array_values(
-			array_filter(
-				\Newspack\WooCommerce_Connection::get_products_for_order( $order_id ),
-				function( $product_id ) {
-					return ! Donations::is_donation_product( $product_id );
-				}
-			)
-		);
-
-		if ( empty( $product_ids ) ) {
+		// Donation orders always have just a single product, but other orders can have more than one.
+		$product_id = Donations::get_order_donation_product_id( $order_id ) ?? array_values( \Newspack\WooCommerce_Connection::get_products_for_order( $order_id ) );
+		if ( empty( $product_id ) ) {
 			return;
 		}
-		$recurrence       = 'once';
+
+		$recurrence       = is_numeric( $product_id ) ? \get_post_meta( $product_id, '_subscription_period', 'once' ) : 'once'; // Only donation products will have this meta.
 		$wcs_is_available = function_exists( 'wcs_get_subscriptions_for_order' ) && function_exists( 'wcs_order_contains_renewal' );
 		$subscriptions    = $wcs_is_available ? array_values( \wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] ) ) : null;
 		$is_renewal       = $wcs_is_available && \wcs_order_contains_renewal( $order );
 		$subscription_id  = ! empty( $subscriptions ) ? $subscriptions[0]->get_id() : null;
-		if ( $subscription_id ) {
+		if ( 'once' === $recurrence && $subscription_id ) {
 			$recurrence = $subscriptions[0]->get_billing_period();
 		}
-
 		return [
 			'user_id'         => $order->get_customer_id(),
 			'email'           => $order->get_billing_email(),
@@ -320,7 +312,7 @@ Data_Events::register_listener(
 			'subscription_id' => $subscription_id,
 			'platform_data'   => [
 				'order_id'   => $order_id,
-				'product_id' => $product_ids,
+				'product_id' => $product_id,
 				'client_id'  => $order->get_meta( NEWSPACK_CLIENT_ID_COOKIE_NAME ),
 			],
 		];
@@ -381,52 +373,13 @@ Data_Events::register_listener(
 );
 
 /**
- * When a non-donation subscription is activated.
- * The subscription will be added to the user's list of active subscriptions.
- */
-Data_Events::register_listener(
-	'woocommerce_subscription_status_active',
-	'product_subscription_active',
-	function( $subscription ) {
-		// We only want to fire this for non-donation products.
-		$product_ids = array_values(
-			array_filter(
-				\Newspack\WooCommerce_Connection::get_products_for_order( $subscription->get_id() ),
-				function( $product_id ) {
-					return ! Donations::is_donation_product( $product_id );
-				}
-			)
-		);
-
-		if ( empty( $product_ids ) ) {
-			return;
-		}
-
-		return [
-			'user_id'         => $subscription->get_customer_id(),
-			'email'           => $subscription->get_billing_email(),
-			'subscription_id' => $subscription->get_id(),
-			'product_ids'     => $product_ids,
-			'amount'          => (float) $subscription->get_total(),
-			'currency'        => $subscription->get_currency(),
-			'recurrence'      => $subscription->get_billing_period(),
-		];
-	}
-);
-
-/**
  * When a non-donation subscription is deactivated.
  * The subscription will be removed from the user's list of active subscriptions.
  */
 Data_Events::register_listener(
 	'woocommerce_subscription_status_updated',
-	'product_subscription_inactive',
+	'product_subscription_changed',
 	function( $subscription, $status_to, $status_from ) {
-		// We only want to fire this for non-active statuses.
-		if ( 'active' === $status_to ) {
-			return;
-		}
-
 		// We only want to fire this for non-donation products.
 		$product_ids = array_values(
 			array_filter(

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -320,7 +320,7 @@ Data_Events::register_listener(
 );
 
 /**
- * For when a WooCommerce Subscription is cancelled.
+ * For when a donation subscription is cancelled.
  */
 Data_Events::register_listener(
 	'woocommerce_subscription_status_updated',
@@ -347,7 +347,7 @@ Data_Events::register_listener(
 );
 
 /**
- * For when a WooCommerce Subscription status changes.
+ * For when a donation subscription status changes.
  */
 Data_Events::register_listener(
 	'woocommerce_subscription_status_updated',
@@ -373,7 +373,7 @@ Data_Events::register_listener(
 );
 
 /**
- * When a non-donation subscription is deactivated.
+ * When a non-donation subscription status changes.
  * The subscription will be removed from the user's list of active subscriptions.
  */
 Data_Events::register_listener(

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -150,6 +150,35 @@ class Newspack_Newsletters {
 				},
 				$raw_keys
 			);
+
+			// Capture UTM params and signup/payment page URLs as meta for registration or payment.
+			if (
+				( isset( $contact['metadata']['current_page_url'] ) || isset( $contact['metadata'][ self::get_metadata_key( 'current_page_url' ) ] ) ) &&
+				( isset( $contact['metadata']['registration_method'] ) || isset( $contact['metadata'][ self::get_metadata_key( 'registration_method' ) ] ) )
+			) {
+				$raw_url             = isset( $contact['metadata']['current_page_url'] ) ? $contact['metadata']['current_page_url'] : $contact['metadata'][ self::get_metadata_key( 'current_page_url' ) ];
+				$parsed_url          = \wp_parse_url( $raw_url );
+				$registration_method = isset( $contact['metadata']['registration_method'] ) ? $contact['metadata']['registration_method'] : $contact['metadata'][ self::get_metadata_key( 'registration_method' ) ];
+				$is_payment          = in_array( $registration_method, [ 'woocommerce', 'woocommerce-memberships', 'stripe-donation' ], true ); // Registration methods from payments/transactions.
+
+				// Maybe set UTM meta.
+				if ( ! empty( $parsed_url['query'] ) ) {
+					$utm_key_prefix = $is_payment ? 'payment_page_utm' : 'signup_page_utm';
+					$params         = [];
+					\wp_parse_str( $parsed_url['query'], $params );
+					foreach ( $params as $param => $value ) {
+						$param = \sanitize_text_field( $param );
+						if ( 'utm' === substr( $param, 0, 3 ) ) {
+							$param = str_replace( 'utm_', '', $param );
+							$key   = self::get_metadata_key( $utm_key_prefix ) . $param;
+							if ( ! isset( $contact['metadata'][ $key ] ) ) {
+								$contact['metadata'][ $key ] = $value;
+							}
+						}
+					}
+				}
+			}
+
 			foreach ( $contact['metadata'] as $meta_key => $meta_value ) {
 				if ( self::should_sync_ras_metadata() ) {
 					if ( in_array( $meta_key, $raw_keys, true ) ) {

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -153,13 +153,20 @@ class Newspack_Newsletters {
 
 			// Capture UTM params and signup/payment page URLs as meta for registration or payment.
 			if (
-				( isset( $contact['metadata']['current_page_url'] ) || isset( $contact['metadata'][ self::get_metadata_key( 'current_page_url' ) ] ) ) &&
-				( isset( $contact['metadata']['registration_method'] ) || isset( $contact['metadata'][ self::get_metadata_key( 'registration_method' ) ] ) )
+				isset( $contact['metadata']['current_page_url'] ) ||
+				isset( $contact['metadata'][ self::get_metadata_key( 'current_page_url' ) ] ) ||
+				isset( $contact['metadata']['payment_page'] ) ||
+				isset( $contact['metadata'][ self::get_metadata_key( 'payment_page' ) ] )
 			) {
-				$raw_url             = isset( $contact['metadata']['current_page_url'] ) ? $contact['metadata']['current_page_url'] : $contact['metadata'][ self::get_metadata_key( 'current_page_url' ) ];
-				$parsed_url          = \wp_parse_url( $raw_url );
-				$registration_method = isset( $contact['metadata']['registration_method'] ) ? $contact['metadata']['registration_method'] : $contact['metadata'][ self::get_metadata_key( 'registration_method' ) ];
-				$is_payment          = in_array( $registration_method, [ 'woocommerce', 'woocommerce-memberships', 'stripe-donation' ], true ); // Registration methods from payments/transactions.
+				$is_payment = isset( $contact['metadata']['payment_page'] ) || isset( $contact['metadata'][ self::get_metadata_key( 'payment_page' ) ] );
+				$raw_url    = false;
+				if ( $is_payment ) {
+					$raw_url = isset( $contact['metadata']['payment_page'] ) ? $contact['metadata']['payment_page'] : $contact['metadata'][ self::get_metadata_key( 'payment_page' ) ];
+				} else {
+					$raw_url = isset( $contact['metadata']['current_page_url'] ) ? $contact['metadata']['current_page_url'] : $contact['metadata'][ self::get_metadata_key( 'current_page_url' ) ];
+				}
+
+				$parsed_url = \wp_parse_url( $raw_url );
 
 				// Maybe set UTM meta.
 				if ( ! empty( $parsed_url['query'] ) ) {

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -442,7 +442,7 @@ final class Reader_Data {
 		
 		$subscription_products = [];
 		foreach ( $active_subscriptions as $subscription ) {
-			$subscription_products = array_merge( $subscription_products, \Newspack\WooCommerce_Connection::get_products_for_subscription( $subscription->get_id() ) );
+			$subscription_products = array_merge( $subscription_products, \Newspack\WooCommerce_Connection::get_products_for_order( $subscription->get_id() ) );
 		}
 		$subscription_products = array_values( array_unique( $subscription_products ) );
 		self::update_item( $data['user_id'], 'active_subscriptions', $subscription_products );

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -34,16 +34,14 @@ final class Reader_Data {
 		add_action( 'wp', [ __CLASS__, 'setup_reader_activity' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'config_script' ] );
 
-		/* Update reader data items on event dispatches */
-		add_action( 'newspack_data_event_dispatch_newsletter_subscribed', [ __CLASS__, 'update_newsletter_subscribed_lists' ], 10, 2 );
-		add_action( 'newspack_data_event_dispatch_newsletter_updated', [ __CLASS__, 'update_newsletter_subscribed_lists' ], 10, 2 );
-		add_action( 'newspack_data_event_dispatch_donation_new', [ __CLASS__, 'set_is_donor' ], 10, 2 );
-		add_action( 'newspack_data_event_dispatch_donation_subscription_cancelled', [ __CLASS__, 'set_is_former_donor' ], 10, 2 );
-		add_action( 'newspack_data_event_dispatch_product_subscription_active', [ __CLASS__, 'update_active_subscriptions' ], 10, 2 );
-		add_action( 'newspack_data_event_dispatch_product_subscription_inactive', [ __CLASS__, 'update_active_subscriptions' ], 10, 2 );
-		add_action( 'newspack_data_event_dispatch_membership_status_active', [ __CLASS__, 'update_active_memberships' ], 10, 2 );
-		add_action( 'newspack_data_event_dispatch_membership_status_inactive', [ __CLASS__, 'update_active_memberships' ], 10, 2 );
-
+		/* Update reader data items on data event dispatches */
+		Data_Events::register_handler( [ __CLASS__, 'update_newsletter_subscribed_lists' ], 'newsletter_subscribed' );
+		Data_Events::register_handler( [ __CLASS__, 'update_newsletter_subscribed_lists' ], 'newsletter_updated' );
+		Data_Events::register_handler( [ __CLASS__, 'set_is_donor' ], 'donation_new' );
+		Data_Events::register_handler( [ __CLASS__, 'set_is_former_donor' ], 'donation_subscription_cancelled' );
+		Data_Events::register_handler( [ __CLASS__, 'update_active_subscriptions' ], 'product_subscription_changed' );
+		Data_Events::register_handler( [ __CLASS__, 'update_active_memberships' ], 'membership_status_active' );
+		Data_Events::register_handler( [ __CLASS__, 'update_active_memberships' ], 'membership_status_inactive' );
 		Data_Events::register_handler( [ __CLASS__, 'check_newsletter_subscription' ], 'reader_logged_in' );
 		Data_Events::register_handler( [ __CLASS__, 'check_product_subscriptions' ], 'reader_logged_in' );
 		Data_Events::register_handler( [ __CLASS__, 'check_memberships' ], 'reader_logged_in' );
@@ -397,13 +395,13 @@ final class Reader_Data {
 	 * @param array $data      Data.
 	 */
 	public static function update_active_subscriptions( $timestamp, $data ) {
-		if ( empty( $data['user_id'] ) || empty( $data['subscription_id'] ) || empty( $data['product_ids'] ) ) {
+		if ( empty( $data['user_id'] ) || empty( $data['subscription_id'] ) || empty( $data['product_ids'] ) || empty( $data['status_after'] ) ) {
 			return;
 		}
 
 		$existing_subscriptions = self::get_data( $data['user_id'], 'active_subscriptions' );
 		$active_subscriptions   = $existing_subscriptions ? json_decode( $existing_subscriptions ) : [];
-		if ( empty( $data['status_after'] ) || 'active' === $data['status_after'] ) {
+		if ( 'active' === $data['status_after'] ) {
 			$active_subscriptions = array_merge( $active_subscriptions, $data['product_ids'] );
 		} else {
 			$active_subscriptions = array_values( array_diff( $active_subscriptions, $data['product_ids'] ) );
@@ -439,7 +437,7 @@ final class Reader_Data {
 		if ( empty( $active_subscriptions ) ) {
 			return;
 		}
-		
+
 		$subscription_products = [];
 		foreach ( $active_subscriptions as $subscription ) {
 			$subscription_products = array_merge( $subscription_products, \Newspack\WooCommerce_Connection::get_products_for_order( $subscription->get_id() ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#2804 fixed syncing of contact metadata for UTM data via purchases, but did not fix for registration via non-transactions. This PR fixes syncing of UTM fields for all registration and purchase-related events, and also does a bit of refactoring to consolidate data syncs in general into the ActiveCampaign and Mailchimp Data Events connectors. Currently, the data syncs are happening in a few different places using different triggers (a mix of Woo hooks, regular WP hooks, Newspack Newsletter hooks, and data events throughout different files). Consolidating them in data events should make it easier to see and control what triggers an ESP sync going forward. As part of this we've added some new data event listeners and tweaked some existing ones to make them a bit more standardized.

### How to test the changes in this Pull Request:

In new incognito sessions, perform the following actions from a URL with UTM parameters appended (e.g. `?utm_source=marketinglist&utm_medium=email&utm_campaign=2023-Newspack-Campaign`):

- Register for a new account via the Registration block without signing up for any newsletter lists
- Sign up for newsletter lists via the Subscription Form block or the Registration block
- Complete a one-time donation
- Complete a subscription donation
- Complete a non-donation non-subscription purchase
- Complete a non-donation subscription purchase

Make sure to repeat the above for both Mailchimp and ActiveCampaign (so the end result should be 12 new contacts). In each case, find the contact synced to the ESP and confirm that UTM metadata fields are synced. For registration-based actions, the field keys should start with `Signup UTM:`. For payment-based actions, the field keys should start with `Payment UTM:`.

Please also smoke test that logging into an existing account and making a renewal order on an active subscription also continue to trigger an ESP data sync as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206082237141820