### PR TITLE
fix(ras-acc): account for null data

### DIFF
--- a/assets/reader-activation-auth/auth-form.js
+++ b/assets/reader-activation-auth/auth-form.js
@@ -234,7 +234,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 						}
 					} else {
 						let labels = newspack_reader_auth_labels.signin;
-						if ( data.registered ) {
+						if ( data?.registered ) {
 							labels = newspack_reader_auth_labels.register;
 						}
 						container.setFormAction( 'success' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

While working on https://github.com/Automattic/newspack-blocks/pull/1660, I noticed the following error triggered by the auth modal:

```
Uncaught TypeError: data is null
    endLoginFlow webpack://newspack/./assets/reader-activation-auth/auth-form.js?:225
    handleReaderChanges webpack://newspack/./assets/reader-activation-auth/auth-form.js?:98
    setTimeout handler*handleReaderChanges webpack://newspack/./assets/reader-activation-auth/auth-form.js?:96
    <anonymous> webpack://newspack/./assets/reader-activation-auth/auth-form.js?:103
    <anonymous> webpack://newspack/./assets/reader-activation-auth/auth-form.js?:23
    domReady webpack://newspack/./assets/reader-activation-auth/utils.js?:23
    <anonymous> webpack://newspack/./assets/reader-activation-auth/auth-form.js?:18
    handlePush webpack://newspack/./assets/reader-activation/index.js?:446
    handlePush webpack://newspack/./assets/reader-activation/index.js?:442
    <anonymous> webpack://newspack/./assets/reader-activation-auth/auth-form.js?:17
    js https://raz.jurassic.tube/wp-content/plugins/newspack-plugin/dist/reader-auth.js?ver=2.16.1:29
    __webpack_require__ https://raz.jurassic.tube/wp-content/plugins/newspack-plugin/dist/reader-auth.js?ver=2.16.1:103
    <anonymous> webpack://newspack/./assets/reader-activation-auth/index.js?:4
    js https://raz.jurassic.tube/wp-content/plugins/newspack-plugin/dist/reader-auth.js?ver=2.16.1:59
    __webpack_require__ https://raz.jurassic.tube/wp-content/plugins/newspack-plugin/dist/reader-auth.js?ver=2.16.1:103
    <anonymous> https://raz.jurassic.tube/wp-content/plugins/newspack-plugin/dist/reader-auth.js?ver=2.16.1:143
    <anonymous> https://raz.jurassic.tube/wp-content/plugins/newspack-plugin/dist/reader-auth.js?ver=2.16.1:148
reader-auth.js:225:17
```

This PR fixes this by properly accounting for `null` data.

### How to test the changes in this Pull Request:

1. code review should be fine for this

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->