### PR TITLE
fix(ras): reset otp inputs when switching login actions

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -250,9 +250,14 @@ window.newspackRAS.push( function ( readerActivation ) {
 					if ( ! readerActivation.getOTPHash() ) {
 						return;
 					}
+					createOTPInputs();
 				}
 				if ( [ 'link', 'pwd' ].includes( action ) ) {
 					readerActivation.setAuthStrategy( action );
+					if ( 'link' === action ) {
+						// Destroy any existing OTP input.
+						destroyOTPInputs();
+					}
 				}
 				actionInput.value = action;
 				container.removeAttribute( 'data-form-status' );
@@ -291,11 +296,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 							? 'register'
 							: readerActivation.getAuthStrategy() || 'link'
 					);
-				}
-			} );
-			readerActivation.on( 'reader', () => {
-				if ( readerActivation.getOTPHash() ) {
-					setFormAction( 'otp' );
 				}
 			} );
 			container.querySelectorAll( '[data-set-action]' ).forEach( item => {
@@ -455,95 +455,111 @@ window.newspackRAS.push( function ( readerActivation ) {
 		/**
 		 * OTP Input
 		 */
-		const otpInputs = document.querySelectorAll( 'input[name="otp_code"]' );
-		otpInputs.forEach( originalInput => {
-			const length = parseInt( originalInput.getAttribute( 'maxlength' ) );
-			if ( ! length ) {
-				return;
-			}
-			const inputContainer = originalInput.parentNode;
-			inputContainer.removeChild( originalInput );
-			const values = [];
-			const otpCodeInput = document.createElement( 'input' );
-			otpCodeInput.setAttribute( 'type', 'hidden' );
-			otpCodeInput.setAttribute( 'name', 'otp_code' );
-			inputContainer.appendChild( otpCodeInput );
-			for ( let i = 0; i < length; i++ ) {
-				const digit = document.createElement( 'input' );
-				digit.setAttribute( 'type', 'text' );
-				digit.setAttribute( 'maxlength', '1' );
-				digit.setAttribute( 'pattern', '[0-9]' );
-				digit.setAttribute( 'autocomplete', 'off' );
-				digit.setAttribute( 'inputmode', 'numeric' );
-				digit.setAttribute( 'data-index', i );
-				digit.addEventListener( 'keydown', ev => {
-					const prev = inputContainer.querySelector( `[data-index="${ i - 1 }"]` );
-					const next = inputContainer.querySelector( `[data-index="${ i + 1 }"]` );
-					switch ( ev.key ) {
-						case 'Backspace':
-							ev.preventDefault();
-							ev.target.value = '';
-							if ( prev ) {
-								prev.focus();
-							}
-							values[ i ] = '';
-							otpCodeInput.value = values.join( '' );
-							break;
-						case 'ArrowLeft':
-							ev.preventDefault();
-							if ( prev ) {
-								prev.focus();
-							}
-							break;
-						case 'ArrowRight':
-							ev.preventDefault();
-							if ( next ) {
-								next.focus();
-							}
-							break;
-						default:
-							if ( ev.key.match( /^[0-9]$/ ) ) {
+		function createOTPInputs() {
+			const otpInputs = document.querySelectorAll( 'input[name="otp_code"]' );
+			otpInputs.forEach( originalInput => {
+				const length = parseInt( originalInput.getAttribute( 'maxlength' ) );
+				if ( ! length ) {
+					return;
+				}
+				const inputContainer = originalInput.parentNode;
+				inputContainer.removeChild( originalInput );
+				const values = [];
+				const otpCodeInput = document.createElement( 'input' );
+				otpCodeInput.setAttribute( 'type', 'hidden' );
+				otpCodeInput.setAttribute( 'name', 'otp_code' );
+				otpCodeInput.setAttribute( 'maxlength', length );
+				inputContainer.appendChild( otpCodeInput );
+				for ( let i = 0; i < length; i++ ) {
+					const digit = document.createElement( 'input' );
+					digit.setAttribute( 'name', 'otp_code_input' );
+					digit.setAttribute( 'type', 'text' );
+					digit.setAttribute( 'maxlength', '1' );
+					digit.setAttribute( 'pattern', '[0-9]' );
+					digit.setAttribute( 'autocomplete', 'off' );
+					digit.setAttribute( 'inputmode', 'numeric' );
+					digit.setAttribute( 'data-index', i );
+					digit.addEventListener( 'keydown', ev => {
+						const prev = inputContainer.querySelector( `[data-index="${ i - 1 }"]` );
+						const next = inputContainer.querySelector( `[data-index="${ i + 1 }"]` );
+						switch ( ev.key ) {
+							case 'Backspace':
 								ev.preventDefault();
-								ev.target.value = ev.key;
-								ev.target.dispatchEvent(
-									new Event( 'input', {
-										bubbles: true,
-										cancelable: true,
-									} )
-								);
+								ev.target.value = '';
+								if ( prev ) {
+									prev.focus();
+								}
+								values[ i ] = '';
+								otpCodeInput.value = values.join( '' );
+								break;
+							case 'ArrowLeft':
+								ev.preventDefault();
+								if ( prev ) {
+									prev.focus();
+								}
+								break;
+							case 'ArrowRight':
+								ev.preventDefault();
 								if ( next ) {
 									next.focus();
 								}
-							}
-							break;
-					}
-				} );
-				digit.addEventListener( 'input', ev => {
-					if ( ev.target.value.match( /^[0-9]$/ ) ) {
-						values[ i ] = ev.target.value;
-					} else {
-						ev.target.value = '';
-					}
-					otpCodeInput.value = values.join( '' );
-				} );
-				digit.addEventListener( 'paste', ev => {
-					ev.preventDefault();
-					const paste = ( ev.clipboardData || window.clipboardData ).getData( 'text' );
-					if ( paste.length !== length ) {
-						return;
-					}
-					for ( let j = 0; j < length; j++ ) {
-						if ( paste[ j ].match( /^[0-9]$/ ) ) {
-							const digitInput = inputContainer.querySelector( `[data-index="${ j }"]` );
-							digitInput.value = paste[ j ];
-							values[ j ] = paste[ j ];
+								break;
+							default:
+								if ( ev.key.match( /^[0-9]$/ ) ) {
+									ev.preventDefault();
+									ev.target.value = ev.key;
+									ev.target.dispatchEvent(
+										new Event( 'input', {
+											bubbles: true,
+											cancelable: true,
+										} )
+									);
+									if ( next ) {
+										next.focus();
+									}
+								}
+								break;
 						}
-					}
-					otpCodeInput.value = values.join( '' );
+					} );
+					digit.addEventListener( 'input', ev => {
+						if ( ev.target.value.match( /^[0-9]$/ ) ) {
+							values[ i ] = ev.target.value;
+						} else {
+							ev.target.value = '';
+						}
+						otpCodeInput.value = values.join( '' );
+					} );
+					digit.addEventListener( 'paste', ev => {
+						ev.preventDefault();
+						const paste = ( ev.clipboardData || window.clipboardData ).getData( 'text' );
+						if ( paste.length !== length ) {
+							return;
+						}
+						for ( let j = 0; j < length; j++ ) {
+							if ( paste[ j ].match( /^[0-9]$/ ) ) {
+								const digitInput = inputContainer.querySelector( `[data-index="${ j }"]` );
+								digitInput.value = paste[ j ];
+								values[ j ] = paste[ j ];
+							}
+						}
+						otpCodeInput.value = values.join( '' );
+					} );
+					inputContainer.appendChild( digit );
+				}
+			} );
+		}
+
+		function destroyOTPInputs() {
+			const otpInputs = document.querySelectorAll( 'input[name="otp_code"]' );
+			otpInputs.forEach( originalInput => {
+				originalInput.value = '';
+				const inputContainer = originalInput.parentNode;
+				const digits = inputContainer.querySelectorAll( 'input[name="otp_code_input"]' );
+				digits.forEach( digit => {
+					inputContainer.removeChild( digit );
 				} );
-				inputContainer.appendChild( digit );
-			}
-		} );
+			} );
+		}
 
 		/**
 		 * Third party auth.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1206709674365921/1205129530451099/f](https://app.asana.com/0/1206709674365921/1205129530451099/f)

This addresses an issue where logging in with OTP does not reset OTP inputs when a reader attempts to either have another code sent OR sign in with a different email address

![Screenshot 2024-03-04 at 15 05 30](https://github.com/Automattic/newspack-plugin/assets/17905991/0be8fff4-14a5-4de9-ac4a-9809e22c23ff)

### How to test the changes in this Pull Request:

1. Access a test site while logged out
2. Click the Sign In button to trigger the RAS login flow
3. Choose to login via email (OTP flow)
4. Enter a valid email address and click the `Send authorization code` button
5. Once the OTP code modal renders, input any values for the OTP code, but DO NOT submit
6. Click either the `Try a different email` OR `Send another code` link at the bottom of the modal

![Screenshot 2024-03-04 at 15 07 52](https://github.com/Automattic/newspack-plugin/assets/17905991/df8ad401-c22a-4a4f-ae71-0b133e39176f)

7. Re-enter a valid email address to retrigger the OTP flow
8. On `trunk` once the OTP code inputs reappear, the previous input will still be present despite no longer being valid. On this branch, they should be empty once again.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205129530451099