### PR TITLE
Epic/network march release merge

### DIFF
--- a/assets/blocks/core-image/figcaption.tsx
+++ b/assets/blocks/core-image/figcaption.tsx
@@ -1,0 +1,69 @@
+/**
+ * Newspack Core Image, Figcaption
+ */
+
+/**
+ * Dependencies
+ */
+// WordPress
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+import * as CoreImageBlockTypes from './types';
+
+/**
+ * Helper to parse credit meta
+ */
+function parseCreditToText( credit: CoreImageBlockTypes.AttributesMeta ) {
+	const parsed = {
+		credit: credit._media_credit ?? undefined,
+		url: credit._media_credit_url ?? undefined,
+		org: credit._navis_media_credit_org ?? undefined,
+	};
+	if ( ! parsed.credit ) {
+		return '';
+	}
+	const org = `${ parsed.org ? ` / ${ parsed.org }` : '' }`;
+	const creditElem = parsed.url ? (
+		<a href={ parsed.url } target="_blank" rel="noreferrer">
+			{ `${ parsed.credit }${ org }` }
+		</a>
+	) : (
+		`${ parsed.credit }${ org }`
+	);
+	return (
+		<>
+			{ __( 'Credit', 'newspack-plugin' ) }: { creditElem }
+		</>
+	);
+}
+
+const FigcaptionCredit = ( {
+	attributes,
+	setAttributes,
+	isCaptionVisible,
+}: CoreImageBlockTypes.AttributeProps & { isCaptionVisible: boolean } ) => {
+	const { caption } = attributes;
+	const credit = parseCreditToText( attributes.meta ?? '' );
+
+	const onChangeCaption = ( newCaption: string ) => {
+		setAttributes( { caption: newCaption } );
+	};
+
+	return (
+		<div className="newspack-block__core-image-caption">
+			{ isCaptionVisible && (
+				<RichText
+					tagName="span"
+					value={ caption }
+					allowedFormats={ [] }
+					onChange={ onChangeCaption }
+					placeholder="Enter caption here."
+				/>
+			) }
+			{ credit !== '' && <span>{ credit }</span> }
+		</div>
+	);
+};
+
+export default FigcaptionCredit;

--- a/assets/blocks/core-image/icon.tsx
+++ b/assets/blocks/core-image/icon.tsx
@@ -1,0 +1,26 @@
+/**
+ * Caption SVG component
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/utils/caption.js#L18
+ * @see https://wordpress.github.io/gutenberg/?path=/story/icons-icon--library
+ */
+const Icon = () => {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M6 5.5h12a.5.5 0 0 1 .5.5v12a.5.5 0 0 1-.5.5H6a.5.5 0 0 1-.5-.5V6a.5.5 0 0 1 .5-.5ZM4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6Zm4 10h2v-1.5H8V16Zm5 0h-2v-1.5h2V16Zm1 0h2v-1.5h-2V16Z"
+			/>
+		</svg>
+	);
+};
+
+export default Icon;

--- a/assets/blocks/core-image/index.tsx
+++ b/assets/blocks/core-image/index.tsx
@@ -1,0 +1,95 @@
+/**
+ * Newspack Core Image group of components for overriding
+ * caption behavior.
+ */
+
+/**
+ * Dependencies
+ */
+// External
+import classnames from 'classnames';
+// WordPress
+import { addFilter } from '@wordpress/hooks';
+import { useState, useEffect } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+// Internal
+import './style.scss';
+import Loader from './loader';
+import Toolbar from './toolbar';
+import Figcaption from './figcaption';
+/**
+ * TS
+ */
+import * as CoreImageBlockTypes from './types';
+
+/**
+ * Add image credit meta to core/image block attributes
+ */
+addFilter(
+	'blocks.registerBlockType',
+	'newspack-plugin/register-hook/core-image',
+	( settings, name ) => {
+		if ( name !== 'core/image' ) {
+			return settings;
+		}
+		return {
+			...settings,
+			attributes: {
+				...settings.attributes,
+				meta: {
+					type: 'object',
+					default: {},
+				},
+			},
+		};
+	}
+);
+
+/**
+ * Populate attributes with meta data.
+ */
+addFilter(
+	'editor.BlockEdit',
+	'newspack-plugin/block-edit-hook/core-image',
+	createHigherOrderComponent( Edit => {
+		const BlockEditHoc = (
+			props: CoreImageBlockTypes.BaseProps< CoreImageBlockTypes.Attributes >
+		) => {
+			const caption = ( props.attributes.caption ?? '' ).trim();
+			const [ isCaptionVisible, setIsCaptionVisible ] = useState< boolean >( '' !== caption );
+
+			// If caption visibility is toggled off, clear the caption
+			useEffect( () => {
+				if ( ! isCaptionVisible && '' !== caption ) {
+					props.setAttributes( { caption: '' } );
+				}
+			}, [ isCaptionVisible ] );
+
+			if ( props.name === 'core/image' ) {
+				const id = props.attributes.id ?? 0;
+				const classes = classnames( props.className, 'newspack-block__core-image' );
+				return (
+					<div className={ classes }>
+						<Edit { ...props } />
+						{ id !== 0 && (
+							<>
+								<Figcaption
+									attributes={ props.attributes }
+									setAttributes={ props.setAttributes }
+									isCaptionVisible={ isCaptionVisible }
+								/>
+								<Loader attributes={ props.attributes } setAttributes={ props.setAttributes } />
+								<Toolbar
+									isCaptionVisible={ isCaptionVisible }
+									setIsCaptionVisible={ setIsCaptionVisible }
+								/>
+							</>
+						) }
+					</div>
+				);
+			}
+			return <Edit { ...props } />;
+		};
+		return BlockEditHoc;
+	}, 'withCustomMetaData' )
+);

--- a/assets/blocks/core-image/index.tsx
+++ b/assets/blocks/core-image/index.tsx
@@ -9,6 +9,7 @@
 // External
 import classnames from 'classnames';
 // WordPress
