### PR TITLE
fix: update text domains for the advertising wizard

### DIFF
--- a/assets/wizards/advertising/components/ad-refresh-control/index.js
+++ b/assets/wizards/advertising/components/ad-refresh-control/index.js
@@ -18,64 +18,64 @@ const fields = [
 	{
 		key: 'viewability_threshold',
 		type: 'int',
-		description: __( 'Viewability Threshold', 'newspack' ),
+		description: __( 'Viewability Threshold', 'newspack-plugin' ),
 		help: __(
 			"The percentage of the ad slot which must be visible in the viewport in order to be considered eligible for being refreshed. It's recommended you do not lower this below 50 or you risk third-party viewability tracking platforms flagging your ad impressions as not having been viewed before refreshing.",
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'refresh_interval',
 		type: 'int',
-		description: __( 'Refresh Interval', 'newspack' ),
+		description: __( 'Refresh Interval', 'newspack-plugin' ),
 		help: __(
 			'The number of seconds that must pass between an ad crossing the viewability threshold and the the ad refreshing. The plugin enforces a minimum of 30 in order to avoid your site being flagged for abusing ad refreshes by advertisers. This value may however be overridden via the avc_refresh_interval_value filter hook.',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'maximum_refreshes',
 		type: 'int',
-		description: __( 'Maximum Refreshes', 'newspack' ),
+		description: __( 'Maximum Refreshes', 'newspack-plugin' ),
 		help: __(
 			'The number of times each ad slot is allowed to be refreshed. If this is set to 4 then an ad slot could have a total of 5 impressions by combining the initial loading of the ad with the 4 times it can refresh.',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'advertiser_ids',
 		type: 'string',
-		description: __( 'Excluded Advertiser IDs', 'newspack' ),
+		description: __( 'Excluded Advertiser IDs', 'newspack-plugin' ),
 		help: __(
 			'Prevent ad refreshes for specific advertiser IDs in the format of a comma separated list (e.g., 125,594,293). If an ad slot ever displays an ad creative from one of the listed advertiser IDs then that ad slot will stop refreshing for the remainder of the page view. AdSense does not allow their ads to be auto-refreshed. When Newspack detects that AdSense is the advertiser for any given impression, a refresh will not take place.',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'line_item_ids',
 		type: 'string',
-		description: __( 'Line Items IDs to Exclude', 'newspack' ),
+		description: __( 'Line Items IDs to Exclude', 'newspack-plugin' ),
 		help: __(
 			'Prevent ad refreshs for specific line item IDs. (Comma Seperated List)',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'sizes_to_exclude',
 		type: 'string',
-		description: __( 'Sizes to Exclude', 'newspack' ),
+		description: __( 'Sizes to Exclude', 'newspack-plugin' ),
 		help: __(
 			'Prevent ad refreshs for specific sizes. Accepts string (fluid) or array (300x250). Example: fluid, 300x250.',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'slot_ids_to_exclude',
 		type: 'string',
-		description: __( 'Slot IDs to Exclude', 'newspack' ),
+		description: __( 'Slot IDs to Exclude', 'newspack-plugin' ),
 		help: __(
 			'Prevent ad refreshs for specific slot IDs e.g. div-gpt-ad-grid-1. (Comma Seperated List).',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 ];
@@ -134,10 +134,10 @@ export default function AdRefreshControlSettings() {
 			error={ error }
 			disabled={ inFlight }
 			sectionKey="ad-refresh-control"
-			title={ __( 'Ad Refresh Control', 'newspack' ) }
+			title={ __( 'Ad Refresh Control', 'newspack-plugin' ) }
 			description={ __(
 				'Enable Active View refresh for Google Ad Manager ads without needing to modify any code.',
-				'newspack'
+				'newspack-plugin'
 			) }
 			active={ ! settings.disable_refresh }
 			fields={ fields }

--- a/assets/wizards/advertising/components/ad-unit-size-control/index.js
+++ b/assets/wizards/advertising/components/ad-unit-size-control/index.js
@@ -70,14 +70,14 @@ const AdUnitSizeControl = ( { value, selectedOptions, onChange } ) => {
 	return (
 		<>
 			<SelectControl
-				label={ __( 'Size', 'newspack' ) }
+				label={ __( 'Size', 'newspack-plugin' ) }
 				value={ sizeIndex }
 				options={ [
 					...options.map( ( size, index ) => ( {
 						label: Array.isArray( size ) ? getSizeLabel( size ) : startCase( size ),
 						value: index,
 					} ) ),
-					{ label: __( 'Custom', 'newspack' ), value: -1 },
+					{ label: __( 'Custom', 'newspack-plugin' ), value: -1 },
 				] }
 				onChange={ index => {
 					const size = options[ index ];
@@ -90,13 +90,13 @@ const AdUnitSizeControl = ( { value, selectedOptions, onChange } ) => {
 				<div className="newspack-advertising-wizard__ad-unit-fluid">
 					{ __(
 						'Fluid is a native ad size that allows more flexibility when styling your ad. It automatically sizes the ad by filling the width of the enclosing column and adjusting the height as appropriate.',
-						'newspack'
+						'newspack-plugin'
 					) }
 				</div>
 			) : (
 				<>
 					<TextControl
-						label={ __( 'Width', 'newspack' ) }
+						label={ __( 'Width', 'newspack-plugin' ) }
 						value={ value[ 0 ] }
 						onChange={ newWidth => onChange( [ newWidth, value[ 1 ] ] ) }
 						disabled={ ! isCustom && sizeIndex !== -1 }
@@ -104,7 +104,7 @@ const AdUnitSizeControl = ( { value, selectedOptions, onChange } ) => {
 						hideLabelFromVision
 					/>
 					<TextControl
-						label={ __( 'Height', 'newspack' ) }
+						label={ __( 'Height', 'newspack-plugin' ) }
 						value={ value[ 1 ] }
 						onChange={ newHeight => onChange( [ value[ 0 ], newHeight ] ) }
 						disabled={ ! isCustom && sizeIndex !== -1 }

--- a/assets/wizards/advertising/components/add-ons/index.js
+++ b/assets/wizards/advertising/components/add-ons/index.js
@@ -18,16 +18,16 @@ export default function AddOns() {
 		<PluginToggle
 			plugins={ {
 				'super-cool-ad-inserter': {
-					actionText: __( 'Configure', 'newspack' ),
+					actionText: __( 'Configure', 'newspack-plugin' ),
 					href: '#/settings',
 				},
 				'ad-refresh-control': {
-					actionText: __( 'Configure', 'newspack' ),
+					actionText: __( 'Configure', 'newspack-plugin' ),
 					href: '#/settings',
 				},
 				'publisher-media-kit': {
 					shouldRefreshAfterUpdate: true,
-					actionText: __( 'Edit Media Kit', 'newspack' ),
+					actionText: __( 'Edit Media Kit', 'newspack-plugin' ),
 					href: newspack_ads_wizard.mediakit_edit_url ? newspack_ads_wizard.mediakit_edit_url : '',
 				},
 			} }

--- a/assets/wizards/advertising/components/onboarding/index.js
+++ b/assets/wizards/advertising/components/onboarding/index.js
@@ -59,7 +59,7 @@ export default function AdsOnboarding( { onUpdate, onSuccess } ) {
 							<p>
 								{ __(
 									'Authenticate with Google in order to connect your Google Ad Manager account:',
-									'newspack'
+									'newspack-plugin'
 								) }
 							</p>
 						) }
@@ -69,31 +69,31 @@ export default function AdsOnboarding( { onUpdate, onSuccess } ) {
 				{ false === useOAuth && (
 					<Fragment>
 						{ isConnected ? (
-							<Notice isSuccess noticeText={ __( "We're all set here!", 'newspack' ) } />
+							<Notice isSuccess noticeText={ __( "We're all set here!", 'newspack-plugin' ) } />
 						) : (
 							<Fragment>
 								<p>
 									{ __(
 										'Enter your Google Ad Manager network code and service account credentials for a full integration:',
-										'newspack'
+										'newspack-plugin'
 									) }
 								</p>
 								<TextControl
 									disabled={ inFlight }
 									isWide
 									name="network_code"
-									label={ __( 'Network code', 'newspack' ) }
+									label={ __( 'Network code', 'newspack-plugin' ) }
 									value={ networkCode }
 									onChange={ setNetworkCode }
 								/>
 								<ButtonCard
 									disabled={ inFlight }
 									onClick={ () => credentialsInputFile.current.click() }
-									title={ __( 'Upload credentials', 'newspack' ) }
+									title={ __( 'Upload credentials', 'newspack-plugin' ) }
 									desc={ [
 										__(
 											'Upload your Service Account credentials file to connect your GAM account.',
-											'newspack'
+											'newspack-plugin'
 										),
 										fileError && <Notice noticeText={ fileError } isError />,
 									] }
@@ -105,7 +105,7 @@ export default function AdsOnboarding( { onUpdate, onSuccess } ) {
 										target="_blank"
 										rel="noopener noreferrer"
 									>
-										{ __( 'How to get a service account user for API access', 'newspack' ) }
+										{ __( 'How to get a service account user for API access', 'newspack-plugin' ) }
 									</a>
 									.
 								</p>

--- a/assets/wizards/advertising/components/placement-control/index.js
+++ b/assets/wizards/advertising/components/placement-control/index.js
@@ -22,7 +22,7 @@ import { Grid, Notice, SelectControl, TextControl } from '../../../../components
 const getProvidersForSelect = providers => {
 	return [
 		{
-			label: __( 'Select a provider', 'newspack' ),
+			label: __( 'Select a provider', 'newspack-plugin' ),
 			value: '',
 		},
 		...providers.map( unit => {
@@ -46,7 +46,7 @@ const getProviderUnitsForSelect = provider => {
 	}
 	return [
 		{
-			label: __( 'Select an Ad Unit', 'newspack' ),
+			label: __( 'Select an Ad Unit', 'newspack-plugin' ),
 			value: '',
 		},
 		...provider.units.map( unit => {
@@ -74,7 +74,7 @@ const hasAnySize = ( sizes, sizesToCheck ) => {
 };
 
 const PlacementControl = ( {
-	label = __( 'Ad Unit', 'newspack' ),
+	label = __( 'Ad Unit', 'newspack-plugin' ),
 	providers = [],
 	bidders = {},
 	value = {},
@@ -99,7 +99,7 @@ const PlacementControl = ( {
 					? null
 					: sprintf(
 							// Translators: Ad bidder name.
-							__( '%s does not support the selected ad unit sizes.', 'newspack' ),
+							__( '%s does not support the selected ad unit sizes.', 'newspack-plugin' ),
 							bidder.name,
 							''
 					  );
@@ -108,14 +108,16 @@ const PlacementControl = ( {
 	}, [ providers, value.ad_unit ] );
 
 	if ( ! providers.length ) {
-		return <Notice isWarning noticeText={ __( 'There is no provider available.', 'newspack' ) } />;
+		return (
+			<Notice isWarning noticeText={ __( 'There is no provider available.', 'newspack-plugin' ) } />
+		);
 	}
 
 	return (
 		<Fragment>
 			<Grid columns={ 2 } gutter={ 32 }>
 				<SelectControl
-					label={ __( 'Provider', 'newspack' ) }
+					label={ __( 'Provider', 'newspack-plugin' ) }
 					value={ placementProvider?.id }
 					options={ getProvidersForSelect( providers ) }
 					onChange={ provider => onChange( { ...value, provider } ) }
@@ -139,7 +141,7 @@ const PlacementControl = ( {
 				Object.keys( bidders ).map( bidderKey => {
 					const bidder = bidders[ bidderKey ];
 					// Translators: Bidder name.
-					const bidderLabel = sprintf( __( '%s Placement ID', 'newspack' ), bidder.name );
+					const bidderLabel = sprintf( __( '%s Placement ID', 'newspack-plugin' ), bidder.name );
 					return (
 						<TextControl
 							key={ bidderKey }

--- a/assets/wizards/advertising/components/utils/index.js
+++ b/assets/wizards/advertising/components/utils/index.js
@@ -18,12 +18,12 @@ export function handleJSONFile( file ) {
 			try {
 				json = JSON.parse( ev.target.result );
 			} catch ( error ) {
-				reject( __( 'Invalid JSON file', 'newspack' ) );
+				reject( __( 'Invalid JSON file', 'newspack-plugin' ) );
 			}
 			resolve( json );
 		};
 		reader.onerror = function () {
-			reject( __( 'Unable to read file', 'newspack' ) );
+			reject( __( 'Unable to read file', 'newspack-plugin' ) );
 		};
 	} );
 }

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -117,7 +117,9 @@ class AdvertisingWizard extends Component {
 	 */
 	deleteAdUnit = id => {
 		if (
-			utils.confirmAction( __( 'Are you sure you want to archive this ad unit?', 'newspack' ) )
+			utils.confirmAction(
+				__( 'Are you sure you want to archive this ad unit?', 'newspack-plugin' )
+			)
 		) {
 			return this.updateWithAPI( {
 				path: '/newspack/v1/wizard/billboard/ad_unit/' + id,
@@ -144,24 +146,24 @@ class AdvertisingWizard extends Component {
 		const { services, adUnits } = advertisingData;
 		const tabs = [
 			{
-				label: __( 'Providers', 'newspack' ),
+				label: __( 'Providers', 'newspack-plugin' ),
 				path: '/',
 				exact: true,
 			},
 			{
-				label: __( 'Placements', 'newspack' ),
+				label: __( 'Placements', 'newspack-plugin' ),
 				path: '/placements',
 			},
 			{
-				label: __( 'Settings', 'newspack' ),
+				label: __( 'Settings', 'newspack-plugin' ),
 				path: '/settings',
 			},
 			{
-				label: __( 'Suppression', 'newspack' ),
+				label: __( 'Suppression', 'newspack-plugin' ),
 				path: '/suppression',
 			},
 			{
-				label: __( 'Add-Ons', 'newspack' ),
+				label: __( 'Add-Ons', 'newspack-plugin' ),
 				path: '/addons',
 			},
 		];
@@ -176,7 +178,10 @@ class AdvertisingWizard extends Component {
 							render={ () => (
 								<Providers
 									headerText="Advertising"
-									subHeaderText={ __( 'Manage ad providers and their settings.', 'newspack' ) }
+									subHeaderText={ __(
+										'Manage ad providers and their settings.',
+										'newspack-plugin'
+									) }
 									services={ services }
 									toggleService={ this.toggleService }
 									fetchAdvertisingData={ this.fetchAdvertisingData }
@@ -188,10 +193,10 @@ class AdvertisingWizard extends Component {
 							path="/placements"
 							render={ () => (
 								<Placements
-									headerText={ __( 'Advertising', 'newspack' ) }
+									headerText={ __( 'Advertising', 'newspack-plugin' ) }
 									subHeaderText={ __(
 										'Define global advertising placements to serve ad units on your site',
-										'newspack'
+										'newspack-plugin'
 									) }
 									tabbedNavigation={ tabs }
 								/>
@@ -201,10 +206,10 @@ class AdvertisingWizard extends Component {
 							path="/settings"
 							render={ () => (
 								<Settings
-									headerText={ __( 'Advertising', 'newspack' ) }
+									headerText={ __( 'Advertising', 'newspack-plugin' ) }
 									subHeaderText={ __(
 										'Configure display and advanced settings for your ads',
-										'newspack'
+										'newspack-plugin'
 									) }
 									tabbedNavigation={ tabs }
 								/>
@@ -218,7 +223,7 @@ class AdvertisingWizard extends Component {
 									headerText="Google Ad Manager"
 									subHeaderText={ __(
 										'Monetize your content through Google Ad Manager',
-										'newspack'
+										'newspack-plugin'
 									) }
 									adUnits={ adUnits }
 									service={ 'google_ad_manager' }
@@ -235,8 +240,8 @@ class AdvertisingWizard extends Component {
 							path={ `/google_ad_manager/${ CREATE_AD_ID_PARAM }` }
 							render={ routeProps => (
 								<AdUnit
-									headerText={ __( 'Add New Ad Unit', 'newspack' ) }
-									subHeaderText={ __( 'Allows you to place ads on your site', 'newspack' ) }
+									headerText={ __( 'Add New Ad Unit', 'newspack-plugin' ) }
+									subHeaderText={ __( 'Allows you to place ads on your site', 'newspack-plugin' ) }
 									adUnit={
 										adUnits[ 0 ] || {
 											id: 0,
@@ -268,8 +273,11 @@ class AdvertisingWizard extends Component {
 								const adId = routeProps.match.params.id;
 								return (
 									<AdUnit
-										headerText={ __( 'Edit Ad Unit', 'newspack' ) }
-										subHeaderText={ __( 'Allows you to place ads on your site', 'newspack' ) }
+										headerText={ __( 'Edit Ad Unit', 'newspack-plugin' ) }
+										subHeaderText={ __(
+											'Allows you to place ads on your site',
+											'newspack-plugin'
+										) }
 										adUnit={ adUnits[ adId ] || {} }
 										service={ 'google_ad_manager' }
 										onChange={ this.onAdUnitChange }
@@ -288,10 +296,10 @@ class AdvertisingWizard extends Component {
 							path="/suppression"
 							render={ () => (
 								<Suppression
-									headerText={ __( 'Advertising', 'newspack' ) }
+									headerText={ __( 'Advertising', 'newspack-plugin' ) }
 									subHeaderText={ __(
 										'Allows you to manage site-wide ad suppression',
-										'newspack'
+										'newspack-plugin'
 									) }
 									tabbedNavigation={ tabs }
 									config={ advertisingData.suppression }
@@ -303,8 +311,8 @@ class AdvertisingWizard extends Component {
 							path="/addons"
 							render={ () => (
 								<AddOns
-									headerText={ __( 'Advertising', 'newspack' ) }
-									subHeaderText={ __( 'Add-ons for enhanced advertising', 'newspack' ) }
+									headerText={ __( 'Advertising', 'newspack-plugin' ) }
+									subHeaderText={ __( 'Add-ons for enhanced advertising', 'newspack-plugin' ) }
 									tabbedNavigation={ tabs }
 								/>
 							) }

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -84,18 +84,18 @@ class AdUnit extends Component {
 		return (
 			<>
 				<Card headerActions noBorder>
-					<h2>{ __( 'Ad Unit Details', 'newspack' ) }</h2>
+					<h2>{ __( 'Ad Unit Details', 'newspack-plugin' ) }</h2>
 				</Card>
 
 				<Grid gutter={ 32 }>
 					<TextControl
-						label={ __( 'Name', 'newspack' ) }
+						label={ __( 'Name', 'newspack-plugin' ) }
 						value={ name || '' }
 						onChange={ value => this.handleOnChange( 'name', value ) }
 					/>
 					{ ( isExistingAdUnit || isLegacy ) && (
 						<TextControl
-							label={ __( 'Code', 'newspack' ) }
+							label={ __( 'Code', 'newspack-plugin' ) }
 							value={ getCodeValue() }
 							className="code"
 							help={
@@ -103,7 +103,7 @@ class AdUnit extends Component {
 									? undefined
 									: __(
 											"Identifies the ad unit in the associated ad tag. Once you've created the ad unit, you can't change the code.",
-											'newspack'
+											'newspack-plugin'
 									  )
 							}
 							disabled={ ! isLegacy }
@@ -115,8 +115,8 @@ class AdUnit extends Component {
 				<Card headerActions noBorder>
 					<h2>
 						{ sizeOptions.length > 1
-							? __( 'Ad Unit Sizes', 'newspack' )
-							: __( 'Ad Unit Size', 'newspack' ) }
+							? __( 'Ad Unit Sizes', 'newspack-plugin' )
+							: __( 'Ad Unit Size', 'newspack-plugin' ) }
 					</h2>
 					<Button
 						variant="secondary"
@@ -124,7 +124,7 @@ class AdUnit extends Component {
 							this.handleOnChange( 'sizes', [ ...sizes, this.getNextAvailableSize() ] )
 						}
 					>
-						{ __( 'Add New Size', 'newspack' ) }
+						{ __( 'Add New Size', 'newspack-plugin' ) }
 					</Button>
 				</Card>
 
@@ -133,16 +133,16 @@ class AdUnit extends Component {
 						isWarning
 						noticeText={ __(
 							'The ad unit must have at least one valid size or fluid size enabled.',
-							'newspack'
+							'newspack-plugin'
 						) }
 					/>
 				) }
 
 				<Grid columns={ 4 } gutter={ 8 } className="newspack-grid__thead">
-					<span>{ __( 'Size', 'newspack' ) }</span>
-					<span>{ __( 'Width', 'newspack' ) }</span>
-					<span>{ __( 'Height', 'newspack' ) }</span>
-					<span className="screen-reader-text">{ __( 'Action', 'newspack' ) }</span>
+					<span>{ __( 'Size', 'newspack-plugin' ) }</span>
+					<span>{ __( 'Width', 'newspack-plugin' ) }</span>
+					<span>{ __( 'Height', 'newspack-plugin' ) }</span>
+					<span className="screen-reader-text">{ __( 'Action', 'newspack-plugin' ) }</span>
 				</Grid>
 
 				{ sizeOptions.map( ( size, index ) => (
@@ -177,7 +177,7 @@ class AdUnit extends Component {
 							} }
 							icon={ trash }
 							disabled={ sizeOptions.length <= 1 }
-							label={ __( 'Delete', 'newspack' ) }
+							label={ __( 'Delete', 'newspack-plugin' ) }
 							showTooltip={ true }
 						/>
 					</Grid>
@@ -189,10 +189,10 @@ class AdUnit extends Component {
 						variant="primary"
 						onClick={ () => onSave( id ) }
 					>
-						{ __( 'Save', 'newspack' ) }
+						{ __( 'Save', 'newspack-plugin' ) }
 					</Button>
 					<Button variant="secondary" onClick={ () => onCancel() } href={ `#/${ service }` }>
-						{ __( 'Cancel', 'newspack' ) }
+						{ __( 'Cancel', 'newspack-plugin' ) }
 					</Button>
 				</div>
 			</>

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -40,7 +40,7 @@ const AdUnits = ( {
 	fetchAdvertisingData,
 } ) => {
 	const gamErrorMessage = serviceData?.status?.error
-		? `${ __( 'Google Ad Manager Error', 'newspack' ) }: ${ serviceData.status.error }`
+		? `${ __( 'Google Ad Manager Error', 'newspack-plugin' ) }: ${ serviceData.status.error }`
 		: false;
 
 	const updateNetworkCode = async ( value, isGam ) => {
@@ -81,13 +81,13 @@ const AdUnits = ( {
 		<>
 			<Card noBorder>
 				<Button isLink href="#/" icon={ arrowLeft }>
-					{ __( 'Back', 'newspack' ) }
+					{ __( 'Back', 'newspack-plugin' ) }
 				</Button>
 			</Card>
 
 			{ ! isLegacy && networkCode && (
 				<SelectControl
-					label={ __( 'Connected GAM network code', 'newspack' ) }
+					label={ __( 'Connected GAM network code', 'newspack-plugin' ) }
 					value={ networkCode }
 					options={ serviceData.available_networks.map( network => ( {
 						label: `${ network.name } (${ network.code })`,
@@ -100,7 +100,7 @@ const AdUnits = ( {
 				<Notice
 					noticeText={ __(
 						'Your GAM network code is different than the network code the site was configured with. Legacy ad units are likely to not load.',
-						'newspack'
+						'newspack-plugin'
 					) }
 					isWarning
 				/>
@@ -109,13 +109,13 @@ const AdUnits = ( {
 			{ serviceData.created_targeting_keys?.length > 0 && (
 				<Notice
 					noticeText={ [
-						__( 'Created custom targeting keys:' ) + '\u00A0',
+						__( 'Created custom targeting keys:', 'newspack-plugin' ) + '\u00A0',
 						serviceData.created_targeting_keys.join( ', ' ) + '. \u00A0',
 						<ExternalLink
 							href={ `https://admanager.google.com/${ serviceData.network_code }#inventory/custom_targeting/list` }
 							key="google-ad-manager-custom-targeting-link"
 						>
-							{ __( 'Visit your GAM dashboard' ) }
+							{ __( 'Visit your GAM dashboard', 'newspack-plugin' ) }
 						</ExternalLink>,
 					] }
 					isSuccess
@@ -124,19 +124,19 @@ const AdUnits = ( {
 			{ isLegacy && serviceData.enabled && (
 				<>
 					<Notice
-						noticeText={ __( 'Currently operating in legacy mode.', 'newspack' ) }
+						noticeText={ __( 'Currently operating in legacy mode.', 'newspack-plugin' ) }
 						isWarning
 					/>
 					<div className="flex items-end">
 						<TextControl
-							label={ __( 'Network Code', 'newspack' ) }
+							label={ __( 'Network Code', 'newspack-plugin' ) }
 							value={ networkCode }
 							onChange={ setNetworkCode }
 							withMargin={ false }
 						/>
 						<span className="pl3">
 							<Button onClick={ updateLegacyNetworkCode } isPrimary>
-								{ __( 'Save', 'newspack' ) }
+								{ __( 'Save', 'newspack-plugin' ) }
 							</Button>
 						</span>
 					</div>
@@ -145,18 +145,18 @@ const AdUnits = ( {
 			<p>
 				{ __(
 					'Set up multiple ad units to use on your homepage, articles and other places throughout your site.',
-					'newspack'
+					'newspack-plugin'
 				) }
 				<br />
 				{ __(
 					'You can place ads through our Newspack Ad Block in the Editor, Newspack Ad widget, and using the global placements.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			</p>
 			<Card headerActions noBorder>
 				<div className="flex justify-end w-100">
 					<Button variant="primary" href={ `#/google_ad_manager/${ CREATE_AD_ID_PARAM }` }>
-						{ __( 'Add New Ad Unit', 'newspack' ) }
+						{ __( 'Add New Ad Unit', 'newspack-plugin' ) }
 					</Button>
 				</div>
 			</Card>
@@ -178,35 +178,35 @@ const AdUnits = ( {
 									<span>
 										{ adUnit.code ? (
 											<>
-												<i>{ __( 'Code:', 'newspack' ) }</i> <code>{ adUnit.code }</code>
+												<i>{ __( 'Code:', 'newspack-plugin' ) }</i> <code>{ adUnit.code }</code>
 											</>
 										) : null }
 										{ adUnit.sizes?.length || adUnit.fluid ? (
 											<>
 												{ ' ' }
-												| { __( 'Sizes:', 'newspack' ) }{ ' ' }
+												| { __( 'Sizes:', 'newspack-plugin' ) }{ ' ' }
 												{ adUnit.sizes.map( ( size, i ) => (
 													<code key={ i }>{ Array.isArray( size ) ? size.join( 'x' ) : size }</code>
 												) ) }
-												{ adUnit.fluid && <code>{ __( 'Fluid', 'newspack' ) }</code> }
+												{ adUnit.fluid && <code>{ __( 'Fluid', 'newspack-plugin' ) }</code> }
 											</>
 										) : null }
 										{ adUnit.is_legacy ? (
 											<>
 												{ ' ' }
-												| <i>{ __( 'Legacy ad unit.', 'newspack' ) }</i>
+												| <i>{ __( 'Legacy ad unit.', 'newspack-plugin' ) }</i>
 											</>
 										) : null }
 										{ adUnit.is_default ? (
 											<>
 												{ ' ' }
-												| <i>{ __( 'Default ad unit.', 'newspack' ) }</i>
+												| <i>{ __( 'Default ad unit.', 'newspack-plugin' ) }</i>
 											</>
 										) : null }
 										{ isDisconnectedGAM( adUnit ) ? (
 											<>
 												{ ' ' }
-												| <i>{ __( 'Disconnected from GAM.', 'newspack' ) }</i>
+												| <i>{ __( 'Disconnected from GAM.', 'newspack-plugin' ) }</i>
 											</>
 										) : null }
 									</span>

--- a/assets/wizards/advertising/views/ad-units/options-popover.js
+++ b/assets/wizards/advertising/views/ad-units/options-popover.js
@@ -35,7 +35,7 @@ const OptionsPopover = props => {
 					onKeyDown={ event => ESCAPE === event.keyCode && toggleVisible }
 				>
 					<MenuItem onClick={ toggleVisible } className="screen-reader-text">
-						{ __( 'Close Popover', 'newspack=plugin' ) }
+						{ __( 'Close Popover', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem href={ editLink } className="newspack-button" isLink>
 						{ __( 'Edit', 'newspack-plugin' ) }

--- a/assets/wizards/advertising/views/ad-units/options-popover.js
+++ b/assets/wizards/advertising/views/ad-units/options-popover.js
@@ -25,7 +25,7 @@ const OptionsPopover = props => {
 				className={ isVisible && 'popover-active' }
 				onClick={ toggleVisible }
 				icon={ moreVertical }
-				label={ __( 'More options', 'newspack' ) }
+				label={ __( 'More options', 'newspack-plugin' ) }
 				tooltipPosition="bottom center"
 			/>
 			{ isVisible && (
@@ -35,13 +35,13 @@ const OptionsPopover = props => {
 					onKeyDown={ event => ESCAPE === event.keyCode && toggleVisible }
 				>
 					<MenuItem onClick={ toggleVisible } className="screen-reader-text">
-						{ __( 'Close Popover', 'newspack' ) }
+						{ __( 'Close Popover', 'newspack=plugin' ) }
 					</MenuItem>
 					<MenuItem href={ editLink } className="newspack-button" isLink>
-						{ __( 'Edit', 'newspack' ) }
+						{ __( 'Edit', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem onClick={ deleteLink } className="newspack-button">
-						{ __( 'Archive', 'newspack' ) }
+						{ __( 'Archive', 'newspack-plugin' ) }
 					</MenuItem>
 				</Popover>
 			) }

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -132,7 +132,10 @@ const Placements = () => {
 	return (
 		<Fragment>
 			{ ! inFlight && ! providers.length && (
-				<Notice isWarning noticeText={ __( 'There is no provider available.', 'newspack' ) } />
+				<Notice
+					isWarning
+					noticeText={ __( 'There is no provider available.', 'newspack-plugin' ) }
+				/>
 			) }
 			<div
 				className={ classnames( {
@@ -156,7 +159,7 @@ const Placements = () => {
 										disabled={ inFlight || ! providers.length }
 										onClick={ () => setEditingPlacement( key ) }
 										icon={ settings }
-										label={ __( 'Placement settings', 'newspack' ) }
+										label={ __( 'Placement settings', 'newspack-plugin' ) }
 										tooltipPosition="bottom center"
 									/>
 								) : null
@@ -169,7 +172,7 @@ const Placements = () => {
 				<Modal
 					title={ sprintf(
 						// translators: %s is the name of the placement
-						__( '%s placement settings', 'newspack' ),
+						__( '%s placement settings', 'newspack-plugin' ),
 						placement.name
 					) }
 					onRequestClose={ () => setEditingPlacement( null ) }
@@ -194,7 +197,7 @@ const Placements = () => {
 							return (
 								<Card noBorder key={ hookKey }>
 									<PlacementControl
-										label={ hook.name + ' ' + __( 'Ad Unit', 'newspack' ) }
+										label={ hook.name + ' ' + __( 'Ad Unit', 'newspack-plugin' ) }
 										providers={ providers }
 										bidders={ bidders }
 										value={ placement.data?.hooks ? placement.data.hooks[ hookKey ] : {} }
@@ -206,7 +209,7 @@ const Placements = () => {
 						} ) }
 					{ placement.supports?.indexOf( 'stick_to_top' ) > -1 && (
 						<ToggleControl
-							label={ __( 'Stick to Top', 'newspack' ) }
+							label={ __( 'Stick to Top', 'newspack-plugin' ) }
 							checked={ !! placement.data?.stick_to_top }
 							onChange={ value => {
 								setPlacements(
@@ -223,7 +226,7 @@ const Placements = () => {
 								setEditingPlacement( null );
 							} }
 						>
-							{ __( 'Cancel', 'newspack' ) }
+							{ __( 'Cancel', 'newspack-plugin' ) }
 						</Button>
 						<Button
 							isPrimary
@@ -233,7 +236,7 @@ const Placements = () => {
 								setEditingPlacement( null );
 							} }
 						>
-							{ __( 'Save', 'newspack' ) }
+							{ __( 'Save', 'newspack-plugin' ) }
 						</Button>
 					</Card>
 				</Modal>

--- a/assets/wizards/advertising/views/providers/index.js
+++ b/assets/wizards/advertising/views/providers/index.js
@@ -52,14 +52,14 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 		notifications = notifications.concat( [ google_ad_manager.status.error, '\u00A0' ] );
 	} else if ( google_ad_manager?.created_targeting_keys?.length > 0 ) {
 		notifications = notifications.concat( [
-			__( 'Created custom targeting keys:' ) + '\u00A0',
+			__( 'Created custom targeting keys:', 'newspack-plugin' ) + '\u00A0',
 			google_ad_manager.created_targeting_keys.join( ', ' ) + '. \u00A0',
 			// eslint-disable-next-line react/jsx-indent
 			<ExternalLink
 				href={ `https://admanager.google.com/${ google_ad_manager.network_code }#inventory/custom_targeting/list` }
 				key="google-ad-manager-custom-targeting-link"
 			>
-				{ __( 'Visit your GAM dashboard' ) }
+				{ __( 'Visit your GAM dashboard', 'newspack-plugin' ) }
 			</ExternalLink>,
 		] );
 	}
@@ -71,7 +71,7 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 	) {
 		notifications.push(
 			<Button key="gam-connect-account" isLink onClick={ () => setIsOnboarding( true ) }>
-				{ __( 'Click here to connect your account.', 'newspack' ) }
+				{ __( 'Click here to connect your account.', 'newspack-plugin' ) }
 			</Button>
 		);
 	}
@@ -79,11 +79,14 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 	return (
 		<>
 			<ActionCard
-				title={ __( 'Google Ad Manager' ) }
+				title={ __( 'Google Ad Manager', 'newspack-plugin' ) }
 				description={ __(
-					'Manage Google Ad Manager ad units and placements directly from the Newspack dashboard.'
+					'Manage Google Ad Manager ad units and placements directly from the Newspack dashboard.',
+					'newspack-plugin'
 				) }
-				actionText={ google_ad_manager && google_ad_manager.enabled && __( 'Configure' ) }
+				actionText={
+					google_ad_manager && google_ad_manager.enabled && __( 'Configure', 'newspack-plugin' )
+				}
 				toggle
 				toggleChecked={ google_ad_manager && google_ad_manager.enabled }
 				toggleOnChange={ value => {
@@ -105,14 +108,14 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 			<PluginToggle
 				plugins={ {
 					broadstreet: {
-						actionText: __( 'Configure' ),
+						actionText: __( 'Configure', 'newspack-plugin' ),
 						href: '/wp-admin/admin.php?page=Broadstreet',
 					},
 				} }
 			/>
 			{ isOnboarding && (
 				<Modal
-					title={ __( 'Google Ad Manager Setup', 'newspack-ads' ) }
+					title={ __( 'Google Ad Manager Setup', 'newspack-plugin' ) }
 					onRequestClose={ () => setIsOnboarding( false ) }
 				>
 					<GAMOnboarding
@@ -124,14 +127,14 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 					/>
 					<Card buttonsCard noBorder className="justify-end">
 						<Button isSecondary disabled={ inFlight } onClick={ () => setIsOnboarding( false ) }>
-							{ __( 'Cancel', 'newspack' ) }
+							{ __( 'Cancel', 'newspack-plugin' ) }
 						</Button>
 						<Button
 							isPrimary
 							disabled={ inFlight || ! networkCode }
 							onClick={ () => updateGAMNetworkCode() }
 						>
-							{ __( 'Save', 'newspack' ) }
+							{ __( 'Save', 'newspack-plugin' ) }
 						</Button>
 					</Card>
 				</Modal>

--- a/assets/wizards/advertising/views/suppression/index.js
+++ b/assets/wizards/advertising/views/suppression/index.js
@@ -69,8 +69,8 @@ const Suppression = () => {
 		<>
 			{ error && <Notice isError noticeText={ error.message } /> }
 			<SectionHeader
-				title={ __( 'Post Types', 'newspack' ) }
-				description={ __( 'Suppress ads on specific post types.', 'newspack' ) }
+				title={ __( 'Post Types', 'newspack-plugin' ) }
+				description={ __( 'Suppress ads on specific post types.', 'newspack-plugin' ) }
 			/>
 			<Grid columns={ 3 } gutter={ 16 }>
 				{ postTypes.map( postType => (
@@ -91,8 +91,11 @@ const Suppression = () => {
 				) ) }
 			</Grid>
 			<SectionHeader
-				title={ __( 'Tags', 'newspack' ) }
-				description={ __( 'Suppress ads on specific tags and their archive pages.', 'newspack' ) }
+				title={ __( 'Tags', 'newspack-plugin' ) }
+				description={ __(
+					'Suppress ads on specific tags and their archive pages.',
+					'newspack-plugin'
+				) }
 			/>
 			<CategoryAutocomplete
 				value={ config.tags?.map( v => parseInt( v ) ) || [] }
@@ -102,7 +105,7 @@ const Suppression = () => {
 						tags: selected.map( item => item.id ),
 					} );
 				} }
-				label={ __( 'Tags to suppress ads on (archives and posts)', 'newspack ' ) }
+				label={ __( 'Tags to suppress ads on (archives and posts)', 'newspack-plugin' ) }
 				taxonomy="tags"
 			/>
 			<ToggleControl
@@ -111,13 +114,13 @@ const Suppression = () => {
 				onChange={ tag_archive_pages => {
 					setConfig( { ...config, tag_archive_pages } );
 				} }
-				label={ __( 'All tag archive pages', 'newspack' ) }
+				label={ __( 'All tag archive pages', 'newspack-plugin' ) }
 			/>
 			<SectionHeader
-				title={ __( 'Categories', 'newspack' ) }
+				title={ __( 'Categories', 'newspack-plugin' ) }
 				description={ __(
 					'Suppress ads on specific categories and their archive pages.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			/>
 			<CategoryAutocomplete
@@ -128,7 +131,7 @@ const Suppression = () => {
 						categories: selected.map( item => item.id ),
 					} );
 				} }
-				label={ __( 'Categories to suppress ads on (archives and posts)', 'newspack ' ) }
+				label={ __( 'Categories to suppress ads on (archives and posts)', 'newspack-plugin' ) }
 			/>
 			<ToggleControl
 				disabled={ config === false }
@@ -136,13 +139,13 @@ const Suppression = () => {
 				onChange={ category_archive_pages => {
 					setConfig( { ...config, category_archive_pages } );
 				} }
-				label={ __( 'All category archive pages', 'newspack' ) }
+				label={ __( 'All category archive pages', 'newspack-plugin' ) }
 			/>
 			<SectionHeader
-				title={ __( 'Author Archive Pages', 'newspack' ) }
+				title={ __( 'Author Archive Pages', 'newspack-plugin' ) }
 				description={ __(
 					'Suppress ads on automatically generated pages displaying a list of posts by an author.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			/>
 			<ToggleControl
@@ -151,11 +154,11 @@ const Suppression = () => {
 				onChange={ author_archive_pages => {
 					setConfig( { ...config, author_archive_pages } );
 				} }
-				label={ __( 'Suppress ads on author archive pages', 'newspack' ) }
+				label={ __( 'Suppress ads on author archive pages', 'newspack-plugin' ) }
 			/>{ ' ' }
 			<Card buttonsCard noBorder className="justify-end">
 				<Button isPrimary disabled={ inFlight } onClick={ updateConfig }>
-					{ __( 'Save', 'newspack' ) }
+					{ __( 'Save', 'newspack-plugin' ) }
 				</Button>
 			</Card>
 		</>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the text domain throughout the assets/wizards/advertising directory, as part of correcting it throughout the plugin.

See 1200550061930446-as-1205509524123559.

### How to test the changes in this Pull Request:

1. Review the code changes to confirm that the text domain for each string has been updated to `newspack-plugin`, and that there aren't any errors. (For the latter you can also try running `npm run build` and checking the Newspack > Advertising screens!). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->