### PR TITLE
fix(auth-form): ui state handling on errors

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -417,6 +417,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 			};
 
 			form.endLoginFlow = ( message = null, status = 500, data = null, redirect ) => {
+				container.setAttribute( 'data-form-status', status );
+				form.style.opacity = 1;
+				submitButtons.forEach( button => {
+					button.disabled = false;
+				} );
 				if ( message ) {
 					const messageNode = document.createElement( 'p' );
 					messageNode.textContent = message;
@@ -433,7 +438,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 					} else {
 						form.replaceWith( messageContentElement.parentNode );
 					}
-					container.setAttribute( 'data-form-status', status );
 				}
 			};
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes an issue in `epic/ras-acc` with the form state upon front-end errors:

| epic/ras-acc | this branch |
| --- | --- |
| <img width="570" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/3b53a934-7614-4868-98d4-91023f60bb99"> | <img width="576" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/820752/2872a6cb-0cef-42e2-b150-87533b830e52"> |

When performing front-end validation the form state is not being restored and the error message does not apply the correct styling.

### How to test the changes in this Pull Request:

1. While in the epic/ras-acc branch, click to Sign In, and without filling in the email input, attempt to "Continue"
2. Confirm the form gets stuck in the "loading" state like in the image above
3. Checkout this branch, try again and confirm the error message is properly styled and the form state is resolved

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->