### PR TITLE
fix(plugins): incorrect plugin slug for Distributor

### DIFF
--- a/assets/wizards/syndication/views/intro/index.js
+++ b/assets/wizards/syndication/views/intro/index.js
@@ -38,7 +38,7 @@ const Intro = () => {
 					'publish-to-apple-news': {
 						name: __( 'Apple News', 'newspack' ),
 					},
-					'distributor-stable': {
+					distributor: {
 						name: __( 'Distributor', 'newspack' ),
 					},
 				} }

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -263,7 +263,7 @@ class Plugin_Manager {
 				'PluginURI'   => esc_url( 'https://wordpress.org/plugins/simple-local-avatars/' ),
 				'Download'    => 'wporg',
 			],
-			'distributor-stable'          => [
+			'distributor'                 => [
 				'Name'        => esc_html__( 'Distributor', 'newspack' ),
 				'Description' => esc_html__( 'Distributor is a WordPress plugin that makes it easy to syndicate and reuse content across your websites — whether in a single multisite or across the web.', 'newspack' ),
 				'Author'      => '10up',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the plugin slug for [Distributor](https://github.com/10up/distributor/) so it matches the current plugin slug (it changed sometime in the past two years). The persistence of the old slug is causing duplicate plugin entries to appear on some sites.

### How to test the changes in this Pull Request:

1. Install/activate the [current release build](https://github.com/Automattic/newspack-plugin/releases/latest) on a fresh JN or other test site. Go through setup or run `wp newspack setup` in CLI to skip the onboarding.
2. Go to WP Admin > Plugins and find the entry for Distributor. Install it using the provided link.
3. In CLI, observe that the plugin was installed to a `wp-content/plugins/distributor-stable` directory. This slug is no longer used by Distributor releases.
4. Check out this branch, build with `npm run release:archive`, and install on the test site.
5. Go to WP Admin > Plugins and observe two entries for Distributor.
6. Delete the `distributor-stable` folder and install Distributor from the link in the Plugins page.
7. Confirm that this time, it was installed to `wp-content/plugins/distributor`, which matches the plugin's slug in newer release packages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->