### PR TITLE
feat(ia): dashboard site status

### DIFF
--- a/assets/wizards/dashboard/components/site-statuses/index.scss
+++ b/assets/wizards/dashboard/components/site-statuses/index.scss
@@ -32,6 +32,16 @@
         color: var(--np-sa-txt-color);
     }
 
+    &:has(span.hidden):hover {
+        span {
+            display: none;
+
+            &.hidden {
+                display: inline-block;
+            }
+        }
+    }
+
     // When loading
     &.newspack-site-status__pending {
         overflow: hidden;
@@ -61,7 +71,8 @@
         }
     }
 
-    &.newspack-site-status__error {
+    // Errors
+    &[class*="newspack-site-status__error"] {
         --np-sa-bg-color: #F7EBEC;
         --np-sa-txt-color: #B32D2E;
 
@@ -76,7 +87,8 @@
         }
     }
 
-    &.newspack-site-status__error-dependency {
+    // Dependency Error
+    &.newspack-site-status__error-dependencies {
         --np-sa-bg-color: #F5F1E1;
         --np-sa-txt-color: #755100;
 
@@ -92,16 +104,15 @@
         &::before {
             background-color: var(--np-sa-txt-color);
         }
+    }
+}
 
-        &:hover {
-            span {
-                display: none;
+a.newspack-site-status {
+    color: inherit;
+    text-decoration: none;
 
-                &.hidden {
-                    display: inline-block;
-                }
-            }
-        }
+    &:hover, &:active, &:focus {
+        color: inherit;
     }
 }
 

--- a/assets/wizards/dashboard/components/site-statuses/index.scss
+++ b/assets/wizards/dashboard/components/site-statuses/index.scss
@@ -1,0 +1,112 @@
+.newspack-site-status {
+    --np-sa-bg-color: #EEE;
+    --np-sa-txt-color: #666;
+    --np-sa-space: 16px;
+
+    animation: none;
+    background-color: var(--np-sa-bg-color);
+    border-radius: 26px;
+    font-weight: 600;
+    overflow: hidden;
+    padding: var(--np-sa-space) 24px;
+    position: relative;
+    line-height: 16px;
+    text-overflow: ellipsis;
+    transition: background-color 0.4s;
+    white-space: nowrap;
+
+    // Dot
+    &::before {
+        content: '';
+        background-color: var(--np-sa-txt-color);
+        border-radius: 4px;
+        display: inline-block;
+        height: 8px;
+        margin-right: 8px;
+        width: 8px;
+        transition: background-color 0.4s;
+    }
+
+    // Status text i.e. Connect/Disconnected
+    span {
+        color: var(--np-sa-txt-color);
+    }
+
+    // When loading
+    &.newspack-site-status__pending {
+        overflow: hidden;
+
+        &::after {
+            animation: loading 2s infinite;
+            background-image: linear-gradient(90deg, rgba(#fff, 0) 0, rgba(#fff, 0.2) 20%, rgba(#fff, 0.6) 60%, rgba(#fff, 0));
+            content: '';
+            inset: 0;
+            position: absolute;
+            transform: translateX(-100%);
+        }
+    }
+
+    &.newspack-site-status__success {
+        --np-sa-bg-color: #E6F2E8;
+        --np-sa-txt-color: #007017;
+
+        background-color: var(--np-sa-bg-color);
+
+        span {
+            color: #007017;
+        }
+
+        &::before {
+            background-color: var(--np-sa-txt-color);
+        }
+    }
+
+    &.newspack-site-status__error {
+        --np-sa-bg-color: #F7EBEC;
+        --np-sa-txt-color: #B32D2E;
+
+        background-color: var(--np-sa-bg-color);
+
+        span {
+            color: #B32D2E;
+        }
+
+        &::before {
+            background-color: var(--np-sa-txt-color);
+        }
+    }
+
+    &.newspack-site-status__error-dependency {
+        --np-sa-bg-color: #F5F1E1;
+        --np-sa-txt-color: #755100;
+
+        background-color: var(--np-sa-bg-color);
+        border: 0;
+        cursor: pointer;
+        text-align: left;
+
+        span {
+            color: var(--np-sa-txt-color);
+        }
+
+        &::before {
+            background-color: var(--np-sa-txt-color);
+        }
+
+        &:hover {
+            span {
+                display: none;
+
+                &.hidden {
+                    display: inline-block;
+                }
+            }
+        }
+    }
+}
+
+@keyframes loading {
+    to {
+        transform: translateX(100%);
+    }
+}

--- a/assets/wizards/dashboard/components/site-statuses/index.scss
+++ b/assets/wizards/dashboard/components/site-statuses/index.scss
@@ -37,7 +37,7 @@
             display: none;
 
             &.hidden {
-                display: inline-block;
+                display: contents;
             }
         }
     }

