### PR TITLE
fix: prevent fatal when redirecting for pixel tracking

### DIFF
--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -313,7 +313,7 @@ final class Data_Events {
 		}
 
 		Logger::log(
-			sprintf( 'Dispatching action "%s" with data:' . "\n" . \wp_json_encode( $data, JSON_PRETTY_PRINT ), $action_name ),
+			sprintf( 'Dispatching action "%s".', $action_name ),
 			self::LOGGER_HEADER
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A Data Event logger throws a fatal if a data event is dispatched without any data.

### How to test the changes in this Pull Request:

1. In WP admin > Newsletters > Tracking, turn on pixel tracking.
2. On `release`, visit a front-end page of your site with a bunch of UTM params. e.g.

```
https://site-domain/?np_newsletters_click=1&id=12345&url=https%3A%2F%2Fsite-domain%2F2023%2F08%2F22%2Ftortor-posuere-vitae-eget-finibus-praesent-sem-interdum-phasellus%2F%3Futm_medium%3Demail&em=test@email.com&utm_source=Newspack+Mailing+List+(including+Members)&utm_campaign=00000000-EMAIL_CAMPAIGN_2024_01_26_07_08&utm_medium=email&utm_term=0_-00000000-[LIST_EMAIL_ID]
```

where the `&url=` param is a URL with UTM params attached and run through `encodeURIComponent()`.

4. Observe a fatal:

```
PHP Fatal error:  Uncaught ArgumentCountError: 4 arguments are required, 2 given in /newspack-repos/newspack-plugin/includes/data-events/class-data-events.php:316
```

5. Check out this branch, refresh the URL, and confirm you're redirected properly to the `url` and that the click is tracked in Newsletters.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->