### PR TITLE
feat: add link to block pattern category page

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -19,6 +19,7 @@ class Patches {
 	public static function init() {
 		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_patterns_menu_link' ] );
+		add_action( 'admin_menu', [ __CLASS__, 'add_pattern_categories_menu_link' ] );
 		add_action( 'manage_edit-wp_block_columns', [ __CLASS__, 'add_custom_columns' ] );
 		add_action( 'manage_edit-wp_block_sortable_columns', [ __CLASS__, 'add_sortable_columns' ] );
 		add_action( 'manage_wp_block_posts_custom_column', [ __CLASS__, 'custom_column_content' ], 10, 2 );
@@ -108,6 +109,13 @@ class Patches {
 	 */
 	public static function add_patterns_menu_link() {
 		add_submenu_page( 'edit.php', 'manage_patterns', __( 'Patterns' ), 'edit_posts', 'edit.php?post_type=wp_block', '', 2 );
+	}
+
+	/**
+	 * Add a menu link in WP Admin to easily edit and manage pattern categories.
+	 */
+	public static function add_pattern_categories_menu_link() {
+		add_submenu_page( 'edit.php', 'manage_pattern_categories', __( 'Pattern Categories' ), 'edit_posts', 'edit-tags.php?taxonomy=wp_pattern_category', '', 3 );
 	}
 
 	/**

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -115,7 +115,7 @@ class Patches {
 	 * Add a menu link in WP Admin to easily edit and manage pattern categories.
 	 */
 	public static function add_pattern_categories_menu_link() {
-		add_submenu_page( 'edit.php', 'manage_pattern_categories', __( 'Pattern Categories' ), 'edit_posts', 'edit-tags.php?taxonomy=wp_pattern_category', '', 3 );
+		add_submenu_page( 'edit.php', 'manage_pattern_categories', __( 'Pattern Categories', 'newspack-plugin' ), 'edit_posts', 'edit-tags.php?taxonomy=wp_pattern_category', '', 3 );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a link to the Pattern Categories page in WP Admin, similar to how the plugin also adds a link to the Patterns page under WP Admin > Posts. 

See 1200550061930446-as-1205909087222912

### How to test the changes in this Pull Request:

1. Apply this PR.
2. On your test site, navigate to WP Admin, and either hover over Posts in the left sidebar to see the flyout menu, or click on it to see the menu displayed in the sidebar. 
3. Confirm that 'Pattern Categories' now displays under Patterns:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/e584ca68-d099-4863-b91b-558f41a18cb4)

6. Confirm that clicking 'Pattern Categories' brings you to a list of the custom pattern categories the site is using, similar to other WordPress taxonomies:
![image](https://github.com/Automattic/newspack-plugin/assets/177561/9ae079ff-bbb6-4b84-af3d-c927f855bbfb)


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->