### PR TITLE
fix: update Campaigns plugin description

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -145,7 +145,7 @@ class Plugin_Manager {
 			],
 			'newspack-popups'             => [
 				'Name'        => esc_html__( 'Newspack Campaigns', 'newspack' ),
-				'Description' => esc_html__( 'Build persuasive call-to-action prompts from scratch and display them as overlays, inline with the story, or above the site header.', 'newspack' ),
+				'Description' => esc_html__( 'Build persuasive call-to-action prompts from scratch and display them as overlays, inline with the story, or above the site header.', 'newspack-plugin' ),
 				'Author'      => esc_html__( 'Automattic', 'newspack' ),
 				'PluginURI'   => esc_url( 'https://newspack.com' ),
 				'AuthorURI'   => esc_url( 'https://automattic.com' ),

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -145,7 +145,7 @@ class Plugin_Manager {
 			],
 			'newspack-popups'             => [
 				'Name'        => esc_html__( 'Newspack Campaigns', 'newspack' ),
-				'Description' => esc_html__( 'AMP-compatible overlay and inline Campaigns.', 'newspack' ),
+				'Description' => esc_html__( 'Build persuasive call-to-action prompts from scratch and display them as overlays, inline with the story, or above the site header.', 'newspack' ),
 				'Author'      => esc_html__( 'Automattic', 'newspack' ),
 				'PluginURI'   => esc_url( 'https://newspack.com' ),
 				'AuthorURI'   => esc_url( 'https://automattic.com' ),


### PR DESCRIPTION
Brings the plugin description in alignment with https://github.com/Automattic/newspack-popups/pull/1182.

### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the plugin description for `newspack-popups`, bringing it in alignment with https://github.com/Automattic/newspack-popups/pull/1182.

### How to test the changes in this Pull Request:

1. Visit `/wp-admin/plugins.php`
2. Note the description for Newspack Campaigns is "AMP-compatible overlay and inline Campaigns."
3. Switch to this branch.
4. Visit `/wp-admin/plugins.php`
5. Note the description for Newspack Campaigns is "Build persuasive call-to-action prompts from scratch and display them as overlays, inline with the story, or above the site header."

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->