### PR TITLE
fix(connections-wizard): error display

### DIFF
--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -19,6 +19,7 @@ import Webhooks from './webhooks';
 
 const Main = () => {
 	const [ error, setError ] = useState();
+	const setErrorWithPrefix = prefix => err => setError( err ? prefix + err : null );
 
 	return (
 		<>
@@ -27,18 +28,18 @@ const Main = () => {
 			<Plugins />
 			<SectionHeader title={ __( 'APIs', 'newspack' ) } />
 			{ newspack_connections_data.can_connect_google && (
-				<GoogleAuth setError={ err => setError( __( 'Google: ', 'newspack-plugin' ) + err ) } />
+				<GoogleAuth setError={ setErrorWithPrefix( __( 'Google: ', 'newspack-plugin' ) ) } />
 			) }
-			<Mailchimp setError={ err => setError( __( 'Mailchimp: ', 'newspack-plugin' ) + err ) } />
+			<Mailchimp setError={ setErrorWithPrefix( __( 'Mailchimp: ', 'newspack-plugin' ) ) } />
 			{ newspack_connections_data.can_connect_fivetran && (
 				<>
 					<SectionHeader title="Fivetran" />
 					<FivetranConnection
-						setError={ err => setError( __( 'FiveTran: ', 'newspack-plugin' ) + err ) }
+						setError={ setErrorWithPrefix( __( 'Fivetran: ', 'newspack-plugin' ) ) }
 					/>
 				</>
 			) }
-			<Recaptcha setError={ err => setError( __( 'reCAPTCHA: ', 'newspack-plugin' ) + err ) } />
+			<Recaptcha setError={ setErrorWithPrefix( __( 'reCAPTCHA: ', 'newspack-plugin' ) ) } />
 			<Webhooks />
 		</>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with false-positive error display in the Connections wizard. 

See 1200550061930446-as-1206088853297652

### How to test the changes in this Pull Request:

1. On `master`,
1. Mock the Google OAuth status response by returning early from `Google_OAuth::api_google_auth_status` – start with a success message (`return \rest_ensure_response($response)`
2. Load the Connections wizard, observe a `Google: undefined` error notice at the top of the view
3. Switch to this branch
4. Reload the wizard, observe no error
5. Mock an error response (`return new \WP_Error(…)`), observe it correctly displayed in the wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206088853297652