### PR TITLE
feat(reg-block): add loading message while registration is processing

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -74,7 +74,7 @@ function enqueue_scripts() {
 	\wp_enqueue_script(
 		$handle,
 		\Newspack\Newspack::plugin_url() . '/dist/reader-registration-block.js',
-		[ 'wp-polyfill', 'newspack-reader-activation' ],
+		[ 'wp-polyfill', 'newspack-reader-activation','wp-i18n' ],
 		NEWSPACK_PLUGIN_VERSION,
 		true
 	);

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -30,6 +30,7 @@ window.newspackRAS = window.newspackRAS || [];
 window.newspackRAS.push( function ( readerActivation ) {
 	domReady( function () {
 		document.querySelectorAll( '.newspack-registration' ).forEach( container => {
+			const { __ } = wp.i18n;
 			const form = container.querySelector( 'form' );
 			if ( ! form ) {
 				return;
@@ -41,25 +42,35 @@ window.newspackRAS.push( function ( readerActivation ) {
 				'.newspack-registration__registration-success'
 			);
 
+			const createMessageNode = message => {
+				const node = document.createElement( 'p' );
+				node.classList.add( 'has-text-align-center' );
+				node.textContent = message;
+				return node;
+			};
+
 			form.startLoginFlow = () => {
-				messageElement.classList.add( 'newspack-registration--hidden' );
-				messageElement.innerHTML = '';
 				submitElement.disabled = true;
 				container.classList.add( 'newspack-registration--in-progress' );
+				const messageNode = createMessageNode(
+					__( 'Registering your account. This can take a few seconds.', 'newspack-plugin' )
+				);
+				messageElement.innerHTML = '';
+				messageElement.appendChild( messageNode );
+				messageElement.classList.remove( 'newspack-registration--hidden' );
 			};
 
 			form.endLoginFlow = ( message = null, status = 500, data = null ) => {
 				let messageNode;
+
+				messageElement.classList.add( 'newspack-registration--hidden' );
 
 				if ( data?.existing_user ) {
 					successElement = container.querySelector( '.newspack-registration__login-success' );
 				}
 
 				if ( message ) {
-					messageNode = document.createElement( 'p' );
-					messageNode.classList.add( 'has-text-align-center' );
-					messageNode.textContent = message;
-
+					messageNode = createMessageNode( message );
 					const defaultMessage = successElement.querySelector( 'p' );
 					if ( defaultMessage && data?.sso ) {
 						defaultMessage.replaceWith( messageNode );
@@ -77,6 +88,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 						readerActivation.setAuthenticated( data?.authenticated );
 					}
 				} else if ( messageNode ) {
+					messageElement.innerHTML = '';
 					messageElement.appendChild( messageNode );
 					messageElement.classList.remove( 'newspack-registration--hidden' );
 				}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1200550061930446/1206650276976874](https://app.asana.com/0/1200550061930446/1206650276976874/f).

This PR adds a "loading" message while the registration block is processing. This is because the block does a lot behind the scenes and can take a good amount of time to complete registration. It must:

- Send a captcha request
- Create a new user account
- If the registration block is set to add ESP contacts, add a new contact

This is similar to https://github.com/Automattic/newspack-newsletters/pull/1456, however we can't optimistically succeed here since in the case of content gates, we need to verify a user has been created before we move on.

So this PR adds a simple loading message while the form processes to reassure users that the gears are still turning.

![Screenshot 2024-03-15 at 17 18 18](https://github.com/Automattic/newspack-plugin/assets/17905991/6d56ef51-763b-4da9-a9b1-acda0424c896)

### How to test the changes in this Pull Request:

1. On a test site, set up a registration wall content gate: https://help.newspack.com/engagement/reader-activation-system/content-gating/#getting-started
2. Activate the memberships plugin and create a membership plan for all new registrations, restricting all posts to members of this plan
3. Visit any post on your site as a logged out user and scroll until the registration wall triggers
4. Enter a valid email address and verify a message appears at the bottom indicating the process may take a few seconds

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->