### PR TITLE
feat(wc): override cart, checkout, and my-account page templates

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -41,6 +41,9 @@ class WooCommerce_Connection {
 
 		\add_action( 'woocommerce_payment_complete', [ __CLASS__, 'order_paid' ], 101 );
 		\add_action( 'option_woocommerce_subscriptions_failed_scheduled_actions', [ __CLASS__, 'filter_subscription_scheduled_actions_errors' ] );
+
+		\add_filter( 'page_template', [ __CLASS__, 'page_template' ] );
+		\add_filter( 'get_post_metadata', [ __CLASS__, 'get_post_metadata' ], 10, 3 );
 	}
 
 	/**
@@ -458,6 +461,45 @@ class WooCommerce_Connection {
 			return;
 		}
 		\wc_add_notice( $message, $type );
+	}
+
+	/**
+	 * Should override the template for the given page?
+	 */
+	private static function should_override_template() {
+		if ( defined( 'NEWSPACK_DISABLE_WC_TEMPLATE_OVERRIDE' ) && NEWSPACK_DISABLE_WC_TEMPLATE_OVERRIDE ) {
+			return false;
+		}
+		if ( ! function_exists( 'WC' ) ) {
+			return false;
+		}
+		return is_checkout() || is_cart() || is_account_page();
+	}
+
+	/**
+	 * Override page templates for WC pages.
+	 *
+	 * @param string $template Template path.
+	 */
+	public static function page_template( $template ) {
+		if ( self::should_override_template() ) {
+			return get_stylesheet_directory() . '/single-wide.php';
+		}
+		return $template;
+	}
+
+	/**
+	 * Override post meta for WC pages.
+	 *
+	 * @param mixed  $value    Meta value to return.
+	 * @param int    $id       Post ID.
+	 * @param string $meta_key Meta key.
+	 */
+	public static function get_post_metadata( $value, $id, $meta_key ) {
+		if ( '_wp_page_template' === $meta_key && self::should_override_template() ) {
+			return 'single-wide';
+		}
+		return $value;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds overriding of the page template for WC pages.

### How to test the changes in this Pull Request:

1. Visit `/cart`, `/checkout`, and `/my-account` pages and confirm these render as single-wide template (-> they have no sidebar)
2. Set `NEWSPACK_DISABLE_WC_TEMPLATE_OVERRIDE` env variable to `true` and observe the pages render with the default template (with sidebar) (unless explicitly configured differently in editor)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->