### PR TITLE
feat: support for MC tags as subscription lists

### DIFF
--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -348,8 +348,8 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 							toggleOnChange={ handleChange( index, 'active' ) }
 							toggleChecked={ list.active }
 							className={
-								list?.id && list.id.startsWith( 'group' )
-									? 'newspack-newsletters-group-list-item'
+								list?.id && ( list.id.startsWith( 'group' ) || list.id.startsWith( 'tag' ) )
+									? 'newspack-newsletters-sub-list-item'
 									: ''
 							}
 							actionText={

--- a/assets/wizards/engagement/views/newsletters/style.scss
+++ b/assets/wizards/engagement/views/newsletters/style.scss
@@ -1,3 +1,3 @@
-.newspack-newsletters-group-list-item {
+.newspack-newsletters-sub-list-item {
 	margin-left: 40px !important;
 }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1556,6 +1556,10 @@ final class Reader_Activation {
 			return null;
 		}
 
+		if ( defined( 'NEWSPACK_ALLOW_MY_ACCOUNT_ACCESS_WITHOUT_VERIFICATION' ) && NEWSPACK_ALLOW_MY_ACCOUNT_ACCESS_WITHOUT_VERIFICATION ) {
+			return true;
+		}
+
 		return (bool) \get_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Related to https://github.com/Automattic/newspack-newsletters/pull/1471. Just some style tweaks to ensure that Tag-based subscription lists get indented to show they're sublists of their parent audience, just like Groups.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-newsletters/pull/1471 for testing instructions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->