### PR TITLE
fix: update WC's required fields if using other RR platforms

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -355,20 +355,17 @@ class WooCommerce_My_Account {
 	 * @param array $required_fields Required fields.
 	 */
 	public static function remove_required_fields( $required_fields ) {
-		if ( Donations::is_platform_wc() ) {
-			$newspack_required_fields = [
-				'account_email'        => __( 'Email address', 'newspack-plugin' ),
-				'account_display_name' => __( 'Display name', 'newspack-plugin' ),
-			];
+		$newspack_required_fields = [
+			'account_email'        => __( 'Email address', 'newspack-plugin' ),
+			'account_display_name' => __( 'Display name', 'newspack-plugin' ),
+		];
 
-			/**
-			 * Filters the fields required when editing account details in My Account.
-			 *
-			 * @param array $newspack_required_fields Required fields, keyed by field name.
-			 */
-			return \apply_filters( 'newspack_myaccount_required_fields', $newspack_required_fields );
-		}
-		return $required_fields;
+		/**
+		 * Filters the fields required when editing account details in My Account.
+		 *
+		 * @param array $newspack_required_fields Required fields, keyed by field name.
+		 */
+		return \apply_filters( 'newspack_myaccount_required_fields', $newspack_required_fields );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#2519 fixed an issue with updating Display Name, but only if WC is used as the Reader Revenue platform. If other platform is used, the issue is reproducible:

<img width="586" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/dd330def-bd02-4699-b14d-08363f735735">

### How to test the changes in this Pull Request:

1. On `release`,
1. Enable Reader Activation and set Reader Revenue platform to News Revenue Hub
2. As a reader, try to update the Display Name in /my-account page, observe it failing on required fields
3. Switch to this branch, repeat, observe the bug is not reproducible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->