### PR TITLE
fix: correct text domains for handoff, healthcheck wizards

### DIFF
--- a/assets/wizards/handoff-banner/index.js
+++ b/assets/wizards/handoff-banner/index.js
@@ -17,9 +17,9 @@ import { Button } from '../../components/src';
 import './style.scss';
 
 const HandoffBanner = ( {
-	bodyText = __( 'Return to Newspack after completing configuration', 'newspack' ),
-	primaryButtonText = __( 'Back to Newspack', 'newspack' ),
-	dismissButtonText = __( 'Dismiss', 'newspack' ),
+	bodyText = __( 'Return to Newspack after completing configuration', 'newspack-plugin' ),
+	primaryButtonText = __( 'Back to Newspack', 'newspack-plugin' ),
+	dismissButtonText = __( 'Dismiss', 'newspack-plugin' ),
 	primaryButtonURL = '/wp-admin/admin.php?page=newspack',
 } ) => {
 	const [ visibility, setVisibility ] = useState( true );

--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -67,12 +67,12 @@ class HealthCheckWizard extends Component {
 		} = healthCheckData;
 		const tabs = [
 			{
-				label: __( 'Plugins', 'newspack' ),
+				label: __( 'Plugins', 'newspack-plugin' ),
 				path: '/',
 				exact: true,
 			},
 			{
-				label: __( 'Configuration' ),
+				label: __( 'Configuration', 'newspack-plugin' ),
 				path: '/configuration',
 			},
 		];
@@ -85,8 +85,8 @@ class HealthCheckWizard extends Component {
 							exact
 							render={ () => (
 								<Plugins
-									headerText={ __( 'Health Check', 'newspack' ) }
-									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
+									headerText={ __( 'Health Check', 'newspack-plugin' ) }
+									subHeaderText={ __( 'Verify and correct site health issues', 'newspack-plugin' ) }
 									deactivateAllPlugins={ this.deactivateAllPlugins }
 									tabbedNavigation={ tabs }
 									missingPlugins={ Object.keys( missingPlugins ) }
@@ -103,8 +103,8 @@ class HealthCheckWizard extends Component {
 							render={ () => (
 								<Configuration
 									hasData={ hasData }
-									headerText={ __( 'Health Check', 'newspack' ) }
-									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
+									headerText={ __( 'Health Check', 'newspack-plugin' ) }
+									subHeaderText={ __( 'Verify and correct site health issues', 'newspack-plugin' ) }
 									tabbedNavigation={ tabs }
 									configurationStatus={ configurationStatus }
 									missingPlugins={ Object.keys( missingPlugins ) }

--- a/assets/wizards/health-check/views/configuration/index.js
+++ b/assets/wizards/health-check/views/configuration/index.js
@@ -28,24 +28,24 @@ class Configuration extends Component {
 				<Fragment>
 					<ActionCard
 						className={ jetpack ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
-						title={ __( 'Jetpack', 'newspack' ) }
+						title={ __( 'Jetpack', 'newspack-plugin' ) }
 						description={
 							jetpack
-								? __( 'Jetpack is connected.', 'newspack' )
-								: __( 'Jetpack is not connected. ', 'newspack' )
+								? __( 'Jetpack is connected.', 'newspack-plugin' )
+								: __( 'Jetpack is not connected. ', 'newspack-plugin' )
 						}
-						actionText={ ! jetpack && __( 'Connect', 'newspack' ) }
+						actionText={ ! jetpack && __( 'Connect', 'newspack-plugin' ) }
 						handoff="jetpack"
 					/>
 					<ActionCard
 						className={ sitekit ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
-						title={ __( 'Google Site Kit', 'newspack' ) }
+						title={ __( 'Google Site Kit', 'newspack-plugin' ) }
 						description={
 							sitekit
-								? __( 'Site Kit is connected.', 'newspack' )
-								: __( 'Site Kit is not connected. ', 'newspack' )
+								? __( 'Site Kit is connected.', 'newspack-plugin' )
+								: __( 'Site Kit is not connected. ', 'newspack-plugin' )
 						}
-						actionText={ ! sitekit && __( 'Connect', 'newspack' ) }
+						actionText={ ! sitekit && __( 'Connect', 'newspack-plugin' ) }
 						handoff="google-site-kit"
 					/>
 				</Fragment>

--- a/assets/wizards/health-check/views/plugins/index.js
+++ b/assets/wizards/health-check/views/plugins/index.js
@@ -33,14 +33,17 @@ class Plugins extends Component {
 			<Grid columns={ 1 } gutter={ 64 }>
 				{ missingPlugins.length ? (
 					<Grid columns={ 1 } gutter={ 16 }>
-						<Notice noticeText={ __( 'These plugins shoud be active:', 'newspack' ) } isWarning />
+						<Notice
+							noticeText={ __( 'These plugins shoud be active:', 'newspack-plugin' ) }
+							isWarning
+						/>
 						<PluginInstaller plugins={ missingPlugins } />
 					</Grid>
 				) : null }
 				{ unsupportedPlugins.length ? (
 					<Grid columns={ 1 } gutter={ 16 }>
 						<Notice
-							noticeText={ __( 'Newspack does not support these plugins:', 'newspack' ) }
+							noticeText={ __( 'Newspack does not support these plugins:', 'newspack-plugin' ) }
 							isError
 						/>
 						{ unsupportedPlugins.map( unsupportedPlugin => (
@@ -53,12 +56,15 @@ class Plugins extends Component {
 						) ) }
 						<div className="newspack-buttons-card">
 							<Button isPrimary onClick={ deactivateAllPlugins }>
-								{ __( 'Deactivate All', 'newspack' ) }
+								{ __( 'Deactivate All', 'newspack-plugin' ) }
 							</Button>
 						</div>
 					</Grid>
 				) : (
-					<Notice noticeText={ __( 'No unsupported plugins found.', 'newspack' ) } isSuccess />
+					<Notice
+						noticeText={ __( 'No unsupported plugins found.', 'newspack-plugin' ) }
+						isSuccess
+					/>
 				) }
 			</Grid>
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR corrects the text-domain in the assets/wizards/handoff and health check directories. 

See 1200550061930446-as-1205509524123559

### How to test the changes in this Pull Request:

1. Spot check the changes in the PR and confirm they're just changing the text domain on translateable strings to `newspack-plugin`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->