### PR TITLE
fix: correct text domains in wizards/engagement

### DIFF
--- a/assets/wizards/engagement/components/active-campaign.js
+++ b/assets/wizards/engagement/components/active-campaign.js
@@ -30,22 +30,25 @@ export default function ActiveCampaign( { value, onChange } ) {
 		<>
 			{ error && (
 				<Notice
-					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+					noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 					isError
 				/>
 			) }
 			<SectionHeader
-				title={ __( 'ActiveCampaign', 'newspack' ) }
-				description={ __( 'Settings for the ActiveCampaign integration.', 'newspack' ) }
+				title={ __( 'ActiveCampaign', 'newspack-plugin' ) }
+				description={ __( 'Settings for the ActiveCampaign integration.', 'newspack-plugin' ) }
 			/>
 			<SelectControl
-				label={ __( 'Master List', 'newspack' ) }
-				help={ __( 'Choose a list to which all registered readers will be added.', 'newspack' ) }
+				label={ __( 'Master List', 'newspack-plugin' ) }
+				help={ __(
+					'Choose a list to which all registered readers will be added.',
+					'newspack-plugin'
+				) }
 				disabled={ inFlight }
 				value={ value.masterList }
 				onChange={ handleChange( 'masterList' ) }
 				options={ [
-					{ value: '', label: __( 'None', 'newspack' ) },
+					{ value: '', label: __( 'None', 'newspack-plugin' ) },
 					...lists.map( list => ( { label: list.name, value: list.id } ) ),
 				] }
 			/>

--- a/assets/wizards/engagement/components/mailchimp.js
+++ b/assets/wizards/engagement/components/mailchimp.js
@@ -30,22 +30,22 @@ export default function Mailchimp( { value, onChange } ) {
 		<>
 			{ error && (
 				<Notice
-					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+					noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 					isError
 				/>
 			) }
 			<SectionHeader
-				title={ __( 'Mailchimp', 'newspack' ) }
-				description={ __( 'Settings for the Mailchimp integration.', 'newspack' ) }
+				title={ __( 'Mailchimp', 'newspack-plugin' ) }
+				description={ __( 'Settings for the Mailchimp integration.', 'newspack-plugin' ) }
 			/>
 			<SelectControl
-				label={ __( 'Audience ID', 'newspack' ) }
-				help={ __( 'Choose an audience to receive reader activity data.', 'newspack' ) }
+				label={ __( 'Audience ID', 'newspack-plugin' ) }
+				help={ __( 'Choose an audience to receive reader activity data.', 'newspack-plugin' ) }
 				disabled={ inFlight }
 				value={ value.audienceId }
 				onChange={ handleChange( 'audienceId' ) }
 				options={ [
-					{ value: '', label: __( 'None', 'newspack' ) },
+					{ value: '', label: __( 'None', 'newspack-plugin' ) },
 					...lists.map( list => ( { label: list.name, value: list.id } ) ),
 				] }
 			/>

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -49,7 +49,7 @@ export default function Prerequisite( {
 						<>
 							{ ' ' }
 							<ExternalLink href={ prerequisite.help_url }>
-								{ __( 'Learn more', 'newspack' ) }
+								{ __( 'Learn more', 'newspack-plugin' ) }
 							</ExternalLink>
 						</>
 					) }
@@ -89,11 +89,11 @@ export default function Prerequisite( {
 								disabled={ inFlight }
 							>
 								{ inFlight
-									? __( 'Saving…', 'newspack' )
+									? __( 'Saving…', 'newspack-plugin' )
 									: sprintf(
 											// Translators: Save or Update settings.
-											__( '%s settings', 'newspack' ),
-											prerequisite.active ? __( 'Update', 'newspack' ) : __( 'Save', 'newspack' )
+											__( '%s settings', 'newspack-plugin' ),
+											prerequisite.active ? __( 'Update', 'newspack-plugin' ) : __( 'Save', 'newspack-plugin' )
 									  ) }
 							</Button>
 						</div>
@@ -119,7 +119,7 @@ export default function Prerequisite( {
 														// Translators: %s is specific instructions for satisfying the prerequisite.
 														__(
 															'%1$s%2$sReturn to the Reader Activation page to complete the settings and activate%3$s.',
-															'newspack'
+															'newspack-plugin'
 														),
 														prerequisite.instructions + ' ',
 														window.newspack_engagement_wizard?.reader_activation_url
@@ -137,10 +137,10 @@ export default function Prerequisite( {
 								>
 									{ /* eslint-disable no-nested-ternary */ }
 									{ ( prerequisite.active
-										? __( 'Update ', 'newspack' )
+										? __( 'Update ', 'newspack-plugin' )
 										: prerequisite.fields
-										? __( 'Save ', 'newspack' )
-										: __( 'Configure ', 'newspack' ) ) + prerequisite.action_text }
+										? __( 'Save ', 'newspack-plugin' )
+										: __( 'Configure ', 'newspack-plugin' ) ) + prerequisite.action_text }
 								</Button>
 							) }
 							{ prerequisite.hasOwnProperty( 'action_enabled' ) && ! prerequisite.action_enabled && (
@@ -155,12 +155,12 @@ export default function Prerequisite( {
 		</>
 	);
 
-	let status = __( 'Pending', 'newspack' );
+	let status = __( 'Pending', 'newspack-plugin' );
 	if ( prerequisite.active ) {
-		status = __( 'Ready', 'newspack' );
+		status = __( 'Ready', 'newspack-plugin' );
 	}
 	if ( prerequisite.is_unavailable ) {
-		status = __( 'Unavailable', 'newspack' );
+		status = __( 'Unavailable', 'newspack-plugin' );
 	}
 
 	return (
@@ -172,7 +172,7 @@ export default function Prerequisite( {
 			title={ prerequisite.label }
 			description={ sprintf(
 				/* translators: %s: Prerequisite status */
-				__( 'Status: %s', 'newspack' ),
+				__( 'Status: %s', 'newspack-plugin' ),
 				status
 			) }
 			checkbox={ prerequisite.active ? 'checked' : 'unchecked' }

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -93,7 +93,9 @@ export default function Prerequisite( {
 									: sprintf(
 											// Translators: Save or Update settings.
 											__( '%s settings', 'newspack-plugin' ),
-											prerequisite.active ? __( 'Update', 'newspack-plugin' ) : __( 'Save', 'newspack-plugin' )
+											prerequisite.active
+												? __( 'Update', 'newspack-plugin' )
+												: __( 'Save', 'newspack-plugin' )
 									  ) }
 							</Button>
 						</div>

--- a/assets/wizards/engagement/components/prompt.tsx
+++ b/assets/wizards/engagement/components/prompt.tsx
@@ -122,7 +122,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 
 	const unblock = hooks.usePrompt(
 		isDirty,
-		__( 'You have unsaved changes. Discard changes?', 'newspack' )
+		__( 'You have unsaved changes. Discard changes?', 'newspack-plugin' )
 	);
 
 	const savePrompt = ( slug: string, data: InputValues ) => {
@@ -143,7 +143,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 			} )
 				.then( ( fetchedPrompts: Array< PromptType > ) => {
 					setPrompts( fetchedPrompts );
-					setSuccess( __( 'Prompt saved.', 'newspack' ) );
+					setSuccess( __( 'Prompt saved.', 'newspack-plugin' ) );
 					setIsDirty( false );
 					res();
 				} )
@@ -167,12 +167,12 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 			title={ prompt.title }
 			description={ sprintf(
 				// Translators: Status of the prompt.
-				__( 'Status: %s', 'newspack' ),
+				__( 'Status: %s', 'newspack-plugin' ),
 				isDirty
-					? __( 'Unsaved changes', 'newspack' )
+					? __( 'Unsaved changes', 'newspack-plugin' )
 					: prompt.ready
-					? __( 'Ready', 'newspack' )
-					: __( 'Pending', 'newspack' )
+					? __( 'Ready', 'newspack-plugin' )
+					: __( 'Pending', 'newspack-plugin' )
 			) }
 			checkbox={ prompt.ready && ! isDirty ? 'checked' : 'unchecked' }
 		>
@@ -274,7 +274,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 										label={ field.label }
 									>
 										<ImageUpload
-											buttonLabel={ __( 'Select file', 'newspack' ) }
+											buttonLabel={ __( 'Select file', 'newspack-plugin' ) }
 											disabled={ inFlight }
 											image={ image }
 											onChange={ ( attachment: Attachment ) => {
@@ -297,7 +297,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 						) ) }
 						{ error && (
 							<Notice
-								noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+								noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 								isError
 							/>
 						) }
@@ -312,11 +312,11 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 								disabled={ inFlight }
 							>
 								{ inFlight
-									? __( 'Saving…', 'newspack' )
+									? __( 'Saving…', 'newspack-plugin' )
 									: sprintf(
 											// Translators: Save or Update settings.
-											__( '%s prompt settings', 'newspack' ),
-											prompt.ready ? __( 'Update', 'newspack' ) : __( 'Save', 'newspack' )
+											__( '%s prompt settings', 'newspack-plugin' ),
+											prompt.ready ? __( 'Update', 'newspack-plugin' ) : __( 'Save', 'newspack-plugin' )
 									  ) }
 							</Button>
 							<WebPreview
@@ -328,7 +328,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 										isSecondary
 										onClick={ async () => showPreview() }
 									>
-										{ __( 'Preview prompt', 'newspack' ) }
+										{ __( 'Preview prompt', 'newspack-plugin' ) }
 									</Button>
 								) }
 							/>
@@ -342,7 +342,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 									<span dangerouslySetInnerHTML={ { __html: helpInfo.description } } />{ ' ' }
 									{ helpInfo.url && (
 										<ExternalLink href={ helpInfo.url }>
-											{ __( 'Learn more', 'newspack' ) }
+											{ __( 'Learn more', 'newspack-plugin' ) }
 										</ExternalLink>
 									) }
 								</p>
@@ -350,7 +350,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 							{ helpInfo.recommendations && (
 								<>
 									<h4 className="newspack-ras-campaign__recommendation-heading">
-										{ __( 'We recommend', 'newspack' ) }
+										{ __( 'We recommend', 'newspack-plugin' ) }
 									</h4>
 									<ul>
 										{ helpInfo.recommendations.map( ( recommendation, index ) => (

--- a/assets/wizards/engagement/components/prompt.tsx
+++ b/assets/wizards/engagement/components/prompt.tsx
@@ -317,7 +317,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 											// Translators: Save or Update settings.
 											__( '%s prompt settings', 'newspack-plugin' ),
 											prompt.ready
-												?__( 'Update', 'newspack-plugin' )
+												? __( 'Update', 'newspack-plugin' )
 												: __( 'Save', 'newspack-plugin' )
 									  ) }
 							</Button>

--- a/assets/wizards/engagement/components/prompt.tsx
+++ b/assets/wizards/engagement/components/prompt.tsx
@@ -316,7 +316,9 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 									: sprintf(
 											// Translators: Save or Update settings.
 											__( '%s prompt settings', 'newspack-plugin' ),
-											prompt.ready ? __( 'Update', 'newspack-plugin' ) : __( 'Save', 'newspack-plugin' )
+											prompt.ready
+												?__( 'Update', 'newspack-plugin' )
+												: __( 'Save', 'newspack-plugin' )
 									  ) }
 							</Button>
 							<WebPreview

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -66,7 +66,8 @@ class EngagementWizard extends Component {
 		} catch ( e ) {
 			this.setState( {
 				relatedPostsError:
-					e.message || __( 'There was an error saving settings. Please try again.', 'newspack' ),
+					e.message ||
+					__( 'There was an error saving settings. Please try again.', 'newspack-plugin' ),
 			} );
 		}
 	};
@@ -82,7 +83,7 @@ class EngagementWizard extends Component {
 		const defaultPath = '/reader-activation';
 		const tabbed_navigation = [
 			{
-				label: __( 'Reader Activation', 'newspack' ),
+				label: __( 'Reader Activation', 'newspack-plugin' ),
 				path: '/reader-activation',
 				exact: true,
 				activeTabPaths: [
@@ -92,22 +93,22 @@ class EngagementWizard extends Component {
 				],
 			},
 			{
-				label: __( 'Newsletters', 'newspack' ),
+				label: __( 'Newsletters', 'newspack-plugin' ),
 				path: '/newsletters',
 				exact: true,
 			},
 			{
-				label: __( 'Social', 'newspack' ),
+				label: __( 'Social', 'newspack-plugin' ),
 				path: '/social',
 				exact: true,
 			},
 			{
-				label: __( 'Recirculation', 'newspack' ),
+				label: __( 'Recirculation', 'newspack-plugin' ),
 				path: '/recirculation',
 			},
 		];
 		const props = {
-			headerText: __( 'Engagement', 'newspack' ),
+			headerText: __( 'Engagement', 'newspack-plugin' ),
 			tabbedNavigation: tabbed_navigation,
 			wizardApiFetch,
 		};
@@ -121,7 +122,10 @@ class EngagementWizard extends Component {
 							exact
 							render={ () => (
 								<ReaderActivation
-									subHeaderText={ __( 'Configure your reader activation settings', 'newspack' ) }
+									subHeaderText={ __(
+										'Configure your reader activation settings',
+										'newspack-plugin'
+									) }
 									{ ...props }
 								/>
 							) }
@@ -132,7 +136,7 @@ class EngagementWizard extends Component {
 								<ReaderActivationCampaign
 									subHeaderText={ __(
 										'Preview and customize the reader activation prompts',
-										'newspack'
+										'newspack-plugin'
 									) }
 									{ ...props }
 								/>
@@ -144,7 +148,7 @@ class EngagementWizard extends Component {
 								<ReaderActivationComplete
 									subHeaderText={ __(
 										'Preview and customize the reader activation prompts',
-										'newspack'
+										'newspack-plugin'
 									) }
 									{ ...props }
 								/>
@@ -154,7 +158,7 @@ class EngagementWizard extends Component {
 							path="/newsletters"
 							render={ () => (
 								<Newsletters
-									subHeaderText={ __( 'Configure your newsletter settings', 'newspack' ) }
+									subHeaderText={ __( 'Configure your newsletter settings', 'newspack-plugin' ) }
 									{ ...props }
 								/>
 							) }
@@ -164,7 +168,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ () => (
 								<Social
-									subHeaderText={ __( 'Share your content to social media', 'newspack' ) }
+									subHeaderText={ __( 'Share your content to social media', 'newspack-plugin' ) }
 									{ ...props }
 								/>
 							) }
@@ -175,11 +179,11 @@ class EngagementWizard extends Component {
 							render={ () => (
 								<RelatedContent
 									{ ...props }
-									subHeaderText={ __( 'Engage visitors with related content', 'newspack' ) }
+									subHeaderText={ __( 'Engage visitors with related content', 'newspack-plugin' ) }
 									relatedPostsEnabled={ relatedPostsEnabled }
 									relatedPostsError={ relatedPostsError }
 									buttonAction={ () => this.updatedRelatedContentSettings() }
-									buttonText={ __( 'Save Settings', 'newspack' ) }
+									buttonText={ __( 'Save Settings', 'newspack-plugin' ) }
 									buttonDisabled={ ! relatedPostsEnabled || ! relatedPostsUpdated }
 									relatedPostsMaxAge={ relatedPostsMaxAge }
 									onChange={ value => {

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -155,17 +155,19 @@ export const NewspackNewsletters = ( {
 		return (
 			<ActionCard
 				isMedium
-				title={ __( 'Email Service Provider', 'newspack' ) }
+				title={ __( 'Email Service Provider', 'newspack-plugin' ) }
 				description={ __(
 					'Connect an email service provider (ESP) to author and send newsletters.',
-					'newspack'
+					'newspack-plugin'
 				) }
-				notification={ error ? error?.message || __( 'Something went wrong.', 'newspack' ) : null }
+				notification={
+					error ? error?.message || __( 'Something went wrong.', 'newspack-plugin' ) : null
+				}
 				notificationLevel="error"
 				hasGreyHeader
 				actionContent={
 					<Button disabled={ inFlight } variant="primary" onClick={ saveNewslettersData }>
-						{ __( 'Save Settings', 'newspack' ) }
+						{ __( 'Save Settings', 'newspack-plugin' ) }
 					</Button>
 				}
 				disabled={ inFlight }
@@ -173,16 +175,16 @@ export const NewspackNewsletters = ( {
 				<Grid gutter={ 16 } columns={ 1 }>
 					{ false !== authUrl && (
 						<Card isSmall>
-							<h3>{ __( 'Authorize Application', 'newspack' ) }</h3>
+							<h3>{ __( 'Authorize Application', 'newspack-plugin' ) }</h3>
 							<p>
 								{ sprintf(
 									// translators: %s is the name of the ESP.
-									__( 'Authorize %s to connect to Newspack.', 'newspack-newsletters' ),
+									__( 'Authorize %s to connect to Newspack.', 'newspack-plugin' ),
 									getSelectedProviderName()
 								) }
 							</p>
 							<Button isSecondary onClick={ handleAuth }>
-								{ __( 'Authorize', 'newspack' ) }
+								{ __( 'Authorize', 'newspack-plugin' ) }
 							</Button>
 						</Card>
 					) }
@@ -297,16 +299,19 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 		<>
 			<ActionCard
 				isMedium
-				title={ __( 'Subscription Lists', 'newspack' ) }
-				description={ __( 'Manage the lists available to readers for subscription.', 'newspack' ) }
+				title={ __( 'Subscription Lists', 'newspack-plugin' ) }
+				description={ __(
+					'Manage the lists available to readers for subscription.',
+					'newspack-plugin'
+				) }
 				notification={
 					/* eslint-disable no-nested-ternary */
 					error
-						? error?.message || __( 'Something went wrong.', 'newspack' )
+						? error?.message || __( 'Something went wrong.', 'newspack-plugin' )
 						: lockedLists
 						? __(
 								'Please save your ESP settings before changing your subscription lists.',
-								'newspack'
+								'newspack-plugin'
 						  )
 						: null
 				}
@@ -320,11 +325,11 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 								disabled={ inFlight || lockedLists }
 								href={ newspack_engagement_wizard.new_subscription_lists_url }
 							>
-								{ __( 'Add New', 'newspack' ) }
+								{ __( 'Add New', 'newspack-plugin' ) }
 							</Button>
 						) }
 						<Button isPrimary onClick={ saveLists } disabled={ inFlight || lockedLists }>
-							{ __( 'Save Subscription Lists', 'newspack' ) }
+							{ __( 'Save Subscription Lists', 'newspack-plugin' ) }
 						</Button>
 					</>
 				}
@@ -350,7 +355,7 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 							actionText={
 								list?.edit_link ? (
 									<ExternalLink href={ list.edit_link }>
-										{ __( 'Edit', 'newspack_newsletters' ) }
+										{ __( 'Edit', 'newspack-plugin' ) }
 									</ExternalLink>
 								) : null
 							}
@@ -358,13 +363,13 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 							{ list.active && 'local' !== list?.type && (
 								<>
 									<TextControl
-										label={ __( 'List title', 'newspack' ) }
+										label={ __( 'List title', 'newspack-plugin' ) }
 										value={ list.title }
 										disabled={ inFlight || 'local' === list?.type }
 										onChange={ handleChange( index, 'title' ) }
 									/>
 									<TextareaControl
-										label={ __( 'List description', 'newspack' ) }
+										label={ __( 'List description', 'newspack-plugin' ) }
 										value={ list.description }
 										disabled={ inFlight || 'local' === list?.type }
 										onChange={ handleChange( index, 'description' ) }
@@ -400,7 +405,7 @@ const Newsletters = () => {
 			{ 'mailchimp' === newslettersConfig?.newspack_newsletters_service_provider && (
 				<>
 					<hr />
-					<SectionHeader title={ __( 'WooCommerce integration', 'newspack' ) } />
+					<SectionHeader title={ __( 'WooCommerce integration', 'newspack-plugin' ) } />
 					<PluginInstaller plugins={ [ 'mailchimp-for-woocommerce' ] } withoutFooterButton />
 				</>
 			) }

--- a/assets/wizards/engagement/views/reader-activation/campaign.js
+++ b/assets/wizards/engagement/views/reader-activation/campaign.js
@@ -54,22 +54,22 @@ export default withWizardScreen( () => {
 	return (
 		<div className="newspack-ras-campaign__prompt-wizard">
 			<SectionHeader
-				title={ __( 'Set Up Reader Activation Campaign', 'newspack' ) }
+				title={ __( 'Set Up Reader Activation Campaign', 'newspack-plugin' ) }
 				description={ __(
 					'Preview and customize the prompts, or use our suggested defaults.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			/>
 			{ error && (
 				<Notice
-					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+					noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 					isError
 				/>
 			) }
 			{ ! prompts && ! error && (
 				<>
 					<Waiting isLeft />
-					{ __( 'Retrieving prompts…', 'newspack' ) }
+					{ __( 'Retrieving prompts…', 'newspack-plugin' ) }
 				</>
 			) }
 			{ prompts &&
@@ -88,10 +88,10 @@ export default withWizardScreen( () => {
 					disabled={ inFlight || ! allReady }
 					href={ `${ reader_activation_url }/complete` }
 				>
-					{ __( 'Continue', 'newspack' ) }
+					{ __( 'Continue', 'newspack-plugin' ) }
 				</Button>
 				<Button isSecondary disabled={ inFlight } href={ reader_activation_url }>
-					{ __( 'Back', 'newspack' ) }
+					{ __( 'Back', 'newspack-plugin' ) }
 				</Button>
 			</div>
 		</div>

--- a/assets/wizards/engagement/views/reader-activation/complete.js
+++ b/assets/wizards/engagement/views/reader-activation/complete.js
@@ -24,22 +24,22 @@ import {
 const listItems = [
 	__(
 		'Your <strong>current segments and prompts</strong> will be deactivated and archived.',
-		'newspack'
+		'newspack-plugin'
 	),
 	__(
 		'<strong>Reader registration</strong> will be activated to enable better targeting for driving engagement and conversations.',
-		'newspack'
+		'newspack-plugin'
 	),
 	__(
 		'The <strong>Reader Activation campaign</strong> will be activated with default segments and settings.',
-		'newspack'
+		'newspack-plugin'
 	),
 ];
 
 const activationSteps = [
-	__( 'Setting up new segments…', 'newspack' ),
-	__( 'Activating reader registration…', 'newspack' ),
-	__( 'Activating Reader Activation Campaign…', 'newspack' ),
+	__( 'Setting up new segments…', 'newspack-plugin' ),
+	__( 'Activating reader registration…', 'newspack-plugin' ),
+	__( 'Activating Reader Activation Campaign…', 'newspack-plugin' ),
 ];
 
 /**
@@ -77,7 +77,7 @@ export default withWizardScreen( () => {
 		}
 		if ( progress === activationSteps.length && completed ) {
 			setProgress( activationSteps.length + 1 ); // Plus one to account for the "Done!" step.
-			setProgressLabel( __( 'Done!', 'newspack' ) );
+			setProgressLabel( __( 'Done!', 'newspack-plugin' ) );
 			setTimeout( () => {
 				setInFlight( false );
 				window.location = reader_activation_url;
@@ -105,12 +105,12 @@ export default withWizardScreen( () => {
 	return (
 		<div className="newspack-ras-campaign__completed">
 			<SectionHeader
-				title={ __( 'Enable Reader Activation', 'newspack' ) }
+				title={ __( 'Enable Reader Activation', 'newspack-plugin' ) }
 				description={ () => (
 					<>
 						{ __(
 							'An easy way to let your readers register for your site, sign up for newsletters, or become donors and paid members. ',
-							'newspack'
+							'newspack-plugin'
 						) }
 
 						{ /** TODO: Update this URL with the real one once the docs are ready. */ }
@@ -132,8 +132,8 @@ export default withWizardScreen( () => {
 			) }
 			{ ! inFlight && (
 				<Card className="newspack-ras-campaign__completed-card">
-					<h2>{ __( "You're all set to enable Reader Activation!", 'newspack' ) }</h2>
-					<p>{ __( 'This is what will happen next:', 'newspack' ) }</p>
+					<h2>{ __( "You're all set to enable Reader Activation!", 'newspack-plugin' ) }</h2>
+					<p>{ __( 'This is what will happen next:', 'newspack-plugin' ) }</p>
 
 					<Card noBorder className="justify-center">
 						<StepsList stepsListItems={ listItems } narrowList />
@@ -141,21 +141,21 @@ export default withWizardScreen( () => {
 
 					{ error && (
 						<Notice
-							noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+							noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 							isError
 						/>
 					) }
 
 					<Card buttonsCard noBorder className="justify-center">
 						<Button isPrimary onClick={ () => activate() }>
-							{ __( 'Enable Reader Activation', 'newspack ' ) }
+							{ __( 'Enable Reader Activation', 'newspack-plugin' ) }
 						</Button>
 					</Card>
 				</Card>
 			) }
 			<div className="newspack-buttons-card">
 				<Button isSecondary disabled={ inFlight } href={ `${ reader_activation_url }/campaign` }>
-					{ __( 'Back', 'newspack' ) }
+					{ __( 'Back', 'newspack-plugin' ) }
 				</Button>
 			</div>
 		</div>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -140,15 +140,15 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 	const getContentGateDescription = () => {
 		let message = __(
 			'Configure the gate rendered on content with restricted access.',
-			'newspack'
+			'newspack-plugin'
 		);
 		if ( 'publish' === membershipsConfig?.gate_status ) {
-			message += ' ' + __( 'The gate is currently published.', 'newspack' );
+			message += ' ' + __( 'The gate is currently published.', 'newspack-plugin' );
 		} else if (
 			'draft' === membershipsConfig?.gate_status ||
 			'trash' === membershipsConfig?.gate_status
 		) {
-			message += ' ' + __( 'The gate is currently a draft.', 'newspack' );
+			message += ' ' + __( 'The gate is currently a draft.', 'newspack-plugin' );
 		}
 		return message;
 	};
@@ -156,12 +156,12 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 	return (
 		<>
 			<SectionHeader
-				title={ __( 'Reader Activation', 'newspack' ) }
+				title={ __( 'Reader Activation', 'newspack-plugin' ) }
 				description={ () => (
 					<>
 						{ __(
 							'Newspack’s Reader Activation system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. ',
-							'newspack'
+							'newspack-plugin'
 						) }
 						<ExternalLink href={ 'https://help.newspack.com/engagement/reader-activation-system' }>
 							{ __( 'Learn more', 'newspack-plugin' ) }
@@ -171,26 +171,32 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 			/>
 			{ error && (
 				<Notice
-					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+					noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 					isError
 				/>
 			) }
 			{ 0 < missingPlugins.length && (
-				<Notice noticeText={ __( 'The following plugins are required.', 'newspack' ) } isWarning />
+				<Notice
+					noticeText={ __( 'The following plugins are required.', 'newspack-plugin' ) }
+					isWarning
+				/>
 			) }
 			{ 0 === missingPlugins.length && prerequisites && ! allReady && (
 				<Notice
-					noticeText={ __( 'Complete these settings to enable Reader Activation.', 'newspack' ) }
+					noticeText={ __(
+						'Complete these settings to enable Reader Activation.',
+						'newspack-plugin'
+					) }
 					isWarning
 				/>
 			) }
 			{ prerequisites && allReady && config.enabled && (
-				<Notice noticeText={ __( 'Reader Activation is enabled.', 'newspack' ) } isSuccess />
+				<Notice noticeText={ __( 'Reader Activation is enabled.', 'newspack-plugin' ) } isSuccess />
 			) }
 			{ ! prerequisites && (
 				<>
 					<Waiting isLeft />
-					{ __( 'Retrieving status…', 'newspack' ) }
+					{ __( 'Retrieving status…', 'newspack-plugin' ) }
 				</>
 			) }
 			{ 0 < missingPlugins.length && prerequisites && (
@@ -219,8 +225,8 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 					<Button variant="link" onClick={ () => setShowAdvanced( ! showAdvanced ) }>
 						{ sprintf(
 							// Translators: Show or Hide advanced settings.
-							__( '%s Advanced Settings', 'newspack' ),
-							showAdvanced ? __( 'Hide', 'newspack' ) : __( 'Show', 'newspack' )
+							__( '%s Advanced Settings', 'newspack-plugin' ),
+							showAdvanced ? __( 'Hide', 'newspack-plugin' ) : __( 'Show', 'newspack-plugin' )
 						) }
 					</Button>
 				</>
@@ -230,22 +236,25 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 					{ newspack_engagement_wizard.has_memberships && membershipsConfig ? (
 						<>
 							<SectionHeader
-								title={ __( 'Memberships Integration', 'newspack' ) }
-								description={ __( 'Improve the reader experience on content gating.', 'newspack' ) }
+								title={ __( 'Memberships Integration', 'newspack-plugin' ) }
+								description={ __(
+									'Improve the reader experience on content gating.',
+									'newspack-plugin'
+								) }
 							/>
 							<ActionCard
-								title={ __( 'Content Gate', 'newspack' ) }
+								title={ __( 'Content Gate', 'newspack-plugin' ) }
 								titleLink={ membershipsConfig.edit_gate_url }
 								href={ membershipsConfig.edit_gate_url }
 								description={ getContentGateDescription() }
-								actionText={ __( 'Configure', 'newspack' ) }
+								actionText={ __( 'Configure', 'newspack-plugin' ) }
 							/>
 							{ membershipsConfig?.plans && 1 < membershipsConfig.plans.length && (
 								<ActionCard
-									title={ __( 'Require membership in all plans', 'newspack' ) }
+									title={ __( 'Require membership in all plans', 'newspack-plugin' ) }
 									description={ __(
 										'When enabled, readers must belong to all membership plans that apply to a restricted content item before they are granted access. Otherwise, they will be able to unlock access to that item with membership in any single plan that applies to it.',
-										'newspack'
+										'newspack-plugin'
 									) }
 									toggleOnChange={ value =>
 										setMembershipsConfig( { ...membershipsConfig, require_all_plans: value } )
@@ -260,8 +269,11 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 					{ emails?.length > 0 && (
 						<>
 							<SectionHeader
-								title={ __( 'Transactional Email Content', 'newspack' ) }
-								description={ __( 'Customize the content of transactional emails.', 'newspack' ) }
+								title={ __( 'Transactional Email Content', 'newspack-plugin' ) }
+								description={ __(
+									'Customize the content of transactional emails.',
+									'newspack-plugin'
+								) }
 							/>
 							{ emails.map( email => (
 								<ActionCard
@@ -270,7 +282,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 									titleLink={ email.edit_link }
 									href={ email.edit_link }
 									description={ email.description }
-									actionText={ __( 'Edit', 'newspack' ) }
+									actionText={ __( 'Edit', 'newspack-plugin' ) }
 									isSmall
 								/>
 							) ) }
@@ -278,12 +290,12 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 						</>
 					) }
 
-					<SectionHeader title={ __( 'Newsletter Subscription Lists', 'newspack' ) } />
+					<SectionHeader title={ __( 'Newsletter Subscription Lists', 'newspack-plugin' ) } />
 					<ActionCard
-						title={ __( 'Custom newsletter lists on registration', 'newspack' ) }
+						title={ __( 'Custom newsletter lists on registration', 'newspack-plugin' ) }
 						description={ __(
 							"Choose which of the Newspack Newsletters's subscription lists should be available upon registration.",
-							'newspack'
+							'newspack-plugin'
 						) }
 						toggleChecked={ config.use_custom_lists }
 						toggleOnChange={ value => updateConfig( 'use_custom_lists', value ) }
@@ -299,24 +311,27 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 					<hr />
 
 					<SectionHeader
-						title={ __( 'Email Service Provider (ESP) Advanced Settings', 'newspack' ) }
-						description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
+						title={ __( 'Email Service Provider (ESP) Advanced Settings', 'newspack-plugin' ) }
+						description={ __(
+							'Settings for Newspack Newsletters integration.',
+							'newspack-plugin'
+						) }
 					/>
 					<TextControl
-						label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
+						label={ __( 'Newsletter subscription text on registration', 'newspack-plugin' ) }
 						help={ __(
 							'The text to display while subscribing to newsletters from the sign-in modal.',
-							'newspack'
+							'newspack-plugin'
 						) }
 						{ ...getSharedProps( 'newsletters_label', 'text' ) }
 					/>
 					{ config.sync_esp && (
 						<>
 							<TextControl
-								label={ __( 'Metadata field prefix', 'newspack' ) }
+								label={ __( 'Metadata field prefix', 'newspack-plugin' ) }
 								help={ __(
 									'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_',
-									'newspack'
+									'newspack-plugin'
 								) }
 								{ ...getSharedProps( 'metadata_prefix', 'text' ) }
 							/>
@@ -358,7 +373,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 							} }
 							disabled={ inFlight }
 						>
-							{ __( 'Save advanced settings', 'newspack' ) }
+							{ __( 'Save advanced settings', 'newspack-plugin' ) }
 						</Button>
 					</div>
 				</Card>

--- a/assets/wizards/engagement/views/related-content/index.js
+++ b/assets/wizards/engagement/views/related-content/index.js
@@ -35,13 +35,13 @@ class RelatedContent extends Component {
 				{ relatedPostsError && <Notice noticeText={ relatedPostsError } isError /> }
 
 				<ActionCard
-					title={ __( 'Related Posts', 'newspack' ) }
+					title={ __( 'Related Posts', 'newspack-plugin' ) }
 					badge="Jetpack"
 					description={ __(
 						'Automatically add related content at the bottom of each post.',
-						'newspack'
+						'newspack-plugin'
 					) }
-					actionText={ __( 'Configure' ) }
+					actionText={ __( 'Configure', 'newspack-plugin' ) }
 					handoff="jetpack"
 					editLink="admin.php?page=jetpack#/traffic"
 				/>
@@ -52,11 +52,11 @@ class RelatedContent extends Component {
 							<TextControl
 								help={ __(
 									'If set, posts will be shown as related content only if published within the past number of months. If 0, any published post can be shown, regardless of publish date.',
-									'newspack'
+									'newspack-plugin'
 								) }
-								label={ __( 'Maximum age of related content, in months', 'newspack' ) }
+								label={ __( 'Maximum age of related content, in months', 'newspack-plugin' ) }
 								onChange={ value => onChange( value ) }
-								placeholder={ __( 'Maximum age of related content, in months' ) }
+								placeholder={ __( 'Maximum age of related content, in months', 'newspack-plugin' ) }
 								type="number"
 								value={ relatedPostsMaxAge || 0 }
 							/>

--- a/assets/wizards/engagement/views/social/index.js
+++ b/assets/wizards/engagement/views/social/index.js
@@ -26,12 +26,13 @@ class Social extends Component {
 		return (
 			<>
 				<ActionCard
-					title={ __( 'Publicize' ) }
+					title={ __( 'Publicize', 'newspack-plugin' ) }
 					badge="Jetpack"
 					description={ __(
-						'Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.'
+						'Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.',
+						'newspack-plugin'
 					) }
-					actionText={ __( 'Configure' ) }
+					actionText={ __( 'Configure', 'newspack-plugin' ) }
 					handoff="jetpack"
 					editLink="admin.php?page=jetpack#/sharing"
 				/>

--- a/assets/wizards/engagement/views/social/meta-pixel.js
+++ b/assets/wizards/engagement/views/social/meta-pixel.js
@@ -11,18 +11,18 @@ import Pixel from './pixel';
 
 const MetaPixel = () => (
 	<Pixel
-		title={ __( 'Meta Pixel', 'newspack' ) }
+		title={ __( 'Meta Pixel', 'newspack-plugin' ) }
 		pixelKey="meta"
 		pixelValueType="integer"
 		description={ __(
 			'Add the Meta pixel (formely known as Facebook pixel) to your site.',
-			'newspack'
+			'newspack-plugin'
 		) }
-		fieldDescription={ __( 'Pixel ID', 'newspack' ) }
+		fieldDescription={ __( 'Pixel ID', 'newspack-plugin' ) }
 		fieldHelp={ createInterpolateElement(
 			__(
 				'The Meta Pixel ID. You only need to add the number, not the full code. Example: 123456789123456789. You can get this information <linkToFb>here</linkToFb>.',
-				'newspack'
+				'newspack-plugin'
 			),
 			{
 				/* eslint-disable jsx-a11y/anchor-has-content */

--- a/assets/wizards/engagement/views/social/twitter-pixel.js
+++ b/assets/wizards/engagement/views/social/twitter-pixel.js
@@ -11,15 +11,15 @@ import Pixel from './pixel';
 
 const TwitterPixel = () => (
 	<Pixel
-		title={ __( 'Twitter Pixel', 'newspack' ) }
+		title={ __( 'Twitter Pixel', 'newspack-plugin' ) }
 		pixelKey="twitter"
-		description={ __( 'Add the Twitter pixel to your site.', 'newspack' ) }
+		description={ __( 'Add the Twitter pixel to your site.', 'newspack-plugin' ) }
 		pixelValueType="text"
-		fieldDescription={ __( 'Pixel ID', 'newspack' ) }
+		fieldDescription={ __( 'Pixel ID', 'newspack-plugin' ) }
 		fieldHelp={ createInterpolateElement(
 			__(
 				'The Twitter Pixel ID. You only need to add the ID, not the full code. Example: ny3ad. You can read more about it <link>here</link>.',
-				'newspack'
+				'newspack-plugin'
 			),
 			{
 				/* eslint-disable jsx-a11y/anchor-has-content */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR corrects the text-domain in the assets/wizards/engagement directory.

See 1200550061930446-as-1205509524123559

### How to test the changes in this Pull Request:

1. Spot check the changes in the PR and confirm they're just changing the text domain on translateable strings to `newspack-plugin`.
2. Run `npm run build` on this branch, and spot-check the Engagement wizard screens.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->