### PR TITLE
feat(ras): updates to metadata fields synced to ESP

### DIFF
--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -146,16 +146,6 @@ class ActiveCampaign {
 			return;
 		}
 
-		/*
-		 * If the subscription is being activated after a successful first or renewal payment,
-		 * the contact will be synced when that order is completed, so no need to sync again.
-		 */
-		if (
-			( 'pending' === $data['status_before'] || 'on-hold' === $data['status_before'] ) &&
-			'active' === $data['status_after'] ) {
-			return;
-		}
-
 		$contact = WooCommerce_Connection::get_contact_from_order( $data['subscription_id'] );
 
 		if ( ! $contact ) {

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -142,7 +142,7 @@ class ActiveCampaign {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function subscription_updated( $timestamp, $data, $client_id ) {
-		if ( empty( $data['status_before'] ) || empty( $data['status_after'] ) || empty( $data['user_id'] ) ) {
+		if ( empty( $data['status_before'] ) || empty( $data['status_after'] ) || empty( $data['subscription_id'] ) ) {
 			return;
 		}
 
@@ -156,8 +156,7 @@ class ActiveCampaign {
 			return;
 		}
 
-		$customer = new \WC_Customer( $data['user_id'] );
-		$contact  = WooCommerce_Connection::get_contact_from_customer( $customer );
+		$contact = WooCommerce_Connection::get_contact_from_order( $data['subscription_id'] );
 
 		if ( ! $contact ) {
 			return;

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -53,12 +53,12 @@ class ActiveCampaign {
 	 *
 	 * @param array $contact Contact info to sync to ESP.
 	 */
-	private static function put( $contact ) {
+	public static function put( $contact ) {
 		$master_list_id = Reader_Activation::get_setting( 'active_campaign_master_list' );
 		if ( ! $master_list_id ) {
 			return;
 		}
-		\Newspack_Newsletters_Subscription::add_contact( $contact, $master_list_id );
+		return \Newspack_Newsletters_Subscription::add_contact( $contact, $master_list_id );
 	}
 
 	/**

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -295,16 +295,6 @@ class Mailchimp {
 			return;
 		}
 
-		/*
-		 * If the subscription is being activated after a successful first or renewal payment,
-		 * the contact will be synced when that order is completed, so no need to sync again.
-		 */
-		if (
-			( 'pending' === $data['status_before'] || 'on-hold' === $data['status_before'] ) &&
-			'active' === $data['status_after'] ) {
-			return;
-		}
-
 		$contact = WooCommerce_Connection::get_contact_from_order( $data['subscription_id'] );
 
 		if ( ! $contact ) {

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -291,7 +291,7 @@ class Mailchimp {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function subscription_updated( $timestamp, $data, $client_id ) {
-		if ( empty( $data['status_before'] ) || empty( $data['status_after'] ) || empty( $data['user_id'] ) ) {
+		if ( empty( $data['status_before'] ) || empty( $data['status_after'] ) || empty( $data['subscription_id'] ) ) {
 			return;
 		}
 
@@ -305,8 +305,7 @@ class Mailchimp {
 			return;
 		}
 
-		$customer = new \WC_Customer( $data['user_id'] );
-		$contact  = WooCommerce_Connection::get_contact_from_customer( $customer );
+		$contact = WooCommerce_Connection::get_contact_from_order( $data['subscription_id'] );
 
 		if ( ! $contact ) {
 			return;

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -150,7 +150,7 @@ class WooCommerce_Connection {
 	 */
 	public static function get_contact_order_metadata( $order, $payment_page_url = false, $is_new = false ) {
 		if ( ! is_a( $order, 'WC_Order' ) ) {
-			$order = new \WC_Order( $order );
+			$order = \wc_get_order( $order );
 		}
 
 		if ( ! self::should_sync_order( $order ) ) {
@@ -318,7 +318,7 @@ class WooCommerce_Connection {
 	 */
 	public static function get_contact_from_order( $order, $payment_page_url = false, $is_new = false ) {
 		if ( ! is_a( $order, 'WC_Order' ) ) {
-			$order = new \WC_Order( $order );
+			$order = \wc_get_order( $order );
 		}
 
 		if ( ! self::should_sync_order( $order ) ) {

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -190,7 +190,7 @@ class WooCommerce_Connection {
 			if ( $is_donation_order ) {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Donor';
 			} else {
-				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Customer';
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'customer';
 			}
 
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = '';

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -182,8 +182,15 @@ class WooCommerce_Connection {
 
 		// One-time transaction.
 		if ( empty( $order_subscriptions ) ) {
+
+			/**
+			 * For donation-type products, use donation membership status as defined by BlueLena.
+			 * For non-donation-type products, we just need to know that the reader is a customer.
+			 */
 			if ( $is_donation_order ) {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Donor';
+			} else {
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Customer';
 			}
 
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = '';
@@ -201,6 +208,10 @@ class WooCommerce_Connection {
 		} else {
 			$current_subscription = reset( $order_subscriptions );
 
+			/**
+			 * For donation-type products, use donation membership status as defined by BlueLena.
+			 * For non-donation-type products, use the subscription's current status.
+			 */
 			if ( $is_donation_order ) {
 				$donor_status = 'Donor';
 				if ( 'month' === $current_subscription->get_billing_period() ) {
@@ -215,6 +226,8 @@ class WooCommerce_Connection {
 					$donor_status = 'Ex-' . $donor_status;
 				}
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = $donor_status;
+			} else {
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = $current_subscription->get_status();
 			}
 
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'sub_start_date' ) ]    = $current_subscription->get_date( 'start' );

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -177,20 +177,13 @@ class WooCommerce_Connection {
 			}
 		}
 
-		$order_subscriptions = \wcs_get_subscriptions_for_order( $order->get_id(), [ 'order_type' => 'any' ] );
+		$order_subscriptions = \wcs_is_subscription( $order ) ? [ $order ] : \wcs_get_subscriptions_for_order( $order->get_id(), [ 'order_type' => 'any' ] );
 		$is_donation_order   = Donations::is_donation_order( $order );
 
 		// One-time transaction.
 		if ( empty( $order_subscriptions ) ) {
-
-			/**
-			 * For donation-type products, use donation membership status as defined by BlueLena.
-			 * For non-donation-type products, we just need to know that the reader is a customer.
-			 */
 			if ( $is_donation_order ) {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Donor';
-			} else {
-				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'customer';
 			}
 
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = '';
@@ -208,10 +201,6 @@ class WooCommerce_Connection {
 		} else {
 			$current_subscription = reset( $order_subscriptions );
 
-			/**
-			 * For donation-type products, use donation membership status as defined by BlueLena.
-			 * For non-donation-type products, use the subscription's current status.
-			 */
 			if ( $is_donation_order ) {
 				$donor_status = 'Donor';
 				if ( 'month' === $current_subscription->get_billing_period() ) {
@@ -226,8 +215,6 @@ class WooCommerce_Connection {
 					$donor_status = 'Ex-' . $donor_status;
 				}
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = $donor_status;
-			} else {
-				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = $current_subscription->get_status();
 			}
 
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'sub_start_date' ) ]    = $current_subscription->get_date( 'start' );

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -182,8 +182,15 @@ class WooCommerce_Connection {
 
 		// One-time transaction.
 		if ( empty( $order_subscriptions ) ) {
+
+			/**
+			 * For donation-type products, use donation membership status as defined by BlueLena.
+			 * For non-donation-type products, we just need to know that the reader is a customer.
+			 */
 			if ( $is_donation_order ) {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'Donor';
+			} else {
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = 'customer';
 			}
 
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'product_name' ) ] = '';
@@ -201,6 +208,10 @@ class WooCommerce_Connection {
 		} else {
 			$current_subscription = reset( $order_subscriptions );
 
+			/**
+			 * For donation-type products, use donation membership status as defined by BlueLena.
+			 * For non-donation-type products, use the subscription's current status.
+			 */
 			if ( $is_donation_order ) {
 				$donor_status = 'Donor';
 				if ( 'month' === $current_subscription->get_billing_period() ) {
@@ -215,6 +226,8 @@ class WooCommerce_Connection {
 					$donor_status = 'Ex-' . $donor_status;
 				}
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = $donor_status;
+			} else {
+				$metadata[ Newspack_Newsletters::get_metadata_key( 'membership_status' ) ] = $current_subscription->get_status();
 			}
 
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'sub_start_date' ) ]    = $current_subscription->get_date( 'start' );


### PR DESCRIPTION
Hotfix version of #2992. Needed because some sites currently mid-migration need this before their migration is completed.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the behavior of the `Membership Status` field when syncing reader data to the connected ESP. Current behavior in `trunk` only syncs this status field for donation-type transactions. This PR also syncs this field for non-donation transactions as follows:

- For one-time purchases: `customer`
- For subscription purchases: the status of the most recent subscription ([see list of possible values](https://woo.com/document/subscriptions/statuses/))

### How to test the changes in this Pull Request:

1. On a site with RAS enabled and connected to an ESP, add the following to a post or page: 
  - A Donate block
  - A checkout button block connected to a non-donation, one-time (non-subscription) product
  - A checkout button block connected to a non-donation subscription product
2. As a new reader, purchase:
  - A one-time donation
  - A subscription donation
  - The one-time non-donation product
  - The subscription non-donation product
3. After each purchase, check the contact data synced to the connected ESP and confirm that the `NP_Membership Status` field value matches the expected behavior:
  - For one-time donations: `Donor`
  - For subscription donations: `Monthly Donor` or `Yearly Donor`
  - For one-time non-donation: `customer`
  - For subscription non-donation: subscription status (generally `pending` or `active` for new subscriptions)
4. Change the statuses of the subscription purchases and confirm that the status is updated as expected:
  - For donations: `Ex-Monthy`/`Ex-Yearly Donor` (`Ex-` is appended if the subscription enters a non-active status)
  - For non-donations: subscription status ([see list of possible values](https://woo.com/document/subscriptions/statuses/))

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->