### PR TITLE
feat: approved plugins list retrieval method

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -424,6 +424,16 @@ class Plugin_Manager {
 	}
 
 	/**
+	 * Get all managed and supported plugins' slugs.
+	 */
+	public static function get_approved_plugins_slugs() {
+		return array_merge(
+			array_keys( self::get_managed_plugins() ),
+			self::get_supported_plugins_slugs()
+		);
+	}
+
+	/**
 	 * Get info about all the unmanaged plugins that are installed.
 	 *
 	 * @return array of plugin info.


### PR DESCRIPTION
Add a method to retrieve all approved plugins. Test by running `\Newspack\Plugin_Manager::get_approved_plugins_slugs();` in a `wp shell` session. 