### PR TITLE
fix(auth-modal): fatal error in auth modal with "other" ESP

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -330,7 +330,7 @@ final class Reader_Activation {
 			$registration_lists = $available_lists;
 		} else {
 			$lists = self::get_setting( 'newsletter_lists' );
-			if ( empty( $lists ) ) {
+			if ( empty( $lists ) || \is_wp_error( $available_lists ) ) {
 				return [];
 			}
 			$registration_lists = [];

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -326,11 +326,14 @@ final class Reader_Activation {
 		}
 		$use_custom_lists = self::get_setting( 'use_custom_lists' );
 		$available_lists  = \Newspack_Newsletters_Subscription::get_lists_config();
+		if ( \is_wp_error( $available_lists ) ) {
+			return [];
+		}
 		if ( ! $use_custom_lists ) {
 			$registration_lists = $available_lists;
 		} else {
 			$lists = self::get_setting( 'newsletter_lists' );
-			if ( empty( $lists ) || \is_wp_error( $available_lists ) ) {
+			if ( empty( $lists ) ) {
 				return [];
 			}
 			$registration_lists = [];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal error I discovered when testing another feature. I don't think this warrants a hotfix as it's an edge case that shouldn't occur for live sites unless they're switching from a supported ESP to a "other/manual" in Newsletters.

### How to test the changes in this Pull Request:

1. Make sure RAS is set up and enabled.
2. In **Newspack > Engagement > Newsletters**, set the active ESP to "Manual/Other" and save.
3. On `master`, visit a page on the front-end that will render the "Sign In" button and auth modal, and observe a fatal error that affects the front-end render:

```
PHP Fatal error:  Uncaught Error: Cannot use object of type WP_Error as array in /newspack-repos/newspack-plugin/includes/reader-activation/class-reader-activation.php:338
Stack trace:
#0 /newspack-repos/newspack-plugin/includes/reader-activation/class-reader-activation.php(1061): Newspack\Reader_Activation::get_registration_newsletter_lists()
```

4. Check out this branch, repeat step 3 and confirm there's no error and that the auth modal works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->