--- a/assets/wizards/dashboard/components/site-statuses/index.tsx
+++ b/assets/wizards/dashboard/components/site-statuses/index.tsx
@@ -24,14 +24,14 @@ const actions: Statuses = {
 	},
 	googleAnalytics: {
 		...siteStatuses.googleAnalytics,
-		then( payload ) {
-			return payload === 'true';
+		then( { propertyID = '' }: { propertyID: string } ) {
+			return propertyID !== '';
 		},
 	},
 	googleAdManager: {
 		...siteStatuses.googleAdManager,
-		then( { user_basic_info } ) {
-			return Boolean( user_basic_info && user_basic_info.email );
+		then( { services: { google_ad_manager } } ) {
+			return google_ad_manager.available && google_ad_manager.enabled === '1';
 		},
 	},
 } as const;

--- a/assets/wizards/dashboard/components/site-statuses/index.tsx
+++ b/assets/wizards/dashboard/components/site-statuses/index.tsx
@@ -15,32 +15,21 @@ const {
 	newspack_dashboard: { siteStatuses },
 } = window;
 
-const actions: Actions = {
+const actions: Statuses = {
 	readerActivation: {
-		label: __( 'Reader Activation', 'newspack-plugin' ),
-		statusLabels: {
-			success: __( 'Enabled', 'newspack-plugin' ),
-			error: __( 'Disabled', 'newspack-plugin' ),
-		},
-		endpoint: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
-		dependencies: siteStatuses.readerActivation.dependencies,
+		...siteStatuses.readerActivation,
 		then( { prerequisites_status }: { prerequisites_status: PrerequisitesStatus } ) {
 			return Object.values( prerequisites_status ).every( status => status.active );
 		},
 	},
 	googleAnalytics: {
-		label: __( 'Google Analytics', 'newspack-plugin' ),
-		endpoint: '/google-site-kit/v1/core/site/data/connection-check',
-		dependencies: siteStatuses.googleAnalytics.dependencies,
+		...siteStatuses.googleAnalytics,
 		then( payload ) {
 			return payload === 'true';
 		},
 	},
 	googleAdManager: {
-		label: __( 'Google Ad Manager', 'newspack-plugin' ),
-		endpoint: '/newspack/v1/oauth/google',
-		canConnect: siteStatuses.googleAdManager.isAvailable,
-		dependencies: siteStatuses.googleAdManager.dependencies,
+		...siteStatuses.googleAdManager,
 		then( { user_basic_info } ) {
 			return Boolean( user_basic_info && user_basic_info.email );
 		},

--- a/assets/wizards/dashboard/components/site-statuses/index.tsx
+++ b/assets/wizards/dashboard/components/site-statuses/index.tsx
@@ -18,8 +18,8 @@ const {
 const actions: Statuses = {
 	readerActivation: {
 		...siteStatuses.readerActivation,
-		then( { prerequisites_status }: { prerequisites_status: PrerequisitesStatus } ) {
-			return Object.values( prerequisites_status ).every( status => status.active );
+		then( { config: { enabled = false } }: { config: { enabled: boolean } } ) {
+			return enabled;
 		},
 	},
 	googleAnalytics: {

--- a/assets/wizards/dashboard/components/site-statuses/index.tsx
+++ b/assets/wizards/dashboard/components/site-statuses/index.tsx
@@ -1,0 +1,63 @@
+/**
+ * Newspack - Dashboard, Site Actions
+ */
+
+/**
+ * Dependencies
+ */
+// WordPress
+import { __ } from '@wordpress/i18n';
+// Internal
+import SiteStatus from './site-status';
+import { Grid } from '../../../../components/src';
+
+const {
+	newspack_dashboard: { siteStatuses },
+} = window;
+
+const actions: Actions = {
+	readerActivation: {
+		label: __( 'Reader Activation', 'newspack-plugin' ),
+		statusLabels: {
+			success: __( 'Enabled', 'newspack-plugin' ),
+			error: __( 'Disabled', 'newspack-plugin' ),
+		},
+		endpoint: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
+		dependencies: siteStatuses.readerActivation.dependencies,
+		then( { prerequisites_status }: { prerequisites_status: PrerequisitesStatus } ) {
+			return Object.values( prerequisites_status ).every( status => status.active );
+		},
+	},
+	googleAnalytics: {
+		label: __( 'Google Analytics', 'newspack-plugin' ),
+		endpoint: '/google-site-kit/v1/core/site/data/connection-check',
+		dependencies: siteStatuses.googleAnalytics.dependencies,
+		then( payload ) {
+			return payload === 'true';
+		},
+	},
+	googleAdManager: {
+		label: __( 'Google Ad Manager', 'newspack-plugin' ),
+		endpoint: '/newspack/v1/oauth/google',
+		canConnect: siteStatuses.googleAdManager.isAvailable,
+		dependencies: siteStatuses.googleAdManager.dependencies,
+		then( { user_basic_info } ) {
+			return Boolean( user_basic_info && user_basic_info.email );
+		},
+	},
+} as const;
+
+const SiteStatuses = () => {
+	return (
+		<div className="newspack-dashboard__section">
+			<h3>{ __( 'Site status', 'newspack-plugin' ) }</h3>
+			<Grid columns={ 3 } gutter={ 24 }>
+				{ Object.keys( actions ).map( id => {
+					return <SiteStatus key={ id } { ...actions[ id ] } />;
+				} ) }
+			</Grid>
+		</div>
+	);
+};
+
+export default SiteStatuses;

--- a/assets/wizards/dashboard/components/site-statuses/site-status-modal.tsx
+++ b/assets/wizards/dashboard/components/site-statuses/site-status-modal.tsx
@@ -1,0 +1,40 @@
+/**
+ * Newspack - Dashboard, Site Action Modal
+ *
+ * Modal component for installing necessary dependencies
+ */
+
+/**
+ * Dependencies
+ */
+// WordPress
+import { __ } from '@wordpress/i18n';
+import { PluginInstaller, Modal } from '../../../../components/src';
+
+const SiteActionModal = ( { onRequestClose, plugins, onSuccess }: SiteActionModal ) => {
+	return (
+		<Modal
+			title={ __( 'Add missing dependencies', 'newspack-plugin' ) }
+			onRequestClose={ () => onRequestClose( false ) }
+		>
+			<PluginInstaller
+				plugins={ plugins }
+				canUninstall
+				onStatus={ ( {
+					complete,
+					pluginInfo,
+				}: {
+					complete: boolean;
+					pluginInfo: Record< string, any >;
+				} ) => {
+					if ( complete ) {
+						onSuccess( pluginInfo );
+						onRequestClose( false );
+					}
+				} }
+			/>
+		</Modal>
+	);
+};
+
+export default SiteActionModal;

--- a/assets/wizards/dashboard/components/site-statuses/site-status.tsx
+++ b/assets/wizards/dashboard/components/site-statuses/site-status.tsx
@@ -1,0 +1,147 @@
+/**
+ * Newspack - Dashboard, Site Action
+ */
+
+/**
+ * Dependencies
+ */
+// WordPress
+import { __, _n, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect } from '@wordpress/element';
+import { Tooltip } from '@wordpress/components';
+// Internal
+import SiteActionModal from './site-status-modal';
+
+const defaultStatusLabels = {
+	idle: '',
+	success: __( 'Connected', 'newspack-plugin' ),
+	pending: __( 'Fetching…', 'newspack-plugin' ),
+	'pending-install': __( 'Installing…', 'newspack-plugin' ),
+	// Error types
+	error: __( 'Disconnected', 'newspack-plugin' ),
+};
+
+const SiteStatus = ( {
+	label = '',
+	canConnect = true,
+	dependencies: dependenciesProp = null,
+	statusLabels,
+	endpoint,
+	then,
+}: SiteStatus ) => {
+	const [ requestStatus, setRequestStatus ] = useState< Statuses >( 'idle' );
+	const [ failedDependencies, setFailedDependencies ] = useState< string[] >( [] );
+	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const parsedStatusLabels = { ...defaultStatusLabels, ...statusLabels };
+
+	const dependencies = structuredClone( dependenciesProp ) as Dependencies;
+
+	useEffect( () => {
+		makeRequest();
+	}, [] );
+
+	const makeRequest = ( pluginInfo = {} ) => {
+		// When/if a dependency is activated update reference.
+		if ( dependencies && Object.keys( pluginInfo ).length > 0 ) {
+			for ( const [ pluginName ] of Object.entries( pluginInfo ) ) {
+				dependencies[ pluginName ].isActive = true;
+			}
+		}
+		return new Promise( ( resolve, reject ) => {
+			// Dependency check
+			if ( dependencies && Object.keys( dependencies ).length > 0 ) {
+				const failedDeps: string[] = [];
+				for ( const [ dependencyName, dependencyInfo ] of Object.entries( dependencies ) ) {
+					// Don't process active
+					if ( dependencyInfo.isActive ) {
+						continue;
+					}
+					failedDeps.push( dependencyName );
+				}
+				setFailedDependencies( failedDeps );
+				if ( failedDeps.length > 0 ) {
+					setRequestStatus( 'error-dependency' );
+					resolve( false );
+					return;
+				}
+			}
+			// Preflight check
+			if ( ! canConnect ) {
+				setRequestStatus( 'error' );
+				resolve( false );
+				return;
+			}
+			// Pending API request
+			setRequestStatus( 'pending' );
+			apiFetch( {
+				path: endpoint,
+			} )
+				.then( data => {
+					const apiRequest = then( data );
+					setRequestStatus( apiRequest ? 'success' : 'error' );
+					resolve( apiRequest );
+				} )
+				.catch( () => {
+					then( false );
+					setRequestStatus( 'error' );
+					reject();
+				} );
+		} );
+	};
+
+	const classes = `newspack-site-status newspack-site-status__${ requestStatus }`;
+
+	const statusLabel =
+		dependencies && 'error-dependency' === requestStatus ? (
+			<Tooltip
+				text={ sprintf(
+					// translators: %s is a comma separated list of needed dependencies.
+					__( '%s must be installed & activated!' ),
+					failedDependencies.map( dep => dependencies[ dep ].label ).join( ', ' )
+				) }
+			>
+				<button
+					onClick={ () => setIsModalVisible( true ) }
+					className={ `${ classes } newspack-site-status__install` }
+				>
+					{ label }:{ ' ' }
+					<span>
+						{ _n(
+							'Missing dependency',
+							'Missing dependencies',
+							failedDependencies.length,
+							'newspack-plugin'
+						) }
+					</span>
+					<span className="hidden">
+						{ _n(
+							'Install dependency',
+							'Install dependencies',
+							failedDependencies.length,
+							'newspack-plugin'
+						) }
+					</span>
+				</button>
+			</Tooltip>
+		) : (
+			<div className={ classes }>
+				{ label }:<span> { parsedStatusLabels[ requestStatus ] }</span>
+			</div>
+		);
+
+	return (
+		<>
+			{ isModalVisible && (
+				<SiteActionModal
+					plugins={ failedDependencies }
+					onSuccess={ makeRequest }
+					onRequestClose={ setIsModalVisible }
+				/>
+			) }
+			{ statusLabel }
+		</>
+	);
+};
+
+export default SiteStatus;

--- a/assets/wizards/dashboard/components/site-statuses/site-status.tsx
+++ b/assets/wizards/dashboard/components/site-statuses/site-status.tsx
@@ -110,7 +110,7 @@ const SiteStatus = ( {
 				<Tooltip text={ __( 'Click to navigate to configuration', 'newspack-plugin' ) }>
 					<a href={ configLink } className={ classes }>
 						{ label }: <span>{ parsedStatusLabels[ requestStatus ] }</span>
-						<span className="hidden">{ __( 'Configure' ) }</span>
+						<span className="hidden">{ __( 'Configure?' ) }</span>
 					</a>
 				</Tooltip>
 			) }

--- a/assets/wizards/dashboard/index.tsx
+++ b/assets/wizards/dashboard/index.tsx
@@ -37,6 +37,7 @@ const Newspack = () => {
 					<>
 						<BrandHeader />
 						<SiteStatuses />
+						<hr />
 						<QuickActions />
 					</>
 				) }

--- a/assets/wizards/dashboard/index.tsx
+++ b/assets/wizards/dashboard/index.tsx
@@ -13,9 +13,9 @@ import { __ } from '@wordpress/i18n';
 import { render } from '@wordpress/element';
 // Internal
 import { GlobalNotices, Footer, Notice, Wizard } from '../../components/src';
-import './style.scss';
 import sections from './components/sections';
-import { Icon, icons } from './components/icons';
+import SiteStatuses from './components/site-statuses';
+import './style.scss';
 
 const {
 	newspack_aux_data: { is_debug_mode: isDebugMode = false },
@@ -31,16 +31,8 @@ const Newspack = () => {
 				sections={ sections }
 				renderAboveSections={ () => (
 					<>
-						{ /* For demo purposes */ }
-						{ Object.keys( icons ).map( icon => {
-							return (
-								icon in icons && (
-									<Icon key={ icon } size={ 32 } icon={ icons[ icon as keyof typeof icons ] } />
-								)
-							);
-						} ) }
 						<p>Brand Header</p>
-						<p>Site Actions</p>
+						<SiteStatuses />
 						<p>Quick Actions</p>
 					</>
 				) }

--- a/assets/wizards/dashboard/style.scss
+++ b/assets/wizards/dashboard/style.scss
@@ -4,6 +4,7 @@
 
 @use '~@wordpress/base-styles/colors' as wp-colors;
 @use '../../shared/scss/colors';
+@use './components/site-statuses/index';
 
 .newspack-dashboard-card {
 	align-items: center;

--- a/assets/wizards/dashboard/types/index.d.ts
+++ b/assets/wizards/dashboard/types/index.d.ts
@@ -4,9 +4,9 @@ declare global {
 	interface Window {
 		newspack_dashboard: {
 			siteStatuses: {
-				readerActivation: ActionLocal;
-				googleAnalytics: ActionLocal;
-				googleAdManager: ActionLocal & {
+				readerActivation: Status;
+				googleAnalytics: Status;
+				googleAdManager: Status & {
 					isAvailable: boolean;
 				};
 			};

--- a/assets/wizards/dashboard/types/index.d.ts
+++ b/assets/wizards/dashboard/types/index.d.ts
@@ -3,11 +3,18 @@ export {};
 declare global {
 	interface Window {
 		newspack_dashboard: {
+			siteStatuses: {
+				readerActivation: ActionLocal;
+				googleAnalytics: ActionLocal;
+				googleAdManager: ActionLocal & {
+					isAvailable: boolean;
+				};
+			};
 			sections: {
 				[ k: string ]: {
 					title: string;
 					desc: string;
-					cards: { href: string; title: string; desc: string; icon: string; }[];
+					cards: { href: string; title: string; desc: string; icon: string }[];
 				};
 			};
 		};

--- a/assets/wizards/dashboard/types/site-statuses.d.ts
+++ b/assets/wizards/dashboard/types/site-statuses.d.ts
@@ -28,11 +28,3 @@ type SiteActionModal = {
 	onSuccess: ( a: Record< string, any > ) => void;
 	plugins: string[];
 };
-
-type PrerequisitesStatus = {
-	prerequisite_status: {
-		[ k: string ]: {
-			active: boolean;
-		};
-	};
-};

--- a/assets/wizards/dashboard/types/site-statuses.d.ts
+++ b/assets/wizards/dashboard/types/site-statuses.d.ts
@@ -1,0 +1,43 @@
+type Dependencies = Record< string, { isActive: boolean; label: string } >;
+
+type Action = {
+	label: string;
+	statusLabels?: { pending?: string; error?: string; success?: string };
+	canConnect?: boolean;
+	endpoint: string;
+	dependencies?: Dependencies;
+	then: ( args: any ) => boolean;
+};
+
+type Actions = {
+	[ k: string ]: Action;
+};
+
+type ActionLocal = {
+	dependencies: Dependencies;
+};
+
+type SiteStatus = {
+	label: string;
+	canConnect?: boolean;
+	statusLabels?: { [ k in Statuses ]?: string };
+	endpoint: string;
+	dependencies?: Dependencies | null;
+	then: ( args?: any ) => boolean;
+};
+
+type SiteActionModal = {
+	onRequestClose: ( a: boolean ) => void;
+	onSuccess: ( a: Record< string, any > ) => void;
+	plugins: string[];
+};
+
+type PrerequisitesStatus = {
+	prerequisite_status: {
+		[ k: string ]: {
+			active: boolean;
+		};
+	};
+};
+
+type Statuses = 'success' | 'error' | 'error-dependency' | 'pending' | 'pending-install' | 'idle';

--- a/assets/wizards/dashboard/types/site-statuses.d.ts
+++ b/assets/wizards/dashboard/types/site-statuses.d.ts
@@ -1,29 +1,26 @@
 type Dependencies = Record< string, { isActive: boolean; label: string } >;
 
-type Action = {
+type StatusLabels =
+	| 'success'
+	| 'error'
+	| 'error-dependencies'
+	| 'error-preflight'
+	| 'pending'
+	| 'pending-install'
+	| 'idle';
+
+type Status = {
 	label: string;
-	statusLabels?: { pending?: string; error?: string; success?: string };
-	canConnect?: boolean;
+	statuses?: Partial<StatusLabels, string>;
+	isPreflightValid?: boolean;
+	configLink: string;
 	endpoint: string;
-	dependencies?: Dependencies;
+	dependencies?: Dependencies | null;
 	then: ( args: any ) => boolean;
 };
 
-type Actions = {
-	[ k: string ]: Action;
-};
-
-type ActionLocal = {
-	dependencies: Dependencies;
-};
-
-type SiteStatus = {
-	label: string;
-	canConnect?: boolean;
-	statusLabels?: { [ k in Statuses ]?: string };
-	endpoint: string;
-	dependencies?: Dependencies | null;
-	then: ( args?: any ) => boolean;
+type Statuses = {
+	[ k: string ]: Status;
 };
 
 type SiteActionModal = {
@@ -39,5 +36,3 @@ type PrerequisitesStatus = {
 		};
 	};
 };
-
-type Statuses = 'success' | 'error' | 'error-dependency' | 'pending' | 'pending-install' | 'idle';

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -304,12 +304,10 @@ class Dashboard extends Wizard {
 					'googleAdManager'  => [
 						'label'            => __( 'Google Ad Manager', 'newspack-plugin' ),
 						'statuses'         => [
-							'success'         => '',
-							'error'           => '',
 							'error-preflight' => __( 'Proxy Not Configured', 'newspack-plugin' ),
 						],
 						'endpoint'         => '/newspack/v1/oauth/google',
-						'isPreflightValid' => OAuth::is_proxy_configured( 'google' ),
+						'isPreflightValid' => ( new Newspack_Ads_Configuration_Manager() )->is_gam_connected(),
 						'configLink'       => admin_url( 'admin.php?page=newspack-advertising-wizard' ),
 						'dependencies'     => [
 							'newspack-ads' => [

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -277,13 +277,13 @@ class Dashboard extends Wizard {
 			'newspack-dashboard', 
 			'newspack_dashboard',
 			[
-				'settings'    => [
+				'settings'     => [
 					'logo'          => false === $logo ? [] : $logo,
 					'headerBgColor' => $theme_mods['header_color_hex'],
 				],
-				'sections'    => $this->get_dashboard(),
-				'plugins'     => get_plugins(),
-				'siteActions' => [
+				'sections'     => $this->get_dashboard(),
+				'plugins'      => get_plugins(),
+				'siteStatuses' => [
 					'readerActivation' => [
 						'dependencies' => [
 							'woocommerce' => [

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -271,8 +271,10 @@ class Dashboard extends Wizard {
 			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
+
 		$theme_mods = get_theme_mods();
 		$logo = wp_get_attachment_image_src( get_theme_mod( 'custom_logo' ), 'full' );
+		
 		wp_localize_script(
 			'newspack-dashboard', 
 			'newspack_dashboard',
@@ -285,6 +287,13 @@ class Dashboard extends Wizard {
 				'plugins'      => get_plugins(),
 				'siteStatuses' => [
 					'readerActivation' => [
+						'label'        => __( 'Reader Activation', 'newspack-plugin' ),
+						'statuses'     => [
+							'success' => __( 'Enabled', 'newspack-plugin' ),
+							'error'   => __( 'Disabled', 'newspack-plugin' ),
+						],
+						'endpoint'     => '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
+						'configLink'   => admin_url( 'admin.php?page=newspack-engagement-wizard#/reader-activation' ),
 						'dependencies' => [
 							'woocommerce' => [
 								'label'    => __( 'Woocommerce', 'newspack-plugin' ),
@@ -293,8 +302,16 @@ class Dashboard extends Wizard {
 						],
 					],
 					'googleAdManager'  => [
-						'isAvailable'  => OAuth::is_proxy_configured( 'google' ),
-						'dependencies' => [
+						'label'            => __( 'Google Ad Manager', 'newspack-plugin' ),
+						'statuses'         => [
+							'success'         => '',
+							'error'           => '',
+							'error-preflight' => __( 'Proxy Not Configured', 'newspack-plugin' ),
+						],
+						'endpoint'         => '/newspack/v1/oauth/google',
+						'isPreflightValid' => OAuth::is_proxy_configured( 'google' ),
+						'configLink'       => admin_url( 'admin.php?page=newspack-advertising-wizard' ),
+						'dependencies'     => [
 							'newspack-ads' => [
 								'label'    => __( 'Newspack Ads', 'newspack-plugin' ),
 								'isActive' => is_plugin_active( 'newspack-ads/newspack-ads.php' ),
@@ -302,6 +319,9 @@ class Dashboard extends Wizard {
 						],
 					],
 					'googleAnalytics'  => [
+						'label'        => __( 'Google Analytics', 'newspack-plugin' ),
+						'endpoint'     => '/google-site-kit/v1/core/site/data/connection-check',
+						'configLink'   => admin_url( 'admin.php?page=googlesitekit-splash' ),
 						'dependencies' => [
 							'google-site-kit' => [
 								'label'    => __( 'Google Site Kit', 'newspack-plugin' ),

--- a/includes/wizards/class-dashboard.php
+++ b/includes/wizards/class-dashboard.php
@@ -306,7 +306,7 @@ class Dashboard extends Wizard {
 						'statuses'         => [
 							'error-preflight' => __( 'Proxy Not Configured', 'newspack-plugin' ),
 						],
-						'endpoint'         => '/newspack/v1/oauth/google',
+						'endpoint'         => '/newspack/v1/wizard/billboard',
 						'isPreflightValid' => ( new Newspack_Ads_Configuration_Manager() )->is_gam_connected(),
 						'configLink'       => admin_url( 'admin.php?page=newspack-advertising-wizard' ),
 						'dependencies'     => [
@@ -318,8 +318,8 @@ class Dashboard extends Wizard {
 					],
 					'googleAnalytics'  => [
 						'label'        => __( 'Google Analytics', 'newspack-plugin' ),
-						'endpoint'     => '/google-site-kit/v1/core/site/data/connection-check',
-						'configLink'   => admin_url( 'admin.php?page=googlesitekit-splash' ),
+						'endpoint'     => '/google-site-kit/v1/modules/analytics-4/data/settings',
+						'configLink'   => in_array( 'analytics', get_option( 'googlesitekit_active_modules', [] ) ) ? admin_url( 'admin.php?page=googlesitekit-settings#/connected-services/analytics-4' ) : admin_url( 'admin.php?page=googlesitekit-splash' ),
 						'dependencies' => [
 							'google-site-kit' => [
 								'label'    => __( 'Google Site Kit', 'newspack-plugin' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds site status component. View `then` properties for determining _successful_ status.

https://github.com/Automattic/newspack-plugin/blob/4503fce97886a1e94289ef85e6321edfa30bd1d8/assets/wizards/dashboard/components/site-statuses/index.tsx#L18-L48

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets i.e. `git checkout feat/ia-dash-sitestatus && npm run build`
2. Navigate to - /wp-admin/admin.php?page=newspack#/
3. Observe you see a variation (depending on how your site is setup) of the below.

![Screenshot 2024-03-28 at 14 36 53](https://github.com/Automattic/newspack-plugin/assets/3676975/2d8a2626-eb9d-4688-962c-fca653d44d85)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?