### PR TITLE
fix(ga4): add default client id

### DIFF
--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -117,7 +117,7 @@ class GA4 {
 		$client_id = $data['ga_client_id'];
 
 		if ( empty( $client_id ) ) {
-			throw new \Exception( 'Missing client ID' );
+			$client_id = 'AnonymousUser-' . md5( $user_id );
 		}
 
 		if ( method_exists( __CLASS__, 'handle_' . $event_name ) ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1200550061930446/1206621861166809/f](https://app.asana.com/0/1200550061930446/1206621861166809/f)

This PR ensures every ga4 event contains a client ID even when the GA cookies are missing.

![Screenshot 2024-02-19 at 16 34 37](https://github.com/Automattic/newspack-plugin/assets/17905991/bf070c34-50a0-4032-8294-9f701598618f)


### How to test the changes in this Pull Request:

1. Make sure [GA4 connector is set up](https://github.com/Automattic/newspack-plugin/tree/trunk/includes/data-events/connectors/ga4#setting-up)
2. Install an ad-blocker that blocks GA cookies, for example AdGuard. Alternatively, I suppose you can just disable cookies.

![Screenshot 2024-02-19 at 16 39 27](https://github.com/Automattic/newspack-plugin/assets/17905991/912d4ef7-9d0a-4e8f-8e0b-4b206663c1c7)


3. On trunk, logged in as a customer on your test site, trigger a GA4 event. For example purchase a donation.
4. Observe GA realtime overview dashboard does not update with the relevant event (`np_donation_new` if donating).
5. Repeat step 3 on this branch.
6. Observe GA realtime overview dashboard does update with the relevant event.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->