+import { useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { useState, useEffect } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -57,6 +58,12 @@ addFilter(
 		) => {
 			const caption = ( props.attributes.caption ?? '' ).trim();
 			const [ isCaptionVisible, setIsCaptionVisible ] = useState< boolean >( '' !== caption );
+			const { url: siteUrl }: { url: string } = useSelect(
+				select => select( 'core' ).getSite(),
+				[ props.attributes.url ]
+			) ?? {
+				url: '',
+			};
 
 			// If caption visibility is toggled off, clear the caption
 			useEffect( () => {
@@ -78,7 +85,9 @@ addFilter(
 									setAttributes={ props.setAttributes }
 									isCaptionVisible={ isCaptionVisible }
 								/>
-								<Loader attributes={ props.attributes } setAttributes={ props.setAttributes } />
+								{ siteUrl && props.attributes.url.includes( siteUrl ) && (
+									<Loader attributes={ props.attributes } setAttributes={ props.setAttributes } />
+								) }
 								<Toolbar
 									isCaptionVisible={ isCaptionVisible }
 									setIsCaptionVisible={ setIsCaptionVisible }

--- a/assets/blocks/core-image/loader.tsx
+++ b/assets/blocks/core-image/loader.tsx
@@ -1,0 +1,51 @@
+/**
+ * Newspack Core Image, Loader
+ */
+
+/**
+ * Dependencies
+ */
+// WordPress
+import { Spinner } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+/**
+ * Types
+ */
+import { AttributesMeta, AttributeProps } from './types';
+
+const Loader = ( { attributes, setAttributes }: AttributeProps ) => {
+	const imageId = attributes.id ?? 0;
+	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
+	const { meta }: { meta: AttributesMeta } = useSelect(
+		select => select( 'core' ).getMedia( imageId ),
+		[ imageId ]
+	) ?? {
+		meta: {},
+	};
+	useEffect( () => {
+		if ( Object.keys( meta ).length ) {
+			const { _media_credit, _media_credit_url, _navis_media_credit_org } = meta;
+			setAttributes( { meta: { _media_credit, _media_credit_url, _navis_media_credit_org } } );
+			unlockPostSaving( 'attachment-meta-empty' );
+		} else {
+			lockPostSaving( 'attachment-meta-empty' );
+		}
+	}, [ Object.keys( meta ).length, attributes.caption ] );
+
+	return (
+		<>
+			{ ! imageId
+				? null
+				: ! Object.keys( meta ).length && (
+						<div className="newspack-block__core-image-background">
+							<div className="newspack-block__core-image-spinner">
+								<Spinner />
+							</div>
+						</div>
+				  ) }
+		</>
+	);
+};
+
+export default Loader;

--- a/assets/blocks/core-image/loader.tsx
+++ b/assets/blocks/core-image/loader.tsx
@@ -8,7 +8,7 @@
 // WordPress
 import { Spinner } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 /**
  * Types
  */
@@ -16,7 +16,6 @@ import { AttributesMeta, AttributeProps } from './types';
 
 const Loader = ( { attributes, setAttributes }: AttributeProps ) => {
 	const imageId = attributes.id ?? 0;
-	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
 	const { meta }: { meta: AttributesMeta } = useSelect(
 		select => select( 'core' ).getMedia( imageId ),
 		[ imageId ]
@@ -27,9 +26,6 @@ const Loader = ( { attributes, setAttributes }: AttributeProps ) => {
 		if ( Object.keys( meta ).length ) {
 			const { _media_credit, _media_credit_url, _navis_media_credit_org } = meta;
 			setAttributes( { meta: { _media_credit, _media_credit_url, _navis_media_credit_org } } );
-			unlockPostSaving( 'attachment-meta-empty' );
-		} else {
-			lockPostSaving( 'attachment-meta-empty' );
 		}
 	}, [ Object.keys( meta ).length, attributes.caption ] );
 

--- a/assets/blocks/core-image/style.scss
+++ b/assets/blocks/core-image/style.scss
@@ -7,8 +7,6 @@
 
 // Base styles for newspack-block__core-image
 .newspack-block__core-image {
-    --wp-block-image-caption-credit: " ";
-
     margin: 0 auto 2em;
     position: relative;
     width: fit-content;

--- a/assets/blocks/core-image/style.scss
+++ b/assets/blocks/core-image/style.scss
@@ -1,0 +1,87 @@
+// Keyframes
+@keyframes loading {
+    to {
+        transform: translateX(100%);
+    }
+}
+
+// Base styles for newspack-block__core-image
+.newspack-block__core-image {
+    --wp-block-image-caption-credit: " ";
+
+    margin: 0 auto 2em;
+    position: relative;
+    width: fit-content;
+
+    figcaption.wp-element-caption {
+        visibility: hidden;
+        position: absolute;
+    }
+
+    figure.wp-block-image {
+        padding-bottom: 1.5em;
+        margin-bottom: 0;
+    }
+
+    &:hover .newspack-block__core-image-background {
+        opacity: 0.5;
+    }
+}
+
+// Background styles
+.newspack-block__core-image-background {
+    background-color: rgba(#fff, 0.7);
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    transition: opacity 0.4s;
+
+    &::before,
+    &::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+    }
+
+    &::after {
+        animation: loading 2s infinite;
+        background-image: linear-gradient(90deg, rgba(#fff, 0) 0, rgba(#fff, 0.2) 20%, rgba(#fff, 0.6) 60%, rgba(#fff, 0));
+        transform: translateX(-100%);
+    }
+}
+
+// Spinner styles
+.newspack-block__core-image-spinner {
+    position: relative;
+    top: 50%;
+    transform: translateY(-8px);
+    text-align: center;
+    z-index: 1;
+}
+
+// Caption styles
+.newspack-block__core-image-caption {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    color: var(--newspack-theme-color-text-light);
+    font-family: var(--newspack-theme-font-heading);
+    font-size: var(--newspack-theme-font-size-xxs);
+    line-height: var(--newspack-theme-font-line-height-body);
+    margin: -2em 0 1em;
+    max-width: 810px;
+    position: relative;
+    z-index: 1;
+
+    & span:nth-child(2) {
+        margin-left: 1ch;
+        user-select: none;
+    }
+}
+
+// Hide default caption buttons that are not part of newspack-block__core-image-caption-btn
+button[aria-label="Add caption"]:not(.newspack-block__core-image-caption-btn),
+button[aria-label="Remove caption"]:not(.newspack-block__core-image-caption-btn) {
+    display: none;
+}

--- a/assets/blocks/core-image/toolbar.tsx
+++ b/assets/blocks/core-image/toolbar.tsx
@@ -1,0 +1,54 @@
+/**
+ * Newspack Core Image, Toolbar
+ */
+
+/**
+ * Dependencies
+ */
+// External
+import { Dispatch } from 'react';
+// WordPress
+import { __ } from '@wordpress/i18n';
+import { BlockControls } from '@wordpress/block-editor';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+// Internal
+import Icon from './icon';
+import * as CoreImageBlockTypes from './types';
+
+/**
+ * Allow `group` prop on component.
+ */
+const CoreImageBlockControls: CoreImageBlockTypes.BlockControls = BlockControls;
+
+/**
+ * Toolbar
+ */
+const Toolbar = ( {
+	setIsCaptionVisible,
+	isCaptionVisible = false,
+}: {
+	setIsCaptionVisible: Dispatch< boolean >;
+	isCaptionVisible: boolean;
+} ) => {
+	return (
+		<CoreImageBlockControls group="block">
+			<ToolbarGroup>
+				<ToolbarButton
+					icon={ Icon }
+					label={
+						isCaptionVisible
+							? __( 'Add caption', 'newspack-plugin' )
+							: __( 'Remove caption', 'newspack-plugin' )
+					}
+					className="newspack-block__core-image-caption-btn"
+					isPressed={ isCaptionVisible }
+					onClick={ () => {
+						setIsCaptionVisible( ! isCaptionVisible );
+					} }
+				/>
+			</ToolbarGroup>
+		</CoreImageBlockControls>
+	);
+};
+
+export default Toolbar;

--- a/assets/blocks/core-image/types.ts
+++ b/assets/blocks/core-image/types.ts
@@ -1,0 +1,55 @@
+import { BlockControls } from '@wordpress/block-editor';
+
+type UnknownObject = Record< string, unknown >;
+
+/**
+ * core/image block custom meta that is `show_in_rest`
+ */
+export interface AttributesMeta {
+	_media_credit: string;
+	_media_credit_url: string;
+	_navis_media_credit_org: string;
+}
+
+/**
+ * core/image block attributes
+ */
+export interface Attributes {
+	id: number;
+	url: string;
+	alt: string;
+	caption: string;
+	meta: AttributesMeta;
+}
+
+/**
+ * Block setAttributes method
+ */
+export type SetAttributes< T = UnknownObject > = ( attributes: T ) => void;
+
+/**
+ * Base block props
+ */
+export interface BaseProps< T = UnknownObject, O = Attributes > {
+	clientId: string;
+	name: string;
+	isSelected: boolean;
+	attributes: T;
+	className?: string;
+	setAttributes: SetAttributes< Partial< O > >;
+}
+
+/**
+ * Add prop `group` to BlockControl allowed props
+ */
+export type BlockControls = typeof BlockControls & {
+	( props: BlockControls.Props & { group: 'block' } ): JSX.Element;
+};
+
+/**
+ * Typical props used across components
+ */
+export type AttributeProps = {
+	attributes: Attributes;
+	setAttributes: SetAttributes< Partial< Attributes > >;
+};

--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -10,6 +10,11 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import * as readerRegistration from './reader-registration';
 
+/**
+ * Block Scripts
+ */
+import './core-image';
+
 export const blocks = [ readerRegistration ];
 
 const readerActivationBlocks = [ 'newspack/reader-registration' ];

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -78,6 +78,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-plugin-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-theme-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-utils.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-data-events.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-webhooks.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-api.php';

--- a/includes/data-events/class-utils.php
+++ b/includes/data-events/class-utils.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Newspack Data Events Utils.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Data_Events;
+
+/**
+ * Main Class.
+ */
+final class Utils {
+	/**
+	 * Get order data.
+	 *
+	 * @param int  $order_id Order ID.
+	 * @param bool $process_donations_only Whether to process only donation orders.
+	 */
+	public static function get_order_data( $order_id, $process_donations_only = false ) {
+		$order = \wc_get_order( $order_id );
+		if ( ! $order ) {
+			return;
+		}
+		if ( ! \Newspack\WooCommerce_Connection::should_sync_order( $order ) ) {
+			return;
+		}
+		if ( $process_donations_only ) {
+			$product_id = \Newspack\Donations::get_order_donation_product_id( $order_id );
+		} else {
+			// Donation orders always have just a single product, but other orders can have more than one.
+			$product_id = array_values( \Newspack\WooCommerce_Connection::get_products_for_order( $order_id ) );
+		}
+		if ( ! $product_id ) {
+			return;
+		}
+		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
+		$is_renewal = function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order );
+		$subscriptions = [];
+		$subscription_id = '';
+		if ( function_exists( 'wcs_get_subscriptions_for_order' ) ) {
+			$subscriptions = array_values( wcs_get_subscriptions_for_order( $order, [ 'order_type' => [ 'parent', 'renewal' ] ] ) );
+		}
+		if ( count( $subscriptions ) > 0 ) {
+			$subscription_id = is_array( $subscriptions ) && ! empty( $subscriptions ) && is_a( $subscriptions[0], 'WC_Subscription' ) ? $subscriptions[0]->get_id() : null;
+		}
+
+		return [
+			'user_id'         => $order->get_customer_id(),
+			'email'           => $order->get_billing_email(),
+			'amount'          => (float) $order->get_total(),
+			'currency'        => $order->get_currency(),
+			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
+			'platform'        => \Newspack\Donations::get_platform_slug(),
+			'referer'         => $order->get_meta( '_newspack_referer' ),
+			'popup_id'        => $order->get_meta( '_newspack_popup_id' ),
+			'is_renewal'      => $is_renewal,
+			'subscription_id' => $subscription_id,
+			'platform_data'   => [
+				'order_id'   => $order_id,
+				'product_id' => $product_id,
+				'client_id'  => $order->get_meta( NEWSPACK_CLIENT_ID_COOKIE_NAME ),
+			],
+		];
+	}
+
+	/**
+	 * Get recurring donation data.
+	 *
+	 * @param WC_Subscription $subscription Subscription which is a recurring donation.
+	 */
+	public static function get_recurring_donation_data( $subscription ) {
+		$product_id = \Newspack\Donations::get_order_donation_product_id( $subscription->get_id() );
+		if ( ! $product_id ) {
+			return;
+		}
+		$recurrence = get_post_meta( $product_id, '_subscription_period', true );
+		return [
+			'user_id'         => $subscription->get_customer_id(),
+			'email'           => $subscription->get_billing_email(),
+			'subscription_id' => $subscription->get_id(),
+			'amount'          => (float) $subscription->get_total(),
+			'currency'        => $subscription->get_currency(),
+			'recurrence'      => empty( $recurrence ) ? 'once' : $recurrence,
+			'platform'        => \Newspack\Donations::get_platform_slug(),
+		];
+	}
+}

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -226,7 +226,12 @@ class Newspack_Newsletters {
 		Logger::log( 'Normalizing contact data for reader ESP sync:' );
 		Logger::log( $contact );
 
-		return $contact;
+		/**
+		 * Filters the normalized contact data before syncing to the ESP.
+		 *
+		 * @param array $contact Contact data.
+		 */
+		return apply_filters( 'newspack_esp_sync_normalize_contact', $contact );
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -662,6 +662,18 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Get the reader roles.
+	 */
+	public static function get_reader_roles() {
+		/**
+		 * Filters the roles that can determine if a user is a reader.
+		 *
+		 * @param string[] $roles Array of user roles.
+		 */
+		return \apply_filters( 'newspack_reader_user_roles', [ 'subscriber', 'customer' ] );
+	}
+
+	/**
 	 * Whether the user is a reader.
 	 *
 	 * @param WP_User $user   User object.
@@ -674,12 +686,7 @@ final class Reader_Activation {
 		$user_data = \get_userdata( $user->ID );
 
 		if ( false === $is_reader && false === $strict ) {
-			/**
-			 * Filters the roles that can determine if a user is a reader.
-			 *
-			 * @param string[] $roles Array of user roles.
-			 */
-			$reader_roles = \apply_filters( 'newspack_reader_user_roles', [ 'subscriber', 'customer' ] );
+			$reader_roles = self::get_reader_roles();
 			if ( ! empty( $reader_roles ) ) {
 				$is_reader = ! empty( array_intersect( $reader_roles, $user_data->roles ) );
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
 				"@testing-library/react": "^12.1.4",
 				"@types/qs": "^6.9.12",
 				"@types/react": "^17.0.75",
+				"@types/wordpress__block-editor": "^11.5.10",
+				"@types/wordpress__blocks": "^12.5.13",
 				"@types/wordpress__components": "^23.0.11",
 				"@wordpress/browserslist-config": "^5.35.0",
 				"eslint": "^7.32.0",
@@ -179,6 +181,7 @@
 		},
 		"node_modules/@babel/core": {
 			"version": "7.16.7",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.16.7",
@@ -207,6 +210,7 @@
 		},
 		"node_modules/@babel/core/node_modules/semver": {
 			"version": "6.3.0",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -216,6 +220,7 @@
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
 			"integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.22.5",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -547,6 +552,7 @@
 		},
 		"node_modules/@babel/helpers": {
 			"version": "7.16.7",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.16.7",
@@ -1924,6 +1930,7 @@
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
 			"integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.22.5",
 				"@babel/generator": "^7.22.5",
@@ -3771,6 +3778,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3784,6 +3792,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3792,6 +3801,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3799,12 +3809,14 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -5097,6 +5109,354 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/wordpress__block-editor": {
+			"version": "11.5.10",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-11.5.10.tgz",
+			"integrity": "sha512-+cv7XP9ht3QZJFb59Os9cLlq6TNHTLugeaf+bR3mPGnzlCRXbyHN81TxfSXjhpB6Y8oKFcDUpVlrVRmoJ9QJGQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/react": "*",
+				"@types/wordpress__blocks": "*",
+				"@types/wordpress__components": "*",
+				"@types/wordpress__keycodes": "*",
+				"@wordpress/data": "^9.13.0",
+				"@wordpress/element": "^5.0.0",
+				"react-autosize-textarea": "^7.1.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@types/react": {
+			"version": "18.2.57",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.57.tgz",
+			"integrity": "sha512-ZvQsktJgSYrQiMirAN60y4O/LRevIV8hUzSOSNB6gfR3/o3wCBFQx3sPwIYtuDMeiVgsSS3UzCV26tEzgnfvQw==",
+			"dev": true,
+			"dependencies": {
+				"@types/prop-types": "*",
+				"@types/scheduler": "*",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@types/react-dom": {
+			"version": "18.2.19",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
+			"integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+			"dev": true,
+			"dependencies": {
+				"@types/react": "*"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/compose": {
+			"version": "6.28.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.28.0.tgz",
+			"integrity": "sha512-Vx1SDgG3wIaiB/sUZcYB6csG0s5H3Lv5p9oKy8NDkA9dVfHoUz/XLwdx/yzsB3mqvDcZqReEQeoYHP7F4HeWqA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^3.51.0",
+				"@wordpress/dom": "^3.51.0",
+				"@wordpress/element": "^5.28.0",
+				"@wordpress/is-shallow-equal": "^4.51.0",
+				"@wordpress/keycodes": "^3.51.0",
+				"@wordpress/priority-queue": "^2.51.0",
+				"@wordpress/undo-manager": "^0.11.0",
+				"change-case": "^4.1.2",
+				"clipboard": "^2.0.11",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/data": {
+			"version": "9.21.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.21.0.tgz",
+			"integrity": "sha512-jEAWHcR+xlnI+V0l5N2WLZrZ7THZ+wQjIs5gDHg1wcRLWo7oxe8JHPQ4sIf0zqNaCwj3/svXFvg7pkaJqkDHAw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/compose": "^6.28.0",
+				"@wordpress/deprecated": "^3.51.0",
+				"@wordpress/element": "^5.28.0",
+				"@wordpress/is-shallow-equal": "^4.51.0",
+				"@wordpress/priority-queue": "^2.51.0",
+				"@wordpress/private-apis": "^0.33.0",
+				"@wordpress/redux-routine": "^4.51.0",
+				"deepmerge": "^4.3.0",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"redux": "^4.1.2",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/element": {
+			"version": "5.28.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.28.0.tgz",
+			"integrity": "sha512-NEoT3mgF+pJvnhnaTQeLuhSgC6ThfooMfl7OoEyIthRZpUtgKFakmMUU2T6ODzP2+k2DV/jNCfoBZ/Haekmwew==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/react": "^18.0.21",
+				"@types/react-dom": "^18.0.6",
+				"@wordpress/escape-html": "^2.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/private-apis": {
+			"version": "0.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.33.0.tgz",
+			"integrity": "sha512-Dc8y7m17gAKnDVFOPDqPcb2jo9cDhDNikLdepTkRXLywYUPT2PFH4GrXsVK87BLc+nCIqgs3DFU/AJx1db4y/w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/undo-manager": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.11.0.tgz",
+			"integrity": "sha512-f9izRRzLlZRBXhve1OU9sBGWRvfGU94nhENN7gtf7l31q3xdsnrGf5NE/R1yhwCAHifUFF1dVcIGC1cfT2jQIg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/is-shallow-equal": "^4.51.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/react": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/react-dom": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.0"
+			},
+			"peerDependencies": {
+				"react": "^18.2.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/rememo": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+			"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+			"dev": true
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/scheduler": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+			"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks": {
+			"version": "12.5.13",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-12.5.13.tgz",
+			"integrity": "sha512-k2nlqxdNyaL6Uf/+zWhXeJJMKaPpikh5GdunNhNtpI1nSHM18Y+86y3rzjt1n0WcUQc1XkosvhcAEiGNYIhL9g==",
+			"dev": true,
+			"dependencies": {
+				"@types/react": "*",
+				"@types/wordpress__components": "*",
+				"@types/wordpress__shortcode": "*",
+				"@wordpress/data": "^9.13.0",
+				"@wordpress/element": "^5.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@types/react": {
+			"version": "18.2.57",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.57.tgz",
+			"integrity": "sha512-ZvQsktJgSYrQiMirAN60y4O/LRevIV8hUzSOSNB6gfR3/o3wCBFQx3sPwIYtuDMeiVgsSS3UzCV26tEzgnfvQw==",
+			"dev": true,
+			"dependencies": {
+				"@types/prop-types": "*",
+				"@types/scheduler": "*",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@types/react-dom": {
+			"version": "18.2.19",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
+			"integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+			"dev": true,
+			"dependencies": {
+				"@types/react": "*"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/compose": {
+			"version": "6.28.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.28.0.tgz",
+			"integrity": "sha512-Vx1SDgG3wIaiB/sUZcYB6csG0s5H3Lv5p9oKy8NDkA9dVfHoUz/XLwdx/yzsB3mqvDcZqReEQeoYHP7F4HeWqA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^3.51.0",
+				"@wordpress/dom": "^3.51.0",
+				"@wordpress/element": "^5.28.0",
+				"@wordpress/is-shallow-equal": "^4.51.0",
+				"@wordpress/keycodes": "^3.51.0",
+				"@wordpress/priority-queue": "^2.51.0",
+				"@wordpress/undo-manager": "^0.11.0",
+				"change-case": "^4.1.2",
+				"clipboard": "^2.0.11",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/data": {
+			"version": "9.21.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.21.0.tgz",
+			"integrity": "sha512-jEAWHcR+xlnI+V0l5N2WLZrZ7THZ+wQjIs5gDHg1wcRLWo7oxe8JHPQ4sIf0zqNaCwj3/svXFvg7pkaJqkDHAw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/compose": "^6.28.0",
+				"@wordpress/deprecated": "^3.51.0",
+				"@wordpress/element": "^5.28.0",
+				"@wordpress/is-shallow-equal": "^4.51.0",
+				"@wordpress/priority-queue": "^2.51.0",
+				"@wordpress/private-apis": "^0.33.0",
+				"@wordpress/redux-routine": "^4.51.0",
+				"deepmerge": "^4.3.0",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"redux": "^4.1.2",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/element": {
+			"version": "5.28.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.28.0.tgz",
+			"integrity": "sha512-NEoT3mgF+pJvnhnaTQeLuhSgC6ThfooMfl7OoEyIthRZpUtgKFakmMUU2T6ODzP2+k2DV/jNCfoBZ/Haekmwew==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@types/react": "^18.0.21",
+				"@types/react-dom": "^18.0.6",
+				"@wordpress/escape-html": "^2.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/private-apis": {
+			"version": "0.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.33.0.tgz",
+			"integrity": "sha512-Dc8y7m17gAKnDVFOPDqPcb2jo9cDhDNikLdepTkRXLywYUPT2PFH4GrXsVK87BLc+nCIqgs3DFU/AJx1db4y/w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/undo-manager": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.11.0.tgz",
+			"integrity": "sha512-f9izRRzLlZRBXhve1OU9sBGWRvfGU94nhENN7gtf7l31q3xdsnrGf5NE/R1yhwCAHifUFF1dVcIGC1cfT2jQIg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/is-shallow-equal": "^4.51.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/react": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/react-dom": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.0"
+			},
+			"peerDependencies": {
+				"react": "^18.2.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/rememo": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+			"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+			"dev": true
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/scheduler": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+			"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			}
+		},
 		"node_modules/@types/wordpress__components": {
 			"version": "23.0.11",
 			"resolved": "https://registry.npmjs.org/@types/wordpress__components/-/wordpress__components-23.0.11.tgz",
@@ -5193,6 +5553,12 @@
 				"@types/react": "*",
 				"redux": "^4.0.1"
 			}
+		},
+		"node_modules/@types/wordpress__keycodes": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__keycodes/-/wordpress__keycodes-2.3.3.tgz",
+			"integrity": "sha512-jOI0L5NbLc0Ht/vkbZwgBfgWZbPKexXS+nxlYZ0kHQCjVCM7tdSwptItksCY3Qc9IV2nRc1pTnj/UJC2E2cUQw==",
+			"dev": true
 		},
 		"node_modules/@types/wordpress__notices": {
 			"version": "3.27.6",
@@ -5483,6 +5849,12 @@
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			}
+		},
+		"node_modules/@types/wordpress__shortcode": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__shortcode/-/wordpress__shortcode-2.3.6.tgz",
+			"integrity": "sha512-H8BVov7QWyLLoxCaI9QyZVC4zTi1mFkZ+eEKiXBCFlaJ0XV8UVfQk+cAetqD5mWOeWv2d4b8uzzyn0TTQ/ep2g==",
+			"dev": true
 		},
 		"node_modules/@types/yargs": {
 			"version": "16.0.4",
@@ -6850,26 +7222,26 @@
 			}
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "3.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.50.0.tgz",
-			"integrity": "sha512-DL01l0Wlo3df9OcSGHP11Ot/nq0HytbdmD+iPkiCCRI6Xctepbs/DzRR2CO3qLrJkWn6RReFwZWZZjzI7lZUqg==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.51.0.tgz",
+			"integrity": "sha512-jbhK5/zhn2D6xW0WqEFitxowgrlIL03CdG0gMQ9JJNlewvI2qg+4fj9k/ORQh8l5UpBUfkwUHVMaGQswtUUaeQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.50.0"
+				"@wordpress/hooks": "^3.51.0"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "3.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.50.0.tgz",
-			"integrity": "sha512-rMnV1ysGOHbKnmjLQYwGkT1co1iEkC3YsKrEObP8mklw1R7rbCy7fc2brIz7kqcHU1DRyg/+7wOCMkg8a/EV/Q==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.51.0.tgz",
+			"integrity": "sha512-5L8iQCq2t+4qHpo4MBZqMg5MqmVZI/U/BaF50yhtTZQSGyhR2SzlixnL8udwatm8KQFteWj8Zwmmu+3GXRTB2Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^3.50.0"
+				"@wordpress/deprecated": "^3.51.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -7388,9 +7760,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "2.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.50.0.tgz",
-			"integrity": "sha512-hBvoMCEZocziZDGCmBanSO+uupnd054mxd7FQ6toQ4UnsZ4JwXSmEC72W2Ed+cRGB1DeJDD0dY9iC0b4xkumsQ==",
+			"version": "2.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.51.0.tgz",
+			"integrity": "sha512-sDDSyctW5yON2IaEkaMGIfk2LiQ3Jpz8xAnElKjKpnFhbHQBIG2B2NS2UQ5DzsPGZrfCPHt13E20fGwWj+lthw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -7400,9 +7772,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "3.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.50.0.tgz",
-			"integrity": "sha512-YIhwT1y0ss7Byfz46NBx08EUmXzWMu+g5DCY7FMuDNhwxSEoZMB8edKMiwNmFk4mFKBCnXM1d5FeONUPIUkJwg==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.51.0.tgz",
+			"integrity": "sha512-u//qLJCfgmGBLEdAtZx5C1KzmhcCYDIk46feYGBR9DHB1/fqdvMpxc20un62i8QgYvJyF7GChmerkPbssa6a8w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -7424,13 +7796,13 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.50.0.tgz",
-			"integrity": "sha512-FkA2se6HMQm4eFC+/kTWvWQqs51VxpZuvY2MlWUp/L1r1d/dMBHXu049x86+/+6yk3ZNqiK5h6j6Z76dvPHZ4w==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.51.0.tgz",
+			"integrity": "sha512-JiMEstT98R1e4bgI8DA+XVCXUSis/6eZ7+RF5nHuDiseIyQ68B2D2FzYoEFaw/zaVebvtWA0lZ8HbHihgsSVPQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.50.0",
+				"@wordpress/hooks": "^3.51.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
@@ -7591,9 +7963,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.50.0.tgz",
-			"integrity": "sha512-lX0fMa1f/TwWYYF+Oj0MG2Eze4Bb+vsnhXX6X1l+Ri3PG34wWGonjq729qHbJRDwm8o1y9GeswCgESIpuAm9wg==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.51.0.tgz",
+			"integrity": "sha512-/Rik1HF5XoLEuodtwvSMFsAMsLC40aRnFei+vzEsaSjcS4/z2kmzgGcIpc8Ca3HEJgtdx6MuziODG1hU9bKRtg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -7656,13 +8028,13 @@
 			"dev": true
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "3.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.50.0.tgz",
-			"integrity": "sha512-ykWpyCbgwcaT8i5kSfotYtd2oOHyMDpWEYR73InYrzEhl7pnS3wD7hi/KfeKLvMfYhbysUXlCVr6q/oH+qK/DQ==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.51.0.tgz",
+			"integrity": "sha512-wudlftpjZ/2tZ2gKY7w2m7BG4LBhmEvDn2K48IbTcMtEyFJidIB0IFpT+skR1aFhIekGDZ7W8UXPQVbjwbWhwA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.50.0"
+				"@wordpress/i18n": "^4.51.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -7907,9 +8279,9 @@
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "2.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.50.0.tgz",
-			"integrity": "sha512-21E842EVFYUd1ZrNTLAW57IyloDCUZr6h1Te6BgqKoeKOEteoTQwA9BemMzZJUiThUSZymW94ot0Omb+C8VX2g==",
+			"version": "2.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.51.0.tgz",
+			"integrity": "sha512-eu5kFXJT1GfZU+g/7VeLi1p0dMt4SAj5qnHxnA1OWdsRd8CSx0ne7VdZxZroeGif1/x/IliBtdb28A8WEZM59A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
@@ -7932,9 +8304,9 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.50.0.tgz",
-			"integrity": "sha512-giHjQYhmFDCpeNEnsZKP0JNPBnpuQwsoxLmHAUUSNFWAmd4rtnNnG6M8HuqOLmgYTvEa8Hlx3Bl+reTGvrtI2g==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.51.0.tgz",
+			"integrity": "sha512-lMEkB4yg0H/P0kvmgWrPcD55ib9lPUROABdgy569ERtIq6F3Ig7Q2SJoGM91VgIVBDb4ZFvJ9Wa/+a2HIHJMuQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
@@ -8814,26 +9186,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/array.prototype.filter": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
-			"integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/array.prototype.find": {
@@ -9735,188 +10087,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/cheerio": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"cheerio-select": "^2.1.0",
-				"dom-serializer": "^2.0.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"htmlparser2": "^8.0.1",
-				"parse5": "^7.0.0",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-select": "^5.1.0",
-				"css-what": "^6.1.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/css-select": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-what": "^6.1.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"nth-check": "^2.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/css-what": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/cheerio-select/node_modules/domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/nth-check": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/nth-check?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/cheerio/node_modules/domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/parse5": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
 		"node_modules/chokidar": {
 			"version": "3.5.2",
 			"dev": true,
@@ -10601,6 +10771,7 @@
 		},
 		"node_modules/convert-source-map": {
 			"version": "1.8.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.1"
@@ -11606,13 +11777,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"dev": true,
@@ -11698,35 +11862,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0"
-			},
-			"engines": {
-				"node": ">= 4"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domhandler?sponsor=1"
-			}
-		},
-		"node_modules/domhandler/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
 		},
 		"node_modules/domutils": {
 			"version": "1.7.0",
@@ -11885,19 +12020,6 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
 		"node_modules/env-ci": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
@@ -11930,40 +12052,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/enzyme": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"array.prototype.flat": "^1.2.3",
-				"cheerio": "^1.0.0-rc.3",
-				"enzyme-shallow-equal": "^1.0.1",
-				"function.prototype.name": "^1.1.2",
-				"has": "^1.0.3",
-				"html-element-map": "^1.2.0",
-				"is-boolean-object": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-number-object": "^1.0.4",
-				"is-regex": "^1.0.5",
-				"is-string": "^1.0.5",
-				"is-subset": "^0.1.1",
-				"lodash.escape": "^4.0.1",
-				"lodash.isequal": "^4.5.0",
-				"object-inspect": "^1.7.0",
-				"object-is": "^1.0.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1",
-				"object.values": "^1.1.1",
-				"raf": "^3.4.1",
-				"rst-selector-parser": "^2.2.3",
-				"string.prototype.trim": "^1.2.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/enzyme-matchers": {
@@ -12010,13 +12098,6 @@
 			"version": "16.13.1",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/enzyme/node_modules/lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/equivalent-key-map": {
 			"version": "0.2.2",
@@ -12094,13 +12175,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/es-module-lexer": {
 			"version": "0.9.3",
@@ -13618,6 +13692,7 @@
 		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -14264,20 +14339,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/html-element-map": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"array.prototype.filter": "^1.0.0",
-				"call-bind": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "2.0.1",
 			"dev": true,
@@ -14304,69 +14365,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/htmlparser2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/fb55/htmlparser2?sponsor=1",
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"entities": "^4.4.0"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/htmlparser2/node_modules/domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -15071,13 +15069,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/is-subset": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/is-symbol": {
 			"version": "1.0.4",
@@ -18065,6 +18056,7 @@
 		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
@@ -18115,6 +18107,7 @@
 		},
 		"node_modules/json5": {
 			"version": "2.2.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5"
@@ -18702,25 +18695,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
 		},
-		"node_modules/lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true
-		},
-		"node_modules/lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/lodash.isarguments": {
 			"version": "3.1.0",
@@ -19541,13 +19520,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -19612,36 +19584,6 @@
 			"version": "1.4.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"bin": {
-				"nearley-railroad": "bin/nearley-railroad.js",
-				"nearley-test": "bin/nearley-test.js",
-				"nearley-unparse": "bin/nearley-unparse.js",
-				"nearleyc": "bin/nearleyc.js"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://nearley.js.org/#give-to-nearley"
-			}
-		},
-		"node_modules/nearley/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -20642,43 +20584,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/react": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/react-dom": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"scheduler": "^0.23.0"
-			},
-			"peerDependencies": {
-				"react": "^18.2.0"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/scheduler": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-			"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0"
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/semver": {
@@ -23982,33 +23887,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/parse5-htmlparser2-tree-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domhandler": "^5.0.2",
-				"parse5": "^7.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
-		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
 		"node_modules/pascal-case": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -25972,27 +25850,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"node_modules/railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"dev": true,
@@ -26134,6 +25991,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
@@ -27170,17 +27028,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/rst-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
-			}
-		},
 		"node_modules/rsvp": {
 			"version": "4.8.5",
 			"dev": true,
@@ -27292,6 +27139,7 @@
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/safe-regex": {
@@ -27668,6 +27516,7 @@
 		},
 		"node_modules/scheduler": {
 			"version": "0.20.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
@@ -28471,6 +28320,7 @@
 		},
 		"node_modules/source-map": {
 			"version": "0.5.7",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -29481,21 +29331,6 @@
 			},
 			"engines": {
 				"node": ">=14.18"
-			}
-		},
-		"node_modules/stylelint/node_modules/typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
 			}
 		},
 		"node_modules/stylelint/node_modules/which": {
@@ -31649,6 +31484,7 @@
 		},
 		"@babel/core": {
 			"version": "7.16.7",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.16.7",
 				"@babel/generator": "^7.16.7",
@@ -31668,7 +31504,8 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.3.0"
+					"version": "6.3.0",
+					"dev": true
 				}
 			}
 		},
@@ -31676,6 +31513,7 @@
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
 			"integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.22.5",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -31917,6 +31755,7 @@
 		},
 		"@babel/helpers": {
 			"version": "7.16.7",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.16.7",
@@ -31978,8 +31817,7 @@
 		"@babel/plugin-proposal-private-property-in-object": {
 			"version": "7.21.0-placeholder-for-preset-env.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-			"integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-			"requires": {}
+			"integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w=="
 		},
 		"@babel/plugin-syntax-async-generators": {
 			"version": "7.8.4",
@@ -32791,6 +32629,7 @@
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
 			"integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.22.5",
 				"@babel/generator": "^7.22.5",
@@ -33219,8 +33058,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.5.0.tgz",
 			"integrity": "sha512-abypo6m9re3clXA00eu5syw+oaPHbJTPapu9C4pzNsJ4hdZDzushT50Zhu+iIYXgEe1CxnRMn7ngsbV+MLrlpQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@csstools/css-tokenizer": {
 			"version": "2.2.3",
@@ -33232,15 +33070,13 @@
 			"version": "2.1.7",
 			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.7.tgz",
 			"integrity": "sha512-lHPKJDkPUECsyAvD60joYfDmp8UERYxHGkFfyLJFTVK/ERJe0sVlIFLXU5XFxdjNDTerp5L4KeaKG+Z5S94qxQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@csstools/selector-specificity": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
 			"integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.5",
@@ -33412,8 +33248,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
 			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@emotion/utils": {
 			"version": "1.0.0",
@@ -34072,6 +33907,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -34081,22 +33917,26 @@
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -34272,8 +34112,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
 			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "6.7.0",
@@ -35104,6 +34943,304 @@
 			"version": "1.16.3",
 			"dev": true
 		},
+		"@types/wordpress__block-editor": {
+			"version": "11.5.10",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-11.5.10.tgz",
+			"integrity": "sha512-+cv7XP9ht3QZJFb59Os9cLlq6TNHTLugeaf+bR3mPGnzlCRXbyHN81TxfSXjhpB6Y8oKFcDUpVlrVRmoJ9QJGQ==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*",
+				"@types/wordpress__blocks": "*",
+				"@types/wordpress__components": "*",
+				"@types/wordpress__keycodes": "*",
+				"@wordpress/data": "^9.13.0",
+				"@wordpress/element": "^5.0.0",
+				"react-autosize-textarea": "^7.1.0"
+			},
+			"dependencies": {
+				"@types/react": {
+					"version": "18.2.57",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.57.tgz",
+					"integrity": "sha512-ZvQsktJgSYrQiMirAN60y4O/LRevIV8hUzSOSNB6gfR3/o3wCBFQx3sPwIYtuDMeiVgsSS3UzCV26tEzgnfvQw==",
+					"dev": true,
+					"requires": {
+						"@types/prop-types": "*",
+						"@types/scheduler": "*",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@types/react-dom": {
+					"version": "18.2.19",
+					"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
+					"integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+					"dev": true,
+					"requires": {
+						"@types/react": "*"
+					}
+				},
+				"@wordpress/compose": {
+					"version": "6.28.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.28.0.tgz",
+					"integrity": "sha512-Vx1SDgG3wIaiB/sUZcYB6csG0s5H3Lv5p9oKy8NDkA9dVfHoUz/XLwdx/yzsB3mqvDcZqReEQeoYHP7F4HeWqA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@types/mousetrap": "^1.6.8",
+						"@wordpress/deprecated": "^3.51.0",
+						"@wordpress/dom": "^3.51.0",
+						"@wordpress/element": "^5.28.0",
+						"@wordpress/is-shallow-equal": "^4.51.0",
+						"@wordpress/keycodes": "^3.51.0",
+						"@wordpress/priority-queue": "^2.51.0",
+						"@wordpress/undo-manager": "^0.11.0",
+						"change-case": "^4.1.2",
+						"clipboard": "^2.0.11",
+						"mousetrap": "^1.6.5",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/data": {
+					"version": "9.21.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.21.0.tgz",
+					"integrity": "sha512-jEAWHcR+xlnI+V0l5N2WLZrZ7THZ+wQjIs5gDHg1wcRLWo7oxe8JHPQ4sIf0zqNaCwj3/svXFvg7pkaJqkDHAw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@wordpress/compose": "^6.28.0",
+						"@wordpress/deprecated": "^3.51.0",
+						"@wordpress/element": "^5.28.0",
+						"@wordpress/is-shallow-equal": "^4.51.0",
+						"@wordpress/priority-queue": "^2.51.0",
+						"@wordpress/private-apis": "^0.33.0",
+						"@wordpress/redux-routine": "^4.51.0",
+						"deepmerge": "^4.3.0",
+						"equivalent-key-map": "^0.2.2",
+						"is-plain-object": "^5.0.0",
+						"is-promise": "^4.0.0",
+						"redux": "^4.1.2",
+						"rememo": "^4.0.2",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/element": {
+					"version": "5.28.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.28.0.tgz",
+					"integrity": "sha512-NEoT3mgF+pJvnhnaTQeLuhSgC6ThfooMfl7OoEyIthRZpUtgKFakmMUU2T6ODzP2+k2DV/jNCfoBZ/Haekmwew==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@types/react": "^18.0.21",
+						"@types/react-dom": "^18.0.6",
+						"@wordpress/escape-html": "^2.51.0",
+						"change-case": "^4.1.2",
+						"is-plain-object": "^5.0.0",
+						"react": "^18.2.0",
+						"react-dom": "^18.2.0"
+					}
+				},
+				"@wordpress/private-apis": {
+					"version": "0.33.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.33.0.tgz",
+					"integrity": "sha512-Dc8y7m17gAKnDVFOPDqPcb2jo9cDhDNikLdepTkRXLywYUPT2PFH4GrXsVK87BLc+nCIqgs3DFU/AJx1db4y/w==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0"
+					}
+				},
+				"@wordpress/undo-manager": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.11.0.tgz",
+					"integrity": "sha512-f9izRRzLlZRBXhve1OU9sBGWRvfGU94nhENN7gtf7l31q3xdsnrGf5NE/R1yhwCAHifUFF1dVcIGC1cfT2jQIg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@wordpress/is-shallow-equal": "^4.51.0"
+					}
+				},
+				"react": {
+					"version": "18.2.0",
+					"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+					"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.1.0"
+					}
+				},
+				"react-dom": {
+					"version": "18.2.0",
+					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+					"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"scheduler": "^0.23.0"
+					}
+				},
+				"rememo": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+					"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+					"dev": true
+				},
+				"scheduler": {
+					"version": "0.23.0",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+					"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.1.0"
+					}
+				}
+			}
+		},
+		"@types/wordpress__blocks": {
+			"version": "12.5.13",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-12.5.13.tgz",
+			"integrity": "sha512-k2nlqxdNyaL6Uf/+zWhXeJJMKaPpikh5GdunNhNtpI1nSHM18Y+86y3rzjt1n0WcUQc1XkosvhcAEiGNYIhL9g==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*",
+				"@types/wordpress__components": "*",
+				"@types/wordpress__shortcode": "*",
+				"@wordpress/data": "^9.13.0",
+				"@wordpress/element": "^5.0.0"
+			},
+			"dependencies": {
+				"@types/react": {
+					"version": "18.2.57",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.57.tgz",
+					"integrity": "sha512-ZvQsktJgSYrQiMirAN60y4O/LRevIV8hUzSOSNB6gfR3/o3wCBFQx3sPwIYtuDMeiVgsSS3UzCV26tEzgnfvQw==",
+					"dev": true,
+					"requires": {
+						"@types/prop-types": "*",
+						"@types/scheduler": "*",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@types/react-dom": {
+					"version": "18.2.19",
+					"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
+					"integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+					"dev": true,
+					"requires": {
+						"@types/react": "*"
+					}
+				},
+				"@wordpress/compose": {
+					"version": "6.28.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.28.0.tgz",
+					"integrity": "sha512-Vx1SDgG3wIaiB/sUZcYB6csG0s5H3Lv5p9oKy8NDkA9dVfHoUz/XLwdx/yzsB3mqvDcZqReEQeoYHP7F4HeWqA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@types/mousetrap": "^1.6.8",
+						"@wordpress/deprecated": "^3.51.0",
+						"@wordpress/dom": "^3.51.0",
+						"@wordpress/element": "^5.28.0",
+						"@wordpress/is-shallow-equal": "^4.51.0",
+						"@wordpress/keycodes": "^3.51.0",
+						"@wordpress/priority-queue": "^2.51.0",
+						"@wordpress/undo-manager": "^0.11.0",
+						"change-case": "^4.1.2",
+						"clipboard": "^2.0.11",
+						"mousetrap": "^1.6.5",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/data": {
+					"version": "9.21.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.21.0.tgz",
+					"integrity": "sha512-jEAWHcR+xlnI+V0l5N2WLZrZ7THZ+wQjIs5gDHg1wcRLWo7oxe8JHPQ4sIf0zqNaCwj3/svXFvg7pkaJqkDHAw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@wordpress/compose": "^6.28.0",
+						"@wordpress/deprecated": "^3.51.0",
+						"@wordpress/element": "^5.28.0",
+						"@wordpress/is-shallow-equal": "^4.51.0",
+						"@wordpress/priority-queue": "^2.51.0",
+						"@wordpress/private-apis": "^0.33.0",
+						"@wordpress/redux-routine": "^4.51.0",
+						"deepmerge": "^4.3.0",
+						"equivalent-key-map": "^0.2.2",
+						"is-plain-object": "^5.0.0",
+						"is-promise": "^4.0.0",
+						"redux": "^4.1.2",
+						"rememo": "^4.0.2",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/element": {
+					"version": "5.28.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.28.0.tgz",
+					"integrity": "sha512-NEoT3mgF+pJvnhnaTQeLuhSgC6ThfooMfl7OoEyIthRZpUtgKFakmMUU2T6ODzP2+k2DV/jNCfoBZ/Haekmwew==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@types/react": "^18.0.21",
+						"@types/react-dom": "^18.0.6",
+						"@wordpress/escape-html": "^2.51.0",
+						"change-case": "^4.1.2",
+						"is-plain-object": "^5.0.0",
+						"react": "^18.2.0",
+						"react-dom": "^18.2.0"
+					}
+				},
+				"@wordpress/private-apis": {
+					"version": "0.33.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.33.0.tgz",
+					"integrity": "sha512-Dc8y7m17gAKnDVFOPDqPcb2jo9cDhDNikLdepTkRXLywYUPT2PFH4GrXsVK87BLc+nCIqgs3DFU/AJx1db4y/w==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0"
+					}
+				},
+				"@wordpress/undo-manager": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.11.0.tgz",
+					"integrity": "sha512-f9izRRzLlZRBXhve1OU9sBGWRvfGU94nhENN7gtf7l31q3xdsnrGf5NE/R1yhwCAHifUFF1dVcIGC1cfT2jQIg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@wordpress/is-shallow-equal": "^4.51.0"
+					}
+				},
+				"react": {
+					"version": "18.2.0",
+					"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+					"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.1.0"
+					}
+				},
+				"react-dom": {
+					"version": "18.2.0",
+					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+					"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"scheduler": "^0.23.0"
+					}
+				},
+				"rememo": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+					"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+					"dev": true
+				},
+				"scheduler": {
+					"version": "0.23.0",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+					"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.1.0"
+					}
+				}
+			}
+		},
 		"@types/wordpress__components": {
 			"version": "23.0.11",
 			"resolved": "https://registry.npmjs.org/@types/wordpress__components/-/wordpress__components-23.0.11.tgz",
@@ -35192,6 +35329,12 @@
 				"@types/react": "*",
 				"redux": "^4.0.1"
 			}
