### PR TITLE
fix: update path to wide template file

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -580,7 +580,7 @@ class WooCommerce_Connection {
 	 */
 	public static function page_template( $template ) {
 		if ( self::should_override_template() ) {
-			return get_stylesheet_directory() . '/single-wide.php';
+			return get_theme_file_path( '/single-wide.php' );
 		}
 		return $template;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes a small tweak to the changes in #2893, which make sure my-account, cart, etc. use the One Column Wide template at all times. This works great for the parent theme, but throws an error for the child themes. 

### How to test the changes in this Pull Request:

1. Running `trunk`, switch to one of the child themes.
2. Go to `/my-account`; note the blank page and/or errors.
3. Switch to this PR.
4. Repeat step 2 and confirm the page loads as expected. 
5. Repeat the testing steps from #2893.
6. Switch to the parent theme and repeat step 2, just to make sure that also works well.
7. Lastly, switch back to a child theme, and copy the single-wide.php template to it -- also make a big change, like deleting the header. Repeat step 2 a final time and confirm that the single-wide.php template you're loading is from the child theme. This case won't happen on any sites we host, but makes sure this still works if someone opts to replace and modify the single-wide.php in their own child theme.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->