### PR TITLE
fix(ras): check for woo when generating password reset link

### DIFF
--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -545,13 +545,17 @@ class Emails {
 	 * @param string  $key Reset key.
 	 */
 	public static function get_password_reset_url( $user, $key ) {
-		return add_query_arg(
-			[
-				'key' => $key,
-				'id'  => $user->ID,
-			],
-			wc_get_account_endpoint_url( 'lost-password' )
-		);
+		if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
+			return add_query_arg(
+				[
+					'key' => $key,
+					'id'  => $user->ID,
+				],
+				wc_get_account_endpoint_url( 'lost-password' )
+			);
+		}
+
+		return wp_lostpassword_url();
 	}
 }
 Emails::init();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1200550061930446/1206731853389179/f](https://app.asana.com/0/1200550061930446/1206731853389179/f).

This fixes a problem where sending a password reset email when WC is not installed results in a fatal:

![Screenshot 2024-03-06 at 16 42 06](https://github.com/Automattic/newspack-plugin/assets/17905991/c3d734af-ee6e-4589-965a-8a01fc1158d8)


### How to test the changes in this Pull Request:

1. On a test site, make sure Woo is not active
2. Go to any users Edit User page
3. Send a password reset link. On `release`, you will see a fatal error box appear (with no text). On this branch the generic lost password link will be sent

![Screenshot 2024-03-06 at 16 44 20](https://github.com/Automattic/newspack-plugin/assets/17905991/64e5fa04-8ed2-4312-abee-f1904def76dd)


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->