### PR TITLE
fix: setup causing fatal when no themes are installed

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -573,7 +573,7 @@ class Plugin_Manager {
 		}
 
 		$plugins = array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'reduce_plugin_info' ) );
-		$themes  = array_reduce( array_keys( wp_get_themes() ), array( __CLASS__, 'reduce_plugin_info' ) );
+		$themes  = array_reduce( array_keys( wp_get_themes() ), array( __CLASS__, 'reduce_plugin_info' ) ) ?? [];
 		return array_merge( $plugins, $themes );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a new site, that has no themes installed, runs the Newspack setup wizard the below fatal is returned.

```sh
PHP Fatal error:  Uncaught TypeError: array_merge(): Argument #2 must be of type array, null given in /var/www/html/.shared/plugins/newspack-plugin/includes/class-plugin-manager.php:577
```

### How to test the changes in this Pull Request:

1. Open up a local site that has not yet been setup OR create a new site.
2. Make sure no themes are present in `/wp-content/themes/`
3. Activate `newspack-plugin` plugin
4. Navigate to Newspack setup wizard i.e. `/wp-admin/admin.php?page=newspack-setup-wizard`
5. Initiate setup.
6. Observe that setup has run successfully with no fatal errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?