### PR TITLE
feat(optional-modules): remove switching from standalone plugin versions

### DIFF
--- a/includes/optional-modules/class-media-partners.php
+++ b/includes/optional-modules/class-media-partners.php
@@ -18,17 +18,11 @@ class Media_Partners {
 	 * Initialize everything.
 	 */
 	public static function init() {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			include_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
 		if ( ! Settings::is_optional_module_active( 'media-partners' ) ) {
 			return;
 		}
 
-		add_action( 'admin_init', [ __CLASS__, 'switch_from_standalone_plugin' ] );
 		add_action( 'init', [ __CLASS__, 'register_taxonomies' ] );
-
 		add_action( 'partner_add_form_fields', [ __CLASS__, 'add_partner_meta_fields' ] );
 		add_action( 'partner_edit_form_fields', [ __CLASS__, 'edit_partner_meta_fields' ] );
 		add_action( 'after-partner-table', [ __CLASS__, 'add_global_settings' ] );
@@ -37,16 +31,6 @@ class Media_Partners {
 		add_action( 'init', [ __CLASS__, 'add_partners_shortcode' ] );
 		add_action( 'admin_init', [ __CLASS__, 'handle_settings_update' ] );
 		add_filter( 'the_content', [ __CLASS__, 'add_content_partner_logo' ] );
-	}
-
-	/**
-	 * If the standalone plugin is active, deactivate it and activate as a module.
-	 */
-	public static function switch_from_standalone_plugin() {
-		if ( is_plugin_active( 'newspack-media-partners/newspack-media-partners.php' ) ) {
-			deactivate_plugins( 'newspack-media-partners/newspack-media-partners.php' );
-			Settings::activate_optional_module( 'media-partners' );
-		}
 	}
 
 	/**

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -18,26 +18,9 @@ class RSS {
 	const FEED_SETTINGS_META = 'partner_feed_settings';
 
 	/**
-	 * Hooks and filters.
-	 */
-	public static function maybe_init() {
-		add_action( 'init', [ __CLASS__, 'init' ] );
-	}
-
-	/**
 	 * Initialise.
 	 */
 	public static function init() {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			include_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		// If the standalone plugin is active, deactivate it and activate as a module.
-		if ( is_plugin_active( 'newspack-rss-enhancements/newspack-rss-enhancements.php' ) ) {
-			deactivate_plugins( 'newspack-rss-enhancements/newspack-rss-enhancements.php' );
-			Settings::activate_optional_module( 'rss' );
-		}
-
 		if ( ! Settings::is_optional_module_active( 'rss' ) ) {
 			return;
 		}
@@ -651,4 +634,4 @@ xmlns:media="http://search.yahoo.com/mrss/"
 		}
 	}
 }
-RSS::maybe_init();
+RSS::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The standalone plugins have been removed from our live environment, so this code can be removed.

### How to test the changes in this Pull Request:

1. Ensure both optional modules are active by calling 
    1. `\Newspack\Settings::activate_optional_module( 'media-partners' )`
    2. `\Newspack\Settings::activate_optional_module( 'rss' )`
3. Load the admin panel, observe a "Media Partners" menu sub-item in "Posts" menu item 
4. Observe a "RSS Feeds" 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->