### PR TITLE
fix: update text domain in wizards/connections directory

### DIFF
--- a/assets/wizards/connections/index.js
+++ b/assets/wizards/connections/index.js
@@ -21,8 +21,8 @@ const MainScreen = withWizardScreen( Main );
 
 const ConnectionsWizard = ( { pluginRequirements, wizardApiFetch, startLoading, doneLoading } ) => {
 	const wizardScreenProps = {
-		headerText: __( 'Connections', 'newspack' ),
-		subHeaderText: __( 'Connections to third-party services', 'newspack' ),
+		headerText: __( 'Connections', 'newspack-plugin' ),
+		subHeaderText: __( 'Connections to third-party services', 'newspack-plugin' ),
 		wizardApiFetch,
 		startLoading,
 		doneLoading,

--- a/assets/wizards/connections/views/main/fivetran.js
+++ b/assets/wizards/connections/views/main/fivetran.js
@@ -20,7 +20,7 @@ import get from 'lodash/get';
 const CONNECTORS = [
 	{
 		service: 'stripe',
-		label: __( 'Stripe', 'newspack' ),
+		label: __( 'Stripe', 'newspack-plugin' ),
 	},
 ];
 
@@ -37,11 +37,11 @@ const getConnectionStatus = ( item, connections ) => {
 		} else if ( isPending ) {
 			label = `${ setupState }, ${ syncState }. ${ __(
 				'Sync is in progress – please check back in a while.',
-				'newspack'
+				'newspack-plugin'
 			) }`;
 		}
 	} else if ( hasConnections ) {
-		label = __( 'Not connected', 'newspack' );
+		label = __( 'Not connected', 'newspack-plugin' );
 	}
 	return {
 		label,
@@ -55,7 +55,8 @@ const FivetranConnection = ( { setError } ) => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ hasAcceptedTOS, setHasAcceptedTOS ] = useState( null );
 
-	const handleError = err => setError( err.message || __( 'Something went wrong.', 'newspack' ) );
+	const handleError = err =>
+		setError( err.message || __( 'Something went wrong.', 'newspack-plugin' ) );
 
 	const hasConnections = connections !== undefined;
 	const isDisabled = inFlight || ! hasConnections || ! hasAcceptedTOS;
@@ -87,9 +88,9 @@ const FivetranConnection = ( { setError } ) => {
 	return (
 		<>
 			<div>
-				{ __( 'In order to use the this features, you must read and accept', 'newspack' ) }{ ' ' }
+				{ __( 'In order to use the this features, you must read and accept', 'newspack-plugin' ) }{ ' ' }
 				<a href="https://newspack.com/terms-of-service/">
-					{ __( 'Newspack Terms of Service', 'newspack' ) }
+					{ __( 'Newspack Terms of Service', 'newspack-plugin' ) }
 				</a>
 				:
 			</div>
@@ -107,7 +108,7 @@ const FivetranConnection = ( { setError } ) => {
 					} );
 					setHasAcceptedTOS( has_accepted );
 				} }
