### PR TITLE
feat: add unit id to ad unit dropdown labels

### DIFF
--- a/assets/wizards/advertising/components/placement-control/index.js
+++ b/assets/wizards/advertising/components/placement-control/index.js
@@ -51,7 +51,12 @@ const getProviderUnitsForSelect = provider => {
 		},
 		...provider.units.map( unit => {
 			return {
-				label: unit.name,
+				label: sprintf(
+					// Translators: 1 is ad unit name and 2 is ad unit id.
+					__( '%1$s (%2$s)', 'newspack-plugin' ),
+					unit.name,
+					unit.value
+				),
 				value: unit.value,
 			};
 		} ),
@@ -118,14 +123,14 @@ const PlacementControl = ( {
 			<Grid columns={ 2 } gutter={ 32 }>
 				<SelectControl
 					label={ __( 'Provider', 'newspack-plugin' ) }
-					value={ placementProvider?.id }
+					value={ placementProvider?.id ?? '' }
 					options={ getProvidersForSelect( providers ) }
 					onChange={ provider => onChange( { ...value, provider } ) }
 					disabled={ disabled }
 				/>
 				<SelectControl
 					label={ label }
-					value={ value.ad_unit }
+					value={ value?.ad_unit ?? '' }
 					options={ getProviderUnitsForSelect( placementProvider ) }
 					onChange={ data => {
 						onChange( {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1206709674365921/1205500978838280/f](https://app.asana.com/0/1206709674365921/1205500978838280/f).

This PR adds the ad unit id to the placement settings ad unit dropdown to help publishers more easily identify ad units.

![Screenshot 2024-03-13 at 12 36 12](https://github.com/Automattic/newspack-plugin/assets/17905991/9f0ad4ad-cc43-4b32-bfd7-f3b26a6edd28)

This also cleans up a react warning the select component was triggering in console:

```
Warning: `value` prop on `select` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
select
```

### How to test the changes in this Pull Request:

1. On a site with Advertising/GAM set up go to the ad placements menu (Newspack > Advertising > Placements)
2. Enable any placement location
3. On the modal that appears (pictured above), select the ad unit dropdown
4. On `trunk` you should not see the add unit id appended in parenthesis for any of the option labels. You will also notice a console warning in browser console. On this branch, you will see ad unit ids appended to each option label and no warning in browsers console.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->