### PR TITLE
fix(ras): handle invalid order sync request

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -368,7 +368,7 @@ class WooCommerce_Connection {
 	 * @param bool|string $payment_page_url Payment page URL. If not provided, checkout URL will be used.
 	 */
 	public static function sync_reader_from_order( $order, $verify_created_via = true, $payment_page_url = false ) {
-		if ( ! self::can_sync_customers() ) {
+		if ( ! $order || ! self::can_sync_customers() ) {
 			return;
 		}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -352,6 +352,10 @@ class WooCommerce_Connection {
 	 * @param WC_Order $order Order object.
 	 */
 	public static function should_sync_order( $order ) {
+		// $order is not a valid WC_Order object, so don't try to sync.
+		if ( ! $order || ! is_a( $order, 'WC_Order' ) ) {
+			return false;
+		}
 		if ( $order->get_meta( '_subscription_switch' ) ) {
 			// This is a "switch" order, which is just recording a subscription update. It has value of 0 and
 			// should not be synced anywhere.
@@ -368,16 +372,16 @@ class WooCommerce_Connection {
 	 * @param bool|string $payment_page_url Payment page URL. If not provided, checkout URL will be used.
 	 */
 	public static function sync_reader_from_order( $order, $verify_created_via = true, $payment_page_url = false ) {
-		if ( ! $order || ! self::can_sync_customers() ) {
+		if ( ! self::can_sync_customers() ) {
+			return;
+		}
+
+		if ( ! self::should_sync_order( $order ) ) {
 			return;
 		}
 
 		if ( $verify_created_via && self::CREATED_VIA_NAME === $order->get_created_via() ) {
 			// Only sync orders not created via the Stripe integration.
-			return;
-		}
-
-		if ( ! self::should_sync_order( $order ) ) {
 			return;
 		}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -353,7 +353,7 @@ class WooCommerce_Connection {
 	 */
 	public static function should_sync_order( $order ) {
 		// $order is not a valid WC_Order object, so don't try to sync.
-		if ( ! $order || ! is_a( $order, 'WC_Order' ) ) {
+		if ( ! is_a( $order, 'WC_Order' ) ) {
 			return false;
 		}
 		if ( $order->get_meta( '_subscription_switch' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal that can happen if `\Newspack\WooCommerce_Connection::sync_reader_from_order()` is called without a valid `$order` arg.

### How to test the changes in this Pull Request:

1. Run `wp shell` and then `\Newspack\WooCommerce_Connection::sync_reader_from_order( false )`. Observe a fatal error
2. Check out this branch, repeat, and observe no error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->