### PR TITLE
fix(newsletters): handle status metadata

### DIFF
--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -202,6 +202,9 @@ class Newspack_Newsletters {
 						$normalized_metadata[ $meta_key ] = $meta_value;
 					}
 				}
+				if ( isset( $contact['metadata']['status'] ) ) {
+					$normalized_metadata['status'] = $contact['metadata']['status'];
+				}
 			}
 			$contact['metadata'] = $normalized_metadata;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

ESP contact "status" field was getting lost in translation. It's default value, with Mailchimp ESP, depends on the "Audience name and campaign defaults" settings and may be uneditable:

<img width="654" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/7251ae93-e8af-45bc-b3ac-1714a70c4bd5">

Related: 1200550061930446-as-1206757452275789/f

### How to test the changes in this Pull Request:

1. Configure site to use Mailchimp ESP
1. On `trunk`, log the value of `$contact['metadata']` passed to the `Newspack_Newsletters_Subscription::add_contact_to_provider` method of `newspack-newsletters` plugin
2. Insert the newsletter signup block on a page and check "Enable double opt-in" in block settings sidebar "Mailchimp Settings" panel 
3. Observe in the logged metadata that there is no status
4. Switch to this branch, observe the status is passed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->