### PR TITLE
RAS UI: add primary colour to modal buttons

### DIFF
--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -39,6 +39,11 @@
 		}
 	}
 	&__modal {
+		// CSS Variables - update button background, with fallbacks to the Newspack UI defaults
+		--newspack-ui-color-button-bg: var( --newspack-ui-color-primary, var( --newspack-ui-color-gray-900 ) );
+		--newspack-ui-color-button-text: var( --newspack-ui-color-against-primary, var( --newspack-ui-color-white ) );
+
+		// Modal styles
 		background: var( --newspack-ui-color-body-bg );
 		border-radius: var( --newspack-ui-border-radius );
 		display: flex;

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -41,6 +41,7 @@
 
 			&:hover {
 				background: var( --newspack-ui-color-button-bg-hover );
+				color: var( --newspack-ui-color-button-text-hover );
 			}
 		}
 
@@ -53,6 +54,7 @@
 
 			&:hover {
 				background: var( --newspack-ui-color-gray-100 );
+				color: var( --newspack-ui-color-text-high-contrast );
 			}
 		}
 
@@ -62,6 +64,7 @@
 
 			&:hover {
 				background: var( --newspack-ui-color-gray-100 );
+				color: var( --newspack-ui-color-text-high-contrast );
 			}
 		}
 	}

--- a/assets/newspack-ui/scss/variables/_colors.scss
+++ b/assets/newspack-ui/scss/variables/_colors.scss
@@ -21,8 +21,8 @@
 	--newpsack-ui-color-alert-red-bg: #fcf0f1;
 
 	// Theme variables - from the classic theme; overridden in class-newspack-ui.php for block theme.
-	--newspack-ui-color-primary: var(--newspack-theme-color-primary);
-	--newspack-ui-color-against-primary: var(--newspack-theme-color-against-primary);
+	--newspack-ui-color-primary: var( --newspack-theme-color-primary );
+	--newspack-ui-color-against-primary: var( --newspack-theme-color-against-primary );
 
 	// Specific assignments - general:
 	--newspack-ui-color-text-high-contrast: var( --newspack-ui-color-gray-900 );

--- a/assets/newspack-ui/scss/variables/_colors.scss
+++ b/assets/newspack-ui/scss/variables/_colors.scss
@@ -20,6 +20,10 @@
 	--newspack-ui-color-alert-green-bg: #edfaef;
 	--newpsack-ui-color-alert-red-bg: #fcf0f1;
 
+	// Theme variables - from the classic theme; overridden in class-newspack-ui.php for block theme.
+	--newspack-ui-color-primary: var(--newspack-theme-color-primary);
+	--newspack-ui-color-against-primary: var(--newspack-theme-color-against-primary);
+
 	// Specific assignments - general:
 	--newspack-ui-color-text-high-contrast: var( --newspack-ui-color-gray-900 );
 	--newspack-ui-color-text-med-contrast: var( --newspack-ui-color-gray-700 );
@@ -30,5 +34,6 @@
 	--newspack-ui-color-button-bg: var( --newspack-ui-color-gray-900 );
 	--newspack-ui-color-button-bg-hover: var( --newspack-ui-color-gray-800 ); // TODO: Replace w/correct value.
 	--newspack-ui-color-button-text: var( --newspack-ui-color-white );
