### PR TITLE
fix: fixes for prod release feb 5

### DIFF
--- a/includes/plugins/class-organic-profile-block.php
+++ b/includes/plugins/class-organic-profile-block.php
@@ -17,6 +17,10 @@ class Organic_Profile_Block {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		\add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 	}

--- a/includes/plugins/class-organic-profile-block.php
+++ b/includes/plugins/class-organic-profile-block.php
@@ -17,10 +17,6 @@ class Organic_Profile_Block {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			include_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		\add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 	}
@@ -31,7 +27,7 @@ class Organic_Profile_Block {
 	 */
 	public static function wp_enqueue_scripts() {
 		if (
-			! \is_plugin_active( 'organic-profile-block/organic-profile-block.php' )
+			! \function_exists( 'organic_profile_block' )
 			&& \has_block( 'organic/profile-block' )
 		) {
 			\wp_enqueue_style(

--- a/includes/plugins/class-organic-profile-block.php
+++ b/includes/plugins/class-organic-profile-block.php
@@ -17,8 +17,8 @@ class Organic_Profile_Block {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
-		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
+		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
+		\add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 	}
 
 	/**
@@ -27,8 +27,8 @@ class Organic_Profile_Block {
 	 */
 	public static function wp_enqueue_scripts() {
 		if (
-			! is_plugin_active( 'organic-profile-block/organic-profile-block.php' )
-			&& has_block( 'organic/profile-block' )
+			! \is_plugin_active( 'organic-profile-block/organic-profile-block.php' )
+			&& \has_block( 'organic/profile-block' )
 		) {
 			\wp_enqueue_style(
 				'organic-profile-block',

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1638,7 +1638,7 @@ final class Reader_Activation {
 				 * Create WooCommerce Customer if possible.
 				 * Email notification for WooCommerce is handled by the plugin.
 				 */
-				$user_id = \wc_create_new_customer( $email, $user_data['user_login'], $user_data['random_password'], $user_data );
+				$user_id = \wc_create_new_customer( $email, $user_data['user_login'], $user_data['user_pass'], $user_data );
 			} else {
 				$user_id = \wp_insert_user( $user_data );
 				\wp_new_user_notification( $user_id, null, 'user' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

**For the Organic Profile issue:**

Installing this version of the plugin on a JN site caused a fatal error:

```
PHP Fatal error: Uncaught Error: Call to undefined function Newspack\is_plugin_active() in /srv/htdocs/wp-content/plugins/newspack-plugin/includes/plugins/class-organic-profile-block.php:30
```

To fix, we replaced the `is_plugin_active` check for one that looks for a function from the plugin. To test:

1. Set up a JN site with this PR; confirm you don't get any fatal errors/errors on the front-end. 
2. Install and activate copy of the [Profile Block](https://wordpress.org/plugins/organic-profile-block/).
3. Add a profile to a post or page and publish.
4. Deactivate the plugin.
5. Confirm that your profile block is still styled (for example, the fonts match how they looked when the plugin was active, and the profile image is aligned left). 

**For the reader registration issue:**

1. On `alpha`, register a new account via the Registration block or auth modal.
2. Observe a PHP warning upon account registration: `PHP Warning:  Undefined array key "random_password" in /newspack-repos/newspack-plugin/includes/reader-activation/class-reader-activation.php on line 1641`
3. Check out this branch, repeat, and confirm the warning doesn't happen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->