### PR TITLE
fix(my-account): fixes for My Account

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -331,13 +331,16 @@ class WooCommerce_My_Account {
 
 	/**
 	 * Redirect to "Account details" if accessing "My Account" directly.
-	 * Do not redirect if the request is a resubscribe request, as resubscribe
-	 * requests do their own redirect to the cart/checkout page.
+	 * Do not redirect if the request is a resubscribe or renewal request, as
+	 * these requests do their own redirect to the cart/checkout page.
 	 */
 	public static function redirect_to_account_details() {
-		$resubscribe_request = isset( $_REQUEST['resubscribe'] ) ? 'shop_subscription' === get_post_type( absint( $_REQUEST['resubscribe'] ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$resubscribe_request    = filter_input( INPUT_GET, 'resubscribe', FILTER_SANITIZE_NUMBER_INT );
+		$is_resubscribe_request = ! empty( $resubscribe_request ) && 'shop_subscription' === get_post_type( $resubscribe_request );
+		$renewal_request        = filter_input( INPUT_GET, 'subscription_renewal_early', FILTER_SANITIZE_NUMBER_INT );
+		$is_renewal_request     = ! empty( $renewal_request ) && 'shop_subscription' === get_post_type( $renewal_request ) && 'true' === filter_input( INPUT_GET, 'subscription_renewal', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
-		if ( \is_user_logged_in() && Reader_Activation::is_enabled() && function_exists( 'wc_get_page_permalink' ) && ! $resubscribe_request ) {
+		if ( \is_user_logged_in() && Reader_Activation::is_enabled() && function_exists( 'wc_get_page_permalink' ) && ! $is_resubscribe_request && ! $is_renewal_request ) {
 			global $wp;
 			$current_url               = \home_url( $wp->request );
 			$my_account_page_permalink = \wc_get_page_permalink( 'myaccount' );

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -108,21 +108,6 @@ class WooCommerce_My_Account {
 
 			$default_disabled_items = array_merge( $default_disabled_items, [ 'dashboard', 'members-area' ] );
 			$customer_id            = \get_current_user_id();
-			if ( function_exists( 'wcs_user_has_subscription' ) && function_exists( 'wcs_get_subscriptions' ) ) {
-				$user_subscriptions             = apply_filters( 'wcs_get_users_subscriptions', [], $customer_id ); // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-				$has_non_newspack_subscriptions = false;
-				foreach ( $user_subscriptions as $subscription ) {
-					if ( ! $subscription->get_meta( WooCommerce_Connection::SUBSCRIPTION_STRIPE_ID_META_KEY ) ) {
-						$has_non_newspack_subscriptions = true;
-						break;
-					}
-				}
-				// Unless user has any subscriptions that aren't tied to a Stripe subscription by Newspack, hide the subscriptions link.
-				// The Stripe-tied subscriptions will be available for management in the "Billing" section.
-				if ( ! $has_non_newspack_subscriptions ) {
-					$default_disabled_items[] = 'subscriptions';
-				}
-			}
 			if ( class_exists( 'WC_Customer' ) ) {
 				$ignored_fields   = [ 'first_name', 'last_name', 'email' ];
 				$customer         = new \WC_Customer( $customer_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a few bugs affecting My Account. Replaces #2899. See also https://github.com/Automattic/newspack-blocks/pull/1661 and https://github.com/Automattic/newspack-theme/pull/2240

### How to test the changes in this Pull Request:

#### Required billing fields for gift recipients

When the recipient of a gifted subscription logs into My Account for the first time, WooCommerce asks them to fill in some required billing information. This info should match the selected fields in Reader Revenue settings.

1. [install the Gift Subscriptions extension](https://woo.com/products/woocommerce-subscriptions-gifting/) if you don't already have it.
2. As a reader, purchase a subscription as a gift for another email address.
3. On `release`, in a new session, log in as the gift recipient. Observe that you're asked for shipping address details in a strangely styled form:

![Screenshot 2024-02-01 at 09-58-43 My account - Newspack](https://github.com/Automattic/newspack-plugin/assets/2230142/14e9db93-374f-46a2-9969-110bfcc0d007)

4. Check out this branch (and https://github.com/Automattic/newspack-plugin/pull/2904 and https://github.com/Automattic/newspack-theme/pull/2240) and the corresponding branch in the Theme and refresh. Confirm that the form now only asks for First Name and Last Name fields, if they're required in Reader Revenue settings.

#### Gift recipients can't see "Subscriptions" menu item in My Account

1. After completing the form in the previous instructions, on `release`, observe that there's no Subscriptions menu item in the My Account navigation sidebar.
2. Check out this branch (and https://github.com/Automattic/newspack-plugin/pull/2904 and https://github.com/Automattic/newspack-theme/pull/2240), refresh, and confirm the Subscriptions menu item now shows up and that clicking it shows the subscription you were gifted.

#### Can't renew subscriptions from the Subscription page

1. As a reader, complete a subscription donation and then log into My Account/verify as needed.
2. On `release`, go to My Subscription and click "Renew Now". Observe that you get redirected with no feedback, and the renewal request is never processed.
3. Check out this branch (and https://github.com/Automattic/newspack-plugin/pull/2904 and https://github.com/Automattic/newspack-theme/pull/2240 and repeat. Now confirm that you clicking "Renew Now" brings you to a checkout form which you can complete to renew early.

#### Thank you page for renewals shows modal checkout thank you template despite not being modal checkout

#1573 added some additional hook callbacks to force modal checkout styles in the thank you page for express checkout methods (Google/Apple Pay), but #1654 implements a similar fix with a more reliable check for whether the express checkout request originated in a modal checkout flow, so these hooks are no longer needed.

1. Check out this branch (and https://github.com/Automattic/newspack-plugin/pull/2904 and https://github.com/Automattic/newspack-theme/pull/2240) and repeat the renewal process as described above.
2. After completing the renewal, confirm that the thank you page shown is the standard WooCommerce thank you template, and not our minimalist modal version.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->