### PR TITLE
fix(cover-fees): save order after setting total

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -61,6 +61,7 @@ class WooCommerce_Cover_Fees {
 		if ( isset( $data[ self::CUSTOM_FIELD_NAME ] ) && 1 === $data[ self::CUSTOM_FIELD_NAME ] ) {
 			$order->add_meta_data( self::WC_ORDER_META_NAME, 1 );
 			$order->set_total( self::get_total_with_fee( $order->get_total() ) );
+			$order->save();
 		}
 		return $order;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We've seen some orders where the order note was added, but the total not updated. While it's not clear what's causing the issue, it's a good practice to call `save()` on the order after updating it. 

### How to test the changes in this Pull Request:

Make a donation and opt in to cover the fees, observe that it goes through as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->