### PR TITLE
feat(fivetran): remove FiveTran connectors other than Stripe

### DIFF
--- a/assets/wizards/connections/views/main/fivetran.js
+++ b/assets/wizards/connections/views/main/fivetran.js
@@ -19,20 +19,8 @@ import get from 'lodash/get';
 
 const CONNECTORS = [
 	{
-		service: 'mailchimp',
-		label: __( 'Mailchimp', 'newspack' ),
-	},
-	{
 		service: 'stripe',
 		label: __( 'Stripe', 'newspack' ),
-	},
-	{
-		service: 'double_click_publishers',
-		label: __( 'Google Ad Manager', 'newspack' ),
-	},
-	{
-		service: 'facebook_pages',
-		label: __( 'Facebook Pages', 'newspack' ),
 	},
 ];
 

--- a/includes/oauth/class-fivetran-connection.php
+++ b/includes/oauth/class-fivetran-connection.php
@@ -108,19 +108,6 @@ class Fivetran_Connection {
 		$service      = $request->get_param( 'service' );
 		$service_data = [];
 
-		// For Google Ad Manager (aka double_click_publishers) - if Newspack Ads knows the network code, let's use it.
-		if (
-			'double_click_publishers' === $service &&
-			method_exists( 'Newspack_Ads\Providers\GAM_Model', 'get_active_network_code' )
-		) {
-			$network_code = \Newspack_Ads\Providers\GAM_Model::get_active_network_code();
-			if ( ! empty( $network_code ) ) {
-				$service_data['double_click_publishers'] = [
-					'network_code' => $network_code,
-				];
-			}
-		}
-
 		$url      = OAuth::authenticate_proxy_url(
 			'fivetran',
 			'/wp-json/newspack-fivetran/v1/connect-card',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In preparation for deprecating support for FiveTran connectors other than Stripe, this removes them from the Newspack > Connections wizard UI.

Closes `1206197591054328/1206413031827389`

### How to test the changes in this Pull Request:

1. If on a dev site, you may need to add an environment variable to be able to see the FiveTran connector options in the Connections wizard. Let me know if you don't know how to do this or what to set it to.
2. Visit **Newspack > Connections** and confirm that only Stripe appears under the FiveTran section:

<img width="1069" alt="Screenshot 2024-01-22 at 4 21 13 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/595b29c1-637b-4e60-bdac-bc94be784fdf">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206413031827389