+		},
+		"@types/wordpress__keycodes": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__keycodes/-/wordpress__keycodes-2.3.3.tgz",
+			"integrity": "sha512-jOI0L5NbLc0Ht/vkbZwgBfgWZbPKexXS+nxlYZ0kHQCjVCM7tdSwptItksCY3Qc9IV2nRc1pTnj/UJC2E2cUQw==",
+			"dev": true
 		},
 		"@types/wordpress__notices": {
 			"version": "3.27.6",
@@ -35444,6 +35587,12 @@
 					}
 				}
 			}
+		},
+		"@types/wordpress__shortcode": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__shortcode/-/wordpress__shortcode-2.3.6.tgz",
+			"integrity": "sha512-H8BVov7QWyLLoxCaI9QyZVC4zTi1mFkZ+eEKiXBCFlaJ0XV8UVfQk+cAetqD5mWOeWv2d4b8uzzyn0TTQ/ep2g==",
+			"dev": true
 		},
 		"@types/yargs": {
 			"version": "16.0.4",
@@ -35742,8 +35891,7 @@
 		},
 		"@webpack-cli/configtest": {
 			"version": "1.1.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.0",
@@ -35754,8 +35902,7 @@
 		},
 		"@webpack-cli/serve": {
 			"version": "1.6.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wojtekmaj/enzyme-adapter-react-17": {
 			"version": "0.6.5",
@@ -35815,8 +35962,7 @@
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "3.1.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "6.5.0",
@@ -36482,23 +36628,23 @@
 			}
 		},
 		"@wordpress/deprecated": {
-			"version": "3.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.50.0.tgz",
-			"integrity": "sha512-DL01l0Wlo3df9OcSGHP11Ot/nq0HytbdmD+iPkiCCRI6Xctepbs/DzRR2CO3qLrJkWn6RReFwZWZZjzI7lZUqg==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.51.0.tgz",
+			"integrity": "sha512-jbhK5/zhn2D6xW0WqEFitxowgrlIL03CdG0gMQ9JJNlewvI2qg+4fj9k/ORQh8l5UpBUfkwUHVMaGQswtUUaeQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.50.0"
+				"@wordpress/hooks": "^3.51.0"
 			}
 		},
 		"@wordpress/dom": {
-			"version": "3.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.50.0.tgz",
-			"integrity": "sha512-rMnV1ysGOHbKnmjLQYwGkT1co1iEkC3YsKrEObP8mklw1R7rbCy7fc2brIz7kqcHU1DRyg/+7wOCMkg8a/EV/Q==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.51.0.tgz",
+			"integrity": "sha512-5L8iQCq2t+4qHpo4MBZqMg5MqmVZI/U/BaF50yhtTZQSGyhR2SzlixnL8udwatm8KQFteWj8Zwmmu+3GXRTB2Q==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^3.50.0"
+				"@wordpress/deprecated": "^3.51.0"
 			}
 		},
 		"@wordpress/dom-ready": {
@@ -36938,18 +37084,18 @@
 			}
 		},
 		"@wordpress/escape-html": {
-			"version": "2.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.50.0.tgz",
-			"integrity": "sha512-hBvoMCEZocziZDGCmBanSO+uupnd054mxd7FQ6toQ4UnsZ4JwXSmEC72W2Ed+cRGB1DeJDD0dY9iC0b4xkumsQ==",
+			"version": "2.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.51.0.tgz",
+			"integrity": "sha512-sDDSyctW5yON2IaEkaMGIfk2LiQ3Jpz8xAnElKjKpnFhbHQBIG2B2NS2UQ5DzsPGZrfCPHt13E20fGwWj+lthw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0"
 			}
 		},
 		"@wordpress/hooks": {
-			"version": "3.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.50.0.tgz",
-			"integrity": "sha512-YIhwT1y0ss7Byfz46NBx08EUmXzWMu+g5DCY7FMuDNhwxSEoZMB8edKMiwNmFk4mFKBCnXM1d5FeONUPIUkJwg==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.51.0.tgz",
+			"integrity": "sha512-u//qLJCfgmGBLEdAtZx5C1KzmhcCYDIk46feYGBR9DHB1/fqdvMpxc20un62i8QgYvJyF7GChmerkPbssa6a8w==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0"
@@ -36965,13 +37111,13 @@
 			}
 		},
 		"@wordpress/i18n": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.50.0.tgz",
