### PR TITLE
fix(ras): check for auth status before updating my account label

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -120,7 +120,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 						try {
 							const labels = JSON.parse( link.getAttribute( 'data-labels' ) );
 							link.querySelector( '.newspack-reader__account-link__label' ).textContent =
-								reader?.email ? labels.signedin : labels.signedout;
+								reader?.email && reader?.authenticated ? labels.signedin : labels.signedout;
 						} catch {}
 					} );
 				}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR addresses an issue where the RAS my account button label was incorrectly outputting the logged in state label when a user logged in user logged out. RAS continues to store the last logged in user email as well as auth state to populate the sign in field for convenience when a user wants to log back in. The my account button label also relies on this email data to decide what text to render (My Account OR Sign In). However, we weren't properly checking auth state when deciding this label text, which led to a mismatch in button labels and a users login state.

![Screenshot 2024-03-04 at 12 43 21](https://github.com/Automattic/newspack-plugin/assets/17905991/9f3bf939-b2e5-47f1-96b5-6c9d9c7b81cf)

### How to test the changes in this Pull Request:

1. Log into a reader account on a test site
2. Log out via the my account menu
3. Go to the homepage
4. On `trunk` you will see the RAS Login/My Account button incorrectly display "My Account" text which is meant to be shown to logged in users
5. On this branch, this will correctly display Sign In

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206594628640816