### PR TITLE
fix: add a check for setup complete before adding homepage pattern

### DIFF
--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -488,7 +488,7 @@ class Setup_Wizard extends Wizard {
 			$homepage_pattern       = $this->get_homepage_patterns( $homepage_pattern_index );
 			if ( false !== $homepage_pattern ) {
 				$homepage_id = get_option( 'page_on_front', false );
-				if ( $homepage_id ) {
+				if ( $homepage_id && ! get_option( NEWSPACK_SETUP_COMPLETE ) ) {
 					wp_update_post(
 						[
 							'ID'           => $homepage_id,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

It looks like we're accidentally re-populating the homepage with a fresh pattern when something is changed and saved in the Newspack > Site Design > Settings screen. This PR adds a check to see if the setup is complete before updating the homepage.

See 1200550061930446-as-1206824469794958

### How to test the changes in this Pull Request:

1. Start with a test site running the release branch.
2. If your homepage isn't particularly distinct, edit it to add something obvious (like the current time) at the top.
3. Navigate to WP Admin > Newspack > Site Design > Settings, and change any of the options (like toggling on or off the Author Bio display, or changing the credit options). Save. 
4. Refresh your homepage and note that it's been replaced with one of the homepage patterns baked into the setup wizard. 
5. Apply this PR. 
6. Repeat steps 2 - 4, and confirm your edits are preserved. 
7. Now we want to make sure that running the setup wizard will still overwrite the homepage -- we only don't want it to do that if the setup wizard is not being run. Start by repeating step 2 (editing your homepage to make it not the default again).
8. Reset Newspack (if you have the `define( 'WP_NEWSPACK_DEBUG', true );` set, you should have a link at the bottom of the Newspack dashboard).
9. Run through the Setup Wizard; on the Design step, leave the homepage layout as is (2/3 and 1/3 column layout at the top).
10. Finish the wizard, and confirm that your homepage layout is correct. 
11. Repeat steps 7 and 8, but on the Design step, pick a different homepage.
12. Confirm that this is what's used on the homepage.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->