### PR TITLE
feat: add get_recurrence_of_order method

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -309,6 +309,23 @@ class Donations {
 	}
 
 	/**
+	 * Get recurrence of an order.
+	 *
+	 * @param \WC_Order $order Order object.
+	 */
+	public static function get_recurrence_of_order( $order ) {
+		$donation_product_id = self::get_order_donation_product_id( $order->get_id() );
+		if ( ! $donation_product_id ) {
+			return;
+		}
+		$recurrence = get_post_meta( $donation_product_id, '_subscription_period', true );
+		if ( empty( $recurrence ) ) {
+			$recurrence = 'once';
+		}
+		return $recurrence;
+	}
+
+	/**
 	 * Get the donation settings.
 	 *
 	 * @return array|WP_Error Donation settings or WP_Error if WooCommerce is not set up.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a `Donations::get_recurrence_of_order` method. This will be used by another plugin, should be available for testing quickly – hence the hotfix.  

### How to test the changes in this Pull Request:

1. Run `wp eval "echo \Newspack\Donations::get_recurrence_of_order(\wc_get_order(<order-id>));"` (replace `<order-id>` with a real order ID
2. For an order tied to a donation, observe the recurrence (`'once'`, `'month'`, or `'year'`) is printed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->