### PR TITLE
fix: prevent post lock when fetching metadata

### DIFF
--- a/assets/blocks/core-image/index.tsx
+++ b/assets/blocks/core-image/index.tsx
@@ -9,6 +9,7 @@
 // External
 import classnames from 'classnames';
 // WordPress
+import { useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { useState, useEffect } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -57,6 +58,12 @@ addFilter(
 		) => {
 			const caption = ( props.attributes.caption ?? '' ).trim();
 			const [ isCaptionVisible, setIsCaptionVisible ] = useState< boolean >( '' !== caption );
+			const { url: siteUrl }: { url: string } = useSelect(
+				select => select( 'core' ).getSite(),
+				[ props.attributes.url ]
+			) ?? {
+				url: '',
+			};
 
 			// If caption visibility is toggled off, clear the caption
 			useEffect( () => {
@@ -78,7 +85,9 @@ addFilter(
 									setAttributes={ props.setAttributes }
 									isCaptionVisible={ isCaptionVisible }
 								/>
-								<Loader attributes={ props.attributes } setAttributes={ props.setAttributes } />
+								{ siteUrl && props.attributes.url.includes( siteUrl ) && (
+									<Loader attributes={ props.attributes } setAttributes={ props.setAttributes } />
+								) }
 								<Toolbar
 									isCaptionVisible={ isCaptionVisible }
 									setIsCaptionVisible={ setIsCaptionVisible }

--- a/assets/blocks/core-image/loader.tsx
+++ b/assets/blocks/core-image/loader.tsx
@@ -8,7 +8,7 @@
 // WordPress
 import { Spinner } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 /**
  * Types
  */
@@ -16,7 +16,6 @@ import { AttributesMeta, AttributeProps } from './types';
 
 const Loader = ( { attributes, setAttributes }: AttributeProps ) => {
 	const imageId = attributes.id ?? 0;
-	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
 	const { meta }: { meta: AttributesMeta } = useSelect(
 		select => select( 'core' ).getMedia( imageId ),
 		[ imageId ]
@@ -27,9 +26,6 @@ const Loader = ( { attributes, setAttributes }: AttributeProps ) => {
 		if ( Object.keys( meta ).length ) {
 			const { _media_credit, _media_credit_url, _navis_media_credit_org } = meta;
 			setAttributes( { meta: { _media_credit, _media_credit_url, _navis_media_credit_org } } );
-			unlockPostSaving( 'attachment-meta-empty' );
-		} else {
-			lockPostSaving( 'attachment-meta-empty' );
 		}
 	}, [ Object.keys( meta ).length, attributes.caption ] );
 

--- a/assets/blocks/core-image/style.scss
+++ b/assets/blocks/core-image/style.scss
@@ -7,8 +7,6 @@
 
 // Base styles for newspack-block__core-image
 .newspack-block__core-image {
-    --wp-block-image-caption-credit: " ";
-
     margin: 0 auto 2em;
     position: relative;
     width: fit-content;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#2936 added a feature to add credit-related metadata to images. If the media post request fails for any reason, the loading animation and post locking will be on indefinitely. 

Ideally, the request failure should be handled somehow, but as a quick solution (just not to block workflow), this PR removes the post locking.

### How to test the changes in this Pull Request:

1. Insert an image with a credit metadata in a post, observe the "Publish" button is not disabled while the metadata is loading, but the image features a loader

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->