### PR TITLE
fix(data-events): fallback logic in get_order_data() util method

### DIFF
--- a/includes/data-events/class-utils.php
+++ b/includes/data-events/class-utils.php
@@ -16,6 +16,8 @@ final class Utils {
 	 *
 	 * @param int  $order_id Order ID.
 	 * @param bool $process_donations_only Whether to process only donation orders.
+	 *
+	 * @return array|null
 	 */
 	public static function get_order_data( $order_id, $process_donations_only = false ) {
 		$order = \wc_get_order( $order_id );
@@ -25,10 +27,10 @@ final class Utils {
 		if ( ! \Newspack\WooCommerce_Connection::should_sync_order( $order ) ) {
 			return;
 		}
-		if ( $process_donations_only ) {
-			$product_id = \Newspack\Donations::get_order_donation_product_id( $order_id );
-		} else {
-			// Donation orders always have just a single product, but other orders can have more than one.
+
+		// Donation orders always have just a single product, but other orders can have more than one.
+		$product_id = \Newspack\Donations::get_order_donation_product_id( $order_id );
+		if ( ! $process_donations_only && ! $product_id ) {
 			$product_id = array_values( \Newspack\WooCommerce_Connection::get_products_for_order( $order_id ) );
 		}
 		if ( ! $product_id ) {

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -202,9 +202,11 @@ class Newspack_Newsletters {
 						$normalized_metadata[ $meta_key ] = $meta_value;
 					}
 				}
-				if ( isset( $contact['metadata']['status'] ) ) {
-					$normalized_metadata['status'] = $contact['metadata']['status'];
-				}
+			}
+
+			// Ensure status is passed, if given.
+			if ( isset( $contact['metadata']['status'] ) ) {
+				$normalized_metadata['status'] = $contact['metadata']['status'];
 			}
 			$contact['metadata'] = $normalized_metadata;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a logical error introduced in #2935. The `get_order_data()` method correctly checks whether it should return data for only donation orders or for any order, but it did so in a way that changed the behavior of `donation_new` vs. `order_completed` data event listeners.

What we want: the `order_completed` listener should return data for _any_ transaction, whether or not it's a donation.

What's happening: `order_completed` is _only_ firing for non-donation orders.

Also refactors one piece of code in the `normalize_contact_data` method which currently sets the `status` field on every iteration of a `foreach` loop, whereas it only needs to be set once after the loop has completed.

### How to test the changes in this Pull Request:

1. On `trunk`, on a RAS-enabled site, make a new donation and observe that not all metadata is synced to the ESP (it will be missing details about the actual transaction).
2. Confirm that a non-donation order via the Checkout Button block does sync all metadata to the ESP.
3. Check out this branch, and confirm that both donation and non-donation-type orders sync all expected metadata to the ESP.
4. Smoke-test the instructions for #2924 to make sure it still works after moving the code to set `status` in the `normalize_contact_data` method.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->