-				label={ __( "I've read and accept Newspack Terms of Service", 'newspack' ) }
+				label={ __( "I've read and accept Newspack Terms of Service", 'newspack-plugin' ) }
 			/>
 			{ CONNECTORS.map( item => {
 				const status = getConnectionStatus( item, connections );
@@ -115,13 +116,13 @@ const FivetranConnection = ( { setError } ) => {
 					<ActionCard
 						key={ item.service }
 						title={ item.label }
-						description={ `${ __( 'Status:', 'newspack' ) } ${ status.label }` }
+						description={ `${ __( 'Status:', 'newspack-plugin' ) } ${ status.label }` }
 						isPending={ status.isPending }
 						actionText={
 							<Button disabled={ isDisabled } onClick={ () => createConnection( item ) } isLink>
 								{ status.isConnected
-									? __( 'Re-connect', 'newspack' )
-									: __( 'Connect', 'newspack' ) }
+									? __( 'Re-connect', 'newspack-plugin' )
+									: __( 'Connect', 'newspack-plugin' ) }
 							</Button>
 						}
 						checkbox={ status.isConnected ? 'checked' : 'unchecked' }

--- a/assets/wizards/connections/views/main/google.js
+++ b/assets/wizards/connections/views/main/google.js
@@ -27,7 +27,7 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ localError, setLocalError ] = useState( null );
 	const handleError = res => {
-		const message = res.message || __( 'Something went wrong.', 'newspack' );
+		const message = res.message || __( 'Something went wrong.', 'newspack-plugin' );
 		setLocalError( message );
 		if ( typeof setError === 'function' ) {
 			setError( message );
@@ -39,7 +39,7 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 	useEffect( () => {
 		if ( isConnected && ! userBasicInfo.has_refresh_token ) {
 			setError( [
-				__( 'Missing Google refresh token. Please', 'newspack' ),
+				__( 'Missing Google refresh token. Please', 'newspack-plugin' ),
 				' ',
 				<a
 					key="link"
@@ -47,10 +47,10 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 					rel="noreferrer"
 					href="https://myaccount.google.com/permissions"
 				>
-					{ __( 'revoke credentials', 'newspack' ) }
+					{ __( 'revoke credentials', 'newspack-plugin' ) }
 				</a>,
 				' ',
-				__( 'and authorise the site again.', 'newspack' ),
+				__( 'and authorise the site again.', 'newspack-plugin' ),
 			] );
 		}
 	}, [ isConnected ] );
@@ -136,22 +136,22 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 			return localError;
 		}
 		if ( inFlight ) {
-			return __( 'Loading…', 'newspack' );
+			return __( 'Loading…', 'newspack-plugin' );
 		}
 		if ( isConnected ) {
 			return sprintf(
 				// Translators: connected user's email address.
-				__( 'Connected as %s', 'newspack' ),
+				__( 'Connected as %s', 'newspack-plugin' ),
 				userBasicInfo.email
 			);
 		}
-		return __( 'Not connected', 'newspack' );
+		return __( 'Not connected', 'newspack-plugin' );
 	};
 
 	return (
 		<ActionCard
-			title={ __( 'Google', 'newspack' ) }
-			description={ `${ __( 'Status:', 'newspack' ) } ${ getDescription() }` }
+			title={ __( 'Google', 'newspack-plugin' ) }
+			description={ `${ __( 'Status:', 'newspack-plugin' ) } ${ getDescription() }` }
 			checkbox={ isConnected ? 'checked' : 'unchecked' }
 			actionText={
 				<Button
@@ -160,7 +160,9 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 					onClick={ isConnected ? disconnect : openAuth }
 					disabled={ inFlight }
 				>
-					{ isConnected ? __( 'Disconnect', 'newspack' ) : __( 'Connect', 'newspack' ) }
+					{ isConnected
+						? __( 'Disconnect', 'newspack-plugin' )
+						: __( 'Connect', 'newspack-plugin' ) }
 				</Button>
 			}
 			isMedium

--- a/assets/wizards/connections/views/main/google.js
+++ b/assets/wizards/connections/views/main/google.js
@@ -50,7 +50,7 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 					{ __( 'revoke credentials', 'newspack-plugin' ) }
 				</a>,
 				' ',
-				__( 'and authorise the site again.', 'newspack-plugin' ),
+				__( 'and authorize the site again.', 'newspack-plugin' ),
 			] );
 		}
 	}, [ isConnected ] );

