### PR TITLE
refactor(data-events): add abstract Connector class for shared methods

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -86,6 +86,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-popups.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/connectors/ga4/class-ga4.php';
+		include_once NEWSPACK_ABSPATH . 'includes/data-events/connectors/class-connector.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/connectors/class-mailchimp.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/connectors/class-activecampaign.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-woo-user-registration.php';

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Main Class.
  */
-class ActiveCampaign {
+class ActiveCampaign extends Connector {
 	/**
 	 * Constructor.
 	 */
@@ -61,99 +61,6 @@ class ActiveCampaign {
 		return \Newspack_Newsletters_Subscription::add_contact( $contact, $master_list_id );
 	}
 
-	/**
-	 * Handle a reader registering.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 * @param int   $client_id ID of the client that triggered the event.
-	 */
-	public static function reader_registered( $timestamp, $data, $client_id ) {
-		$account_key           = Newspack_Newsletters::get_metadata_key( 'account' );
-		$registration_date_key = Newspack_Newsletters::get_metadata_key( 'registration_date' );
-		$metadata              = [
-			$account_key           => $data['user_id'],
-			$registration_date_key => gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $timestamp ),
-		];
-		if ( isset( $data['metadata']['current_page_url'] ) ) {
-			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_page' ) ] = $data['metadata']['current_page_url'];
-		}
-		if ( isset( $data['metadata']['registration_method'] ) ) {
-			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_method' ) ] = $data['metadata']['registration_method'];
-		}
-		$contact = [
-			'email'    => $data['email'],
-			'metadata' => $metadata,
-		];
-		self::put( $contact );
-	}
-
-	/**
-	 * Sync reader data on login.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 * @param int   $client_id ID of the client that triggered the event.
-	 */
-	public static function reader_logged_in( $timestamp, $data, $client_id ) {
-		if ( empty( $data['email'] ) || empty( $data['user_id'] ) ) {
-			return;
-		}
-
-		$customer = new \WC_Customer( $data['user_id'] );
-
-		// If user is not a Woo customer, don't need to sync them.
-		if ( ! $customer->get_order_count() ) {
-			return;
-		}
-
-		$contact = WooCommerce_Connection::get_contact_from_customer( $customer );
-
-		self::put( $contact );
-	}
-
-	/**
-	 * Handle a completed order of any type.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 * @param int   $client_id ID of the client that triggered the event.
-	 */
-	public static function order_completed( $timestamp, $data, $client_id ) {
-		if ( ! isset( $data['platform_data']['order_id'] ) ) {
-			return;
-		}
-
-		$order_id = $data['platform_data']['order_id'];
-		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, $data['referer'], true );
-
-		if ( ! $contact ) {
-			return;
-		}
-
-		self::put( $contact );
-	}
-
-	/**
-	 * Handle a change in subscription status.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 * @param int   $client_id ID of the client that triggered the event.
-	 */
-	public static function subscription_updated( $timestamp, $data, $client_id ) {
-		if ( empty( $data['status_before'] ) || empty( $data['status_after'] ) || empty( $data['subscription_id'] ) ) {
-			return;
-		}
-
-		$contact = WooCommerce_Connection::get_contact_from_order( $data['subscription_id'] );
-
-		if ( ! $contact ) {
-			return;
-		}
-
-		self::put( $contact );
-	}
 
 	/**
 	 * Handle newsletter subscription update.

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -10,8 +10,6 @@ namespace Newspack\Data_Events\Connectors;
 use Newspack\Data_Events;
 use Newspack\Newspack_Newsletters;
 use Newspack\Reader_Activation;
-use Newspack\WooCommerce_Connection;
-use Newspack\Donations;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/data-events/connectors/class-connector.php
+++ b/includes/data-events/connectors/class-connector.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Abstract Newspack Data Events Connector class
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Data_Events\Connectors;
+
+use Newspack\Newspack_Newsletters;
+use Newspack\WooCommerce_Connection;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Standard methods shared by all connectors.
+ */
+abstract class Connector {
+	/**
+	 * Handle a reader registering.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 */
+	public static function reader_registered( $timestamp, $data, $client_id ) {
+		$account_key           = Newspack_Newsletters::get_metadata_key( 'account' );
+		$registration_date_key = Newspack_Newsletters::get_metadata_key( 'registration_date' );
+		$metadata              = [
+			$account_key           => $data['user_id'],
+			$registration_date_key => gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $timestamp ),
+		];
+		if ( isset( $data['metadata']['current_page_url'] ) ) {
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_page' ) ] = $data['metadata']['current_page_url'];
+		}
+		if ( isset( $data['metadata']['registration_method'] ) ) {
+			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_method' ) ] = $data['metadata']['registration_method'];
+		}
+		$contact = [
+			'email'    => $data['email'],
+			'metadata' => $metadata,
+		];
+		static::put( $contact );
+	}
+
+	/**
+	 * Sync reader data on login.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 */
+	public static function reader_logged_in( $timestamp, $data, $client_id ) {
+		if ( empty( $data['email'] ) || empty( $data['user_id'] ) ) {
+			return;
+		}
+
+		$customer = new \WC_Customer( $data['user_id'] );
+
+		// If user is not a Woo customer, don't need to sync them.
+		if ( ! $customer->get_order_count() ) {
+			return;
+		}
+
+		$contact = WooCommerce_Connection::get_contact_from_customer( $customer );
+
+		static::put( $contact );
+	}
+
+	/**
+	 * Handle a completed order of any type.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 */
+	public static function order_completed( $timestamp, $data, $client_id ) {
+		if ( ! isset( $data['platform_data']['order_id'] ) ) {
+			return;
+		}
+
+		$order_id = $data['platform_data']['order_id'];
+		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, $data['referer'], true );
+
+		if ( ! $contact ) {
+			return;
+		}
+
+		static::put( $contact );
+	}
+
+	/**
+	 * Handle a change in subscription status.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 */
+	public static function subscription_updated( $timestamp, $data, $client_id ) {
+		if ( empty( $data['status_before'] ) || empty( $data['status_after'] ) || empty( $data['subscription_id'] ) ) {
+			return;
+		}
+
+		/*
+		 * If the subscription is being activated after a successful first or renewal payment,
+		 * the contact will be synced when that order is completed, so no need to sync again.
+		 */
+		if (
+			( 'pending' === $data['status_before'] || 'on-hold' === $data['status_before'] ) &&
+			'active' === $data['status_after'] ) {
+			return;
+		}
+
+		$contact = WooCommerce_Connection::get_contact_from_order( $data['subscription_id'] );
+
+		if ( ! $contact ) {
+			return;
+		}
+
+		static::put( $contact );
+	}
+
+	/**
+	 * Handle newsletter subscription update.
+	 *
+	 * @param int   $timestamp Timestamp.
+	 * @param array $data      Data.
+	 */
+	public static function newsletter_updated( $timestamp, $data ) {
+		if ( empty( $data['user_id'] ) || empty( $data['email'] ) ) {
+			return;
+		}
+		if ( ! class_exists( '\Newspack_Newsletters' ) || ! class_exists( '\Newspack_Newsletters_Subscription' ) ) {
+			return;
+		}
+		$subscribed_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $data['email'] );
+		if ( is_wp_error( $subscribed_lists ) || ! is_array( $subscribed_lists ) ) {
+			return;
+		}
+		$lists = \Newspack_Newsletters_Subscription::get_lists();
+		if ( is_wp_error( $lists ) ) {
+			return;
+		}
+		$lists_names = [];
+		foreach ( $subscribed_lists as $subscribed_list_id ) {
+			foreach ( $lists as $list ) {
+				if ( $list['id'] === $subscribed_list_id ) {
+					$lists_names[] = $list['name'];
+				}
+			}
+		}
+
+		$account_key              = Newspack_Newsletters::get_metadata_key( 'account' );
+		$newsletter_selection_key = Newspack_Newsletters::get_metadata_key( 'newsletter_selection' );
+
+		$metadata = [
+			$account_key              => $data['user_id'],
+			$newsletter_selection_key => implode( ', ', $lists_names ),
+		];
+		$contact  = [
+			'email'    => $data['email'],
+			'metadata' => $metadata,
+		];
+		static::put( $contact );
+	}
+}

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -12,8 +12,6 @@ use Newspack\Data_Events;
 use Newspack\Mailchimp_API;
 use Newspack\Newspack_Newsletters;
 use Newspack\Reader_Activation;
