### PR TITLE
fix: ensure WC session is present if triggering WC notice

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -369,7 +369,7 @@ final class Recaptcha {
 		$token = isset( $_POST['g-recaptcha-response'] ) ? sanitize_text_field( wp_unslash( $_POST['g-recaptcha-response'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$check = self::verify_captcha( $token );
 		if ( \is_wp_error( $check ) ) {
-			\wc_add_notice( $check->get_error_message(), 'error' );
+			WooCommerce_Connection::add_wc_notice( $check->get_error_message(), 'error' );
 		}
 	}
 }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -724,9 +724,7 @@ final class Reader_Activation {
 
 		\update_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
 
-		if ( function_exists( '\wc_add_notice' ) ) {
-			\wc_add_notice( __( 'Thank you for verifying your account!', 'newspack-plugin' ), 'success' );
-		}
+		WooCommerce_Connection::add_wc_notice( __( 'Thank you for verifying your account!', 'newspack-plugin' ), 'success' );
 
 		/**
 		 * Fires after a reader's email address is verified.

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -572,8 +572,8 @@ class WooCommerce_My_Account {
 	 * Show a logout success message to readers after logging out via My Account.
 	 */
 	public static function show_message_after_logout() {
-		if ( isset( $_GET['logged_out'] ) && function_exists( 'wc_add_notice' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			\wc_add_notice( __( 'You have successfully logged out.', 'newspack-plugin' ), 'success' );
+		if ( isset( $_GET['logged_out'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			WooCommerce_Connection::add_wc_notice( __( 'You have successfully logged out.', 'newspack-plugin' ), 'success' );
 		}
 	}
 }

--- a/includes/reader-revenue/templates/myaccount-delete-account.php
+++ b/includes/reader-revenue/templates/myaccount-delete-account.php
@@ -17,19 +17,19 @@ $delete_account_form = WooCommerce_My_Account::DELETE_ACCOUNT_FORM;
 
 $nonce_value = isset( $_GET[ $delete_account_form ] ) ? \sanitize_text_field( $_GET[ $delete_account_form ] ) : '';
 if ( ! \wp_verify_nonce( $nonce_value, $delete_account_form ) ) {
-	\wc_add_notice( __( 'Invalid nonce.', 'newspack' ), 'error' );
+	WooCommerce_Connection::add_wc_notice( __( 'Invalid nonce.', 'newspack' ), 'error' );
 	return;
 }
 
 if ( ! isset( $_GET['token'] ) ) {
-	\wc_add_notice( __( 'Invalid token', 'newspack' ), 'error' );
+	WooCommerce_Connection::add_wc_notice( __( 'Invalid token', 'newspack' ), 'error' );
 	return;
 }
 
 $token           = \sanitize_text_field( $_GET['token'] );
 $transient_token = get_transient( 'np_reader_account_delete_' . \get_current_user_id() );
 if ( ! $transient_token || $transient_token !== $token ) {
-	\wc_add_notice( __( 'Invalid token', 'newspack' ), 'error' );
+	WooCommerce_Connection::add_wc_notice( __( 'Invalid token', 'newspack' ), 'error' );
 	return;
 }
 ?>

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -1301,6 +1301,22 @@ class WooCommerce_Connection {
 
 		return $product_ids;
 	}
+
+	/**
+	 * Add a WC notice.
+	 *
+	 * @param string $message Message to display.
+	 * @param string $type Type of notice.
+	 */
+	public static function add_wc_notice( $message, $type ) {
+		if ( ! function_exists( '\wc_add_notice' ) || ! function_exists( 'WC' ) ) {
+			return;
+		}
+		if ( ! WC()->session ) {
+			return;
+		}
+		\wc_add_notice( $message, $type );
+	}
 }
 
 WooCommerce_Connection::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds an additional check when triggering a WC notice. 

When testing, an error with the following stack trace was encountered:

```
PHP Fatal error:  Uncaught Error: Call to a member function get() on null in /srv/htdocs/wp-content/plugins/woocommerce/includes/wc-notice-functions.php:80
Stack trace:
#0 /srv/htdocs/wp-content/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php(728): wc_add_notice('Thank you for v...', 'success')
#1 /srv/htdocs/wp-content/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php(1684): Newspack\Reader_Activation::set_reader_verified(3)
```

The `get()` mentioned is called on `WC()->session`. In order to prevent this issue, all calls to `wc_add_notice` are now wrapped in a `WooCommerce_Connection::add_wc_notice` method, which will check for validity of `WC()->session`. 

### How to test the changes in this Pull Request:

I could not reproduce the issue locally, but it appeared on a JN test site. 

1. Use Google to register with a RAS-configured site, observe that the reader registration works as expected
2. In a different session, create a new account (without SSO, simply with an email) and then verify the account
3. After following the verification link, observe the WC notice displayed:

<img width="680" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/bc15591b-60b5-43f5-b6fc-0afd386030e5">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->