### PR TITLE
fix: correct issue with media sizes not saving

### DIFF
--- a/includes/class-rss-add-image.php
+++ b/includes/class-rss-add-image.php
@@ -55,13 +55,13 @@ class RSS_Add_Image {
 		);
 
 		register_setting(
-			'rss_image_sizes',
+			'media',
 			self::OPTION_RSS_IMAGE_WIDTH,
 			[ __CLASS__, 'sanitize_rss_image_size_value' ]
 		);
 
 		register_setting(
-			'rss_image_sizes',
+			'media',
 			self::OPTION_RSS_IMAGE_HEIGHT,
 			[ __CLASS__, 'sanitize_rss_image_size_value' ]
 		);
@@ -119,7 +119,7 @@ class RSS_Add_Image {
 		?>
 		<fieldset style="margin-bottom: -40px;">
 			<label for="<?php echo esc_attr( self::OPTION_RSS_IMAGE_WIDTH ); ?>">
-				<?php esc_html_e( 'Max Width', 'newspack' ); ?>
+				<?php esc_html_e( 'Max Width', 'newspack-plugin' ); ?>
 			</label>
 			<input name="<?php echo esc_attr( self::OPTION_RSS_IMAGE_WIDTH ); ?>" type="number" step="1" min="0" id="<?php echo esc_attr( self::OPTION_RSS_IMAGE_WIDTH ); ?>" value="<?php echo esc_attr( $saved_width ); ?>" class="small-text" />
 		</fieldset>
@@ -134,7 +134,7 @@ class RSS_Add_Image {
 		?>
 		<fieldset>
 			<label for="<?php echo esc_attr( self::OPTION_RSS_IMAGE_HEIGHT ); ?>">
-				<?php esc_html_e( 'Max Height', 'newspack' ); ?>
+				<?php esc_html_e( 'Max Height', 'newspack-plugin' ); ?>
 			</label>
 			<input name="<?php echo esc_attr( self::OPTION_RSS_IMAGE_HEIGHT ); ?>" type="number" step="1" min="0" id="<?php echo esc_attr( self::OPTION_RSS_IMAGE_HEIGHT ); ?>" value="<?php echo esc_attr( $saved_height ); ?>" class="small-text" />
 		</fieldset>
@@ -145,8 +145,7 @@ class RSS_Add_Image {
 	 * Render the size fields on the media settings page.
 	 */
 	public static function add_image_size_fields() {
-		settings_fields( 'rss_image_sizes' );
-		do_settings_sections( 'newspack-rss-image-settings' );
+		echo '<p>' . esc_html__( 'Customize the featured image sizes used in the RSS feed', 'newspack-plugin' ) . '</p>';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Due to how the [RSS Image Size options](https://github.com/Automattic/newspack-plugin/pull/2553) were originally set up (basically creating a duplicate nonce field), the Media default sizes under Settings > Media were not saving for the Large, Medium, and Thumbnail sizes. 

This PR hopefully addresses the issue, but could probably use a careful eye just to make sure it's not introducing any new issues. 

### How to test the changes in this Pull Request:

1. On a test site, navigate to WP Admin > Settings > Media. 
2. Try changing any of the Thumbnail, Medium, or Large image size values and click 'Save Changes'. Note that they revert to their original values when the page refreshes. 
3. Try changing the RSS Image Size values and click 'Save Changes'. Confirm that those changes DO stick.
4. Optionally inspect the RSS Image Sizes section, and note that there are duplicate hidden fields for the option_page, action, and nonce:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/91374bac-245b-4743-bb27-72dd8ef49410)

5. Apply this PR.
6. Refresh the page, and confirm that the values look okay. 
7. Repeat steps 2 and 3, and confirm that both values save correctly. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->