-use Newspack\WooCommerce_Connection;
-use Newspack\Donations;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -57,7 +55,7 @@ class Mailchimp extends Connector {
 		$audience_id = Reader_Activation::get_setting( 'mailchimp_audience_id' );
 		/** Attempt to use list ID from "Mailchimp for WooCommerce" */
 		if ( ! $audience_id && function_exists( 'mailchimp_get_list_id' ) ) {
-			$audience_id = mailchimp_get_list_id();
+			$audience_id = \mailchimp_get_list_id();
 		}
 		return ! empty( $audience_id ) ? $audience_id : false;
 	}

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Main Class.
  */
-class Mailchimp {
+class Mailchimp extends Connector {
 	/**
 	 * Constructor.
 	 */
@@ -230,100 +230,6 @@ class Mailchimp {
 			"lists/$audience_id/members/$hash",
 			$payload
 		);
-	}
-
-	/**
-	 * Handle a reader registering.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 * @param int   $client_id ID of the client that triggered the event.
-	 */
-	public static function reader_registered( $timestamp, $data, $client_id ) {
-		$account_key           = Newspack_Newsletters::get_metadata_key( 'account' );
-		$registration_date_key = Newspack_Newsletters::get_metadata_key( 'registration_date' );
-		$metadata              = [
-			$account_key           => $data['user_id'],
-			$registration_date_key => gmdate( Newspack_Newsletters::METADATA_DATE_FORMAT, $timestamp ),
-		];
-		if ( isset( $data['metadata']['current_page_url'] ) ) {
-			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_page' ) ] = $data['metadata']['current_page_url'];
-		}
-		if ( isset( $data['metadata']['registration_method'] ) ) {
-			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_method' ) ] = $data['metadata']['registration_method'];
-		}
-		$contact = [
-			'email'    => $data['email'],
-			'metadata' => $metadata,
-		];
-		self::put( $contact );
-	}
-
-	/**
-	 * Sync reader data on login.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 * @param int   $client_id ID of the client that triggered the event.
-	 */
-	public static function reader_logged_in( $timestamp, $data, $client_id ) {
-		if ( empty( $data['email'] ) || empty( $data['user_id'] ) ) {
-			return;
-		}
-
-		$customer = new \WC_Customer( $data['user_id'] );
-
-		// If user is not a Woo customer, don't need to sync them.
-		if ( ! $customer->get_order_count() ) {
-			return;
-		}
-
-		$contact = WooCommerce_Connection::get_contact_from_customer( $customer );
-
-		self::put( $contact );
-	}
-
-	/**
-	 * Handle a completed order of any type.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 * @param int   $client_id ID of the client that triggered the event.
-	 */
-	public static function order_completed( $timestamp, $data, $client_id ) {
-		if ( ! isset( $data['platform_data']['order_id'] ) ) {
-			return;
-		}
-
-		$order_id = $data['platform_data']['order_id'];
-		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, $data['referer'], true );
-
-		if ( ! $contact ) {
-			return;
-		}
-
-		self::put( $contact );
-	}
-
-	/**
-	 * Handle a change in subscription status.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 * @param int   $client_id ID of the client that triggered the event.
-	 */
-	public static function subscription_updated( $timestamp, $data, $client_id ) {
-		if ( empty( $data['status_before'] ) || empty( $data['status_after'] ) || empty( $data['subscription_id'] ) ) {
-			return;
-		}
-
-		$contact = WooCommerce_Connection::get_contact_from_order( $data['subscription_id'] );
-
-		if ( ! $contact ) {
-			return;
-		}
-
-		self::put( $contact );
 	}
 }
 new Mailchimp();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Just a small refactor of Data Events to get rid of some duplicated code in two very similar classes. Creates an abstract `Connector` class with shared methods that can be extended for ESP-specific functionality.

### How to test the changes in this Pull Request:

No changes to functionality—test that RAS contact syncing still works as before with both Mailchimp and ActiveCampaign.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->