### PR TITLE
feat: add cli command to fix stripe covered fees

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * CLI tools for the woocommerce support
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Order UTM class.
+ */
+class WooCommerce_Cli {
+
+	/**
+	 * Lists the subscriptions that needs to be fixed by the fix_subscriptions_missing_fee command.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, csv, json, count, yaml. Default: table
+	 *
+	 * @param array $args Args.
+	 * @param array $assoc_args Assoc args.
+	 */
+	public function list_subscriptions_missing_fee( $args, $assoc_args ) {
+
+		$format = isset( $assoc_args['format'] ) ? $assoc_args['format'] : 'table';
+
+		$subscriptions = $this->get_all_old_subscriptions();
+
+		$subscriptions = array_filter(
+			$subscriptions,
+			function( $subscription ) {
+				return empty( $subscription->get_fees() );
+			}
+		);
+
+		if ( empty( $subscriptions ) ) {
+			WP_CLI::success( 'No subscriptions missing fees found.' );
+			return;
+		}
+
+		WP_CLI::success( 'Subscriptions missing fees:' );
+		$this->output_subscriptions( $subscriptions, $format );
+
+	}
+
+	/**
+	 * Lists the subscriptions that were already fixed by the fix_subscriptions_missing_fee command.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, csv, json, count, yaml. Default: table
+	 *
+	 * @param array $args Args.
+	 * @param array $assoc_args Assoc args.
+	 */
+	public function list_subscriptions_missing_fee_fixed( $args, $assoc_args ) {
+
+		$format = isset( $assoc_args['format'] ) ? $assoc_args['format'] : 'table';
+
+		$subscriptions = $this->get_all_old_subscriptions();
+
+		$subscriptions = array_filter(
+			$subscriptions,
+			function( $subscription ) {
+				return ! empty( $subscription->get_fees() );
+			}
+		);
+
+		if ( empty( $subscriptions ) ) {
+			WP_CLI::success( 'No subscriptions missing fees found.' );
+			return;
+		}
+
+		WP_CLI::success( 'Fixed subscriptions that had missing fees:' );
+		$this->output_subscriptions( $subscriptions, $format );
+
+	}
+
+	/**
+	 * Updates the subscriptions that had the Stripe cover fee option added in the old way.
+	 *
+	 * Will look for all subcriptions that had fees added in the old way and fix them.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : If set, no changes will be made.
+	 *
+	 * @param [type] $args Args.
+	 * @param [type] $assoc_args Assoc args.
+	 */
+	public function fix_subscriptions_missing_fee( $args, $assoc_args ) {
+
+		$dry_run = isset( $assoc_args['dry-run'] ) && $assoc_args['dry-run'];
+
+		if ( ! $dry_run ) {
+			WP_CLI::line( 'This command will modify the database.' );
+			WP_CLI::line( 'Consider running it with --dry-run first to see what it will do.' );
+			WP_CLI::confirm( 'Are you sure you want to continue?', $assoc_args );
+		}
+
+		$subscriptions = $this->get_all_old_subscriptions();
+
+		$subscriptions = array_filter(
+			$subscriptions,
+			function( $subscription ) {
+				return empty( $subscription->get_fees() );
+			}
+		);
+
+		if ( empty( $subscriptions ) ) {
+			WP_CLI::success( 'No subscriptions missing fees found.' );
+			return;
+		}
+
+		foreach ( $subscriptions as $subscription ) {
+
+			WP_CLI::success( 'Fixing subscription #' . $subscription->get_id() );
+			WP_CLI::log( 'Subscription total is ' . $subscription->get_total() );
+
+			$fee_value = WooCommerce_Cover_Fees::get_fee_value( $subscription->get_total() );
+			WP_CLI::log( 'Fee value will be: ' . $fee_value );
+
+			$fee_display_value = WooCommerce_Cover_Fees::get_fee_display_value( $subscription->get_total() );
+			WP_CLI::log( 'Fee display value will be: ' . $fee_display_value );
+
+			$new_total = WooCommerce_Cover_Fees::get_total_with_fee( $subscription->get_total() );
+			WP_CLI::log( 'Subscription new total will be: ' . $new_total );
+
+			if ( $dry_run ) {
+				WP_CLI::warning( 'Dry run, not saving.' );
+				continue;
+			}
+
+			$fee_name = sprintf(
+				// Translators: %s is the fee percentage.
+				__( 'Transaction fee (%s)', 'newspack-plugin' ),
+				$fee_display_value
+			);
+
+			$fee = (object) [
+				'name'     => $fee_name,
+				'amount'   => $fee_value,
+				'tax'      => '',
+				'taxable'  => false,
+				'tax_data' => '',
+			];
+
+			$subscription->add_fee( $fee );
+			$subscription->legacy_set_total( $new_total );
+			$subscription->add_order_note( 'Subscription fee fixed and added via script' );
+			// No need to save, we don't want to trigger any hooks.
+
+			WP_CLI::success( 'Subscription #' . $subscription->get_id() . ' fixed.' );
+			WP_CLI::log( '' );
+		}
+
+	}
+
+	/**
+	 * Outputs a list of subscription in CLI
+	 *
+	 * @param WC_Subscription[] $subscriptions The subscriptions.
+	 * @param string            $format The output format.
+	 * @return void
+	 */
+	private function output_subscriptions( $subscriptions, $format = 'table' ) {
+		$subscriptions = array_map(
+			function( $subscription ) {
+				return [
+					'id'     => $subscription->get_id(),
+					'amount' => $subscription->get_total(),
+				];
+			},
+			$subscriptions
+		);
+
+		WP_CLI\Utils\format_items( $format, $subscriptions, [ 'id', 'amount' ] );
+	}
+
+	/**
+	 * Get all subscriptions that had the Stripe cover fee option added in the old way.
+	 *
+	 * We look at the order notes, and not the subscription meta, because there was a bug where the meta was not stored sometimes.
+	 *
+	 * @return ?WP_Subscription[] The subscriptions.
+	 */
+	private function get_all_old_subscriptions() {
+		global $wpdb;
+
+		// phpcs:ignore
+		$parent_order_ids = $wpdb->get_col(
+			"SELECT comment_post_ID FROM {$wpdb->comments} WHERE comment_content LIKE '%transaction fee. The total amount will be updated.'"
+		);
+
+		$subscriptions = [];
+
+		foreach ( $parent_order_ids as $parent_order_id ) {
+			$subs = wcs_get_subscriptions_for_order( $parent_order_id );
+			if ( is_array( $subs ) && ! empty( $subs ) ) {
+				$subscriptions[] = array_shift( $subs );
+			}
+		}
+
+		return $subscriptions;
+
+	}
+
+
+}

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -175,16 +175,19 @@ class WooCommerce_Cli {
 	private function output_subscriptions( $subscriptions, $format = 'table' ) {
 		$subscriptions = array_map(
 			function( $subscription ) {
+				$user  = $subscription->get_user();
+				$email = $user instanceof \WP_User ? $user->user_email : 'guest';
 				return [
 					'id'           => $subscription->get_id(),
 					'date_created' => $subscription->get_date_created()->__toString(),
 					'amount'       => $subscription->get_total(),
+					'user_email'   => $email,
 				];
 			},
 			$subscriptions
 		);
 
-		WP_CLI\Utils\format_items( $format, $subscriptions, [ 'id', 'amount', 'date_created' ] );
+		WP_CLI\Utils\format_items( $format, $subscriptions, [ 'id', 'amount', 'user_email', 'date_created' ] );
 		WP_CLI::log( count( $subscriptions ) . ' subscriptions found.' );
 	}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -157,6 +157,7 @@ class WooCommerce_Cli {
 			$subscription->add_fee( $fee );
 			$subscription->legacy_set_total( $new_total );
 			$subscription->add_order_note( 'Subscription fee fixed and added via script' );
+			update_post_meta( $subscription->get_id(), '_newspack_fixed_subscription_fees', 1 );
 			// No need to save, we don't want to trigger any hooks.
 
 			WP_CLI::success( 'Subscription #' . $subscription->get_id() . ' fixed.' );

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -176,14 +176,16 @@ class WooCommerce_Cli {
 		$subscriptions = array_map(
 			function( $subscription ) {
 				return [
-					'id'     => $subscription->get_id(),
-					'amount' => $subscription->get_total(),
+					'id'           => $subscription->get_id(),
+					'date_created' => $subscription->get_date_created()->__toString(),
+					'amount'       => $subscription->get_total(),
 				];
 			},
 			$subscriptions
 		);
 
-		WP_CLI\Utils\format_items( $format, $subscriptions, [ 'id', 'amount' ] );
+		WP_CLI\Utils\format_items( $format, $subscriptions, [ 'id', 'amount', 'date_created' ] );
+		WP_CLI::log( count( $subscriptions ) . ' subscriptions found.' );
 	}
 
 	/**
@@ -202,11 +204,16 @@ class WooCommerce_Cli {
 		);
 
 		$subscriptions = [];
+		$ids           = [];
 
 		foreach ( $parent_order_ids as $parent_order_id ) {
 			$subs = wcs_get_subscriptions_for_order( $parent_order_id );
 			if ( is_array( $subs ) && ! empty( $subs ) ) {
-				$subscriptions[] = array_shift( $subs );
+				$sub = array_shift( $subs );
+				if ( ! in_array( $sub->get_id(), $ids, true ) ) {
+					$subscriptions[] = $sub;
+					$ids[]           = $sub->get_id();
+				}
 			}
 		}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -41,6 +41,7 @@ class WooCommerce_Connection {
 	public static function init() {
 		include_once __DIR__ . '/class-woocommerce-order-utm.php';
 		include_once __DIR__ . '/class-woocommerce-cover-fees.php';
+		include_once __DIR__ . '/class-woocommerce-cli.php';
 
 		\add_action( 'admin_init', [ __CLASS__, 'disable_woocommerce_setup' ] );
 		\add_filter( 'option_woocommerce_subscriptions_allow_switching', [ __CLASS__, 'force_allow_subscription_switching' ], 10, 2 );
@@ -50,6 +51,7 @@ class WooCommerce_Connection {
 		\add_filter( 'default_option_woocommerce_subscriptions_allow_switching_nyp_price', [ __CLASS__, 'force_allow_subscription_switching' ], 10, 2 );
 		\add_filter( 'default_option_woocommerce_subscriptions_enable_retry', [ __CLASS__, 'force_allow_failed_payment_retry' ] );
 		\add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'send_customizable_receipt_email' ], 10, 3 );
+		\add_action( 'cli_init', [ __CLASS__, 'register_cli_commands' ] );
 
 		// WooCommerce Subscriptions.
 		\add_action( 'add_meta_boxes', [ __CLASS__, 'remove_subscriptions_schedule_meta_box' ], 45 );
@@ -70,6 +72,15 @@ class WooCommerce_Connection {
 		\add_action( 'option_woocommerce_subscriptions_failed_scheduled_actions', [ __CLASS__, 'filter_subscription_scheduled_actions_errors' ] );
 
 		\add_action( 'wp_login', [ __CLASS__, 'sync_reader_on_customer_login' ], 10, 2 );
+	}
+
+	/**
+	 * Register CLI command
+	 *
+	 * @return void
+	 */
+	public static function register_cli_commands() {
+		\WP_CLI::add_command( 'newspack-woocommerce', 'Newspack\\WooCommerce_Cli' );
 	}
 
 	/**
@@ -1172,9 +1183,9 @@ class WooCommerce_Connection {
 	/**
 	 * Force option for allowing retries for failed payments to ON unless the
 	 * NEWSPACK_PREVENT_WC_ALLOW_FAILED_PAYMENT_RETRIES_OVERRIDE constant is set.
-	 * 
+	 *
 	 * See: https://woo.com/document/subscriptions/failed-payment-retry/
-	 * 
+	 *
 	 * @param bool $should_retry Whether WooCommerce should automatically retry failed payments.
 	 *
 	 * @return string Option value.

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -79,9 +79,9 @@ class WooCommerce_Cover_Fees {
 			sprintf(
 				// Translators: %s is the fee percentage.
 				__( 'Transaction fee (%s)', 'newspack-plugin' ),
-				self::get_fee_display_value()
+				self::get_cart_fee_display_value()
 			),
-			self::get_fee_value()
+			self::get_cart_fee_value()
 		);
 	}
 
@@ -175,7 +175,7 @@ class WooCommerce_Cover_Fees {
 								'I’d like to cover the %1$s transaction fee to ensure my full donation goes towards %2$s mission.',
 								'newspack-plugin'
 							),
-							esc_html( self::get_fee_display_value() ),
+							esc_html( self::get_cart_fee_display_value() ),
 							esc_html( self::get_possessive( get_option( 'blogname' ) ) )
 						);
 					}
@@ -236,10 +236,11 @@ class WooCommerce_Cover_Fees {
 
 	/**
 	 * Get the fee display value.
+	 *
+	 * @param float $subtotal The subtotal to calculate the fee for.
 	 */
-	public static function get_fee_display_value() {
-		$subtotal = WC()->cart->get_subtotal();
-		$total    = self::get_total_with_fee();
+	public static function get_fee_display_value( $subtotal ) {
+		$total = self::get_total_with_fee( $subtotal );
 		// Just one decimal place, please.
 		$flat_percentage = (float) number_format( ( ( $total - $subtotal ) * 100 ) / $subtotal, 1 );
 		return $flat_percentage . '%';
@@ -247,11 +248,12 @@ class WooCommerce_Cover_Fees {
 
 	/**
 	 * Get the fee value.
+	 *
+	 * @param float $subtotal The subtotal to calculate the fee for.
 	 */
-	public static function get_fee_value() {
+	public static function get_fee_value( $subtotal ) {
 		$fee_multiplier = self::get_stripe_fee_multiplier_value();
 		$fee_static     = self::get_stripe_fee_static_value();
-		$subtotal       = WC()->cart->get_subtotal();
 		$fee            = ( ( ( $subtotal + $fee_static ) / ( 100 - $fee_multiplier ) ) * 100 - $subtotal );
 		return $fee;
 	}
@@ -259,10 +261,38 @@ class WooCommerce_Cover_Fees {
 	/**
 	 * Calculate the adjusted total, taking the fee into account.
 	 *
+	 * @param float $subtotal The subtotal to calculate the total for.
 	 * @return float
 	 */
-	private static function get_total_with_fee() {
-		return WC()->cart->get_subtotal() + self::get_fee_value();
+	public static function get_total_with_fee( $subtotal ) {
+		return $subtotal + self::get_fee_value( $subtotal );
+	}
+
+	/**
+	 * Get the fee value for the current cart.
+	 *
+	 * @return float
+	 */
+	public static function get_cart_fee_value() {
+		return self::get_fee_value( WC()->cart->get_subtotal() );
+	}
+
+	/**
+	 * Get the fee display value for the current cart.
+	 *
+	 * @return string
+	 */
+	public static function get_cart_fee_display_value() {
+		return self::get_fee_display_value( WC()->cart->get_subtotal() );
+	}
+
+	/**
+	 * Get the total with fee for the current cart.
+	 *
+	 * @return float
+	 */
+	public static function get_cart_total_with_fee() {
+		return self::get_total_with_fee( WC()->cart->get_subtotal() );
 	}
 }
 WooCommerce_Cover_Fees::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Since https://github.com/Automattic/newspack-plugin/pull/2820 we use an actual woocommerce Fee to add the Stripe fee to the order. Before that, we would manually add the fee to the order total if a metadata was present.

We didn't take into account the need to update existing subscriptions so that renewal orders will also get the fee added. (we assumed they would copy from the Sub's parent order, but they don't).

This PR adds a CLI command to migrate the subscriptions that had fees added the old way to the new way.

It's a CLI command because it should affect few subscriptions in a few sites.

### How to test the changes in this Pull Request:

1. Checkout the plugin in the version prior to #2820 `git checkout v2.12.0`
2. Make sure the option for the donor to cover fees is enabled
3. Make a recurring donation covering Stripe fees
4. Checkout master or this branch
5. Force the subscription to renewal and verify the total of the renewal order does not include the fee
6. Run the commands in this PR to and confirm the subscription is listed to be fixed, and that the fix is applied
7. `wp newspack-woocommerce list_subscriptions_missing_fee` should list the subscription
8. `wp newspack-woocommerce fix_subscriptions_missing_fee --dry-run` should output what the fix will look like
9.  `wp newspack-woocommerce fix_subscriptions_missing_fee` should fix it
10. Go back to the admin, see the subscription, verify that the fee is there and the total is updated
11. Force a renewal and confirm the renewal order has the fee
12. Also test a new recurring subscription on this branch with fees covered, and its renewal orders, to make sure we didn't break anything

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->