### PR TITLE
feat: new option for auto-populating image credits

### DIFF
--- a/assets/wizards/site-design/views/theme-settings/index.js
+++ b/assets/wizards/site-design/views/theme-settings/index.js
@@ -35,6 +35,7 @@ const ThemeSettings = props => {
 		newspack_image_credits_placeholder_url: imageCreditsPlaceholderUrl,
 		newspack_image_credits_class_name: imageCreditsClassName = '',
 		newspack_image_credits_prefix_label: imageCreditsPrefix = '',
+		newspack_image_credits_auto_populate: imageCreditsAutoPopulate = true,
 	} = themeSettings;
 
 	useEffect( () => {
@@ -224,6 +225,15 @@ const ThemeSettings = props => {
 							'A placeholder image to be displayed in place of images without credits. If none is chosen, the image will be displayed normally whether or not it has a credit.',
 							'newspack-plugin'
 						) }
+					/>
+					<ToggleControl
+						label={ __( 'Auto-populate image credits', 'newspack-plugin' ) }
+						help={ __(
+							'Automatically populate image credits from EXIF or IPTC metadata when uploading new images.',
+							'newspack-plugin'
+						) }
+						checked={ imageCreditsAutoPopulate }
+						onChange={ value => setThemeMods( { newspack_image_credits_auto_populate: value } ) }
 					/>
 				</Grid>
 			</Grid>

--- a/assets/wizards/site-design/views/theme-settings/index.js
+++ b/assets/wizards/site-design/views/theme-settings/index.js
@@ -35,7 +35,7 @@ const ThemeSettings = props => {
 		newspack_image_credits_placeholder_url: imageCreditsPlaceholderUrl,
 		newspack_image_credits_class_name: imageCreditsClassName = '',
 		newspack_image_credits_prefix_label: imageCreditsPrefix = '',
-		newspack_image_credits_auto_populate: imageCreditsAutoPopulate = true,
+		newspack_image_credits_auto_populate: imageCreditsAutoPopulate = false,
 	} = themeSettings;
 
 	useEffect( () => {

--- a/includes/class-newspack-image-credits.php
+++ b/includes/class-newspack-image-credits.php
@@ -344,10 +344,12 @@ class Newspack_Image_Credits {
 	/**
 	 * Default values for site-wide settings.
 	 *
+	 * @param string|null $key (Optional) Key name of a single setting to get. If not given, will return all settings.
+	 *
 	 * @return array Array of default settings.
 	 */
-	public static function get_default_settings() {
-		return [
+	public static function get_default_settings( $key = null ) {
+		$default_settings = [
 			[
 				'description' => __( 'A CSS class name to be applied to all image credit elements. Leave blank to display no class name.', 'newspack-image-credits' ),
 				'key'         => 'newspack_image_credits_class_name',
@@ -369,7 +371,26 @@ class Newspack_Image_Credits {
 				'type'        => 'image',
 				'value'       => null,
 			],
+			[
+				'description' => __( 'Automatically populate image credits from EXIF or IPTC metadata when uploading new images.', 'newspack-image-credits' ),
+				'key'         => 'newspack_image_credits_auto_populate',
+				'label'       => __( 'Auto-populate image credits', 'newspack-image-credits' ),
+				'type'        => 'boolean',
+				'value'       => true,
+			],
 		];
+
+		if ( $key ) {
+			$setting = array_filter(
+				$default_settings,
+				function( $setting ) use ( $key ) {
+					return $setting['key'] === $key;
+				}
+			);
+			return reset( array_values( $setting ) );
+		}
+
+		return $default_settings;
 	}
 
 	/**
@@ -387,7 +408,7 @@ class Newspack_Image_Credits {
 			$defaults,
 			function( $acc, $setting ) use ( $get_default ) {
 				$key         = $setting['key'];
-				$value       = $get_default ? $setting['value'] : get_option( $key, $setting['value'] );
+				$value       = $get_default ? $setting['value'] : get_theme_mod( $key, $setting['value'] );
 				$acc[ $key ] = $value;
 				return $acc;
 			},
@@ -410,11 +431,12 @@ class Newspack_Image_Credits {
 	 * @param mixed  $value Updated value.
 	 */
 	public static function update_setting( $key, $value ) {
-		$defaults = self::get_default_settings();
-
-		if ( in_array( $key, array_keys( $defaults ) ) ) {
-			update_option( $key, $value );
+		$default_setting = self::get_default_settings( $key );
+		if ( ! isset( $default_setting['value'] ) ) {
+			return;
 		}
+
+		set_theme_mod( $key, self::sanitize_option_value( $value ) );
 	}
 
 	/**
@@ -488,8 +510,7 @@ class Newspack_Image_Credits {
 	 * @return array
 	 */
 	public static function populate_credit( $metadata, $attachment_id, $context ) {
-
-		if ( 'create' !== $context ) {
+		if ( 'create' !== $context || ! self::get_settings( 'newspack_image_credits_auto_populate' ) ) {
 			return $metadata;
 		}
 

--- a/includes/class-newspack-image-credits.php
+++ b/includes/class-newspack-image-credits.php
@@ -376,7 +376,7 @@ class Newspack_Image_Credits {
 				'key'         => 'newspack_image_credits_auto_populate',
 				'label'       => __( 'Auto-populate image credits', 'newspack-image-credits' ),
 				'type'        => 'boolean',
-				'value'       => true,
+				'value'       => false,
 			],
 		];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#2858 added behavior to automatically populate image credits if a `credit` field existed on the image's EXIF or IPTC metadata. Some publishers do not want this behavior. This PR adds an option to theme settings to disable this behavior to accommodate those publishers.

Closes `1206709674365921/1206754105927437` .

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Visit **Newspack > Site Design > Settings**. Observe a new setting under "Media Credits" to "Auto-populate image credits", enabled by default

<img width="1006" alt="Screenshot 2024-03-05 at 12 11 53 AM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/a25d396c-76b5-4e89-a536-452d544a346f">

3. Go to **Media Library > Add New Media File** and upload an image that contains credit EXIF data (see Asana task for an example image for testing).
4. Confirm that the "Credit" field is automatically populated from the credit EXIF field.
5. Toggle off the "Auto-populate image credits" in **Newspack > Site Design > Settings**.
6. Repeat step 3 and confirm that the credit is NOT auto-populated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206754105927437