### PR TITLE
fix: correct translation strings for half of assets/components

### DIFF
--- a/assets/components/src/autocomplete-with-suggestions/index.js
+++ b/assets/components/src/autocomplete-with-suggestions/index.js
@@ -17,16 +17,16 @@ import './style.scss';
 const AutocompleteWithSuggestions = ( {
 	fetchSavedPosts = false, // If passed, will use this function to fetch saved data.
 	fetchSuggestions = false, // If passed, will use this function to fetch suggestions data.
-	help = __( 'Begin typing search term, click autocomplete result to select.', 'newspack' ),
+	help = __( 'Begin typing search term, click autocomplete result to select.', 'newspack-plugin' ),
 	hideHelp = false, // If true, all help text will be hidden.
-	label = __( 'Search', 'newspack' ),
+	label = __( 'Search', 'newspack-plugin' ),
 	maxItemsToSuggest = 0, // If passed, will be used to determine "load more" state. Necessary if you want "load more" functionality when using a custom `fetchSuggestions` function.
 	multiSelect = false, // If true, component can select multiple values at once.
 	onChange = false, // Function to call when selections change.
 	onPostTypeChange = false, // Funciton to call when the post type selector is changed.
 	postTypes = [ { slug: 'post', label: 'Post' } ], // If passed, will render a selector to change the post type queried for suggestions.
-	postTypeLabel = __( 'item', 'newspack' ), // String to describe the data being shown.
-	postTypeLabelPlural = __( 'items', 'newspack' ), // Plural string to describe the data being shown.
+	postTypeLabel = __( 'item', 'newspack-plugin' ), // String to describe the data being shown.
+	postTypeLabelPlural = __( 'items', 'newspack-plugin' ), // Plural string to describe the data being shown.
 	selectedItems = [], // Array of saved items.
 	selectedPost = 0, // Legacy prop when single-select was the only option.
 	suggestionsToFetch = 10, // Number of suggestions to fetch per query.
@@ -96,7 +96,7 @@ const AutocompleteWithSuggestions = ( {
 
 				return posts.map( post => ( {
 					value: parseInt( post.id ),
-					label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
+					label: decodeEntities( post.title ) || __( '(no title)', 'newspack-plugin' ),
 				} ) );
 		  };
 
@@ -130,7 +130,7 @@ const AutocompleteWithSuggestions = ( {
 				return posts.reduce( ( acc, post ) => {
 					acc.push( {
 						value: parseInt( post.id ),
-						label: decodeEntities( post?.title.rendered ) || __( '(no title)', 'newspack' ),
+						label: decodeEntities( post?.title.rendered ) || __( '(no title)', 'newspack-plugin' ),
 					} );
 
 					return acc;
@@ -177,21 +177,21 @@ const AutocompleteWithSuggestions = ( {
 		const selectedMessage = multiSelect
 			? sprintf(
 					// Translators: %1: the length of selections. %2: the selection leabel.
-					__( '%1$s %2$s selected', 'newspack' ),
+					__( '%1$s %2$s selected', 'newspack-plugin' ),
 					selections.length,
 					selections.length > 1 ? postTypeLabelPlural : postTypeLabel
 			  )
 			: // Translators: %s: The label for the selection.
-			  sprintf( __( 'Selected %s', 'newspack' ), postTypeLabel );
+			  sprintf( __( 'Selected %s', 'newspack-plugin' ), postTypeLabel );
 
 		return (
 			<div className="newspack-autocomplete-with-suggestions__selected-items">
 				<p className="newspack-autocomplete-with-suggestions__label">
 					{ selectedMessage }
-					{ 1 < selections.length && _x( ' – ', 'separator character', 'newspack' ) }
+					{ 1 < selections.length && _x( ' – ', 'separator character', 'newspack-plugin' ) }
 					{ 1 < selections.length && (
 						<Button onClick={ () => onChange( [] ) } isLink isDestructive>
-							{ __( 'Clear all', 'newspack' ) }
+							{ __( 'Clear all', 'newspack-plugin' ) }
 						</Button>
 					) }
 				</p>
@@ -219,7 +219,7 @@ const AutocompleteWithSuggestions = ( {
 			<SelectControl
 				label={ sprintf(
 					// Translators: %s: The name of the type.
-					__( '%s type', 'newspack' ),
+					__( '%s type', 'newspack-plugin' ),
 					postTypeLabel.charAt( 0 ).toUpperCase() + postTypeLabel.slice( 1 )
 				) }
 				value={ postTypeToSearch }
@@ -279,7 +279,7 @@ const AutocompleteWithSuggestions = ( {
 					<p className="newspack-autocomplete-with-suggestions__label">
 						{
 							/* Translators: %s: the name of a post type. */ sprintf(
-								__( 'Or, select a recent %s:', 'newspack' ),
+								__( 'Or, select a recent %s:', 'newspack-plugin' ),
 								postTypeLabel
 							)
 						}
@@ -293,7 +293,9 @@ const AutocompleteWithSuggestions = ( {
 							isSecondary
 							onClick={ () => setIsLoadingMore( true ) }
 						>
-							{ isLoadingMore ? __( 'Loading…', 'newspack' ) : __( 'Load more', 'newspack' ) }
+							{ isLoadingMore
+								? __( 'Loading…', 'newspack-plugin' )
+								: __( 'Load more', 'newspack-plugin' ) }
 						</Button>
 					) }
 				</div>

--- a/assets/components/src/footer/index.js
+++ b/assets/components/src/footer/index.js
@@ -32,43 +32,43 @@ const Footer = ( { simple } ) => {
 			external: true,
 		},
 		{
-			label: __( 'About', 'newspack' ),
+			label: __( 'About', 'newspack-plugin' ),
 			url: 'https://newspack.com/',
 			external: true,
 		},
 		{
-			label: __( 'Documentation', 'newspack' ),
+			label: __( 'Documentation', 'newspack-plugin' ),
 			url: support,
 			external: true,
 		},
 	];
 	if ( componentsDemo ) {
 		footerElements.push( {
-			label: __( 'Components Demo', 'newspack' ),
+			label: __( 'Components Demo', 'newspack-plugin' ),
 			url: componentsDemo,
 		} );
 	}
 	if ( setupWizard ) {
 		footerElements.push( {
-			label: __( 'Setup Wizard', 'newspack' ),
+			label: __( 'Setup Wizard', 'newspack-plugin' ),
 			url: setupWizard,
 		} );
 	}
 	if ( resetUrl ) {
 		footerElements.push( {
-			label: __( 'Reset Newspack', 'newspack' ),
+			label: __( 'Reset Newspack', 'newspack-plugin' ),
 			url: resetUrl,
 		} );
 	}
 	if ( removeStarterContent ) {
 		footerElements.push( {
-			label: __( 'Remove Starter Content', 'newspack' ),
+			label: __( 'Remove Starter Content', 'newspack-plugin' ),
 			url: removeStarterContent,
 		} );
 	}
 	if ( supportEmail ) {
 		footerElements.push( {
-			label: __( 'Contact Support', 'newspack' ),
+			label: __( 'Contact Support', 'newspack-plugin' ),
 			url: `mailto:${ supportEmail }`,
 		} );
 	}

--- a/assets/components/src/handoff/index.js
+++ b/assets/components/src/handoff/index.js
@@ -52,10 +52,11 @@ class Handoff extends Component {
 	textForPlugin = pluginInfo => {
 		const defaults = {
 			modalBody: null,
-			modalTitle: pluginInfo.Name && `${ __( 'Manage', 'newspack' ) } ${ pluginInfo.Name }`,
-			primaryButton: pluginInfo.Name && `${ __( 'Manage', 'newspack' ) } ${ pluginInfo.Name }`,
-			primaryModalButton: __( 'Manage', 'newspack' ),
-			dismissModalButton: __( 'Dismiss', 'newspack' ),
+			modalTitle: pluginInfo.Name && `${ __( 'Manage', 'newspack-plugin' ) } ${ pluginInfo.Name }`,
+			primaryButton:
+				pluginInfo.Name && `${ __( 'Manage', 'newspack-plugin' ) } ${ pluginInfo.Name }`,
+			primaryModalButton: __( 'Manage', 'newspack-plugin' ),
+			dismissModalButton: __( 'Dismiss', 'newspack-plugin' ),
 		};
 		return assign( defaults, this.props );
 	};
@@ -115,7 +116,7 @@ class Handoff extends Component {
 				) }
 				{ Name && 'active' !== Status && (
 					<Button className={ classes } variant="secondary" disabled { ...otherProps }>
-						{ Name + __( ' not installed', 'newspack' ) }
+						{ Name + __( ' not installed', 'newspack-plugin' ) }
 					</Button>
 				) }
 				{ ! Name && (
@@ -126,7 +127,7 @@ class Handoff extends Component {
 					>
 						<Fragment>
 							{ ! compact && <Waiting isLeft /> }
-							{ __( 'Retrieving Plugin Info', 'newspack' ) }
+							{ __( 'Retrieving Plugin Info', 'newspack-plugin' ) }
 						</Fragment>
 					</Button>
 				) }

--- a/assets/components/src/image-upload/index.js
+++ b/assets/components/src/image-upload/index.js
@@ -102,11 +102,11 @@ class ImageUpload extends Component {
 							<img
 								data-testid="image-upload"
 								src={ image.url }
-								alt={ __( 'Image preview', 'newspack' ) }
+								alt={ __( 'Image preview', 'newspack-plugin' ) }
 							/>
 							<div className="newspack-image-upload__controls">
 								<Button disabled={ disabled } onClick={ this.openModal } isLink>
-									{ __( 'Replace', 'newspack' ) }
+									{ __( 'Replace', 'newspack-plugin' ) }
 								</Button>
 								<span className="sep" />
 								<Button
@@ -115,13 +115,13 @@ class ImageUpload extends Component {
 									isLink
 									isDestructive
 								>
-									{ __( 'Remove', 'newspack' ) }
+									{ __( 'Remove', 'newspack-plugin' ) }
 								</Button>
 							</div>
 						</>
 					) : (
 						<Button disabled={ disabled } onClick={ this.openModal } isLink>
-							{ buttonLabel ? buttonLabel : __( 'Upload', 'newspack' ) }
+							{ buttonLabel ? buttonLabel : __( 'Upload', 'newspack-plugin' ) }
 						</Button>
 					) }
 				</div>

--- a/assets/components/src/notice/index.js
+++ b/assets/components/src/notice/index.js
@@ -62,7 +62,7 @@ class Notice extends Component {
 				{ <Icon icon={ noticeIcon } /> }
 				<div className="newspack-notice__content">
 					{ rawHTML ? <RawHTML>{ noticeText }</RawHTML> : noticeText }
-					{ debugMode && __( 'Debug Mode', 'newspack' ) }
+					{ debugMode && __( 'Debug Mode', 'newspack-plugin' ) }
 					{ children || null }
 				</div>
 			</div>

--- a/assets/components/src/patrons-logo/index.js
+++ b/assets/components/src/patrons-logo/index.js
@@ -21,7 +21,10 @@ class PatronsLogo extends Component {
 				height="16"
 				viewBox="0 0 438 32"
 				className="patrons-logo"
-				aria-label={ __( 'A project of WordPress.com and the Google News Initiative', 'newspack' ) }
+				aria-label={ __(
+					'A project of WordPress.com and the Google News Initiative',
+					'newspack-plugin'
+				) }
 			>
 				<Path
 					fillRule="evenodd"

--- a/assets/components/src/plugin-installer/index.js
+++ b/assets/components/src/plugin-installer/index.js
@@ -170,8 +170,8 @@ class PluginInstaller extends Component {
 			currentStatus === 'active' || currentStatus === 'inactive';
 
 		const buttonText = currentPluginStatuses.every( pluginInstalled )
-			? __( 'Activate', 'newspack' )
-			: __( 'Install', 'newspack' );
+			? __( 'Activate', 'newspack-plugin' )
+			: __( 'Install', 'newspack-plugin' );
 
 		const needsInstall = slugs.some( slug => {
 			const plugin = pluginInfo[ slug ];
@@ -183,7 +183,7 @@ class PluginInstaller extends Component {
 				{ ( ! pluginInfo || ! Object.keys( pluginInfo ).length ) && (
 					<div className="newspack-plugin-installer_is-waiting">
 						<Waiting isLeft />
-						{ __( 'Retrieving plugin information…' ) }
+						{ __( 'Retrieving plugin information…', 'newspack-plugin' ) }
 					</div>
 				) }
 				{ pluginInfo &&
@@ -202,8 +202,8 @@ class PluginInstaller extends Component {
 							actionText = (
 								<span className="newspack-plugin-installer__status">
 									{ isAtomic
-										? __( 'Contact Newspack support to install', 'newspack' )
-										: __( 'Plugin must be installed manually', 'newspack' ) }
+										? __( 'Contact Newspack support to install', 'newspack-plugin' )
+										: __( 'Plugin must be installed manually', 'newspack-plugin' ) }
 									<span className="newspack-checkbox-icon" />
 								</span>
 							);
@@ -217,14 +217,14 @@ class PluginInstaller extends Component {
 						} else if ( Status === 'inactive' ) {
 							actionText = (
 								<span className="newspack-plugin-installer__status">
-									{ __( 'Activate', 'newspack' ) }
+									{ __( 'Activate', 'newspack-plugin' ) }
 									<span className="newspack-checkbox-icon" />
 								</span>
 							);
 						} else if ( Status === 'active' ) {
 							actionText = (
 								<span className="newspack-plugin-installer__status">
-									{ __( 'Installed', 'newspack' ) }
+									{ __( 'Installed', 'newspack-plugin' ) }
 									<span className="newspack-checkbox-icon newspack-checkbox-icon--checked">
 										<Icon icon={ check } />
 									</span>

--- a/assets/components/src/plugin-settings/index.js
+++ b/assets/components/src/plugin-settings/index.js
@@ -205,7 +205,7 @@ class PluginSettings extends Component {
 }
 
 PluginSettings.defaultProps = {
-	title: __( 'General Settings', 'newspack' ),
+	title: __( 'General Settings', 'newspack-plugin' ),
 };
 
 PluginSettings.Section = SettingsSection;

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -67,7 +67,9 @@ class PluginToggle extends Component {
 								...pluginInfo,
 								[ plugin ]: {
 									...pluginInfo[ plugin ],
-									error: e.message || __( 'There was an error managing this plugin.', 'newspack' ),
+									error:
+										e.message ||
+										__( 'There was an error managing this plugin.', 'newspack-plugin' ),
 								},
 							},
 						} );
@@ -148,21 +150,21 @@ class PluginToggle extends Component {
 		if ( 'configure' === inFlight ) {
 			return (
 				<Fragment>
-					{ __( 'Installing…', 'newspack' ) } <Waiting isRight />
+					{ __( 'Installing…', 'newspack-plugin' ) } <Waiting isRight />
 				</Fragment>
 			);
 		}
 		if ( 'deactivate' === inFlight ) {
 			return (
 				<Fragment>
-					{ __( 'Deactivating…', 'newspack' ) } <Waiting isRight />
+					{ __( 'Deactivating…', 'newspack-plugin' ) } <Waiting isRight />
 				</Fragment>
 			);
 		}
 		if ( ! name ) {
 			return (
 				<Fragment>
-					{ __( 'Loading…', 'newspack' ) } <Waiting isRight />
+					{ __( 'Loading…', 'newspack-plugin' ) } <Waiting isRight />
 				</Fragment>
 			);
 		}
@@ -171,7 +173,7 @@ class PluginToggle extends Component {
 			return null;
 		}
 		if ( href || editPath ) {
-			return actionText ? actionText : __( 'Configure', 'newspack' );
+			return actionText ? actionText : __( 'Configure', 'newspack-plugin' );
 		}
 	};
 

--- a/assets/components/src/position-control/index.js
+++ b/assets/components/src/position-control/index.js
@@ -32,70 +32,70 @@ export default function PositionControl( {
 					{
 						value: 'top',
 						/* translators: Overlay Position */
-						label: __( 'Top', 'newspack' ),
+						label: __( 'Top', 'newspack-plugin' ),
 					},
 					{
 						value: 'center',
 						/* translators: Overlay Position */
-						label: __( 'Center', 'newspack' ),
+						label: __( 'Center', 'newspack-plugin' ),
 					},
 					{
 						value: 'bottom',
 						/* translators: Overlay Position */
-						label: __( 'Bottom', 'newspack' ),
+						label: __( 'Bottom', 'newspack-plugin' ),
 					},
 			  ]
 			: [
 					{
 						value: 'top_left',
 						/* translators: Overlay Position */
-						label: __( 'Top Left', 'newspack' ),
+						label: __( 'Top Left', 'newspack-plugin' ),
 					},
 					{
 						value: 'top',
 						/* translators: Overlay Position */
-						label: __( 'Top Center', 'newspack' ),
+						label: __( 'Top Center', 'newspack-plugin' ),
 					},
 					{
 						value: 'top_right',
 						/* translators: Overlay Position */
-						label: __( 'Top Right', 'newspack' ),
+						label: __( 'Top Right', 'newspack-plugin' ),
 					},
 					{
 						value: 'center_left',
 						/* translators: Overlay Position */
-						label: __( 'Center Left', 'newspack' ),
+						label: __( 'Center Left', 'newspack-plugin' ),
 					},
 					{
 						value: 'center',
 						/* translators: Overlay Position */
-						label: __( 'Center', 'newspack' ),
+						label: __( 'Center', 'newspack-plugin' ),
 					},
 					{
 						value: 'center_right',
 						/* translators: Overlay Position */
-						label: __( 'Center Right', 'newspack' ),
+						label: __( 'Center Right', 'newspack-plugin' ),
 					},
 					{
 						value: 'bottom_left',
 						/* translators: Overlay Position */
-						label: __( 'Bottom Left', 'newspack' ),
+						label: __( 'Bottom Left', 'newspack-plugin' ),
 					},
 					{
 						value: 'bottom',
 						/* translators: Overlay Position */
-						label: __( 'Bottom Center', 'newspack' ),
+						label: __( 'Bottom Center', 'newspack-plugin' ),
 					},
 					{
 						value: 'bottom_right',
 						/* translators: Overlay Position */
-						label: __( 'Bottom Right', 'newspack' ),
+						label: __( 'Bottom Right', 'newspack-plugin' ),
 					},
 			  ];
 	return (
 		<div className={ classnames( 'newspack-position-placement-control', 'size-' + size ) }>
 			<p className="components-base-control__label">{ label }</p>
-			<ButtonGroup aria-label={ __( 'Select Position', 'newspack' ) } { ...props }>
+			<ButtonGroup aria-label={ __( 'Select Position', 'newspack-plugin' ) } { ...props }>
 				{ options.map( ( option, index ) => {
 					return (
 						<div

--- a/assets/components/src/select-control/GroupedSelectControl.js
+++ b/assets/components/src/select-control/GroupedSelectControl.js
@@ -52,7 +52,7 @@ export default function GroupedSelectControl( {
 					aria-describedby={ !! help ? `${ id }__help` : undefined }
 					{ ...props }
 				>
-					<option value="">{ __( '-- Select --', 'newspack' ) }</option>
+					<option value="">{ __( '-- Select --', 'newspack-plugin' ) }</option>
 					{ optgroups.map( ( { label: optgroupLabel, options }, optgroupIndex ) => (
 						<optgroup label={ optgroupLabel } key={ optgroupIndex }>
 							{ options.map( ( option, optionIndex ) => (

--- a/assets/components/src/settings/MinMaxSetting.js
+++ b/assets/components/src/settings/MinMaxSetting.js
@@ -24,7 +24,7 @@ const MinMaxSetting = ( {
 				<CheckboxControl
 					checked={ min > 0 }
 					onChange={ value => onChangeMin( value ? 1 : 0 ) }
-					label={ __( 'Min', 'newspack' ) }
+					label={ __( 'Min', 'newspack-plugin' ) }
 				/>
 				<TextControl
 					data-testid="min"
@@ -38,7 +38,7 @@ const MinMaxSetting = ( {
 				<CheckboxControl
 					checked={ max > 0 }
 					onChange={ value => onChangeMax( value ? min || 1 : 0 ) }
-					label={ __( 'Max', 'newspack' ) }
+					label={ __( 'Max', 'newspack-plugin' ) }
 				/>
 				<TextControl
 					data-testid="max"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is part of a set that corrects the text domain in the Newspack plugin  -- hopefully broken down in a way that makes them easier to review!

This PR covers the `/assets/components/src/autocomplete` through to the `/assets/components/src/settings` directory.

See 1200550061930446-1205509524123559

### How to test the changes in this Pull Request:

1. Spot check the changes, and confirm that all text domains are now `newspack-plugin` in any strings marked for translation.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->