--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -24,9 +24,9 @@ const Main = () => {
 	return (
 		<>
 			{ error && <Notice isError noticeText={ error } /> }
-			<SectionHeader title={ __( 'Plugins', 'newspack' ) } />
+			<SectionHeader title={ __( 'Plugins', 'newspack-plugin' ) } />
 			<Plugins />
-			<SectionHeader title={ __( 'APIs', 'newspack' ) } />
+			<SectionHeader title={ __( 'APIs', 'newspack-plugin' ) } />
 			{ newspack_connections_data.can_connect_google && (
 				<GoogleAuth setError={ setErrorWithPrefix( __( 'Google: ', 'newspack-plugin' ) ) } />
 			) }

--- a/assets/wizards/connections/views/main/mailchimp.js
+++ b/assets/wizards/connections/views/main/mailchimp.js
@@ -21,7 +21,8 @@ const Mailchimp = ( { setError } ) => {
 	const modalTextRef = useRef( null );
 	const isConnected = Boolean( authState && authState.username );
 
-	const handleError = res => setError( res.message || __( 'Something went wrong.', 'newspack' ) );
+	const handleError = res =>
+		setError( res.message || __( 'Something went wrong.', 'newspack-plugin' ) );
 
 	const openModal = () => setisModalOpen( true );
 	const closeModal = () => {
@@ -62,7 +63,10 @@ const Mailchimp = ( { setError } ) => {
 			.catch( e => {
 				setError(
 					e.message ||
-						__( 'Something went wrong during verification of your Mailchimp API key.', 'newspack' )
+						__(
+							'Something went wrong during verification of your Mailchimp API key.',
+							'newspack-plugin'
+						)
 				);
 			} )
 			.finally( () => {
@@ -86,30 +90,30 @@ const Mailchimp = ( { setError } ) => {
 
 	const getDescription = () => {
 		if ( isLoading ) {
-			return __( 'Loading…', 'newspack' );
+			return __( 'Loading…', 'newspack-plugin' );
 		}
 		if ( isConnected ) {
 			// Translators: user connection status message.
-			return sprintf( __( 'Connected as %s', 'newspack' ), authState.username );
+			return sprintf( __( 'Connected as %s', 'newspack-plugin' ), authState.username );
 		}
-		return __( 'Not connected', 'newspack' );
+		return __( 'Not connected', 'newspack-plugin' );
 	};
 
 	const getModalButtonText = () => {
 		if ( isLoading ) {
-			return __( 'Connecting…', 'newspack' );
+			return __( 'Connecting…', 'newspack-plugin' );
 		}
 		if ( isConnected ) {
-			return __( 'Connected', 'newspack' );
+			return __( 'Connected', 'newspack-plugin' );
 		}
-		return __( 'Connect', 'newspack' );
+		return __( 'Connect', 'newspack-plugin' );
 	};
 
 	return (
 		<>
 			<ActionCard
 				title="Mailchimp"
-				description={ `${ __( 'Status:', 'newspack' ) } ${ getDescription() }` }
+				description={ `${ __( 'Status:', 'newspack-plugin' ) } ${ getDescription() }` }
 				checkbox={ isConnected ? 'checked' : 'unchecked' }
 				actionText={
 					<Button
@@ -118,18 +122,23 @@ const Mailchimp = ( { setError } ) => {
 						onClick={ isConnected ? disconnect : openModal }
 						disabled={ isLoading }
 					>
-						{ isConnected ? __( 'Disconnect', 'newspack' ) : __( 'Connect', 'newspack' ) }
+						{ isConnected
+							? __( 'Disconnect', 'newspack-plugin' )
+							: __( 'Connect', 'newspack-plugin' ) }
 					</Button>
 				}
 				isMedium
 			/>
 			{ isModalOpen && (
-				<Modal title={ __( 'Add Mailchimp API Key', 'newspack' ) } onRequestClose={ closeModal }>
+				<Modal
+					title={ __( 'Add Mailchimp API Key', 'newspack-plugin' ) }
+					onRequestClose={ closeModal }
+				>
 					<div ref={ modalTextRef }>
 						<Grid columns={ 1 } gutter={ 8 }>
 							<TextControl
 								placeholder="123457103961b1f4dc0b2b2fd59c137b-us1"
-								label={ __( 'Mailchimp API Key', 'newspack' ) }
+								label={ __( 'Mailchimp API Key', 'newspack-plugin' ) }
 								hideLabelFromVision={ true }
 								value={ apiKey }
 								onChange={ setAPIKey }
@@ -142,14 +151,14 @@ const Mailchimp = ( { setError } ) => {
 							/>
 							<p>
 								<ExternalLink href="https://mailchimp.com/help/about-api-keys/#Find_or_generate_your_API_key">
-									{ __( 'Find or generate your API key', 'newspack' ) }
+									{ __( 'Find or generate your API key', 'newspack-plugin' ) }
 								</ExternalLink>
 							</p>
 						</Grid>
 					</div>
 					<Card buttonsCard noBorder className="justify-end">
 						<Button isSecondary onClick={ closeModal }>
-							{ __( 'Cancel', 'newspack' ) }
+							{ __( 'Cancel', 'newspack-plugin' ) }
 						</Button>
 						<Button isPrimary disabled={ ! apiKey } onClick={ submitAPIKey }>
 							{ getModalButtonText() }

--- a/assets/wizards/connections/views/main/plugins.js
+++ b/assets/wizards/connections/views/main/plugins.js
@@ -23,7 +23,7 @@ const PLUGINS = {
 	'google-site-kit': {
 		pluginSlug: 'google-site-kit',
 		editLink: 'admin.php?page=googlesitekit-splash',
-		name: __( 'Site Kit by Google', 'newspack' ),
+		name: __( 'Site Kit by Google', 'newspack-plugin' ),
 		fetchStatus: () =>
 			apiFetch( { path: '/newspack/v1/plugins/google-site-kit' } ).then( result => ( {
 				'google-site-kit': { status: result.Configured ? result.Status : 'inactive' },
@@ -35,20 +35,22 @@ const pluginConnectButton = plugin => {
 	if ( plugin.pluginSlug ) {
 		return (
 			<Handoff plugin={ plugin.pluginSlug } editLink={ plugin.editLink } compact isLink>
-				{ __( 'Connect', 'newspack' ) }
+				{ __( 'Connect', 'newspack-plugin' ) }
 			</Handoff>
 		);
 	}
 	if ( plugin.url ) {
 		return (
 			<Button isLink href={ plugin.url } target="_blank">
-				{ __( 'Connect', 'newspack' ) }
+				{ __( 'Connect', 'newspack-plugin' ) }
 			</Button>
 		);
 	}
 	if ( plugin.error?.code === 'unavailable_site_id' ) {
 		return (
-			<span className="i newspack-error">{ __( 'Jetpack connection required', 'newspack' ) }</span>
+			<span className="i newspack-error">
+				{ __( 'Jetpack connection required', 'newspack-plugin' ) }
+			</span>
 		);
 	}
 };
@@ -70,21 +72,21 @@ const Plugins = ( { setError } ) => {
 				const isLoading = ! plugin.status;
 				const getDescription = () => {
 					if ( isLoading ) {
-						return __( 'Loading…', 'newspack' );
+						return __( 'Loading…', 'newspack-plugin' );
 					}
 					if ( isInactive ) {
 						if ( plugin.pluginSlug === 'google-site-kit' ) {
-							return __( 'Not connected for this user', 'newspack' );
+							return __( 'Not connected for this user', 'newspack-plugin' );
 						}
-						return __( 'Not connected', 'newspack' );
+						return __( 'Not connected', 'newspack-plugin' );
 					}
-					return __( 'Connected', 'newspack' );
+					return __( 'Connected', 'newspack-plugin' );
 				};
 				return (
 					<ActionCard
 						key={ plugin.name }
 						title={ plugin.name }
-						description={ `${ __( 'Status:', 'newspack' ) } ${ getDescription() }` }
+						description={ `${ __( 'Status:', 'newspack-plugin' ) } ${ getDescription() }` }
 						actionText={ isInactive ? pluginConnectButton( plugin ) : null }
 						checkbox={ isInactive || isLoading ? 'unchecked' : 'checked' }
 						badge={ plugin.badge }

--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -73,7 +73,7 @@ const Recaptcha = () => {
 							'newspack-plugin'
 						) }{ ' ' }
 						<ExternalLink href="https://www.google.com/recaptcha/admin/create">
-							{ __( 'Get started' ) }
+							{ __( 'Get started', 'newspack-plugin' ) }
 						</ExternalLink>
 					</>
 				) }

--- a/assets/wizards/connections/views/main/webhooks.js
+++ b/assets/wizards/connections/views/main/webhooks.js
@@ -83,7 +83,7 @@ const EndpointActions = ( {
 				onClick={ () => setPopoverVisible( ! popoverVisible ) }
 				icon={ moreVertical }
 				disabled={ disabled }
-				label={ __( 'Endpoint Actions', 'newspack' ) }
+				label={ __( 'Endpoint Actions', 'newspack-plugin' ) }
 				tooltipPosition={ position }
 			/>
 			{ popoverVisible && (
@@ -93,19 +93,19 @@ const EndpointActions = ( {
 					onKeyDown={ event => ESCAPE === event.keyCode && setPopoverVisible( false ) }
 				>
 					<MenuItem onClick={ () => setPopoverVisible( false ) } className="screen-reader-text">
-						{ __( 'Close Endpoint Actions', 'newspack' ) }
+						{ __( 'Close Endpoint Actions', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem onClick={ onView } className="newspack-button">
-						{ __( 'View Requests', 'newspack' ) }
+						{ __( 'View Requests', 'newspack-plugin' ) }
 					</MenuItem>
 					{ ! isSystem && (
 						<MenuItem onClick={ onEdit } className="newspack-button">
-							{ __( 'Edit', 'newspack' ) }
+							{ __( 'Edit', 'newspack-plugin' ) }
 						</MenuItem>
 					) }
 					{ ! isSystem && (
 						<MenuItem onClick={ onDelete } className="newspack-button" isDestructive>
-							{ __( 'Remove', 'newspack' ) }
+							{ __( 'Remove', 'newspack-plugin' ) }
 						</MenuItem>
 					) }
 				</Popover>
@@ -120,10 +120,10 @@ const ConfirmationModal = ( { disabled, onConfirm, onClose, title, description }
 			<p>{ description }</p>
 			<Card buttonsCard noBorder className="justify-end">
 				<Button isSecondary onClick={ onClose } disabled={ disabled }>
-					{ __( 'Cancel', 'newspack' ) }
+					{ __( 'Cancel', 'newspack-plugin' ) }
 				</Button>
 				<Button isPrimary onClick={ onConfirm } disabled={ disabled }>
-					{ __( 'Confirm', 'newspack' ) }
+					{ __( 'Confirm', 'newspack-plugin' ) }
 				</Button>
 			</Card>
 		</Modal>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR corrects the text-domain in the assets/wizards/connections directory.

See 1200550061930446-as-1205509524123559

### How to test the changes in this Pull Request:

1. Spot check the changes in the PR and confirm they're just changing the text domain on translateable strings to `newspack-plugin`.
2. Run `npm run build` on this branch, and spot-check the Connections wizard screens.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->