### PR TITLE
fix(engagement-wizard): handle error when retrieving subscription lists

### DIFF
--- a/includes/configuration_managers/class-newspack-newsletters-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-newsletters-configuration-manager.php
@@ -87,7 +87,11 @@ class Newspack_Newsletters_Configuration_Manager extends Configuration_Manager {
 		if ( ! $this->is_configured() ) {
 			return self::get_unconfigured_error();
 		}
-		return array_values( \Newspack_Newsletters_Subscription::get_lists() );
+		$lists = \Newspack_Newsletters_Subscription::get_lists();
+		if ( is_wp_error( $lists ) ) {
+			return $lists;
+		}
+		return array_values( $lists );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue in Engagement wizard.

### How to test the changes in this Pull Request:

1. On `master`, set ESP of Newspack Newsletters to "Other/Manual" 
2. Visit the Enagement wizard, observe an ugly error message:

<img width="743" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/4630be03-8dac-4f2f-865b-c39a20934f0a">

4. Switch to this branch, reload, observe a nice error message: 

<img width="750" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/8d13b6ed-88b1-46ed-8ff5-c4e596a5c2b7">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->