### PR TITLE
Feat/tweaks for network update

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -78,6 +78,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-plugin-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-theme-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-utils.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-data-events.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-webhooks.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-api.php';

--- a/includes/data-events/class-utils.php
+++ b/includes/data-events/class-utils.php
@@ -14,9 +14,10 @@ final class Utils {
 	/**
 	 * Get order data.
 	 *
-	 * @param int $order_id Order ID.
+	 * @param int  $order_id Order ID.
+	 * @param bool $process_donations_only Whether to process only donation orders.
 	 */
-	public static function get_order_data( $order_id ) {
+	public static function get_order_data( $order_id, $process_donations_only = false ) {
 		$order = \wc_get_order( $order_id );
 		if ( ! $order ) {
 			return;
@@ -24,8 +25,12 @@ final class Utils {
 		if ( ! \Newspack\WooCommerce_Connection::should_sync_order( $order ) ) {
 			return;
 		}
-		// Donation orders always have just a single product, but other orders can have more than one.
-		$product_id = \Newspack\Donations::get_order_donation_product_id( $order_id ) ?? array_values( \Newspack\WooCommerce_Connection::get_products_for_order( $order_id ) );
+		if ( $process_donations_only ) {
+			$product_id = \Newspack\Donations::get_order_donation_product_id( $order_id );
+		} else {
+			// Donation orders always have just a single product, but other orders can have more than one.
+			$product_id = array_values( \Newspack\WooCommerce_Connection::get_products_for_order( $order_id ) );
+		}
 		if ( ! $product_id ) {
 			return;
 		}
@@ -60,11 +65,11 @@ final class Utils {
 	}
 
 	/**
-	 * Get subscription data.
+	 * Get recurring donation data.
 	 *
-	 * @param WC_Subscription $subscription Subscription.
+	 * @param WC_Subscription $subscription Subscription which is a recurring donation.
 	 */
-	public static function get_subscription_data( $subscription ) {
+	public static function get_recurring_donation_data( $subscription ) {
 		$product_id = \Newspack\Donations::get_order_donation_product_id( $subscription->get_id() );
 		if ( ! $product_id ) {
 			return;

--- a/includes/data-events/class-utils.php
+++ b/includes/data-events/class-utils.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Newspack Data Events Utils.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Data_Events;
+
+/**
+ * Main Class.
+ */
+final class Utils {
+	/**
+	 * Get order data.
+	 *
+	 * @param int $order_id Order ID.
+	 */
+	public static function get_order_data( $order_id ) {
+		$order = \wc_get_order( $order_id );
+		if ( ! $order ) {
+			return;
+		}
+		if ( ! \Newspack\WooCommerce_Connection::should_sync_order( $order ) ) {
+			return;
+		}
+		// Donation orders always have just a single product, but other orders can have more than one.
+		$product_id = \Newspack\Donations::get_order_donation_product_id( $order_id ) ?? array_values( \Newspack\WooCommerce_Connection::get_products_for_order( $order_id ) );
+		if ( ! $product_id ) {
+			return;
+		}
+		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
+		$is_renewal = function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order );
+		$subscriptions = [];
+		$subscription_id = '';
+		if ( function_exists( 'wcs_get_subscriptions_for_order' ) ) {
+			$subscriptions = array_values( wcs_get_subscriptions_for_order( $order, [ 'order_type' => [ 'parent', 'renewal' ] ] ) );
+		}
+		if ( count( $subscriptions ) > 0 ) {
+			$subscription_id = is_array( $subscriptions ) && ! empty( $subscriptions ) && is_a( $subscriptions[0], 'WC_Subscription' ) ? $subscriptions[0]->get_id() : null;
+		}
+
+		return [
+			'user_id'         => $order->get_customer_id(),
+			'email'           => $order->get_billing_email(),
+			'amount'          => (float) $order->get_total(),
+			'currency'        => $order->get_currency(),
+			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
+			'platform'        => \Newspack\Donations::get_platform_slug(),
+			'referer'         => $order->get_meta( '_newspack_referer' ),
+			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),
+			'is_renewal'      => $is_renewal,
+			'subscription_id' => $subscription_id,
+			'platform_data'   => [
+				'order_id'   => $order_id,
+				'product_id' => $product_id,
+				'client_id'  => $order->get_meta( NEWSPACK_CLIENT_ID_COOKIE_NAME ),
+			],
+		];
+	}
+
+	/**
+	 * Get subscription data.
+	 *
+	 * @param WC_Subscription $subscription Subscription.
+	 */
+	public static function get_subscription_data( $subscription ) {
+		$product_id = \Newspack\Donations::get_order_donation_product_id( $subscription->get_id() );
+		if ( ! $product_id ) {
+			return;
+		}
+		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
+		return [
+			'user_id'         => $subscription->get_customer_id(),
+			'email'           => $subscription->get_billing_email(),
+			'subscription_id' => $subscription->get_id(),
+			'amount'          => (float) $subscription->get_total(),
+			'currency'        => $subscription->get_currency(),
+			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
+			'platform'        => \Newspack\Donations::get_platform_slug(),
+		];
+	}
+}

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -423,7 +423,7 @@ final class Webhooks {
 			[
 				'taxonomy'   => self::ENDPOINT_TAXONOMY,
 				'hide_empty' => false,
-			] 
+			]
 		);
 		$endpoints = array_map( [ __CLASS__, 'get_endpoint_by_term' ], $terms );
 
@@ -521,6 +521,15 @@ final class Webhooks {
 	}
 
 	/**
+	 * Format request data for saving in the DB.
+	 *
+	 * @param array $data Request data.
+	 */
+	public static function format_request_data( $data ) {
+		return addslashes( \wp_json_encode( $data ) );
+	}
+
+	/**
 	 * Create webhook request.
 	 *
 	 * @param int    $endpoint_id Endpoint ID.
@@ -574,9 +583,11 @@ final class Webhooks {
 		$body = apply_filters( 'newspack_webhooks_request_body', $body, $endpoint_id );
 
 		// addslashes prevents JSON from breaking if the data contains quotes or another json encoded string inside it.
-		$body_value = addslashes( \wp_json_encode( $body ) );
+		$body_value = self::format_request_data( $body );
 
 		\update_post_meta( $request_id, 'body', $body_value );
+		\update_post_meta( $request_id, 'data', self::format_request_data( $data ) );
+		\update_post_meta( $request_id, 'timestamp', $timestamp );
 		\update_post_meta( $request_id, 'action_name', $action_name );
 		\update_post_meta( $request_id, 'client_id', $action_name );
 
@@ -824,7 +835,7 @@ final class Webhooks {
 	 * @param array  $data        Event data.
 	 * @param string $client_id   Optional user session's client ID.
 	 */
-	public static function handle_dispatch( $action_name, $timestamp, $data, $client_id ) {
+	public static function handle_dispatch( $action_name, $timestamp, $data, $client_id = '' ) {
 		$endpoints = self::get_endpoints_for_action( $action_name );
 		if ( empty( $endpoints ) ) {
 			return;

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -134,37 +134,7 @@ Data_Events::register_listener(
 	'newspack_donation_order_processed',
 	'woocommerce_donation_order_processed',
 	function( $order_id, $product_id ) {
-		$order = \wc_get_order( $order_id );
-		if ( ! $order ) {
-			return;
-		}
-		if ( ! \Newspack\WooCommerce_Connection::should_sync_order( $order ) ) {
-			return;
-		}
-		$recurrence      = get_post_meta( $product_id, '_subscription_period', true );
-		$is_renewal      = function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order );
-		$subscription_id = null;
-		if ( function_exists( 'wcs_get_subscriptions_for_renewal_order' ) ) {
-			$subscriptions   = array_values( wcs_get_subscriptions_for_renewal_order( $order ) );
-			$subscription_id = is_array( $subscriptions ) && ! empty( $subscriptions ) && is_a( $subscriptions[0], 'WC_Subscription' ) ? $subscriptions[0]->get_id() : null;
-		}
-
-		return [
-			'user_id'         => $order->get_customer_id(),
-			'email'           => $order->get_billing_email(),
-			'amount'          => (float) $order->get_total(),
-			'currency'        => $order->get_currency(),
-			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
-			'platform'        => 'wc',
-			'referer'         => $order->get_meta( '_newspack_referer' ),
-			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),
-			'is_renewal'      => $is_renewal,
-			'subscription_id' => $subscription_id,
-			'platform_data'   => [
-				'order_id'   => $order_id,
-				'product_id' => $product_id,
-			],
-		];
+		return \Newspack\Data_Events\Utils::get_order_data( $order_id );
 	}
 );
 
@@ -178,35 +148,7 @@ Data_Events::register_listener(
 	'woocommerce_order_status_failed',
 	'woocommerce_order_failed',
 	function( $order_id, $order ) {
-		$product_id = Donations::get_order_donation_product_id( $order_id );
-		if ( ! $product_id ) {
-			return;
-		}
-		$recurrence      = get_post_meta( $product_id, '_subscription_period', true );
-		$is_renewal      = function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order );
-		$subscription_id = null;
-		if ( function_exists( 'wcs_get_subscriptions_for_renewal_order' ) ) {
-			$subscriptions   = array_values( wcs_get_subscriptions_for_renewal_order( $order ) );
-			$subscription_id = is_array( $subscriptions ) && ! empty( $subscriptions ) && is_a( $subscriptions[0], 'WC_Subscription' ) ? $subscriptions[0]->get_id() : null;
-		}
-
-		return [
-			'user_id'         => $order->get_customer_id(),
-			'email'           => $order->get_billing_email(),
-			'amount'          => (float) $order->get_total(),
-			'currency'        => $order->get_currency(),
-			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
-			'platform'        => Donations::get_platform_slug(),
-			'referer'         => $order->get_meta( '_newspack_referer' ),
-			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),
-			'is_renewal'      => $is_renewal,
-			'subscription_id' => $subscription_id,
-			'platform_data'   => [
-				'order_id'   => $order_id,
-				'product_id' => $product_id,
-				'client_id'  => $order->get_meta( NEWSPACK_CLIENT_ID_COOKIE_NAME ),
-			],
-		];
+		return \Newspack\Data_Events\Utils::get_order_data( $order_id );
 	}
 );
 
@@ -246,36 +188,7 @@ Data_Events::register_listener(
 	'woocommerce_order_status_completed',
 	'donation_new',
 	function ( $order_id, $order ) {
-		if ( ! \Newspack\WooCommerce_Connection::should_sync_order( $order ) ) {
-			return;
-		}
-		$product_id = Donations::get_order_donation_product_id( $order_id );
-		if ( ! $product_id ) {
-			return;
-		}
-		$recurrence       = \get_post_meta( $product_id, '_subscription_period', true );
-		$wcs_is_available = function_exists( 'wcs_is_subscription' ) && function_exists( 'wcs_get_subscriptions_for_order' ) && function_exists( 'wcs_order_contains_renewal' );
-		$subscriptions    = $wcs_is_available ? array_values( \wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] ) ) : null;
-		$is_renewal       = $wcs_is_available && \wcs_order_contains_renewal( $order );
-		$subscription_id  = ! empty( $subscriptions ) ? $subscriptions[0]->get_id() : null;
-
-		return [
-			'user_id'         => $order->get_customer_id(),
-			'email'           => $order->get_billing_email(),
-			'amount'          => (float) $order->get_total(),
-			'currency'        => $order->get_currency(),
-			'recurrence'      => ! empty( $recurrence ) ? $recurrence : 'once',
-			'platform'        => Donations::get_platform_slug(),
-			'referer'         => $order->get_meta( '_newspack_referer' ),
-			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),
-			'is_renewal'      => $is_renewal,
-			'subscription_id' => $subscription_id,
-			'platform_data'   => [
-				'order_id'   => $order_id,
-				'product_id' => $product_id,
-				'client_id'  => $order->get_meta( NEWSPACK_CLIENT_ID_COOKIE_NAME ),
-			],
-		];
+		return \Newspack\Data_Events\Utils::get_order_data( $order_id );
 	}
 );
 
@@ -286,32 +199,7 @@ Data_Events::register_listener(
 	'woocommerce_order_status_completed',
 	'order_completed',
 	function( $order_id, $order ) {
-		// Donation orders always have just a single product, but other orders can have more than one.
-		$product_id = Donations::get_order_donation_product_id( $order_id ) ?? array_values( \Newspack\WooCommerce_Connection::get_products_for_order( $order_id ) );
-		if ( empty( $product_id ) ) {
-			return;
-		}
-
-		$wcs_is_available = function_exists( 'wcs_get_subscriptions_for_order' ) && function_exists( 'wcs_order_contains_renewal' );
-		$subscriptions    = $wcs_is_available ? array_values( \wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] ) ) : null;
-		$is_renewal       = $wcs_is_available && \wcs_order_contains_renewal( $order );
-		$subscription_id  = ! empty( $subscriptions ) ? $subscriptions[0]->get_id() : null;
-
-		return [
-			'user_id'         => $order->get_customer_id(),
-			'email'           => $order->get_billing_email(),
-			'amount'          => (float) $order->get_total(),
-			'currency'        => $order->get_currency(),
-			'referer'         => $order->get_meta( '_newspack_referer' ),
-			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),
-			'is_renewal'      => $is_renewal,
-			'subscription_id' => $subscription_id,
-			'platform_data'   => [
-				'order_id'   => $order_id,
-				'product_id' => $product_id,
-				'client_id'  => $order->get_meta( NEWSPACK_CLIENT_ID_COOKIE_NAME ),
-			],
-		];
+		return \Newspack\Data_Events\Utils::get_order_data( $order_id );
 	}
 );
 
