### PR TITLE
fix: correct text domains for popup wizard

### DIFF
--- a/assets/wizards/popups/components/campaign-management-popover/index.js
+++ b/assets/wizards/popups/components/campaign-management-popover/index.js
@@ -33,7 +33,7 @@ const CampaignManagementPopover = ( {
 		onKeyDown={ event => ESCAPE === event.keyCode && dismiss() }
 	>
 		<MenuItem onClick={ () => dismiss() } className="screen-reader-text">
-			{ __( 'Close Popover', 'newspack' ) }
+			{ __( 'Close Popover', 'newspack-plugin' ) }
 		</MenuItem>
 
 		{ hasPrompts && (
@@ -44,7 +44,7 @@ const CampaignManagementPopover = ( {
 				} }
 				className="newspack-button"
 			>
-				{ __( 'Activate all prompts', 'newspack' ) }
+				{ __( 'Activate all prompts', 'newspack-plugin' ) }
 			</MenuItem>
 		) }
 		{ hasPublished && (
@@ -55,7 +55,7 @@ const CampaignManagementPopover = ( {
 				} }
 				className="newspack-button"
 			>
-				{ __( 'Deactivate all prompts', 'newspack' ) }
+				{ __( 'Deactivate all prompts', 'newspack-plugin' ) }
 			</MenuItem>
 		) }
 		<MenuItem
@@ -65,7 +65,7 @@ const CampaignManagementPopover = ( {
 			} }
 			className="newspack-button"
 		>
-			{ __( 'Duplicate', 'newspack' ) }
+			{ __( 'Duplicate', 'newspack-plugin' ) }
 		</MenuItem>
 		<MenuItem
 			onClick={ () => {
@@ -74,7 +74,7 @@ const CampaignManagementPopover = ( {
 			} }
 			className="newspack-button"
 		>
-			{ __( 'Rename', 'newspack' ) }
+			{ __( 'Rename', 'newspack-plugin' ) }
 		</MenuItem>
 		{ ! isArchive && (
 			<MenuItem
@@ -84,7 +84,7 @@ const CampaignManagementPopover = ( {
 				} }
 				className="newspack-button"
 			>
-				{ __( 'Archive', 'newspack' ) }
+				{ __( 'Archive', 'newspack-plugin' ) }
 			</MenuItem>
 		) }
 		{ isArchive && (
@@ -95,7 +95,7 @@ const CampaignManagementPopover = ( {
 				} }
 				className="newspack-button"
 			>
-				{ __( 'Unarchive', 'newspack' ) }
+				{ __( 'Unarchive', 'newspack-plugin' ) }
 			</MenuItem>
 		) }
 		<MenuItem
@@ -105,7 +105,7 @@ const CampaignManagementPopover = ( {
 			} }
 			className="newspack-button"
 		>
-			{ __( 'Delete', 'newspack' ) }
+			{ __( 'Delete', 'newspack-plugin' ) }
 		</MenuItem>
 	</Popover>
 );

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -54,7 +54,7 @@ const PromptActionCard = props => {
 
 			setDuplicateTitle( defaultTitle );
 		} catch ( e ) {
-			setDuplicateTitle( title + __( ' copy', 'newspack-popups' ) );
+			setDuplicateTitle( title + __( ' copy', 'newspack-plugin' ) );
 		}
 	};
 
@@ -64,7 +64,7 @@ const PromptActionCard = props => {
 				isSmall
 				badge={ placementForPopup( prompt ) }
 				className={ className }
-				title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack' ) }
+				title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack-plugin' ) }
 				titleLink={ decodeEntities( editLink ) }
 				key={ id }
 				description={ description }
@@ -77,14 +77,14 @@ const PromptActionCard = props => {
 								className={ isSettingsModalVisible && 'popover-active' }
 								onClick={ () => setIsSettingsModalVisible( ! isSettingsModalVisible ) }
 								icon={ settings }
-								label={ __( 'Prompt settings', 'newspack' ) }
+								label={ __( 'Prompt settings', 'newspack-plugin' ) }
 								tooltipPosition="bottom center"
 							/>
 							<Button
 								className={ popoverVisibility && 'popover-active' }
 								onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
 								icon={ moreVertical }
-								label={ __( 'More options', 'newspack' ) }
+								label={ __( 'More options', 'newspack-plugin' ) }
 								tooltipPosition="bottom center"
 							/>
 							{ popoverVisibility && (
@@ -113,7 +113,7 @@ const PromptActionCard = props => {
 					className="newspack-popups__duplicate-modal"
 					title={
 						// Translators: %s: The title of the item.
-						sprintf( __( 'Duplicate “%s”', 'newspack' ), title )
+						sprintf( __( 'Duplicate “%s”', 'newspack-plugin' ), title )
 					}
 					onRequestClose={ () => {
 						setIsDuplicatePromptModalVisible( false );
@@ -127,7 +127,7 @@ const PromptActionCard = props => {
 								isSuccess
 								noticeText={ sprintf(
 									// Translators: %s: The title of the item.
-									__( 'Duplicate of “%s” created as a draft.', 'newspack' ),
+									__( 'Duplicate of “%s” created as a draft.', 'newspack-plugin' ),
 									title
 								) }
 							/>
@@ -136,7 +136,7 @@ const PromptActionCard = props => {
 									isWarning
 									noticeText={ __(
 										'This prompt is currently not assigned to any campaign.',
-										'newspack'
+										'newspack-plugin'
 									) }
 								/>
 							) }
@@ -149,10 +149,10 @@ const PromptActionCard = props => {
 										resetDuplicated();
 									} }
 								>
-									{ __( 'Close', 'newspack' ) }
+									{ __( 'Close', 'newspack-plugin' ) }
 								</Button>
 								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
-									{ __( 'Edit', 'newspack' ) }
+									{ __( 'Edit', 'newspack-plugin' ) }
 								</Button>
 							</Card>
 						</>
@@ -163,13 +163,13 @@ const PromptActionCard = props => {
 									isWarning
 									noticeText={ __(
 										'This prompt will not be assigned to any campaign.',
-										'newspack'
+										'newspack-plugin'
 									) }
 								/>
 							) }
 							<TextControl
 								disabled={ inFlight || null === duplicateTitle }
-								label={ __( 'Title', 'newspack' ) }
+								label={ __( 'Title', 'newspack-plugin' ) }
 								value={ duplicateTitle }
 								onChange={ value => setDuplicateTitle( value ) }
 							/>
@@ -183,7 +183,7 @@ const PromptActionCard = props => {
 										resetDuplicated();
 									} }
 								>
-									{ __( 'Cancel', 'newspack' ) }
+									{ __( 'Cancel', 'newspack-plugin' ) }
 								</Button>
 								<Button
 									disabled={ inFlight || null === duplicateTitle }
@@ -193,7 +193,7 @@ const PromptActionCard = props => {
 										duplicatePopup( id, titleForDuplicate );
 									} }
 								>
-									{ __( 'Duplicate', 'newspack' ) }
+									{ __( 'Duplicate', 'newspack-plugin' ) }
 								</Button>
 							</Card>
 						</>

--- a/assets/wizards/popups/components/prompt-popovers/primary.js
+++ b/assets/wizards/popups/components/prompt-popovers/primary.js
@@ -38,15 +38,15 @@ const PrimaryPromptPopover = ( {
 			className="newspack-popover__campaigns__primary-popover"
 		>
 			<MenuItem onClick={ () => onFocusOutside() } className="screen-reader-text">
-				{ __( 'Close Popover', 'newspack' ) }
+				{ __( 'Close Popover', 'newspack-plugin' ) }
 			</MenuItem>
 			{ isTrash ? (
 				<>
 					<MenuItem onClick={ () => restorePopup( id ) } className="newspack-button">
-						{ __( 'Restore', 'newspack' ) }
+						{ __( 'Restore', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem onClick={ () => deletePopup( id ) } className="newspack-button">
-						{ __( 'Delete permanently', 'newspack' ) }
+						{ __( 'Delete permanently', 'newspack-plugin' ) }
 					</MenuItem>
 				</>
 			) : (
@@ -58,16 +58,16 @@ const PrimaryPromptPopover = ( {
 						} }
 						className="newspack-button"
 					>
-						{ __( 'Preview', 'newspack' ) }
+						{ __( 'Preview', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem href={ decodeEntities( editLink ) } className="newspack-button" isLink>
-						{ __( 'Edit', 'newspack' ) }
+						{ __( 'Edit', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem
 						onClick={ () => setIsDuplicatePromptModalVisible( true ) }
 						className="newspack-button"
 					>
-						{ __( 'Duplicate', 'newspack' ) }
+						{ __( 'Duplicate', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem
 						onClick={ () => {
@@ -76,15 +76,17 @@ const PrimaryPromptPopover = ( {
 						} }
 						className="newspack-button"
 					>
-						{ isPublished ? __( 'Deactivate', 'newspack' ) : __( 'Activate', 'newspack' ) }
+						{ isPublished
+							? __( 'Deactivate', 'newspack-plugin' )
+							: __( 'Activate', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem onClick={ () => deletePopup( id ) } className="newspack-button">
-						{ __( 'Delete', 'newspack' ) }
+						{ __( 'Delete', 'newspack-plugin' ) }
 					</MenuItem>
 				</>
 			) }
 			<div className="newspack-popover__campaigns__info">
-				{ __( 'ID:', 'newspack' ) } { id }
+				{ __( 'ID:', 'newspack-plugin' ) } { id }
 			</div>
 		</Popover>
 	);

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -54,12 +54,12 @@ const SegmentGroup = props => {
 
 	let emptySegmentText;
 	if ( 'unassigned' === campaignId ) {
-		emptySegmentText = __( 'No unassigned prompts in this segment.', 'newspack' );
+		emptySegmentText = __( 'No unassigned prompts in this segment.', 'newspack-plugin' );
 	} else if ( campaignData ) {
 		emptySegmentText =
-			__( 'No prompts in this segment for', 'newspack' ) + ' ' + campaignData.name + '.';
+			__( 'No prompts in this segment for', 'newspack-plugin' ) + ' ' + campaignData.name + '.';
 	} else {
-		emptySegmentText = __( 'No active prompts in this segment.', 'newspack' );
+		emptySegmentText = __( 'No active prompts in this segment.', 'newspack-plugin' );
 	}
 
 	const description = segmentDescription( segment );
@@ -71,12 +71,12 @@ const SegmentGroup = props => {
 						{ id ? (
 							<Button
 								href={ `#/segments/${ id }` }
-								label={ __( 'Edit Segment ', 'newspack' ) }
+								label={ __( 'Edit Segment ', 'newspack-plugin' ) }
 								isLink
 								showTooltip
 								tooltipPosition="bottom center"
 							>
-								{ __( 'Segment: ', 'newspack' ) }
+								{ __( 'Segment: ', 'newspack-plugin' ) }
 								{ label }
 							</Button>
 						) : (
@@ -84,7 +84,7 @@ const SegmentGroup = props => {
 						) }
 					</h3>
 					<span className="newspack-campaigns__segment-group__description">
-						{ id ? description() : __( 'All readers, regardless of segment', 'newspack' ) }
+						{ id ? description() : __( 'All readers, regardless of segment', 'newspack-plugin' ) }
 					</span>
 				</div>
 				<div className="newspack-campaigns__segment-group__card__segment-actions">
@@ -94,7 +94,7 @@ const SegmentGroup = props => {
 						showUnpublished={ !! campaignId } // Only if previewing a specific campaign/group.
 						renderButton={ ( { showPreview } ) => (
 							<Button isSmall variant="tertiary" onClick={ () => showPreview() }>
-								{ __( 'Preview Segment', 'newspack' ) }
+								{ __( 'Preview Segment', 'newspack-plugin' ) }
 							</Button>
 						) }
 					/>
@@ -105,11 +105,11 @@ const SegmentGroup = props => {
 								variant="secondary"
 								onClick={ () => setModalVisible( ! modalVisible ) }
 							>
-								{ __( 'Add New Prompt', 'newspack' ) }
+								{ __( 'Add New Prompt', 'newspack-plugin' ) }
 							</Button>
 							{ modalVisible && (
 								<Modal
-									title={ __( 'Add New Prompt', 'newspack' ) }
+									title={ __( 'Add New Prompt', 'newspack-plugin' ) }
 									onRequestClose={ () => setModalVisible( false ) }
 									shouldCloseOnEsc={ false }
 									shouldCloseOnClickOutside={ false }
@@ -118,52 +118,55 @@ const SegmentGroup = props => {
 									<Grid gutter={ 32 } columns={ 3 }>
 										<ButtonCard
 											href={ addNewURL( 'overlay-center', campaignId, id ) }
-											title={ __( 'Center Overlay', 'newspack' ) }
-											desc={ __( 'Fixed at the center of the screen', 'newspack' ) }
+											title={ __( 'Center Overlay', 'newspack-plugin' ) }
+											desc={ __( 'Fixed at the center of the screen', 'newspack-plugin' ) }
 											icon={ iconOverlayCenter }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'overlay-top', campaignId, id ) }
-											title={ __( 'Top Overlay', 'newspack' ) }
-											desc={ __( 'Fixed at the top of the screen', 'newspack' ) }
+											title={ __( 'Top Overlay', 'newspack-plugin' ) }
+											desc={ __( 'Fixed at the top of the screen', 'newspack-plugin' ) }
 											icon={ iconOverlayTop }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'overlay-bottom', campaignId, id ) }
-											title={ __( 'Bottom Overlay', 'newspack' ) }
-											desc={ __( 'Fixed at the bottom of the screen', 'newspack' ) }
+											title={ __( 'Bottom Overlay', 'newspack-plugin' ) }
+											desc={ __( 'Fixed at the bottom of the screen', 'newspack-plugin' ) }
 											icon={ iconOverlayBottom }
 										/>
 										<ButtonCard
 											href={ addNewURL( null, campaignId, id ) }
-											title={ __( 'Inline', 'newspack' ) }
-											desc={ __( 'Embedded in content', 'newspack' ) }
+											title={ __( 'Inline', 'newspack-plugin' ) }
+											desc={ __( 'Embedded in content', 'newspack-plugin' ) }
 											icon={ iconInline }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'archives', campaignId, id ) }
-											title={ __( 'In Archive Pages', 'newspack' ) }
-											desc={ __( 'Embedded once or many times in archive pages', 'newspack' ) }
+											title={ __( 'In Archive Pages', 'newspack-plugin' ) }
+											desc={ __(
+												'Embedded once or many times in archive pages',
+												'newspack-plugin'
+											) }
 											icon={ postList }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'above-header', campaignId, id ) }
-											title={ __( 'Above Header', 'newspack' ) }
-											desc={ __( 'Embedded at the very top of the page', 'newspack' ) }
+											title={ __( 'Above Header', 'newspack-plugin' ) }
+											desc={ __( 'Embedded at the very top of the page', 'newspack-plugin' ) }
 											icon={ header }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'custom', campaignId, id ) }
-											title={ __( 'Custom Placement', 'newspack' ) }
-											desc={ __( 'Only appears when placed in content', 'newspack' ) }
+											title={ __( 'Custom Placement', 'newspack-plugin' ) }
+											desc={ __( 'Only appears when placed in content', 'newspack-plugin' ) }
 											icon={ layout }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'manual', campaignId, id ) }
-											title={ __( 'Manual Only', 'newspack' ) }
+											title={ __( 'Manual Only', 'newspack-plugin' ) }
 											desc={ __(
 												'Only appears where Single Prompt block is inserted',
-												'newspack'
+												'newspack-plugin'
 											) }
 											icon={ blockTable }
 										/>

--- a/assets/wizards/popups/components/settings-modal/index.js
+++ b/assets/wizards/popups/components/settings-modal/index.js
@@ -41,14 +41,14 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 	return (
 		<Modal title={ prompt.title } onRequestClose={ onClose } isWide>
 			<Button onClick={ () => onClose() } className="screen-reader-text">
-				{ __( 'Close Modal', 'newspack' ) }
+				{ __( 'Close Modal', 'newspack-plugin' ) }
 			</Button>
 			<Grid gutter={ 64 } columns={ 1 }>
 				<SettingsCard
-					title={ __( 'Campaigns', 'newspack' ) }
+					title={ __( 'Campaigns', 'newspack-plugin' ) }
 					description={ __(
 						'Assign a prompt to one or more campaigns for easier management',
-						'newspack'
+						'newspack-plugin'
 					) }
 					columns={ 1 }
 					className="newspack-settings__campaigns"
@@ -58,22 +58,22 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 						disabled={ disabled }
 						value={ promptConfig.campaign_groups || [] }
 						onChange={ tokens => setPromptConfig( { campaign_groups: tokens } ) }
-						label={ __( 'Campaigns', 'newspack' ) }
+						label={ __( 'Campaigns', 'newspack-plugin' ) }
 						taxonomy="newspack_popups_taxonomy"
 						hideLabelFromVision
 					/>
 				</SettingsCard>
 
 				<SettingsCard
-					title={ __( 'Settings', 'newspack' ) }
-					description={ __( 'When and how should the prompt be displayed', 'newspack' ) }
+					title={ __( 'Settings', 'newspack-plugin' ) }
+					description={ __( 'When and how should the prompt be displayed', 'newspack-plugin' ) }
 					columns={ isOverlay( prompt ) ? 3 : 2 }
 					className="newspack-settings__settings"
 					rowGap={ 16 }
 					noBorder
 				>
 					<SelectControl
-						label={ __( 'Frequency', 'newspack' ) }
+						label={ __( 'Frequency', 'newspack-plugin' ) }
 						disabled={ disabled }
 						onChange={ value => {
 							setPromptConfig( { options: { frequency: value } } );
@@ -82,7 +82,11 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 						value={ promptConfig.options.frequency }
 					/>
 					<SelectControl
-						label={ isOverlay( prompt ) ? __( 'Position' ) : __( 'Placement' ) }
+						label={
+							isOverlay( prompt )
+								? __( 'Position', 'newspack-plugin' )
+								: __( 'Placement', 'newspack-plugin' )
+						}
 						disabled={ disabled }
 						onChange={ value => {
 							setPromptConfig( { options: { placement: value } } );
@@ -92,7 +96,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 					/>
 					{ isOverlay( prompt ) && (
 						<SelectControl
-							label={ __( 'Size' ) }
+							label={ __( 'Size', 'newspack-plugin' ) }
 							disabled={ disabled }
 							onChange={ value => {
 								setPromptConfig( { options: { overlay_size: value } } );
@@ -104,14 +108,14 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 				</SettingsCard>
 
 				<SettingsCard
-					title={ __( 'Targeting', 'newspack' ) }
+					title={ __( 'Targeting', 'newspack-plugin' ) }
 					description={ () => (
 						<>
-							{ __( 'Under which conditions should the prompt be displayed', 'newspack' ) }
+							{ __( 'Under which conditions should the prompt be displayed', 'newspack-plugin' ) }
 							<br />
 							{ __(
 								'If multiple conditions are set, all will have to be satisfied in order to display the prompt',
-								'newspack'
+								'newspack-plugin'
 							) }
 						</>
 					) }
@@ -125,22 +129,22 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 							disabled={ disabled }
 							value={ promptConfig.segments || [] }
 							onChange={ tokens => setPromptConfig( { segments: tokens } ) }
-							label={ __( 'Segments', 'newspack' ) }
+							label={ __( 'Segments', 'newspack-plugin' ) }
 							taxonomy="popup_segment"
 						/>
 						<CategoryAutocomplete
-							label={ __( 'Post categories', 'newspack ' ) }
+							label={ __( 'Post categories', 'newspack-plugin' ) }
 							disabled={ disabled }
 							hideHelpFromVision
 							value={ promptConfig.categories || [] }
 							onChange={ tokens => setPromptConfig( { categories: tokens } ) }
 							description={ __(
 								'Prompt will only appear on posts with the specified categories.',
-								'newspack'
+								'newspack-plugin'
 							) }
 						/>
 						<CategoryAutocomplete
-							label={ __( 'Post tags', 'newspack ' ) }
+							label={ __( 'Post tags', 'newspack-plugin' ) }
 							disabled={ disabled }
 							hideHelpFromVision
 							taxonomy="tags"
@@ -148,7 +152,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 							onChange={ tokens => setPromptConfig( { tags: tokens } ) }
 							description={ __(
 								'Prompt will only appear on posts with the specified tags.',
-								'newspack'
+								'newspack-plugin'
 							) }
 						/>
 					</Grid>
@@ -156,15 +160,15 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 						<Button isLink onClick={ () => setShowAdvanced( ! showAdvanced ) }>
 							{ sprintf(
 								// Translators: whether to show or hide advanced settings fields.
-								__( '%s Advanced Settings', 'newspack_popups_taxonomy' ),
-								showAdvanced ? __( 'Hide', 'newspack' ) : __( 'Show', 'newspack' )
+								__( '%s Advanced Settings', 'newspack-plugin' ),
+								showAdvanced ? __( 'Hide', 'newspack-plugin' ) : __( 'Show', 'newspack-plugin' )
 							) }
 						</Button>
 					</div>
 					{ showAdvanced && (
 						<Grid columns={ 3 } rowGap={ 16 }>
 							<CategoryAutocomplete
-								label={ __( 'Category Exclusions', 'newspack ' ) }
+								label={ __( 'Category Exclusions', 'newspack-plugin' ) }
 								disabled={ disabled }
 								hideHelpFromVision
 								value={ excludedCategories || [] }
@@ -177,11 +181,11 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 								}
 								description={ __(
 									'Prompt will not appear on posts with the specified categories.',
-									'newspack'
+									'newspack-plugin'
 								) }
 							/>
 							<CategoryAutocomplete
-								label={ __( 'Tag Exclusions', 'newspack ' ) }
+								label={ __( 'Tag Exclusions', 'newspack-plugin' ) }
 								disabled={ disabled }
 								hideHelpFromVision
 								taxonomy="tags"
@@ -195,7 +199,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 								}
 								description={ __(
 									'Prompt will not appear on posts with the specified tags.',
-									'newspack'
+									'newspack-plugin'
 								) }
 							/>
 						</Grid>
@@ -205,10 +209,10 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 
 			<Card buttonsCard noBorder className="justify-end">
 				<Button onClick={ onClose } variant="secondary">
-					{ __( 'Cancel', 'newspack' ) }
+					{ __( 'Cancel', 'newspack-plugin' ) }
 				</Button>
 				<Button onClick={ handleSave } variant="primary">
-					{ __( 'Save', 'newspack' ) }
+					{ __( 'Save', 'newspack-plugin' ) }
 				</Button>
 			</Card>
 		</Modal>

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -26,27 +26,27 @@ import { CampaignsContext } from './contexts';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
-const headerText = __( 'Campaigns', 'newspack' );
-const subHeaderText = __( 'Reach your readers with configurable campaigns', 'newspack' );
+const headerText = __( 'Campaigns', 'newspack-plugin' );
+const subHeaderText = __( 'Reach your readers with configurable campaigns', 'newspack-plugin' );
 
 const tabbedNavigation = [
 	{
-		label: __( 'Campaigns', 'newpack' ),
+		label: __( 'Campaigns', 'newpack-plugin' ),
 		path: '/campaigns',
 		exact: true,
 	},
 	{
-		label: __( 'Segments', 'newpack' ),
+		label: __( 'Segments', 'newpack-plugin' ),
 		path: '/segments',
 		exact: true,
 	},
 	{
-		label: __( 'Analytics', 'newpack' ),
+		label: __( 'Analytics', 'newpack-plugin' ),
 		path: '/analytics',
 		exact: true,
 	},
 	{
-		label: __( 'Settings', 'newpack' ),
+		label: __( 'Settings', 'newpack-plugin' ),
 		path: '/settings',
 		exact: true,
 	},
@@ -175,7 +175,7 @@ class PopupsWizard extends Component {
 			.catch( () => {
 				setError( {
 					code: 'duplicate_prompt_error',
-					message: __( 'Error duplicating prompt. Please try again later.', 'newspack' ),
+					message: __( 'Error duplicating prompt. Please try again later.', 'newspack-plugin' ),
 				} );
 			} );
 	};

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -49,25 +49,25 @@ export const isCustomPlacement = popup => {
 export const isInline = prompt => ! isOverlay( prompt );
 
 const placementMap = {
-	top: __( 'Top Overlay', 'newspack' ),
-	top_left: __( 'Top Left Overlay', 'newspack' ),
-	top_right: __( 'Top Right Overlay', 'newspack' ),
-	center: __( 'Center Overlay', 'newspack' ),
-	center_left: __( 'Center Left Overlay', 'newspack' ),
-	center_right: __( 'Center Right Overlay', 'newspack' ),
-	bottom: __( 'Bottom Overlay', 'newspack' ),
-	bottom_left: __( 'Bottom Left Overlay', 'newspack' ),
-	bottom_right: __( 'Bottom Right Overlay', 'newspack' ),
-	inline: __( 'Inline', 'newspack' ),
-	archives: __( 'In archive pages', 'newspack' ),
-	above_header: __( 'Above Header', 'newspack' ),
-	manual: __( 'Manual Only', 'newspack' ),
+	top: __( 'Top Overlay', 'newspack-plugin' ),
+	top_left: __( 'Top Left Overlay', 'newspack-plugin' ),
+	top_right: __( 'Top Right Overlay', 'newspack-plugin' ),
+	center: __( 'Center Overlay', 'newspack-plugin' ),
+	center_left: __( 'Center Left Overlay', 'newspack-plugin' ),
+	center_right: __( 'Center Right Overlay', 'newspack-plugin' ),
+	bottom: __( 'Bottom Overlay', 'newspack-plugin' ),
+	bottom_left: __( 'Bottom Left Overlay', 'newspack-plugin' ),
+	bottom_right: __( 'Bottom Right Overlay', 'newspack-plugin' ),
+	inline: __( 'Inline', 'newspack-plugin' ),
+	archives: __( 'In archive pages', 'newspack-plugin' ),
+	above_header: __( 'Above Header', 'newspack-plugin' ),
+	manual: __( 'Manual Only', 'newspack-plugin' ),
 };
 
 export const placementForPopup = ( { options: { frequency, placement } } ) => {
 	const customPlacements = window.newspack_popups_wizard_data?.custom_placements || {};
 	if ( 'manual' === frequency || customPlacements.hasOwnProperty( placement ) ) {
-		return __( 'Custom Placement', 'newspack' );
+		return __( 'Custom Placement', 'newspack-plugin' );
 	}
 	return placementMap[ placement ];
 };
@@ -96,11 +96,11 @@ export const placementsForPopups = prompt => {
 };
 
 const frequencyMap = {
-	once: __( 'Once a month', 'newspack' ),
-	weekly: __( 'Once a week', 'newspack' ),
-	daily: __( 'Once a day', 'newspack' ),
-	always: __( 'Every pageview', 'newspack' ),
-	custom: __( 'Custom frequency (edit prompt to manage)', 'newspack' ),
+	once: __( 'Once a month', 'newspack-plugin' ),
+	weekly: __( 'Once a week', 'newspack-plugin' ),
+	daily: __( 'Once a day', 'newspack-plugin' ),
+	always: __( 'Every pageview', 'newspack-plugin' ),
+	custom: __( 'Custom frequency (edit prompt to manage)', 'newspack-plugin' ),
 };
 
 export const frequenciesForPopup = () => {
@@ -125,27 +125,28 @@ export const promptDescription = prompt => {
 		const campaignsList = campaigns.map( ( { name } ) => name ).join( ', ' );
 		descriptionMessages.push(
 			( campaigns.length === 1
-				? __( 'Campaign: ', 'newspack' )
-				: __( 'Campaigns: ', 'newspack' ) ) + campaignsList
+				? __( 'Campaign: ', 'newspack-plugin' )
+				: __( 'Campaigns: ', 'newspack-plugin' ) ) + campaignsList
 		);
 	}
 	if ( categories.length > 0 ) {
 		descriptionMessages.push(
-			__( 'Categories: ', 'newspack' ) + categories.map( category => category.name ).join( ', ' )
+			__( 'Categories: ', 'newspack-plugin' ) +
+				categories.map( category => category.name ).join( ', ' )
 		);
 	}
 	if ( tags.length > 0 ) {
 		descriptionMessages.push(
-			__( 'Tags: ', 'newspack' ) + tags.map( tag => tag.name ).join( ', ' )
+			__( 'Tags: ', 'newspack-plugin' ) + tags.map( tag => tag.name ).join( ', ' )
 		);
 	}
 	if ( 'pending' === status ) {
-		descriptionMessages.push( __( 'Pending review', 'newspack' ) );
+		descriptionMessages.push( __( 'Pending review', 'newspack-plugin' ) );
 	}
 	if ( 'future' === status ) {
-		descriptionMessages.push( __( 'Scheduled', 'newspack' ) );
+		descriptionMessages.push( __( 'Scheduled', 'newspack-plugin' ) );
 	}
-	descriptionMessages.push( __( 'Frequency: ', 'newspack' ) + frequencyForPopup( prompt ) );
+	descriptionMessages.push( __( 'Frequency: ', 'newspack-plugin' ) + frequencyForPopup( prompt ) );
 	return descriptionMessages.length ? descriptionMessages.join( ' | ' ) : null;
 };
 
@@ -154,7 +155,7 @@ export const segmentDescription = segment => {
 
 	// If the segment is disabled.
 	if ( segment.configuration.is_disabled ) {
-		descriptionMessages.push( __( 'Segment disabled', 'newspack' ) );
+		descriptionMessages.push( __( 'Segment disabled', 'newspack-plugin' ) );
 	}
 
 	if ( segment.criteria ) {
@@ -237,7 +238,7 @@ const FavoriteCategoriesNames = ( { ids } ) => {
 	}
 	return (
 		<span>
-			{ __( 'Favorite Categories:', 'newspack' ) }{ ' ' }
+			{ __( 'Favorite Categories:', 'newspack-plugin' ) }{ ' ' }
 			{ favoriteCategoryNames.length ? favoriteCategoryNames.join( ', ' ) : '' }
 		</span>
 	);
@@ -305,7 +306,9 @@ addFilter(
 			return (
 				<ItemNames
 					label={
-						config.id === 'subscribed_lists' ? __( 'Subscribed to:' ) : __( 'Not subscribed to:' )
+						config.id === 'subscribed_lists'
+							? __( 'Subscribed to:', 'newspack-plugin' )
+							: __( 'Not subscribed to:', 'newspack-plugin' )
 					}
 					ids={ item.value }
 					path="/newspack-newsletters/v1/lists_config"
@@ -328,8 +331,8 @@ addFilter(
 				<ItemNames
 					label={
 						config.id === 'active_subscriptions'
-							? __( 'Has active subscription(s):' )
-							: __( 'Does not have active subscription(s):' )
+							? __( 'Has active subscription(s):', 'newspack-plugin' )
+							: __( 'Does not have active subscription(s):', 'newspack-plugin' )
 					}
 					ids={ item.value }
 					path="/newspack/v1/wizard/newspack-popups-wizard/subscription-products"
@@ -352,8 +355,8 @@ addFilter(
 				<ItemNames
 					label={
 						config.id === 'active_memberships'
-							? __( 'Has active membership(s):' )
-							: __( 'Does not have active membership(s):' )
+							? __( 'Has active membership(s):', 'newspack-plugin' )
+							: __( 'Does not have active membership(s):', 'newspack-plugin' )
 					}
 					ids={ item.value }
 					path="/wc/v3/memberships/plans?per_page=100"
@@ -382,13 +385,14 @@ export const buildWarning = ( prompt, promptCategories ) => {
 		return sprintf(
 			// Translators: %1: 'uncetegorized' if no categories. %2: 'above-header prompts' if above header, 'overlays' otherwise. %3: 'and category filtering' if categories.
 			__(
-				'If multiple%1$s %2$s share the same segment%3$s, only the most recent one will be displayed.'
+				'If multiple%1$s %2$s share the same segment%3$s, only the most recent one will be displayed.',
+				'newspack-plugin'
 			),
-			0 === promptCategories.length ? __( ' uncategorized', 'newspack' ) : '',
+			0 === promptCategories.length ? __( ' uncategorized', 'newspack-plugin' ) : '',
 			isAboveHeader( prompt )
-				? __( 'above-header prompts', 'newspack' )
-				: __( 'overlays', 'newspack' ),
-			0 < promptCategories.length ? __( ' and category filtering', 'newspack' ) : ''
+				? __( 'above-header prompts', 'newspack-plugin' )
+				: __( 'overlays', 'newspack-plugin' ),
+			0 < promptCategories.length ? __( ' and category filtering', 'newspack-plugin' ) : ''
 		);
 	}
 
@@ -396,10 +400,11 @@ export const buildWarning = ( prompt, promptCategories ) => {
 		return sprintf(
 			// Translators: %1: 'uncetegorized' if no categories. %2: 'and category filtering' if categories.
 			__(
-				'If multiple%1$s prompts in the same custom placement share the same segment%2$s, only the most recent one will be displayed.'
+				'If multiple%1$s prompts in the same custom placement share the same segment%2$s, only the most recent one will be displayed.',
+				'newspack-plugin'
 			),
-			0 === promptCategories.length ? __( ' uncategorized', 'newspack' ) : '',
-			0 < promptCategories.length ? __( ' and category filtering', 'newspack' ) : ''
+			0 === promptCategories.length ? __( ' uncategorized', 'newspack-plugin' ) : '',
+			0 < promptCategories.length ? __( ' and category filtering', 'newspack-plugin' ) : ''
 		);
 	}
 
@@ -448,10 +453,10 @@ export const warningForPopup = ( prompts, prompt ) => {
 					<strong>
 						{ sprintf(
 							// Translators: %s: 'Conflicts' or 'Conflict' depending on number of conflicts.
-							__( '%s detected:', 'newspack' ),
+							__( '%s detected:', 'newspack-plugin' ),
 							1 < filteredConflictingPrompts.length
-								? __( 'Conflicts', 'newspack' )
-								: __( 'Conflict', 'newspack' )
+								? __( 'Conflicts', 'newspack-plugin' )
+								: __( 'Conflict', 'newspack-plugin' )
 						) }
 					</strong>
 					<ul>

--- a/assets/wizards/popups/views/analytics/index.js
+++ b/assets/wizards/popups/views/analytics/index.js
@@ -15,17 +15,17 @@ import './style.scss';
 const PopupAnalytics = () => (
 	<div className="newspack-campaigns-wizard-analytics__wrapper">
 		<Card isNarrow>
-			<h2>{ __( 'Coming soon', 'newspack' ) }</h2>
+			<h2>{ __( 'Coming soon', 'newspack-plugin' ) }</h2>
 			<p>
 				<>
 					{ __(
 						'We’re currently redesigning this dashboard to accommodate GA4 and give you deeper insights into Campaign performance. In the meantime, you can find Campaign event data within your GA account. Review this ',
-						'newspack'
+						'newspack-plugin'
 					) }
 					<a target="_blank" rel="noopener noreferrer" href="https://help.newspack.com/analytics/">
-						{ __( 'help page', 'newspack' ) }
+						{ __( 'help page', 'newspack-plugin' ) }
 					</a>
-					{ __( ' to see how Campaign data is being recorded in GA.', 'newspack' ) },
+					{ __( ' to see how Campaign data is being recorded in GA.', 'newspack-plugin' ) },
 				</>
 			</p>
 			<Card buttonsCard noBorder>
@@ -35,7 +35,7 @@ const PopupAnalytics = () => (
 					href="https://help.newspack.com/analytics/"
 					isPrimary
 				>
-					{ __( 'View the help page', 'newspack' ) }
+					{ __( 'View the help page', 'newspack-plugin' ) }
 				</Button>
 			</Card>
 		</Card>

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -43,20 +43,20 @@ const DEFAULT_CAMPAIGNS_FILTER = 'active';
 
 const modalTitle = modalType => {
 	if ( MODAL_TYPE_RENAME === modalType ) {
-		return __( 'Rename Campaign', 'newspack' );
+		return __( 'Rename Campaign', 'newspack-plugin' );
 	} else if ( MODAL_TYPE_DUPLICATE === modalType ) {
-		return __( 'Duplicate Campaign', 'newspack' );
+		return __( 'Duplicate Campaign', 'newspack-plugin' );
 	}
-	return __( 'Add New Campaign', 'newspack' );
+	return __( 'Add New Campaign', 'newspack-plugin' );
 };
 
 const modalButton = modalType => {
 	if ( MODAL_TYPE_RENAME === modalType ) {
-		return __( 'Rename', 'newspack' );
+		return __( 'Rename', 'newspack-plugin' );
 	} else if ( MODAL_TYPE_DUPLICATE === modalType ) {
-		return __( 'Duplicate', 'newspack' );
+		return __( 'Duplicate', 'newspack-plugin' );
 	}
-	return __( 'Add', 'newspack' );
+	return __( 'Add', 'newspack-plugin' );
 };
 
 const filterByCampaign = ( prompts, campaignId ) => {
@@ -99,7 +99,7 @@ const groupBySegment = ( segments, prompts ) => {
 		} ) )
 	);
 	grouped.push( {
-		label: __( 'Everyone', 'newspack' ),
+		label: __( 'Everyone', 'newspack-plugin' ),
 		id: '',
 		prompts: prompts.filter( ( { segments: _segments } ) => _segments.length === 0 ),
 		configuration: {},
@@ -160,21 +160,21 @@ const Campaigns = props => {
 	const campaignsSelectOptions = [
 		{
 			key: DEFAULT_CAMPAIGNS_FILTER,
-			name: __( 'Active Prompts', 'newspack' ),
+			name: __( 'Active Prompts', 'newspack-plugin' ),
 		},
 		{
 			key: 'all',
-			name: __( 'All Prompts', 'newspack' ),
+			name: __( 'All Prompts', 'newspack-plugin' ),
 		},
 		{
 			key: 'trash',
-			name: __( 'Trash', 'newspack' ),
+			name: __( 'Trash', 'newspack-plugin' ),
 		},
 		...( hasUnassigned
 			? [
 					{
 						key: 'unassigned',
-						name: __( 'Unassigned Prompts', 'newspack' ),
+						name: __( 'Unassigned Prompts', 'newspack-plugin' ),
 					},
 			  ]
 			: [] ),
@@ -182,7 +182,7 @@ const Campaigns = props => {
 			? [
 					{
 						key: 'header-campaigns',
-						name: __( 'Campaigns', 'newspack' ),
+						name: __( 'Campaigns', 'newspack-plugin' ),
 						className: 'is-header',
 					},
 			  ]
@@ -196,14 +196,14 @@ const Campaigns = props => {
 			? [
 					{
 						key: 'header-archived-campaigns',
-						name: __( 'Archived Campaigns', 'newspack' ),
+						name: __( 'Archived Campaigns', 'newspack-plugin' ),
 						className: 'is-header',
 					},
 			  ]
 			: [] ),
 		...archivedCampaigns.map( ( { term_id: id, name } ) => ( {
 			key: String( id ),
-			name: name + ' ' + __( '(archived)', 'newspack' ),
+			name: name + ' ' + __( '(archived)', 'newspack-plugin' ),
 			className: 'newspack-campaigns__campaign-group__select-control-group-item',
 		} ) ),
 	];
@@ -213,7 +213,7 @@ const Campaigns = props => {
 			<Card headerActions noBorder>
 				<div className="newspack-campaigns__campaign-group__filter-group-actions">
 					<CustomSelectControl
-						label={ __( 'Campaigns', 'newspack' ) }
+						label={ __( 'Campaigns', 'newspack-plugin' ) }
 						options={ campaignsSelectOptions.map( option => ( {
 							...option,
 							className: classnames( option.className, {
@@ -237,7 +237,7 @@ const Campaigns = props => {
 								className={ popoverVisible && 'popover-active' }
 								onClick={ () => setPopoverVisible( ! popoverVisible ) }
 								icon={ moreVertical }
-								label={ __( 'Actions', 'newspack' ) }
+								label={ __( 'Actions', 'newspack-plugin' ) }
 								tooltipPosition="bottom center"
 							/>
 							{ popoverVisible && (
@@ -275,7 +275,7 @@ const Campaigns = props => {
 							setModalType( MODAL_TYPE_NEW );
 						} }
 					>
-						{ __( 'Add New Campaign', 'newspack' ) }
+						{ __( 'Add New Campaign', 'newspack-plugin' ) }
 					</Button>
 					{ modalVisible && (
 						<Modal
@@ -286,9 +286,9 @@ const Campaigns = props => {
 						>
 							<div ref={ modalTextRef }>
 								<TextControl
-									placeholder={ __( 'Campaign Name', 'newspack' ) }
+									placeholder={ __( 'Campaign Name', 'newspack-plugin' ) }
 									onChange={ setCampaignName }
-									label={ __( 'Campaign Name', 'newspack' ) }
+									label={ __( 'Campaign Name', 'newspack-plugin' ) }
 									hideLabelFromVision={ true }
 									value={ campaignName }
 									onKeyDown={ event => {
@@ -306,7 +306,7 @@ const Campaigns = props => {
 										setModalVisible( false );
 									} }
 								>
-									{ __( 'Cancel', 'newspack' ) }
+									{ __( 'Cancel', 'newspack-plugin' ) }
 								</Button>
 								<Button
 									variant="primary"

--- a/assets/wizards/popups/views/segments/segments-list.js
+++ b/assets/wizards/popups/views/segments/segments-list.js
@@ -17,7 +17,7 @@ const { NavLink, useHistory } = Router;
 
 const AddNewSegmentLink = () => (
 	<NavLink to="segments/new">
-		<Button variant="primary">{ __( 'Add New Segment', 'newspack' ) }</Button>
+		<Button variant="primary">{ __( 'Add New Segment', 'newspack-plugin' ) }</Button>
 	</NavLink>
 );
 
@@ -181,7 +181,7 @@ const SegmentActionCard = ( {
 							<>
 								<Button
 									onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
-									label={ __( 'More options', 'newspack' ) }
+									label={ __( 'More options', 'newspack-plugin' ) }
 									icon={ moreVertical }
 									className={ popoverVisibility && 'popover-active' }
 								/>
@@ -192,19 +192,19 @@ const SegmentActionCard = ( {
 										onFocusOutside={ onFocusOutside }
 									>
 										<MenuItem onClick={ () => onFocusOutside() } className="screen-reader-text">
-											{ __( 'Close Popover', 'newspack' ) }
+											{ __( 'Close Popover', 'newspack-plugin' ) }
 										</MenuItem>
 										<MenuItem
 											onClick={ () => history.push( `/segments/${ segment.id }` ) }
 											className="newspack-button"
 										>
-											{ __( 'Edit', 'newspack' ) }
+											{ __( 'Edit', 'newspack-plugin' ) }
 										</MenuItem>
 										<MenuItem
 											onClick={ () => deleteSegment( segment ) }
 											className="newspack-button"
 										>
-											{ __( 'Delete', 'newspack' ) }
+											{ __( 'Delete', 'newspack-plugin' ) }
 										</MenuItem>
 									</Popover>
 								) }
@@ -225,13 +225,13 @@ const SegmentActionCard = ( {
 									icon={ chevronUp }
 									onClick={ moveUp }
 									disabled={ isFirstTarget }
-									label={ __( 'Move segment position up', 'newspack' ) }
+									label={ __( 'Move segment position up', 'newspack-plugin' ) }
 								/>
 								<Button
 									icon={ chevronDown }
 									onClick={ moveDown }
 									disabled={ isLastTarget }
-									label={ __( 'Move segment position down', 'newspack' ) }
+									label={ __( 'Move segment position down', 'newspack-plugin' ) }
 								/>
 							</div>
 						</div>
@@ -307,7 +307,10 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 			} )
 			.catch( e => {
 				setInFlight( false );
-				setError( e.message || __( 'There was an error sorting segments. Please try again.' ) );
+				setError(
+					e.message ||
+						__( 'There was an error sorting segments. Please try again.', 'newspack-plugin' )
+				);
 				setSegments( segments );
 			} );
 	};
@@ -323,7 +326,7 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 		<Fragment>
 			{ error && <Notice noticeText={ error } isError /> }
 			<Card headerActions noBorder>
-				<h2>{ __( 'Audience segments', 'newspack' ) }</h2>
+				<h2>{ __( 'Audience segments', 'newspack-plugin' ) }</h2>
 				<AddNewSegmentLink />
 			</Card>
 			<div
@@ -351,13 +354,13 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 	) : (
 		<Fragment>
 			<Card headerActions noBorder>
-				<h2>{ __( 'You have no saved audience segments.', 'newspack' ) }</h2>
+				<h2>{ __( 'You have no saved audience segments.', 'newspack-plugin' ) }</h2>
 				<AddNewSegmentLink />
 			</Card>
 			<p>
 				{ __(
 					'Create audience segments to target visitors by engagement, activity, and more.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			</p>
 		</Fragment>

--- a/assets/wizards/popups/views/segments/single-segment.js
+++ b/assets/wizards/popups/views/segments/single-segment.js
@@ -55,7 +55,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 
 	const unblock = hooks.usePrompt(
 		isDirty,
-		__( 'There are unsaved changes to this segment. Discard changes?', 'newspack' )
+		__( 'There are unsaved changes to this segment. Discard changes?', 'newspack-plugin' )
 	);
 
 	const isNew = segmentId === 'new';
@@ -169,31 +169,31 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	return (
 		<Fragment>
 			<TextControl
-				placeholder={ __( 'Untitled Segment', 'newspack' ) }
+				placeholder={ __( 'Untitled Segment', 'newspack-plugin' ) }
 				value={ name }
 				onChange={ setName }
-				label={ __( 'Title', 'newspack' ) }
+				label={ __( 'Title', 'newspack-plugin' ) }
 				className={ 'newspack-campaigns-wizard-segments__title' }
 			/>
 
 			<SettingsCard
-				title={ __( 'Segment Status', 'newspack' ) }
+				title={ __( 'Segment Status', 'newspack-plugin' ) }
 				description={ __(
 					'If not enabled, the segment will be ignored for reader segmentation.',
-					'newspack'
+					'newspack-plugin'
 				) }
 				noBorder
 			>
 				<ToggleControl
-					label={ __( 'Segment enabled', 'newspack' ) }
+					label={ __( 'Segment enabled', 'newspack-plugin' ) }
 					checked={ ! segmentConfig.is_disabled }
 					onChange={ () => updateSegmentConfig( { is_disabled: ! segmentConfig.is_disabled } ) }
 				/>
 			</SettingsCard>
 
 			<SettingsCard
-				title={ __( 'Reader Engagement', 'newspack' ) }
-				description={ __( 'Target readers based on their browsing behavior.', 'newspack' ) }
+				title={ __( 'Reader Engagement', 'newspack-plugin' ) }
+				description={ __( 'Target readers based on their browsing behavior.', 'newspack-plugin' ) }
 				noBorder
 			>
 				{ allCriteria
@@ -209,10 +209,10 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					) ) }
 			</SettingsCard>
 			<SettingsCard
-				title={ __( 'Registration', 'newspack' ) }
+				title={ __( 'Registration', 'newspack-plugin' ) }
 				description={ __(
 					'Target readers based on their user account registration status.',
-					'newspack'
+					'newspack-plugin'
 				) }
 				columns={ 3 }
 				noBorder
@@ -230,10 +230,10 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					) ) }
 			</SettingsCard>
 			<SettingsCard
-				title={ __( 'Newsletters', 'newspack' ) }
+				title={ __( 'Newsletters', 'newspack-plugin' ) }
 				description={ __(
 					'Target readers based on their newsletter subscription status.',
-					'newspack'
+					'newspack-plugin'
 				) }
 				columns={ 3 }
 				noBorder
@@ -251,8 +251,8 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					) ) }
 			</SettingsCard>
 			<SettingsCard
-				title={ __( 'Reader Revenue', 'newspack' ) }
-				description={ __( 'Target readers based on their revenue activity.', 'newspack' ) }
+				title={ __( 'Reader Revenue', 'newspack-plugin' ) }
+				description={ __( 'Target readers based on their revenue activity.', 'newspack-plugin' ) }
 				columns={ 3 }
 				noBorder
 			>
@@ -269,11 +269,14 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					) ) }
 			</SettingsCard>
 			<SettingsCard
-				title={ __( 'Referrer Sources', 'newspack' ) }
-				description={ __( 'Target readers based on where they’re coming from.', 'newspack' ) }
+				title={ __( 'Referrer Sources', 'newspack-plugin' ) }
+				description={ __(
+					'Target readers based on where they’re coming from.',
+					'newspack-plugin'
+				) }
 				notification={ __(
 					'Segments using these options will apply only to the first page visited after coming from an external source.',
-					'newspack'
+					'newspack-plugin'
 				) }
 				columns={ 2 }
 				noBorder
@@ -296,10 +299,10 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					isPrimary
 					onClick={ saveSegment }
 				>
-					{ __( 'Save', 'newspack' ) }
+					{ __( 'Save', 'newspack-plugin' ) }
 				</Button>
 				<Button isSecondary href="#/segments">
-					{ __( 'Cancel', 'newspack' ) }
+					{ __( 'Cancel', 'newspack-plugin' ) }
 				</Button>
 			</div>
 		</Fragment>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR corrects the text-domain in the assets/wizards/popups directory.

See 1200550061930446-as-1205509524123559

### How to test the changes in this Pull Request:

1. Spot check the changes in the PR and confirm they're just changing the text domain on translateable strings to `newspack-plugin`.
2. Run `npm run build` on this branch, and spot-check the Campaign wizard screens.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->