### PR TITLE
fix: prevent switch order synchronisation

### DIFF
--- a/includes/data-events/class-memberships.php
+++ b/includes/data-events/class-memberships.php
@@ -229,7 +229,10 @@ final class Memberships {
 	 */
 	public static function woocommerce_checkout_order_processed( $order_id ) {
 		$order = \wc_get_order( $order_id );
-		$data  = self::get_order_data( $order_id, $order );
+		if ( ! \Newspack\WooCommerce_Connection::should_sync_order( $order ) ) {
+			return;
+		}
+		$data = self::get_order_data( $order_id, $order );
 		if ( empty( $data ) ) {
 			return;
 		}

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -138,6 +138,9 @@ Data_Events::register_listener(
 		if ( ! $order ) {
 			return;
 		}
+		if ( ! \Newspack\WooCommerce_Connection::should_sync_order( $order ) ) {
+			return;
+		}
 		$recurrence      = get_post_meta( $product_id, '_subscription_period', true );
 		$is_renewal      = function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order );
 		$subscription_id = null;
@@ -242,7 +245,10 @@ Data_Events::register_listener(
 Data_Events::register_listener(
 	'woocommerce_order_status_completed',
 	'donation_new',
-	function( $order_id, $order ) {
+	function ( $order_id, $order ) {
+		if ( ! \Newspack\WooCommerce_Connection::should_sync_order( $order ) ) {
+			return;
+		}
 		$product_id = Donations::get_order_donation_product_id( $order_id );
 		if ( ! $product_id ) {
 			return;

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -336,6 +336,20 @@ class WooCommerce_Connection {
 	}
 
 	/**
+	 * Should an order be synchronized with the integrations?
+	 *
+	 * @param WC_Order $order Order object.
+	 */
+	public static function should_sync_order( $order ) {
+		if ( $order->get_meta( '_subscription_switch' ) ) {
+			// This is a "switch" order, which is just recording a subscription update. It has value of 0 and
+			// should not be synced anywhere.
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Sync a customer to the ESP from an order.
 	 *
 	 * @param WC_Order    $order Order object.
@@ -349,6 +363,10 @@ class WooCommerce_Connection {
 
 		if ( $verify_created_via && self::CREATED_VIA_NAME === $order->get_created_via() ) {
 			// Only sync orders not created via the Stripe integration.
+			return;
+		}
+
+		if ( ! self::should_sync_order( $order ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When a subscription is switched to a different amount, WC creates a "switch order", which is an order of 0 value. This order should not be synchronised to third parties, as it's not a real order.  

### How to test the changes in this Pull Request:

1. On `master`,
1. Allow subscription switching in WC Settings -> Subscriptions
2. Ensure logging is enabled (`NEWSPACK_LOG_LEVEL` set to `2`)
3. Run through the process of starting a donation subscription and updating its amount*
5. Observe in the logs that events are being dispatched, most importantly and ESP contact update
6. Switch to this branch, repeat, observe that the events are not being dispatched**
7. Make another recurring donation, observe events being dispatched as before

\* It's a confusing process – go to /my-account page, Subscriptions, then click "Change price", update the price, proceed to cart to "buy" the 0-value item
\** With the Newspack Network plugin active, `newspack_node_order_changed` event will be the only one dispatched

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206209020023382