### PR TITLE
fix: allow + character in reader account email

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1716,7 +1716,7 @@ final class Reader_Activation {
 			return $user_data;
 		}
 
-		$user_login      = \sanitize_user( $user_data['user_email'] ); // Matches the email address.
+		$user_login      = str_replace( '+', '_', \sanitize_user( $user_data['user_email'] ) ); // Matches the email address, but replace + with _ to allow for Gmail aliases.
 		$random_password = \wp_generate_password();
 		$user_nicename   = self::generate_user_nicename( ! empty( $user_data['display_name'] ) ? $user_data['display_name'] : $user_data['user_email'] );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#2845 made reader account `user_login` strings match the email address, for consistency and readability. But this had a side effect of disallowing the `+` character in email addresses, because [`sanitize_user`](https://developer.wordpress.org/reference/functions/sanitize_user/) doesn't allow this character to exist in `user_login`. The Gmail feature of creating aliases on the fly using a `+` is really useful for testing, so this PR works around the limitation by replacing `+` with the allowed `_` character in `user_login`. So it won't match the email address exactly, but most accounts who are affected by this are probably test accounts anyway.

### How to test the changes in this Pull Request:

1. On `trunk`, attempt to register a new account as a reader using an email address that contains a `+` character. Observe an error message that prevents the account from being created: 

<img width="431" alt="Screenshot 2024-03-08 at 2 06 45 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/07586d88-b66e-4632-b917-e4d3211566fc">

2. Check out this branch, repeat, and confirm that the account is created.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->