@@ -325,20 +213,7 @@ Data_Events::register_listener(
 		if ( 'cancelled' !== $status_to ) {
 			return;
 		}
-		$product_id = Donations::get_order_donation_product_id( $subscription->get_id() );
-		if ( ! $product_id ) {
-			return;
-		}
-		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
-		return [
-			'user_id'         => $subscription->get_customer_id(),
-			'email'           => $subscription->get_billing_email(),
-			'subscription_id' => $subscription->get_id(),
-			'amount'          => (float) $subscription->get_total(),
-			'currency'        => $subscription->get_currency(),
-			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
-			'platform'        => Donations::get_platform_slug(),
-		];
+		return \Newspack\Data_Events\Utils::get_subscription_data( $subscription );
 	}
 );
 
@@ -349,22 +224,17 @@ Data_Events::register_listener(
 	'woocommerce_subscription_status_updated',
 	'donation_subscription_changed',
 	function( $subscription, $status_to, $status_from ) {
-		$product_id = Donations::get_order_donation_product_id( $subscription->get_id() );
-		if ( ! $product_id ) {
+		$data = \Newspack\Data_Events\Utils::get_subscription_data( $subscription );
+		if ( ! is_array( $data ) ) {
 			return;
 		}
-		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
-		return [
-			'user_id'         => $subscription->get_customer_id(),
-			'email'           => $subscription->get_billing_email(),
-			'subscription_id' => $subscription->get_id(),
-			'status_before'   => $status_from,
-			'status_after'    => $status_to,
-			'amount'          => (float) $subscription->get_total(),
-			'currency'        => $subscription->get_currency(),
-			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
-			'platform'        => Donations::get_platform_slug(),
-		];
+		return array_merge(
+			$data,
+			[
+				'status_before' => $status_from,
+				'status_after'  => $status_to,
+			]
+		);
 	}
 );
 

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -134,7 +134,7 @@ Data_Events::register_listener(
 	'newspack_donation_order_processed',
 	'woocommerce_donation_order_processed',
 	function( $order_id, $product_id ) {
-		return \Newspack\Data_Events\Utils::get_order_data( $order_id );
+		return \Newspack\Data_Events\Utils::get_order_data( $order_id, true );
 	}
 );
 
@@ -148,7 +148,7 @@ Data_Events::register_listener(
 	'woocommerce_order_status_failed',
 	'woocommerce_order_failed',
 	function( $order_id, $order ) {
-		return \Newspack\Data_Events\Utils::get_order_data( $order_id );
+		return \Newspack\Data_Events\Utils::get_order_data( $order_id, true );
 	}
 );
 
@@ -188,7 +188,7 @@ Data_Events::register_listener(
 	'woocommerce_order_status_completed',
 	'donation_new',
 	function ( $order_id, $order ) {
-		return \Newspack\Data_Events\Utils::get_order_data( $order_id );
+		return \Newspack\Data_Events\Utils::get_order_data( $order_id, true );
 	}
 );
 
@@ -213,7 +213,7 @@ Data_Events::register_listener(
 		if ( 'cancelled' !== $status_to ) {
 			return;
 		}
-		return \Newspack\Data_Events\Utils::get_subscription_data( $subscription );
+		return \Newspack\Data_Events\Utils::get_recurring_donation_data( $subscription );
 	}
 );
 