+	--newspack-ui-color-button-text-hover: var( --newspack-ui-color-white );
 	--newspack-ui-color-radio-bg: var( --newspack-ui-color-gray-900 );
 }

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -515,7 +515,7 @@ class Newspack_UI {
 
 						<section class="newspack-ui__modal__content">
 
-							<button class="newspack-ui__button__secondary newspack-ui__button__wide">
+							<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">
 								<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
 									<path fill-rule="evenodd" clip-rule="evenodd" d="M19.6 10.227C19.6 9.51801 19.536 8.83701 19.418 8.18201H10V12.05H15.382C15.2706 12.6619 15.0363 13.2448 14.6932 13.7635C14.3501 14.2822 13.9054 14.726 13.386 15.068V17.578H16.618C18.509 15.836 19.6 13.273 19.6 10.228V10.227Z" fill="#4285F4"></path>
 									<path fill-rule="evenodd" clip-rule="evenodd" d="M9.99996 20C12.7 20 14.964 19.105 16.618 17.577L13.386 15.068C12.491 15.668 11.346 16.023 9.99996 16.023C7.39496 16.023 5.18996 14.263 4.40496 11.9H1.06396V14.49C1.89597 16.1468 3.17234 17.5395 4.7504 18.5126C6.32846 19.4856 8.14603 20.0006 9.99996 20Z" fill="#34A853"></path>
@@ -537,8 +537,8 @@ class Newspack_UI {
 									<input type="email" placeholder="Email Address">
 								</p>
 
-								<button class="newspack-ui__button__primary newspack-ui__button__wide">Sign In</button>
-								<button class="newspack-ui__button__tertiary newspack-ui__button__wide">Sign in to existing account</button>
+								<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Sign In</button>
+								<button class="newspack-ui__button newspack-ui__button--tertiary newspack-ui__button--wide">Sign in to existing account</button>
 							</form>
 						</section>
 

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -19,10 +19,14 @@ class Newspack_UI {
 	public static function init() {
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_styles' ] );
 		\add_filter( 'the_content', [ __CLASS__, 'load_demo' ] );
+		// Only run if the site is using a block theme.
+		if ( wp_theme_has_theme_json() ) {
+			\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'colors_css_wrap' ] );
+		}
 	}
 
 	/**
-	 * Enqueue script and styles for Handoff Banner.
+	 * Enqueue styles for the Newspack UI.
 	 */
 	public static function enqueue_styles() {
 		\wp_enqueue_style(
@@ -31,6 +35,24 @@ class Newspack_UI {
 			[],
 			NEWSPACK_PLUGIN_VERSION
 		);
+	}
+
+	/**
+	 * Adds inline styles CSS for the element/button colors from the theme.json.
+	 * See: https://developer.wordpress.org/reference/functions/wp_get_global_styles/
+	 */
+	public static function colors_css_wrap() {
+		$global_styles = wp_get_global_styles();
+
+		$custom_css = 'body {';
+		if ( isset( $global_styles['elements']['button']['color']['background'] ) ) {
+			$custom_css .= '--newspack-ui-color-primary: ' . $global_styles['elements']['button']['color']['background'] . ';';
+		}
+		if ( isset( $global_styles['elements']['button']['color']['text'] ) ) {
+			$custom_css .= '--newspack-ui-color-against-primary: ' . $global_styles['elements']['button']['color']['text'] . ';';
+		}
+		$custom_css .= '}';
+		wp_add_inline_style( 'newspack-ui', $custom_css );
 	}
 
 	/**
@@ -202,7 +224,7 @@ class Newspack_UI {
 
 			<h2>Buttons</h2>
 			<p><code>newspack-ui__button--primary</code>, <code>--secondary</code>, and <code>--tertiary</code> classes for colours/borders, and <code>newspack-ui__button--wide</code> for being 100% wide</p>
-			<button>Default Theme Button</button><br>
+			<button class="newspack-ui__button">Default Theme Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--primary">Primary Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--secondary">Secondary Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--tertiary">Tertiary Button</button><br>
@@ -476,7 +498,7 @@ class Newspack_UI {
 				</div><!-- .newspack-ui__modal--small -->
 			</div><!-- .newspack-ui__box -->
 
-			<button id="open-modal-example" class="newspack-ui__button__primary">Open Modal</button>
+			<button id="open-modal-example" class="newspack-ui__button newspack-ui__button--primary">Open Modal</button>
 			<div id="newspack-modal-example" class="newspack-ui__modal-container">
 				<div class="newspack-ui__modal-container__overlay"></div>
 				<div class="newspack-ui__modal newspack-ui__modal__small">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR does a couple things: 

1. It fixes a couple small issues in the demo content CSS classes (just minor stuff I noticed on the buttons to do with font sizing/spacing/hover states).
2. It adds the CSS variables `--newspack-ui-primary-color` and `--newspack-ui-color-against-primary`
3. It sets the default values for those variables to the ones in the classic Newspack theme. 
4. It also checks for a block theme, and if one exists, tries to set those values to match the element/button colours (background and text); by default this should be the equivalent of the primary colour, but if not, will at least be a contrasting background/text combo we can use on the site. 
5. It then uses the `--newspack-ui-primary-color` and `--newspack-ui-color-against-primary` CSS variables for the modal buttons.

See 1205234045751551-as-1206301643351944

### How to test the changes in this Pull Request:

1. To start, make sure the Newspack Theme is up to date on your test site; [it recently had a PR merged](https://github.com/Automattic/newspack-theme/pull/2109) that's required for this to work. 
2. Apply this PR, and view the /?ui-demo page of your test site. 
3. Review the button styles, focusing on the colours used by the "modals"; the buttons should use the default dark grey outside of the modals, and use the theme's primary colour inside of the modals.

![image](https://github.com/Automattic/newspack-plugin/assets/177561/afb0e52c-270b-4f74-a1ea-4b7770f1119d)

4. Navigate to Customizer > Colors, and change the primary colour; confirm it still works:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/ad9fd23e-764d-4052-a947-bd0041d3c722)

This next bit is a little out of scope for what we actually need right now, but I wanted to make sure we could actually do something like this with a block theme, too. Also, this approach may not be the way we want to go for getting the custom colours from this theme!

5. Switch the theme [to this theme](https://github.com/automattic/newspack-block-theme). 
6. Repeat the testing steps 2 and 3 and confirm that the regular buttons are using the dark grey, and the buttons inside of the modal are using the primary colour (it should be dark blue by default). Note: there are some display issues around `<button>` and `<input>`, but they can be sorted out later. 
7. Navigate to Edit Site > Styles (if you drop into the Templates or Front Page section, you may need to hit the back arrow next to the heading to get to the 'Design' header, where the Styles live).

![Screen Shot 2024-01-23 at 9 48 08 AM](https://github.com/Automattic/newspack-plugin/assets/177561/aea5be83-ba6b-41c9-b37b-a29a8f632194)

8. Under Styles, click 'Colors', then change the button colour: 

![image](https://github.com/Automattic/newspack-plugin/assets/177561/03384850-6dd7-46b8-9aba-2a4ff60ec742)

11. Repeat steps 2 and 3, and confirm that this new colour is being picked up. This is specifically the colour set for the `button` element, which is picked up by the button blocks (at the moment we don't define a separate colour for those blocks, but we could). While the button may not always be the "primary" colour, this will make sure the modal buttons are using a colour from the site, with text with adequate contrast.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->