### PR TITLE
fix: avoid a reCAPTCHA API error when script is enqueued with a version param

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -82,7 +82,7 @@ final class Recaptcha {
 	 */
 	public static function register_script() {
 		if ( self::can_use_captcha() ) {
-			// Note: version arg Must be null to avoid the & ver param being read as part of the reCAPTCHA site key .
+			// Note: version arg Must be null to avoid the &ver param being read as part of the reCAPTCHA site key .
 			\wp_register_script(
 				self::SCRIPT_HANDLE,
 				\esc_url( self::get_script_url() ),

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -82,11 +82,12 @@ final class Recaptcha {
 	 */
 	public static function register_script() {
 		if ( self::can_use_captcha() ) {
+			// Note: version arg Must be null to avoid the & ver param being read as part of the reCAPTCHA site key .
 			\wp_register_script(
 				self::SCRIPT_HANDLE,
 				\esc_url( self::get_script_url() ),
 				null,
-				NEWSPACK_PLUGIN_VERSION,
+				null, // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 				true
 			);
 			\wp_script_add_data( self::SCRIPT_HANDLE, 'async', true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced by #2843.

### How to test the changes in this Pull Request:

1. On `release`, configure reCAPTCHA in the Newspack > Connections wizard.
2. On the front-end, try to submit a form protected by reCAPTCHA (such as the Newsletter Subscription Form)
3. Observe a JS console error that prevents form submission: `Uncaught Error: Invalid site key or not loaded in api.js`
4. Check out this branch, refresh, repeat, and confirm the form submits.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->