### PR TITLE
fix: allow media lib access if explicitly set

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -405,7 +405,7 @@ class Patches {
 	public static function restrict_media_library_access_ajax( $query_args ) {
 		$current_user_id = get_current_user_id();
 
-		if ( $current_user_id && ! current_user_can( 'edit_others_posts' ) ) {
+		if ( $current_user_id && ! current_user_can( 'edit_others_posts' ) && ! current_user_can( 'edit_files' ) ) {
 			$query_args['author'] = $current_user_id;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adjusts the overly restrictive changes from https://github.com/Automattic/newspack-plugin/pull/1541 – it added blocking access to media library unless user had `edit_others_posts` capability. This PR allows for access to media library if the user has `edit_files` capability.

See 1200550061930446-as-1206529111267127/f

### How to test the changes in this Pull Request:

1. On `trunk`, install the `capability-manager-enhanced` plugin (PublishPress Capabilities)
2. Add the `edit_files` cap to the Author role (Capabilities -> Capabilities) 
3. Log in as author, observe that you can't see any media files in the media library (unless uploaded by you)
4. Switch to this branch, observe the media files are viewable now

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->