### PR TITLE
feat(my-account): require confirmation before cancelling subscription

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -64,6 +64,22 @@ class WooCommerce_My_Account {
 	 */
 	public static function enqueue_scripts() {
 		if ( function_exists( 'is_account_page' ) && is_account_page() ) {
+			\wp_enqueue_script(
+				'my-account',
+				\Newspack\Newspack::plugin_url() . '/dist/my-account.js',
+				[],
+				NEWSPACK_PLUGIN_VERSION,
+				true
+			);
+			\wp_localize_script(
+				'my-account',
+				'newspack_my_account',
+				[
+					'labels' => [
+						'cancel_subscription_message' => __( 'Are you sure you want to cancel this subscription?', 'newspack-plugin' ),
+					],
+				]
+			);
 			\wp_enqueue_style(
 				'my-account',
 				\Newspack\Newspack::plugin_url() . '/dist/my-account.css',

--- a/includes/reader-revenue/my-account/index.js
+++ b/includes/reader-revenue/my-account/index.js
@@ -1,1 +1,46 @@
+/* globals newspack_my_account */
+
+/**
+ * Internal dependencies.
+ */
 import './style.scss';
+
+/**
+ * Specify a function to execute when the DOM is fully loaded.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
+ *
+ * @param {Function} callback A function to execute after the DOM is ready.
+ * @return {void}
+ */
+function domReady( callback ) {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+	if (
+		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+	) {
+		return void callback();
+	}
+	// DOMContentLoaded has not fired yet, delay callback until then.
+	document.addEventListener( 'DOMContentLoaded', callback );
+}
+
+domReady( function () {
+	const cancelButton = document.querySelector( '.subscription_details .button.cancel' );
+
+	if ( cancelButton ) {
+		const confirmCancel = event => {
+			const message =
+				newspack_my_account?.labels?.cancel_subscription_message ||
+				'Are you sure you want to cancel this subscription?';
+
+			// eslint-disable-next-line no-alert
+			if ( ! confirm( message ) ) {
+				event.preventDefault();
+			}
+		};
+		cancelButton.addEventListener( 'click', confirmCancel );
+	}
+} );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a browser-based confirmation prompt when cancelling a subscription in My Account. Adds a tiny bit of friction to prevent accidental cancellations.

Closes `1206098184615535/1205860975049753`.

See also https://github.com/Automattic/newspack-theme/pull/2221

### How to test the changes in this Pull Request:

1. Check out this branch.
2. As a reader, purchase a subscription.
3. Visit My Account and verify if needed.
4. Visit Subscriptions and click "View" to view details for the subscription.
5. Click "Cancel" (or highlight with the keyboard and hit "Enter") and confirm there's a new prompt asking for confirmation:

<img width="437" alt="Screenshot 2024-01-15 at 6 11 56 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/0ffc8a0f-b1b3-40cd-b00c-aca76febfce8">

6. Click "Cancel" (in the prompt) and confirm that the cancellation does not occur.
7. Click the "Cancel" button again and this time click "OK". Confirm that the subscription is cancelled as requested.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->