-			"integrity": "sha512-FkA2se6HMQm4eFC+/kTWvWQqs51VxpZuvY2MlWUp/L1r1d/dMBHXu049x86+/+6yk3ZNqiK5h6j6Z76dvPHZ4w==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.51.0.tgz",
+			"integrity": "sha512-JiMEstT98R1e4bgI8DA+XVCXUSis/6eZ7+RF5nHuDiseIyQ68B2D2FzYoEFaw/zaVebvtWA0lZ8HbHihgsSVPQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.50.0",
+				"@wordpress/hooks": "^3.51.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
@@ -37104,9 +37250,9 @@
 			}
 		},
 		"@wordpress/is-shallow-equal": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.50.0.tgz",
-			"integrity": "sha512-lX0fMa1f/TwWYYF+Oj0MG2Eze4Bb+vsnhXX6X1l+Ri3PG34wWGonjq729qHbJRDwm8o1y9GeswCgESIpuAm9wg==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.51.0.tgz",
+			"integrity": "sha512-/Rik1HF5XoLEuodtwvSMFsAMsLC40aRnFei+vzEsaSjcS4/z2kmzgGcIpc8Ca3HEJgtdx6MuziODG1hU9bKRtg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0"
@@ -37156,13 +37302,13 @@
 			}
 		},
 		"@wordpress/keycodes": {
-			"version": "3.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.50.0.tgz",
-			"integrity": "sha512-ykWpyCbgwcaT8i5kSfotYtd2oOHyMDpWEYR73InYrzEhl7pnS3wD7hi/KfeKLvMfYhbysUXlCVr6q/oH+qK/DQ==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.51.0.tgz",
+			"integrity": "sha512-wudlftpjZ/2tZ2gKY7w2m7BG4LBhmEvDn2K48IbTcMtEyFJidIB0IFpT+skR1aFhIekGDZ7W8UXPQVbjwbWhwA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.50.0"
+				"@wordpress/i18n": "^4.51.0"
 			}
 		},
 		"@wordpress/media-utils": {
@@ -37356,9 +37502,9 @@
 			}
 		},
 		"@wordpress/priority-queue": {
-			"version": "2.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.50.0.tgz",
-			"integrity": "sha512-21E842EVFYUd1ZrNTLAW57IyloDCUZr6h1Te6BgqKoeKOEteoTQwA9BemMzZJUiThUSZymW94ot0Omb+C8VX2g==",
+			"version": "2.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.51.0.tgz",
+			"integrity": "sha512-eu5kFXJT1GfZU+g/7VeLi1p0dMt4SAj5qnHxnA1OWdsRd8CSx0ne7VdZxZroeGif1/x/IliBtdb28A8WEZM59A==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0",
@@ -37375,9 +37521,9 @@
 			}
 		},
 		"@wordpress/redux-routine": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.50.0.tgz",
