### PR TITLE
fix: add frequency tab options for donations, even when tiers are disabled

### DIFF
--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -208,24 +208,44 @@ export const DonationAmounts = () => {
 			) : (
 				<Card isMedium>
 					<Grid columns={ 3 } rowGap={ 16 }>
-						{ availableFrequencies.map( section => (
-							<MoneyInput
-								currencySymbol={ currencySymbol }
-								label={ section.staticLabel }
-								value={ amounts[ section.key ][ 3 ] }
-								min={ minimumDonationFloat }
-								error={
-									amounts[ section.key ][ 3 ] < minimumDonationFloat
-										? __(
-												'Warning: suggested donations should be at least the minimum donation amount.',
-												'newspack'
-										  )
-										: null
-								}
-								onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
-								key={ section.key }
-							/>
-						) ) }
+						{ availableFrequencies.map( section => {
+							const isFrequencyDisabled = disabledFrequencies[ section.key ];
+							const isOneFrequencyActive =
+								Object.values( disabledFrequencies ).filter( Boolean ).length ===
+								FREQUENCY_SLUGS.length - 1;
+							return (
+								<Grid columns={ 1 } gutter={ 16 }>
+									<ToggleControl
+											checked={ ! isFrequencyDisabled }
+											onChange={ () =>
+												changeHandler( [ 'disabledFrequencies', section.key ] )(
+													! isFrequencyDisabled
+												)
+											}
+											label={ section.tieredLabel }
+											disabled={ ! isFrequencyDisabled && isOneFrequencyActive }
+										/>
+									{ ! isFrequencyDisabled && (
+										<MoneyInput
+											currencySymbol={ currencySymbol }
+											label={ section.staticLabel }
+											value={ amounts[ section.key ][ 3 ] }
+											min={ minimumDonationFloat }
+											error={
+												amounts[ section.key ][ 3 ] < minimumDonationFloat
+													? __(
+															'Warning: suggested donations should be at least the minimum donation amount.',
+															'newspack'
+													  )
+													: null
+											}
+											onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
+											key={ section.key }
+										/>
+									) }
+								</Grid>
+							);
+						} ) }
 					</Grid>
 				</Card>
 			) }

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -214,17 +214,17 @@ export const DonationAmounts = () => {
 								Object.values( disabledFrequencies ).filter( Boolean ).length ===
 								FREQUENCY_SLUGS.length - 1;
 							return (
-								<Grid columns={ 1 } gutter={ 16 }>
+								<Grid columns={ 1 } gutter={ 16 } key={ section.key }>
 									<ToggleControl
-											checked={ ! isFrequencyDisabled }
-											onChange={ () =>
-												changeHandler( [ 'disabledFrequencies', section.key ] )(
-													! isFrequencyDisabled
-												)
-											}
-											label={ section.tieredLabel }
-											disabled={ ! isFrequencyDisabled && isOneFrequencyActive }
-										/>
+										checked={ ! isFrequencyDisabled }
+										onChange={ () =>
+											changeHandler( [ 'disabledFrequencies', section.key ] )(
+												! isFrequencyDisabled
+											)
+										}
+										label={ section.tieredLabel }
+										disabled={ ! isFrequencyDisabled && isOneFrequencyActive }
+									/>
 									{ ! isFrequencyDisabled && (
 										<MoneyInput
 											currencySymbol={ currencySymbol }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This change comes out of feedback for the alpha release for this change: https://github.com/Automattic/newspack-plugin/pull/2866 

If you don't install Name Your Price, or you turn off the Tiered view of the donate block's site-wide settings under Newspack > Reader Revenue > Donations, you can no longer change the frequency amount site-wide. Instead, it's sticks to whatever the last saved selection was when the Tiered view was visible. 

This is not a new issue, but is more noticeable with us supporting not using Name Your Price: with that plugin, you can still switch back to the Tiered view and change the default frequencies. Without it, you can't.

I'm not entirely sold on the UI decisions I made here, but this PR adds the frequency toggles to the untiered view. I'm definitely open to other suggestions about fixing this both for the short and long term! 

See pamTN9-8My-p2-#comment-10416

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`. 
2. Navigate to Newspack > Reader Revenue > Donations.
3. Toggle the view to 'Untiered', and confirm that you now see frequency toggles above each field:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/f221fc3a-1830-470b-be95-536d1cdff04e)

4. Try toggling different options on and off. Confirm that the associated field is hidden when the frequency is 'off'. 
5. Try toggling between the Tiered and Untiered view, and make changes to the frequency settings on each. Confirmed they're carried over, even when the page is saved and refreshed. 
6. With the Untiered view selected and one or more frequencies is disabled, add a Donate block to a page, and confirm the initial appearance matches your selection (for example, if you've disabled the One-Time donation option, it should not appear in the block by default): 

![image](https://github.com/Automattic/newspack-plugin/assets/177561/70e9c6ee-fd80-4928-9f7d-2048347c7fd8)

7. Turn back on the Tiered view under Reader Revenue > Donations, and change the selection again and save it.
8. Try disabling the Name Your Price plugin, and confirm your active frequencies remain the same.
9. Change the frequencies again and save. 
10. Try adding another Donation block to a page, and confirm the visible tabs match your frequency choices. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->