### PR TITLE
fix: update template version number for Woo

### DIFF
--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -4,7 +4,7 @@
  * Based on woocommerce/templates/myaccount/form-edit-account.php.
  *
  * @package Newspack
- * @version 7.0.1
+ * @version 8.7.0
  */
 
 namespace Newspack;
@@ -67,7 +67,14 @@ endif;
 		<input type="hidden" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
 	</p>
 
-	<?php \do_action( 'newspack_woocommerce_edit_account_form' ); ?>
+	<?php
+		/**
+		 * My Account edit account form.
+		 *
+		 * Newspack equivalent of do_action( 'woocommerce_edit_account_form' );
+		 */
+		\do_action( 'newspack_woocommerce_edit_account_form' );
+	?>
 
 	<p class="woocommerce-buttons-card">
 		<?php \wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In WooCommerce 8.7.0, the `woocommerce/templates/myaccount/form-edit-account.php` template received a couple updates, causing our `includes/reader-revenue/templates/myaccount-edit-account.php` template to be considered out of date. This is causing a warning to be thrown:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/e7388ff0-08e9-4d66-80bb-b9125f70deec)

I reviewed [the changes](https://github.com/Automattic/woocommerce/commit/d858d2293044e844c1091350695f8e675eca41c4#diff-fa1b452a90f972190216ad5efd0fbd6acdd409e7575fa9fadd1c963a235afb5f), and it looks like they involve:
* Adding a hook
* Adding a comment to describe an existing hook

In the Newspack plugin, the markup is slightly different than WooCommerce, so the existing hook and the new one would be back-to-back. We've also replaced all of the WooCommerce hooks with ones prefaced with `newspack-`, so they're don't have 1:1 names.

Due to the above, to get the template up-to-date I opted to add a code an equivalent for the one added before it in Woo, `'woocommerce_edit_account_form_fields'`, since their placement kind of makes them interchangeable. 

See: 1200550061930446-as-1206883834710822


### How to test the changes in this Pull Request:

1. Apply this PR.
2. Spot check the changes against the changes to [the same section in WooCommerce](https://github.com/Automattic/woocommerce/commit/d858d2293044e844c1091350695f8e675eca41c4#diff-fa1b452a90f972190216ad5efd0fbd6acdd409e7575fa9fadd1c963a235afb5f), to make sure they make sense.
3. Chime in on whether this makes sense, or whether you think we should also add an equivalent to the `'woocommerce_edit_account_form_fields'` hook added in 8.7.0. Thanks!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->