### PR TITLE
hotfix(optional-modules): ensure the switch to media-partners can happen

### DIFF
--- a/includes/optional-modules/class-media-partners.php
+++ b/includes/optional-modules/class-media-partners.php
@@ -18,17 +18,13 @@ class Media_Partners {
 	 * Initialize everything.
 	 */
 	public static function init() {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			include_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
+		add_action( 'admin_init', [ __CLASS__, 'switch_from_standalone_plugin' ] );
 
 		if ( ! Settings::is_optional_module_active( 'media-partners' ) ) {
 			return;
 		}
 
-		add_action( 'admin_init', [ __CLASS__, 'switch_from_standalone_plugin' ] );
 		add_action( 'init', [ __CLASS__, 'register_taxonomies' ] );
-
 		add_action( 'partner_add_form_fields', [ __CLASS__, 'add_partner_meta_fields' ] );
 		add_action( 'partner_edit_form_fields', [ __CLASS__, 'edit_partner_meta_fields' ] );
 		add_action( 'after-partner-table', [ __CLASS__, 'add_global_settings' ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-plugin/pull/2753 introduced a new optional module. The module should be switched on if the corresponding plugin is active, and then the plugin should be deactivated. Because of a logical error, though, that would never happen, because the is-module-active check happens before the potential switch. This PR fixes that. 

Also, an unneeded check for `is_plugin_active` function existence is removed. Since the method is called on `admin_init` hook, this won't be needed. 

### How to test the changes in this Pull Request:

1. Follow instructions in https://github.com/Automattic/newspack-plugin/pull/2753

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->