### PR TITLE
fix: correct translation strings for second half of assets/components

### DIFF
--- a/assets/components/src/sortable-newsletter-list-control/index.js
+++ b/assets/components/src/sortable-newsletter-list-control/index.js
@@ -52,7 +52,7 @@ export default function SortableNewsletterListControl( {
 											onChange( newSelected );
 										} }
 									/>
-									{ __( 'Checked by default', 'newspack' ) }
+									{ __( 'Checked by default', 'newspack-plugin' ) }
 								</>
 							) }
 							isSmall
@@ -62,7 +62,7 @@ export default function SortableNewsletterListControl( {
 										onClick={ () =>
 											onChange( selected.filter( ( { id } ) => id !== selectedList.id ) )
 										}
-										label={ __( 'Remove', 'newspack' ) }
+										label={ __( 'Remove', 'newspack-plugin' ) }
 										icon={ trash }
 									/>
 								</>
@@ -115,9 +115,9 @@ export default function SortableNewsletterListControl( {
 			{ getAvailableLists().length > 0 && (
 				<p className="newspack__newsletter-list-control__lists">
 					{ selected.length > 0 ? (
-						<strong>{ __( 'Add more lists:', 'newspack' ) }</strong>
+						<strong>{ __( 'Add more lists:', 'newspack-plugin' ) }</strong>
 					) : (
-						<strong>{ __( 'Select lists:', 'newspack' ) }</strong>
+						<strong>{ __( 'Select lists:', 'newspack-plugin' ) }</strong>
 					) }{ ' ' }
 					{ getAvailableLists().map( list => {
 						return (

--- a/assets/components/src/style-card/index.js
+++ b/assets/components/src/style-card/index.js
@@ -38,25 +38,31 @@ class StyleCard extends Component {
 					{ imageType === 'html' ? (
 						<div dangerouslySetInnerHTML={ image } />
 					) : (
-						<img src={ image } alt={ cardTitle + ' ' + __( 'Thumbnail', 'newspack' ) } />
+						<img src={ image } alt={ cardTitle + ' ' + __( 'Thumbnail', 'newspack-plugin' ) } />
 					) }
 					<div className="newspack-style-card__actions">
 						{ isActive ? (
 							<span className="newspack-style-card__actions__badge">
-								{ __( 'Selected', 'newspack' ) }
+								{ __( 'Selected', 'newspack-plugin' ) }
 							</span>
 						) : (
 							<Button
 								variant="link"
 								onClick={ onClick }
-								aria-label={ ariaLabel ? ariaLabel : __( 'Select', 'newspack' ) + ' ' + cardTitle }
+								aria-label={
+									ariaLabel ? ariaLabel : __( 'Select', 'newspack-plugin' ) + ' ' + cardTitle
+								}
 								tabIndex="0"
 							>
-								{ __( 'Select', 'newspack' ) }
+								{ __( 'Select', 'newspack-plugin' ) }
 							</Button>
 						) }
 						{ url && (
-							<WebPreview url={ url } label={ __( 'View Demo', 'newspack' ) } variant="link" />
+							<WebPreview
+								url={ url }
+								label={ __( 'View Demo', 'newspack-plugin' ) }
+								variant="link"
+							/>
 						) }
 					</div>
 				</div>

--- a/assets/components/src/text-control/index.tsx
+++ b/assets/components/src/text-control/index.tsx
@@ -38,7 +38,7 @@ const TextControl = ( {
 		}
 		const labelEl = wrapperRef.current.querySelector( 'label' );
 		if ( labelEl ) {
-			labelEl.setAttribute( 'data-required-text', __( '(required)', 'newspack' ) );
+			labelEl.setAttribute( 'data-required-text', __( '(required)', 'newspack-plugin' ) );
 		}
 	}, [ wrapperRef.current ] );
 	const classes = classNames(

--- a/assets/components/src/web-preview/index.js
+++ b/assets/components/src/web-preview/index.js
@@ -81,19 +81,19 @@ class WebPreview extends Component {
 									onClick={ () => this.setState( { device: 'desktop' } ) }
 									variant={ 'desktop' === device && 'primary' }
 									icon={ desktop }
-									label={ __( 'Preview Desktop Size', 'newspack' ) }
+									label={ __( 'Preview Desktop Size', 'newspack-plugin' ) }
 								/>
 								<Button
 									onClick={ () => this.setState( { device: 'tablet' } ) }
 									variant={ 'tablet' === device && 'primary' }
 									icon={ tablet }
-									label={ __( 'Preview Tablet Size', 'newspack' ) }
+									label={ __( 'Preview Tablet Size', 'newspack-plugin' ) }
 								/>
 								<Button
 									onClick={ () => this.setState( { device: 'phone' } ) }
 									variant={ 'phone' === device && 'primary' }
 									icon={ mobile }
-									label={ __( 'Preview Phone Size', 'newspack' ) }
+									label={ __( 'Preview Phone Size', 'newspack-plugin' ) }
 								/>
 							</ButtonGroup>
 						</div>
@@ -104,7 +104,7 @@ class WebPreview extends Component {
 									this.setState( { isPreviewVisible: false, loaded: false } );
 								} }
 								icon={ closeSmall }
-								label={ __( 'Close Preview', 'newspack' ) }
+								label={ __( 'Close Preview', 'newspack-plugin' ) }
 							/>
 						</div>
 					</div>
@@ -112,7 +112,7 @@ class WebPreview extends Component {
 						{ ! loaded && (
 							<div className="newspack-web-preview__is-waiting">
 								<Waiting isLeft />
-								{ __( 'Loading…', 'newspack' ) }
+								{ __( 'Loading…', 'newspack-plugin' ) }
 							</div>
 						) }
 						<iframe
@@ -166,7 +166,7 @@ class WebPreview extends Component {
 
 WebPreview.defaultProps = {
 	url: '//newspack.com',
-	label: __( 'Preview', 'newspack' ),
+	label: __( 'Preview', 'newspack-plugin' ),
 	onLoad: () => {},
 };
 

--- a/assets/components/src/with-wizard-screen/index.js
+++ b/assets/components/src/with-wizard-screen/index.js
@@ -66,7 +66,7 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton 
 							<Button
 								isLink
 								href={ newspack_urls.dashboard }
-								label={ __( 'Return to Dashboard', 'newspack' ) }
+								label={ __( 'Return to Dashboard', 'newspack-plugin' ) }
 								showTooltip={ true }
 								icon={ category }
 								iconSize={ 36 }

--- a/assets/components/src/with-wizard/index.js
+++ b/assets/components/src/with-wizard/index.js
@@ -105,7 +105,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 					<Notice noticeText={ message } isError rawHTML />
 					<Card buttonsCard noBorder className="justify-end">
 						<Button isPrimary href={ fallbackURL }>
-							{ __( 'Return to Dashboard', 'newspack' ) }
+							{ __( 'Return to Dashboard', 'newspack-plugin' ) }
 						</Button>
 					</Card>
 				</Modal>
@@ -219,7 +219,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 											<Button
 												isLink
 												href={ newspack_urls.dashboard }
-												label={ __( 'Return to Dashboard', 'newspack' ) }
+												label={ __( 'Return to Dashboard', 'newspack-plugin' ) }
 												showTooltip={ true }
 												icon={ home }
 												iconSize={ 36 }
@@ -229,8 +229,8 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 											<div>
 												<h2>
 													{ requiredPlugins.length > 1
-														? __( 'Required plugins', 'newspack' )
-														: __( 'Required plugin', 'newspack' ) }
+														? __( 'Required plugins', 'newspack-plugin' )
+														: __( 'Required plugin', 'newspack-plugin' ) }
 												</h2>
 											</div>
 										</div>

--- a/assets/components/src/wizard/components/WizardError.js
+++ b/assets/components/src/wizard/components/WizardError.js
@@ -41,7 +41,7 @@ const WizardError = () => {
 				{ fallbackURL && (
 					<Card buttonsCard noBorder className="justify-end">
 						<Button isPrimary href={ fallbackURL }>
-							{ __( 'Return to Dashboard', 'newspack' ) }
+							{ __( 'Return to Dashboard', 'newspack-plugin' ) }
 						</Button>
 					</Card>
 				) }

--- a/assets/components/src/wizard/index.js
+++ b/assets/components/src/wizard/index.js
@@ -57,8 +57,8 @@ const Wizard = ( {
 	if ( ! pluginRequirementsSatisfied ) {
 		headerText =
 			requiredPlugins.length > 1
-				? __( 'Required plugins', 'newspack' )
-				: __( 'Required plugin', 'newspack' );
+				? __( 'Required plugins', 'newspack-plugin' )
+				: __( 'Required plugin', 'newspack-plugin' );
 		displayedSections = [
 			{
 				path: '/',
@@ -90,7 +90,7 @@ const Wizard = ( {
 								<Button
 									isLink
 									href={ newspack_urls.dashboard }
-									label={ __( 'Return to Dashboard', 'newspack' ) }
+									label={ __( 'Return to Dashboard', 'newspack-plugin' ) }
 									showTooltip={ true }
 									icon={ category }
 									iconSize={ 36 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is part of a set that corrects the text domain in the Newspack plugin  -- hopefully broken down in a way that makes them easier to review!

This PR covers the `/assets/components/src//sortable-newsletter-list-control` through to the `/assets/components/src/wizard` directory.

See 1200550061930446-1205509524123559

### How to test the changes in this Pull Request:

1. Spot check the changes, and confirm that all text domains are now `newspack-plugin` in any strings marked for translation.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->