### PR TITLE
fix: set wc default address option when donation country optional but state is required

### DIFF
--- a/assets/wizards/engagement/components/types.ts
+++ b/assets/wizards/engagement/components/types.ts
@@ -44,6 +44,7 @@ declare global {
 		};
 		newspack_reader_revenue: {
 			can_use_name_your_price: boolean;
+			is_platform_wc: boolean;
 		};
 	}
 }

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -295,6 +295,11 @@ const BillingFields = () => {
 		? wizardData.donation_data.billingFields
 		: Object.keys( availableFields );
 
+	const isDefaultBillingCountryForced =
+		window.newspack_reader_revenue?.is_platform_wc &&
+		! billingFields.includes( 'billing_country' ) &&
+		billingFields.includes( 'billing_state' );
+
 	return (
 		<>
 			<Card noBorder headerActions>
@@ -326,6 +331,15 @@ const BillingFields = () => {
 					/>
 				) ) }
 			</Grid>
+			{ isDefaultBillingCountryForced && (
+				<Notice
+					isHelp
+					noticeText={ __(
+						'Your WooCommerce store address will be used to determine billing country for new customers.',
+						'newspack'
+					) }
+				/>
+			) }
 		</>
 	);
 };

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -43,6 +43,7 @@ class Donations {
 			'label' => 'Campaign Content',
 		],
 	];
+	const WOOCOMMERCE_DEFAULT_CUSTOMER_ADDRESS_OPTION = 'woocommerce_default_customer_address';
 
 	/**
 	 * Donation product WC name;
@@ -462,6 +463,7 @@ class Donations {
 			if ( ! empty( $billing_fields ) ) {
 				$billing_fields = array_map( 'sanitize_text_field', $billing_fields );
 				self::update_billing_fields( $billing_fields );
+				self::maybe_update_woocommerce_default_customer_address( $billing_fields );
 			}
 		}
 
@@ -1056,6 +1058,22 @@ class Donations {
 		if ( ! self::is_donation_cart( $cart ) ) {
 			return $enabled;
 		}
+		return false;
+	}
+
+	/**
+	 * Update the woocommerce_default_customer_address option to base when country is optional, but state is a required billing field.
+	 * We need to set this for this configuration to correctly populate state in donation checkout for new customers.
+	 *
+	 * @param string[] $billing_fields Checkout fields keys.
+	 *
+	 * @return bool Whether the woocommerce_default_customer_address option was updated.
+	 */
+	public static function maybe_update_woocommerce_default_customer_address( $billing_fields ) {
+		if ( ! in_array( 'billing_country', $billing_fields, true ) && in_array( 'billing_state', $billing_fields, true ) ) {
+			return update_option( self::WOOCOMMERCE_DEFAULT_CUSTOMER_ADDRESS_OPTION, 'base' );
+		}
+
 		return false;
 	}
 }

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -557,6 +557,7 @@ class Reader_Revenue_Wizard extends Wizard {
 				'email_cpt'               => Emails::POST_TYPE,
 				'salesforce_redirect_url' => Salesforce::get_redirect_url(),
 				'can_use_name_your_price' => Donations::can_use_name_your_price(),
+				'is_platform_wc'          => Donations::is_platform_wc(),
 			]
 		);
 		\wp_enqueue_script( 'newspack-reader-revenue-wizard' );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1206331646877121/1205955387558360/f
](https://app.asana.com/0/1206331646877121/1205955387558360/f)

This addresses a bug where, when WC is platform, and donation country is optional, but state is required, the donation checkout field errors with a missing state warning. We fix this by ensuring the `woocommerce_default_customer_address` setting is `base` for this specific configuration.

![Screenshot 2024-02-27 at 12 17 13](https://github.com/Automattic/newspack-plugin/assets/17905991/1dbb3373-c0c1-4270-9378-0bb6e89c55d5)

### How to test the changes in this Pull Request:

1. In WooCommerce Settings set `Default customer location` to `no location by default`: WooCommerce > Settings
2. On a test site with donations setup via WooCommerce, go to the donations settings: Newspack > Reader Revenue > Donations
3. In the billing fields section of donations settings, unset country as a required field and set state as a required field (pictured above). This configuration causes a checkout bug where new customers can't get past the billing fields portion since new customers have no default country set and billing states won't populate as expected.
4. Confirm an information notice appears letting you know default store country will be used for new customers
5. Check the WC settings page again and confirm the `Default customer location` is now set to `Shop country/region`

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->