### PR TITLE
Fix/tweaks

### DIFF
--- a/assets/components/src/sortable-newsletter-list-control/index.js
+++ b/assets/components/src/sortable-newsletter-list-control/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Icon, chevronUp, chevronDown, trash } from '@wordpress/icons';
+import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -16,6 +17,13 @@ export default function SortableNewsletterListControl( {
 	selected = [],
 	onChange = () => {},
 } ) {
+	if ( ! Array.isArray( lists ) && lists.errors ) {
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ Object.values( lists.errors ).join( ', ' ) }
+			</Notice>
+		);
+	}
 	const getList = id => lists.find( list => list.id === id );
 	const getAvailableLists = () => {
 		return lists.filter( list => list.active && ! selected.find( ( { id } ) => id === list.id ) );

--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -40,7 +40,7 @@ const Main = () => {
 				</>
 			) }
 			<Recaptcha setError={ setErrorWithPrefix( __( 'reCAPTCHA: ', 'newspack-plugin' ) ) } />
-			<Webhooks />
+			{ newspack_connections_data.can_use_webhooks && <Webhooks /> }
 		</>
 	);
 };

--- a/assets/wizards/connections/views/main/plugins.js
+++ b/assets/wizards/connections/views/main/plugins.js
@@ -73,6 +73,9 @@ const Plugins = ( { setError } ) => {
 						return __( 'Loading…', 'newspack' );
 					}
 					if ( isInactive ) {
+						if ( plugin.pluginSlug === 'google-site-kit' ) {
+							return __( 'Not connected for this user', 'newspack' );
+						}
 						return __( 'Not connected', 'newspack' );
 					}
 					return __( 'Connected', 'newspack' );

--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -106,7 +106,7 @@ const Recaptcha = () => {
 						) }
 						<Grid noMargin rowGap={ 16 }>
 							<TextControl
-								value={ settingsToUpdate?.site_key }
+								value={ settingsToUpdate?.site_key || '' }
 								label={ __( 'Site Key', 'newspack-plugin' ) }
 								onChange={ value =>
 									setSettingsToUpdate( { ...settingsToUpdate, site_key: value } )
@@ -116,7 +116,7 @@ const Recaptcha = () => {
 							/>
 							<TextControl
 								type="password"
-								value={ settingsToUpdate?.site_secret }
+								value={ settingsToUpdate?.site_secret || '' }
 								label={ __( 'Site Secret', 'newspack-plugin' ) }
 								onChange={ value =>
 									setSettingsToUpdate( { ...settingsToUpdate, site_secret: value } )
@@ -129,7 +129,7 @@ const Recaptcha = () => {
 								step="0.05"
 								min="0"
 								max="1"
-								value={ settingsToUpdate?.threshold }
+								value={ settingsToUpdate?.threshold || '' }
 								label={ __( 'Threshold', 'newspack-plugin' ) }
 								onChange={ value =>
 									setSettingsToUpdate( { ...settingsToUpdate, threshold: value } )

--- a/assets/wizards/connections/views/main/webhooks.js
+++ b/assets/wizards/connections/views/main/webhooks.js
@@ -1,4 +1,3 @@
-/* global newspack_connections_data */
 /**
  * External dependencies
  */
@@ -251,10 +250,6 @@ const Webhooks = () => {
 		setEditingError( false );
 		setTestError( false );
 	}, [ editing ] );
-
-	if ( ! newspack_connections_data.can_use_webhooks ) {
-		return null;
-	}
 
 	return (
 		<Card noBorder className="mt64">
@@ -534,7 +529,7 @@ const Webhooks = () => {
 											key={ i }
 											disabled={ editing.global || inFlight }
 											label={ action }
-											checked={ editing.actions && editing.actions.includes( action ) }
+											checked={ ( editing.actions && editing.actions.includes( action ) ) || false }
 											indeterminate={ editing.global }
 											onChange={ () => {
 												const currentActions = editing.actions || [];

--- a/assets/wizards/popups/views/segments/segments-list.js
+++ b/assets/wizards/popups/views/segments/segments-list.js
@@ -265,7 +265,6 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 			},
 		} )
 			.then( _segments => {
-				console.log( _segments );
 				setInFlight( false );
 				setSegments( _segments );
 			} )

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -168,25 +168,6 @@ abstract class Wizard {
 	}
 
 	/**
-	 * Check capabilities for using API when endpoint involves unfiltered HTML.
-	 *
-	 * @param WP_REST_Request $request API request object.
-	 * @return bool|WP_Error
-	 */
-	public function api_permissions_check_unfiltered_html( $request ) {
-		if ( ! current_user_can( 'unfiltered_html' ) ) {
-			return new \WP_Error(
-				'newspack_rest_forbidden',
-				esc_html__( 'You cannot use this resource.', 'newspack' ),
-				[
-					'status' => 403,
-				]
-			);
-		}
-		return true;
-	}
-
-	/**
 	 * Check whether a value is not empty.
 	 * Intended for use as a `validate_callback` when registering API endpoints.
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A couple of small tweaks:

- removes an unused `api_permissions_check_unfiltered_html` method
- removes a `console.log` statement
- UX improvements in Engagement and Connections wizard

### How to test the changes in this Pull Request:

1. On `master`,
1. Set ESP to "Manual / Other" in the Engagement wizard's Newsletters tab
2. Go to Engagement wizard, Reader Activation section, click "Show Advanced Settings" and toggle on – observe the page crashing. If it was already of, then the page should crash instantly. 
3. Log in as another administrator-role user and go to Connections wizard. Observe that the "Site Kit by Google" connection box says "Status: Not connected" 
4. Switch to this branch, observe that the setting in the Engagement wizard can be toggled on and displays an error message below 
5. Observe that the Connections wizard now says "Status: Not connected for this user" 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->