-			"integrity": "sha512-giHjQYhmFDCpeNEnsZKP0JNPBnpuQwsoxLmHAUUSNFWAmd4rtnNnG6M8HuqOLmgYTvEa8Hlx3Bl+reTGvrtI2g==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.51.0.tgz",
+			"integrity": "sha512-lMEkB4yg0H/P0kvmgWrPcD55ib9lPUROABdgy569ERtIq6F3Ig7Q2SJoGM91VgIVBDb4ZFvJ9Wa/+a2HIHJMuQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0",
@@ -37853,13 +37999,11 @@
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-walk": {
 			"version": "7.2.0",
@@ -37917,8 +38061,7 @@
 		},
 		"ajv-keywords": {
 			"version": "3.5.2",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -38045,20 +38188,6 @@
 		"array-unique": {
 			"version": "0.3.2",
 			"dev": true
-		},
-		"array.prototype.filter": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
-			"integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			}
 		},
 		"array.prototype.find": {
 			"version": "2.2.1",
@@ -38666,144 +38795,6 @@
 			"version": "0.7.0",
 			"dev": true
 		},
-		"cheerio": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"cheerio-select": "^2.1.0",
-				"dom-serializer": "^2.0.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"htmlparser2": "^8.0.1",
-				"parse5": "^7.0.0",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-					"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.3"
-					}
-				},
-				"parse5": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-					"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"entities": "^4.4.0"
-					}
-				}
-			}
-		},
-		"cheerio-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"boolbase": "^1.0.0",
-				"css-select": "^5.1.0",
-				"css-what": "^6.1.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1"
-			},
-			"dependencies": {
-				"css-select": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-					"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"boolbase": "^1.0.0",
-						"css-what": "^6.1.0",
-						"domhandler": "^5.0.2",
-						"domutils": "^3.0.1",
-						"nth-check": "^2.0.1"
-					}
-				},
-				"css-what": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-					"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-					"dev": true,
-					"peer": true
-				},
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-					"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.3"
-					}
-				},
-				"nth-check": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-					"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"boolbase": "^1.0.0"
-					}
-				}
-			}
-		},
 		"chokidar": {
 			"version": "3.5.2",
 			"dev": true,
@@ -39315,6 +39306,7 @@
 		},
 		"convert-source-map": {
 			"version": "1.8.0",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -39361,8 +39353,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
 			"integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"create-react-class": {
 			"version": "15.6.3",
@@ -39983,13 +39974,6 @@
 			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
 			"dev": true
 		},
