### PR TITLE
fix(ras): only sync spend total and last payment amounts for completed orders

### DIFF
--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -107,8 +107,7 @@ class ActiveCampaign {
 			return;
 		}
 
-		$last_order = $customer->get_last_order();
-		$contact    = WooCommerce_Connection::get_contact_from_order( $last_order );
+		$contact = WooCommerce_Connection::get_contact_from_customer( $customer );
 
 		self::put( $contact );
 	}

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -125,7 +125,7 @@ class ActiveCampaign {
 		}
 
 		$order_id = $data['platform_data']['order_id'];
-		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, false, true );
+		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, $data['referer'], true );
 
 		if ( ! $contact ) {
 			return;
@@ -142,7 +142,7 @@ class ActiveCampaign {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function subscription_updated( $timestamp, $data, $client_id ) {
-		if ( empty( $data['subscription_id'] ) || empty( $data['status_before'] ) || empty( $data['status_after'] ) ) {
+		if ( empty( $data['status_before'] ) || empty( $data['status_after'] ) || empty( $data['user_id'] ) ) {
 			return;
 		}
 
@@ -156,9 +156,8 @@ class ActiveCampaign {
 			return;
 		}
 
-		$subscription = \wcs_get_subscription( $data['subscription_id'] );
-		$order        = $subscription->get_last_order( 'all' );
-		$contact      = WooCommerce_Connection::get_contact_from_order( $order );
+		$customer = new \WC_Customer( $data['user_id'] );
+		$contact  = WooCommerce_Connection::get_contact_from_customer( $customer );
 
 		if ( ! $contact ) {
 			return;

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -274,7 +274,7 @@ class Mailchimp {
 		}
 
 		$order_id = $data['platform_data']['order_id'];
-		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, false, true );
+		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, $data['referer'], true );
 
 		if ( ! $contact ) {
 			return;
@@ -291,7 +291,7 @@ class Mailchimp {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function subscription_updated( $timestamp, $data, $client_id ) {
-		if ( empty( $data['subscription_id'] ) || empty( $data['status_before'] ) || empty( $data['status_after'] ) ) {
+		if ( empty( $data['status_before'] ) || empty( $data['status_after'] ) || empty( $data['user_id'] ) ) {
 			return;
 		}
 
@@ -305,9 +305,8 @@ class Mailchimp {
 			return;
 		}
 
-		$subscription = \wcs_get_subscription( $data['subscription_id'] );
-		$order        = $subscription->get_last_order( 'all' );
-		$contact      = WooCommerce_Connection::get_contact_from_order( $order );
+		$customer = new \WC_Customer( $data['user_id'] );
+		$contact  = WooCommerce_Connection::get_contact_from_customer( $customer );
 
 		if ( ! $contact ) {
 			return;

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -256,8 +256,7 @@ class Mailchimp {
 			return;
 		}
 
-		$last_order = $customer->get_last_order();
-		$contact    = WooCommerce_Connection::get_contact_from_order( $last_order );
+		$contact = WooCommerce_Connection::get_contact_from_customer( $customer );
 
 		self::put( $contact );
 	}

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -136,7 +136,7 @@ class WooCommerce_Connection {
 		}
 
 		// Only update last payment data if new payment has been received.
-		$payment_received = $is_new && in_array( $order->get_status(), [ 'processing', 'completed' ], true );
+		$payment_received = $is_new && $order->has_status( [ 'processing', 'completed' ] );
 
 		$metadata = [];
 
@@ -170,7 +170,7 @@ class WooCommerce_Connection {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = reset( $order_items )->get_name();
 			}
 			$order_date_paid = $order->get_date_paid();
-			if ( $payment_received && null !== $order_date_paid ) {
+			if ( $payment_received && ! empty( $order_date_paid ) ) {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'last_payment_amount' ) ] = \wc_format_localized_price( $order->get_total() );
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'last_payment_date' ) ]   = $order_date_paid->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
 			}
@@ -189,7 +189,7 @@ class WooCommerce_Connection {
 				}
 
 				// If the subscription has moved to a cancelled or expired status.
-				if ( in_array( $current_subscription->get_status(), [ 'cancelled', 'expired' ], true ) ) {
+				if ( $current_subscription->has_status( [ 'cancelled', 'expired' ] ) ) {
 					$donor_status = 'Ex-' . $donor_status;
 				}
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = $donor_status;

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -161,10 +161,6 @@ class WooCommerce_Connection {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Donor';
 			}
 
-			if ( $is_new && 'pending' === $order->get_status() ) {
-				$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ] += \wc_format_localized_price( $order->get_total() );
-			}
-
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = '';
 			$order_items = $order->get_items();
 			if ( $order_items ) {
@@ -213,10 +209,6 @@ class WooCommerce_Connection {
 			$next_payment_date = $current_subscription->get_date( 'next_payment' );
 			if ( $next_payment_date ) {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'next_payment_date' ) ] = $next_payment_date;
-			}
-
-			if ( $is_new && 'pending' === $order->get_status() ) {
-				$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ] += \wc_format_localized_price( $current_subscription->get_total() );
 			}
 
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = '';
@@ -317,8 +309,13 @@ class WooCommerce_Connection {
 		if ( ! is_a( $order, 'WC_Order' ) ) {
 			return false;
 		}
+		// If the order lacks a customer.
+		$user_id = $order->get_customer_id();
+		if ( ! $user_id ) {
+			return [];
+		}
+		// If the order isn't pending or wasn't successfully completed.
 		if ( ! in_array( $order->get_status(), [ 'pending', 'completed' ], true ) ) {
-			// The order was not successful. Don't sync data about it.
 			return false;
 		}
 		if ( $order->get_meta( '_subscription_switch' ) ) {

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -180,24 +180,19 @@ class WooCommerce_Connection {
 			$current_subscription = reset( $order_subscriptions );
 
 			if ( $is_donation_order ) {
-				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Donor';
-				if ( 'active' === $current_subscription->get_status() || 'pending' === $current_subscription->get_status() ) {
-					if ( 'month' === $current_subscription->get_billing_period() ) {
-						$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Monthly Donor';
-					}
-
-					if ( 'year' === $current_subscription->get_billing_period() ) {
-						$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Yearly Donor';
-					}
-				} else {
-					if ( 'month' === $current_subscription->get_billing_period() ) {
-						$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Ex-Monthly Donor';
-					}
-
-					if ( 'year' === $current_subscription->get_billing_period() ) {
-						$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Ex-Yearly Donor';
-					}
+				$donor_status = 'Donor';
+				if ( 'month' === $current_subscription->get_billing_period() ) {
+					$donor_status = 'Monthly ' . $donor_status;
 				}
+				if ( 'year' === $current_subscription->get_billing_period() ) {
+					$donor_status = 'Yearly ' . $donor_status;
+				}
+
+				// If the subscription has moved to a cancelled or expired status.
+				if ( in_array( $current_subscription->get_status(), [ 'cancelled', 'expired' ], true ) ) {
+					$donor_status = 'Ex-' . $donor_status;
+				}
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = $donor_status;
 			}
 
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'sub_start_date' ) ]    = $current_subscription->get_date( 'start' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a logical error in our reader data when syncing "last payment" amounts for a contact. Currently, when a reader logs into an existing account, we resync their contact data, including info about their last order. But the `get_last_order` method Woo provides to get a customer's last order gets any order, even failed ones. This means that for any reader whose most recent transaction resulted in the creation of a new order which subsequently failed (which could happen if the credit card they used is declined by the bank after the point of service in Stripe), the last payment amount will reflect this failed payment, instead of the most recent _successful_ payment amount. (Amusing anecdote: we discovered this bug after a customer made a probably fraudulent $1,000,000 donation that got declined despite the order completing successfully—maybe because the card itself was valid, but the amount was not?)

This PR adds some additional logic to ensure that we're only syncing data about successful orders going forward. It also adds some measures to ensure that the correct total spend and last payment amount values are synced to any existing reader account upon login.

### How to test the changes in this Pull Request:

1. On `master`, as a new reader, complete a donation on a site with Stripe in test mode. Use this test credit card number to simulate a card that successfully creates the order in Woo, but then fails after when the charge is subsequently declined by the bank: `4000 0000 0000 0341`
2. Note the amount of money of the failed order, then in a new session log in as that reader. In the contact data synced to the connected ESP, observe that the "Last Payment Amount" gets set to this failed order amount.
3. Check out this branch and log in as the same reader in a new session again. After the resync, confirm that the "Last Payment Amount" gets reset to zero.
4. In another new session, complete a successful donation with the same reader using a "successful" test card number: `4242 4242 4242 4242`. Confirm that both the Last Payment Amount and Total Paid fields get synced to the amount of this successful order.
5. In yet another new session, complete another successful donation with a different amount. Make sure this one is a subscription. Confirm that the Last Payment Amount gets set to this amount, and the Total Paid amount gets set to the cumulative spend (it should match the "Total spend" figure in the WooCommerce > Customers table in WP admin).
6. In WP admin, trigger a renewal for the subscription purchased in step 5. Again, confirm that the Payment Amount and Total Paid fields get updated correctly in the ESP.
7. In WP admin, cancel the subscription. Confirm that the contact data in the ESP is updated to reflect "Ex-" donor status.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->