### PR TITLE
fix: update text domains for the analytics, components screens

### DIFF
--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -22,12 +22,12 @@ const { HashRouter, Redirect, Route, Switch } = Router;
 
 const TABS = [
 	{
-		label: __( 'Plugins', 'newspack' ),
+		label: __( 'Plugins', 'newspack-plugin' ),
 		path: '/',
 		exact: true,
 	},
 	{
-		label: __( 'Newspack Custom Events', 'newspack' ),
+		label: __( 'Newspack Custom Events', 'newspack-plugin' ),
 		path: '/newspack-custom-events',
 	},
 ];
@@ -39,8 +39,8 @@ class AnalyticsWizard extends Component {
 	render() {
 		const { pluginRequirements, wizardApiFetch, isLoading } = this.props;
 		const sharedProps = {
-			headerText: __( 'Analytics', 'newspack' ),
-			subHeaderText: __( 'Manage Google Analytics Configuration', 'newspack' ),
+			headerText: __( 'Analytics', 'newspack-plugin' ),
+			subHeaderText: __( 'Manage Google Analytics Configuration', 'newspack-plugin' ),
 			tabbedNavigation: TABS,
 			wizardApiFetch,
 			isLoading,

--- a/assets/wizards/analytics/views/newspack-custom-events/index.js
+++ b/assets/wizards/analytics/views/newspack-custom-events/index.js
@@ -52,17 +52,17 @@ class NewspackCustomEvents extends Component {
 			<div className="newspack__analytics-configuration">
 				<div className="newspack__analytics-configuration__header">
 					<SectionHeader
-						title={ __( 'Activate Newspack Custom Events', 'newspack' ) }
+						title={ __( 'Activate Newspack Custom Events', 'newspack-plugin' ) }
 						description={ __(
 							'Allows Newspack to send enhanced custom event data to your Google Analytics.',
-							'newspack'
+							'newspack-plugin'
 						) }
 						noMargin
 					/>
 					<p>
 						{ __(
 							"Newspack already sends some custom event data to your GA account, but adding the credentials below enables enhanced events that are fired from your site's backend. For example, when a donation is confirmed or when a user successfully subscribes to a newsletter.",
-							'newspack'
+							'newspack-plugin'
 						) }
 					</p>
 				</div>
@@ -71,10 +71,10 @@ class NewspackCustomEvents extends Component {
 				<Grid noMargin rowGap={ 16 }>
 					<TextControl
 						value={ ga4Credendials?.measurement_id }
-						label={ __( 'Measurement ID', 'newspack' ) }
+						label={ __( 'Measurement ID', 'newspack-plugin' ) }
 						help={ __(
 							'You can find this in Site Kit Settings, or in Google Analytics > Admin > Data Streams and clickng the data stream. Example: G-ABCD1234',
-							'newspack'
+							'newspack-plugin'
 						) }
 						onChange={ value =>
 							this.setState( {
@@ -88,10 +88,10 @@ class NewspackCustomEvents extends Component {
 					<TextControl
 						type="password"
 						value={ ga4Credendials?.measurement_protocol_secret }
-						label={ __( 'Measurement Protocol API Secret', 'newspack' ) }
+						label={ __( 'Measurement Protocol API Secret', 'newspack-plugin' ) }
 						help={ __(
 							'Generate an API secret from your GA dashboard in Admin > Data Streams and opening your data stream. Select "Measurement Protocol API secrets" under the Events section. Create a new secret.',
-							'newspack'
+							'newspack-plugin'
 						) }
 						onChange={ value =>
 							this.setState( {
@@ -109,7 +109,7 @@ class NewspackCustomEvents extends Component {
 					disabled={ isLoading }
 					onClick={ this.updateGa4Credentials }
 				>
-					{ __( 'Save', 'newspack' ) }
+					{ __( 'Save', 'newspack-plugin' ) }
 				</Button>
 			</div>
 		);

--- a/assets/wizards/analytics/views/plugins/index.js
+++ b/assets/wizards/analytics/views/plugins/index.js
@@ -26,9 +26,9 @@ class Plugins extends Component {
 		return (
 			<Fragment>
 				<ActionCard
-					title={ __( 'Google Analytics' ) }
-					description={ __( 'Configure and view site analytics' ) }
-					actionText={ __( 'View' ) }
+					title={ __( 'Google Analytics', 'newspack-plugin' ) }
+					description={ __( 'Configure and view site analytics', 'newspack-plugin' ) }
+					actionText={ __( 'View', 'newspack-plugin' ) }
 					handoff="google-site-kit"
 					editLink={
 						newspack_analytics_wizard_data.analyticsConnectionError

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -82,7 +82,7 @@ class ComponentsDemo extends Component {
 							<Button
 								isLink
 								href={ newspack_urls.dashboard }
-								label={ __( 'Return to Dashboard', 'newspack' ) }
+								label={ __( 'Return to Dashboard', 'newspack-plugin' ) }
 								showTooltip={ true }
 								icon={ home }
 								iconSize={ 36 }
@@ -90,9 +90,12 @@ class ComponentsDemo extends Component {
 								<NewspackIcon size={ 36 } />
 							</Button>
 							<div>
-								<h2>{ __( 'Components Demo', 'newspack' ) }</h2>
+								<h2>{ __( 'Components Demo', 'newspack-plugin' ) }</h2>
 								<span>
-									{ __( 'Simple components used for composing the UI of Newspack', 'newspack' ) }
+									{ __(
+										'Simple components used for composing the UI of Newspack',
+										'newspack-plugin'
+									) }
 								</span>
 							</div>
 						</div>
@@ -100,12 +103,12 @@ class ComponentsDemo extends Component {
 				</div>
 				<div className="newspack-wizard newspack-wizard__content">
 					<Card>
-						<h2>{ __( 'Autocomplete with Suggestions (single-select)', 'newspack' ) }</h2>
+						<h2>{ __( 'Autocomplete with Suggestions (single-select)', 'newspack-plugin' ) }</h2>
 						<AutocompleteWithSuggestions
-							label={ __( 'Search for a post', 'newspack' ) }
+							label={ __( 'Search for a post', 'newspack-plugin' ) }
 							help={ __(
 								'Begin typing post title, click autocomplete result to select.',
-								'newspack'
+								'newspack-plugin'
 							) }
 							onChange={ items =>
 								this.setState( { selectedPostForAutocompleteWithSuggestions: items } )
@@ -115,14 +118,14 @@ class ComponentsDemo extends Component {
 
 						<hr />
 
-						<h2>{ __( 'Autocomplete with Suggestions (multi-select)', 'newspack' ) }</h2>
+						<h2>{ __( 'Autocomplete with Suggestions (multi-select)', 'newspack-plugin' ) }</h2>
 						<AutocompleteWithSuggestions
 							hideHelp
 							multiSelect
-							label={ __( 'Search widgets', 'newspack' ) }
+							label={ __( 'Search widgets', 'newspack-plugin' ) }
 							help={ __(
 								'Begin typing post title, click autocomplete result to select.',
-								'newspack'
+								'newspack-plugin'
 							) }
 							onChange={ items =>
 								this.setState( { selectedPostsForAutocompleteWithSuggestionsMultiSelect: items } )
@@ -137,70 +140,70 @@ class ComponentsDemo extends Component {
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Plugin toggles', 'newspack' ) }</h2>
+						<h2>{ __( 'Plugin toggles', 'newspack-plugin' ) }</h2>
 						<PluginToggle
 							plugins={ {
 								woocommerce: {
 									shouldRefreshAfterUpdate: true,
 								},
 								'fb-instant-articles': {
-									actionText: __( 'Configure Instant Articles' ),
+									actionText: __( 'Configure Instant Articles', 'newspack-plugin' ),
 									href: '/wp-admin/admin.php?page=newspack',
 								},
 							} }
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Web Previews', 'newspack' ) }</h2>
+						<h2>{ __( 'Web Previews', 'newspack-plugin' ) }</h2>
 						<Card buttonsCard noBorder className="items-center">
 							<WebPreview
 								url="//newspack.com/"
-								label={ __( 'Preview Newspack Blog', 'newspack' ) }
+								label={ __( 'Preview Newspack Blog', 'newspack-plugin' ) }
 								variant="primary"
 							/>
 							<WebPreview
 								url="//newspack.com/"
 								renderButton={ ( { showPreview } ) => (
 									<a href="#" onClick={ showPreview }>
-										{ __( 'Preview Newspack Blog', 'newspack' ) }
+										{ __( 'Preview Newspack Blog', 'newspack-plugin' ) }
 									</a>
 								) }
 							/>
 						</Card>
 					</Card>
 					<Card>
-						<h2>{ __( 'Waiting', 'newspack' ) }</h2>
+						<h2>{ __( 'Waiting', 'newspack-plugin' ) }</h2>
 						<Card buttonsCard noBorder>
 							<Grid columns={ 1 } gutter={ 16 } className="w-100">
 								<Waiting />
 								<div className="flex items-center">
 									<Waiting isLeft />
-									{ __( 'Spinner on the left', 'newspack' ) }
+									{ __( 'Spinner on the left', 'newspack-plugin' ) }
 								</div>
 								<div className="flex items-center">
 									<Waiting isRight />
-									{ __( 'Spinner on the right', 'newspack' ) }
+									{ __( 'Spinner on the right', 'newspack-plugin' ) }
 								</div>
 								<Waiting isCenter />
 							</Grid>
 						</Card>
 					</Card>
 					<Card>
-						<h2>{ __( 'Color picker', 'newspack' ) }</h2>
+						<h2>{ __( 'Color picker', 'newspack-plugin' ) }</h2>
 						<ColorPicker
-							label={ __( 'Color Picker', 'newspack' ) }
+							label={ __( 'Color Picker', 'newspack-plugin' ) }
 							color={ color1 }
 							onChange={ color => this.setState( { color1: color } ) }
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Handoff Buttons', 'newspack' ) }</h2>
+						<h2>{ __( 'Handoff Buttons', 'newspack-plugin' ) }</h2>
 						<Card buttonsCard noBorder>
 							<Handoff
-								modalTitle={ __( 'Manage AMP', 'newspack' ) }
+								modalTitle={ __( 'Manage AMP', 'newspack-plugin' ) }
 								modalBody={ __(
 									'Click to go to the AMP dashboard. There will be a notification bar at the top with a link to return to Newspack.',
-									'newspack'
+									'newspack-plugin'
 								) }
 								plugin="amp"
 								isTertiary
@@ -213,49 +216,49 @@ class ComponentsDemo extends Component {
 								isPrimary
 								editLink="/wp-admin/admin.php?page=wpseo_dashboard#top#features"
 							>
-								{ __( 'Specific Yoast Page', 'newspack' ) }
+								{ __( 'Specific Yoast Page', 'newspack-plugin' ) }
 							</Handoff>
 						</Card>
 					</Card>
 					<Card>
-						<h2>{ __( 'Modal', 'newspack' ) }</h2>
+						<h2>{ __( 'Modal', 'newspack-plugin' ) }</h2>
 						<Card buttonsCard noBorder>
 							<Button isPrimary onClick={ () => this.setState( { modalShown: true } ) }>
-								{ __( 'Open modal', 'newspack' ) }
+								{ __( 'Open modal', 'newspack-plugin' ) }
 							</Button>
 						</Card>
 						{ modalShown && (
 							<Modal
-								title={ __( 'This is the modal title', 'newspack' ) }
+								title={ __( 'This is the modal title', 'newspack-plugin' ) }
 								onRequestClose={ () => this.setState( { modalShown: false } ) }
 							>
 								<p>
 									{ __(
 										'Based on industry research, we advise to test the modal component, and continuing this sentence so we can see how the text wraps is one good way of doing that.',
-										'newspack'
+										'newspack-plugin'
 									) }
 								</p>
 								<Card buttonsCard noBorder className="justify-end">
 									<Button isPrimary onClick={ () => this.setState( { modalShown: false } ) }>
-										{ __( 'Dismiss', 'newspack' ) }
+										{ __( 'Dismiss', 'newspack-plugin' ) }
 									</Button>
 									<Button isSecondary onClick={ () => this.setState( { modalShown: false } ) }>
-										{ __( 'Also dismiss', 'newspack' ) }
+										{ __( 'Also dismiss', 'newspack-plugin' ) }
 									</Button>
 								</Card>
 							</Modal>
 						) }
 					</Card>
 					<Card>
-						<h2>{ __( 'Notice', 'newspack' ) }</h2>
-						<Notice noticeText={ __( 'This is an info notice.', 'newspack' ) } />
-						<Notice noticeText={ __( 'This is an error notice.', 'newspack' ) } isError />
-						<Notice noticeText={ __( 'This is a help notice.', 'newspack' ) } isHelp />
-						<Notice noticeText={ __( 'This is a success notice.', 'newspack' ) } isSuccess />
-						<Notice noticeText={ __( 'This is a warning notice.', 'newspack' ) } isWarning />
+						<h2>{ __( 'Notice', 'newspack-plugin' ) }</h2>
+						<Notice noticeText={ __( 'This is an info notice.', 'newspack-plugin' ) } />
+						<Notice noticeText={ __( 'This is an error notice.', 'newspack-plugin' ) } isError />
+						<Notice noticeText={ __( 'This is a help notice.', 'newspack-plugin' ) } isHelp />
+						<Notice noticeText={ __( 'This is a success notice.', 'newspack-plugin' ) } isSuccess />
+						<Notice noticeText={ __( 'This is a warning notice.', 'newspack-plugin' ) } isWarning />
 					</Card>
 					<Card>
-						<h2>{ __( 'Plugin installer', 'newspack' ) }</h2>
+						<h2>{ __( 'Plugin installer', 'newspack-plugin' ) }</h2>
 						<PluginInstaller
 							plugins={ [ 'woocommerce', 'wordpress-seo' ] }
 							canUninstall
@@ -270,7 +273,7 @@ class ComponentsDemo extends Component {
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Plugin installer (small)', 'newspack' ) }</h2>
+						<h2>{ __( 'Plugin installer (small)', 'newspack-plugin' ) }</h2>
 						<PluginInstaller
 							plugins={ [ 'woocommerce', 'wordpress-seo' ] }
 							isSmall
@@ -286,18 +289,18 @@ class ComponentsDemo extends Component {
 						/>
 					</Card>
 					<ActionCard
-						title={ __( 'Example One', 'newspack' ) }
-						description={ __( 'Has an action button.', 'newspack' ) }
-						actionText={ __( 'Install', 'newspack' ) }
+						title={ __( 'Example One', 'newspack-plugin' ) }
+						description={ __( 'Has an action button.', 'newspack-plugin' ) }
+						actionText={ __( 'Install', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Install clicked' );
 						} }
 					/>
 					<ActionCard
-						title={ __( 'Example Two', 'newspack' ) }
-						description={ __( 'Has action button and secondary button.', 'newspack' ) }
-						actionText={ __( 'Edit', 'newspack' ) }
-						secondaryActionText={ __( 'Delete', 'newspack' ) }
+						title={ __( 'Example Two', 'newspack-plugin' ) }
+						description={ __( 'Has action button and secondary button.', 'newspack-plugin' ) }
+						actionText={ __( 'Edit', 'newspack-plugin' ) }
+						secondaryActionText={ __( 'Delete', 'newspack-plugin' ) }
 						secondaryDestructive
 						onClick={ () => {
 							console.log( 'Edit clicked' );
@@ -307,15 +310,15 @@ class ComponentsDemo extends Component {
 						} }
 					/>
 					<ActionCard
-						title={ __( 'Example Three', 'newspack' ) }
-						description={ __( 'Waiting/in-progress state, no action button.', 'newspack' ) }
-						actionText={ __( 'Installing…', 'newspack' ) }
+						title={ __( 'Example Three', 'newspack-plugin' ) }
+						description={ __( 'Waiting/in-progress state, no action button.', 'newspack-plugin' ) }
+						actionText={ __( 'Installing…', 'newspack-plugin' ) }
 						isWaiting
 					/>
 					<ActionCard
-						title={ __( 'Example Four', 'newspack' ) }
-						description={ __( 'Error notification', 'newspack' ) }
-						actionText={ __( 'Install', 'newspack' ) }
+						title={ __( 'Example Four', 'newspack-plugin' ) }
+						description={ __( 'Error notification', 'newspack-plugin' ) }
+						actionText={ __( 'Install', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Install clicked' );
 						} }
@@ -327,8 +330,8 @@ class ComponentsDemo extends Component {
 						notificationLevel="error"
 					/>
 					<ActionCard
-						title={ __( 'Example Five', 'newspack' ) }
-						description={ __( 'Warning notification, action button', 'newspack' ) }
+						title={ __( 'Example Five', 'newspack-plugin' ) }
+						description={ __( 'Warning notification, action button', 'newspack-plugin' ) }
 						notification={
 							<Fragment>
 								There is a new version available. <a href="#">View details</a> or{ ' ' }
@@ -338,24 +341,24 @@ class ComponentsDemo extends Component {
 						notificationLevel="warning"
 					/>
 					<ActionCard
-						title={ __( 'Example Six', 'newspack' ) }
-						description={ __( 'Static text, no button', 'newspack' ) }
-						actionText={ __( 'Active', 'newspack' ) }
+						title={ __( 'Example Six', 'newspack-plugin' ) }
+						description={ __( 'Static text, no button', 'newspack-plugin' ) }
+						actionText={ __( 'Active', 'newspack-plugin' ) }
 					/>
 					<ActionCard
-						title={ __( 'Example Seven', 'newspack' ) }
-						description={ __( 'Static text, secondary action button.', 'newspack' ) }
-						actionText={ __( 'Active', 'newspack' ) }
-						secondaryActionText={ __( 'Delete', 'newspack' ) }
+						title={ __( 'Example Seven', 'newspack-plugin' ) }
+						description={ __( 'Static text, secondary action button.', 'newspack-plugin' ) }
+						actionText={ __( 'Active', 'newspack-plugin' ) }
+						secondaryActionText={ __( 'Delete', 'newspack-plugin' ) }
 						secondaryDestructive
 						onSecondaryActionClick={ () => {
 							console.log( 'Delete clicked' );
 						} }
 					/>
 					<ActionCard
-						title={ __( 'Example Eight', 'newspack' ) }
-						description={ __( 'Image with link and action button.', 'newspack' ) }
-						actionText={ __( 'Configure', 'newspack' ) }
+						title={ __( 'Example Eight', 'newspack-plugin' ) }
+						description={ __( 'Image with link and action button.', 'newspack-plugin' ) }
+						actionText={ __( 'Configure', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Configure clicked' );
 						} }
@@ -363,9 +366,9 @@ class ComponentsDemo extends Component {
 						imageLink="https://newspack.com"
 					/>
 					<ActionCard
-						title={ __( 'Example Nine', 'newspack' ) }
-						description={ __( 'Action Card with Toggle Control.', 'newspack' ) }
-						actionText={ actionCardToggleChecked && __( 'Configure', 'newspack' ) }
+						title={ __( 'Example Nine', 'newspack-plugin' ) }
+						description={ __( 'Action Card with Toggle Control.', 'newspack-plugin' ) }
+						actionText={ actionCardToggleChecked && __( 'Configure', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Configure clicked' );
 						} }
@@ -373,78 +376,83 @@ class ComponentsDemo extends Component {
 						toggleChecked={ actionCardToggleChecked }
 					/>
 					<ActionCard
-						badge={ __( 'Premium', 'newspack' ) }
-						title={ __( 'Example Ten', 'newspack' ) }
-						description={ __( 'An example of an action card with a badge.', 'newspack' ) }
-						actionText={ __( 'Install', 'newspack' ) }
+						badge={ __( 'Premium', 'newspack-plugin' ) }
+						title={ __( 'Example Ten', 'newspack-plugin' ) }
+						description={ __( 'An example of an action card with a badge.', 'newspack-plugin' ) }
+						actionText={ __( 'Install', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Install clicked' );
 						} }
 					/>
 					<ActionCard
 						isSmall
-						title={ __( 'Example Eleven', 'newspack' ) }
-						description={ __( 'An example of a small action card.', 'newspack' ) }
-						actionText={ __( 'Installing', 'newspack' ) }
+						title={ __( 'Example Eleven', 'newspack-plugin' ) }
+						description={ __( 'An example of a small action card.', 'newspack-plugin' ) }
+						actionText={ __( 'Installing', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Install clicked' );
 						} }
 					/>
 					<ActionCard
-						title={ __( 'Example Twelve', 'newspack' ) }
-						description={ __( 'Action card with an unchecked checkbox.', 'newspack' ) }
-						actionText={ __( 'Configure', 'newspack' ) }
+						title={ __( 'Example Twelve', 'newspack-plugin' ) }
+						description={ __( 'Action card with an unchecked checkbox.', 'newspack-plugin' ) }
+						actionText={ __( 'Configure', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Configure' );
 						} }
 						checkbox="unchecked"
 					/>
 					<ActionCard
-						title={ __( 'Example Thirteen', 'newspack' ) }
-						description={ __( 'Action card with a checked checkbox.', 'newspack' ) }
-						secondaryActionText={ __( 'Disconnect', 'newspack' ) }
+						title={ __( 'Example Thirteen', 'newspack-plugin' ) }
+						description={ __( 'Action card with a checked checkbox.', 'newspack-plugin' ) }
+						secondaryActionText={ __( 'Disconnect', 'newspack-plugin' ) }
 						onSecondaryActionClick={ () => {
 							console.log( 'Disconnect' );
 						} }
 						checkbox="checked"
 					/>
 					<ActionCard
-						badge={ [ __( 'Premium', 'newspack' ), __( 'Archived', 'newspack' ) ] }
-						title={ __( 'Example Fourteen', 'newspack' ) }
-						description={ __( 'An example of an action card with two badges.', 'newspack' ) }
-						actionText={ __( 'Install', 'newspack' ) }
+						badge={ [ __( 'Premium', 'newspack-plugin' ), __( 'Archived', 'newspack-plugin' ) ] }
+						title={ __( 'Example Fourteen', 'newspack-plugin' ) }
+						description={ __( 'An example of an action card with two badges.', 'newspack-plugin' ) }
+						actionText={ __( 'Install', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Install clicked' );
 						} }
 					/>
 					<ActionCard
-						title={ __( 'Handoff', 'newspack' ) }
-						description={ __( 'An example of an action card with Handoff.', 'newspack' ) }
-						actionText={ __( 'Configure', 'newspack' ) }
+						title={ __( 'Handoff', 'newspack-plugin' ) }
+						description={ __( 'An example of an action card with Handoff.', 'newspack-plugin' ) }
+						actionText={ __( 'Configure', 'newspack-plugin' ) }
 						handoff="jetpack"
 					/>
 					<ActionCard
-						title={ __( 'Handoff', 'newspack' ) }
+						title={ __( 'Handoff', 'newspack-plugin' ) }
 						description={ __(
 							' An example of an action card with Handoff and EditLink.',
-							'newspack'
+							'newspack-plugin'
 						) }
-						actionText={ __( 'Configure', 'newspack' ) }
+						actionText={ __( 'Configure', 'newspack-plugin' ) }
 						handoff="jetpack"
 						editLink="admin.php?page=jetpack#/settings"
 					/>
 					<ActionCard
 						expandable
-						title={ __( 'Expandable', 'newspack' ) }
+						title={ __( 'Expandable', 'newspack-plugin' ) }
 						description={ __(
 							' An example of an action card with expandable inner content.',
-							'newspack'
+							'newspack-plugin'
 						) }
 					>
-						<p>{ __( 'Some inner content to display when the card is expanded.', 'newspack' ) }</p>
+						<p>
+							{ __(
+								'Some inner content to display when the card is expanded.',
+								'newspack-plugin'
+							) }
+						</p>
 					</ActionCard>
 					<Card>
-						<h2>{ __( 'Image Uploader', 'newspack' ) }</h2>
+						<h2>{ __( 'Image Uploader', 'newspack-plugin' ) }</h2>
 						<ImageUpload
 							image={ this.state.image }
 							onChange={ image => {
@@ -455,171 +463,175 @@ class ComponentsDemo extends Component {
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Progress bar', 'newspack' ) }</h2>
+						<h2>{ __( 'Progress bar', 'newspack-plugin' ) }</h2>
 						<ProgressBar completed="2" total="3" />
-						<ProgressBar completed="2" total="5" label={ __( 'Progress made', 'newspack' ) } />
+						<ProgressBar
+							completed="2"
+							total="5"
+							label={ __( 'Progress made', 'newspack-plugin' ) }
+						/>
 						<ProgressBar completed="0" total="5" displayFraction />
 						<ProgressBar
 							completed="3"
 							total="8"
-							label={ __( 'Progress made', 'newspack' ) }
+							label={ __( 'Progress made', 'newspack-plugin' ) }
 							displayFraction
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Select dropdowns', 'newspack' ) }</h2>
+						<h2>{ __( 'Select dropdowns', 'newspack-plugin' ) }</h2>
 						<Grid columns={ 1 } gutter={ 16 }>
 							<SelectControl
-								label={ __( 'Label for Select with a preselection', 'newspack' ) }
+								label={ __( 'Label for Select with a preselection', 'newspack-plugin' ) }
 								value={ selectValue1 }
 								options={ [
-									{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
-									{ value: '1st', label: __( 'First', 'newspack' ) },
-									{ value: '2nd', label: __( 'Second', 'newspack' ) },
-									{ value: '3rd', label: __( 'Third', 'newspack' ) },
+									{ value: null, label: __( '- Select -', 'newspack-plugin' ), disabled: true },
+									{ value: '1st', label: __( 'First', 'newspack-plugin' ) },
+									{ value: '2nd', label: __( 'Second', 'newspack-plugin' ) },
+									{ value: '3rd', label: __( 'Third', 'newspack-plugin' ) },
 								] }
 								onChange={ value => this.setState( { selectValue1: value } ) }
 							/>
 							<SelectControl
-								label={ __( 'Label for Select with no preselection', 'newspack' ) }
+								label={ __( 'Label for Select with no preselection', 'newspack-plugin' ) }
 								value={ selectValue2 }
 								options={ [
-									{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
-									{ value: '1st', label: __( 'First', 'newspack' ) },
-									{ value: '2nd', label: __( 'Second', 'newspack' ) },
-									{ value: '3rd', label: __( 'Third', 'newspack' ) },
+									{ value: null, label: __( '- Select -', 'newspack-plugin' ), disabled: true },
+									{ value: '1st', label: __( 'First', 'newspack-plugin' ) },
+									{ value: '2nd', label: __( 'Second', 'newspack-plugin' ) },
+									{ value: '3rd', label: __( 'Third', 'newspack-plugin' ) },
 								] }
 								onChange={ value => this.setState( { selectValue2: value } ) }
 							/>
 							<SelectControl
-								label={ __( 'Label for disabled Select', 'newspack' ) }
+								label={ __( 'Label for disabled Select', 'newspack-plugin' ) }
 								disabled
 								options={ [
-									{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
-									{ value: '1st', label: __( 'First', 'newspack' ) },
-									{ value: '2nd', label: __( 'Second', 'newspack' ) },
-									{ value: '3rd', label: __( 'Third', 'newspack' ) },
+									{ value: null, label: __( '- Select -', 'newspack-plugin' ), disabled: true },
+									{ value: '1st', label: __( 'First', 'newspack-plugin' ) },
+									{ value: '2nd', label: __( 'Second', 'newspack-plugin' ) },
+									{ value: '3rd', label: __( 'Third', 'newspack-plugin' ) },
 								] }
 							/>
 							<SelectControl
-								label={ __( 'Small', 'newspack' ) }
+								label={ __( 'Small', 'newspack-plugin' ) }
 								value={ selectValue3 }
 								isSmall
 								options={ [
-									{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
-									{ value: '1st', label: __( 'First', 'newspack' ) },
-									{ value: '2nd', label: __( 'Second', 'newspack' ) },
-									{ value: '3rd', label: __( 'Third', 'newspack' ) },
+									{ value: null, label: __( '- Select -', 'newspack-plugin' ), disabled: true },
+									{ value: '1st', label: __( 'First', 'newspack-plugin' ) },
+									{ value: '2nd', label: __( 'Second', 'newspack-plugin' ) },
+									{ value: '3rd', label: __( 'Third', 'newspack-plugin' ) },
 								] }
 								onChange={ value => this.setState( { selectValue3: value } ) }
 							/>
 							<SelectControl
 								multiple
-								label={ __( 'Multi-select', 'newspack' ) }
+								label={ __( 'Multi-select', 'newspack-plugin' ) }
 								value={ this.state.selectValues }
 								options={ [
-									{ value: '1st', label: __( 'First', 'newspack' ) },
-									{ value: '2nd', label: __( 'Second', 'newspack' ) },
-									{ value: '3rd', label: __( 'Third', 'newspack' ) },
-									{ value: '4th', label: __( 'Fourth', 'newspack' ) },
-									{ value: '5th', label: __( 'Fifth', 'newspack' ) },
-									{ value: '6th', label: __( 'Sixth', 'newspack' ) },
-									{ value: '7th', label: __( 'Seventh', 'newspack' ) },
+									{ value: '1st', label: __( 'First', 'newspack-plugin' ) },
+									{ value: '2nd', label: __( 'Second', 'newspack-plugin' ) },
+									{ value: '3rd', label: __( 'Third', 'newspack-plugin' ) },
+									{ value: '4th', label: __( 'Fourth', 'newspack-plugin' ) },
+									{ value: '5th', label: __( 'Fifth', 'newspack-plugin' ) },
+									{ value: '6th', label: __( 'Sixth', 'newspack-plugin' ) },
+									{ value: '7th', label: __( 'Seventh', 'newspack-plugin' ) },
 								] }
 								onChange={ selectValues => this.setState( { selectValues } ) }
 							/>
 							<Notice
 								noticeText={
 									<>
-										{ __( 'Selected:', 'newspack' ) }{ ' ' }
+										{ __( 'Selected:', 'newspack-plugin' ) }{ ' ' }
 										{ this.state.selectValues.length > 0
 											? this.state.selectValues.join( ', ' )
-											: __( 'none', 'newspack' ) }
+											: __( 'none', 'newspack-plugin' ) }
 									</>
 								}
 							/>
 						</Grid>
 					</Card>
 					<Card>
-						<h2>{ __( 'Buttons', 'newspack' ) }</h2>
+						<h2>{ __( 'Buttons', 'newspack-plugin' ) }</h2>
 						<Grid columns={ 1 } gutter={ 16 }>
 							<p>
-								<strong>{ __( 'Default', 'newspack' ) }</strong>
+								<strong>{ __( 'Default', 'newspack-plugin' ) }</strong>
 							</p>
 							<Card buttonsCard noBorder>
-								<Button variant="primary">Primary</Button>
-								<Button variant="secondary">Secondary</Button>
-								<Button variant="tertiary">Tertiary</Button>
-								<Button>Default</Button>
-								<Button isLink>isLink</Button>
+								<Button variant="primary">{ __( 'Primary', 'newspack-plugin' ) }</Button>
+								<Button variant="secondary">{ __( 'Secondary', 'newspack-plugin' ) }</Button>
+								<Button variant="tertiary">{ __( 'Tertiary', 'newspack-plugin' ) }</Button>
+								<Button>{ __( 'Default', 'newspack-plugin' ) }</Button>
+								<Button isLink>{ __( 'isLink', 'newspack-plugin' ) }</Button>
 							</Card>
 							<p>
-								<strong>{ __( 'Disabled', 'newspack' ) }</strong>
+								<strong>{ __( 'Disabled', 'newspack-plugin' ) }</strong>
 							</p>
 							<Card buttonsCard noBorder>
 								<Button variant="primary" disabled>
-									Primary
+									{ __( 'Primary', 'newspack-plugin' ) }
 								</Button>
 								<Button variant="secondary" disabled>
-									Secondary
+									{ __( 'Secondary', 'newspack-plugin' ) }
 								</Button>
 								<Button variant="tertiary" disabled>
-									Tertiary
+									{ __( 'Tertiary', 'newspack-plugin' ) }
 								</Button>
-								<Button disabled>Default</Button>
+								<Button disabled>{ __( 'Default', 'newspack-plugin' ) }</Button>
 								<Button isLink disabled>
-									isLink
+									{ __( 'isLink', 'newspack-plugin' ) }
 								</Button>
 							</Card>
 							<p>
-								<strong>{ __( 'Small', 'newspack' ) }</strong>
+								<strong>{ __( 'Small', 'newspack-plugin' ) }</strong>
 							</p>
 							<Card buttonsCard noBorder>
 								<Button variant="primary" isSmall>
-									isPrimary
+									{ __( 'isPrimary', 'newspack-plugin' ) }
 								</Button>
 								<Button variant="secondary" isSmall>
-									isSecondary
+									{ __( 'isSecondary', 'newspack-plugin' ) }
 								</Button>
 								<Button variant="tertiary" isSmall>
-									isTertiary
+									{ __( 'isTertiary', 'newspack-plugin' ) }
 								</Button>
-								<Button isSmall>Default</Button>
+								<Button isSmall>{ __( 'Default', 'newspack-plugin' ) }</Button>
 								<Button isLink isSmall>
-									isLink
+									{ __( 'isLink', 'newspack-plugin' ) }
 								</Button>
 							</Card>
 						</Grid>
 					</Card>
 					<Card>
-						<h2>ButtonCard</h2>
+						<h2>{ __( 'ButtonCard', 'newspack-plugin' ) }</h2>
 						<ButtonCard
 							href="admin.php?page=newspack-site-design-wizard"
-							title={ __( 'Site Design', 'newspack' ) }
-							desc={ __( 'Customize the look and feel of your site', 'newspack' ) }
+							title={ __( 'Site Design', 'newspack-plugin' ) }
+							desc={ __( 'Customize the look and feel of your site', 'newspack-plugin' ) }
 							icon={ typography }
 							chevron
 						/>
 						<ButtonCard
 							href="#"
-							title={ __( 'Start a new site', 'newspack' ) }
-							desc={ __( "You don't have content to import", 'newspack' ) }
+							title={ __( 'Start a new site', 'newspack-plugin' ) }
+							desc={ __( "You don't have content to import", 'newspack-plugin' ) }
 							icon={ plus }
 							className="br--top"
 							grouped
 						/>
 						<ButtonCard
 							href="#"
-							title={ __( 'Migrate an existing site', 'newspack' ) }
-							desc={ __( 'You have content to import', 'newspack' ) }
+							title={ __( 'Migrate an existing site', 'newspack-plugin' ) }
+							desc={ __( 'You have content to import', 'newspack-plugin' ) }
 							icon={ reusableBlock }
 							className="br--bottom"
 							grouped
 						/>
 						<ButtonCard
 							href="#"
-							title={ __( 'Add a new Podcast', 'newspack' ) }
-							desc={ ( 'Small', 'newspack' ) }
+							title={ __( 'Add a new Podcast', 'newspack-plugin' ) }
+							desc={ ( 'Small', 'newspack-plugin' ) }
 							icon={ audio }
 							className="br--top"
 							isSmall
@@ -627,8 +639,8 @@ class ComponentsDemo extends Component {
 						/>
 						<ButtonCard
 							href="#"
-							title={ __( 'Add a new Font', 'newspack' ) }
-							desc={ ( 'Small + chevron', 'newspack' ) }
+							title={ __( 'Add a new Font', 'newspack-plugin' ) }
+							desc={ ( 'Small + chevron', 'newspack-plugin' ) }
 							icon={ typography }
 							className="br--bottom"
 							chevron
@@ -637,57 +649,57 @@ class ComponentsDemo extends Component {
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Plugin Settings Section', 'newspack' ) }</h2>
+						<h2>{ __( 'Plugin Settings Section', 'newspack-plugin' ) }</h2>
 						<PluginSettings.Section
 							sectionKey="example"
-							title={ __( 'Example plugin settings', 'newspack' ) }
-							description={ __( 'Example plugin settings description', 'newspack' ) }
+							title={ __( 'Example plugin settings', 'newspack-plugin' ) }
+							description={ __( 'Example plugin settings description', 'newspack-plugin' ) }
 							active={ true }
 							fields={ [
 								{
 									key: 'example_field',
 									type: 'string',
-									description: 'Example Text Field',
-									help: 'Example text field help text',
-									value: 'Example Value',
+									description: __( 'Example Text Field', 'newspack-plugin' ),
+									help: __( 'Example text field help text', 'newspack-plugin' ),
+									value: __( 'Example Value', 'newspack-plugin' ),
 								},
 								{
 									key: 'example_checkbox_field',
 									type: 'boolean',
-									description: 'Example checkbox Field',
-									help: 'Example checkbox field help text',
+									description: __( 'Example checkbox Field', 'newspack-plugin' ),
+									help: __( 'Example checkbox field help text', 'newspack-plugin' ),
 									value: false,
 								},
 								{
 									key: 'example_options_field',
 									type: 'string',
-									description: 'Example options field',
-									help: 'Example options field help text',
+									description: __( 'Example options field', 'newspack-plugin' ),
+									help: __( 'Example options field help text', 'newspack-plugin' ),
 									options: [
 										{
 											value: 'example_value_1',
-											name: 'Example Value 1',
+											name: __( 'Example Value 1', 'newspack-plugin' ),
 										},
 										{
 											value: 'example_value_2',
-											name: 'Example Value 2',
+											name: __( 'Example Value 2', 'newspack-plugin' ),
 										},
 									],
 								},
 								{
 									key: 'example_multi_options_field',
 									type: 'string',
-									description: 'Example multiple options field',
-									help: 'Example multiple options field help text',
+									description: __( 'Example multiple options field', 'newspack-plugin' ),
+									help: __( 'Example multiple options field help text', 'newspack-plugin' ),
 									multiple: true,
 									options: [
 										{
 											value: 'example_value_1',
-											name: 'Example Value 1',
+											name: __( 'Example Value 1', 'newspack-plugin' ),
 										},
 										{
 											value: 'example_value_2',
-											name: 'Example Value 2',
+											name: __( 'Example Value 2', 'newspack-plugin' ),
 										},
 									],
 								},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the text domains throughout the wizards/analytics and wizard/components screens. For the latter, I opted to leave the strings in the `console.log`s as not marked for translation. 

See 1200550061930446-as-1205509524123559

### How to test the changes in this Pull Request:

Review the code changes to confirm that the text domain for each string has been updated to `newspack-plugin`, and that there aren't any errors. (For the latter you can also try running `npm run build` and checking the Newspack > Analytics and Newspack > Component Demo screens).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->