### PR TITLE
feat: automatically fill the credit meta for images

### DIFF
--- a/includes/class-newspack-image-credits.php
+++ b/includes/class-newspack-image-credits.php
@@ -44,6 +44,7 @@ class Newspack_Image_Credits {
 		add_filter( 'render_block', [ __CLASS__, 'add_credit_to_image_block' ], 10, 2 );
 		add_filter( 'wp_get_attachment_image_src', [ __CLASS__, 'maybe_show_placeholder_image' ], 11, 4 );
 		add_filter( 'ajax_query_attachments_args', [ __CLASS__, 'filter_ajax_query_attachments' ] );
+		add_filter( 'wp_generate_attachment_metadata', [ __CLASS__, 'populate_credit' ], 10, 3 );
 	}
 
 	/**
@@ -476,6 +477,31 @@ class Newspack_Image_Credits {
 		$post_ids          = array_map( 'absint', $post_ids );
 		$clauses['where'] .= " OR ( {$wpdb->posts}.ID IN ( " . implode( ',', $post_ids ) . ' ) )';
 		return $clauses;
+	}
+
+	/**
+	 * When a new image is uploaded, check if it has a credit in the EXIF/IPTC data and save it.
+	 *
+	 * @param array  $metadata      An array of attachment meta data.
+	 * @param int    $attachment_id Current attachment ID.
+	 * @param string $context       Additional context. Can be 'create' when metadata was initially created for new attachment
+	 *                              or 'update' when the metadata was updated.
+	 * @return array
+	 */
+	public static function populate_credit( $metadata, $attachment_id, $context ) {
+
+		$file_path  = get_attached_file( $attachment_id );
+		$attachment = get_post( $attachment_id );
+		$mime_type  = get_post_mime_type( $attachment );
+
+		if ( preg_match( '!^image/!', $mime_type ) && file_is_displayable_image( $file_path ) ) {
+			$meta = wp_read_image_metadata( $file_path );
+			if ( ! empty( $meta['credit'] ) ) {
+				update_post_meta( $attachment_id, self::MEDIA_CREDIT_META, $meta['credit'] );
+			}
+		}
+
+		return $metadata;
 	}
 }
 Newspack_Image_Credits::init();

--- a/includes/class-newspack-image-credits.php
+++ b/includes/class-newspack-image-credits.php
@@ -494,15 +494,8 @@ class Newspack_Image_Credits {
 			return $metadata;
 		}
 
-		$file_path  = get_attached_file( $attachment_id );
-		$attachment = get_post( $attachment_id );
-		$mime_type  = get_post_mime_type( $attachment );
-
-		if ( preg_match( '!^image/!', $mime_type ) && file_is_displayable_image( $file_path ) ) {
-			$meta = wp_read_image_metadata( $file_path );
-			if ( ! empty( $meta['credit'] ) ) {
-				update_post_meta( $attachment_id, self::MEDIA_CREDIT_META, $meta['credit'] );
-			}
+		if ( ! empty( $metadata['image_meta']['credit'] ) ) {
+			update_post_meta( $attachment_id, self::MEDIA_CREDIT_META, $metadata['image_meta']['credit'] );
 		}
 
 		return $metadata;

--- a/includes/class-newspack-image-credits.php
+++ b/includes/class-newspack-image-credits.php
@@ -490,6 +490,10 @@ class Newspack_Image_Credits {
 	 */
 	public static function populate_credit( $metadata, $attachment_id, $context ) {
 
+		if ( 'create' !== $context ) {
+			return $metadata;
+		}
+
 		$file_path  = get_attached_file( $attachment_id );
 		$attachment = get_post( $attachment_id );
 		$mime_type  = get_post_mime_type( $attachment );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Automatically populates the Newspack custom "Credit" attachment meta field with the credit present in the image metadata (EXIF or IPTC)

### How to test the changes in this Pull Request:

1. Upload a new image that has one of the following exif/iptc fields filled: (check the asana task for a sample image)

IPTC Credit field (2#110)
IPTC Creator field (2#080)
EXIF Artist field
EXIF Author field

2. Check that our "Credit" field was automatically filled

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205675205413421