### PR TITLE
fix(woo): disable related products

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -73,11 +73,16 @@ class WooCommerce_Connection {
 	}
 
 	/**
-	 * Disable related products on product pages
+	 * Disable related products on product pages.
+	 *
+	 * @param array $related_products Related products.
 	 *
 	 * @return array
 	 */
-	public static function disable_related_products() {
+	public static function disable_related_products( $related_products ) {
+		if ( defined( 'NEWSPACK_ALLOW_DISABLED_PRODUCTS' ) && NEWSPACK_ALLOW_DISABLED_PRODUCTS ) {
+			return $related_products;
+		}
 		return [];
 	}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -80,7 +80,7 @@ class WooCommerce_Connection {
 	 * @return array
 	 */
 	public static function disable_related_products( $related_products ) {
-		if ( defined( 'NEWSPACK_ALLOW_DISABLED_PRODUCTS' ) && NEWSPACK_ALLOW_DISABLED_PRODUCTS ) {
+		if ( defined( 'NEWSPACK_ALLOW_RELATED_PRODUCTS' ) && NEWSPACK_ALLOW_RELATED_PRODUCTS ) {
 			return $related_products;
 		}
 		return [];

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -35,6 +35,7 @@ class WooCommerce_Connection {
 		\add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'send_customizable_receipt_email' ], 10, 3 );
 		\add_action( 'woocommerce_order_status_completed', [ __CLASS__, 'maybe_update_reader_display_name' ], 10, 2 );
 		\add_action( 'option_woocommerce_feature_order_attribution_enabled', [ __CLASS__, 'force_disable_order_attribution' ] );
+		\add_filter( 'woocommerce_related_products', [ __CLASS__, 'disable_related_products' ] );
 		\add_action( 'cli_init', [ __CLASS__, 'register_cli_commands' ] );
 
 		// WooCommerce Subscriptions.
@@ -69,6 +70,15 @@ class WooCommerce_Connection {
 				$task_list->hide();
 			}
 		}
+	}
+
+	/**
+	 * Disable related products on product pages
+	 *
+	 * @return array
+	 */
+	public static function disable_related_products() {
+		return [];
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Disables related products for Newspack sites unless a `NEWSPACK_ALLOW_RELATED_PRODUCTS` is defined.

Closes `1206709674365921/1206491259200450`.

### How to test the changes in this Pull Request:

1. On `release`, log into My Account with an account that owns a subscription. Visit Subscriptions and click "Change Price".
2. On the product page that follows, observe a "Related Products" section at the bottom of the page.
3. Check out this branch.
4. Refresh the product page from step 2 and confirm that the "Related Products" section no longer appears.
5. Add `define( 'NEWSPACK_ALLOW_RELATED_PRODUCTS', true );` to wp-config.php. Refresh the product page and confirm that "Related Products" reappears.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206491259200450