### PR TITLE
fix: alpha fixes

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -40,7 +40,7 @@ class WooCommerce_My_Account {
 		\add_action( 'init', [ __CLASS__, 'add_rewrite_endpoints' ] );
 		\add_action( 'woocommerce_account_' . self::BILLING_ENDPOINT . '_endpoint', [ __CLASS__, 'render_billing_template' ] );
 		\add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'my_account_menu_items' ], 1000 );
-		\add_filter( 'woocommerce_default_address_fields', [ __CLASS__, 'edit_address_required_fields' ] );
+		\add_filter( 'woocommerce_billing_fields', [ __CLASS__, 'edit_address_required_fields' ] );
 
 		// Reader Activation mods.
 		if ( Reader_Activation::is_enabled() ) {
@@ -485,7 +485,7 @@ class WooCommerce_My_Account {
 
 		$required_fields = Donations::get_billing_fields();
 		foreach ( $fields as $field_name => $field_config ) {
-			if ( ! in_array( 'billing_' . $field_name, $required_fields, true ) ) {
+			if ( ! in_array( $field_name, $required_fields, true ) ) {
 				$fields[ $field_name ]['required'] = false;
 			}
 		}

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -431,10 +431,19 @@ class WooCommerce_My_Account {
 	 * Add the necessary endpoints to rewrite rules.
 	 */
 	public static function add_rewrite_endpoints() {
+		$has_set_up_custom_billing_endpoint = \get_option( '_newspack_has_set_up_custom_billing_endpoint' );
+		if ( ! Donations::is_platform_stripe() ) {
+			if ( $has_set_up_custom_billing_endpoint ) {
+				\delete_option( '_newspack_has_set_up_custom_billing_endpoint' );
+				\flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+				Logger::log( 'Flushed rewrite rules to remove Stripe billing endpoint' );
+			}
+			return;
+		}
 		\add_rewrite_endpoint( self::BILLING_ENDPOINT, EP_PAGES );
-		if ( ! \get_option( '_newspack_has_set_up_custom_billing_endpoint' ) ) {
+		if ( ! $has_set_up_custom_billing_endpoint ) {
 			\flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
-			Logger::log( 'Flushed rewrite rules to add billing endpoint' );
+			Logger::log( 'Flushed rewrite rules to add Stripe billing endpoint' );
 			\update_option( '_newspack_has_set_up_custom_billing_endpoint', true );
 		}
 	}

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -40,6 +40,7 @@ class WooCommerce_My_Account {
 		\add_action( 'init', [ __CLASS__, 'add_rewrite_endpoints' ] );
 		\add_action( 'woocommerce_account_' . self::BILLING_ENDPOINT . '_endpoint', [ __CLASS__, 'render_billing_template' ] );
 		\add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'my_account_menu_items' ], 1000 );
+		\add_filter( 'woocommerce_default_address_fields', [ __CLASS__, 'edit_address_required_fields' ] );
 
 		// Reader Activation mods.
 		if ( Reader_Activation::is_enabled() ) {
@@ -461,6 +462,35 @@ class WooCommerce_My_Account {
 			];
 		}
 		return [];
+	}
+
+	/**
+	 * Ensure that only billing address fields enabled in Reader Revenue settings
+	 * are required in My Account edit billing address page.
+	 *
+	 * @param array $fields Address fields.
+	 * @return array Filtered address fields.
+	 */
+	public static function edit_address_required_fields( $fields ) {
+		global $wp;
+
+		if (
+			! function_exists( 'is_account_page' ) ||
+			! \is_account_page() || // Only on My Account page.
+			! isset( $wp->query_vars['edit-address'] ) || // Only when editing address.
+			'billing' !== $wp->query_vars['edit-address'] // Only when editing billing address.
+			) {
+			return $fields;
+		}
+
+		$required_fields = Donations::get_billing_fields();
+		foreach ( $fields as $field_name => $field_config ) {
+			if ( ! in_array( 'billing_' . $field_name, $required_fields, true ) ) {
+				$fields[ $field_name ]['required'] = false;
+			}
+		}
+
+		return $fields;
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -48,20 +48,6 @@ class WooCommerce_Cover_Fees {
 	}
 
 	/**
-	 * Persist the transaction fee selection in the Woo sesion when updating the
-	 * order review.
-	 *
-	 * @param string $posted_data Posted posted_data.
-	 */
-	public static function set_total_with_fees( $order, $data ) {
-		if ( isset( $data[ self::CUSTOM_FIELD_NAME ] ) && 1 === $data[ self::CUSTOM_FIELD_NAME ] ) {
-			$order->add_meta_data( self::WC_ORDER_META_NAME, 1 );
-			$order->set_total( self::get_total_with_fee( $order->get_total() ) );
-			$order->save();
-		}
-	}
-
-	/**
 	 * Add fee.
 	 *
 	 * @param \WC_Cart $cart Cart object.

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -48,6 +48,22 @@ class WooCommerce_Cover_Fees {
 	}
 
 	/**
+	 * Persist the transaction fee selection in the Woo sesion when updating the
+	 * order review.
+	 *
+	 * @param string $posted_data Posted posted_data.
+	 */
+	public static function persist_fee_selection( $posted_data ) {
+		$data = [];
+		parse_str( $posted_data, $data );
+		if ( self::should_apply_fee( $data ) ) {
+			\WC()->session->set( self::CUSTOM_FIELD_NAME, 1 );
+		} else {
+			\WC()->session->set( self::CUSTOM_FIELD_NAME, 0 );
+		}
+	}
+
+	/**
 	 * Add fee.
 	 *
 	 * @param \WC_Cart $cart Cart object.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes some issues resulting from a bad hotfix merge.

### How to test the changes in this Pull Request:

1. Follow testing instructions in #2820 and make sure they work
2. Follow testing instructions in #2733 and make sure they work
3. Re: [this comment](https://github.com/Automattic/newspack-plugin/pull/2835#pullrequestreview-1805563860), enable some but not all billing address fields in **Newspack > Reader Revenue > Donations**. 
4. Complete a purchase of a shippable product, then log into/verify My Account, then visit Addresses.
5. Confirm that when editing the **billing** address, only the fields enabled in Reader Revenue in step 3 are required, and that you can save with empty "optional" fields (but not with empty "required" fields).
6. Confirm that when editing the **shipping** address, all default address fields are still required.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->