### PR TITLE
feat(ras): better reader display/nice names

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -26,11 +26,11 @@ final class Reader_Activation {
 	/**
 	 * Reader user meta keys.
 	 */
-	const READER                          = 'np_reader';
-	const EMAIL_VERIFIED                  = 'np_reader_email_verified';
-	const WITHOUT_PASSWORD                = 'np_reader_without_password';
-	const REGISTRATION_METHOD             = 'np_reader_registration_method';
-	const READER_HAS_GENERIC_DISPLAY_NAME = 'np_reader_has_generic_display_name';
+	const READER                            = 'np_reader';
+	const EMAIL_VERIFIED                    = 'np_reader_email_verified';
+	const WITHOUT_PASSWORD                  = 'np_reader_without_password';
+	const REGISTRATION_METHOD               = 'np_reader_registration_method';
+	const READER_SAVED_GENERIC_DISPLAY_NAME = 'np_reader_saved_generic_display_name';
 
 	/**
 	 * Unverified email rate limiting
@@ -1756,6 +1756,7 @@ final class Reader_Activation {
 				if ( empty( $userdata['display_name'] ) ) {
 					// If the reader lacks a display name, generate one.
 					$data['display_name'] = self::generate_user_nicename( $userdata['user_email'] );
+					\delete_user_meta( $user_id, self::READER_SAVED_GENERIC_DISPLAY_NAME );
 				} else {
 					// Otherwise, don't update it.
 					$data['display_name'] = $userdata['display_name'];
@@ -1767,7 +1768,7 @@ final class Reader_Activation {
 				self::generate_user_nicename( $userdata['user_email'] ) === $data['display_name'] || // New generated construction (URL-sanitized version of the email address minus domain).
 				self::strip_email_domain( $userdata['user_email'] ) === $data['display_name'] // Legacy generated construction (just the email address minus domain).
 			) {
-				\update_user_meta( $user_id, self::READER_HAS_GENERIC_DISPLAY_NAME, 1 );
+				\update_user_meta( $user_id, self::READER_SAVED_GENERIC_DISPLAY_NAME, 1 );
 			}
 		}
 
@@ -1830,7 +1831,7 @@ final class Reader_Activation {
 		}
 
 		// If the reader has intentionally saved a display name we consider generic, treat it as not generic.
-		if ( \get_user_meta( $user_id, self::READER_HAS_GENERIC_DISPLAY_NAME, true ) ) {
+		if ( \get_user_meta( $user_id, self::READER_SAVED_GENERIC_DISPLAY_NAME, true ) ) {
 			return false;
 		}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -81,7 +81,7 @@ final class Reader_Activation {
 			\add_action( 'init', [ __CLASS__, 'setup_nav_menu' ] );
 			\add_action( 'wc_get_template', [ __CLASS__, 'replace_woocommerce_auth_form' ], 10, 2 );
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
-			\add_filter( 'woocommerce_new_customer_data', [ __CLASS__, 'sanitize_user_data' ] );
+			\add_filter( 'woocommerce_new_customer_data', [ __CLASS__, 'canonize_user_data' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
 			\add_filter( 'woocommerce_email_actions', [ __CLASS__, 'disable_woocommerce_new_user_email' ] );
 			\add_filter( 'retrieve_password_notification_email', [ __CLASS__, 'password_reset_configuration' ], 10, 4 );
@@ -1620,7 +1620,7 @@ final class Reader_Activation {
 			/**
 			 * Create new reader.
 			 */
-			$user_data = self::sanitize_user_data(
+			$user_data = self::canonize_user_data(
 				[
 					'display_name' => $display_name,
 					'user_email'   => $email,
@@ -1697,7 +1697,7 @@ final class Reader_Activation {
 	 * @param array $user_data          Default args for the new user.
 	 *              $user_data['email] Email address for the new user (required).
 	 */
-	public static function sanitize_user_data( $user_data = [] ) {
+	public static function canonize_user_data( $user_data = [] ) {
 		if ( empty( $user_data['user_email'] ) ) {
 			return $user_data;
 		}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1756,6 +1756,10 @@ final class Reader_Activation {
 	 * @return bool True if the display name was generated.
 	 */
 	public static function reader_has_generic_display_name( $user_id = 0 ) {
+		// Allow an environment constant to override this check.
+		if ( defined( 'NEWSPACK_ALLOW_GENERIC_READER_DISPLAY_NAMES' ) && NEWSPACK_ALLOW_GENERIC_READER_DISPLAY_NAMES ) {
+			return false;
+		}
 		if ( ! $user_id ) {
 			$user_id = \get_current_user_id();
 		}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1726,7 +1726,7 @@ final class Reader_Activation {
 		 * Filters the user_data used to register a new RAS reader account.
 		 * See https://developer.wordpress.org/reference/functions/wp_insert_user/ for supported args.
 		 */
-		return apply_filters( 'newspack_register_reader_user_data', $user_data );
+		return \apply_filters( 'newspack_register_reader_user_data', $user_data );
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -81,7 +81,7 @@ final class Reader_Activation {
 			\add_action( 'init', [ __CLASS__, 'setup_nav_menu' ] );
 			\add_action( 'wc_get_template', [ __CLASS__, 'replace_woocommerce_auth_form' ], 10, 2 );
 			\add_action( 'template_redirect', [ __CLASS__, 'process_auth_form' ] );
-			\add_filter( 'woocommerce_new_customer_data', [ __CLASS__, 'get_user_data' ] );
+			\add_filter( 'woocommerce_new_customer_data', [ __CLASS__, 'sanitize_user_data' ] );
 			\add_filter( 'amp_native_post_form_allowed', '__return_true' );
 			\add_filter( 'woocommerce_email_actions', [ __CLASS__, 'disable_woocommerce_new_user_email' ] );
 			\add_filter( 'retrieve_password_notification_email', [ __CLASS__, 'password_reset_configuration' ], 10, 4 );
@@ -1620,7 +1620,7 @@ final class Reader_Activation {
 			/**
 			 * Create new reader.
 			 */
-			$user_data = self::get_user_data(
+			$user_data = self::sanitize_user_data(
 				[
 					'display_name' => $display_name,
 					'user_email'   => $email,
@@ -1691,13 +1691,13 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Get user data args for creating a new WP user.
+	 * Get sanitized user data args for creating a new reader user account.
 	 * See https://developer.wordpress.org/reference/functions/wp_insert_user/ for supported args.
 	 *
 	 * @param array $user_data          Default args for the new user.
 	 *              $user_data['email] Email address for the new user (required).
 	 */
-	public static function get_user_data( $user_data = [] ) {
+	public static function sanitize_user_data( $user_data = [] ) {
 		if ( empty( $user_data['user_email'] ) ) {
 			return $user_data;
 		}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1620,11 +1620,11 @@ final class Reader_Activation {
 			 * Create new reader.
 			 */
 			if ( empty( $display_name ) ) {
-				$display_name = explode( '@', $email, 2 )[0];
+				$display_name = \sanitize_email( $email );
 			}
 
-			$user_login = \sanitize_user( $email, true );
-
+			$user_login      = \sanitize_user( $email );
+			$user_nicename   = \sanitize_title( \sanitize_user( strstr( $display_name, '@', true ), true ) );
 			$random_password = \wp_generate_password();
 
 			if ( function_exists( '\wc_create_new_customer' ) ) {
@@ -1637,10 +1637,11 @@ final class Reader_Activation {
 			} else {
 				$user_id = \wp_insert_user(
 					[
-						'user_login'   => $user_login,
-						'user_email'   => $email,
-						'user_pass'    => $random_password,
-						'display_name' => $display_name,
+						'user_login'    => $user_login,
+						'user_email'    => $email,
+						'user_pass'     => $random_password,
+						'user_nicename' => $user_nicename,
+						'display_name'  => $display_name,
 					]
 				);
 				\wp_new_user_notification( $user_id, null, 'user' );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1699,7 +1699,7 @@ final class Reader_Activation {
 	 */
 	public static function get_user_data( $user_data = [] ) {
 		if ( empty( $user_data['user_email'] ) ) {
-			return new \WP_Error( 'newspack_register_reader_empty_email', __( 'Please enter a valid email address.', 'newspack-plugin' ) );
+			return $user_data;
 		}
 
 		// If we don't have a display name, make it match the email address.

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -662,8 +662,8 @@ final class Reader_Activation {
 	/**
 	 * Whether the user is a reader.
 	 *
-	 * @param \WP_User $user   User object.
-	 * @param bool     $strict Whether to check if the user was created through reader registration. Default false.
+	 * @param WP_User $user   User object.
+	 * @param bool    $strict Whether to check if the user was created through reader registration. Default false.
 	 *
 	 * @return bool Whether the user is a reader.
 	 */
@@ -1761,14 +1761,6 @@ final class Reader_Activation {
 					// Otherwise, don't update it.
 					$data['display_name'] = $userdata['display_name'];
 				}
-			}
-
-			// If the reader has intentionally saved a display name we consider generic, mark it as such.
-			if (
-				self::generate_user_nicename( $userdata['user_email'] ) === $data['display_name'] || // New generated construction (URL-sanitized version of the email address minus domain).
-				self::strip_email_domain( $userdata['user_email'] ) === $data['display_name'] // Legacy generated construction (just the email address minus domain).
-			) {
-				\update_user_meta( $user_id, self::READER_SAVED_GENERIC_DISPLAY_NAME, 1 );
 			}
 		}
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -457,15 +457,16 @@ class WooCommerce_My_Account {
 	public static function remove_required_fields( $required_fields ) {
 		if ( Donations::is_platform_wc() ) {
 			$newspack_required_fields = [
-				'account_email' => __( 'Email address', 'newspack-plugin' ),
+				'account_email'        => __( 'Email address', 'newspack-plugin' ),
+				'account_display_name' => __( 'Display name', 'newspack-plugin' ),
 			];
 
-			// Require display name only if user account has real, non-generated one.
-			if ( ! Reader_Activation::reader_has_generic_display_name() ) {
-				$newspack_required_fields['account_display_name'] = __( 'Display name', 'newspack-plugin' );
-			}
-
-			return $newspack_required_fields;
+			/**
+			 * Filters the fields required when editing account details in My Account.
+			 *
+			 * @param array $newspack_required_fields Required fields, keyed by field name.
+			 */
+			return \apply_filters( 'newspack_myaccount_required_fields', $newspack_required_fields );
 		}
 		return $required_fields;
 	}

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -54,6 +54,7 @@ class WooCommerce_My_Account {
 			\add_action( 'template_redirect', [ __CLASS__, 'edit_account_prevent_email_update' ] );
 			\add_action( 'init', [ __CLASS__, 'restrict_account_content' ], 100 );
 			\add_filter( 'woocommerce_save_account_details_required_fields', [ __CLASS__, 'remove_required_fields' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'verify_saved_account_details' ] );
 			\add_action( 'logout_redirect', [ __CLASS__, 'add_param_after_logout' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'show_message_after_logout' ] );
 		}
@@ -469,6 +470,37 @@ class WooCommerce_My_Account {
 			return \apply_filters( 'newspack_myaccount_required_fields', $newspack_required_fields );
 		}
 		return $required_fields;
+	}
+
+	/**
+	 * Intercept account details saved by the reader in My Account.
+	 */
+	public static function verify_saved_account_details() {
+		$action       = filter_input( INPUT_POST, 'action', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$display_name = filter_input( INPUT_POST, 'account_display_name', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$email        = filter_input( INPUT_POST, 'account_email', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+
+		if ( empty( $action ) || 'save_account_details' !== $action || empty( $display_name ) || empty( $email ) ) {
+			return;
+		}
+
+		$user_id = \get_current_user_id();
+		if ( $user_id <= 0 ) {
+			return;
+		}
+
+		$user = \get_user_by( 'id', $user_id );
+		if ( ! Reader_Activation::is_user_reader( $user ) || $user->data->user_email !== $email ) {
+			return false;
+		}
+
+		// If the reader has intentionally saved a display name we consider generic, mark it as such.
+		if (
+			Reader_Activation::generate_user_nicename( $email ) === $display_name || // New generated construction (URL-sanitized version of the email address minus domain).
+			Reader_Activation::strip_email_domain( $email ) === $display_name // Legacy generated construction (just the email address minus domain).
+		) {
+			\update_user_meta( $user_id, Reader_Activation::READER_SAVED_GENERIC_DISPLAY_NAME, 1 );
+		}
 	}
 
 	/**

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -456,12 +456,18 @@ class WooCommerce_My_Account {
 	 */
 	public static function remove_required_fields( $required_fields ) {
 		if ( Donations::is_platform_wc() ) {
-			return [
-				'account_display_name' => __( 'Display name', 'newspack-plugin' ),
-				'account_email'        => __( 'Email address', 'newspack-plugin' ),
+			$newspack_required_fields = [
+				'account_email' => __( 'Email address', 'newspack-plugin' ),
 			];
+
+			// Require display name only if user account has real, non-generated one.
+			if ( ! Reader_Activation::reader_has_generic_display_name() ) {
+				$newspack_required_fields['account_display_name'] = __( 'Display name', 'newspack-plugin' );
+			}
+
+			return $newspack_required_fields;
 		}
-		return [];
+		return $required_fields;
 	}
 
 	/**
@@ -520,6 +526,10 @@ class WooCommerce_My_Account {
 	 * Restrict account content for unverified readers.
 	 */
 	public static function restrict_account_content() {
+		if ( defined( 'NEWSPACK_ALLOW_MY_ACCOUNT_ACCESS_WITHOUT_VERIFICATION' ) && NEWSPACK_ALLOW_MY_ACCOUNT_ACCESS_WITHOUT_VERIFICATION ) {
+			return;
+		}
+
 		if ( \is_user_logged_in() && ! self::is_user_verified() ) {
 			\remove_all_actions( 'woocommerce_account_content' );
 			\add_action(

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -47,15 +47,22 @@ endif;
 
 	<?php \do_action( 'newspack_woocommerce_edit_account_form_start' ); ?>
 
-	<?php if ( ! Reader_Activation::reader_has_generic_display_name() ) : ?>
 	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mt0">
 		<label for="account_display_name"><?php \esc_html_e( 'Display name', 'newspack-plugin' ); ?>&nbsp;<span class="required">*</span></label>
-		<input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="account_display_name" id="account_display_name" autocomplete="name" value="<?php echo \esc_attr( $user->display_name ); ?>" />
+		<input
+			type="text"
+			class="woocommerce-Input woocommerce-Input--text input-text"
+			name="account_display_name"
+			id="account_display_name"
+			autocomplete="name"
+			placeholder="<?php esc_attr_e( 'Your Name', 'newspack-plugin' ); ?>"
+			value="<?php echo ! Reader_Activation::reader_has_generic_display_name() ? \esc_attr( $user->display_name ) : ''; ?>"
+		/>
+		<span><em><?php esc_html_e( 'This is how your name is displayed publicly.', 'woocommerce' ); ?></em></span>
 	</p>
-	<?php endif; ?>
 
 	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mt0">
-		<label for="account_email_display"><?php \esc_html_e( 'Email address', 'newspack-plugin' ); ?>&nbsp;<span class="required">*</span></label>
+		<label for="account_email_display"><?php \esc_html_e( 'Email address', 'newspack-plugin' ); ?>
 		<input type="email" disabled class="woocommerce-Input woocommerce-Input--email input-text" name="account_email_display" id="account_email_display" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
 		<input type="hidden" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
 	</p>

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -47,12 +47,14 @@ endif;
 
 	<?php \do_action( 'newspack_woocommerce_edit_account_form_start' ); ?>
 
+	<?php if ( ! Reader_Activation::reader_has_generic_display_name() ) : ?>
 	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mt0">
 		<label for="account_display_name"><?php \esc_html_e( 'Display name', 'newspack-plugin' ); ?>&nbsp;<span class="required">*</span></label>
 		<input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="account_display_name" id="account_display_name" autocomplete="name" value="<?php echo \esc_attr( $user->display_name ); ?>" />
 	</p>
+	<?php endif; ?>
 
-	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mt0">
 		<label for="account_email_display"><?php \esc_html_e( 'Email address', 'newspack-plugin' ); ?>&nbsp;<span class="required">*</span></label>
 		<input type="email" disabled class="woocommerce-Input woocommerce-Input--email input-text" name="account_email_display" id="account_email_display" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
 		<input type="hidden" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks and standardizes the logic that generates default user display names (updatable by the user), nicenames (the slug used for author archive pages, which shouldn't affect reader accounts unless they're upgraded to an author/editor/admin role), and login strings (never updatable) when registering a new RAS reader account. This only affects newly registered accounts going forward, not preexisting accounts unless they make a purchase and provide a billing name to reset the display name.

Also adds support for a new environment constant, mainly for dev convenience, but could also be used by publishers if the behavior is desired. If `NEWSPACK_ALLOW_MY_ACCOUNT_ACCESS_WITHOUT_VERIFICATION` is defined and true, My Account will allow logged-in users to access and update account settings without requiring verification via email.

Another new environment constant `NEWSPACK_ALLOW_GENERIC_READER_DISPLAY_NAMES` allows generated display names to be shown in My Account, if the publisher desires.

Two new filters allow for further customization of behavior on a per-site basis:

- `newspack_register_reader_user_data` filters the user data array right before the reader account is created by [`wp_insert_user`](https://developer.wordpress.org/reference/functions/wp_insert_user/)
- `newspack_myaccount_required_fields` filters the fields required for saving account details in My Account. Currently we only show and require Display Name and Email, but this could theoretically be changed via a custom plugin using this filter plus a custom `form-edit-account.php` template.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. In a new session, register a reader via the Registration block or auth modal (which accepts an email address only). Note the user ID of the generated account for the next step.
3. Run `wp shell` and then `get_userdata( $user_id )`. Confirm that the user's data looks like the following:
  - `user_login`: Matches the user's email address.
  - `user_nicename`: A URL-sanitized version of the user's email address, minus the domain (everything up to the `@`). Unfortunately this can't be updated once the user has been created.
  - `display_name`: Matches the `user_nicename`.

4. Log into this user's account and confirm that the "Display Name" field here renders blank (the generated display name isn't shown). Confirm that if you try to click "save changes" without filling out Display Name, you get the "Display Name is a required field" error (no reason not to require it for saving since it's the only field we show—this might even encourage people to enter a true value). 

<img width="773" alt="Screenshot 2024-01-15 at 3 22 11 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/16c4fb96-3c15-4e11-8d6e-a8b917f744b3">

5. In the same session, complete a new purchase with billing names (to test updating an existing user account upon purchase). Then go to My Account, verify if needed, and confirm that the display name is shown with the billing name value, and that you can update it to something else, as long as it's not empty or the same as the reader's email address—if the latter, you should see an error message like this:

<img width="768" alt="Screenshot 2024-01-15 at 3 12 57 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/ceca0a6e-c1af-414d-bcd2-e0778ea81319">

6. Still in the same session while in My Account, enter a "generic" display name (such as the email address minus the `@domain` part) and save, and confirm that it's now shown for this user. If the the reader intentionally saves a display name that matches our generated ones, we add a user meta value that tells us this so we can treat this value as the reader's preferred display name. 
7. In a new session, complete a purchase including billing first name + last name (to test new user registration upon purchase).
8.  Run `wp shell` and then `get_userdata( $user_id )`. Confirm that the user's data looks like the following:
  - `display_name`: Matches the user's full name (billing first + last names).
  - `user_login`: Matches the user's email address.
  - `user_nicename`: A URL-sanitized version of the user's display name (e.g. `firstname-lastname`).
9. Go to My Account, verify as needed, and confirm that you can see and update the display name.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->