### PR TITLE
fix(donations): prevent warning on coupon filter

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -1046,6 +1046,9 @@ class Donations {
 	 * @return bool
 	 */
 	public static function disable_coupons( $enabled ) {
+		if ( is_admin() ) {
+			return $enabled;
+		}
 		$cart = WC()->cart;
 		if ( ! $cart ) {
 			return $enabled;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `woocommerce_coupons_enabled` filter is also applied in the Woo settings page. This PR prevents the donation-related filter from running in this context.

### How to test the changes in this Pull Request:

1. While on the master branch, visit Woo settings page
2. Confirm you get the `wc_get_product was called incorrectly.` warning in the PHP logs
3. Check out this branch, refresh and confirm the warnings are gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->