### PR TITLE
hotfix: check for woocommerce on password reset

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -120,7 +120,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 						try {
 							const labels = JSON.parse( link.getAttribute( 'data-labels' ) );
 							link.querySelector( '.newspack-reader__account-link__label' ).textContent =
-								reader?.email ? labels.signedin : labels.signedout;
+								reader?.email && reader?.authenticated ? labels.signedin : labels.signedout;
 						} catch {}
 					} );
 				}

--- a/assets/wizards/advertising/components/ad-refresh-control/index.js
+++ b/assets/wizards/advertising/components/ad-refresh-control/index.js
@@ -18,64 +18,64 @@ const fields = [
 	{
 		key: 'viewability_threshold',
 		type: 'int',
-		description: __( 'Viewability Threshold', 'newspack' ),
+		description: __( 'Viewability Threshold', 'newspack-plugin' ),
 		help: __(
 			"The percentage of the ad slot which must be visible in the viewport in order to be considered eligible for being refreshed. It's recommended you do not lower this below 50 or you risk third-party viewability tracking platforms flagging your ad impressions as not having been viewed before refreshing.",
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'refresh_interval',
 		type: 'int',
-		description: __( 'Refresh Interval', 'newspack' ),
+		description: __( 'Refresh Interval', 'newspack-plugin' ),
 		help: __(
 			'The number of seconds that must pass between an ad crossing the viewability threshold and the the ad refreshing. The plugin enforces a minimum of 30 in order to avoid your site being flagged for abusing ad refreshes by advertisers. This value may however be overridden via the avc_refresh_interval_value filter hook.',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'maximum_refreshes',
 		type: 'int',
-		description: __( 'Maximum Refreshes', 'newspack' ),
+		description: __( 'Maximum Refreshes', 'newspack-plugin' ),
 		help: __(
 			'The number of times each ad slot is allowed to be refreshed. If this is set to 4 then an ad slot could have a total of 5 impressions by combining the initial loading of the ad with the 4 times it can refresh.',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'advertiser_ids',
 		type: 'string',
-		description: __( 'Excluded Advertiser IDs', 'newspack' ),
+		description: __( 'Excluded Advertiser IDs', 'newspack-plugin' ),
 		help: __(
 			'Prevent ad refreshes for specific advertiser IDs in the format of a comma separated list (e.g., 125,594,293). If an ad slot ever displays an ad creative from one of the listed advertiser IDs then that ad slot will stop refreshing for the remainder of the page view. AdSense does not allow their ads to be auto-refreshed. When Newspack detects that AdSense is the advertiser for any given impression, a refresh will not take place.',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'line_item_ids',
 		type: 'string',
-		description: __( 'Line Items IDs to Exclude', 'newspack' ),
+		description: __( 'Line Items IDs to Exclude', 'newspack-plugin' ),
 		help: __(
 			'Prevent ad refreshs for specific line item IDs. (Comma Seperated List)',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'sizes_to_exclude',
 		type: 'string',
-		description: __( 'Sizes to Exclude', 'newspack' ),
+		description: __( 'Sizes to Exclude', 'newspack-plugin' ),
 		help: __(
 			'Prevent ad refreshs for specific sizes. Accepts string (fluid) or array (300x250). Example: fluid, 300x250.',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 	{
 		key: 'slot_ids_to_exclude',
 		type: 'string',
-		description: __( 'Slot IDs to Exclude', 'newspack' ),
+		description: __( 'Slot IDs to Exclude', 'newspack-plugin' ),
 		help: __(
 			'Prevent ad refreshs for specific slot IDs e.g. div-gpt-ad-grid-1. (Comma Seperated List).',
-			'newspack'
+			'newspack-plugin'
 		),
 	},
 ];
@@ -134,10 +134,10 @@ export default function AdRefreshControlSettings() {
 			error={ error }
 			disabled={ inFlight }
 			sectionKey="ad-refresh-control"
-			title={ __( 'Ad Refresh Control', 'newspack' ) }
+			title={ __( 'Ad Refresh Control', 'newspack-plugin' ) }
 			description={ __(
 				'Enable Active View refresh for Google Ad Manager ads without needing to modify any code.',
-				'newspack'
+				'newspack-plugin'
 			) }
 			active={ ! settings.disable_refresh }
 			fields={ fields }

--- a/assets/wizards/advertising/components/ad-unit-size-control/index.js
+++ b/assets/wizards/advertising/components/ad-unit-size-control/index.js
@@ -70,14 +70,14 @@ const AdUnitSizeControl = ( { value, selectedOptions, onChange } ) => {
 	return (
 		<>
 			<SelectControl
-				label={ __( 'Size', 'newspack' ) }
+				label={ __( 'Size', 'newspack-plugin' ) }
 				value={ sizeIndex }
 				options={ [
 					...options.map( ( size, index ) => ( {
 						label: Array.isArray( size ) ? getSizeLabel( size ) : startCase( size ),
 						value: index,
 					} ) ),
-					{ label: __( 'Custom', 'newspack' ), value: -1 },
+					{ label: __( 'Custom', 'newspack-plugin' ), value: -1 },
 				] }
 				onChange={ index => {
 					const size = options[ index ];
@@ -90,13 +90,13 @@ const AdUnitSizeControl = ( { value, selectedOptions, onChange } ) => {
 				<div className="newspack-advertising-wizard__ad-unit-fluid">
 					{ __(
 						'Fluid is a native ad size that allows more flexibility when styling your ad. It automatically sizes the ad by filling the width of the enclosing column and adjusting the height as appropriate.',
-						'newspack'
+						'newspack-plugin'
 					) }
 				</div>
 			) : (
 				<>
 					<TextControl
-						label={ __( 'Width', 'newspack' ) }
+						label={ __( 'Width', 'newspack-plugin' ) }
 						value={ value[ 0 ] }
 						onChange={ newWidth => onChange( [ newWidth, value[ 1 ] ] ) }
 						disabled={ ! isCustom && sizeIndex !== -1 }
@@ -104,7 +104,7 @@ const AdUnitSizeControl = ( { value, selectedOptions, onChange } ) => {
 						hideLabelFromVision
 					/>
 					<TextControl
-						label={ __( 'Height', 'newspack' ) }
+						label={ __( 'Height', 'newspack-plugin' ) }
 						value={ value[ 1 ] }
 						onChange={ newHeight => onChange( [ value[ 0 ], newHeight ] ) }
 						disabled={ ! isCustom && sizeIndex !== -1 }

--- a/assets/wizards/advertising/components/add-ons/index.js
+++ b/assets/wizards/advertising/components/add-ons/index.js
@@ -18,16 +18,16 @@ export default function AddOns() {
 		<PluginToggle
 			plugins={ {
 				'super-cool-ad-inserter': {
-					actionText: __( 'Configure', 'newspack' ),
+					actionText: __( 'Configure', 'newspack-plugin' ),
 					href: '#/settings',
 				},
 				'ad-refresh-control': {
-					actionText: __( 'Configure', 'newspack' ),
+					actionText: __( 'Configure', 'newspack-plugin' ),
 					href: '#/settings',
 				},
 				'publisher-media-kit': {
 					shouldRefreshAfterUpdate: true,
-					actionText: __( 'Edit Media Kit', 'newspack' ),
+					actionText: __( 'Edit Media Kit', 'newspack-plugin' ),
 					href: newspack_ads_wizard.mediakit_edit_url ? newspack_ads_wizard.mediakit_edit_url : '',
 				},
 			} }

--- a/assets/wizards/advertising/components/onboarding/index.js
+++ b/assets/wizards/advertising/components/onboarding/index.js
@@ -59,7 +59,7 @@ export default function AdsOnboarding( { onUpdate, onSuccess } ) {
 							<p>
 								{ __(
 									'Authenticate with Google in order to connect your Google Ad Manager account:',
-									'newspack'
+									'newspack-plugin'
 								) }
 							</p>
 						) }
@@ -69,31 +69,31 @@ export default function AdsOnboarding( { onUpdate, onSuccess } ) {
 				{ false === useOAuth && (
 					<Fragment>
 						{ isConnected ? (
-							<Notice isSuccess noticeText={ __( "We're all set here!", 'newspack' ) } />
+							<Notice isSuccess noticeText={ __( "We're all set here!", 'newspack-plugin' ) } />
 						) : (
 							<Fragment>
 								<p>
 									{ __(
 										'Enter your Google Ad Manager network code and service account credentials for a full integration:',
-										'newspack'
+										'newspack-plugin'
 									) }
 								</p>
 								<TextControl
 									disabled={ inFlight }
 									isWide
 									name="network_code"
-									label={ __( 'Network code', 'newspack' ) }
+									label={ __( 'Network code', 'newspack-plugin' ) }
 									value={ networkCode }
 									onChange={ setNetworkCode }
 								/>
 								<ButtonCard
 									disabled={ inFlight }
 									onClick={ () => credentialsInputFile.current.click() }
-									title={ __( 'Upload credentials', 'newspack' ) }
+									title={ __( 'Upload credentials', 'newspack-plugin' ) }
 									desc={ [
 										__(
 											'Upload your Service Account credentials file to connect your GAM account.',
-											'newspack'
+											'newspack-plugin'
 										),
 										fileError && <Notice noticeText={ fileError } isError />,
 									] }
@@ -105,7 +105,7 @@ export default function AdsOnboarding( { onUpdate, onSuccess } ) {
 										target="_blank"
 										rel="noopener noreferrer"
 									>
-										{ __( 'How to get a service account user for API access', 'newspack' ) }
+										{ __( 'How to get a service account user for API access', 'newspack-plugin' ) }
 									</a>
 									.
 								</p>

--- a/assets/wizards/advertising/components/placement-control/index.js
+++ b/assets/wizards/advertising/components/placement-control/index.js
@@ -22,7 +22,7 @@ import { Grid, Notice, SelectControl, TextControl } from '../../../../components
 const getProvidersForSelect = providers => {
 	return [
 		{
-			label: __( 'Select a provider', 'newspack' ),
+			label: __( 'Select a provider', 'newspack-plugin' ),
 			value: '',
 		},
 		...providers.map( unit => {
@@ -46,7 +46,7 @@ const getProviderUnitsForSelect = provider => {
 	}
 	return [
 		{
-			label: __( 'Select an Ad Unit', 'newspack' ),
+			label: __( 'Select an Ad Unit', 'newspack-plugin' ),
 			value: '',
 		},
 		...provider.units.map( unit => {
@@ -74,7 +74,7 @@ const hasAnySize = ( sizes, sizesToCheck ) => {
 };
 
 const PlacementControl = ( {
-	label = __( 'Ad Unit', 'newspack' ),
+	label = __( 'Ad Unit', 'newspack-plugin' ),
 	providers = [],
 	bidders = {},
 	value = {},
@@ -99,7 +99,7 @@ const PlacementControl = ( {
 					? null
 					: sprintf(
 							// Translators: Ad bidder name.
-							__( '%s does not support the selected ad unit sizes.', 'newspack' ),
+							__( '%s does not support the selected ad unit sizes.', 'newspack-plugin' ),
 							bidder.name,
 							''
 					  );
@@ -108,14 +108,16 @@ const PlacementControl = ( {
 	}, [ providers, value.ad_unit ] );
 
 	if ( ! providers.length ) {
-		return <Notice isWarning noticeText={ __( 'There is no provider available.', 'newspack' ) } />;
+		return (
+			<Notice isWarning noticeText={ __( 'There is no provider available.', 'newspack-plugin' ) } />
+		);
 	}
 
 	return (
 		<Fragment>
 			<Grid columns={ 2 } gutter={ 32 }>
 				<SelectControl
-					label={ __( 'Provider', 'newspack' ) }
+					label={ __( 'Provider', 'newspack-plugin' ) }
 					value={ placementProvider?.id }
 					options={ getProvidersForSelect( providers ) }
 					onChange={ provider => onChange( { ...value, provider } ) }
@@ -139,7 +141,7 @@ const PlacementControl = ( {
 				Object.keys( bidders ).map( bidderKey => {
 					const bidder = bidders[ bidderKey ];
 					// Translators: Bidder name.
-					const bidderLabel = sprintf( __( '%s Placement ID', 'newspack' ), bidder.name );
+					const bidderLabel = sprintf( __( '%s Placement ID', 'newspack-plugin' ), bidder.name );
 					return (
 						<TextControl
 							key={ bidderKey }

--- a/assets/wizards/advertising/components/utils/index.js
+++ b/assets/wizards/advertising/components/utils/index.js
@@ -18,12 +18,12 @@ export function handleJSONFile( file ) {
 			try {
 				json = JSON.parse( ev.target.result );
 			} catch ( error ) {
-				reject( __( 'Invalid JSON file', 'newspack' ) );
+				reject( __( 'Invalid JSON file', 'newspack-plugin' ) );
 			}
 			resolve( json );
 		};
 		reader.onerror = function () {
-			reject( __( 'Unable to read file', 'newspack' ) );
+			reject( __( 'Unable to read file', 'newspack-plugin' ) );
 		};
 	} );
 }

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -117,7 +117,9 @@ class AdvertisingWizard extends Component {
 	 */
 	deleteAdUnit = id => {
 		if (
-			utils.confirmAction( __( 'Are you sure you want to archive this ad unit?', 'newspack' ) )
+			utils.confirmAction(
+				__( 'Are you sure you want to archive this ad unit?', 'newspack-plugin' )
+			)
 		) {
 			return this.updateWithAPI( {
 				path: '/newspack/v1/wizard/billboard/ad_unit/' + id,
@@ -144,24 +146,24 @@ class AdvertisingWizard extends Component {
 		const { services, adUnits } = advertisingData;
 		const tabs = [
 			{
-				label: __( 'Providers', 'newspack' ),
+				label: __( 'Providers', 'newspack-plugin' ),
 				path: '/',
 				exact: true,
 			},
 			{
-				label: __( 'Placements', 'newspack' ),
+				label: __( 'Placements', 'newspack-plugin' ),
 				path: '/placements',
 			},
 			{
-				label: __( 'Settings', 'newspack' ),
+				label: __( 'Settings', 'newspack-plugin' ),
 				path: '/settings',
 			},
 			{
-				label: __( 'Suppression', 'newspack' ),
+				label: __( 'Suppression', 'newspack-plugin' ),
 				path: '/suppression',
 			},
 			{
-				label: __( 'Add-Ons', 'newspack' ),
+				label: __( 'Add-Ons', 'newspack-plugin' ),
 				path: '/addons',
 			},
 		];
@@ -176,7 +178,10 @@ class AdvertisingWizard extends Component {
 							render={ () => (
 								<Providers
 									headerText="Advertising"
-									subHeaderText={ __( 'Manage ad providers and their settings.', 'newspack' ) }
+									subHeaderText={ __(
+										'Manage ad providers and their settings.',
+										'newspack-plugin'
+									) }
 									services={ services }
 									toggleService={ this.toggleService }
 									fetchAdvertisingData={ this.fetchAdvertisingData }
@@ -188,10 +193,10 @@ class AdvertisingWizard extends Component {
 							path="/placements"
 							render={ () => (
 								<Placements
-									headerText={ __( 'Advertising', 'newspack' ) }
+									headerText={ __( 'Advertising', 'newspack-plugin' ) }
 									subHeaderText={ __(
 										'Define global advertising placements to serve ad units on your site',
-										'newspack'
+										'newspack-plugin'
 									) }
 									tabbedNavigation={ tabs }
 								/>
@@ -201,10 +206,10 @@ class AdvertisingWizard extends Component {
 							path="/settings"
 							render={ () => (
 								<Settings
-									headerText={ __( 'Advertising', 'newspack' ) }
+									headerText={ __( 'Advertising', 'newspack-plugin' ) }
 									subHeaderText={ __(
 										'Configure display and advanced settings for your ads',
-										'newspack'
+										'newspack-plugin'
 									) }
 									tabbedNavigation={ tabs }
 								/>
@@ -218,7 +223,7 @@ class AdvertisingWizard extends Component {
 									headerText="Google Ad Manager"
 									subHeaderText={ __(
 										'Monetize your content through Google Ad Manager',
-										'newspack'
+										'newspack-plugin'
 									) }
 									adUnits={ adUnits }
 									service={ 'google_ad_manager' }
@@ -235,8 +240,8 @@ class AdvertisingWizard extends Component {
 							path={ `/google_ad_manager/${ CREATE_AD_ID_PARAM }` }
 							render={ routeProps => (
 								<AdUnit
-									headerText={ __( 'Add New Ad Unit', 'newspack' ) }
-									subHeaderText={ __( 'Allows you to place ads on your site', 'newspack' ) }
+									headerText={ __( 'Add New Ad Unit', 'newspack-plugin' ) }
+									subHeaderText={ __( 'Allows you to place ads on your site', 'newspack-plugin' ) }
 									adUnit={
 										adUnits[ 0 ] || {
 											id: 0,
@@ -268,8 +273,11 @@ class AdvertisingWizard extends Component {
 								const adId = routeProps.match.params.id;
 								return (
 									<AdUnit
-										headerText={ __( 'Edit Ad Unit', 'newspack' ) }
-										subHeaderText={ __( 'Allows you to place ads on your site', 'newspack' ) }
+										headerText={ __( 'Edit Ad Unit', 'newspack-plugin' ) }
+										subHeaderText={ __(
+											'Allows you to place ads on your site',
+											'newspack-plugin'
+										) }
 										adUnit={ adUnits[ adId ] || {} }
 										service={ 'google_ad_manager' }
 										onChange={ this.onAdUnitChange }
@@ -288,10 +296,10 @@ class AdvertisingWizard extends Component {
 							path="/suppression"
 							render={ () => (
 								<Suppression
-									headerText={ __( 'Advertising', 'newspack' ) }
+									headerText={ __( 'Advertising', 'newspack-plugin' ) }
 									subHeaderText={ __(
 										'Allows you to manage site-wide ad suppression',
-										'newspack'
+										'newspack-plugin'
 									) }
 									tabbedNavigation={ tabs }
 									config={ advertisingData.suppression }
@@ -303,8 +311,8 @@ class AdvertisingWizard extends Component {
 							path="/addons"
 							render={ () => (
 								<AddOns
-									headerText={ __( 'Advertising', 'newspack' ) }
-									subHeaderText={ __( 'Add-ons for enhanced advertising', 'newspack' ) }
+									headerText={ __( 'Advertising', 'newspack-plugin' ) }
+									subHeaderText={ __( 'Add-ons for enhanced advertising', 'newspack-plugin' ) }
 									tabbedNavigation={ tabs }
 								/>
 							) }

--- a/assets/wizards/advertising/views/ad-unit/index.js
+++ b/assets/wizards/advertising/views/ad-unit/index.js
@@ -84,18 +84,18 @@ class AdUnit extends Component {
 		return (
 			<>
 				<Card headerActions noBorder>
-					<h2>{ __( 'Ad Unit Details', 'newspack' ) }</h2>
+					<h2>{ __( 'Ad Unit Details', 'newspack-plugin' ) }</h2>
 				</Card>
 
 				<Grid gutter={ 32 }>
 					<TextControl
-						label={ __( 'Name', 'newspack' ) }
+						label={ __( 'Name', 'newspack-plugin' ) }
 						value={ name || '' }
 						onChange={ value => this.handleOnChange( 'name', value ) }
 					/>
 					{ ( isExistingAdUnit || isLegacy ) && (
 						<TextControl
-							label={ __( 'Code', 'newspack' ) }
+							label={ __( 'Code', 'newspack-plugin' ) }
 							value={ getCodeValue() }
 							className="code"
 							help={
@@ -103,7 +103,7 @@ class AdUnit extends Component {
 									? undefined
 									: __(
 											"Identifies the ad unit in the associated ad tag. Once you've created the ad unit, you can't change the code.",
-											'newspack'
+											'newspack-plugin'
 									  )
 							}
 							disabled={ ! isLegacy }
@@ -115,8 +115,8 @@ class AdUnit extends Component {
 				<Card headerActions noBorder>
 					<h2>
 						{ sizeOptions.length > 1
-							? __( 'Ad Unit Sizes', 'newspack' )
-							: __( 'Ad Unit Size', 'newspack' ) }
+							? __( 'Ad Unit Sizes', 'newspack-plugin' )
+							: __( 'Ad Unit Size', 'newspack-plugin' ) }
 					</h2>
 					<Button
 						variant="secondary"
@@ -124,7 +124,7 @@ class AdUnit extends Component {
 							this.handleOnChange( 'sizes', [ ...sizes, this.getNextAvailableSize() ] )
 						}
 					>
-						{ __( 'Add New Size', 'newspack' ) }
+						{ __( 'Add New Size', 'newspack-plugin' ) }
 					</Button>
 				</Card>
 
@@ -133,16 +133,16 @@ class AdUnit extends Component {
 						isWarning
 						noticeText={ __(
 							'The ad unit must have at least one valid size or fluid size enabled.',
-							'newspack'
+							'newspack-plugin'
 						) }
 					/>
 				) }
 
 				<Grid columns={ 4 } gutter={ 8 } className="newspack-grid__thead">
-					<span>{ __( 'Size', 'newspack' ) }</span>
-					<span>{ __( 'Width', 'newspack' ) }</span>
-					<span>{ __( 'Height', 'newspack' ) }</span>
-					<span className="screen-reader-text">{ __( 'Action', 'newspack' ) }</span>
+					<span>{ __( 'Size', 'newspack-plugin' ) }</span>
+					<span>{ __( 'Width', 'newspack-plugin' ) }</span>
+					<span>{ __( 'Height', 'newspack-plugin' ) }</span>
+					<span className="screen-reader-text">{ __( 'Action', 'newspack-plugin' ) }</span>
 				</Grid>
 
 				{ sizeOptions.map( ( size, index ) => (
@@ -177,7 +177,7 @@ class AdUnit extends Component {
 							} }
 							icon={ trash }
 							disabled={ sizeOptions.length <= 1 }
-							label={ __( 'Delete', 'newspack' ) }
+							label={ __( 'Delete', 'newspack-plugin' ) }
 							showTooltip={ true }
 						/>
 					</Grid>
@@ -189,10 +189,10 @@ class AdUnit extends Component {
 						variant="primary"
 						onClick={ () => onSave( id ) }
 					>
-						{ __( 'Save', 'newspack' ) }
+						{ __( 'Save', 'newspack-plugin' ) }
 					</Button>
 					<Button variant="secondary" onClick={ () => onCancel() } href={ `#/${ service }` }>
-						{ __( 'Cancel', 'newspack' ) }
+						{ __( 'Cancel', 'newspack-plugin' ) }
 					</Button>
 				</div>
 			</>

--- a/assets/wizards/advertising/views/ad-units/index.js
+++ b/assets/wizards/advertising/views/ad-units/index.js
@@ -40,7 +40,7 @@ const AdUnits = ( {
 	fetchAdvertisingData,
 } ) => {
 	const gamErrorMessage = serviceData?.status?.error
-		? `${ __( 'Google Ad Manager Error', 'newspack' ) }: ${ serviceData.status.error }`
+		? `${ __( 'Google Ad Manager Error', 'newspack-plugin' ) }: ${ serviceData.status.error }`
 		: false;
 
 	const updateNetworkCode = async ( value, isGam ) => {
@@ -81,13 +81,13 @@ const AdUnits = ( {
 		<>
 			<Card noBorder>
 				<Button isLink href="#/" icon={ arrowLeft }>
-					{ __( 'Back', 'newspack' ) }
+					{ __( 'Back', 'newspack-plugin' ) }
 				</Button>
 			</Card>
 
 			{ ! isLegacy && networkCode && (
 				<SelectControl
-					label={ __( 'Connected GAM network code', 'newspack' ) }
+					label={ __( 'Connected GAM network code', 'newspack-plugin' ) }
 					value={ networkCode }
 					options={ serviceData.available_networks.map( network => ( {
 						label: `${ network.name } (${ network.code })`,
@@ -100,7 +100,7 @@ const AdUnits = ( {
 				<Notice
 					noticeText={ __(
 						'Your GAM network code is different than the network code the site was configured with. Legacy ad units are likely to not load.',
-						'newspack'
+						'newspack-plugin'
 					) }
 					isWarning
 				/>
@@ -109,13 +109,13 @@ const AdUnits = ( {
 			{ serviceData.created_targeting_keys?.length > 0 && (
 				<Notice
 					noticeText={ [
-						__( 'Created custom targeting keys:' ) + '\u00A0',
+						__( 'Created custom targeting keys:', 'newspack-plugin' ) + '\u00A0',
 						serviceData.created_targeting_keys.join( ', ' ) + '. \u00A0',
 						<ExternalLink
 							href={ `https://admanager.google.com/${ serviceData.network_code }#inventory/custom_targeting/list` }
 							key="google-ad-manager-custom-targeting-link"
 						>
-							{ __( 'Visit your GAM dashboard' ) }
+							{ __( 'Visit your GAM dashboard', 'newspack-plugin' ) }
 						</ExternalLink>,
 					] }
 					isSuccess
@@ -124,19 +124,19 @@ const AdUnits = ( {
 			{ isLegacy && serviceData.enabled && (
 				<>
 					<Notice
-						noticeText={ __( 'Currently operating in legacy mode.', 'newspack' ) }
+						noticeText={ __( 'Currently operating in legacy mode.', 'newspack-plugin' ) }
 						isWarning
 					/>
 					<div className="flex items-end">
 						<TextControl
-							label={ __( 'Network Code', 'newspack' ) }
+							label={ __( 'Network Code', 'newspack-plugin' ) }
 							value={ networkCode }
 							onChange={ setNetworkCode }
 							withMargin={ false }
 						/>
 						<span className="pl3">
 							<Button onClick={ updateLegacyNetworkCode } isPrimary>
-								{ __( 'Save', 'newspack' ) }
+								{ __( 'Save', 'newspack-plugin' ) }
 							</Button>
 						</span>
 					</div>
@@ -145,18 +145,18 @@ const AdUnits = ( {
 			<p>
 				{ __(
 					'Set up multiple ad units to use on your homepage, articles and other places throughout your site.',
-					'newspack'
+					'newspack-plugin'
 				) }
 				<br />
 				{ __(
 					'You can place ads through our Newspack Ad Block in the Editor, Newspack Ad widget, and using the global placements.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			</p>
 			<Card headerActions noBorder>
 				<div className="flex justify-end w-100">
 					<Button variant="primary" href={ `#/google_ad_manager/${ CREATE_AD_ID_PARAM }` }>
-						{ __( 'Add New Ad Unit', 'newspack' ) }
+						{ __( 'Add New Ad Unit', 'newspack-plugin' ) }
 					</Button>
 				</div>
 			</Card>
@@ -178,35 +178,35 @@ const AdUnits = ( {
 									<span>
 										{ adUnit.code ? (
 											<>
-												<i>{ __( 'Code:', 'newspack' ) }</i> <code>{ adUnit.code }</code>
+												<i>{ __( 'Code:', 'newspack-plugin' ) }</i> <code>{ adUnit.code }</code>
 											</>
 										) : null }
 										{ adUnit.sizes?.length || adUnit.fluid ? (
 											<>
 												{ ' ' }
-												| { __( 'Sizes:', 'newspack' ) }{ ' ' }
+												| { __( 'Sizes:', 'newspack-plugin' ) }{ ' ' }
 												{ adUnit.sizes.map( ( size, i ) => (
 													<code key={ i }>{ Array.isArray( size ) ? size.join( 'x' ) : size }</code>
 												) ) }
-												{ adUnit.fluid && <code>{ __( 'Fluid', 'newspack' ) }</code> }
+												{ adUnit.fluid && <code>{ __( 'Fluid', 'newspack-plugin' ) }</code> }
 											</>
 										) : null }
 										{ adUnit.is_legacy ? (
 											<>
 												{ ' ' }
-												| <i>{ __( 'Legacy ad unit.', 'newspack' ) }</i>
+												| <i>{ __( 'Legacy ad unit.', 'newspack-plugin' ) }</i>
 											</>
 										) : null }
 										{ adUnit.is_default ? (
 											<>
 												{ ' ' }
-												| <i>{ __( 'Default ad unit.', 'newspack' ) }</i>
+												| <i>{ __( 'Default ad unit.', 'newspack-plugin' ) }</i>
 											</>
 										) : null }
 										{ isDisconnectedGAM( adUnit ) ? (
 											<>
 												{ ' ' }
-												| <i>{ __( 'Disconnected from GAM.', 'newspack' ) }</i>
+												| <i>{ __( 'Disconnected from GAM.', 'newspack-plugin' ) }</i>
 											</>
 										) : null }
 									</span>

--- a/assets/wizards/advertising/views/ad-units/options-popover.js
+++ b/assets/wizards/advertising/views/ad-units/options-popover.js
@@ -25,7 +25,7 @@ const OptionsPopover = props => {
 				className={ isVisible && 'popover-active' }
 				onClick={ toggleVisible }
 				icon={ moreVertical }
-				label={ __( 'More options', 'newspack' ) }
+				label={ __( 'More options', 'newspack-plugin' ) }
 				tooltipPosition="bottom center"
 			/>
 			{ isVisible && (
@@ -35,13 +35,13 @@ const OptionsPopover = props => {
 					onKeyDown={ event => ESCAPE === event.keyCode && toggleVisible }
 				>
 					<MenuItem onClick={ toggleVisible } className="screen-reader-text">
-						{ __( 'Close Popover', 'newspack' ) }
+						{ __( 'Close Popover', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem href={ editLink } className="newspack-button" isLink>
-						{ __( 'Edit', 'newspack' ) }
+						{ __( 'Edit', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem onClick={ deleteLink } className="newspack-button">
-						{ __( 'Archive', 'newspack' ) }
+						{ __( 'Archive', 'newspack-plugin' ) }
 					</MenuItem>
 				</Popover>
 			) }

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -132,7 +132,10 @@ const Placements = () => {
 	return (
 		<Fragment>
 			{ ! inFlight && ! providers.length && (
-				<Notice isWarning noticeText={ __( 'There is no provider available.', 'newspack' ) } />
+				<Notice
+					isWarning
+					noticeText={ __( 'There is no provider available.', 'newspack-plugin' ) }
+				/>
 			) }
 			<div
 				className={ classnames( {
@@ -156,7 +159,7 @@ const Placements = () => {
 										disabled={ inFlight || ! providers.length }
 										onClick={ () => setEditingPlacement( key ) }
 										icon={ settings }
-										label={ __( 'Placement settings', 'newspack' ) }
+										label={ __( 'Placement settings', 'newspack-plugin' ) }
 										tooltipPosition="bottom center"
 									/>
 								) : null
@@ -169,7 +172,7 @@ const Placements = () => {
 				<Modal
 					title={ sprintf(
 						// translators: %s is the name of the placement
-						__( '%s placement settings', 'newspack' ),
+						__( '%s placement settings', 'newspack-plugin' ),
 						placement.name
 					) }
 					onRequestClose={ () => setEditingPlacement( null ) }
@@ -194,7 +197,7 @@ const Placements = () => {
 							return (
 								<Card noBorder key={ hookKey }>
 									<PlacementControl
-										label={ hook.name + ' ' + __( 'Ad Unit', 'newspack' ) }
+										label={ hook.name + ' ' + __( 'Ad Unit', 'newspack-plugin' ) }
 										providers={ providers }
 										bidders={ bidders }
 										value={ placement.data?.hooks ? placement.data.hooks[ hookKey ] : {} }
@@ -206,7 +209,7 @@ const Placements = () => {
 						} ) }
 					{ placement.supports?.indexOf( 'stick_to_top' ) > -1 && (
 						<ToggleControl
-							label={ __( 'Stick to Top', 'newspack' ) }
+							label={ __( 'Stick to Top', 'newspack-plugin' ) }
 							checked={ !! placement.data?.stick_to_top }
 							onChange={ value => {
 								setPlacements(
@@ -223,7 +226,7 @@ const Placements = () => {
 								setEditingPlacement( null );
 							} }
 						>
-							{ __( 'Cancel', 'newspack' ) }
+							{ __( 'Cancel', 'newspack-plugin' ) }
 						</Button>
 						<Button
 							isPrimary
@@ -233,7 +236,7 @@ const Placements = () => {
 								setEditingPlacement( null );
 							} }
 						>
-							{ __( 'Save', 'newspack' ) }
+							{ __( 'Save', 'newspack-plugin' ) }
 						</Button>
 					</Card>
 				</Modal>

--- a/assets/wizards/advertising/views/providers/index.js
+++ b/assets/wizards/advertising/views/providers/index.js
@@ -52,14 +52,14 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 		notifications = notifications.concat( [ google_ad_manager.status.error, '\u00A0' ] );
 	} else if ( google_ad_manager?.created_targeting_keys?.length > 0 ) {
 		notifications = notifications.concat( [
-			__( 'Created custom targeting keys:' ) + '\u00A0',
+			__( 'Created custom targeting keys:', 'newspack-plugin' ) + '\u00A0',
 			google_ad_manager.created_targeting_keys.join( ', ' ) + '. \u00A0',
 			// eslint-disable-next-line react/jsx-indent
 			<ExternalLink
 				href={ `https://admanager.google.com/${ google_ad_manager.network_code }#inventory/custom_targeting/list` }
 				key="google-ad-manager-custom-targeting-link"
 			>
-				{ __( 'Visit your GAM dashboard' ) }
+				{ __( 'Visit your GAM dashboard', 'newspack-plugin' ) }
 			</ExternalLink>,
 		] );
 	}
@@ -71,7 +71,7 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 	) {
 		notifications.push(
 			<Button key="gam-connect-account" isLink onClick={ () => setIsOnboarding( true ) }>
-				{ __( 'Click here to connect your account.', 'newspack' ) }
+				{ __( 'Click here to connect your account.', 'newspack-plugin' ) }
 			</Button>
 		);
 	}
@@ -79,11 +79,14 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 	return (
 		<>
 			<ActionCard
-				title={ __( 'Google Ad Manager' ) }
+				title={ __( 'Google Ad Manager', 'newspack-plugin' ) }
 				description={ __(
-					'Manage Google Ad Manager ad units and placements directly from the Newspack dashboard.'
+					'Manage Google Ad Manager ad units and placements directly from the Newspack dashboard.',
+					'newspack-plugin'
 				) }
-				actionText={ google_ad_manager && google_ad_manager.enabled && __( 'Configure' ) }
+				actionText={
+					google_ad_manager && google_ad_manager.enabled && __( 'Configure', 'newspack-plugin' )
+				}
 				toggle
 				toggleChecked={ google_ad_manager && google_ad_manager.enabled }
 				toggleOnChange={ value => {
@@ -105,14 +108,14 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 			<PluginToggle
 				plugins={ {
 					broadstreet: {
-						actionText: __( 'Configure' ),
+						actionText: __( 'Configure', 'newspack-plugin' ),
 						href: '/wp-admin/admin.php?page=Broadstreet',
 					},
 				} }
 			/>
 			{ isOnboarding && (
 				<Modal
-					title={ __( 'Google Ad Manager Setup', 'newspack-ads' ) }
+					title={ __( 'Google Ad Manager Setup', 'newspack-plugin' ) }
 					onRequestClose={ () => setIsOnboarding( false ) }
 				>
 					<GAMOnboarding
@@ -124,14 +127,14 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 					/>
 					<Card buttonsCard noBorder className="justify-end">
 						<Button isSecondary disabled={ inFlight } onClick={ () => setIsOnboarding( false ) }>
-							{ __( 'Cancel', 'newspack' ) }
+							{ __( 'Cancel', 'newspack-plugin' ) }
 						</Button>
 						<Button
 							isPrimary
 							disabled={ inFlight || ! networkCode }
 							onClick={ () => updateGAMNetworkCode() }
 						>
-							{ __( 'Save', 'newspack' ) }
+							{ __( 'Save', 'newspack-plugin' ) }
 						</Button>
 					</Card>
 				</Modal>

--- a/assets/wizards/advertising/views/suppression/index.js
+++ b/assets/wizards/advertising/views/suppression/index.js
@@ -69,8 +69,8 @@ const Suppression = () => {
 		<>
 			{ error && <Notice isError noticeText={ error.message } /> }
 			<SectionHeader
-				title={ __( 'Post Types', 'newspack' ) }
-				description={ __( 'Suppress ads on specific post types.', 'newspack' ) }
+				title={ __( 'Post Types', 'newspack-plugin' ) }
+				description={ __( 'Suppress ads on specific post types.', 'newspack-plugin' ) }
 			/>
 			<Grid columns={ 3 } gutter={ 16 }>
 				{ postTypes.map( postType => (
@@ -91,8 +91,11 @@ const Suppression = () => {
 				) ) }
 			</Grid>
 			<SectionHeader
-				title={ __( 'Tags', 'newspack' ) }
-				description={ __( 'Suppress ads on specific tags and their archive pages.', 'newspack' ) }
+				title={ __( 'Tags', 'newspack-plugin' ) }
+				description={ __(
+					'Suppress ads on specific tags and their archive pages.',
+					'newspack-plugin'
+				) }
 			/>
 			<CategoryAutocomplete
 				value={ config.tags?.map( v => parseInt( v ) ) || [] }
@@ -102,7 +105,7 @@ const Suppression = () => {
 						tags: selected.map( item => item.id ),
 					} );
 				} }
-				label={ __( 'Tags to suppress ads on (archives and posts)', 'newspack ' ) }
+				label={ __( 'Tags to suppress ads on (archives and posts)', 'newspack-plugin' ) }
 				taxonomy="tags"
 			/>
 			<ToggleControl
@@ -111,13 +114,13 @@ const Suppression = () => {
 				onChange={ tag_archive_pages => {
 					setConfig( { ...config, tag_archive_pages } );
 				} }
-				label={ __( 'All tag archive pages', 'newspack' ) }
+				label={ __( 'All tag archive pages', 'newspack-plugin' ) }
 			/>
 			<SectionHeader
-				title={ __( 'Categories', 'newspack' ) }
+				title={ __( 'Categories', 'newspack-plugin' ) }
 				description={ __(
 					'Suppress ads on specific categories and their archive pages.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			/>
 			<CategoryAutocomplete
@@ -128,7 +131,7 @@ const Suppression = () => {
 						categories: selected.map( item => item.id ),
 					} );
 				} }
-				label={ __( 'Categories to suppress ads on (archives and posts)', 'newspack ' ) }
+				label={ __( 'Categories to suppress ads on (archives and posts)', 'newspack-plugin' ) }
 			/>
 			<ToggleControl
 				disabled={ config === false }
@@ -136,13 +139,13 @@ const Suppression = () => {
 				onChange={ category_archive_pages => {
 					setConfig( { ...config, category_archive_pages } );
 				} }
-				label={ __( 'All category archive pages', 'newspack' ) }
+				label={ __( 'All category archive pages', 'newspack-plugin' ) }
 			/>
 			<SectionHeader
-				title={ __( 'Author Archive Pages', 'newspack' ) }
+				title={ __( 'Author Archive Pages', 'newspack-plugin' ) }
 				description={ __(
 					'Suppress ads on automatically generated pages displaying a list of posts by an author.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			/>
 			<ToggleControl
@@ -151,11 +154,11 @@ const Suppression = () => {
 				onChange={ author_archive_pages => {
 					setConfig( { ...config, author_archive_pages } );
 				} }
-				label={ __( 'Suppress ads on author archive pages', 'newspack' ) }
+				label={ __( 'Suppress ads on author archive pages', 'newspack-plugin' ) }
 			/>{ ' ' }
 			<Card buttonsCard noBorder className="justify-end">
 				<Button isPrimary disabled={ inFlight } onClick={ updateConfig }>
-					{ __( 'Save', 'newspack' ) }
+					{ __( 'Save', 'newspack-plugin' ) }
 				</Button>
 			</Card>
 		</>

--- a/assets/wizards/analytics/index.js
+++ b/assets/wizards/analytics/index.js
@@ -22,12 +22,12 @@ const { HashRouter, Redirect, Route, Switch } = Router;
 
 const TABS = [
 	{
-		label: __( 'Plugins', 'newspack' ),
+		label: __( 'Plugins', 'newspack-plugin' ),
 		path: '/',
 		exact: true,
 	},
 	{
-		label: __( 'Newspack Custom Events', 'newspack' ),
+		label: __( 'Newspack Custom Events', 'newspack-plugin' ),
 		path: '/newspack-custom-events',
 	},
 ];
@@ -39,8 +39,8 @@ class AnalyticsWizard extends Component {
 	render() {
 		const { pluginRequirements, wizardApiFetch, isLoading } = this.props;
 		const sharedProps = {
-			headerText: __( 'Analytics', 'newspack' ),
-			subHeaderText: __( 'Manage Google Analytics Configuration', 'newspack' ),
+			headerText: __( 'Analytics', 'newspack-plugin' ),
+			subHeaderText: __( 'Manage Google Analytics Configuration', 'newspack-plugin' ),
 			tabbedNavigation: TABS,
 			wizardApiFetch,
 			isLoading,

--- a/assets/wizards/analytics/views/newspack-custom-events/index.js
+++ b/assets/wizards/analytics/views/newspack-custom-events/index.js
@@ -52,17 +52,17 @@ class NewspackCustomEvents extends Component {
 			<div className="newspack__analytics-configuration">
 				<div className="newspack__analytics-configuration__header">
 					<SectionHeader
-						title={ __( 'Activate Newspack Custom Events', 'newspack' ) }
+						title={ __( 'Activate Newspack Custom Events', 'newspack-plugin' ) }
 						description={ __(
 							'Allows Newspack to send enhanced custom event data to your Google Analytics.',
-							'newspack'
+							'newspack-plugin'
 						) }
 						noMargin
 					/>
 					<p>
 						{ __(
 							"Newspack already sends some custom event data to your GA account, but adding the credentials below enables enhanced events that are fired from your site's backend. For example, when a donation is confirmed or when a user successfully subscribes to a newsletter.",
-							'newspack'
+							'newspack-plugin'
 						) }
 					</p>
 				</div>
@@ -71,10 +71,10 @@ class NewspackCustomEvents extends Component {
 				<Grid noMargin rowGap={ 16 }>
 					<TextControl
 						value={ ga4Credendials?.measurement_id }
-						label={ __( 'Measurement ID', 'newspack' ) }
+						label={ __( 'Measurement ID', 'newspack-plugin' ) }
 						help={ __(
 							'You can find this in Site Kit Settings, or in Google Analytics > Admin > Data Streams and clickng the data stream. Example: G-ABCD1234',
-							'newspack'
+							'newspack-plugin'
 						) }
 						onChange={ value =>
 							this.setState( {
@@ -88,10 +88,10 @@ class NewspackCustomEvents extends Component {
 					<TextControl
 						type="password"
 						value={ ga4Credendials?.measurement_protocol_secret }
-						label={ __( 'Measurement Protocol API Secret', 'newspack' ) }
+						label={ __( 'Measurement Protocol API Secret', 'newspack-plugin' ) }
 						help={ __(
 							'Generate an API secret from your GA dashboard in Admin > Data Streams and opening your data stream. Select "Measurement Protocol API secrets" under the Events section. Create a new secret.',
-							'newspack'
+							'newspack-plugin'
 						) }
 						onChange={ value =>
 							this.setState( {
@@ -109,7 +109,7 @@ class NewspackCustomEvents extends Component {
 					disabled={ isLoading }
 					onClick={ this.updateGa4Credentials }
 				>
-					{ __( 'Save', 'newspack' ) }
+					{ __( 'Save', 'newspack-plugin' ) }
 				</Button>
 			</div>
 		);

--- a/assets/wizards/analytics/views/plugins/index.js
+++ b/assets/wizards/analytics/views/plugins/index.js
@@ -26,9 +26,9 @@ class Plugins extends Component {
 		return (
 			<Fragment>
 				<ActionCard
-					title={ __( 'Google Analytics' ) }
-					description={ __( 'Configure and view site analytics' ) }
-					actionText={ __( 'View' ) }
+					title={ __( 'Google Analytics', 'newspack-plugin' ) }
+					description={ __( 'Configure and view site analytics', 'newspack-plugin' ) }
+					actionText={ __( 'View', 'newspack-plugin' ) }
 					handoff="google-site-kit"
 					editLink={
 						newspack_analytics_wizard_data.analyticsConnectionError

--- a/assets/wizards/componentsDemo/index.js
+++ b/assets/wizards/componentsDemo/index.js
@@ -82,7 +82,7 @@ class ComponentsDemo extends Component {
 							<Button
 								isLink
 								href={ newspack_urls.dashboard }
-								label={ __( 'Return to Dashboard', 'newspack' ) }
+								label={ __( 'Return to Dashboard', 'newspack-plugin' ) }
 								showTooltip={ true }
 								icon={ home }
 								iconSize={ 36 }
@@ -90,9 +90,12 @@ class ComponentsDemo extends Component {
 								<NewspackIcon size={ 36 } />
 							</Button>
 							<div>
-								<h2>{ __( 'Components Demo', 'newspack' ) }</h2>
+								<h2>{ __( 'Components Demo', 'newspack-plugin' ) }</h2>
 								<span>
-									{ __( 'Simple components used for composing the UI of Newspack', 'newspack' ) }
+									{ __(
+										'Simple components used for composing the UI of Newspack',
+										'newspack-plugin'
+									) }
 								</span>
 							</div>
 						</div>
@@ -100,12 +103,12 @@ class ComponentsDemo extends Component {
 				</div>
 				<div className="newspack-wizard newspack-wizard__content">
 					<Card>
-						<h2>{ __( 'Autocomplete with Suggestions (single-select)', 'newspack' ) }</h2>
+						<h2>{ __( 'Autocomplete with Suggestions (single-select)', 'newspack-plugin' ) }</h2>
 						<AutocompleteWithSuggestions
-							label={ __( 'Search for a post', 'newspack' ) }
+							label={ __( 'Search for a post', 'newspack-plugin' ) }
 							help={ __(
 								'Begin typing post title, click autocomplete result to select.',
-								'newspack'
+								'newspack-plugin'
 							) }
 							onChange={ items =>
 								this.setState( { selectedPostForAutocompleteWithSuggestions: items } )
@@ -115,14 +118,14 @@ class ComponentsDemo extends Component {
 
 						<hr />
 
-						<h2>{ __( 'Autocomplete with Suggestions (multi-select)', 'newspack' ) }</h2>
+						<h2>{ __( 'Autocomplete with Suggestions (multi-select)', 'newspack-plugin' ) }</h2>
 						<AutocompleteWithSuggestions
 							hideHelp
 							multiSelect
-							label={ __( 'Search widgets', 'newspack' ) }
+							label={ __( 'Search widgets', 'newspack-plugin' ) }
 							help={ __(
 								'Begin typing post title, click autocomplete result to select.',
-								'newspack'
+								'newspack-plugin'
 							) }
 							onChange={ items =>
 								this.setState( { selectedPostsForAutocompleteWithSuggestionsMultiSelect: items } )
@@ -137,70 +140,70 @@ class ComponentsDemo extends Component {
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Plugin toggles', 'newspack' ) }</h2>
+						<h2>{ __( 'Plugin toggles', 'newspack-plugin' ) }</h2>
 						<PluginToggle
 							plugins={ {
 								woocommerce: {
 									shouldRefreshAfterUpdate: true,
 								},
 								'fb-instant-articles': {
-									actionText: __( 'Configure Instant Articles' ),
+									actionText: __( 'Configure Instant Articles', 'newspack-plugin' ),
 									href: '/wp-admin/admin.php?page=newspack',
 								},
 							} }
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Web Previews', 'newspack' ) }</h2>
+						<h2>{ __( 'Web Previews', 'newspack-plugin' ) }</h2>
 						<Card buttonsCard noBorder className="items-center">
 							<WebPreview
 								url="//newspack.com/"
-								label={ __( 'Preview Newspack Blog', 'newspack' ) }
+								label={ __( 'Preview Newspack Blog', 'newspack-plugin' ) }
 								variant="primary"
 							/>
 							<WebPreview
 								url="//newspack.com/"
 								renderButton={ ( { showPreview } ) => (
 									<a href="#" onClick={ showPreview }>
-										{ __( 'Preview Newspack Blog', 'newspack' ) }
+										{ __( 'Preview Newspack Blog', 'newspack-plugin' ) }
 									</a>
 								) }
 							/>
 						</Card>
 					</Card>
 					<Card>
-						<h2>{ __( 'Waiting', 'newspack' ) }</h2>
+						<h2>{ __( 'Waiting', 'newspack-plugin' ) }</h2>
 						<Card buttonsCard noBorder>
 							<Grid columns={ 1 } gutter={ 16 } className="w-100">
 								<Waiting />
 								<div className="flex items-center">
 									<Waiting isLeft />
-									{ __( 'Spinner on the left', 'newspack' ) }
+									{ __( 'Spinner on the left', 'newspack-plugin' ) }
 								</div>
 								<div className="flex items-center">
 									<Waiting isRight />
-									{ __( 'Spinner on the right', 'newspack' ) }
+									{ __( 'Spinner on the right', 'newspack-plugin' ) }
 								</div>
 								<Waiting isCenter />
 							</Grid>
 						</Card>
 					</Card>
 					<Card>
-						<h2>{ __( 'Color picker', 'newspack' ) }</h2>
+						<h2>{ __( 'Color picker', 'newspack-plugin' ) }</h2>
 						<ColorPicker
-							label={ __( 'Color Picker', 'newspack' ) }
+							label={ __( 'Color Picker', 'newspack-plugin' ) }
 							color={ color1 }
 							onChange={ color => this.setState( { color1: color } ) }
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Handoff Buttons', 'newspack' ) }</h2>
+						<h2>{ __( 'Handoff Buttons', 'newspack-plugin' ) }</h2>
 						<Card buttonsCard noBorder>
 							<Handoff
-								modalTitle={ __( 'Manage AMP', 'newspack' ) }
+								modalTitle={ __( 'Manage AMP', 'newspack-plugin' ) }
 								modalBody={ __(
 									'Click to go to the AMP dashboard. There will be a notification bar at the top with a link to return to Newspack.',
-									'newspack'
+									'newspack-plugin'
 								) }
 								plugin="amp"
 								isTertiary
@@ -213,49 +216,49 @@ class ComponentsDemo extends Component {
 								isPrimary
 								editLink="/wp-admin/admin.php?page=wpseo_dashboard#top#features"
 							>
-								{ __( 'Specific Yoast Page', 'newspack' ) }
+								{ __( 'Specific Yoast Page', 'newspack-plugin' ) }
 							</Handoff>
 						</Card>
 					</Card>
 					<Card>
-						<h2>{ __( 'Modal', 'newspack' ) }</h2>
+						<h2>{ __( 'Modal', 'newspack-plugin' ) }</h2>
 						<Card buttonsCard noBorder>
 							<Button isPrimary onClick={ () => this.setState( { modalShown: true } ) }>
-								{ __( 'Open modal', 'newspack' ) }
+								{ __( 'Open modal', 'newspack-plugin' ) }
 							</Button>
 						</Card>
 						{ modalShown && (
 							<Modal
-								title={ __( 'This is the modal title', 'newspack' ) }
+								title={ __( 'This is the modal title', 'newspack-plugin' ) }
 								onRequestClose={ () => this.setState( { modalShown: false } ) }
 							>
 								<p>
 									{ __(
 										'Based on industry research, we advise to test the modal component, and continuing this sentence so we can see how the text wraps is one good way of doing that.',
-										'newspack'
+										'newspack-plugin'
 									) }
 								</p>
 								<Card buttonsCard noBorder className="justify-end">
 									<Button isPrimary onClick={ () => this.setState( { modalShown: false } ) }>
-										{ __( 'Dismiss', 'newspack' ) }
+										{ __( 'Dismiss', 'newspack-plugin' ) }
 									</Button>
 									<Button isSecondary onClick={ () => this.setState( { modalShown: false } ) }>
-										{ __( 'Also dismiss', 'newspack' ) }
+										{ __( 'Also dismiss', 'newspack-plugin' ) }
 									</Button>
 								</Card>
 							</Modal>
 						) }
 					</Card>
 					<Card>
-						<h2>{ __( 'Notice', 'newspack' ) }</h2>
-						<Notice noticeText={ __( 'This is an info notice.', 'newspack' ) } />
-						<Notice noticeText={ __( 'This is an error notice.', 'newspack' ) } isError />
-						<Notice noticeText={ __( 'This is a help notice.', 'newspack' ) } isHelp />
-						<Notice noticeText={ __( 'This is a success notice.', 'newspack' ) } isSuccess />
-						<Notice noticeText={ __( 'This is a warning notice.', 'newspack' ) } isWarning />
+						<h2>{ __( 'Notice', 'newspack-plugin' ) }</h2>
+						<Notice noticeText={ __( 'This is an info notice.', 'newspack-plugin' ) } />
+						<Notice noticeText={ __( 'This is an error notice.', 'newspack-plugin' ) } isError />
+						<Notice noticeText={ __( 'This is a help notice.', 'newspack-plugin' ) } isHelp />
+						<Notice noticeText={ __( 'This is a success notice.', 'newspack-plugin' ) } isSuccess />
+						<Notice noticeText={ __( 'This is a warning notice.', 'newspack-plugin' ) } isWarning />
 					</Card>
 					<Card>
-						<h2>{ __( 'Plugin installer', 'newspack' ) }</h2>
+						<h2>{ __( 'Plugin installer', 'newspack-plugin' ) }</h2>
 						<PluginInstaller
 							plugins={ [ 'woocommerce', 'wordpress-seo' ] }
 							canUninstall
@@ -270,7 +273,7 @@ class ComponentsDemo extends Component {
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Plugin installer (small)', 'newspack' ) }</h2>
+						<h2>{ __( 'Plugin installer (small)', 'newspack-plugin' ) }</h2>
 						<PluginInstaller
 							plugins={ [ 'woocommerce', 'wordpress-seo' ] }
 							isSmall
@@ -286,18 +289,18 @@ class ComponentsDemo extends Component {
 						/>
 					</Card>
 					<ActionCard
-						title={ __( 'Example One', 'newspack' ) }
-						description={ __( 'Has an action button.', 'newspack' ) }
-						actionText={ __( 'Install', 'newspack' ) }
+						title={ __( 'Example One', 'newspack-plugin' ) }
+						description={ __( 'Has an action button.', 'newspack-plugin' ) }
+						actionText={ __( 'Install', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Install clicked' );
 						} }
 					/>
 					<ActionCard
-						title={ __( 'Example Two', 'newspack' ) }
-						description={ __( 'Has action button and secondary button.', 'newspack' ) }
-						actionText={ __( 'Edit', 'newspack' ) }
-						secondaryActionText={ __( 'Delete', 'newspack' ) }
+						title={ __( 'Example Two', 'newspack-plugin' ) }
+						description={ __( 'Has action button and secondary button.', 'newspack-plugin' ) }
+						actionText={ __( 'Edit', 'newspack-plugin' ) }
+						secondaryActionText={ __( 'Delete', 'newspack-plugin' ) }
 						secondaryDestructive
 						onClick={ () => {
 							console.log( 'Edit clicked' );
@@ -307,15 +310,15 @@ class ComponentsDemo extends Component {
 						} }
 					/>
 					<ActionCard
-						title={ __( 'Example Three', 'newspack' ) }
-						description={ __( 'Waiting/in-progress state, no action button.', 'newspack' ) }
-						actionText={ __( 'Installing…', 'newspack' ) }
+						title={ __( 'Example Three', 'newspack-plugin' ) }
+						description={ __( 'Waiting/in-progress state, no action button.', 'newspack-plugin' ) }
+						actionText={ __( 'Installing…', 'newspack-plugin' ) }
 						isWaiting
 					/>
 					<ActionCard
-						title={ __( 'Example Four', 'newspack' ) }
-						description={ __( 'Error notification', 'newspack' ) }
-						actionText={ __( 'Install', 'newspack' ) }
+						title={ __( 'Example Four', 'newspack-plugin' ) }
+						description={ __( 'Error notification', 'newspack-plugin' ) }
+						actionText={ __( 'Install', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Install clicked' );
 						} }
@@ -327,8 +330,8 @@ class ComponentsDemo extends Component {
 						notificationLevel="error"
 					/>
 					<ActionCard
-						title={ __( 'Example Five', 'newspack' ) }
-						description={ __( 'Warning notification, action button', 'newspack' ) }
+						title={ __( 'Example Five', 'newspack-plugin' ) }
+						description={ __( 'Warning notification, action button', 'newspack-plugin' ) }
 						notification={
 							<Fragment>
 								There is a new version available. <a href="#">View details</a> or{ ' ' }
@@ -338,24 +341,24 @@ class ComponentsDemo extends Component {
 						notificationLevel="warning"
 					/>
 					<ActionCard
-						title={ __( 'Example Six', 'newspack' ) }
-						description={ __( 'Static text, no button', 'newspack' ) }
-						actionText={ __( 'Active', 'newspack' ) }
+						title={ __( 'Example Six', 'newspack-plugin' ) }
+						description={ __( 'Static text, no button', 'newspack-plugin' ) }
+						actionText={ __( 'Active', 'newspack-plugin' ) }
 					/>
 					<ActionCard
-						title={ __( 'Example Seven', 'newspack' ) }
-						description={ __( 'Static text, secondary action button.', 'newspack' ) }
-						actionText={ __( 'Active', 'newspack' ) }
-						secondaryActionText={ __( 'Delete', 'newspack' ) }
+						title={ __( 'Example Seven', 'newspack-plugin' ) }
+						description={ __( 'Static text, secondary action button.', 'newspack-plugin' ) }
+						actionText={ __( 'Active', 'newspack-plugin' ) }
+						secondaryActionText={ __( 'Delete', 'newspack-plugin' ) }
 						secondaryDestructive
 						onSecondaryActionClick={ () => {
 							console.log( 'Delete clicked' );
 						} }
 					/>
 					<ActionCard
-						title={ __( 'Example Eight', 'newspack' ) }
-						description={ __( 'Image with link and action button.', 'newspack' ) }
-						actionText={ __( 'Configure', 'newspack' ) }
+						title={ __( 'Example Eight', 'newspack-plugin' ) }
+						description={ __( 'Image with link and action button.', 'newspack-plugin' ) }
+						actionText={ __( 'Configure', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Configure clicked' );
 						} }
@@ -363,9 +366,9 @@ class ComponentsDemo extends Component {
 						imageLink="https://newspack.com"
 					/>
 					<ActionCard
-						title={ __( 'Example Nine', 'newspack' ) }
-						description={ __( 'Action Card with Toggle Control.', 'newspack' ) }
-						actionText={ actionCardToggleChecked && __( 'Configure', 'newspack' ) }
+						title={ __( 'Example Nine', 'newspack-plugin' ) }
+						description={ __( 'Action Card with Toggle Control.', 'newspack-plugin' ) }
+						actionText={ actionCardToggleChecked && __( 'Configure', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Configure clicked' );
 						} }
@@ -373,78 +376,83 @@ class ComponentsDemo extends Component {
 						toggleChecked={ actionCardToggleChecked }
 					/>
 					<ActionCard
-						badge={ __( 'Premium', 'newspack' ) }
-						title={ __( 'Example Ten', 'newspack' ) }
-						description={ __( 'An example of an action card with a badge.', 'newspack' ) }
-						actionText={ __( 'Install', 'newspack' ) }
+						badge={ __( 'Premium', 'newspack-plugin' ) }
+						title={ __( 'Example Ten', 'newspack-plugin' ) }
+						description={ __( 'An example of an action card with a badge.', 'newspack-plugin' ) }
+						actionText={ __( 'Install', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Install clicked' );
 						} }
 					/>
 					<ActionCard
 						isSmall
-						title={ __( 'Example Eleven', 'newspack' ) }
-						description={ __( 'An example of a small action card.', 'newspack' ) }
-						actionText={ __( 'Installing', 'newspack' ) }
+						title={ __( 'Example Eleven', 'newspack-plugin' ) }
+						description={ __( 'An example of a small action card.', 'newspack-plugin' ) }
+						actionText={ __( 'Installing', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Install clicked' );
 						} }
 					/>
 					<ActionCard
-						title={ __( 'Example Twelve', 'newspack' ) }
-						description={ __( 'Action card with an unchecked checkbox.', 'newspack' ) }
-						actionText={ __( 'Configure', 'newspack' ) }
+						title={ __( 'Example Twelve', 'newspack-plugin' ) }
+						description={ __( 'Action card with an unchecked checkbox.', 'newspack-plugin' ) }
+						actionText={ __( 'Configure', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Configure' );
 						} }
 						checkbox="unchecked"
 					/>
 					<ActionCard
-						title={ __( 'Example Thirteen', 'newspack' ) }
-						description={ __( 'Action card with a checked checkbox.', 'newspack' ) }
-						secondaryActionText={ __( 'Disconnect', 'newspack' ) }
+						title={ __( 'Example Thirteen', 'newspack-plugin' ) }
+						description={ __( 'Action card with a checked checkbox.', 'newspack-plugin' ) }
+						secondaryActionText={ __( 'Disconnect', 'newspack-plugin' ) }
 						onSecondaryActionClick={ () => {
 							console.log( 'Disconnect' );
 						} }
 						checkbox="checked"
 					/>
 					<ActionCard
-						badge={ [ __( 'Premium', 'newspack' ), __( 'Archived', 'newspack' ) ] }
-						title={ __( 'Example Fourteen', 'newspack' ) }
-						description={ __( 'An example of an action card with two badges.', 'newspack' ) }
-						actionText={ __( 'Install', 'newspack' ) }
+						badge={ [ __( 'Premium', 'newspack-plugin' ), __( 'Archived', 'newspack-plugin' ) ] }
+						title={ __( 'Example Fourteen', 'newspack-plugin' ) }
+						description={ __( 'An example of an action card with two badges.', 'newspack-plugin' ) }
+						actionText={ __( 'Install', 'newspack-plugin' ) }
 						onClick={ () => {
 							console.log( 'Install clicked' );
 						} }
 					/>
 					<ActionCard
-						title={ __( 'Handoff', 'newspack' ) }
-						description={ __( 'An example of an action card with Handoff.', 'newspack' ) }
-						actionText={ __( 'Configure', 'newspack' ) }
+						title={ __( 'Handoff', 'newspack-plugin' ) }
+						description={ __( 'An example of an action card with Handoff.', 'newspack-plugin' ) }
+						actionText={ __( 'Configure', 'newspack-plugin' ) }
 						handoff="jetpack"
 					/>
 					<ActionCard
-						title={ __( 'Handoff', 'newspack' ) }
+						title={ __( 'Handoff', 'newspack-plugin' ) }
 						description={ __(
 							' An example of an action card with Handoff and EditLink.',
-							'newspack'
+							'newspack-plugin'
 						) }
-						actionText={ __( 'Configure', 'newspack' ) }
+						actionText={ __( 'Configure', 'newspack-plugin' ) }
 						handoff="jetpack"
 						editLink="admin.php?page=jetpack#/settings"
 					/>
 					<ActionCard
 						expandable
-						title={ __( 'Expandable', 'newspack' ) }
+						title={ __( 'Expandable', 'newspack-plugin' ) }
 						description={ __(
 							' An example of an action card with expandable inner content.',
-							'newspack'
+							'newspack-plugin'
 						) }
 					>
-						<p>{ __( 'Some inner content to display when the card is expanded.', 'newspack' ) }</p>
+						<p>
+							{ __(
+								'Some inner content to display when the card is expanded.',
+								'newspack-plugin'
+							) }
+						</p>
 					</ActionCard>
 					<Card>
-						<h2>{ __( 'Image Uploader', 'newspack' ) }</h2>
+						<h2>{ __( 'Image Uploader', 'newspack-plugin' ) }</h2>
 						<ImageUpload
 							image={ this.state.image }
 							onChange={ image => {
@@ -455,171 +463,175 @@ class ComponentsDemo extends Component {
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Progress bar', 'newspack' ) }</h2>
+						<h2>{ __( 'Progress bar', 'newspack-plugin' ) }</h2>
 						<ProgressBar completed="2" total="3" />
-						<ProgressBar completed="2" total="5" label={ __( 'Progress made', 'newspack' ) } />
+						<ProgressBar
+							completed="2"
+							total="5"
+							label={ __( 'Progress made', 'newspack-plugin' ) }
+						/>
 						<ProgressBar completed="0" total="5" displayFraction />
 						<ProgressBar
 							completed="3"
 							total="8"
-							label={ __( 'Progress made', 'newspack' ) }
+							label={ __( 'Progress made', 'newspack-plugin' ) }
 							displayFraction
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Select dropdowns', 'newspack' ) }</h2>
+						<h2>{ __( 'Select dropdowns', 'newspack-plugin' ) }</h2>
 						<Grid columns={ 1 } gutter={ 16 }>
 							<SelectControl
-								label={ __( 'Label for Select with a preselection', 'newspack' ) }
+								label={ __( 'Label for Select with a preselection', 'newspack-plugin' ) }
 								value={ selectValue1 }
 								options={ [
-									{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
-									{ value: '1st', label: __( 'First', 'newspack' ) },
-									{ value: '2nd', label: __( 'Second', 'newspack' ) },
-									{ value: '3rd', label: __( 'Third', 'newspack' ) },
+									{ value: null, label: __( '- Select -', 'newspack-plugin' ), disabled: true },
+									{ value: '1st', label: __( 'First', 'newspack-plugin' ) },
+									{ value: '2nd', label: __( 'Second', 'newspack-plugin' ) },
+									{ value: '3rd', label: __( 'Third', 'newspack-plugin' ) },
 								] }
 								onChange={ value => this.setState( { selectValue1: value } ) }
 							/>
 							<SelectControl
-								label={ __( 'Label for Select with no preselection', 'newspack' ) }
+								label={ __( 'Label for Select with no preselection', 'newspack-plugin' ) }
 								value={ selectValue2 }
 								options={ [
-									{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
-									{ value: '1st', label: __( 'First', 'newspack' ) },
-									{ value: '2nd', label: __( 'Second', 'newspack' ) },
-									{ value: '3rd', label: __( 'Third', 'newspack' ) },
+									{ value: null, label: __( '- Select -', 'newspack-plugin' ), disabled: true },
+									{ value: '1st', label: __( 'First', 'newspack-plugin' ) },
+									{ value: '2nd', label: __( 'Second', 'newspack-plugin' ) },
+									{ value: '3rd', label: __( 'Third', 'newspack-plugin' ) },
 								] }
 								onChange={ value => this.setState( { selectValue2: value } ) }
 							/>
 							<SelectControl
-								label={ __( 'Label for disabled Select', 'newspack' ) }
+								label={ __( 'Label for disabled Select', 'newspack-plugin' ) }
 								disabled
 								options={ [
-									{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
-									{ value: '1st', label: __( 'First', 'newspack' ) },
-									{ value: '2nd', label: __( 'Second', 'newspack' ) },
-									{ value: '3rd', label: __( 'Third', 'newspack' ) },
+									{ value: null, label: __( '- Select -', 'newspack-plugin' ), disabled: true },
+									{ value: '1st', label: __( 'First', 'newspack-plugin' ) },
+									{ value: '2nd', label: __( 'Second', 'newspack-plugin' ) },
+									{ value: '3rd', label: __( 'Third', 'newspack-plugin' ) },
 								] }
 							/>
 							<SelectControl
-								label={ __( 'Small', 'newspack' ) }
+								label={ __( 'Small', 'newspack-plugin' ) }
 								value={ selectValue3 }
 								isSmall
 								options={ [
-									{ value: null, label: __( '- Select -', 'newspack' ), disabled: true },
-									{ value: '1st', label: __( 'First', 'newspack' ) },
-									{ value: '2nd', label: __( 'Second', 'newspack' ) },
-									{ value: '3rd', label: __( 'Third', 'newspack' ) },
+									{ value: null, label: __( '- Select -', 'newspack-plugin' ), disabled: true },
+									{ value: '1st', label: __( 'First', 'newspack-plugin' ) },
+									{ value: '2nd', label: __( 'Second', 'newspack-plugin' ) },
+									{ value: '3rd', label: __( 'Third', 'newspack-plugin' ) },
 								] }
 								onChange={ value => this.setState( { selectValue3: value } ) }
 							/>
 							<SelectControl
 								multiple
-								label={ __( 'Multi-select', 'newspack' ) }
+								label={ __( 'Multi-select', 'newspack-plugin' ) }
 								value={ this.state.selectValues }
 								options={ [
-									{ value: '1st', label: __( 'First', 'newspack' ) },
-									{ value: '2nd', label: __( 'Second', 'newspack' ) },
-									{ value: '3rd', label: __( 'Third', 'newspack' ) },
-									{ value: '4th', label: __( 'Fourth', 'newspack' ) },
-									{ value: '5th', label: __( 'Fifth', 'newspack' ) },
-									{ value: '6th', label: __( 'Sixth', 'newspack' ) },
-									{ value: '7th', label: __( 'Seventh', 'newspack' ) },
+									{ value: '1st', label: __( 'First', 'newspack-plugin' ) },
+									{ value: '2nd', label: __( 'Second', 'newspack-plugin' ) },
+									{ value: '3rd', label: __( 'Third', 'newspack-plugin' ) },
+									{ value: '4th', label: __( 'Fourth', 'newspack-plugin' ) },
+									{ value: '5th', label: __( 'Fifth', 'newspack-plugin' ) },
+									{ value: '6th', label: __( 'Sixth', 'newspack-plugin' ) },
+									{ value: '7th', label: __( 'Seventh', 'newspack-plugin' ) },
 								] }
 								onChange={ selectValues => this.setState( { selectValues } ) }
 							/>
 							<Notice
 								noticeText={
 									<>
-										{ __( 'Selected:', 'newspack' ) }{ ' ' }
+										{ __( 'Selected:', 'newspack-plugin' ) }{ ' ' }
 										{ this.state.selectValues.length > 0
 											? this.state.selectValues.join( ', ' )
-											: __( 'none', 'newspack' ) }
+											: __( 'none', 'newspack-plugin' ) }
 									</>
 								}
 							/>
 						</Grid>
 					</Card>
 					<Card>
-						<h2>{ __( 'Buttons', 'newspack' ) }</h2>
+						<h2>{ __( 'Buttons', 'newspack-plugin' ) }</h2>
 						<Grid columns={ 1 } gutter={ 16 }>
 							<p>
-								<strong>{ __( 'Default', 'newspack' ) }</strong>
+								<strong>{ __( 'Default', 'newspack-plugin' ) }</strong>
 							</p>
 							<Card buttonsCard noBorder>
-								<Button variant="primary">Primary</Button>
-								<Button variant="secondary">Secondary</Button>
-								<Button variant="tertiary">Tertiary</Button>
-								<Button>Default</Button>
-								<Button isLink>isLink</Button>
+								<Button variant="primary">{ __( 'Primary', 'newspack-plugin' ) }</Button>
+								<Button variant="secondary">{ __( 'Secondary', 'newspack-plugin' ) }</Button>
+								<Button variant="tertiary">{ __( 'Tertiary', 'newspack-plugin' ) }</Button>
+								<Button>{ __( 'Default', 'newspack-plugin' ) }</Button>
+								<Button isLink>{ __( 'isLink', 'newspack-plugin' ) }</Button>
 							</Card>
 							<p>
-								<strong>{ __( 'Disabled', 'newspack' ) }</strong>
+								<strong>{ __( 'Disabled', 'newspack-plugin' ) }</strong>
 							</p>
 							<Card buttonsCard noBorder>
 								<Button variant="primary" disabled>
-									Primary
+									{ __( 'Primary', 'newspack-plugin' ) }
 								</Button>
 								<Button variant="secondary" disabled>
-									Secondary
+									{ __( 'Secondary', 'newspack-plugin' ) }
 								</Button>
 								<Button variant="tertiary" disabled>
-									Tertiary
+									{ __( 'Tertiary', 'newspack-plugin' ) }
 								</Button>
-								<Button disabled>Default</Button>
+								<Button disabled>{ __( 'Default', 'newspack-plugin' ) }</Button>
 								<Button isLink disabled>
-									isLink
+									{ __( 'isLink', 'newspack-plugin' ) }
 								</Button>
 							</Card>
 							<p>
-								<strong>{ __( 'Small', 'newspack' ) }</strong>
+								<strong>{ __( 'Small', 'newspack-plugin' ) }</strong>
 							</p>
 							<Card buttonsCard noBorder>
 								<Button variant="primary" isSmall>
-									isPrimary
+									{ __( 'isPrimary', 'newspack-plugin' ) }
 								</Button>
 								<Button variant="secondary" isSmall>
-									isSecondary
+									{ __( 'isSecondary', 'newspack-plugin' ) }
 								</Button>
 								<Button variant="tertiary" isSmall>
-									isTertiary
+									{ __( 'isTertiary', 'newspack-plugin' ) }
 								</Button>
-								<Button isSmall>Default</Button>
+								<Button isSmall>{ __( 'Default', 'newspack-plugin' ) }</Button>
 								<Button isLink isSmall>
-									isLink
+									{ __( 'isLink', 'newspack-plugin' ) }
 								</Button>
 							</Card>
 						</Grid>
 					</Card>
 					<Card>
-						<h2>ButtonCard</h2>
+						<h2>{ __( 'ButtonCard', 'newspack-plugin' ) }</h2>
 						<ButtonCard
 							href="admin.php?page=newspack-site-design-wizard"
-							title={ __( 'Site Design', 'newspack' ) }
-							desc={ __( 'Customize the look and feel of your site', 'newspack' ) }
+							title={ __( 'Site Design', 'newspack-plugin' ) }
+							desc={ __( 'Customize the look and feel of your site', 'newspack-plugin' ) }
 							icon={ typography }
 							chevron
 						/>
 						<ButtonCard
 							href="#"
-							title={ __( 'Start a new site', 'newspack' ) }
-							desc={ __( "You don't have content to import", 'newspack' ) }
+							title={ __( 'Start a new site', 'newspack-plugin' ) }
+							desc={ __( "You don't have content to import", 'newspack-plugin' ) }
 							icon={ plus }
 							className="br--top"
 							grouped
 						/>
 						<ButtonCard
 							href="#"
-							title={ __( 'Migrate an existing site', 'newspack' ) }
-							desc={ __( 'You have content to import', 'newspack' ) }
+							title={ __( 'Migrate an existing site', 'newspack-plugin' ) }
+							desc={ __( 'You have content to import', 'newspack-plugin' ) }
 							icon={ reusableBlock }
 							className="br--bottom"
 							grouped
 						/>
 						<ButtonCard
 							href="#"
-							title={ __( 'Add a new Podcast', 'newspack' ) }
-							desc={ ( 'Small', 'newspack' ) }
+							title={ __( 'Add a new Podcast', 'newspack-plugin' ) }
+							desc={ ( 'Small', 'newspack-plugin' ) }
 							icon={ audio }
 							className="br--top"
 							isSmall
@@ -627,8 +639,8 @@ class ComponentsDemo extends Component {
 						/>
 						<ButtonCard
 							href="#"
-							title={ __( 'Add a new Font', 'newspack' ) }
-							desc={ ( 'Small + chevron', 'newspack' ) }
+							title={ __( 'Add a new Font', 'newspack-plugin' ) }
+							desc={ ( 'Small + chevron', 'newspack-plugin' ) }
 							icon={ typography }
 							className="br--bottom"
 							chevron
@@ -637,57 +649,57 @@ class ComponentsDemo extends Component {
 						/>
 					</Card>
 					<Card>
-						<h2>{ __( 'Plugin Settings Section', 'newspack' ) }</h2>
+						<h2>{ __( 'Plugin Settings Section', 'newspack-plugin' ) }</h2>
 						<PluginSettings.Section
 							sectionKey="example"
-							title={ __( 'Example plugin settings', 'newspack' ) }
-							description={ __( 'Example plugin settings description', 'newspack' ) }
+							title={ __( 'Example plugin settings', 'newspack-plugin' ) }
+							description={ __( 'Example plugin settings description', 'newspack-plugin' ) }
 							active={ true }
 							fields={ [
 								{
 									key: 'example_field',
 									type: 'string',
-									description: 'Example Text Field',
-									help: 'Example text field help text',
-									value: 'Example Value',
+									description: __( 'Example Text Field', 'newspack-plugin' ),
+									help: __( 'Example text field help text', 'newspack-plugin' ),
+									value: __( 'Example Value', 'newspack-plugin' ),
 								},
 								{
 									key: 'example_checkbox_field',
 									type: 'boolean',
-									description: 'Example checkbox Field',
-									help: 'Example checkbox field help text',
+									description: __( 'Example checkbox Field', 'newspack-plugin' ),
+									help: __( 'Example checkbox field help text', 'newspack-plugin' ),
 									value: false,
 								},
 								{
 									key: 'example_options_field',
 									type: 'string',
-									description: 'Example options field',
-									help: 'Example options field help text',
+									description: __( 'Example options field', 'newspack-plugin' ),
+									help: __( 'Example options field help text', 'newspack-plugin' ),
 									options: [
 										{
 											value: 'example_value_1',
-											name: 'Example Value 1',
+											name: __( 'Example Value 1', 'newspack-plugin' ),
 										},
 										{
 											value: 'example_value_2',
-											name: 'Example Value 2',
+											name: __( 'Example Value 2', 'newspack-plugin' ),
 										},
 									],
 								},
 								{
 									key: 'example_multi_options_field',
 									type: 'string',
-									description: 'Example multiple options field',
-									help: 'Example multiple options field help text',
+									description: __( 'Example multiple options field', 'newspack-plugin' ),
+									help: __( 'Example multiple options field help text', 'newspack-plugin' ),
 									multiple: true,
 									options: [
 										{
 											value: 'example_value_1',
-											name: 'Example Value 1',
+											name: __( 'Example Value 1', 'newspack-plugin' ),
 										},
 										{
 											value: 'example_value_2',
-											name: 'Example Value 2',
+											name: __( 'Example Value 2', 'newspack-plugin' ),
 										},
 									],
 								},

--- a/assets/wizards/connections/index.js
+++ b/assets/wizards/connections/index.js
@@ -21,8 +21,8 @@ const MainScreen = withWizardScreen( Main );
 
 const ConnectionsWizard = ( { pluginRequirements, wizardApiFetch, startLoading, doneLoading } ) => {
 	const wizardScreenProps = {
-		headerText: __( 'Connections', 'newspack' ),
-		subHeaderText: __( 'Connections to third-party services', 'newspack' ),
+		headerText: __( 'Connections', 'newspack-plugin' ),
+		subHeaderText: __( 'Connections to third-party services', 'newspack-plugin' ),
 		wizardApiFetch,
 		startLoading,
 		doneLoading,

--- a/assets/wizards/connections/views/main/fivetran.js
+++ b/assets/wizards/connections/views/main/fivetran.js
@@ -20,7 +20,7 @@ import get from 'lodash/get';
 const CONNECTORS = [
 	{
 		service: 'stripe',
-		label: __( 'Stripe', 'newspack' ),
+		label: __( 'Stripe', 'newspack-plugin' ),
 	},
 ];
 
@@ -37,11 +37,11 @@ const getConnectionStatus = ( item, connections ) => {
 		} else if ( isPending ) {
 			label = `${ setupState }, ${ syncState }. ${ __(
 				'Sync is in progress – please check back in a while.',
-				'newspack'
+				'newspack-plugin'
 			) }`;
 		}
 	} else if ( hasConnections ) {
-		label = __( 'Not connected', 'newspack' );
+		label = __( 'Not connected', 'newspack-plugin' );
 	}
 	return {
 		label,
@@ -55,7 +55,8 @@ const FivetranConnection = ( { setError } ) => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ hasAcceptedTOS, setHasAcceptedTOS ] = useState( null );
 
-	const handleError = err => setError( err.message || __( 'Something went wrong.', 'newspack' ) );
+	const handleError = err =>
+		setError( err.message || __( 'Something went wrong.', 'newspack-plugin' ) );
 
 	const hasConnections = connections !== undefined;
 	const isDisabled = inFlight || ! hasConnections || ! hasAcceptedTOS;
@@ -87,9 +88,9 @@ const FivetranConnection = ( { setError } ) => {
 	return (
 		<>
 			<div>
-				{ __( 'In order to use the this features, you must read and accept', 'newspack' ) }{ ' ' }
+				{ __( 'In order to use the this features, you must read and accept', 'newspack-plugin' ) }{ ' ' }
 				<a href="https://newspack.com/terms-of-service/">
-					{ __( 'Newspack Terms of Service', 'newspack' ) }
+					{ __( 'Newspack Terms of Service', 'newspack-plugin' ) }
 				</a>
 				:
 			</div>
@@ -107,7 +108,7 @@ const FivetranConnection = ( { setError } ) => {
 					} );
 					setHasAcceptedTOS( has_accepted );
 				} }
-				label={ __( "I've read and accept Newspack Terms of Service", 'newspack' ) }
+				label={ __( "I've read and accept Newspack Terms of Service", 'newspack-plugin' ) }
 			/>
 			{ CONNECTORS.map( item => {
 				const status = getConnectionStatus( item, connections );
@@ -115,13 +116,13 @@ const FivetranConnection = ( { setError } ) => {
 					<ActionCard
 						key={ item.service }
 						title={ item.label }
-						description={ `${ __( 'Status:', 'newspack' ) } ${ status.label }` }
+						description={ `${ __( 'Status:', 'newspack-plugin' ) } ${ status.label }` }
 						isPending={ status.isPending }
 						actionText={
 							<Button disabled={ isDisabled } onClick={ () => createConnection( item ) } isLink>
 								{ status.isConnected
-									? __( 'Re-connect', 'newspack' )
-									: __( 'Connect', 'newspack' ) }
+									? __( 'Re-connect', 'newspack-plugin' )
+									: __( 'Connect', 'newspack-plugin' ) }
 							</Button>
 						}
 						checkbox={ status.isConnected ? 'checked' : 'unchecked' }

--- a/assets/wizards/connections/views/main/google.js
+++ b/assets/wizards/connections/views/main/google.js
@@ -27,7 +27,7 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ localError, setLocalError ] = useState( null );
 	const handleError = res => {
-		const message = res.message || __( 'Something went wrong.', 'newspack' );
+		const message = res.message || __( 'Something went wrong.', 'newspack-plugin' );
 		setLocalError( message );
 		if ( typeof setError === 'function' ) {
 			setError( message );
@@ -39,7 +39,7 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 	useEffect( () => {
 		if ( isConnected && ! userBasicInfo.has_refresh_token ) {
 			setError( [
-				__( 'Missing Google refresh token. Please', 'newspack' ),
+				__( 'Missing Google refresh token. Please', 'newspack-plugin' ),
 				' ',
 				<a
 					key="link"
@@ -47,10 +47,10 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 					rel="noreferrer"
 					href="https://myaccount.google.com/permissions"
 				>
-					{ __( 'revoke credentials', 'newspack' ) }
+					{ __( 'revoke credentials', 'newspack-plugin' ) }
 				</a>,
 				' ',
-				__( 'and authorise the site again.', 'newspack' ),
+				__( 'and authorize the site again.', 'newspack-plugin' ),
 			] );
 		}
 	}, [ isConnected ] );
@@ -136,22 +136,22 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 			return localError;
 		}
 		if ( inFlight ) {
-			return __( 'Loading…', 'newspack' );
+			return __( 'Loading…', 'newspack-plugin' );
 		}
 		if ( isConnected ) {
 			return sprintf(
 				// Translators: connected user's email address.
-				__( 'Connected as %s', 'newspack' ),
+				__( 'Connected as %s', 'newspack-plugin' ),
 				userBasicInfo.email
 			);
 		}
-		return __( 'Not connected', 'newspack' );
+		return __( 'Not connected', 'newspack-plugin' );
 	};
 
 	return (
 		<ActionCard
-			title={ __( 'Google', 'newspack' ) }
-			description={ `${ __( 'Status:', 'newspack' ) } ${ getDescription() }` }
+			title={ __( 'Google', 'newspack-plugin' ) }
+			description={ `${ __( 'Status:', 'newspack-plugin' ) } ${ getDescription() }` }
 			checkbox={ isConnected ? 'checked' : 'unchecked' }
 			actionText={
 				<Button
@@ -160,7 +160,9 @@ const GoogleOAuth = ( { setError, onInit, onSuccess } ) => {
 					onClick={ isConnected ? disconnect : openAuth }
 					disabled={ inFlight }
 				>
-					{ isConnected ? __( 'Disconnect', 'newspack' ) : __( 'Connect', 'newspack' ) }
+					{ isConnected
+						? __( 'Disconnect', 'newspack-plugin' )
+						: __( 'Connect', 'newspack-plugin' ) }
 				</Button>
 			}
 			isMedium

--- a/assets/wizards/connections/views/main/index.js
+++ b/assets/wizards/connections/views/main/index.js
@@ -24,9 +24,9 @@ const Main = () => {
 	return (
 		<>
 			{ error && <Notice isError noticeText={ error } /> }
-			<SectionHeader title={ __( 'Plugins', 'newspack' ) } />
+			<SectionHeader title={ __( 'Plugins', 'newspack-plugin' ) } />
 			<Plugins />
-			<SectionHeader title={ __( 'APIs', 'newspack' ) } />
+			<SectionHeader title={ __( 'APIs', 'newspack-plugin' ) } />
 			{ newspack_connections_data.can_connect_google && (
 				<GoogleAuth setError={ setErrorWithPrefix( __( 'Google: ', 'newspack-plugin' ) ) } />
 			) }

--- a/assets/wizards/connections/views/main/mailchimp.js
+++ b/assets/wizards/connections/views/main/mailchimp.js
@@ -21,7 +21,8 @@ const Mailchimp = ( { setError } ) => {
 	const modalTextRef = useRef( null );
 	const isConnected = Boolean( authState && authState.username );
 
-	const handleError = res => setError( res.message || __( 'Something went wrong.', 'newspack' ) );
+	const handleError = res =>
+		setError( res.message || __( 'Something went wrong.', 'newspack-plugin' ) );
 
 	const openModal = () => setisModalOpen( true );
 	const closeModal = () => {
@@ -62,7 +63,10 @@ const Mailchimp = ( { setError } ) => {
 			.catch( e => {
 				setError(
 					e.message ||
-						__( 'Something went wrong during verification of your Mailchimp API key.', 'newspack' )
+						__(
+							'Something went wrong during verification of your Mailchimp API key.',
+							'newspack-plugin'
+						)
 				);
 			} )
 			.finally( () => {
@@ -86,30 +90,30 @@ const Mailchimp = ( { setError } ) => {
 
 	const getDescription = () => {
 		if ( isLoading ) {
-			return __( 'Loading…', 'newspack' );
+			return __( 'Loading…', 'newspack-plugin' );
 		}
 		if ( isConnected ) {
 			// Translators: user connection status message.
-			return sprintf( __( 'Connected as %s', 'newspack' ), authState.username );
+			return sprintf( __( 'Connected as %s', 'newspack-plugin' ), authState.username );
 		}
-		return __( 'Not connected', 'newspack' );
+		return __( 'Not connected', 'newspack-plugin' );
 	};
 
 	const getModalButtonText = () => {
 		if ( isLoading ) {
-			return __( 'Connecting…', 'newspack' );
+			return __( 'Connecting…', 'newspack-plugin' );
 		}
 		if ( isConnected ) {
-			return __( 'Connected', 'newspack' );
+			return __( 'Connected', 'newspack-plugin' );
 		}
-		return __( 'Connect', 'newspack' );
+		return __( 'Connect', 'newspack-plugin' );
 	};
 
 	return (
 		<>
 			<ActionCard
 				title="Mailchimp"
-				description={ `${ __( 'Status:', 'newspack' ) } ${ getDescription() }` }
+				description={ `${ __( 'Status:', 'newspack-plugin' ) } ${ getDescription() }` }
 				checkbox={ isConnected ? 'checked' : 'unchecked' }
 				actionText={
 					<Button
@@ -118,18 +122,23 @@ const Mailchimp = ( { setError } ) => {
 						onClick={ isConnected ? disconnect : openModal }
 						disabled={ isLoading }
 					>
-						{ isConnected ? __( 'Disconnect', 'newspack' ) : __( 'Connect', 'newspack' ) }
+						{ isConnected
+							? __( 'Disconnect', 'newspack-plugin' )
+							: __( 'Connect', 'newspack-plugin' ) }
 					</Button>
 				}
 				isMedium
 			/>
 			{ isModalOpen && (
-				<Modal title={ __( 'Add Mailchimp API Key', 'newspack' ) } onRequestClose={ closeModal }>
+				<Modal
+					title={ __( 'Add Mailchimp API Key', 'newspack-plugin' ) }
+					onRequestClose={ closeModal }
+				>
 					<div ref={ modalTextRef }>
 						<Grid columns={ 1 } gutter={ 8 }>
 							<TextControl
 								placeholder="123457103961b1f4dc0b2b2fd59c137b-us1"
-								label={ __( 'Mailchimp API Key', 'newspack' ) }
+								label={ __( 'Mailchimp API Key', 'newspack-plugin' ) }
 								hideLabelFromVision={ true }
 								value={ apiKey }
 								onChange={ setAPIKey }
@@ -142,14 +151,14 @@ const Mailchimp = ( { setError } ) => {
 							/>
 							<p>
 								<ExternalLink href="https://mailchimp.com/help/about-api-keys/#Find_or_generate_your_API_key">
-									{ __( 'Find or generate your API key', 'newspack' ) }
+									{ __( 'Find or generate your API key', 'newspack-plugin' ) }
 								</ExternalLink>
 							</p>
 						</Grid>
 					</div>
 					<Card buttonsCard noBorder className="justify-end">
 						<Button isSecondary onClick={ closeModal }>
-							{ __( 'Cancel', 'newspack' ) }
+							{ __( 'Cancel', 'newspack-plugin' ) }
 						</Button>
 						<Button isPrimary disabled={ ! apiKey } onClick={ submitAPIKey }>
 							{ getModalButtonText() }

--- a/assets/wizards/connections/views/main/plugins.js
+++ b/assets/wizards/connections/views/main/plugins.js
@@ -23,7 +23,7 @@ const PLUGINS = {
 	'google-site-kit': {
 		pluginSlug: 'google-site-kit',
 		editLink: 'admin.php?page=googlesitekit-splash',
-		name: __( 'Site Kit by Google', 'newspack' ),
+		name: __( 'Site Kit by Google', 'newspack-plugin' ),
 		fetchStatus: () =>
 			apiFetch( { path: '/newspack/v1/plugins/google-site-kit' } ).then( result => ( {
 				'google-site-kit': { status: result.Configured ? result.Status : 'inactive' },
@@ -35,20 +35,22 @@ const pluginConnectButton = plugin => {
 	if ( plugin.pluginSlug ) {
 		return (
 			<Handoff plugin={ plugin.pluginSlug } editLink={ plugin.editLink } compact isLink>
-				{ __( 'Connect', 'newspack' ) }
+				{ __( 'Connect', 'newspack-plugin' ) }
 			</Handoff>
 		);
 	}
 	if ( plugin.url ) {
 		return (
 			<Button isLink href={ plugin.url } target="_blank">
-				{ __( 'Connect', 'newspack' ) }
+				{ __( 'Connect', 'newspack-plugin' ) }
 			</Button>
 		);
 	}
 	if ( plugin.error?.code === 'unavailable_site_id' ) {
 		return (
-			<span className="i newspack-error">{ __( 'Jetpack connection required', 'newspack' ) }</span>
+			<span className="i newspack-error">
+				{ __( 'Jetpack connection required', 'newspack-plugin' ) }
+			</span>
 		);
 	}
 };
@@ -70,21 +72,21 @@ const Plugins = ( { setError } ) => {
 				const isLoading = ! plugin.status;
 				const getDescription = () => {
 					if ( isLoading ) {
-						return __( 'Loading…', 'newspack' );
+						return __( 'Loading…', 'newspack-plugin' );
 					}
 					if ( isInactive ) {
 						if ( plugin.pluginSlug === 'google-site-kit' ) {
-							return __( 'Not connected for this user', 'newspack' );
+							return __( 'Not connected for this user', 'newspack-plugin' );
 						}
-						return __( 'Not connected', 'newspack' );
+						return __( 'Not connected', 'newspack-plugin' );
 					}
-					return __( 'Connected', 'newspack' );
+					return __( 'Connected', 'newspack-plugin' );
 				};
 				return (
 					<ActionCard
 						key={ plugin.name }
 						title={ plugin.name }
-						description={ `${ __( 'Status:', 'newspack' ) } ${ getDescription() }` }
+						description={ `${ __( 'Status:', 'newspack-plugin' ) } ${ getDescription() }` }
 						actionText={ isInactive ? pluginConnectButton( plugin ) : null }
 						checkbox={ isInactive || isLoading ? 'unchecked' : 'checked' }
 						badge={ plugin.badge }

--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -73,7 +73,7 @@ const Recaptcha = () => {
 							'newspack-plugin'
 						) }{ ' ' }
 						<ExternalLink href="https://www.google.com/recaptcha/admin/create">
-							{ __( 'Get started' ) }
+							{ __( 'Get started', 'newspack-plugin' ) }
 						</ExternalLink>
 					</>
 				) }

--- a/assets/wizards/connections/views/main/webhooks.js
+++ b/assets/wizards/connections/views/main/webhooks.js
@@ -83,7 +83,7 @@ const EndpointActions = ( {
 				onClick={ () => setPopoverVisible( ! popoverVisible ) }
 				icon={ moreVertical }
 				disabled={ disabled }
-				label={ __( 'Endpoint Actions', 'newspack' ) }
+				label={ __( 'Endpoint Actions', 'newspack-plugin' ) }
 				tooltipPosition={ position }
 			/>
 			{ popoverVisible && (
@@ -93,19 +93,19 @@ const EndpointActions = ( {
 					onKeyDown={ event => ESCAPE === event.keyCode && setPopoverVisible( false ) }
 				>
 					<MenuItem onClick={ () => setPopoverVisible( false ) } className="screen-reader-text">
-						{ __( 'Close Endpoint Actions', 'newspack' ) }
+						{ __( 'Close Endpoint Actions', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem onClick={ onView } className="newspack-button">
-						{ __( 'View Requests', 'newspack' ) }
+						{ __( 'View Requests', 'newspack-plugin' ) }
 					</MenuItem>
 					{ ! isSystem && (
 						<MenuItem onClick={ onEdit } className="newspack-button">
-							{ __( 'Edit', 'newspack' ) }
+							{ __( 'Edit', 'newspack-plugin' ) }
 						</MenuItem>
 					) }
 					{ ! isSystem && (
 						<MenuItem onClick={ onDelete } className="newspack-button" isDestructive>
-							{ __( 'Remove', 'newspack' ) }
+							{ __( 'Remove', 'newspack-plugin' ) }
 						</MenuItem>
 					) }
 				</Popover>
@@ -120,10 +120,10 @@ const ConfirmationModal = ( { disabled, onConfirm, onClose, title, description }
 			<p>{ description }</p>
 			<Card buttonsCard noBorder className="justify-end">
 				<Button isSecondary onClick={ onClose } disabled={ disabled }>
-					{ __( 'Cancel', 'newspack' ) }
+					{ __( 'Cancel', 'newspack-plugin' ) }
 				</Button>
 				<Button isPrimary onClick={ onConfirm } disabled={ disabled }>
-					{ __( 'Confirm', 'newspack' ) }
+					{ __( 'Confirm', 'newspack-plugin' ) }
 				</Button>
 			</Card>
 		</Modal>

--- a/assets/wizards/engagement/components/active-campaign.js
+++ b/assets/wizards/engagement/components/active-campaign.js
@@ -30,22 +30,25 @@ export default function ActiveCampaign( { value, onChange } ) {
 		<>
 			{ error && (
 				<Notice
-					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+					noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 					isError
 				/>
 			) }
 			<SectionHeader
-				title={ __( 'ActiveCampaign', 'newspack' ) }
-				description={ __( 'Settings for the ActiveCampaign integration.', 'newspack' ) }
+				title={ __( 'ActiveCampaign', 'newspack-plugin' ) }
+				description={ __( 'Settings for the ActiveCampaign integration.', 'newspack-plugin' ) }
 			/>
 			<SelectControl
-				label={ __( 'Master List', 'newspack' ) }
-				help={ __( 'Choose a list to which all registered readers will be added.', 'newspack' ) }
+				label={ __( 'Master List', 'newspack-plugin' ) }
+				help={ __(
+					'Choose a list to which all registered readers will be added.',
+					'newspack-plugin'
+				) }
 				disabled={ inFlight }
 				value={ value.masterList }
 				onChange={ handleChange( 'masterList' ) }
 				options={ [
-					{ value: '', label: __( 'None', 'newspack' ) },
+					{ value: '', label: __( 'None', 'newspack-plugin' ) },
 					...lists.map( list => ( { label: list.name, value: list.id } ) ),
 				] }
 			/>

--- a/assets/wizards/engagement/components/mailchimp.js
+++ b/assets/wizards/engagement/components/mailchimp.js
@@ -30,22 +30,22 @@ export default function Mailchimp( { value, onChange } ) {
 		<>
 			{ error && (
 				<Notice
-					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+					noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 					isError
 				/>
 			) }
 			<SectionHeader
-				title={ __( 'Mailchimp', 'newspack' ) }
-				description={ __( 'Settings for the Mailchimp integration.', 'newspack' ) }
+				title={ __( 'Mailchimp', 'newspack-plugin' ) }
+				description={ __( 'Settings for the Mailchimp integration.', 'newspack-plugin' ) }
 			/>
 			<SelectControl
-				label={ __( 'Audience ID', 'newspack' ) }
-				help={ __( 'Choose an audience to receive reader activity data.', 'newspack' ) }
+				label={ __( 'Audience ID', 'newspack-plugin' ) }
+				help={ __( 'Choose an audience to receive reader activity data.', 'newspack-plugin' ) }
 				disabled={ inFlight }
 				value={ value.audienceId }
 				onChange={ handleChange( 'audienceId' ) }
 				options={ [
-					{ value: '', label: __( 'None', 'newspack' ) },
+					{ value: '', label: __( 'None', 'newspack-plugin' ) },
 					...lists.map( list => ( { label: list.name, value: list.id } ) ),
 				] }
 			/>

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -49,7 +49,7 @@ export default function Prerequisite( {
 						<>
 							{ ' ' }
 							<ExternalLink href={ prerequisite.help_url }>
-								{ __( 'Learn more', 'newspack' ) }
+								{ __( 'Learn more', 'newspack-plugin' ) }
 							</ExternalLink>
 						</>
 					) }
@@ -89,11 +89,13 @@ export default function Prerequisite( {
 								disabled={ inFlight }
 							>
 								{ inFlight
-									? __( 'Saving…', 'newspack' )
+									? __( 'Saving…', 'newspack-plugin' )
 									: sprintf(
 											// Translators: Save or Update settings.
-											__( '%s settings', 'newspack' ),
-											prerequisite.active ? __( 'Update', 'newspack' ) : __( 'Save', 'newspack' )
+											__( '%s settings', 'newspack-plugin' ),
+											prerequisite.active
+												? __( 'Update', 'newspack-plugin' )
+												: __( 'Save', 'newspack-plugin' )
 									  ) }
 							</Button>
 						</div>
@@ -119,7 +121,7 @@ export default function Prerequisite( {
 														// Translators: %s is specific instructions for satisfying the prerequisite.
 														__(
 															'%1$s%2$sReturn to the Reader Activation page to complete the settings and activate%3$s.',
-															'newspack'
+															'newspack-plugin'
 														),
 														prerequisite.instructions + ' ',
 														window.newspack_engagement_wizard?.reader_activation_url
@@ -137,10 +139,10 @@ export default function Prerequisite( {
 								>
 									{ /* eslint-disable no-nested-ternary */ }
 									{ ( prerequisite.active
-										? __( 'Update ', 'newspack' )
+										? __( 'Update ', 'newspack-plugin' )
 										: prerequisite.fields
-										? __( 'Save ', 'newspack' )
-										: __( 'Configure ', 'newspack' ) ) + prerequisite.action_text }
+										? __( 'Save ', 'newspack-plugin' )
+										: __( 'Configure ', 'newspack-plugin' ) ) + prerequisite.action_text }
 								</Button>
 							) }
 							{ prerequisite.hasOwnProperty( 'action_enabled' ) && ! prerequisite.action_enabled && (
@@ -155,12 +157,12 @@ export default function Prerequisite( {
 		</>
 	);
 
-	let status = __( 'Pending', 'newspack' );
+	let status = __( 'Pending', 'newspack-plugin' );
 	if ( prerequisite.active ) {
-		status = __( 'Ready', 'newspack' );
+		status = __( 'Ready', 'newspack-plugin' );
 	}
 	if ( prerequisite.is_unavailable ) {
-		status = __( 'Unavailable', 'newspack' );
+		status = __( 'Unavailable', 'newspack-plugin' );
 	}
 
 	return (
@@ -172,7 +174,7 @@ export default function Prerequisite( {
 			title={ prerequisite.label }
 			description={ sprintf(
 				/* translators: %s: Prerequisite status */
-				__( 'Status: %s', 'newspack' ),
+				__( 'Status: %s', 'newspack-plugin' ),
 				status
 			) }
 			checkbox={ prerequisite.active ? 'checked' : 'unchecked' }

--- a/assets/wizards/engagement/components/prompt.tsx
+++ b/assets/wizards/engagement/components/prompt.tsx
@@ -122,7 +122,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 
 	const unblock = hooks.usePrompt(
 		isDirty,
-		__( 'You have unsaved changes. Discard changes?', 'newspack' )
+		__( 'You have unsaved changes. Discard changes?', 'newspack-plugin' )
 	);
 
 	const savePrompt = ( slug: string, data: InputValues ) => {
@@ -143,7 +143,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 			} )
 				.then( ( fetchedPrompts: Array< PromptType > ) => {
 					setPrompts( fetchedPrompts );
-					setSuccess( __( 'Prompt saved.', 'newspack' ) );
+					setSuccess( __( 'Prompt saved.', 'newspack-plugin' ) );
 					setIsDirty( false );
 					res();
 				} )
@@ -167,12 +167,12 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 			title={ prompt.title }
 			description={ sprintf(
 				// Translators: Status of the prompt.
-				__( 'Status: %s', 'newspack' ),
+				__( 'Status: %s', 'newspack-plugin' ),
 				isDirty
-					? __( 'Unsaved changes', 'newspack' )
+					? __( 'Unsaved changes', 'newspack-plugin' )
 					: prompt.ready
-					? __( 'Ready', 'newspack' )
-					: __( 'Pending', 'newspack' )
+					? __( 'Ready', 'newspack-plugin' )
+					: __( 'Pending', 'newspack-plugin' )
 			) }
 			checkbox={ prompt.ready && ! isDirty ? 'checked' : 'unchecked' }
 		>
@@ -274,7 +274,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 										label={ field.label }
 									>
 										<ImageUpload
-											buttonLabel={ __( 'Select file', 'newspack' ) }
+											buttonLabel={ __( 'Select file', 'newspack-plugin' ) }
 											disabled={ inFlight }
 											image={ image }
 											onChange={ ( attachment: Attachment ) => {
@@ -297,7 +297,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 						) ) }
 						{ error && (
 							<Notice
-								noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+								noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 								isError
 							/>
 						) }
@@ -312,11 +312,13 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 								disabled={ inFlight }
 							>
 								{ inFlight
-									? __( 'Saving…', 'newspack' )
+									? __( 'Saving…', 'newspack-plugin' )
 									: sprintf(
 											// Translators: Save or Update settings.
-											__( '%s prompt settings', 'newspack' ),
-											prompt.ready ? __( 'Update', 'newspack' ) : __( 'Save', 'newspack' )
+											__( '%s prompt settings', 'newspack-plugin' ),
+											prompt.ready
+												? __( 'Update', 'newspack-plugin' )
+												: __( 'Save', 'newspack-plugin' )
 									  ) }
 							</Button>
 							<WebPreview
@@ -328,7 +330,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 										isSecondary
 										onClick={ async () => showPreview() }
 									>
-										{ __( 'Preview prompt', 'newspack' ) }
+										{ __( 'Preview prompt', 'newspack-plugin' ) }
 									</Button>
 								) }
 							/>
@@ -342,7 +344,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 									<span dangerouslySetInnerHTML={ { __html: helpInfo.description } } />{ ' ' }
 									{ helpInfo.url && (
 										<ExternalLink href={ helpInfo.url }>
-											{ __( 'Learn more', 'newspack' ) }
+											{ __( 'Learn more', 'newspack-plugin' ) }
 										</ExternalLink>
 									) }
 								</p>
@@ -350,7 +352,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 							{ helpInfo.recommendations && (
 								<>
 									<h4 className="newspack-ras-campaign__recommendation-heading">
-										{ __( 'We recommend', 'newspack' ) }
+										{ __( 'We recommend', 'newspack-plugin' ) }
 									</h4>
 									<ul>
 										{ helpInfo.recommendations.map( ( recommendation, index ) => (

--- a/assets/wizards/engagement/index.js
+++ b/assets/wizards/engagement/index.js
@@ -66,7 +66,8 @@ class EngagementWizard extends Component {
 		} catch ( e ) {
 			this.setState( {
 				relatedPostsError:
-					e.message || __( 'There was an error saving settings. Please try again.', 'newspack' ),
+					e.message ||
+					__( 'There was an error saving settings. Please try again.', 'newspack-plugin' ),
 			} );
 		}
 	};
@@ -82,7 +83,7 @@ class EngagementWizard extends Component {
 		const defaultPath = '/reader-activation';
 		const tabbed_navigation = [
 			{
-				label: __( 'Reader Activation', 'newspack' ),
+				label: __( 'Reader Activation', 'newspack-plugin' ),
 				path: '/reader-activation',
 				exact: true,
 				activeTabPaths: [
@@ -92,22 +93,22 @@ class EngagementWizard extends Component {
 				],
 			},
 			{
-				label: __( 'Newsletters', 'newspack' ),
+				label: __( 'Newsletters', 'newspack-plugin' ),
 				path: '/newsletters',
 				exact: true,
 			},
 			{
-				label: __( 'Social', 'newspack' ),
+				label: __( 'Social', 'newspack-plugin' ),
 				path: '/social',
 				exact: true,
 			},
 			{
-				label: __( 'Recirculation', 'newspack' ),
+				label: __( 'Recirculation', 'newspack-plugin' ),
 				path: '/recirculation',
 			},
 		];
 		const props = {
-			headerText: __( 'Engagement', 'newspack' ),
+			headerText: __( 'Engagement', 'newspack-plugin' ),
 			tabbedNavigation: tabbed_navigation,
 			wizardApiFetch,
 		};
@@ -121,7 +122,10 @@ class EngagementWizard extends Component {
 							exact
 							render={ () => (
 								<ReaderActivation
-									subHeaderText={ __( 'Configure your reader activation settings', 'newspack' ) }
+									subHeaderText={ __(
+										'Configure your reader activation settings',
+										'newspack-plugin'
+									) }
 									{ ...props }
 								/>
 							) }
@@ -132,7 +136,7 @@ class EngagementWizard extends Component {
 								<ReaderActivationCampaign
 									subHeaderText={ __(
 										'Preview and customize the reader activation prompts',
-										'newspack'
+										'newspack-plugin'
 									) }
 									{ ...props }
 								/>
@@ -144,7 +148,7 @@ class EngagementWizard extends Component {
 								<ReaderActivationComplete
 									subHeaderText={ __(
 										'Preview and customize the reader activation prompts',
-										'newspack'
+										'newspack-plugin'
 									) }
 									{ ...props }
 								/>
@@ -154,7 +158,7 @@ class EngagementWizard extends Component {
 							path="/newsletters"
 							render={ () => (
 								<Newsletters
-									subHeaderText={ __( 'Configure your newsletter settings', 'newspack' ) }
+									subHeaderText={ __( 'Configure your newsletter settings', 'newspack-plugin' ) }
 									{ ...props }
 								/>
 							) }
@@ -164,7 +168,7 @@ class EngagementWizard extends Component {
 							exact
 							render={ () => (
 								<Social
-									subHeaderText={ __( 'Share your content to social media', 'newspack' ) }
+									subHeaderText={ __( 'Share your content to social media', 'newspack-plugin' ) }
 									{ ...props }
 								/>
 							) }
@@ -175,11 +179,11 @@ class EngagementWizard extends Component {
 							render={ () => (
 								<RelatedContent
 									{ ...props }
-									subHeaderText={ __( 'Engage visitors with related content', 'newspack' ) }
+									subHeaderText={ __( 'Engage visitors with related content', 'newspack-plugin' ) }
 									relatedPostsEnabled={ relatedPostsEnabled }
 									relatedPostsError={ relatedPostsError }
 									buttonAction={ () => this.updatedRelatedContentSettings() }
-									buttonText={ __( 'Save Settings', 'newspack' ) }
+									buttonText={ __( 'Save Settings', 'newspack-plugin' ) }
 									buttonDisabled={ ! relatedPostsEnabled || ! relatedPostsUpdated }
 									relatedPostsMaxAge={ relatedPostsMaxAge }
 									onChange={ value => {

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -155,17 +155,19 @@ export const NewspackNewsletters = ( {
 		return (
 			<ActionCard
 				isMedium
-				title={ __( 'Email Service Provider', 'newspack' ) }
+				title={ __( 'Email Service Provider', 'newspack-plugin' ) }
 				description={ __(
 					'Connect an email service provider (ESP) to author and send newsletters.',
-					'newspack'
+					'newspack-plugin'
 				) }
-				notification={ error ? error?.message || __( 'Something went wrong.', 'newspack' ) : null }
+				notification={
+					error ? error?.message || __( 'Something went wrong.', 'newspack-plugin' ) : null
+				}
 				notificationLevel="error"
 				hasGreyHeader
 				actionContent={
 					<Button disabled={ inFlight } variant="primary" onClick={ saveNewslettersData }>
-						{ __( 'Save Settings', 'newspack' ) }
+						{ __( 'Save Settings', 'newspack-plugin' ) }
 					</Button>
 				}
 				disabled={ inFlight }
@@ -173,16 +175,16 @@ export const NewspackNewsletters = ( {
 				<Grid gutter={ 16 } columns={ 1 }>
 					{ false !== authUrl && (
 						<Card isSmall>
-							<h3>{ __( 'Authorize Application', 'newspack' ) }</h3>
+							<h3>{ __( 'Authorize Application', 'newspack-plugin' ) }</h3>
 							<p>
 								{ sprintf(
 									// translators: %s is the name of the ESP.
-									__( 'Authorize %s to connect to Newspack.', 'newspack-newsletters' ),
+									__( 'Authorize %s to connect to Newspack.', 'newspack-plugin' ),
 									getSelectedProviderName()
 								) }
 							</p>
 							<Button isSecondary onClick={ handleAuth }>
-								{ __( 'Authorize', 'newspack' ) }
+								{ __( 'Authorize', 'newspack-plugin' ) }
 							</Button>
 						</Card>
 					) }
@@ -297,16 +299,19 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 		<>
 			<ActionCard
 				isMedium
-				title={ __( 'Subscription Lists', 'newspack' ) }
-				description={ __( 'Manage the lists available to readers for subscription.', 'newspack' ) }
+				title={ __( 'Subscription Lists', 'newspack-plugin' ) }
+				description={ __(
+					'Manage the lists available to readers for subscription.',
+					'newspack-plugin'
+				) }
 				notification={
 					/* eslint-disable no-nested-ternary */
 					error
-						? error?.message || __( 'Something went wrong.', 'newspack' )
+						? error?.message || __( 'Something went wrong.', 'newspack-plugin' )
 						: lockedLists
 						? __(
 								'Please save your ESP settings before changing your subscription lists.',
-								'newspack'
+								'newspack-plugin'
 						  )
 						: null
 				}
@@ -320,11 +325,11 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 								disabled={ inFlight || lockedLists }
 								href={ newspack_engagement_wizard.new_subscription_lists_url }
 							>
-								{ __( 'Add New', 'newspack' ) }
+								{ __( 'Add New', 'newspack-plugin' ) }
 							</Button>
 						) }
 						<Button isPrimary onClick={ saveLists } disabled={ inFlight || lockedLists }>
-							{ __( 'Save Subscription Lists', 'newspack' ) }
+							{ __( 'Save Subscription Lists', 'newspack-plugin' ) }
 						</Button>
 					</>
 				}
@@ -350,7 +355,7 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 							actionText={
 								list?.edit_link ? (
 									<ExternalLink href={ list.edit_link }>
-										{ __( 'Edit', 'newspack_newsletters' ) }
+										{ __( 'Edit', 'newspack-plugin' ) }
 									</ExternalLink>
 								) : null
 							}
@@ -358,13 +363,13 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 							{ list.active && 'local' !== list?.type && (
 								<>
 									<TextControl
-										label={ __( 'List title', 'newspack' ) }
+										label={ __( 'List title', 'newspack-plugin' ) }
 										value={ list.title }
 										disabled={ inFlight || 'local' === list?.type }
 										onChange={ handleChange( index, 'title' ) }
 									/>
 									<TextareaControl
-										label={ __( 'List description', 'newspack' ) }
+										label={ __( 'List description', 'newspack-plugin' ) }
 										value={ list.description }
 										disabled={ inFlight || 'local' === list?.type }
 										onChange={ handleChange( index, 'description' ) }
@@ -400,7 +405,7 @@ const Newsletters = () => {
 			{ 'mailchimp' === newslettersConfig?.newspack_newsletters_service_provider && (
 				<>
 					<hr />
-					<SectionHeader title={ __( 'WooCommerce integration', 'newspack' ) } />
+					<SectionHeader title={ __( 'WooCommerce integration', 'newspack-plugin' ) } />
 					<PluginInstaller plugins={ [ 'mailchimp-for-woocommerce' ] } withoutFooterButton />
 				</>
 			) }

--- a/assets/wizards/engagement/views/reader-activation/campaign.js
+++ b/assets/wizards/engagement/views/reader-activation/campaign.js
@@ -54,22 +54,22 @@ export default withWizardScreen( () => {
 	return (
 		<div className="newspack-ras-campaign__prompt-wizard">
 			<SectionHeader
-				title={ __( 'Set Up Reader Activation Campaign', 'newspack' ) }
+				title={ __( 'Set Up Reader Activation Campaign', 'newspack-plugin' ) }
 				description={ __(
 					'Preview and customize the prompts, or use our suggested defaults.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			/>
 			{ error && (
 				<Notice
-					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+					noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 					isError
 				/>
 			) }
 			{ ! prompts && ! error && (
 				<>
 					<Waiting isLeft />
-					{ __( 'Retrieving prompts…', 'newspack' ) }
+					{ __( 'Retrieving prompts…', 'newspack-plugin' ) }
 				</>
 			) }
 			{ prompts &&
@@ -88,10 +88,10 @@ export default withWizardScreen( () => {
 					disabled={ inFlight || ! allReady }
 					href={ `${ reader_activation_url }/complete` }
 				>
-					{ __( 'Continue', 'newspack' ) }
+					{ __( 'Continue', 'newspack-plugin' ) }
 				</Button>
 				<Button isSecondary disabled={ inFlight } href={ reader_activation_url }>
-					{ __( 'Back', 'newspack' ) }
+					{ __( 'Back', 'newspack-plugin' ) }
 				</Button>
 			</div>
 		</div>

--- a/assets/wizards/engagement/views/reader-activation/complete.js
+++ b/assets/wizards/engagement/views/reader-activation/complete.js
@@ -24,22 +24,22 @@ import {
 const listItems = [
 	__(
 		'Your <strong>current segments and prompts</strong> will be deactivated and archived.',
-		'newspack'
+		'newspack-plugin'
 	),
 	__(
 		'<strong>Reader registration</strong> will be activated to enable better targeting for driving engagement and conversations.',
-		'newspack'
+		'newspack-plugin'
 	),
 	__(
 		'The <strong>Reader Activation campaign</strong> will be activated with default segments and settings.',
-		'newspack'
+		'newspack-plugin'
 	),
 ];
 
 const activationSteps = [
-	__( 'Setting up new segments…', 'newspack' ),
-	__( 'Activating reader registration…', 'newspack' ),
-	__( 'Activating Reader Activation Campaign…', 'newspack' ),
+	__( 'Setting up new segments…', 'newspack-plugin' ),
+	__( 'Activating reader registration…', 'newspack-plugin' ),
+	__( 'Activating Reader Activation Campaign…', 'newspack-plugin' ),
 ];
 
 /**
@@ -77,7 +77,7 @@ export default withWizardScreen( () => {
 		}
 		if ( progress === activationSteps.length && completed ) {
 			setProgress( activationSteps.length + 1 ); // Plus one to account for the "Done!" step.
-			setProgressLabel( __( 'Done!', 'newspack' ) );
+			setProgressLabel( __( 'Done!', 'newspack-plugin' ) );
 			setTimeout( () => {
 				setInFlight( false );
 				window.location = reader_activation_url;
@@ -105,12 +105,12 @@ export default withWizardScreen( () => {
 	return (
 		<div className="newspack-ras-campaign__completed">
 			<SectionHeader
-				title={ __( 'Enable Reader Activation', 'newspack' ) }
+				title={ __( 'Enable Reader Activation', 'newspack-plugin' ) }
 				description={ () => (
 					<>
 						{ __(
 							'An easy way to let your readers register for your site, sign up for newsletters, or become donors and paid members. ',
-							'newspack'
+							'newspack-plugin'
 						) }
 
 						{ /** TODO: Update this URL with the real one once the docs are ready. */ }
@@ -132,8 +132,8 @@ export default withWizardScreen( () => {
 			) }
 			{ ! inFlight && (
 				<Card className="newspack-ras-campaign__completed-card">
-					<h2>{ __( "You're all set to enable Reader Activation!", 'newspack' ) }</h2>
-					<p>{ __( 'This is what will happen next:', 'newspack' ) }</p>
+					<h2>{ __( "You're all set to enable Reader Activation!", 'newspack-plugin' ) }</h2>
+					<p>{ __( 'This is what will happen next:', 'newspack-plugin' ) }</p>
 
 					<Card noBorder className="justify-center">
 						<StepsList stepsListItems={ listItems } narrowList />
@@ -141,21 +141,21 @@ export default withWizardScreen( () => {
 
 					{ error && (
 						<Notice
-							noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+							noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 							isError
 						/>
 					) }
 
 					<Card buttonsCard noBorder className="justify-center">
 						<Button isPrimary onClick={ () => activate() }>
-							{ __( 'Enable Reader Activation', 'newspack ' ) }
+							{ __( 'Enable Reader Activation', 'newspack-plugin' ) }
 						</Button>
 					</Card>
 				</Card>
 			) }
 			<div className="newspack-buttons-card">
 				<Button isSecondary disabled={ inFlight } href={ `${ reader_activation_url }/campaign` }>
-					{ __( 'Back', 'newspack' ) }
+					{ __( 'Back', 'newspack-plugin' ) }
 				</Button>
 			</div>
 		</div>

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -140,15 +140,15 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 	const getContentGateDescription = () => {
 		let message = __(
 			'Configure the gate rendered on content with restricted access.',
-			'newspack'
+			'newspack-plugin'
 		);
 		if ( 'publish' === membershipsConfig?.gate_status ) {
-			message += ' ' + __( 'The gate is currently published.', 'newspack' );
+			message += ' ' + __( 'The gate is currently published.', 'newspack-plugin' );
 		} else if (
 			'draft' === membershipsConfig?.gate_status ||
 			'trash' === membershipsConfig?.gate_status
 		) {
-			message += ' ' + __( 'The gate is currently a draft.', 'newspack' );
+			message += ' ' + __( 'The gate is currently a draft.', 'newspack-plugin' );
 		}
 		return message;
 	};
@@ -156,12 +156,12 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 	return (
 		<>
 			<SectionHeader
-				title={ __( 'Reader Activation', 'newspack' ) }
+				title={ __( 'Reader Activation', 'newspack-plugin' ) }
 				description={ () => (
 					<>
 						{ __(
 							'Newspack’s Reader Activation system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. ',
-							'newspack'
+							'newspack-plugin'
 						) }
 						<ExternalLink href={ 'https://help.newspack.com/engagement/reader-activation-system' }>
 							{ __( 'Learn more', 'newspack-plugin' ) }
@@ -171,26 +171,32 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 			/>
 			{ error && (
 				<Notice
-					noticeText={ error?.message || __( 'Something went wrong.', 'newspack' ) }
+					noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) }
 					isError
 				/>
 			) }
 			{ 0 < missingPlugins.length && (
-				<Notice noticeText={ __( 'The following plugins are required.', 'newspack' ) } isWarning />
+				<Notice
+					noticeText={ __( 'The following plugins are required.', 'newspack-plugin' ) }
+					isWarning
+				/>
 			) }
 			{ 0 === missingPlugins.length && prerequisites && ! allReady && (
 				<Notice
-					noticeText={ __( 'Complete these settings to enable Reader Activation.', 'newspack' ) }
+					noticeText={ __(
+						'Complete these settings to enable Reader Activation.',
+						'newspack-plugin'
+					) }
 					isWarning
 				/>
 			) }
 			{ prerequisites && allReady && config.enabled && (
-				<Notice noticeText={ __( 'Reader Activation is enabled.', 'newspack' ) } isSuccess />
+				<Notice noticeText={ __( 'Reader Activation is enabled.', 'newspack-plugin' ) } isSuccess />
 			) }
 			{ ! prerequisites && (
 				<>
 					<Waiting isLeft />
-					{ __( 'Retrieving status…', 'newspack' ) }
+					{ __( 'Retrieving status…', 'newspack-plugin' ) }
 				</>
 			) }
 			{ 0 < missingPlugins.length && prerequisites && (
@@ -219,8 +225,8 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 					<Button variant="link" onClick={ () => setShowAdvanced( ! showAdvanced ) }>
 						{ sprintf(
 							// Translators: Show or Hide advanced settings.
-							__( '%s Advanced Settings', 'newspack' ),
-							showAdvanced ? __( 'Hide', 'newspack' ) : __( 'Show', 'newspack' )
+							__( '%s Advanced Settings', 'newspack-plugin' ),
+							showAdvanced ? __( 'Hide', 'newspack-plugin' ) : __( 'Show', 'newspack-plugin' )
 						) }
 					</Button>
 				</>
@@ -230,22 +236,25 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 					{ newspack_engagement_wizard.has_memberships && membershipsConfig ? (
 						<>
 							<SectionHeader
-								title={ __( 'Memberships Integration', 'newspack' ) }
-								description={ __( 'Improve the reader experience on content gating.', 'newspack' ) }
+								title={ __( 'Memberships Integration', 'newspack-plugin' ) }
+								description={ __(
+									'Improve the reader experience on content gating.',
+									'newspack-plugin'
+								) }
 							/>
 							<ActionCard
-								title={ __( 'Content Gate', 'newspack' ) }
+								title={ __( 'Content Gate', 'newspack-plugin' ) }
 								titleLink={ membershipsConfig.edit_gate_url }
 								href={ membershipsConfig.edit_gate_url }
 								description={ getContentGateDescription() }
-								actionText={ __( 'Configure', 'newspack' ) }
+								actionText={ __( 'Configure', 'newspack-plugin' ) }
 							/>
 							{ membershipsConfig?.plans && 1 < membershipsConfig.plans.length && (
 								<ActionCard
-									title={ __( 'Require membership in all plans', 'newspack' ) }
+									title={ __( 'Require membership in all plans', 'newspack-plugin' ) }
 									description={ __(
 										'When enabled, readers must belong to all membership plans that apply to a restricted content item before they are granted access. Otherwise, they will be able to unlock access to that item with membership in any single plan that applies to it.',
-										'newspack'
+										'newspack-plugin'
 									) }
 									toggleOnChange={ value =>
 										setMembershipsConfig( { ...membershipsConfig, require_all_plans: value } )
@@ -260,8 +269,11 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 					{ emails?.length > 0 && (
 						<>
 							<SectionHeader
-								title={ __( 'Transactional Email Content', 'newspack' ) }
-								description={ __( 'Customize the content of transactional emails.', 'newspack' ) }
+								title={ __( 'Transactional Email Content', 'newspack-plugin' ) }
+								description={ __(
+									'Customize the content of transactional emails.',
+									'newspack-plugin'
+								) }
 							/>
 							{ emails.map( email => (
 								<ActionCard
@@ -270,7 +282,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 									titleLink={ email.edit_link }
 									href={ email.edit_link }
 									description={ email.description }
-									actionText={ __( 'Edit', 'newspack' ) }
+									actionText={ __( 'Edit', 'newspack-plugin' ) }
 									isSmall
 								/>
 							) ) }
@@ -278,12 +290,12 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 						</>
 					) }
 
-					<SectionHeader title={ __( 'Newsletter Subscription Lists', 'newspack' ) } />
+					<SectionHeader title={ __( 'Newsletter Subscription Lists', 'newspack-plugin' ) } />
 					<ActionCard
-						title={ __( 'Custom newsletter lists on registration', 'newspack' ) }
+						title={ __( 'Custom newsletter lists on registration', 'newspack-plugin' ) }
 						description={ __(
 							"Choose which of the Newspack Newsletters's subscription lists should be available upon registration.",
-							'newspack'
+							'newspack-plugin'
 						) }
 						toggleChecked={ config.use_custom_lists }
 						toggleOnChange={ value => updateConfig( 'use_custom_lists', value ) }
@@ -299,24 +311,27 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 					<hr />
 
 					<SectionHeader
-						title={ __( 'Email Service Provider (ESP) Advanced Settings', 'newspack' ) }
-						description={ __( 'Settings for Newspack Newsletters integration.', 'newspack' ) }
+						title={ __( 'Email Service Provider (ESP) Advanced Settings', 'newspack-plugin' ) }
+						description={ __(
+							'Settings for Newspack Newsletters integration.',
+							'newspack-plugin'
+						) }
 					/>
 					<TextControl
-						label={ __( 'Newsletter subscription text on registration', 'newspack' ) }
+						label={ __( 'Newsletter subscription text on registration', 'newspack-plugin' ) }
 						help={ __(
 							'The text to display while subscribing to newsletters from the sign-in modal.',
-							'newspack'
+							'newspack-plugin'
 						) }
 						{ ...getSharedProps( 'newsletters_label', 'text' ) }
 					/>
 					{ config.sync_esp && (
 						<>
 							<TextControl
-								label={ __( 'Metadata field prefix', 'newspack' ) }
+								label={ __( 'Metadata field prefix', 'newspack-plugin' ) }
 								help={ __(
 									'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_',
-									'newspack'
+									'newspack-plugin'
 								) }
 								{ ...getSharedProps( 'metadata_prefix', 'text' ) }
 							/>
@@ -358,7 +373,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 							} }
 							disabled={ inFlight }
 						>
-							{ __( 'Save advanced settings', 'newspack' ) }
+							{ __( 'Save advanced settings', 'newspack-plugin' ) }
 						</Button>
 					</div>
 				</Card>

--- a/assets/wizards/engagement/views/related-content/index.js
+++ b/assets/wizards/engagement/views/related-content/index.js
@@ -35,13 +35,13 @@ class RelatedContent extends Component {
 				{ relatedPostsError && <Notice noticeText={ relatedPostsError } isError /> }
 
 				<ActionCard
-					title={ __( 'Related Posts', 'newspack' ) }
+					title={ __( 'Related Posts', 'newspack-plugin' ) }
 					badge="Jetpack"
 					description={ __(
 						'Automatically add related content at the bottom of each post.',
-						'newspack'
+						'newspack-plugin'
 					) }
-					actionText={ __( 'Configure' ) }
+					actionText={ __( 'Configure', 'newspack-plugin' ) }
 					handoff="jetpack"
 					editLink="admin.php?page=jetpack#/traffic"
 				/>
@@ -52,11 +52,11 @@ class RelatedContent extends Component {
 							<TextControl
 								help={ __(
 									'If set, posts will be shown as related content only if published within the past number of months. If 0, any published post can be shown, regardless of publish date.',
-									'newspack'
+									'newspack-plugin'
 								) }
-								label={ __( 'Maximum age of related content, in months', 'newspack' ) }
+								label={ __( 'Maximum age of related content, in months', 'newspack-plugin' ) }
 								onChange={ value => onChange( value ) }
-								placeholder={ __( 'Maximum age of related content, in months' ) }
+								placeholder={ __( 'Maximum age of related content, in months', 'newspack-plugin' ) }
 								type="number"
 								value={ relatedPostsMaxAge || 0 }
 							/>

--- a/assets/wizards/engagement/views/social/index.js
+++ b/assets/wizards/engagement/views/social/index.js
@@ -26,12 +26,13 @@ class Social extends Component {
 		return (
 			<>
 				<ActionCard
-					title={ __( 'Publicize' ) }
+					title={ __( 'Publicize', 'newspack-plugin' ) }
 					badge="Jetpack"
 					description={ __(
-						'Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.'
+						'Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.',
+						'newspack-plugin'
 					) }
-					actionText={ __( 'Configure' ) }
+					actionText={ __( 'Configure', 'newspack-plugin' ) }
 					handoff="jetpack"
 					editLink="admin.php?page=jetpack#/sharing"
 				/>

--- a/assets/wizards/engagement/views/social/meta-pixel.js
+++ b/assets/wizards/engagement/views/social/meta-pixel.js
@@ -11,18 +11,18 @@ import Pixel from './pixel';
 
 const MetaPixel = () => (
 	<Pixel
-		title={ __( 'Meta Pixel', 'newspack' ) }
+		title={ __( 'Meta Pixel', 'newspack-plugin' ) }
 		pixelKey="meta"
 		pixelValueType="integer"
 		description={ __(
 			'Add the Meta pixel (formely known as Facebook pixel) to your site.',
-			'newspack'
+			'newspack-plugin'
 		) }
-		fieldDescription={ __( 'Pixel ID', 'newspack' ) }
+		fieldDescription={ __( 'Pixel ID', 'newspack-plugin' ) }
 		fieldHelp={ createInterpolateElement(
 			__(
 				'The Meta Pixel ID. You only need to add the number, not the full code. Example: 123456789123456789. You can get this information <linkToFb>here</linkToFb>.',
-				'newspack'
+				'newspack-plugin'
 			),
 			{
 				/* eslint-disable jsx-a11y/anchor-has-content */

--- a/assets/wizards/engagement/views/social/twitter-pixel.js
+++ b/assets/wizards/engagement/views/social/twitter-pixel.js
@@ -11,15 +11,15 @@ import Pixel from './pixel';
 
 const TwitterPixel = () => (
 	<Pixel
-		title={ __( 'Twitter Pixel', 'newspack' ) }
+		title={ __( 'Twitter Pixel', 'newspack-plugin' ) }
 		pixelKey="twitter"
-		description={ __( 'Add the Twitter pixel to your site.', 'newspack' ) }
+		description={ __( 'Add the Twitter pixel to your site.', 'newspack-plugin' ) }
 		pixelValueType="text"
-		fieldDescription={ __( 'Pixel ID', 'newspack' ) }
+		fieldDescription={ __( 'Pixel ID', 'newspack-plugin' ) }
 		fieldHelp={ createInterpolateElement(
 			__(
 				'The Twitter Pixel ID. You only need to add the ID, not the full code. Example: ny3ad. You can read more about it <link>here</link>.',
-				'newspack'
+				'newspack-plugin'
 			),
 			{
 				/* eslint-disable jsx-a11y/anchor-has-content */

--- a/assets/wizards/handoff-banner/index.js
+++ b/assets/wizards/handoff-banner/index.js
@@ -17,9 +17,9 @@ import { Button } from '../../components/src';
 import './style.scss';
 
 const HandoffBanner = ( {
-	bodyText = __( 'Return to Newspack after completing configuration', 'newspack' ),
-	primaryButtonText = __( 'Back to Newspack', 'newspack' ),
-	dismissButtonText = __( 'Dismiss', 'newspack' ),
+	bodyText = __( 'Return to Newspack after completing configuration', 'newspack-plugin' ),
+	primaryButtonText = __( 'Back to Newspack', 'newspack-plugin' ),
+	dismissButtonText = __( 'Dismiss', 'newspack-plugin' ),
 	primaryButtonURL = '/wp-admin/admin.php?page=newspack',
 } ) => {
 	const [ visibility, setVisibility ] = useState( true );

--- a/assets/wizards/health-check/index.js
+++ b/assets/wizards/health-check/index.js
@@ -67,12 +67,12 @@ class HealthCheckWizard extends Component {
 		} = healthCheckData;
 		const tabs = [
 			{
-				label: __( 'Plugins', 'newspack' ),
+				label: __( 'Plugins', 'newspack-plugin' ),
 				path: '/',
 				exact: true,
 			},
 			{
-				label: __( 'Configuration' ),
+				label: __( 'Configuration', 'newspack-plugin' ),
 				path: '/configuration',
 			},
 		];
@@ -85,8 +85,8 @@ class HealthCheckWizard extends Component {
 							exact
 							render={ () => (
 								<Plugins
-									headerText={ __( 'Health Check', 'newspack' ) }
-									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
+									headerText={ __( 'Health Check', 'newspack-plugin' ) }
+									subHeaderText={ __( 'Verify and correct site health issues', 'newspack-plugin' ) }
 									deactivateAllPlugins={ this.deactivateAllPlugins }
 									tabbedNavigation={ tabs }
 									missingPlugins={ Object.keys( missingPlugins ) }
@@ -103,8 +103,8 @@ class HealthCheckWizard extends Component {
 							render={ () => (
 								<Configuration
 									hasData={ hasData }
-									headerText={ __( 'Health Check', 'newspack' ) }
-									subHeaderText={ __( 'Verify and correct site health issues', 'newspack' ) }
+									headerText={ __( 'Health Check', 'newspack-plugin' ) }
+									subHeaderText={ __( 'Verify and correct site health issues', 'newspack-plugin' ) }
 									tabbedNavigation={ tabs }
 									configurationStatus={ configurationStatus }
 									missingPlugins={ Object.keys( missingPlugins ) }

--- a/assets/wizards/health-check/views/configuration/index.js
+++ b/assets/wizards/health-check/views/configuration/index.js
@@ -28,24 +28,24 @@ class Configuration extends Component {
 				<Fragment>
 					<ActionCard
 						className={ jetpack ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
-						title={ __( 'Jetpack', 'newspack' ) }
+						title={ __( 'Jetpack', 'newspack-plugin' ) }
 						description={
 							jetpack
-								? __( 'Jetpack is connected.', 'newspack' )
-								: __( 'Jetpack is not connected. ', 'newspack' )
+								? __( 'Jetpack is connected.', 'newspack-plugin' )
+								: __( 'Jetpack is not connected. ', 'newspack-plugin' )
 						}
-						actionText={ ! jetpack && __( 'Connect', 'newspack' ) }
+						actionText={ ! jetpack && __( 'Connect', 'newspack-plugin' ) }
 						handoff="jetpack"
 					/>
 					<ActionCard
 						className={ sitekit ? 'newspack-card__is-supported' : 'newspack-card__is-unsupported' }
-						title={ __( 'Google Site Kit', 'newspack' ) }
+						title={ __( 'Google Site Kit', 'newspack-plugin' ) }
 						description={
 							sitekit
-								? __( 'Site Kit is connected.', 'newspack' )
-								: __( 'Site Kit is not connected. ', 'newspack' )
+								? __( 'Site Kit is connected.', 'newspack-plugin' )
+								: __( 'Site Kit is not connected. ', 'newspack-plugin' )
 						}
-						actionText={ ! sitekit && __( 'Connect', 'newspack' ) }
+						actionText={ ! sitekit && __( 'Connect', 'newspack-plugin' ) }
 						handoff="google-site-kit"
 					/>
 				</Fragment>

--- a/assets/wizards/health-check/views/plugins/index.js
+++ b/assets/wizards/health-check/views/plugins/index.js
@@ -33,14 +33,17 @@ class Plugins extends Component {
 			<Grid columns={ 1 } gutter={ 64 }>
 				{ missingPlugins.length ? (
 					<Grid columns={ 1 } gutter={ 16 }>
-						<Notice noticeText={ __( 'These plugins shoud be active:', 'newspack' ) } isWarning />
+						<Notice
+							noticeText={ __( 'These plugins shoud be active:', 'newspack-plugin' ) }
+							isWarning
+						/>
 						<PluginInstaller plugins={ missingPlugins } />
 					</Grid>
 				) : null }
 				{ unsupportedPlugins.length ? (
 					<Grid columns={ 1 } gutter={ 16 }>
 						<Notice
-							noticeText={ __( 'Newspack does not support these plugins:', 'newspack' ) }
+							noticeText={ __( 'Newspack does not support these plugins:', 'newspack-plugin' ) }
 							isError
 						/>
 						{ unsupportedPlugins.map( unsupportedPlugin => (
@@ -53,12 +56,15 @@ class Plugins extends Component {
 						) ) }
 						<div className="newspack-buttons-card">
 							<Button isPrimary onClick={ deactivateAllPlugins }>
-								{ __( 'Deactivate All', 'newspack' ) }
+								{ __( 'Deactivate All', 'newspack-plugin' ) }
 							</Button>
 						</div>
 					</Grid>
 				) : (
-					<Notice noticeText={ __( 'No unsupported plugins found.', 'newspack' ) } isSuccess />
+					<Notice
+						noticeText={ __( 'No unsupported plugins found.', 'newspack-plugin' ) }
+						isSuccess
+					/>
 				) }
 			</Grid>
 		);

--- a/assets/wizards/popups/components/campaign-management-popover/index.js
+++ b/assets/wizards/popups/components/campaign-management-popover/index.js
@@ -33,7 +33,7 @@ const CampaignManagementPopover = ( {
 		onKeyDown={ event => ESCAPE === event.keyCode && dismiss() }
 	>
 		<MenuItem onClick={ () => dismiss() } className="screen-reader-text">
-			{ __( 'Close Popover', 'newspack' ) }
+			{ __( 'Close Popover', 'newspack-plugin' ) }
 		</MenuItem>
 
 		{ hasPrompts && (
@@ -44,7 +44,7 @@ const CampaignManagementPopover = ( {
 				} }
 				className="newspack-button"
 			>
-				{ __( 'Activate all prompts', 'newspack' ) }
+				{ __( 'Activate all prompts', 'newspack-plugin' ) }
 			</MenuItem>
 		) }
 		{ hasPublished && (
@@ -55,7 +55,7 @@ const CampaignManagementPopover = ( {
 				} }
 				className="newspack-button"
 			>
-				{ __( 'Deactivate all prompts', 'newspack' ) }
+				{ __( 'Deactivate all prompts', 'newspack-plugin' ) }
 			</MenuItem>
 		) }
 		<MenuItem
@@ -65,7 +65,7 @@ const CampaignManagementPopover = ( {
 			} }
 			className="newspack-button"
 		>
-			{ __( 'Duplicate', 'newspack' ) }
+			{ __( 'Duplicate', 'newspack-plugin' ) }
 		</MenuItem>
 		<MenuItem
 			onClick={ () => {
@@ -74,7 +74,7 @@ const CampaignManagementPopover = ( {
 			} }
 			className="newspack-button"
 		>
-			{ __( 'Rename', 'newspack' ) }
+			{ __( 'Rename', 'newspack-plugin' ) }
 		</MenuItem>
 		{ ! isArchive && (
 			<MenuItem
@@ -84,7 +84,7 @@ const CampaignManagementPopover = ( {
 				} }
 				className="newspack-button"
 			>
-				{ __( 'Archive', 'newspack' ) }
+				{ __( 'Archive', 'newspack-plugin' ) }
 			</MenuItem>
 		) }
 		{ isArchive && (
@@ -95,7 +95,7 @@ const CampaignManagementPopover = ( {
 				} }
 				className="newspack-button"
 			>
-				{ __( 'Unarchive', 'newspack' ) }
+				{ __( 'Unarchive', 'newspack-plugin' ) }
 			</MenuItem>
 		) }
 		<MenuItem
@@ -105,7 +105,7 @@ const CampaignManagementPopover = ( {
 			} }
 			className="newspack-button"
 		>
-			{ __( 'Delete', 'newspack' ) }
+			{ __( 'Delete', 'newspack-plugin' ) }
 		</MenuItem>
 	</Popover>
 );

--- a/assets/wizards/popups/components/prompt-action-card/index.js
+++ b/assets/wizards/popups/components/prompt-action-card/index.js
@@ -54,7 +54,7 @@ const PromptActionCard = props => {
 
 			setDuplicateTitle( defaultTitle );
 		} catch ( e ) {
-			setDuplicateTitle( title + __( ' copy', 'newspack-popups' ) );
+			setDuplicateTitle( title + __( ' copy', 'newspack-plugin' ) );
 		}
 	};
 
@@ -64,7 +64,7 @@ const PromptActionCard = props => {
 				isSmall
 				badge={ placementForPopup( prompt ) }
 				className={ className }
-				title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack' ) }
+				title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack-plugin' ) }
 				titleLink={ decodeEntities( editLink ) }
 				key={ id }
 				description={ description }
@@ -77,14 +77,14 @@ const PromptActionCard = props => {
 								className={ isSettingsModalVisible && 'popover-active' }
 								onClick={ () => setIsSettingsModalVisible( ! isSettingsModalVisible ) }
 								icon={ settings }
-								label={ __( 'Prompt settings', 'newspack' ) }
+								label={ __( 'Prompt settings', 'newspack-plugin' ) }
 								tooltipPosition="bottom center"
 							/>
 							<Button
 								className={ popoverVisibility && 'popover-active' }
 								onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
 								icon={ moreVertical }
-								label={ __( 'More options', 'newspack' ) }
+								label={ __( 'More options', 'newspack-plugin' ) }
 								tooltipPosition="bottom center"
 							/>
 							{ popoverVisibility && (
@@ -113,7 +113,7 @@ const PromptActionCard = props => {
 					className="newspack-popups__duplicate-modal"
 					title={
 						// Translators: %s: The title of the item.
-						sprintf( __( 'Duplicate “%s”', 'newspack' ), title )
+						sprintf( __( 'Duplicate “%s”', 'newspack-plugin' ), title )
 					}
 					onRequestClose={ () => {
 						setIsDuplicatePromptModalVisible( false );
@@ -127,7 +127,7 @@ const PromptActionCard = props => {
 								isSuccess
 								noticeText={ sprintf(
 									// Translators: %s: The title of the item.
-									__( 'Duplicate of “%s” created as a draft.', 'newspack' ),
+									__( 'Duplicate of “%s” created as a draft.', 'newspack-plugin' ),
 									title
 								) }
 							/>
@@ -136,7 +136,7 @@ const PromptActionCard = props => {
 									isWarning
 									noticeText={ __(
 										'This prompt is currently not assigned to any campaign.',
-										'newspack'
+										'newspack-plugin'
 									) }
 								/>
 							) }
@@ -149,10 +149,10 @@ const PromptActionCard = props => {
 										resetDuplicated();
 									} }
 								>
-									{ __( 'Close', 'newspack' ) }
+									{ __( 'Close', 'newspack-plugin' ) }
 								</Button>
 								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
-									{ __( 'Edit', 'newspack' ) }
+									{ __( 'Edit', 'newspack-plugin' ) }
 								</Button>
 							</Card>
 						</>
@@ -163,13 +163,13 @@ const PromptActionCard = props => {
 									isWarning
 									noticeText={ __(
 										'This prompt will not be assigned to any campaign.',
-										'newspack'
+										'newspack-plugin'
 									) }
 								/>
 							) }
 							<TextControl
 								disabled={ inFlight || null === duplicateTitle }
-								label={ __( 'Title', 'newspack' ) }
+								label={ __( 'Title', 'newspack-plugin' ) }
 								value={ duplicateTitle }
 								onChange={ value => setDuplicateTitle( value ) }
 							/>
@@ -183,7 +183,7 @@ const PromptActionCard = props => {
 										resetDuplicated();
 									} }
 								>
-									{ __( 'Cancel', 'newspack' ) }
+									{ __( 'Cancel', 'newspack-plugin' ) }
 								</Button>
 								<Button
 									disabled={ inFlight || null === duplicateTitle }
@@ -193,7 +193,7 @@ const PromptActionCard = props => {
 										duplicatePopup( id, titleForDuplicate );
 									} }
 								>
-									{ __( 'Duplicate', 'newspack' ) }
+									{ __( 'Duplicate', 'newspack-plugin' ) }
 								</Button>
 							</Card>
 						</>

--- a/assets/wizards/popups/components/prompt-popovers/primary.js
+++ b/assets/wizards/popups/components/prompt-popovers/primary.js
@@ -38,15 +38,15 @@ const PrimaryPromptPopover = ( {
 			className="newspack-popover__campaigns__primary-popover"
 		>
 			<MenuItem onClick={ () => onFocusOutside() } className="screen-reader-text">
-				{ __( 'Close Popover', 'newspack' ) }
+				{ __( 'Close Popover', 'newspack-plugin' ) }
 			</MenuItem>
 			{ isTrash ? (
 				<>
 					<MenuItem onClick={ () => restorePopup( id ) } className="newspack-button">
-						{ __( 'Restore', 'newspack' ) }
+						{ __( 'Restore', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem onClick={ () => deletePopup( id ) } className="newspack-button">
-						{ __( 'Delete permanently', 'newspack' ) }
+						{ __( 'Delete permanently', 'newspack-plugin' ) }
 					</MenuItem>
 				</>
 			) : (
@@ -58,16 +58,16 @@ const PrimaryPromptPopover = ( {
 						} }
 						className="newspack-button"
 					>
-						{ __( 'Preview', 'newspack' ) }
+						{ __( 'Preview', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem href={ decodeEntities( editLink ) } className="newspack-button" isLink>
-						{ __( 'Edit', 'newspack' ) }
+						{ __( 'Edit', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem
 						onClick={ () => setIsDuplicatePromptModalVisible( true ) }
 						className="newspack-button"
 					>
-						{ __( 'Duplicate', 'newspack' ) }
+						{ __( 'Duplicate', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem
 						onClick={ () => {
@@ -76,15 +76,17 @@ const PrimaryPromptPopover = ( {
 						} }
 						className="newspack-button"
 					>
-						{ isPublished ? __( 'Deactivate', 'newspack' ) : __( 'Activate', 'newspack' ) }
+						{ isPublished
+							? __( 'Deactivate', 'newspack-plugin' )
+							: __( 'Activate', 'newspack-plugin' ) }
 					</MenuItem>
 					<MenuItem onClick={ () => deletePopup( id ) } className="newspack-button">
-						{ __( 'Delete', 'newspack' ) }
+						{ __( 'Delete', 'newspack-plugin' ) }
 					</MenuItem>
 				</>
 			) }
 			<div className="newspack-popover__campaigns__info">
-				{ __( 'ID:', 'newspack' ) } { id }
+				{ __( 'ID:', 'newspack-plugin' ) } { id }
 			</div>
 		</Popover>
 	);

--- a/assets/wizards/popups/components/segment-group/index.js
+++ b/assets/wizards/popups/components/segment-group/index.js
@@ -54,12 +54,12 @@ const SegmentGroup = props => {
 
 	let emptySegmentText;
 	if ( 'unassigned' === campaignId ) {
-		emptySegmentText = __( 'No unassigned prompts in this segment.', 'newspack' );
+		emptySegmentText = __( 'No unassigned prompts in this segment.', 'newspack-plugin' );
 	} else if ( campaignData ) {
 		emptySegmentText =
-			__( 'No prompts in this segment for', 'newspack' ) + ' ' + campaignData.name + '.';
+			__( 'No prompts in this segment for', 'newspack-plugin' ) + ' ' + campaignData.name + '.';
 	} else {
-		emptySegmentText = __( 'No active prompts in this segment.', 'newspack' );
+		emptySegmentText = __( 'No active prompts in this segment.', 'newspack-plugin' );
 	}
 
 	const description = segmentDescription( segment );
@@ -71,12 +71,12 @@ const SegmentGroup = props => {
 						{ id ? (
 							<Button
 								href={ `#/segments/${ id }` }
-								label={ __( 'Edit Segment ', 'newspack' ) }
+								label={ __( 'Edit Segment ', 'newspack-plugin' ) }
 								isLink
 								showTooltip
 								tooltipPosition="bottom center"
 							>
-								{ __( 'Segment: ', 'newspack' ) }
+								{ __( 'Segment: ', 'newspack-plugin' ) }
 								{ label }
 							</Button>
 						) : (
@@ -84,7 +84,7 @@ const SegmentGroup = props => {
 						) }
 					</h3>
 					<span className="newspack-campaigns__segment-group__description">
-						{ id ? description() : __( 'All readers, regardless of segment', 'newspack' ) }
+						{ id ? description() : __( 'All readers, regardless of segment', 'newspack-plugin' ) }
 					</span>
 				</div>
 				<div className="newspack-campaigns__segment-group__card__segment-actions">
@@ -94,7 +94,7 @@ const SegmentGroup = props => {
 						showUnpublished={ !! campaignId } // Only if previewing a specific campaign/group.
 						renderButton={ ( { showPreview } ) => (
 							<Button isSmall variant="tertiary" onClick={ () => showPreview() }>
-								{ __( 'Preview Segment', 'newspack' ) }
+								{ __( 'Preview Segment', 'newspack-plugin' ) }
 							</Button>
 						) }
 					/>
@@ -105,11 +105,11 @@ const SegmentGroup = props => {
 								variant="secondary"
 								onClick={ () => setModalVisible( ! modalVisible ) }
 							>
-								{ __( 'Add New Prompt', 'newspack' ) }
+								{ __( 'Add New Prompt', 'newspack-plugin' ) }
 							</Button>
 							{ modalVisible && (
 								<Modal
-									title={ __( 'Add New Prompt', 'newspack' ) }
+									title={ __( 'Add New Prompt', 'newspack-plugin' ) }
 									onRequestClose={ () => setModalVisible( false ) }
 									shouldCloseOnEsc={ false }
 									shouldCloseOnClickOutside={ false }
@@ -118,52 +118,55 @@ const SegmentGroup = props => {
 									<Grid gutter={ 32 } columns={ 3 }>
 										<ButtonCard
 											href={ addNewURL( 'overlay-center', campaignId, id ) }
-											title={ __( 'Center Overlay', 'newspack' ) }
-											desc={ __( 'Fixed at the center of the screen', 'newspack' ) }
+											title={ __( 'Center Overlay', 'newspack-plugin' ) }
+											desc={ __( 'Fixed at the center of the screen', 'newspack-plugin' ) }
 											icon={ iconOverlayCenter }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'overlay-top', campaignId, id ) }
-											title={ __( 'Top Overlay', 'newspack' ) }
-											desc={ __( 'Fixed at the top of the screen', 'newspack' ) }
+											title={ __( 'Top Overlay', 'newspack-plugin' ) }
+											desc={ __( 'Fixed at the top of the screen', 'newspack-plugin' ) }
 											icon={ iconOverlayTop }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'overlay-bottom', campaignId, id ) }
-											title={ __( 'Bottom Overlay', 'newspack' ) }
-											desc={ __( 'Fixed at the bottom of the screen', 'newspack' ) }
+											title={ __( 'Bottom Overlay', 'newspack-plugin' ) }
+											desc={ __( 'Fixed at the bottom of the screen', 'newspack-plugin' ) }
 											icon={ iconOverlayBottom }
 										/>
 										<ButtonCard
 											href={ addNewURL( null, campaignId, id ) }
-											title={ __( 'Inline', 'newspack' ) }
-											desc={ __( 'Embedded in content', 'newspack' ) }
+											title={ __( 'Inline', 'newspack-plugin' ) }
+											desc={ __( 'Embedded in content', 'newspack-plugin' ) }
 											icon={ iconInline }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'archives', campaignId, id ) }
-											title={ __( 'In Archive Pages', 'newspack' ) }
-											desc={ __( 'Embedded once or many times in archive pages', 'newspack' ) }
+											title={ __( 'In Archive Pages', 'newspack-plugin' ) }
+											desc={ __(
+												'Embedded once or many times in archive pages',
+												'newspack-plugin'
+											) }
 											icon={ postList }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'above-header', campaignId, id ) }
-											title={ __( 'Above Header', 'newspack' ) }
-											desc={ __( 'Embedded at the very top of the page', 'newspack' ) }
+											title={ __( 'Above Header', 'newspack-plugin' ) }
+											desc={ __( 'Embedded at the very top of the page', 'newspack-plugin' ) }
 											icon={ header }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'custom', campaignId, id ) }
-											title={ __( 'Custom Placement', 'newspack' ) }
-											desc={ __( 'Only appears when placed in content', 'newspack' ) }
+											title={ __( 'Custom Placement', 'newspack-plugin' ) }
+											desc={ __( 'Only appears when placed in content', 'newspack-plugin' ) }
 											icon={ layout }
 										/>
 										<ButtonCard
 											href={ addNewURL( 'manual', campaignId, id ) }
-											title={ __( 'Manual Only', 'newspack' ) }
+											title={ __( 'Manual Only', 'newspack-plugin' ) }
 											desc={ __(
 												'Only appears where Single Prompt block is inserted',
-												'newspack'
+												'newspack-plugin'
 											) }
 											icon={ blockTable }
 										/>

--- a/assets/wizards/popups/components/settings-modal/index.js
+++ b/assets/wizards/popups/components/settings-modal/index.js
@@ -41,14 +41,14 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 	return (
 		<Modal title={ prompt.title } onRequestClose={ onClose } isWide>
 			<Button onClick={ () => onClose() } className="screen-reader-text">
-				{ __( 'Close Modal', 'newspack' ) }
+				{ __( 'Close Modal', 'newspack-plugin' ) }
 			</Button>
 			<Grid gutter={ 64 } columns={ 1 }>
 				<SettingsCard
-					title={ __( 'Campaigns', 'newspack' ) }
+					title={ __( 'Campaigns', 'newspack-plugin' ) }
 					description={ __(
 						'Assign a prompt to one or more campaigns for easier management',
-						'newspack'
+						'newspack-plugin'
 					) }
 					columns={ 1 }
 					className="newspack-settings__campaigns"
@@ -58,22 +58,22 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 						disabled={ disabled }
 						value={ promptConfig.campaign_groups || [] }
 						onChange={ tokens => setPromptConfig( { campaign_groups: tokens } ) }
-						label={ __( 'Campaigns', 'newspack' ) }
+						label={ __( 'Campaigns', 'newspack-plugin' ) }
 						taxonomy="newspack_popups_taxonomy"
 						hideLabelFromVision
 					/>
 				</SettingsCard>
 
 				<SettingsCard
-					title={ __( 'Settings', 'newspack' ) }
-					description={ __( 'When and how should the prompt be displayed', 'newspack' ) }
+					title={ __( 'Settings', 'newspack-plugin' ) }
+					description={ __( 'When and how should the prompt be displayed', 'newspack-plugin' ) }
 					columns={ isOverlay( prompt ) ? 3 : 2 }
 					className="newspack-settings__settings"
 					rowGap={ 16 }
 					noBorder
 				>
 					<SelectControl
-						label={ __( 'Frequency', 'newspack' ) }
+						label={ __( 'Frequency', 'newspack-plugin' ) }
 						disabled={ disabled }
 						onChange={ value => {
 							setPromptConfig( { options: { frequency: value } } );
@@ -82,7 +82,11 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 						value={ promptConfig.options.frequency }
 					/>
 					<SelectControl
-						label={ isOverlay( prompt ) ? __( 'Position' ) : __( 'Placement' ) }
+						label={
+							isOverlay( prompt )
+								? __( 'Position', 'newspack-plugin' )
+								: __( 'Placement', 'newspack-plugin' )
+						}
 						disabled={ disabled }
 						onChange={ value => {
 							setPromptConfig( { options: { placement: value } } );
@@ -92,7 +96,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 					/>
 					{ isOverlay( prompt ) && (
 						<SelectControl
-							label={ __( 'Size' ) }
+							label={ __( 'Size', 'newspack-plugin' ) }
 							disabled={ disabled }
 							onChange={ value => {
 								setPromptConfig( { options: { overlay_size: value } } );
@@ -104,14 +108,14 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 				</SettingsCard>
 
 				<SettingsCard
-					title={ __( 'Targeting', 'newspack' ) }
+					title={ __( 'Targeting', 'newspack-plugin' ) }
 					description={ () => (
 						<>
-							{ __( 'Under which conditions should the prompt be displayed', 'newspack' ) }
+							{ __( 'Under which conditions should the prompt be displayed', 'newspack-plugin' ) }
 							<br />
 							{ __(
 								'If multiple conditions are set, all will have to be satisfied in order to display the prompt',
-								'newspack'
+								'newspack-plugin'
 							) }
 						</>
 					) }
@@ -125,22 +129,22 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 							disabled={ disabled }
 							value={ promptConfig.segments || [] }
 							onChange={ tokens => setPromptConfig( { segments: tokens } ) }
-							label={ __( 'Segments', 'newspack' ) }
+							label={ __( 'Segments', 'newspack-plugin' ) }
 							taxonomy="popup_segment"
 						/>
 						<CategoryAutocomplete
-							label={ __( 'Post categories', 'newspack ' ) }
+							label={ __( 'Post categories', 'newspack-plugin' ) }
 							disabled={ disabled }
 							hideHelpFromVision
 							value={ promptConfig.categories || [] }
 							onChange={ tokens => setPromptConfig( { categories: tokens } ) }
 							description={ __(
 								'Prompt will only appear on posts with the specified categories.',
-								'newspack'
+								'newspack-plugin'
 							) }
 						/>
 						<CategoryAutocomplete
-							label={ __( 'Post tags', 'newspack ' ) }
+							label={ __( 'Post tags', 'newspack-plugin' ) }
 							disabled={ disabled }
 							hideHelpFromVision
 							taxonomy="tags"
@@ -148,7 +152,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 							onChange={ tokens => setPromptConfig( { tags: tokens } ) }
 							description={ __(
 								'Prompt will only appear on posts with the specified tags.',
-								'newspack'
+								'newspack-plugin'
 							) }
 						/>
 					</Grid>
@@ -156,15 +160,15 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 						<Button isLink onClick={ () => setShowAdvanced( ! showAdvanced ) }>
 							{ sprintf(
 								// Translators: whether to show or hide advanced settings fields.
-								__( '%s Advanced Settings', 'newspack_popups_taxonomy' ),
-								showAdvanced ? __( 'Hide', 'newspack' ) : __( 'Show', 'newspack' )
+								__( '%s Advanced Settings', 'newspack-plugin' ),
+								showAdvanced ? __( 'Hide', 'newspack-plugin' ) : __( 'Show', 'newspack-plugin' )
 							) }
 						</Button>
 					</div>
 					{ showAdvanced && (
 						<Grid columns={ 3 } rowGap={ 16 }>
 							<CategoryAutocomplete
-								label={ __( 'Category Exclusions', 'newspack ' ) }
+								label={ __( 'Category Exclusions', 'newspack-plugin' ) }
 								disabled={ disabled }
 								hideHelpFromVision
 								value={ excludedCategories || [] }
@@ -177,11 +181,11 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 								}
 								description={ __(
 									'Prompt will not appear on posts with the specified categories.',
-									'newspack'
+									'newspack-plugin'
 								) }
 							/>
 							<CategoryAutocomplete
-								label={ __( 'Tag Exclusions', 'newspack ' ) }
+								label={ __( 'Tag Exclusions', 'newspack-plugin' ) }
 								disabled={ disabled }
 								hideHelpFromVision
 								taxonomy="tags"
@@ -195,7 +199,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 								}
 								description={ __(
 									'Prompt will not appear on posts with the specified tags.',
-									'newspack'
+									'newspack-plugin'
 								) }
 							/>
 						</Grid>
@@ -205,10 +209,10 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 
 			<Card buttonsCard noBorder className="justify-end">
 				<Button onClick={ onClose } variant="secondary">
-					{ __( 'Cancel', 'newspack' ) }
+					{ __( 'Cancel', 'newspack-plugin' ) }
 				</Button>
 				<Button onClick={ handleSave } variant="primary">
-					{ __( 'Save', 'newspack' ) }
+					{ __( 'Save', 'newspack-plugin' ) }
 				</Button>
 			</Card>
 		</Modal>

--- a/assets/wizards/popups/index.js
+++ b/assets/wizards/popups/index.js
@@ -26,27 +26,27 @@ import { CampaignsContext } from './contexts';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
-const headerText = __( 'Campaigns', 'newspack' );
-const subHeaderText = __( 'Reach your readers with configurable campaigns', 'newspack' );
+const headerText = __( 'Campaigns', 'newspack-plugin' );
+const subHeaderText = __( 'Reach your readers with configurable campaigns', 'newspack-plugin' );
 
 const tabbedNavigation = [
 	{
-		label: __( 'Campaigns', 'newpack' ),
+		label: __( 'Campaigns', 'newpack-plugin' ),
 		path: '/campaigns',
 		exact: true,
 	},
 	{
-		label: __( 'Segments', 'newpack' ),
+		label: __( 'Segments', 'newpack-plugin' ),
 		path: '/segments',
 		exact: true,
 	},
 	{
-		label: __( 'Analytics', 'newpack' ),
+		label: __( 'Analytics', 'newpack-plugin' ),
 		path: '/analytics',
 		exact: true,
 	},
 	{
-		label: __( 'Settings', 'newpack' ),
+		label: __( 'Settings', 'newpack-plugin' ),
 		path: '/settings',
 		exact: true,
 	},
@@ -175,7 +175,7 @@ class PopupsWizard extends Component {
 			.catch( () => {
 				setError( {
 					code: 'duplicate_prompt_error',
-					message: __( 'Error duplicating prompt. Please try again later.', 'newspack' ),
+					message: __( 'Error duplicating prompt. Please try again later.', 'newspack-plugin' ),
 				} );
 			} );
 	};

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -49,25 +49,25 @@ export const isCustomPlacement = popup => {
 export const isInline = prompt => ! isOverlay( prompt );
 
 const placementMap = {
-	top: __( 'Top Overlay', 'newspack' ),
-	top_left: __( 'Top Left Overlay', 'newspack' ),
-	top_right: __( 'Top Right Overlay', 'newspack' ),
-	center: __( 'Center Overlay', 'newspack' ),
-	center_left: __( 'Center Left Overlay', 'newspack' ),
-	center_right: __( 'Center Right Overlay', 'newspack' ),
-	bottom: __( 'Bottom Overlay', 'newspack' ),
-	bottom_left: __( 'Bottom Left Overlay', 'newspack' ),
-	bottom_right: __( 'Bottom Right Overlay', 'newspack' ),
-	inline: __( 'Inline', 'newspack' ),
-	archives: __( 'In archive pages', 'newspack' ),
-	above_header: __( 'Above Header', 'newspack' ),
-	manual: __( 'Manual Only', 'newspack' ),
+	top: __( 'Top Overlay', 'newspack-plugin' ),
+	top_left: __( 'Top Left Overlay', 'newspack-plugin' ),
+	top_right: __( 'Top Right Overlay', 'newspack-plugin' ),
+	center: __( 'Center Overlay', 'newspack-plugin' ),
+	center_left: __( 'Center Left Overlay', 'newspack-plugin' ),
+	center_right: __( 'Center Right Overlay', 'newspack-plugin' ),
+	bottom: __( 'Bottom Overlay', 'newspack-plugin' ),
+	bottom_left: __( 'Bottom Left Overlay', 'newspack-plugin' ),
+	bottom_right: __( 'Bottom Right Overlay', 'newspack-plugin' ),
+	inline: __( 'Inline', 'newspack-plugin' ),
+	archives: __( 'In archive pages', 'newspack-plugin' ),
+	above_header: __( 'Above Header', 'newspack-plugin' ),
+	manual: __( 'Manual Only', 'newspack-plugin' ),
 };
 
 export const placementForPopup = ( { options: { frequency, placement } } ) => {
 	const customPlacements = window.newspack_popups_wizard_data?.custom_placements || {};
 	if ( 'manual' === frequency || customPlacements.hasOwnProperty( placement ) ) {
-		return __( 'Custom Placement', 'newspack' );
+		return __( 'Custom Placement', 'newspack-plugin' );
 	}
 	return placementMap[ placement ];
 };
@@ -96,11 +96,11 @@ export const placementsForPopups = prompt => {
 };
 
 const frequencyMap = {
-	once: __( 'Once a month', 'newspack' ),
-	weekly: __( 'Once a week', 'newspack' ),
-	daily: __( 'Once a day', 'newspack' ),
-	always: __( 'Every pageview', 'newspack' ),
-	custom: __( 'Custom frequency (edit prompt to manage)', 'newspack' ),
+	once: __( 'Once a month', 'newspack-plugin' ),
+	weekly: __( 'Once a week', 'newspack-plugin' ),
+	daily: __( 'Once a day', 'newspack-plugin' ),
+	always: __( 'Every pageview', 'newspack-plugin' ),
+	custom: __( 'Custom frequency (edit prompt to manage)', 'newspack-plugin' ),
 };
 
 export const frequenciesForPopup = () => {
@@ -125,27 +125,28 @@ export const promptDescription = prompt => {
 		const campaignsList = campaigns.map( ( { name } ) => name ).join( ', ' );
 		descriptionMessages.push(
 			( campaigns.length === 1
-				? __( 'Campaign: ', 'newspack' )
-				: __( 'Campaigns: ', 'newspack' ) ) + campaignsList
+				? __( 'Campaign: ', 'newspack-plugin' )
+				: __( 'Campaigns: ', 'newspack-plugin' ) ) + campaignsList
 		);
 	}
 	if ( categories.length > 0 ) {
 		descriptionMessages.push(
-			__( 'Categories: ', 'newspack' ) + categories.map( category => category.name ).join( ', ' )
+			__( 'Categories: ', 'newspack-plugin' ) +
+				categories.map( category => category.name ).join( ', ' )
 		);
 	}
 	if ( tags.length > 0 ) {
 		descriptionMessages.push(
-			__( 'Tags: ', 'newspack' ) + tags.map( tag => tag.name ).join( ', ' )
+			__( 'Tags: ', 'newspack-plugin' ) + tags.map( tag => tag.name ).join( ', ' )
 		);
 	}
 	if ( 'pending' === status ) {
-		descriptionMessages.push( __( 'Pending review', 'newspack' ) );
+		descriptionMessages.push( __( 'Pending review', 'newspack-plugin' ) );
 	}
 	if ( 'future' === status ) {
-		descriptionMessages.push( __( 'Scheduled', 'newspack' ) );
+		descriptionMessages.push( __( 'Scheduled', 'newspack-plugin' ) );
 	}
-	descriptionMessages.push( __( 'Frequency: ', 'newspack' ) + frequencyForPopup( prompt ) );
+	descriptionMessages.push( __( 'Frequency: ', 'newspack-plugin' ) + frequencyForPopup( prompt ) );
 	return descriptionMessages.length ? descriptionMessages.join( ' | ' ) : null;
 };
 
@@ -154,7 +155,7 @@ export const segmentDescription = segment => {
 
 	// If the segment is disabled.
 	if ( segment.configuration.is_disabled ) {
-		descriptionMessages.push( __( 'Segment disabled', 'newspack' ) );
+		descriptionMessages.push( __( 'Segment disabled', 'newspack-plugin' ) );
 	}
 
 	if ( segment.criteria ) {
@@ -237,7 +238,7 @@ const FavoriteCategoriesNames = ( { ids } ) => {
 	}
 	return (
 		<span>
-			{ __( 'Favorite Categories:', 'newspack' ) }{ ' ' }
+			{ __( 'Favorite Categories:', 'newspack-plugin' ) }{ ' ' }
 			{ favoriteCategoryNames.length ? favoriteCategoryNames.join( ', ' ) : '' }
 		</span>
 	);
@@ -305,7 +306,9 @@ addFilter(
 			return (
 				<ItemNames
 					label={
-						config.id === 'subscribed_lists' ? __( 'Subscribed to:' ) : __( 'Not subscribed to:' )
+						config.id === 'subscribed_lists'
+							? __( 'Subscribed to:', 'newspack-plugin' )
+							: __( 'Not subscribed to:', 'newspack-plugin' )
 					}
 					ids={ item.value }
 					path="/newspack-newsletters/v1/lists_config"
@@ -328,8 +331,8 @@ addFilter(
 				<ItemNames
 					label={
 						config.id === 'active_subscriptions'
-							? __( 'Has active subscription(s):' )
-							: __( 'Does not have active subscription(s):' )
+							? __( 'Has active subscription(s):', 'newspack-plugin' )
+							: __( 'Does not have active subscription(s):', 'newspack-plugin' )
 					}
 					ids={ item.value }
 					path="/newspack/v1/wizard/newspack-popups-wizard/subscription-products"
@@ -352,8 +355,8 @@ addFilter(
 				<ItemNames
 					label={
 						config.id === 'active_memberships'
-							? __( 'Has active membership(s):' )
-							: __( 'Does not have active membership(s):' )
+							? __( 'Has active membership(s):', 'newspack-plugin' )
+							: __( 'Does not have active membership(s):', 'newspack-plugin' )
 					}
 					ids={ item.value }
 					path="/wc/v3/memberships/plans?per_page=100"
@@ -382,13 +385,14 @@ export const buildWarning = ( prompt, promptCategories ) => {
 		return sprintf(
 			// Translators: %1: 'uncetegorized' if no categories. %2: 'above-header prompts' if above header, 'overlays' otherwise. %3: 'and category filtering' if categories.
 			__(
-				'If multiple%1$s %2$s share the same segment%3$s, only the most recent one will be displayed.'
+				'If multiple%1$s %2$s share the same segment%3$s, only the most recent one will be displayed.',
+				'newspack-plugin'
 			),
-			0 === promptCategories.length ? __( ' uncategorized', 'newspack' ) : '',
+			0 === promptCategories.length ? __( ' uncategorized', 'newspack-plugin' ) : '',
 			isAboveHeader( prompt )
-				? __( 'above-header prompts', 'newspack' )
-				: __( 'overlays', 'newspack' ),
-			0 < promptCategories.length ? __( ' and category filtering', 'newspack' ) : ''
+				? __( 'above-header prompts', 'newspack-plugin' )
+				: __( 'overlays', 'newspack-plugin' ),
+			0 < promptCategories.length ? __( ' and category filtering', 'newspack-plugin' ) : ''
 		);
 	}
 
@@ -396,10 +400,11 @@ export const buildWarning = ( prompt, promptCategories ) => {
 		return sprintf(
 			// Translators: %1: 'uncetegorized' if no categories. %2: 'and category filtering' if categories.
 			__(
-				'If multiple%1$s prompts in the same custom placement share the same segment%2$s, only the most recent one will be displayed.'
+				'If multiple%1$s prompts in the same custom placement share the same segment%2$s, only the most recent one will be displayed.',
+				'newspack-plugin'
 			),
-			0 === promptCategories.length ? __( ' uncategorized', 'newspack' ) : '',
-			0 < promptCategories.length ? __( ' and category filtering', 'newspack' ) : ''
+			0 === promptCategories.length ? __( ' uncategorized', 'newspack-plugin' ) : '',
+			0 < promptCategories.length ? __( ' and category filtering', 'newspack-plugin' ) : ''
 		);
 	}
 
@@ -448,10 +453,10 @@ export const warningForPopup = ( prompts, prompt ) => {
 					<strong>
 						{ sprintf(
 							// Translators: %s: 'Conflicts' or 'Conflict' depending on number of conflicts.
-							__( '%s detected:', 'newspack' ),
+							__( '%s detected:', 'newspack-plugin' ),
 							1 < filteredConflictingPrompts.length
-								? __( 'Conflicts', 'newspack' )
-								: __( 'Conflict', 'newspack' )
+								? __( 'Conflicts', 'newspack-plugin' )
+								: __( 'Conflict', 'newspack-plugin' )
 						) }
 					</strong>
 					<ul>

--- a/assets/wizards/popups/views/analytics/index.js
+++ b/assets/wizards/popups/views/analytics/index.js
@@ -15,17 +15,17 @@ import './style.scss';
 const PopupAnalytics = () => (
 	<div className="newspack-campaigns-wizard-analytics__wrapper">
 		<Card isNarrow>
-			<h2>{ __( 'Coming soon', 'newspack' ) }</h2>
+			<h2>{ __( 'Coming soon', 'newspack-plugin' ) }</h2>
 			<p>
 				<>
 					{ __(
 						'We’re currently redesigning this dashboard to accommodate GA4 and give you deeper insights into Campaign performance. In the meantime, you can find Campaign event data within your GA account. Review this ',
-						'newspack'
+						'newspack-plugin'
 					) }
 					<a target="_blank" rel="noopener noreferrer" href="https://help.newspack.com/analytics/">
-						{ __( 'help page', 'newspack' ) }
+						{ __( 'help page', 'newspack-plugin' ) }
 					</a>
-					{ __( ' to see how Campaign data is being recorded in GA.', 'newspack' ) },
+					{ __( ' to see how Campaign data is being recorded in GA.', 'newspack-plugin' ) },
 				</>
 			</p>
 			<Card buttonsCard noBorder>
@@ -35,7 +35,7 @@ const PopupAnalytics = () => (
 					href="https://help.newspack.com/analytics/"
 					isPrimary
 				>
-					{ __( 'View the help page', 'newspack' ) }
+					{ __( 'View the help page', 'newspack-plugin' ) }
 				</Button>
 			</Card>
 		</Card>

--- a/assets/wizards/popups/views/campaigns/index.js
+++ b/assets/wizards/popups/views/campaigns/index.js
@@ -43,20 +43,20 @@ const DEFAULT_CAMPAIGNS_FILTER = 'active';
 
 const modalTitle = modalType => {
 	if ( MODAL_TYPE_RENAME === modalType ) {
-		return __( 'Rename Campaign', 'newspack' );
+		return __( 'Rename Campaign', 'newspack-plugin' );
 	} else if ( MODAL_TYPE_DUPLICATE === modalType ) {
-		return __( 'Duplicate Campaign', 'newspack' );
+		return __( 'Duplicate Campaign', 'newspack-plugin' );
 	}
-	return __( 'Add New Campaign', 'newspack' );
+	return __( 'Add New Campaign', 'newspack-plugin' );
 };
 
 const modalButton = modalType => {
 	if ( MODAL_TYPE_RENAME === modalType ) {
-		return __( 'Rename', 'newspack' );
+		return __( 'Rename', 'newspack-plugin' );
 	} else if ( MODAL_TYPE_DUPLICATE === modalType ) {
-		return __( 'Duplicate', 'newspack' );
+		return __( 'Duplicate', 'newspack-plugin' );
 	}
-	return __( 'Add', 'newspack' );
+	return __( 'Add', 'newspack-plugin' );
 };
 
 const filterByCampaign = ( prompts, campaignId ) => {
@@ -99,7 +99,7 @@ const groupBySegment = ( segments, prompts ) => {
 		} ) )
 	);
 	grouped.push( {
-		label: __( 'Everyone', 'newspack' ),
+		label: __( 'Everyone', 'newspack-plugin' ),
 		id: '',
 		prompts: prompts.filter( ( { segments: _segments } ) => _segments.length === 0 ),
 		configuration: {},
@@ -160,21 +160,21 @@ const Campaigns = props => {
 	const campaignsSelectOptions = [
 		{
 			key: DEFAULT_CAMPAIGNS_FILTER,
-			name: __( 'Active Prompts', 'newspack' ),
+			name: __( 'Active Prompts', 'newspack-plugin' ),
 		},
 		{
 			key: 'all',
-			name: __( 'All Prompts', 'newspack' ),
+			name: __( 'All Prompts', 'newspack-plugin' ),
 		},
 		{
 			key: 'trash',
-			name: __( 'Trash', 'newspack' ),
+			name: __( 'Trash', 'newspack-plugin' ),
 		},
 		...( hasUnassigned
 			? [
 					{
 						key: 'unassigned',
-						name: __( 'Unassigned Prompts', 'newspack' ),
+						name: __( 'Unassigned Prompts', 'newspack-plugin' ),
 					},
 			  ]
 			: [] ),
@@ -182,7 +182,7 @@ const Campaigns = props => {
 			? [
 					{
 						key: 'header-campaigns',
-						name: __( 'Campaigns', 'newspack' ),
+						name: __( 'Campaigns', 'newspack-plugin' ),
 						className: 'is-header',
 					},
 			  ]
@@ -196,14 +196,14 @@ const Campaigns = props => {
 			? [
 					{
 						key: 'header-archived-campaigns',
-						name: __( 'Archived Campaigns', 'newspack' ),
+						name: __( 'Archived Campaigns', 'newspack-plugin' ),
 						className: 'is-header',
 					},
 			  ]
 			: [] ),
 		...archivedCampaigns.map( ( { term_id: id, name } ) => ( {
 			key: String( id ),
-			name: name + ' ' + __( '(archived)', 'newspack' ),
+			name: name + ' ' + __( '(archived)', 'newspack-plugin' ),
 			className: 'newspack-campaigns__campaign-group__select-control-group-item',
 		} ) ),
 	];
@@ -213,7 +213,7 @@ const Campaigns = props => {
 			<Card headerActions noBorder>
 				<div className="newspack-campaigns__campaign-group__filter-group-actions">
 					<CustomSelectControl
-						label={ __( 'Campaigns', 'newspack' ) }
+						label={ __( 'Campaigns', 'newspack-plugin' ) }
 						options={ campaignsSelectOptions.map( option => ( {
 							...option,
 							className: classnames( option.className, {
@@ -237,7 +237,7 @@ const Campaigns = props => {
 								className={ popoverVisible && 'popover-active' }
 								onClick={ () => setPopoverVisible( ! popoverVisible ) }
 								icon={ moreVertical }
-								label={ __( 'Actions', 'newspack' ) }
+								label={ __( 'Actions', 'newspack-plugin' ) }
 								tooltipPosition="bottom center"
 							/>
 							{ popoverVisible && (
@@ -275,7 +275,7 @@ const Campaigns = props => {
 							setModalType( MODAL_TYPE_NEW );
 						} }
 					>
-						{ __( 'Add New Campaign', 'newspack' ) }
+						{ __( 'Add New Campaign', 'newspack-plugin' ) }
 					</Button>
 					{ modalVisible && (
 						<Modal
@@ -286,9 +286,9 @@ const Campaigns = props => {
 						>
 							<div ref={ modalTextRef }>
 								<TextControl
-									placeholder={ __( 'Campaign Name', 'newspack' ) }
+									placeholder={ __( 'Campaign Name', 'newspack-plugin' ) }
 									onChange={ setCampaignName }
-									label={ __( 'Campaign Name', 'newspack' ) }
+									label={ __( 'Campaign Name', 'newspack-plugin' ) }
 									hideLabelFromVision={ true }
 									value={ campaignName }
 									onKeyDown={ event => {
@@ -306,7 +306,7 @@ const Campaigns = props => {
 										setModalVisible( false );
 									} }
 								>
-									{ __( 'Cancel', 'newspack' ) }
+									{ __( 'Cancel', 'newspack-plugin' ) }
 								</Button>
 								<Button
 									variant="primary"

--- a/assets/wizards/popups/views/segments/segments-list.js
+++ b/assets/wizards/popups/views/segments/segments-list.js
@@ -17,7 +17,7 @@ const { NavLink, useHistory } = Router;
 
 const AddNewSegmentLink = () => (
 	<NavLink to="segments/new">
-		<Button variant="primary">{ __( 'Add New Segment', 'newspack' ) }</Button>
+		<Button variant="primary">{ __( 'Add New Segment', 'newspack-plugin' ) }</Button>
 	</NavLink>
 );
 
@@ -181,7 +181,7 @@ const SegmentActionCard = ( {
 							<>
 								<Button
 									onClick={ () => setPopoverVisibility( ! popoverVisibility ) }
-									label={ __( 'More options', 'newspack' ) }
+									label={ __( 'More options', 'newspack-plugin' ) }
 									icon={ moreVertical }
 									className={ popoverVisibility && 'popover-active' }
 								/>
@@ -192,19 +192,19 @@ const SegmentActionCard = ( {
 										onFocusOutside={ onFocusOutside }
 									>
 										<MenuItem onClick={ () => onFocusOutside() } className="screen-reader-text">
-											{ __( 'Close Popover', 'newspack' ) }
+											{ __( 'Close Popover', 'newspack-plugin' ) }
 										</MenuItem>
 										<MenuItem
 											onClick={ () => history.push( `/segments/${ segment.id }` ) }
 											className="newspack-button"
 										>
-											{ __( 'Edit', 'newspack' ) }
+											{ __( 'Edit', 'newspack-plugin' ) }
 										</MenuItem>
 										<MenuItem
 											onClick={ () => deleteSegment( segment ) }
 											className="newspack-button"
 										>
-											{ __( 'Delete', 'newspack' ) }
+											{ __( 'Delete', 'newspack-plugin' ) }
 										</MenuItem>
 									</Popover>
 								) }
@@ -225,13 +225,13 @@ const SegmentActionCard = ( {
 									icon={ chevronUp }
 									onClick={ moveUp }
 									disabled={ isFirstTarget }
-									label={ __( 'Move segment position up', 'newspack' ) }
+									label={ __( 'Move segment position up', 'newspack-plugin' ) }
 								/>
 								<Button
 									icon={ chevronDown }
 									onClick={ moveDown }
 									disabled={ isLastTarget }
-									label={ __( 'Move segment position down', 'newspack' ) }
+									label={ __( 'Move segment position down', 'newspack-plugin' ) }
 								/>
 							</div>
 						</div>
@@ -307,7 +307,10 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 			} )
 			.catch( e => {
 				setInFlight( false );
-				setError( e.message || __( 'There was an error sorting segments. Please try again.' ) );
+				setError(
+					e.message ||
+						__( 'There was an error sorting segments. Please try again.', 'newspack-plugin' )
+				);
 				setSegments( segments );
 			} );
 	};
@@ -323,7 +326,7 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 		<Fragment>
 			{ error && <Notice noticeText={ error } isError /> }
 			<Card headerActions noBorder>
-				<h2>{ __( 'Audience segments', 'newspack' ) }</h2>
+				<h2>{ __( 'Audience segments', 'newspack-plugin' ) }</h2>
 				<AddNewSegmentLink />
 			</Card>
 			<div
@@ -351,13 +354,13 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 	) : (
 		<Fragment>
 			<Card headerActions noBorder>
-				<h2>{ __( 'You have no saved audience segments.', 'newspack' ) }</h2>
+				<h2>{ __( 'You have no saved audience segments.', 'newspack-plugin' ) }</h2>
 				<AddNewSegmentLink />
 			</Card>
 			<p>
 				{ __(
 					'Create audience segments to target visitors by engagement, activity, and more.',
-					'newspack'
+					'newspack-plugin'
 				) }
 			</p>
 		</Fragment>

--- a/assets/wizards/popups/views/segments/single-segment.js
+++ b/assets/wizards/popups/views/segments/single-segment.js
@@ -55,7 +55,7 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 
 	const unblock = hooks.usePrompt(
 		isDirty,
-		__( 'There are unsaved changes to this segment. Discard changes?', 'newspack' )
+		__( 'There are unsaved changes to this segment. Discard changes?', 'newspack-plugin' )
 	);
 
 	const isNew = segmentId === 'new';
@@ -169,31 +169,31 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 	return (
 		<Fragment>
 			<TextControl
-				placeholder={ __( 'Untitled Segment', 'newspack' ) }
+				placeholder={ __( 'Untitled Segment', 'newspack-plugin' ) }
 				value={ name }
 				onChange={ setName }
-				label={ __( 'Title', 'newspack' ) }
+				label={ __( 'Title', 'newspack-plugin' ) }
 				className={ 'newspack-campaigns-wizard-segments__title' }
 			/>
 
 			<SettingsCard
-				title={ __( 'Segment Status', 'newspack' ) }
+				title={ __( 'Segment Status', 'newspack-plugin' ) }
 				description={ __(
 					'If not enabled, the segment will be ignored for reader segmentation.',
-					'newspack'
+					'newspack-plugin'
 				) }
 				noBorder
 			>
 				<ToggleControl
-					label={ __( 'Segment enabled', 'newspack' ) }
+					label={ __( 'Segment enabled', 'newspack-plugin' ) }
 					checked={ ! segmentConfig.is_disabled }
 					onChange={ () => updateSegmentConfig( { is_disabled: ! segmentConfig.is_disabled } ) }
 				/>
 			</SettingsCard>
 
 			<SettingsCard
-				title={ __( 'Reader Engagement', 'newspack' ) }
-				description={ __( 'Target readers based on their browsing behavior.', 'newspack' ) }
+				title={ __( 'Reader Engagement', 'newspack-plugin' ) }
+				description={ __( 'Target readers based on their browsing behavior.', 'newspack-plugin' ) }
 				noBorder
 			>
 				{ allCriteria
@@ -209,10 +209,10 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					) ) }
 			</SettingsCard>
 			<SettingsCard
-				title={ __( 'Registration', 'newspack' ) }
+				title={ __( 'Registration', 'newspack-plugin' ) }
 				description={ __(
 					'Target readers based on their user account registration status.',
-					'newspack'
+					'newspack-plugin'
 				) }
 				columns={ 3 }
 				noBorder
@@ -230,10 +230,10 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					) ) }
 			</SettingsCard>
 			<SettingsCard
-				title={ __( 'Newsletters', 'newspack' ) }
+				title={ __( 'Newsletters', 'newspack-plugin' ) }
 				description={ __(
 					'Target readers based on their newsletter subscription status.',
-					'newspack'
+					'newspack-plugin'
 				) }
 				columns={ 3 }
 				noBorder
@@ -251,8 +251,8 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					) ) }
 			</SettingsCard>
 			<SettingsCard
-				title={ __( 'Reader Revenue', 'newspack' ) }
-				description={ __( 'Target readers based on their revenue activity.', 'newspack' ) }
+				title={ __( 'Reader Revenue', 'newspack-plugin' ) }
+				description={ __( 'Target readers based on their revenue activity.', 'newspack-plugin' ) }
 				columns={ 3 }
 				noBorder
 			>
@@ -269,11 +269,14 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					) ) }
 			</SettingsCard>
 			<SettingsCard
-				title={ __( 'Referrer Sources', 'newspack' ) }
-				description={ __( 'Target readers based on where they’re coming from.', 'newspack' ) }
+				title={ __( 'Referrer Sources', 'newspack-plugin' ) }
+				description={ __(
+					'Target readers based on where they’re coming from.',
+					'newspack-plugin'
+				) }
 				notification={ __(
 					'Segments using these options will apply only to the first page visited after coming from an external source.',
-					'newspack'
+					'newspack-plugin'
 				) }
 				columns={ 2 }
 				noBorder
@@ -296,10 +299,10 @@ const SingleSegment = ( { segmentId, setSegments, wizardApiFetch } ) => {
 					isPrimary
 					onClick={ saveSegment }
 				>
-					{ __( 'Save', 'newspack' ) }
+					{ __( 'Save', 'newspack-plugin' ) }
 				</Button>
 				<Button isSecondary href="#/segments">
-					{ __( 'Cancel', 'newspack' ) }
+					{ __( 'Cancel', 'newspack-plugin' ) }
 				</Button>
 			</div>
 		</Fragment>

--- a/composer.lock
+++ b/composer.lock
@@ -216,16 +216,16 @@
         },
         {
             "name": "google/auth",
-            "version": "v1.35.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "6e9c9fd4e2bbd7042f50083076346e4a1eff4e4b"
+                "reference": "5f16f67375b6f202b857183d7ef4e076acd7d4aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/6e9c9fd4e2bbd7042f50083076346e4a1eff4e4b",
-                "reference": "6e9c9fd4e2bbd7042f50083076346e4a1eff4e4b",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/5f16f67375b6f202b857183d7ef4e076acd7d4aa",
+                "reference": "5f16f67375b6f202b857183d7ef4e076acd7d4aa",
                 "shasum": ""
             },
             "require": {
@@ -268,9 +268,9 @@
             "support": {
                 "docs": "https://googleapis.github.io/google-auth-library-php/main/",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.35.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.37.0"
             },
-            "time": "2024-02-01T20:41:08+00:00"
+            "time": "2024-02-21T17:03:52+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -3610,16 +3610,16 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/bc45c394692b948b4d383a08d7753968bed9a83d",
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d",
                 "shasum": ""
             },
             "require": {
@@ -3630,9 +3630,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3674,7 +3671,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3690,20 +3687,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "42292d99c55abe617799667f454222c54c60e229"
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
-                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
                 "shasum": ""
             },
             "require": {
@@ -3717,9 +3714,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3757,7 +3751,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3773,7 +3767,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-28T09:04:16+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php73",

--- a/composer.lock
+++ b/composer.lock
@@ -1305,16 +1305,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.0",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4a21235f7e56e713259a6f76bf4b5ea08502b9dc"
+                "reference": "2218c2252c874a4624ab2f613d86ac32d227bc69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4a21235f7e56e713259a6f76bf4b5ea08502b9dc",
-                "reference": "4a21235f7e56e713259a6f76bf4b5ea08502b9dc",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/2218c2252c874a4624ab2f613d86ac32d227bc69",
+                "reference": "2218c2252c874a4624ab2f613d86ac32d227bc69",
                 "shasum": ""
             },
             "require": {
@@ -1357,9 +1357,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.1"
             },
-            "time": "2024-01-07T17:17:35+00:00"
+            "time": "2024-02-21T19:24:10+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2118,16 +2118,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.16",
+            "version": "9.6.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f"
+                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3767b2c56ce02d01e3491046f33466a1ae60a37f",
-                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1a156980d78a6666721b7e8e8502fe210b587fcd",
+                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd",
                 "shasum": ""
             },
             "require": {
@@ -2201,7 +2201,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.16"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.17"
             },
             "funding": [
                 {
@@ -2217,7 +2217,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-19T07:03:14+00:00"
+            "time": "2024-02-23T13:14:51+00:00"
         },
         {
             "name": "psr/container",

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -573,7 +573,7 @@ class Plugin_Manager {
 		}
 
 		$plugins = array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'reduce_plugin_info' ) );
-		$themes  = array_reduce( array_keys( wp_get_themes() ), array( __CLASS__, 'reduce_plugin_info' ) );
+		$themes  = array_reduce( array_keys( wp_get_themes() ), array( __CLASS__, 'reduce_plugin_info' ) ) ?? [];
 		return array_merge( $plugins, $themes );
 	}
 

--- a/includes/data-events/connectors/ga4/README.md
+++ b/includes/data-events/connectors/ga4/README.md
@@ -44,7 +44,7 @@ Additional parameters:
 
 * `registration_method`
 * `newspack_popup_id`: If the action was triggered from inside a popup, the popup id.
-* `referer`
+* `referrer`
 
 ### donation_new
 
@@ -56,7 +56,7 @@ Additional parameters:
 * `currency`
 * `recurrence`
 * `platform`
-* `referer`
+* `referrer`
 * `is_renewal`: If this is a subscription renewal (recurring payment).
 * `subscription_id`: The related subscription id (if any).
 * `popup_id`: If the action was triggered from inside a popup, the popup id.
@@ -80,7 +80,7 @@ Additional parameters:
 
 * `newsletters_subscription_method`
 * `newspack_popup_id`: If the action was triggered from inside a popup, the popup id.
-* `referer`
+* `referrer`
 * `lists`: comma separated list of the list IDs the readers subscribed to (note: truncated at 100 characters)
 * `registration_method`: If the newsletter subscription was triggered by a registration form
 

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -270,6 +270,9 @@ class GA4 {
 			$params = array_merge( $params, self::get_sanitized_popup_params( $data['metadata']['newspack_popup_id'] ) );
 		}
 		if ( ! empty( $data['metadata']['referer'] ) ) {
+			$params['referrer'] = substr( $data['metadata']['referer'], 0, 100 );
+
+			// Retain both instances of referrer spelling to ensure publisher reports are not broken.
 			$params['referer'] = substr( $data['metadata']['referer'], 0, 100 );
 		}
 		return $params;
@@ -288,6 +291,8 @@ class GA4 {
 		$params['currency']        = $data['currency'];
 		$params['recurrence']      = $data['recurrence'];
 		$params['platform']        = $data['platform'];
+		$params['referrer']        = $data['referer'] ?? '';
+		// Retain both instances of referrer spelling to ensure publisher reports are not broken.
 		$params['referer']         = $data['referer'] ?? '';
 		$params['popup_id']        = $data['popup_id'] ?? '';
 		$params['is_renewal']      = $data['is_renewal'] ? 'yes' : 'no';
@@ -354,7 +359,10 @@ class GA4 {
 			$params = array_merge( $params, self::get_sanitized_popup_params( $metadata['newspack_popup_id'] ) );
 		}
 		$params['newsletters_subscription_method'] = $metadata['newsletters_subscription_method'] ?? '';
-		$params['referer']                         = $metadata['current_page_url'] ?? '';
+		$params['referrer']                        = $metadata['current_page_url'] ?? '';
+
+		// Retain both instances of referrer spelling to ensure publisher reports are not broken.
+		$params['referer'] = $metadata['current_page_url'] ?? '';
 
 		// In case the subscription happened as part of the registration process, we should also have the registration method.
 		$params['registration_method'] = $metadata['registration_method'] ?? '';
@@ -397,6 +405,8 @@ class GA4 {
 		$params['gate_post_id'] = $data['gate_post_id'] ?? '';
 		$params['action']       = $data['action'] ?? '';
 		$params['action_type']  = $data['action_type'] ?? '';
+		$params['referrer']     = $data['referer'] ?? '';
+		// Retain both instances of referrer spelling to ensure publisher reports are not broken.
 		$params['referer']      = $data['referer'] ?? '';
 		$params['order_id']     = $data['order_id'] ?? '';
 		$params['product_id']   = $data['product_id'] ?? '';

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -545,13 +545,17 @@ class Emails {
 	 * @param string  $key Reset key.
 	 */
 	public static function get_password_reset_url( $user, $key ) {
-		return add_query_arg(
-			[
-				'key' => $key,
-				'id'  => $user->ID,
-			],
-			wc_get_account_endpoint_url( 'lost-password' )
-		);
+		if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
+			return add_query_arg(
+				[
+					'key' => $key,
+					'id'  => $user->ID,
+				],
+				wc_get_account_endpoint_url( 'lost-password' )
+			);
+		}
+
+		return wp_lostpassword_url();
 	}
 }
 Emails::init();

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -26,6 +26,122 @@ class Jetpack {
 	];
 
 	/**
+	 * Default modules
+	 *
+	 * @var string[]
+	 */
+	public static $default_active_modules = [
+		/** 
+		 * Assets CDN
+		 *
+		 * @link https://jetpack.com/support/site-accelerator/
+		 */
+		'photon-cdn',
+		/** 
+		 * Image CDN
+		 *
+		 * @link https://jetpack.com/support/site-accelerator/
+		 */
+		'photon',
+		/** 
+		 * Contact Form
+		 *
+		 * @link https://jetpack.com/support/contact-form/
+		 */
+		'contact-form',
+		/** 
+		 * Brute Force Protection. 
+		 *
+		 * @link https://jetpack.com/support/protect/
+		 */
+		'protect',
+		/** 
+		 * JSON API 
+		 *
+		 * @link https://jetpack.com/support/json-api/
+		 */
+		'json-api',
+		/** 
+		 * Notifications
+		 *
+		 * @link https://jetpack.com/support/notifications/
+		 */
+		'notes',
+		/**
+		 * Stats
+		 *
+		 * @link https://jetpack.com/support/jetpack-stats/
+		 */
+		'stats',
+		/**
+		 * Site Verification
+		 *
+		 * @link https://jetpack.com/support/site-verification-tools/
+		 */
+		'verification-tools',
+		/**
+		 * Carousel
+		 *
+		 * @link https://jetpack.com/support/carousel/
+		 */
+		'carousel',
+		/**
+		 * Copy Post
+		 *
+		 * @link https://jetpack.com/support/copy-post/
+		 */
+		'copy-post',
+		/**
+		 * Extra Sidebar Widgets
+		 *
+		 * @link https://jetpack.com/support/extra-sidebar-widgets/
+		 */
+		'widgets',
+		/**
+		 * Gravatar Hovercards
+		 *
+		 * @link https://jetpack.com/support/gravatar-hovercards
+		 */
+		'gravatar-hovercards',
+		/**
+		 * Social
+		 *
+		 * @link https://jetpack.com/support/jetpack-social/
+		 */
+		'publicize',
+		/**
+		 * Related Posts
+		 *
+		 * @link https://jetpack.com/support/related-posts/
+		 */
+		'related-posts',
+		/**
+		 * Sharing
+		 *
+		 * @link https://jetpack.com/support/sharing/
+		 */
+		'sharedaddy',
+		/**
+		 * Sitemaps
+		 *
+		 * @link https://jetpack.com/support/sitemaps
+		 */
+		'sitemaps',
+		/**
+		 * Tiled Gallery
+		 *
+		 * @link https://jetpack.com/support/jetpack-blocks/tiled-galleries/
+		 */
+		'tiled-gallery',
+		/**
+		 * Widget Visibility
+		 *
+		 * @link https://jetpack.com/support/widget-visibility/
+		 */
+		'widget-visibility',
+	];
+
+	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
@@ -36,8 +152,12 @@ class Jetpack {
 		add_filter( 'wp_calculate_image_srcset', [ __CLASS__, 'filter_srcset_array' ], 100, 5 );
 
 		// Disables Google Analytics.
-		add_filter( 'jetpack_active_modules', array( __CLASS__, 'remove_google_analytics_from_active' ), 10, 2 );
-		add_filter( 'jetpack_get_available_modules', array( __CLASS__, 'remove_google_analytics_from_available' ) );
+		add_filter( 'jetpack_active_modules', [ __CLASS__, 'remove_google_analytics_from_active' ], 10, 2 );
+		add_filter( 'jetpack_get_available_modules', [ __CLASS__, 'remove_google_analytics_from_available' ] );
+
+		// Set Jetpack default modules on Newspack setup.
+		add_action( 'add_option_newspack_setup_complete', [ __CLASS__, 'set_default_modules' ], 10, 2 );
+		add_action( 'update_option_newspack_setup_complete', [ __CLASS__, 'set_default_modules' ], 10, 2 );
 	}
 
 	/**
@@ -180,6 +300,19 @@ class Jetpack {
 			unset( $modules['google-analytics'] );
 		}
 		return $modules;
+	}
+
+	/**
+	 * Set Jetpack Default Modules on newspack setup complete.
+	 *
+	 * @param string $old_val_or_opt_name If adding will be opt name. If updating will be old value.
+	 * @param string $new_val Value correlated to update/add.
+	 * @return void 
+	 */
+	public static function set_default_modules( string $old_val_or_opt_name, string $new_val ) {
+		if ( $new_val === '1' ) {
+			update_option( 'jetpack_active_modules', static::$default_active_modules );
+		}
 	}
 }
 Jetpack::init();

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -202,6 +202,9 @@ class Newspack_Newsletters {
 						$normalized_metadata[ $meta_key ] = $meta_value;
 					}
 				}
+				if ( isset( $contact['metadata']['status'] ) ) {
+					$normalized_metadata['status'] = $contact['metadata']['status'];
+				}
 			}
 			$contact['metadata'] = $normalized_metadata;
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "3.3.1",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@babel/plugin-transform-runtime": "^7.23.9",
+				"@babel/plugin-transform-runtime": "^7.24.0",
 				"@babel/preset-env": "^7.24.0",
 				"classnames": "^2.5.1",
 				"colord": "^2.9.3",
@@ -1556,12 +1556,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.9.tgz",
-			"integrity": "sha512-A7clW3a0aSjm3ONU9o2HAILSegJCYlEZmOhmBRReVtIpY/Z/p7yIZ+wR41Z+UipwdGuqwtID/V/dOdZXjwi9gQ==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.0.tgz",
+			"integrity": "sha512-zc0GA5IitLKJrSfXlXmp8KDqLrnGECK7YRfQBmEKg1NmBOQ7e+KuclBEKJgzifQeUYLdNiAw4B4bjyvzWVLiSA==",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"babel-plugin-polyfill-corejs2": "^0.4.8",
 				"babel-plugin-polyfill-corejs3": "^0.9.0",
 				"babel-plugin-polyfill-regenerator": "^0.5.5",
@@ -32523,12 +32523,12 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.9.tgz",
-			"integrity": "sha512-A7clW3a0aSjm3ONU9o2HAILSegJCYlEZmOhmBRReVtIpY/Z/p7yIZ+wR41Z+UipwdGuqwtID/V/dOdZXjwi9gQ==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.0.tgz",
+			"integrity": "sha512-zc0GA5IitLKJrSfXlXmp8KDqLrnGECK7YRfQBmEKg1NmBOQ7e+KuclBEKJgzifQeUYLdNiAw4B4bjyvzWVLiSA==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"babel-plugin-polyfill-corejs2": "^0.4.8",
 				"babel-plugin-polyfill-corejs3": "^0.9.0",
 				"babel-plugin-polyfill-regenerator": "^0.5.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"@types/qs": "^6.9.11",
 				"@types/react": "^17.0.75",
 				"@types/wordpress__components": "^23.0.11",
-				"@wordpress/browserslist-config": "^5.34.0",
+				"@wordpress/browserslist-config": "^5.35.0",
 				"eslint": "^7.32.0",
 				"lint-staged": "^15.2.2",
 				"newspack-scripts": "^5.3.0",
@@ -6609,9 +6609,9 @@
 			"dev": true
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "5.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.34.0.tgz",
-			"integrity": "sha512-LafF3XoetOAN99bktOzc9hSOv7cPoQEe0/KPgiw24t77xvRqLuWww+zYbiHAHYSzdBGngrlNwRLgloSifnp+hg==",
+			"version": "5.35.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.35.0.tgz",
+			"integrity": "sha512-hybMVNdGXvKxN1P9Vc2YBxYJqKM1wA9clsx94qjVh73Q1f47olshmwsqp0whDV0piDBReD0irJsz9jszhd8Z1A==",
 			"dev": true,
 			"engines": {
 				"node": ">=14"
@@ -36288,9 +36288,9 @@
 			}
 		},
 		"@wordpress/browserslist-config": {
-			"version": "5.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.34.0.tgz",
-			"integrity": "sha512-LafF3XoetOAN99bktOzc9hSOv7cPoQEe0/KPgiw24t77xvRqLuWww+zYbiHAHYSzdBGngrlNwRLgloSifnp+hg==",
+			"version": "5.35.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.35.0.tgz",
+			"integrity": "sha512-hybMVNdGXvKxN1P9Vc2YBxYJqKM1wA9clsx94qjVh73Q1f47olshmwsqp0whDV0piDBReD0irJsz9jszhd8Z1A==",
 			"dev": true
 		},
 		"@wordpress/components": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 			"devDependencies": {
 				"@rushstack/eslint-patch": "^1.7.2",
 				"@testing-library/react": "^12.1.4",
-				"@types/qs": "^6.9.11",
+				"@types/qs": "^6.9.12",
 				"@types/react": "^17.0.75",
 				"@types/wordpress__components": "^23.0.11",
 				"@wordpress/browserslist-config": "^5.35.0",
@@ -5032,9 +5032,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/qs": {
-			"version": "6.9.11",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
-			"integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
+			"version": "6.9.12",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.12.tgz",
+			"integrity": "sha512-bZcOkJ6uWrL0Qb2NAWKa7TBU+mJHPzhx9jjLL1KHF+XpzEcR7EXHvjbHlGtR/IsP1vyPrehuS6XqkmaePy//mg==",
 			"dev": true
 		},
 		"node_modules/@types/react": {
@@ -35044,9 +35044,9 @@
 			"dev": true
 		},
 		"@types/qs": {
-			"version": "6.9.11",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
-			"integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
+			"version": "6.9.12",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.12.tgz",
+			"integrity": "sha512-bZcOkJ6uWrL0Qb2NAWKa7TBU+mJHPzhx9jjLL1KHF+XpzEcR7EXHvjbHlGtR/IsP1vyPrehuS6XqkmaePy//mg==",
 			"dev": true
 		},
 		"@types/react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"hasInstallScript": true,
 			"dependencies": {
 				"@babel/plugin-transform-runtime": "^7.23.9",
-				"@babel/preset-env": "^7.23.9",
+				"@babel/preset-env": "^7.24.0",
 				"classnames": "^2.5.1",
 				"colord": "^2.9.3",
 				"deep-map-keys": "^2.0.1",
@@ -436,9 +436,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+			"integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1342,13 +1342,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz",
-			"integrity": "sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.0.tgz",
+			"integrity": "sha512-y/yKMm7buHpFFXfxVFS4Vk1ToRJDilIa6fKRioB9Vjichv58TDGXTvqV0dN7plobAmTW5eSEGXDngE+Mm+uO+w==",
 			"dependencies": {
-				"@babel/compat-data": "^7.23.3",
-				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-compilation-targets": "^7.23.6",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
 				"@babel/plugin-transform-parameters": "^7.23.3"
 			},
@@ -1730,13 +1730,13 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
-			"integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.0.tgz",
+			"integrity": "sha512-ZxPEzV9IgvGn73iK0E6VB9/95Nd7aMFpbE0l8KQFDG70cOV9IxRP7Y2FUPmlK0v6ImlLqYX50iuZ3ZTVhOF2lA==",
 			"dependencies": {
 				"@babel/compat-data": "^7.23.5",
 				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/helper-validator-option": "^7.23.5",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
@@ -1789,7 +1789,7 @@
 				"@babel/plugin-transform-new-target": "^7.23.3",
 				"@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
 				"@babel/plugin-transform-numeric-separator": "^7.23.4",
-				"@babel/plugin-transform-object-rest-spread": "^7.23.4",
+				"@babel/plugin-transform-object-rest-spread": "^7.24.0",
 				"@babel/plugin-transform-object-super": "^7.23.3",
 				"@babel/plugin-transform-optional-catch-binding": "^7.23.4",
 				"@babel/plugin-transform-optional-chaining": "^7.23.4",
@@ -31842,9 +31842,9 @@
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg=="
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+			"integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w=="
 		},
 		"@babel/helper-remap-async-to-generator": {
 			"version": "7.22.20",
@@ -32397,13 +32397,13 @@
 			}
 		},
 		"@babel/plugin-transform-object-rest-spread": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz",
-			"integrity": "sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.0.tgz",
+			"integrity": "sha512-y/yKMm7buHpFFXfxVFS4Vk1ToRJDilIa6fKRioB9Vjichv58TDGXTvqV0dN7plobAmTW5eSEGXDngE+Mm+uO+w==",
 			"requires": {
-				"@babel/compat-data": "^7.23.3",
-				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-compilation-targets": "^7.23.6",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
 				"@babel/plugin-transform-parameters": "^7.23.3"
 			}
@@ -32630,13 +32630,13 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
-			"integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.0.tgz",
+			"integrity": "sha512-ZxPEzV9IgvGn73iK0E6VB9/95Nd7aMFpbE0l8KQFDG70cOV9IxRP7Y2FUPmlK0v6ImlLqYX50iuZ3ZTVhOF2lA==",
 			"requires": {
 				"@babel/compat-data": "^7.23.5",
 				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/helper-validator-option": "^7.23.5",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
@@ -32689,7 +32689,7 @@
 				"@babel/plugin-transform-new-target": "^7.23.3",
 				"@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
 				"@babel/plugin-transform-numeric-separator": "^7.23.4",
-				"@babel/plugin-transform-object-rest-spread": "^7.23.4",
+				"@babel/plugin-transform-object-rest-spread": "^7.24.0",
 				"@babel/plugin-transform-object-super": "^7.23.3",
 				"@babel/plugin-transform-optional-catch-binding": "^7.23.4",
 				"@babel/plugin-transform-optional-chaining": "^7.23.4",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"postinstall": "rm -rf node_modules/newspack-scripts/node_modules/prettier"
 	},
 	"dependencies": {
-		"@babel/plugin-transform-runtime": "^7.23.9",
+		"@babel/plugin-transform-runtime": "^7.24.0",
 		"@babel/preset-env": "^7.24.0",
 		"classnames": "^2.5.1",
 		"colord": "^2.9.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"devDependencies": {
 		"@rushstack/eslint-patch": "^1.7.2",
 		"@testing-library/react": "^12.1.4",
-		"@types/qs": "^6.9.11",
+		"@types/qs": "^6.9.12",
 		"@types/react": "^17.0.75",
 		"@types/wordpress__components": "^23.0.11",
 		"@wordpress/browserslist-config": "^5.35.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@types/qs": "^6.9.11",
 		"@types/react": "^17.0.75",
 		"@types/wordpress__components": "^23.0.11",
-		"@wordpress/browserslist-config": "^5.34.0",
+		"@wordpress/browserslist-config": "^5.35.0",
 		"eslint": "^7.32.0",
 		"lint-staged": "^15.2.2",
 		"newspack-scripts": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	},
 	"dependencies": {
 		"@babel/plugin-transform-runtime": "^7.23.9",
-		"@babel/preset-env": "^7.23.9",
+		"@babel/preset-env": "^7.24.0",
 		"classnames": "^2.5.1",
 		"colord": "^2.9.3",
 		"deep-map-keys": "^2.0.1",


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1200550061930446/1206731853389179/f](https://app.asana.com/0/1200550061930446/1206731853389179/f).

This fixes a problem where sending a password reset email when WC is not installed results in a fatal:

![Screenshot 2024-03-06 at 16 42 06](https://github.com/Automattic/newspack-plugin/assets/17905991/c3d734af-ee6e-4589-965a-8a01fc1158d8)


### How to test the changes in this Pull Request:

1. On a test site, make sure Woo is not active
2. Go to any users Edit User page
3. Send a password reset link. On `release`, you will see a fatal error box appear (with no text). On this branch the generic lost password link will be sent

![Screenshot 2024-03-06 at 16 44 20](https://github.com/Automattic/newspack-plugin/assets/17905991/64e5fa04-8ed2-4312-abee-f1904def76dd)


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->