@@ -224,7 +224,7 @@ Data_Events::register_listener(
 	'woocommerce_subscription_status_updated',
 	'donation_subscription_changed',
 	function( $subscription, $status_to, $status_from ) {
-		$data = \Newspack\Data_Events\Utils::get_subscription_data( $subscription );
+		$data = \Newspack\Data_Events\Utils::get_recurring_donation_data( $subscription );
 		if ( ! is_array( $data ) ) {
 			return;
 		}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -665,6 +665,11 @@ final class Reader_Activation {
 	 * Get the reader roles.
 	 */
 	public static function get_reader_roles() {
+		/**
+		 * Filters the roles that can determine if a user is a reader.
+		 *
+		 * @param string[] $roles Array of user roles.
+		 */
 		return \apply_filters( 'newspack_reader_user_roles', [ 'subscriber', 'customer' ] );
 	}
 
@@ -681,11 +686,6 @@ final class Reader_Activation {
 		$user_data = \get_userdata( $user->ID );
 
 		if ( false === $is_reader && false === $strict ) {
-			/**
-			 * Filters the roles that can determine if a user is a reader.
-			 *
-			 * @param string[] $roles Array of user roles.
-			 */
 			$reader_roles = self::get_reader_roles();
 			if ( ! empty( $reader_roles ) ) {
 				$is_reader = ! empty( array_intersect( $reader_roles, $user_data->roles ) );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -662,6 +662,13 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Get the reader roles.
+	 */
+	public static function get_reader_roles() {
+		return \apply_filters( 'newspack_reader_user_roles', [ 'subscriber', 'customer' ] );
+	}
+
+	/**
 	 * Whether the user is a reader.
 	 *
 	 * @param WP_User $user   User object.
@@ -679,7 +686,7 @@ final class Reader_Activation {
 			 *
 			 * @param string[] $roles Array of user roles.
 			 */
-			$reader_roles = \apply_filters( 'newspack_reader_user_roles', [ 'subscriber', 'customer' ] );
+			$reader_roles = self::get_reader_roles();
 			if ( ! empty( $reader_roles ) ) {
 				$is_reader = ! empty( array_intersect( $reader_roles, $user_data->roles ) );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A few tweaks for the upcoming changes to `newspack-network`, and one fix:

1. Extricates a `get_reader_roles` method in Reader Activation
2. Adds metadata to webhook request posts, so they can be found later (and avoid duplication)
3. Fixes an issue where `subscription_id` was set only on renewal orders, not on the initial order of a subscription

### How to test the changes in this Pull Request:

_Follow instructions in https://github.com/Automattic/newspack-network/pull/51_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->