### PR TITLE
feat: remove new tab default on image credits

### DIFF
--- a/includes/class-newspack-image-credits.php
+++ b/includes/class-newspack-image-credits.php
@@ -110,7 +110,7 @@ class Newspack_Image_Credits {
 		}
 
 		if ( $credit_info['credit_url'] ) {
-			$credit = '<a href="' . $credit_info['credit_url'] . '"' . $credit . '</a>';
+			$credit = '<a href="' . $credit_info['credit_url'] . '">' . $credit . '</a>';
 		}
 
 		$class_name    = self::get_settings( 'newspack_image_credits_class_name' );

--- a/includes/class-newspack-image-credits.php
+++ b/includes/class-newspack-image-credits.php
@@ -110,7 +110,7 @@ class Newspack_Image_Credits {
 		}
 
 		if ( $credit_info['credit_url'] ) {
-			$credit = '<a href="' . $credit_info['credit_url'] . '" target="_blank">' . $credit . '</a>';
+			$credit = '<a href="' . $credit_info['credit_url'] . '"' . $credit . '</a>';
 		}
 
 		$class_name    = self::get_settings( 'newspack_image_credits_class_name' );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Image credits with links currently default to opening in a new tab. In general, opening in a new tab is not a great user experience, as it deprives the user of the freedom of whether to open it in the current tab or a new one.

There are also accessibility considerations, as opening in a new tab makes the site problematic for users with disabilities who use assistive technologies.

This handy guide explains why it’s not a great idea and details some narrow cases where it might be preferable:

https://css-tricks.com/use-target_blank/ 

The thinking on this has evolved fairly recently, but current best practices are to open most, if not all, links in the same tab (with possible exceptions for when it opens a document like a PDF or something else that takes you out of your regular browser experience). There's more about the approach in this article from DMXzone:

https://www.dmxzone.com/go/10742/free-beware-of-opening-links-in-a-new-window/

WordPress 6.3 and later have downplayed the prevalence of new tab behavior, as seen in https://github.com/WordPress/gutenberg/issues/50950

Publishers who prefer that credits open in a new tab are welcome to install a separate plugin that enforces this behavior, as opposed to it being decided by the theme.

### How to test the changes in this Pull Request:

1. Upload an image and provide credit metadata, including a source URL.
2. Set the uploaded image as a featured image (such as position: "Behind") on a post.
3. View the post. Observe that the image credit link opens in a new tab.
4. Switch to this branch.
5. Observe that the image credit link now opens in the same tab.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->