### PR TITLE
fix(sitekit): use updated analytics 4 module

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -8,6 +8,7 @@
 namespace Newspack;
 
 use Google\Site_Kit\Context;
+use Google\Site_Kit\Modules\Analytics_4\Settings;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -91,8 +92,8 @@ class GoogleSiteKit {
 	 * Get the name of the option under which Site Kit's GA4 settings are stored.
 	 */
 	private static function get_sitekit_ga4_settings_option_name() {
-		if ( class_exists( '\Google\Site_Kit\Modules\Analytics_4\Settings' ) ) {
-			return \Google\Site_Kit\Modules\Analytics_4\Settings::OPTION;
+		if ( class_exists( 'Google\Site_Kit\Modules\Analytics_4\Settings' ) ) {
+			return Settings::OPTION;
 		}
 		return false;
 	}
@@ -133,10 +134,11 @@ class GoogleSiteKit {
 			return;
 		}
 
-		$sitekit_ga_settings = get_option( \Google\Site_Kit\Modules\Analytics\Settings::OPTION, false );
+		$sitekit_ga_settings = get_option( Settings::OPTION, false );
 		if ( false === $sitekit_ga_settings || ! isset( $sitekit_ga_settings['accountID'] ) ) {
 			return;
 		}
+
 		$account_id = $sitekit_ga_settings['accountID'];
 
 		try {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://a8c.slack.com/archives/C01C378QWRX/p1711414340087199.

Looks like Site Kit has deprecated the Analytics module in favor of the Analytics_4 module in their latest release. This PR fixes a fatal in which our setup was relying on this old method.

```
[28-Mar-2024 21:31:40 UTC] PHP Fatal error:  Uncaught Error: Class "Google\Site_Kit\Modules\Analytics\Settings" not found in /Users/raz/Sites/newspack/plugin/includes/plugins/google-site-kit/class-googlesitekit.php:136
Stack trace:
#0 /Users/raz/Sites/newspack/site/wp-includes/class-wp-hook.php(324): Newspack\GoogleSiteKit::setup_sitekit_ga4('')
#1 /Users/raz/Sites/newspack/site/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#2 /Users/raz/Sites/newspack/site/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#3 /Users/raz/Sites/newspack/site/wp-admin/admin.php(175): do_action('admin_init')
#4 /Users/raz/.composer/vendor/laravel/valet/server.php(110): require('/Users/raz/Site...')
#5 {main}
  thrown in /Users/raz/Sites/newspack/plugin/includes/plugins/google-site-kit/class-googlesitekit.php on line 136
```

### How to test the changes in this Pull Request:

1. Ensure you have a test site not connected to Site Kit. You can reset your site kit connection via Site Kit > Settings > Admin Settings
2. Enable logging and monitor
3. Connect to site kit, ensuring you check the `Connect Google Analytics as part of your setup` box in the process
4. On release you will see a fatal related to a missing Site Kit class. On this branch you should not

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->