### PR TITLE
fix: donate block layout for NRH

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -127,6 +127,11 @@ class Donations {
 	 * @return bool True if available, false if not.
 	 */
 	public static function can_use_name_your_price() {
+		// If the donation platform is NRH, the Donate block should behave as if Name Your Price is available.
+		if ( self::is_platform_nrh() ) {
+			return true;
+		}
+
 		return class_exists( 'WC_Name_Your_Price_Helpers' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-blocks/pull/1682, fixes a regression introduced by #2866.

### How to test the changes in this Pull Request:

1. On `release`, set your Reader Revenue platform to NRH and disable WooCommerce.
2. View a Donate block in the editor and on the front-end.
3. Observe that the Frequency-based Donate block has only a single static option per frequency (no tiers) and no "other" number input. Similar to how it appears with Woo minus NYP:

<img width="803" alt="Screenshot 2024-01-19 at 12 33 13 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/013cec1f-3930-4c7e-bc47-f95a06b377a3">

4. Observe that the Tiers-based Donate block shows "0" in all tiers in the editor.
5. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/1682, and confirm that the blocks appear more as expected:

<img width="829" alt="Screenshot 2024-02-27 at 6 22 13 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/34684ac0-a75f-4ce1-8cd3-928ad6e2f535">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->