### PR TITLE
fix: correct translation strings for number of assets files

### DIFF
--- a/assets/memberships-gate/editor.js
+++ b/assets/memberships-gate/editor.js
@@ -16,21 +16,21 @@ import PositionControl from '../components/src/position-control';
 import './editor.scss';
 
 const styles = [
-	{ value: 'inline', label: __( 'Inline', 'newspack' ) },
-	{ value: 'overlay', label: __( 'Overlay', 'newspack' ) },
+	{ value: 'inline', label: __( 'Inline', 'newspack-plugin' ) },
+	{ value: 'overlay', label: __( 'Overlay', 'newspack-plugin' ) },
 ];
 
 const overlayPositionsLabels = {
-	center: __( 'center', 'newspack' ),
-	bottom: __( 'bottom', 'newspack' ),
+	center: __( 'center', 'newspack-plugin' ),
+	bottom: __( 'bottom', 'newspack-plugin' ),
 };
 
 const overlaySizes = [
-	{ value: 'x-small', label: __( 'Extra Small', 'newspack' ) },
-	{ value: 'small', label: __( 'Small', 'newspack' ) },
-	{ value: 'medium', label: __( 'Medium', 'newspack' ) },
-	{ value: 'large', label: __( 'Large', 'newspack' ) },
-	{ value: 'full-width', label: __( 'Full Width', 'newspack' ) },
+	{ value: 'x-small', label: __( 'Extra Small', 'newspack-plugin' ) },
+	{ value: 'small', label: __( 'Small', 'newspack-plugin' ) },
+	{ value: 'medium', label: __( 'Medium', 'newspack-plugin' ) },
+	{ value: 'large', label: __( 'Large', 'newspack-plugin' ) },
+	{ value: 'full-width', label: __( 'Full Width', 'newspack-plugin' ) },
 ];
 
 function GateEdit() {
@@ -59,7 +59,7 @@ function GateEdit() {
 				'info',
 				sprintf(
 					// translators: %s is the list of plans.
-					__( "You're currently editing a gate for content restricted by: %s", 'newspack' ),
+					__( "You're currently editing a gate for content restricted by: %s", 'newspack-plugin' ),
 					Object.values( newspack_memberships_gate.gate_plans ).join( ', ' )
 				)
 			);
@@ -79,7 +79,7 @@ function GateEdit() {
 					<p>
 						{ __(
 							"Newspack Campaign prompts won't be displayed when rendering gated content.",
-							'newspack'
+							'newspack-plugin'
 						) }
 					</p>
 				</PluginPostStatusInfo>
@@ -87,14 +87,14 @@ function GateEdit() {
 			{ newspack_memberships_gate.plans.length > 1 && (
 				<PluginDocumentSettingPanel
 					name="memberships-gate-plans"
-					title={ __( 'WooCommerce Memberships', 'newspack' ) }
+					title={ __( 'WooCommerce Memberships', 'newspack-plugin' ) }
 				>
 					{ ! Object.keys( newspack_memberships_gate.gate_plans ).length ? (
 						<Fragment>
 							<p>
 								{ __(
 									'This gate will be rendered for all membership plans. Manage custom gates for when the content is locked behind a specific plan:',
-									'newspack'
+									'newspack-plugin'
 								) }
 							</p>
 						</Fragment>
@@ -105,7 +105,7 @@ function GateEdit() {
 									// translators: %s is the list of plans.
 									__(
 										'This gate will be rendered for the following membership plans: %s',
-										'newspack'
+										'newspack-plugin'
 									),
 									Object.values( newspack_memberships_gate.gate_plans ).join( ', ' )
 								) }
@@ -115,7 +115,7 @@ function GateEdit() {
 								dangerouslySetInnerHTML={ {
 									__html: sprintf(
 										// translators: %s is the link to the primary gate.
-										__( 'Edit the <a href="%s">primary gate</a>, or:', 'newspack' ),
+										__( 'Edit the <a href="%s">primary gate</a>, or:', 'newspack-plugin' ),
 										newspack_memberships_gate.edit_gate_url
 									),
 								} }
@@ -130,14 +130,16 @@ function GateEdit() {
 									<Fragment>
 										<strong>
 											{ plan.gate_status === 'publish'
-												? __( 'published', 'newspack' )
-												: __( 'draft', 'newspack' ) }
+												? __( 'published', 'newspack-plugin' )
+												: __( 'draft', 'newspack-plugin' ) }
 										</strong>{ ' ' }
 										-{ ' ' }
 									</Fragment>
 								) }
 								<a href={ newspack_memberships_gate.edit_gate_url + '&plan_id=' + plan.id }>
-									{ plan.gate_id ? __( 'edit gate', 'newspack' ) : __( 'create gate', 'newspack' ) }
+									{ plan.gate_id
+										? __( 'edit gate', 'newspack-plugin' )
+										: __( 'create gate', 'newspack-plugin' ) }
 								</a>
 								)
 							</li>
@@ -147,7 +149,7 @@ function GateEdit() {
 			) }
 			<PluginDocumentSettingPanel
 				name="memberships-gate-styles-panel"
-				title={ __( 'Styles', 'newspack' ) }
+				title={ __( 'Styles', 'newspack-plugin' ) }
 			>
 				<div className="newspack-memberships-gate-style-selector">
 					{ styles.map( style => (
@@ -164,32 +166,32 @@ function GateEdit() {
 				</div>
 				{ meta.style === 'inline' && (
 					<CheckboxControl
-						label={ __( 'Apply fade to last paragraph', 'newspack' ) }
+						label={ __( 'Apply fade to last paragraph', 'newspack-plugin' ) }
 						checked={ meta.inline_fade }
 						onChange={ value => editPost( { meta: { inline_fade: value } } ) }
 						help={ __(
 							'Whether to apply a gradient fade effect before rendering the gate.',
-							'newspack'
+							'newspack-plugin'
 						) }
 					/>
 				) }
 				{ meta.style === 'overlay' && (
 					<Fragment>
 						<SelectControl
-							label={ __( 'Size', 'newspack' ) }
+							label={ __( 'Size', 'newspack-plugin' ) }
 							value={ meta.overlay_size }
 							options={ overlaySizes }
 							onChange={ value => editPost( { meta: { overlay_size: value } } ) }
 						/>
 						<PositionControl
-							label={ __( 'Position', 'newspack' ) }
+							label={ __( 'Position', 'newspack-plugin' ) }
 							value={ meta.overlay_position }
 							size={ meta.overlay_size }
 							allowedPositions={ [ 'bottom', 'center' ] }
 							onChange={ value => editPost( { meta: { overlay_position: value } } ) }
 							help={ sprintf(
 								// translators: %s is the placement of the gate.
-								__( 'The gate will be displayed at the %s of the screen.', 'newspack' ),
+								__( 'The gate will be displayed at the %s of the screen.', 'newspack-plugin' ),
 								overlayPositionsLabels[ meta.overlay_position ]
 							) }
 						/>
@@ -198,41 +200,41 @@ function GateEdit() {
 			</PluginDocumentSettingPanel>
 			<PluginDocumentSettingPanel
 				name="memberships-gate-settings-panel"
-				title={ __( 'Settings', 'newspack' ) }
+				title={ __( 'Settings', 'newspack-plugin' ) }
 			>
 				<TextControl
 					type="number"
 					min="0"
 					value={ meta.visible_paragraphs }
-					label={ __( 'Default paragraph count', 'newspack' ) }
+					label={ __( 'Default paragraph count', 'newspack-plugin' ) }
 					onChange={ value => editPost( { meta: { visible_paragraphs: value } } ) }
 					help={ __(
 						'Number of paragraphs that readers can see above the content gate.',
-						'newspack'
+						'newspack-plugin'
 					) }
 				/>
 				<hr />
 				<CheckboxControl
-					label={ __( 'Use “More” tag to manually place content gate', 'newspack' ) }
+					label={ __( 'Use “More” tag to manually place content gate', 'newspack-plugin' ) }
 					checked={ meta.use_more_tag }
 					onChange={ value => editPost( { meta: { use_more_tag: value } } ) }
 					help={ __(
 						'Override the default paragraph count on pages where a “More” block has been placed.',
-						'newspack'
+						'newspack-plugin'
 					) }
 				/>
 			</PluginDocumentSettingPanel>
 			<PluginDocumentSettingPanel
 				name="memberships-gate-metering-panel"
-				title={ __( 'Metering', 'newspack' ) }
+				title={ __( 'Metering', 'newspack-plugin' ) }
 			>
 				<CheckboxControl
-					label={ __( 'Enable metering', 'newspack' ) }
+					label={ __( 'Enable metering', 'newspack-plugin' ) }
 					checked={ meta.metering }
 					onChange={ value => editPost( { meta: { metering: value } } ) }
 					help={ __(
 						'Implement metering to configure access to restricted content before showing the gate.',
-						'newspack'
+						'newspack-plugin'
 					) }
 				/>
 				{ meta.metering && (
@@ -241,36 +243,36 @@ function GateEdit() {
 							type="number"
 							min="0"
 							value={ meta.metering_anonymous_count }
-							label={ __( 'Available views for anonymous readers', 'newspack' ) }
+							label={ __( 'Available views for anonymous readers', 'newspack-plugin' ) }
 							onChange={ value => editPost( { meta: { metering_anonymous_count: value } } ) }
 							help={ __(
 								'Number of times an anonymous reader can view gated content. If set to 0, anonymous readers will always render the gate.',
-								'newspack'
+								'newspack-plugin'
 							) }
 						/>
 						<TextControl
 							type="number"
 							min="0"
 							value={ meta.metering_registered_count }
-							label={ __( 'Available views for registered readers', 'newspack' ) }
+							label={ __( 'Available views for registered readers', 'newspack-plugin' ) }
 							onChange={ value => editPost( { meta: { metering_registered_count: value } } ) }
 							help={ __(
 								'Number of times a registered reader can view gated content. If set to 0, registered readers without membership plan will always render the gate.',
-								'newspack'
+								'newspack-plugin'
 							) }
 						/>
 						<SelectControl
-							label={ __( 'Time period', 'newspack' ) }
+							label={ __( 'Time period', 'newspack-plugin' ) }
 							value={ meta.metering_period }
 							options={ [
-								{ value: 'day', label: __( 'Day', 'newspack' ) },
-								{ value: 'week', label: __( 'Week', 'newspack' ) },
-								{ value: 'month', label: __( 'Month', 'newspack' ) },
+								{ value: 'day', label: __( 'Day', 'newspack-plugin' ) },
+								{ value: 'week', label: __( 'Week', 'newspack-plugin' ) },
+								{ value: 'month', label: __( 'Month', 'newspack-plugin' ) },
 							] }
 							onChange={ value => editPost( { meta: { metering_period: value } } ) }
 							help={ __(
 								'The time period during which the metering views will be counted. For example, if the metering period is set to a week, the metering views will be reset every week.',
-								'newspack'
+								'newspack-plugin'
 							) }
 						/>
 					</Fragment>

--- a/assets/other-scripts/emails/index.js
+++ b/assets/other-scripts/emails/index.js
@@ -56,7 +56,7 @@ const ReaderRevenueEmailSidebar = compose( [
 			'info',
 			sprintf(
 				/* translators: 1: "From" email address 2: "From" email name */
-				__( 'This email will be sent from %1$s <%2$s>.', 'newspack' ),
+				__( 'This email will be sent from %1$s <%2$s>.', 'newspack-plugin' ),
 				config.from_name || newspack_emails.from_name,
 				config.from_email || newspack_emails.from_email
 			),
@@ -78,10 +78,10 @@ const ReaderRevenueEmailSidebar = compose( [
 			},
 		} )
 			.then( () => {
-				createNotice( 'success', __( 'Test email sent!', 'newspack' ) );
+				createNotice( 'success', __( 'Test email sent!', 'newspack-plugin' ) );
 			} )
 			.catch( () => {
-				createNotice( 'error', __( 'Test email was not sent.', 'newspack' ) );
+				createNotice( 'error', __( 'Test email was not sent.', 'newspack-plugin' ) );
 			} )
 			.finally( () => {
 				setInFlight( false );
@@ -92,11 +92,11 @@ const ReaderRevenueEmailSidebar = compose( [
 			{ config.available_placeholders?.length && (
 				<PluginDocumentSettingPanel
 					name="email-instructions-panel"
-					title={ __( 'Instructions', 'newspack' ) }
+					title={ __( 'Instructions', 'newspack-plugin' ) }
 				>
 					{ __(
 						'Use the following placeholders to insert dynamic content in the email:',
-						'newspack'
+						'newspack-plugin'
 					) }
 					<ul>
 						{ config.available_placeholders.map( ( item, i ) => (
@@ -109,24 +109,27 @@ const ReaderRevenueEmailSidebar = compose( [
 			) }
 			<PluginDocumentSettingPanel
 				name="email-settings-panel"
-				title={ __( 'Settings', 'newspack' ) }
+				title={ __( 'Settings', 'newspack-plugin' ) }
 			>
 				<TextControl
-					label={ __( 'Subject', 'newspack' ) }
+					label={ __( 'Subject', 'newspack-plugin' ) }
 					value={ title }
 					onChange={ updatePostTitle }
 				/>
 			</PluginDocumentSettingPanel>
-			<PluginDocumentSettingPanel name="email-testing-panel" title={ __( 'Testing', 'newspack' ) }>
+			<PluginDocumentSettingPanel
+				name="email-testing-panel"
+				title={ __( 'Testing', 'newspack-plugin' ) }
+			>
 				<TextControl
-					label={ __( 'Send to', 'newspack' ) }
+					label={ __( 'Send to', 'newspack-plugin' ) }
 					value={ settings.testRecipient }
 					type="email"
 					onChange={ updateSettings( 'testRecipient' ) }
 				/>
 				<div className="newspack__testing-controls">
 					<Button isPrimary onClick={ sendTestEmail } disabled={ inFlight }>
-						{ inFlight ? __( 'Sending…', 'newspack' ) : __( 'Send', 'newspack' ) }
+						{ inFlight ? __( 'Sending…', 'newspack-plugin' ) : __( 'Send', 'newspack-plugin' ) }
 					</Button>
 					{ inFlight && <Spinner /> }
 				</div>

--- a/assets/other-scripts/salesforce/index.js
+++ b/assets/other-scripts/salesforce/index.js
@@ -25,23 +25,23 @@ import { __ } from '@wordpress/i18n';
 			.then( opportunityId => {
 				if ( false === opportunityId ) {
 					statusMarker.classList.add( 'status-failed' );
-					statusMarkerLabel.textContent = __( 'Not synced', 'newspack' );
+					statusMarkerLabel.textContent = __( 'Not synced', 'newspack-plugin' );
 				} else if ( 'string' === typeof opportunityId ) {
 					const anchor = document.createElement( 'a' );
 					statusMarker.classList.add( 'status-completed' );
 					anchor.href = `${ salesforceUrl }/lightning/r/Opportunity/${ opportunityId }/view`;
 					anchor.setAttribute( 'target', '_blank' );
 					anchor.setAttribute( 'rel', 'noopener noreferrer' );
-					anchor.textContent = __( 'Synced', 'newspack' );
+					anchor.textContent = __( 'Synced', 'newspack-plugin' );
 					statusMarkerLabel.textContent = '';
 					statusMarkerLabel.appendChild( anchor );
 				} else {
-					throw __( 'Error fetching status', 'newspack' );
+					throw __( 'Error fetching status', 'newspack-plugin' );
 				}
 			} )
 			.catch( e => {
 				statusMarker.classList.add( 'status-failed' );
-				statusMarkerLabel.textContent = e || __( 'Error fetching status', 'newspack' );
+				statusMarkerLabel.textContent = e || __( 'Error fetching status', 'newspack-plugin' );
 			} );
 	}
 } )();

--- a/assets/plugins-screen/plugins-screen.js
+++ b/assets/plugins-screen/plugins-screen.js
@@ -47,25 +47,25 @@ const getCreateButton =
 		};
 
 		modalEl.classList.add( 'newspack-plugin-info-modal' );
-		modalHeadingEl.innerText = wp.i18n.__( 'Plugin review required', 'newspack' );
+		modalHeadingEl.innerText = wp.i18n.__( 'Plugin review required', 'newspack-plugin' );
 		modalPEl.innerText = wp.i18n.__(
 			'Please submit a plugin for review by the Newspack Team before installing it on your website. If you plan to install an approved plugin, feel free to close this message.',
-			'newspack'
+			'newspack-plugin'
 		);
 		modalCloseEl.innerHTML =
 			'<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"></path></svg>';
 		modalCloseEl.onclick = closeModal;
 
 		createButton(
-			wp.i18n.__( 'Plugin Review Form', 'newspack' ),
+			wp.i18n.__( 'Plugin Review Form', 'newspack-plugin' ),
 			newspack_plugin_info.plugin_review_link,
 			true
 		);
 		createButton(
-			wp.i18n.__( 'Approved Plugins List', 'newspack' ),
+			wp.i18n.__( 'Approved Plugins List', 'newspack-plugin' ),
 			newspack_plugin_info.approved_plugins_list_link
 		);
-		createButton( wp.i18n.__( 'Close this message', 'newspack' ), closeModal );
+		createButton( wp.i18n.__( 'Close this message', 'newspack-plugin' ), closeModal );
 
 		modalEl.appendChild( modalContentEl );
 		modalContentEl.appendChild( modalHeadingEl );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is part of a set that corrects the text domain in the Newspack plugin  -- hopefully broken down in a way that makes them easier to review!

This PR covers the `/assets/membership-gate` through to the `/assets/plugins-screen` directory.

See 1200550061930446-1205509524123559

### How to test the changes in this Pull Request:

1. Spot check the changes, and confirm that all text domains are now `newspack-plugin` in any strings marked for translation.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->