### PR TITLE
fix: prevent autocompletetokenfield input reset on multiple inputs

### DIFF
--- a/assets/components/src/autocomplete-tokenfield/index.js
+++ b/assets/components/src/autocomplete-tokenfield/index.js
@@ -158,16 +158,16 @@ class AutocompleteTokenField extends Component {
 						return;
 					}
 
+					const { validValues } = this.state;
 					const currentSuggestions = [ ...suggestions ];
-					const currentValidValues = {};
 
 					suggestions.forEach( suggestion => {
-						currentValidValues[ suggestion.value ] = suggestion.label;
+						validValues[ suggestion.value ] = suggestion.label;
 					} );
 
 					this.setState( {
 						suggestions: currentSuggestions,
-						validValues: currentValidValues,
+						validValues,
 						loading: false,
 					} );
 				} )


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1200550061930446/1206954289829309/f

This PR fixes an issue where the autocompletetokenfield component would always clear the first input whenever a second input was entered. 

![Screenshot 2024-03-29 at 10 59 01](https://github.com/Automattic/newspack-plugin/assets/17905991/66b0003c-883a-4084-bd38-10ec5196d27b)


### How to test the changes in this Pull Request:

This one is a bit tricky to test since it requires pointing the `newspack-components` npm package in another newspack repo to your local instance of the newspack plugin components directory. Here's how to do that.

1. We will be testing with Newsletters, so in your local newsletters `package.json`, look for the `newspack-components` dependency
2. Update the dependency value to `file:../RELATIVE/PATH/TO/LOCAL/COMPONENTS`:
![Screenshot 2024-03-29 at 11 02 00](https://github.com/Automattic/newspack-plugin/assets/17905991/23376ddf-46d1-4a01-b7e2-195ddb9632ff)
3. In the `newspack-plugin` repo, make sure these changes are pulled and you've run `npm install && npm run build`
4. Navigate to the `assets/components/` directory and run `npm run prepublishOnly`
5. Back in the newsletter plugin, run `npm install && npm run build`

**Testing changes:**

1. Create a new Newsletter
2. Add a Post Inserter Block
3. In block settings, click the `Show Advanced Filters` link
4. In the Exclude category field, enter any category and select
5. In the same field, enter a second category. BEFORE selecting wait for the field to finish loading suggestions, then select the second category from the dropdown
6. On `trunk` the first category you input should disappear and be replaced by the second. On this branch the first and second categories should be present as expected

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->