### PR TITLE
fix(my-account): fix "renew now" button for subscriptions

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -358,13 +358,16 @@ class WooCommerce_My_Account {
 
 	/**
 	 * Redirect to "Account details" if accessing "My Account" directly.
-	 * Do not redirect if the request is a resubscribe request, as resubscribe
-	 * requests do their own redirect to the cart/checkout page.
+	 * Do not redirect if the request is a resubscribe or renewal request, as
+	 * these requests do their own redirect to the cart/checkout page.
 	 */
 	public static function redirect_to_account_details() {
-		$resubscribe_request = isset( $_REQUEST['resubscribe'] ) ? 'shop_subscription' === get_post_type( absint( $_REQUEST['resubscribe'] ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$resubscribe_request    = filter_input( INPUT_GET, 'resubscribe', FILTER_SANITIZE_NUMBER_INT );
+		$is_resubscribe_request = ! empty( $resubscribe_request ) && 'shop_subscription' === get_post_type( $resubscribe_request );
+		$renewal_request        = filter_input( INPUT_GET, 'subscription_renewal_early', FILTER_SANITIZE_NUMBER_INT );
+		$is_renewal_request     = ! empty( $renewal_request ) && 'shop_subscription' === get_post_type( $renewal_request ) && 'true' === filter_input( INPUT_GET, 'subscription_renewal', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
-		if ( \is_user_logged_in() && Reader_Activation::is_enabled() && function_exists( 'wc_get_page_permalink' ) && ! $resubscribe_request ) {
+		if ( \is_user_logged_in() && Reader_Activation::is_enabled() && function_exists( 'wc_get_page_permalink' ) && ! $is_resubscribe_request && ! $is_renewal_request ) {
 			global $wp;
 			$current_url               = \home_url( $wp->request );
 			$my_account_page_permalink = \wc_get_page_permalink( 'myaccount' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug that prevents early renewals from going through from My Account.

### How to test the changes in this Pull Request:

1. As a reader, complete a subscription donation and then log into My Account/verify as needed.
2. On `release`, go to My Subscription and click "Renew Now". Observe that you get redirected with no feedback, and the renewal request is never processed.
3. Check out this branch and repeat. Now confirm that you clicking "Renew Now" brings you to a checkout form which you can complete to renew early.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->