### PR TITLE
fix(reader-reg-block): respect newsletter subscription checkbox state

### DIFF
--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -117,7 +117,7 @@ export default function ReaderRegistrationEdit( {
 	};
 
 	const isListSelected = listId => {
-		return ! listsCheckboxes.hasOwnProperty( listId ) || listsCheckboxes[ listId ];
+		return listsCheckboxes.hasOwnProperty( listId ) && listsCheckboxes[ listId ];
 	};
 	const toggleListCheckbox = listId => () => {
 		const newListsCheckboxes = { ...listsCheckboxes };


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1200550061930446/1206911937712363/f

Fixes an issue where the reader registration block was not respecting the newsletter subscription checkbox state:

![Screenshot 2024-03-29 at 11 29 53](https://github.com/Automattic/newspack-plugin/assets/17905991/e0e230d5-e8f1-4532-9adc-ec3dd5653f86)

### How to test the changes in this Pull Request:

1. Add the reader registration block to any page.
2. Ensure the `Subscribe to our newsletter` checkbox is checked in the editor
3. Update/Publish the page
4. Visit the page while logged in as a reader
5. On `trunk` the checkbox will not be checked by default. On this branch it will

![Screenshot 2024-03-29 at 11 32 03](https://github.com/Automattic/newspack-plugin/assets/17905991/b7eff99e-4bdd-49a5-9049-6ccdb4315726)


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->