-		"discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"dev": true,
-			"peer": true
-		},
 		"doctrine": {
 			"version": "3.0.0",
 			"dev": true,
@@ -40048,25 +40032,6 @@
 				"webidl-conversions": {
 					"version": "5.0.0",
 					"dev": true
-				}
-			}
-		},
-		"domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
 				}
 			}
 		},
@@ -40194,13 +40159,6 @@
 				"ansi-colors": "^4.1.1"
 			}
 		},
-		"entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"peer": true
-		},
 		"env-ci": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
@@ -40221,46 +40179,6 @@
 		"envinfo": {
 			"version": "7.8.1",
 			"dev": true
-		},
-		"enzyme": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"array.prototype.flat": "^1.2.3",
-				"cheerio": "^1.0.0-rc.3",
-				"enzyme-shallow-equal": "^1.0.1",
-				"function.prototype.name": "^1.1.2",
-				"has": "^1.0.3",
-				"html-element-map": "^1.2.0",
-				"is-boolean-object": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-number-object": "^1.0.4",
-				"is-regex": "^1.0.5",
-				"is-string": "^1.0.5",
-				"is-subset": "^0.1.1",
-				"lodash.escape": "^4.0.1",
-				"lodash.isequal": "^4.5.0",
-				"object-inspect": "^1.7.0",
-				"object-is": "^1.0.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1",
-				"object.values": "^1.1.1",
-				"raf": "^3.4.1",
-				"rst-selector-parser": "^2.2.3",
-				"string.prototype.trim": "^1.2.1"
-			},
-			"dependencies": {
-				"lodash.isequal": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-					"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-					"dev": true,
-					"peer": true
-				}
-			}
 		},
 		"enzyme-matchers": {
 			"version": "7.1.2",
@@ -40358,13 +40276,6 @@
 				"unbox-primitive": "^1.0.2",
 				"which-typed-array": "^1.1.11"
 			}
