### PR TITLE
fix: update newsletter scroll styles

### DIFF
--- a/assets/reader-activation/auth.scss
+++ b/assets/reader-activation/auth.scss
@@ -402,7 +402,7 @@
 		padding: 0.5em;
 		box-sizing: border-box;
 		max-height: 21vh;
-		overflow-y: scroll;
+		overflow-y: auto;
 		h3 {
 			display: none;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes a small tweak to the Newsletter section of the RAS sign up modal, to remove the scrollbars when they're not needed. This specifically affects Windows users, or Mac users who have their scrollbars set to always display (which is not the default setting).

See 1200550061930446-as-1206456908157509

### How to test the changes in this Pull Request:

1. If a Mac user: navigate to System Preferences > General, and set 'Show Scrollbars' to 'Always'. 
2. Set up a test site to have RAS enabled, and at least one newsletters list turned on under Newspack > Engagement > Advanced Settings, under the 'Newsletter Subscription Lists' header. 
3. View on the front-end in an incognito window, and click the 'Sign In' button. 
4. Click 'I don't have an account' at the top of the modal. 
5. Note that an unscrollable scrollbar appears next to your newsletters: 

![image](https://github.com/Automattic/newspack-plugin/assets/177561/733da468-07c1-4c34-9574-6e96da1f8104)

6. Apply the PR and run `npm run build`. 
7. Refresh the site in the incognito window, and repeat steps 3 and 4.
8. Confirm that the scrollbar is now gone: 

![image](https://github.com/Automattic/newspack-plugin/assets/177561/a163df92-217c-4ad4-b909-9d99b211ec94)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->