### PR TITLE
feat: jetpack default modules

### DIFF
--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -155,7 +155,7 @@ class Jetpack {
 		add_filter( 'jetpack_active_modules', [ __CLASS__, 'remove_google_analytics_from_active' ], 10, 2 );
 		add_filter( 'jetpack_get_available_modules', [ __CLASS__, 'remove_google_analytics_from_available' ] );
 
-		add_filter( 'jetpack_get_default_modules', [ __CLASS__, 'default_modules' ] );
+		add_filter( 'jetpack_get_default_modules', [ __CLASS__, 'get_default_modules' ] );
 	}
 
 	/**
@@ -306,7 +306,7 @@ class Jetpack {
 	 * @uses https://developer.jetpack.com/hooks/jetpack_get_default_modules/
 	 * @return string[] Default active modules
 	 */
-	public static function default_modules() {
+	public static function get_default_modules() {
 		return static::$default_active_modules;
 	}
 }

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -92,11 +92,11 @@ class Jetpack {
 		 */
 		'copy-post',
 		/**
-				 * Extra Sidebar Widgets
-				 *
-				 * @link https://jetpack.com/support/extra-sidebar-widgets/
-				 */
-			'widgets',
+		 * Extra Sidebar Widgets
+		 *
+		 * @link https://jetpack.com/support/extra-sidebar-widgets/
+		 */
+		'widgets',
 		/**
 		 * Gravatar Hovercards
 		 *

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -26,6 +26,122 @@ class Jetpack {
 	];
 
 	/**
+	 * Default modules
+	 *
+	 * @var string[]
+	 */
+	private static $default_active_modules = [
+		/** 
+		 * Assets CDN
+		 *
+		 * @link https://jetpack.com/support/site-accelerator/
+		 */
+		'photon-cdn',
+		/** 
+		 * Image CDN
+		 *
+		 * @link https://jetpack.com/support/site-accelerator/
+		 */
+		'photon',
+		/** 
+		 * Contact Form
+		 *
+		 * @link https://jetpack.com/support/contact-form/
+		 */
+		'contact-form',
+		/** 
+		 * Brute Force Protection. 
+		 *
+		 * @link https://jetpack.com/support/protect/
+		 */
+		'protect',
+		/** 
+		 * JSON API 
+		 *
+		 * @link https://jetpack.com/support/json-api/
+		 */
+		'json-api',
+		/** 
+		 * Notifications
+		 *
+		 * @link https://jetpack.com/support/notifications/
+		 */
+		'notes',
+		/**
+		 * Stats
+		 *
+		 * @link https://jetpack.com/support/jetpack-stats/
+		 */
+		'stats',
+		/**
+		 * Site Verification
+		 *
+		 * @link https://jetpack.com/support/site-verification-tools/
+		 */
+		'verification-tools',
+		/**
+		 * Carousel
+		 *
+		 * @link https://jetpack.com/support/carousel/
+		 */
+		'carousel',
+		/**
+		 * Copy Post
+		 *
+		 * @link https://jetpack.com/support/copy-post/
+		 */
+		'copy-post',
+		/**
+				 * Extra Sidebar Widgets
+				 *
+				 * @link https://jetpack.com/support/extra-sidebar-widgets/
+				 */
+			'widgets',
+		/**
+		 * Gravatar Hovercards
+		 *
+		 * @link https://jetpack.com/support/gravatar-hovercards
+		 */
+		'gravatar-hovercards',
+		/**
+		 * Social
+		 *
+		 * @link https://jetpack.com/support/jetpack-social/
+		 */
+		'publicize',
+		/**
+		 * Related Posts
+		 *
+		 * @link https://jetpack.com/support/related-posts/
+		 */
+		'related-posts',
+		/**
+		 * Sharing
+		 *
+		 * @link https://jetpack.com/support/sharing/
+		 */
+		'sharedaddy',
+		/**
+		 * Sitemaps
+		 *
+		 * @link https://jetpack.com/support/sitemaps
+		 */
+		'sitemaps',
+		/**
+		 * Tiled Gallery
+		 *
+		 * @link https://jetpack.com/support/jetpack-blocks/tiled-galleries/
+		 */
+		'tiled-gallery',
+		/**
+		 * Widget Visibility
+		 *
+		 * @link https://jetpack.com/support/widget-visibility/
+		 */
+		'widget-visibility',
+	];
+
+	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
@@ -36,8 +152,10 @@ class Jetpack {
 		add_filter( 'wp_calculate_image_srcset', [ __CLASS__, 'filter_srcset_array' ], 100, 5 );
 
 		// Disables Google Analytics.
-		add_filter( 'jetpack_active_modules', array( __CLASS__, 'remove_google_analytics_from_active' ), 10, 2 );
-		add_filter( 'jetpack_get_available_modules', array( __CLASS__, 'remove_google_analytics_from_available' ) );
+		add_filter( 'jetpack_active_modules', [ __CLASS__, 'remove_google_analytics_from_active' ], 10, 2 );
+		add_filter( 'jetpack_get_available_modules', [ __CLASS__, 'remove_google_analytics_from_available' ] );
+
+		add_filter( 'jetpack_get_default_modules', [ __CLASS__, 'default_modules' ] );
 	}
 
 	/**
@@ -180,6 +298,16 @@ class Jetpack {
 			unset( $modules['google-analytics'] );
 		}
 		return $modules;
+	}
+
+	/**
+	 * Jetpack Default Modules
+	 *
+	 * @uses https://developer.jetpack.com/hooks/jetpack_get_default_modules/
+	 * @return string[] Default active modules
+	 */
+	public static function default_modules() {
+		return static::$default_active_modules;
 	}
 }
 Jetpack::init();

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -155,7 +155,9 @@ class Jetpack {
 		add_filter( 'jetpack_active_modules', [ __CLASS__, 'remove_google_analytics_from_active' ], 10, 2 );
 		add_filter( 'jetpack_get_available_modules', [ __CLASS__, 'remove_google_analytics_from_available' ] );
 
-		add_filter( 'jetpack_get_default_modules', [ __CLASS__, 'get_default_modules' ] );
+		// Set Jetpack default modules on Newspack setup.
+		add_action( 'add_option_newspack_setup_complete', [ __CLASS__, 'set_default_modules' ], 10, 2 );
+		add_action( 'update_option_newspack_setup_complete', [ __CLASS__, 'set_default_modules' ], 10, 2 );
 	}
 
 	/**
@@ -301,13 +303,16 @@ class Jetpack {
 	}
 
 	/**
-	 * Jetpack Default Modules
+	 * Set Jetpack Default Modules on newspack setup complete.
 	 *
-	 * @uses https://developer.jetpack.com/hooks/jetpack_get_default_modules/
-	 * @return string[] Default active modules
+	 * @param string $old_val_or_opt_name If adding will be opt name. If updating will be old value.
+	 * @param string $new_val Value correlated to update/add.
+	 * @return void 
 	 */
-	public static function get_default_modules() {
-		return static::$default_active_modules;
+	public static function set_default_modules( string $old_val_or_opt_name, string $new_val ) {
+		if ( $new_val === '1' ) {
+			update_option( 'jetpack_active_modules', static::$default_active_modules );
+		}
 	}
 }
 Jetpack::init();

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -30,7 +30,7 @@ class Jetpack {
 	 *
 	 * @var string[]
 	 */
-	private static $default_active_modules = [
+	public static $default_active_modules = [
 		/** 
 		 * Assets CDN
 		 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds `jetpack_get_default_modules` hook for delegating Jetpack default active modules on install. 

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run `wp jetpack reset modules` and confirm with "yes".
3. Navigate to Jetpack modules admin page i.e. `/wp-admin/admin.php?page=jetpack_modules&activated=true`
4. Cross reference list of active modules matches the list on https://github.com/Automattic/newspack-plugin/blob/feat/jetpack-default-modules/includes/plugins/class-jetpack.php#L33

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?