-		},
-		"es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true,
-			"peer": true
 		},
 		"es-module-lexer": {
 			"version": "0.9.3",
@@ -40619,8 +40530,7 @@
 		},
 		"eslint-config-prettier": {
 			"version": "8.3.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -41389,7 +41299,8 @@
 			"dev": true
 		},
 		"gensync": {
-			"version": "1.0.0-beta.2"
+			"version": "1.0.0-beta.2",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -41843,17 +41754,6 @@
 			"version": "1.0.0",
 			"dev": true
 		},
-		"html-element-map": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"array.prototype.filter": "^1.0.0",
-				"call-bind": "^1.0.2"
-			}
-		},
 		"html-encoding-sniffer": {
 			"version": "2.0.1",
 			"dev": true,
@@ -41870,52 +41770,6 @@
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
 			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
 			"dev": true
-		},
-		"htmlparser2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"entities": "^4.4.0"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-					"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.3"
-					}
-				}
-			}
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
@@ -41955,8 +41809,7 @@
 		},
 		"icss-utils": {
 			"version": "5.1.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ignore": {
 			"version": "5.3.0",
@@ -42356,13 +42209,6 @@
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
-		},
-		"is-subset": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-			"dev": true,
-			"peer": true
 		},
 		"is-symbol": {
 			"version": "1.0.4",
@@ -43774,8 +43620,7 @@
 		},
 		"jest-pnp-resolver": {
 			"version": "1.2.2",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "27.4.0",
@@ -44365,7 +44210,8 @@
 			}
 		},
 		"jsesc": {
-			"version": "2.5.2"
+			"version": "2.5.2",
+			"dev": true
 		},
 		"json-buffer": {
 			"version": "3.0.1",
@@ -44403,6 +44249,7 @@
 		},
 		"json5": {
 			"version": "2.2.0",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -44787,25 +44634,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
 		},
