### PR TITLE
Turn off WooCommerce Order Attribution 

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -34,6 +34,7 @@ class WooCommerce_Connection {
 		\add_filter( 'default_option_woocommerce_subscriptions_enable_retry', [ __CLASS__, 'force_allow_failed_payment_retry' ] );
 		\add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'send_customizable_receipt_email' ], 10, 3 );
 		\add_action( 'woocommerce_order_status_completed', [ __CLASS__, 'maybe_update_reader_display_name' ], 10, 2 );
+		\add_action( 'option_woocommerce_feature_order_attribution_enabled', [ __CLASS__, 'force_disable_order_attribution'] );
 		\add_action( 'cli_init', [ __CLASS__, 'register_cli_commands' ] );
 
 		// WooCommerce Subscriptions.
@@ -308,6 +309,24 @@ class WooCommerce_Connection {
 		}
 
 		return 'yes';
+	}
+
+	/**
+	 * Force option for enabling order attribution to OFF unless the
+	 * NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBTION_OVERRIDE constant is set.
+	 * Right now, it causes JavaScript errors in the modal checkout.
+	 *
+	 * See:https://woo.com/document/order-attribution-tracking/
+	 *
+	 * @param bool $should_allow Whether WooCommerce should allow enabling Order Attribution.
+	 *
+	 * @return string Option value.
+	 */
+	public static function force_disable_order_attribution( $should_allow ) {
+		if ( defined( 'NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBTION_OVERRIDE' ) && NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBTION_OVERRIDE ) {
+			return $should_allow;
+		}
+		return false;
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -34,7 +34,7 @@ class WooCommerce_Connection {
 		\add_filter( 'default_option_woocommerce_subscriptions_enable_retry', [ __CLASS__, 'force_allow_failed_payment_retry' ] );
 		\add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'send_customizable_receipt_email' ], 10, 3 );
 		\add_action( 'woocommerce_order_status_completed', [ __CLASS__, 'maybe_update_reader_display_name' ], 10, 2 );
-		\add_action( 'option_woocommerce_feature_order_attribution_enabled', [ __CLASS__, 'force_disable_order_attribution'] );
+		\add_action( 'option_woocommerce_feature_order_attribution_enabled', [ __CLASS__, 'force_disable_order_attribution' ] );
 		\add_action( 'cli_init', [ __CLASS__, 'register_cli_commands' ] );
 
 		// WooCommerce Subscriptions.

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -313,7 +313,7 @@ class WooCommerce_Connection {
 
 	/**
 	 * Force option for enabling order attribution to OFF unless the
-	 * NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBTION_OVERRIDE constant is set.
+	 * NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBUTION_OVERRIDE constant is set.
 	 * Right now, it causes JavaScript errors in the modal checkout.
 	 *
 	 * See:https://woo.com/document/order-attribution-tracking/
@@ -323,7 +323,7 @@ class WooCommerce_Connection {
 	 * @return string Option value.
 	 */
 	public static function force_disable_order_attribution( $should_allow ) {
-		if ( defined( 'NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBTION_OVERRIDE' ) && NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBTION_OVERRIDE ) {
+		if ( defined( 'NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBUTION_OVERRIDE' ) && NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBUTION_OVERRIDE ) {
 			return $should_allow;
 		}
 		return false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WooCommerce 8.5 includes a new [Order Attribution feature](https://woo.com/document/order-attribution-tracking/). Unfortunately, out of the box it throws JavaScript errors in our modal checkout, possibly related to how we're splitting the checkout form into multiple screens. This causes other issues, like the Coupon toggle no longer displaying the coupon form.

This PR turns off this option on Newspack sites, and adds a `NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBUTION_OVERRIDE` constant for overriding it.

See 1200550061930446-as-1206508452114800.

### How to test the changes in this Pull Request:

1. On a test site running `release` (or `trunk`), set up a donate block or checkout button.
2. Open the console, then trigger a purchase to open the modal checkout.
3. Note the JavaScript errors in the console: `Uncaught TypeError: s(...) is null` coming from `/wp-content/plugins/woocommerce/assets/js/frontend/order-attribution.min.js?ver=8.5.2:1`
4. Navigate to WP Admin > WooCommerce > Advanced > Features, and note that `Enable this feature to track and credit channels and campaigns that contribute to orders on your site ` is checked next to the Order Attributions header.
5. Apply the PR.
6. Confirm that `Enable this feature to track and credit channels and campaigns that contribute to orders on your site` is no longer checked.
7. Confirm that checking it and saving it does not allow you to turn on the option.
8. Repeat steps 2 and 3, and confirm that the modal checkout no longer displays the JavaScript error.
9. Add `define( 'NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBUTION_OVERRIDE', true );` to your wp-config.php file.
10. Refresh the WooCommerce settings page, and confirm that you can turn on the `Enable this feature to track and credit channels and campaigns that contribute to orders on your site`, and that it stays on.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->