### PR TITLE
fix: add filters for Data Events reader_registered handlers

### DIFF
--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -81,7 +81,16 @@ class ActiveCampaign {
 		if ( isset( $data['metadata']['registration_method'] ) ) {
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_method' ) ] = $data['metadata']['registration_method'];
 		}
-		$contact = [
+		/**
+		 * Filters the contact metadata sent to the ESP when a reader account is registered for the first time.
+		 *
+		 * @param array $metadata The contact metadata.
+		 * @param int   $user_id The ID of the user.
+		 *
+		 * @return array The modified contact metadata.
+		 */
+		$metadata = \apply_filters( 'newspack_data_events_reader_registered_metadata', $metadata, $data['user_id'] );
+		$contact  = [
 			'email'    => $data['email'],
 			'metadata' => $metadata,
 		];

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -252,7 +252,17 @@ class Mailchimp {
 		if ( isset( $data['metadata']['registration_method'] ) ) {
 			$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_method' ) ] = $data['metadata']['registration_method'];
 		}
-		$contact = [
+
+		/**
+		 * Filters the contact metadata sent to the ESP when a reader account is registered for the first time.
+		 *
+		 * @param array $metadata The contact metadata.
+		 * @param int   $user_id The ID of the user.
+		 *
+		 * @return array The modified contact metadata.
+		 */
+		$metadata = \apply_filters( 'newspack_data_events_reader_registered_metadata', $metadata, $data['user_id'] );
+		$contact  = [
 			'email'    => $data['email'],
 			'metadata' => $metadata,
 		];


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For https://github.com/Automattic/newspack-network/pull/87. Adds a new `newspack_data_events_reader_registered_metadata` filter to Data Events connectors which allow the custom `Network Registration Site` meta field to be added to contact metadata in all registration scenarios. Previously, registrations via Mailchimp that did not involve signing up for any newsletter lists were not adding the custom field.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-network/pull/87

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->