-		"lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-			"dev": true,
-			"peer": true
-		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true
-		},
-		"lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"peer": true
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -45344,13 +45177,6 @@
 				"moment": ">= 2.9.0"
 			}
 		},
-		"moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"dev": true,
-			"peer": true
-		},
 		"mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -45395,28 +45221,6 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"dev": true
-		},
-		"nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true,
-					"peer": true
-				}
-			}
 		},
 		"neo-async": {
 			"version": "2.6.2",
@@ -45944,8 +45748,7 @@
 				},
 				"eslint-plugin-react-hooks": {
 					"version": "4.3.0",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"espree": {
 					"version": "9.3.0",
@@ -46106,37 +45909,6 @@
 					"integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
 					"dev": true
 				},
-				"react": {
-					"version": "18.2.0",
-					"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-					"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0"
-					}
-				},
-				"react-dom": {
-					"version": "18.2.0",
-					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-					"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"scheduler": "^0.23.0"
-					}
-				},
-				"scheduler": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-					"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"dev": true
@@ -46221,8 +45993,7 @@
 							"version": "10.0.1",
 							"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
 							"integrity": "sha512-TQ4xQ48tW4QSlODcti7pgSRqBZcUaBzuh0jPpfiMhwJKBPkqzTIAU+IrSWL/7BgXlOM90DjB7YaNgFpx8QWhuA==",
-							"dev": true,
-							"requires": {}
+							"dev": true
 						}
 					}
 				},
@@ -48424,29 +48195,6 @@
 			"version": "6.0.1",
 			"dev": true
 		},
-		"parse5-htmlparser2-tree-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domhandler": "^5.0.2",
-				"parse5": "^7.0.0"
-			},
-			"dependencies": {
-				"parse5": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-					"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"entities": "^4.4.0"
-					}
-				}
-			}
-		},
 		"pascal-case": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -49061,8 +48809,7 @@
 		},
 		"postcss-modules-extract-imports": {
 			"version": "3.0.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -49459,15 +49206,13 @@
 		},
 		"postcss-safe-parser": {
 			"version": "6.0.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-scss": {
 			"version": "4.0.9",
 			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
 			"integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-selector-parser": {
 			"version": "6.0.15",
@@ -49709,24 +49454,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"dev": true,
-			"peer": true
-		},
-		"randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			}
-		},
 		"randombytes": {
 			"version": "2.1.0",
 			"dev": true,
@@ -49758,8 +49485,7 @@
 			"version": "6.9.9",
 			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
 			"integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"react": {
 			"version": "17.0.2",
@@ -49791,8 +49517,7 @@
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
 			"integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"react-daterange-picker": {
 			"version": "2.0.1",
@@ -49832,6 +49557,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -50167,8 +49893,7 @@
 			"version": "0.15.2",
 			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
 			"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"reakit-warning": {
 			"version": "0.6.2",
@@ -50574,17 +50299,6 @@
 				"glob": "^7.1.3"
 			}
 		},
-		"rst-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
-			}
-		},
 		"rsvp": {
 			"version": "4.8.5",
 			"dev": true
@@ -50656,7 +50370,8 @@
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.2"
+			"version": "5.1.2",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -50910,6 +50625,7 @@
 		},
 		"scheduler": {
 			"version": "0.20.2",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -51521,7 +51237,8 @@
 			"dev": true
 		},
 		"source-map": {
-			"version": "0.5.7"
+			"version": "0.5.7",
+			"dev": true
 		},
 		"source-map-js": {
 			"version": "1.0.2",
@@ -51999,8 +51716,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.1.tgz",
 					"integrity": "sha512-NPljRHkq4a14YzZ3YD406uaxh7s0g6eAq3L9aLOWywoqe8PkYamAvtsh7KNX6c++ihDrJ0RiU+/z7rGnhlZ5ww==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"argparse": {
 					"version": "2.0.1",
@@ -52156,8 +51872,7 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
 					"integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"rimraf": {
 					"version": "5.0.5",
@@ -52229,14 +51944,6 @@
 						"has-flag": "^4.0.0",
 						"supports-color": "^7.0.0"
 					}
-				},
-				"typescript": {
-					"version": "5.3.3",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-					"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-					"dev": true,
-					"optional": true,
-					"peer": true
 				},
 				"which": {
 					"version": "1.3.1",
@@ -53087,8 +52794,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
 			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"use-lilius": {
 			"version": "2.0.3",
@@ -53103,15 +52809,13 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
 			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"use-sync-external-store": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
 			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -53518,8 +53222,7 @@
 		},
 		"ws": {
 			"version": "7.5.5",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"@testing-library/react": "^12.1.4",
 		"@types/qs": "^6.9.12",
 		"@types/react": "^17.0.75",
+		"@types/wordpress__block-editor": "^11.5.10",
+		"@types/wordpress__blocks": "^12.5.13",
 		"@types/wordpress__components": "^23.0.11",
 		"@wordpress/browserslist-config": "^5.35.0",
 		"eslint": "^7.32.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
-	"extends": "newspack-scripts/config/tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "assets"
-	},
-	"include": [
-		"assets",
-		"assets/**/*.json"
-	]
+  "extends": "newspack-scripts/config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "assets",
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "assets",
+    "assets/**/*.json"
+  ]
 }


### PR DESCRIPTION
Following changes were extricated from `trunk` in https://github.com/Automattic/newspack-plugin/pull/2944 in order to form an `epic` release to first test them. Now these can be merged back in, along with a fix for one of the changes (#2968):

- https://github.com/Automattic/newspack-plugin/pull/2935
- https://github.com/Automattic/newspack-plugin/pull/2936
- https://github.com/Automattic/newspack-plugin/pull/2940

The changes were already tested (look at the respective PRs), so just a smoke test is required. 