### PR TITLE
fix(health-check): PHP Fatal error:  Call to undefined function get_plugins()

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -586,7 +586,7 @@ class Plugin_Manager {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
-		$plugins = array_merge( \get_plugins(), \wp_get_themes() );
+		$plugins = array_merge( get_plugins(), wp_get_themes() );
 
 		$installed_plugins_info = [];
 		foreach ( self::get_installed_plugins() as $key => $path ) {

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -583,6 +583,9 @@ class Plugin_Manager {
 	 * @return array of 'plugin_slug => []' entries for all installed plugins.
 	 */
 	public static function get_installed_plugins_info() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
 		$plugins = array_merge( \get_plugins(), \wp_get_themes() );
 
 		$installed_plugins_info = [];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR addresses a Fatal Error when navigating to WP Admin > Newspack > Health Check, by including a check for `get_plugins` and include `wp-admin/includes/plugin.php` if missing.
```sh
PHP Fatal error:  Uncaught Error: Call to undefined function get_plugins() in /var/www/html/.shared/plugins/newspack-plugin/includes/class-plugin-manager.php:587
```
![Screenshot 2024-03-19 at 10 36 04](https://github.com/Automattic/newspack-plugin/assets/3676975/ec1dac7b-bd39-4411-b4e0-66ef3d616631)

### How to test the changes in this Pull Request:

1. Navigate to - /wp-admin/admin.php?page=newspack-health-check-wizard#/
2. Ensure no errors are received.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->