### PR TITLE
Update UI components

### DIFF
--- a/assets/newspack-ui/scss/_mixins.scss
+++ b/assets/newspack-ui/scss/_mixins.scss
@@ -1,0 +1,9 @@
+@mixin newspack-ui-elevation($size: 1) {
+    @if $size == 1 {
+        box-shadow: 0 1px 10px rgba( 0, 0, 0, 0.07 );
+    } @else if $size == 2 {
+        box-shadow: 0 2px 20px rgba( 0, 0, 0, 0.14 );
+    }  @else if $size == 3 {
+        box-shadow: 0 3px 30px rgba( 0, 0, 0, 0.21 );
+    }
+}

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -108,8 +108,8 @@
 	}
 	&__modal {
 		// CSS Variables - update button background, with fallbacks to the Newspack UI defaults
-		--newspack-ui-color-button-bg: var( --newspack-ui-color-primary, var( --newspack-ui-color-gray-900 ) );
-		--newspack-ui-color-button-text: var( --newspack-ui-color-against-primary, var( --newspack-ui-color-white ) );
+		--newspack-ui-color-button-bg: var( --newspack-ui-color-primary, var( --newspack-ui-color-neutral-90 ) );
+		--newspack-ui-color-button-text: var( --newspack-ui-color-against-primary, var( --newspack-ui-color-neutral-0 ) );
 
 		// Modal styles
 		background: var( --newspack-ui-color-body-bg );
@@ -135,6 +135,7 @@
 			border-bottom: 1px solid var( --newspack-ui-color-border );
 
 			h2 {
+				font-family: var( --newspack-ui-font-family );
 				font-size: var( --newspack-ui-font-size-medium );
 				margin: 0;
 			}
@@ -144,13 +145,13 @@
 			margin: -2px -5px 0 0; // Offsets a padding in the SVG.
 			padding: 0 0 0 8px;
 			background: transparent;
-			color: var( --newspack-ui-color-text-high-contrast );
+			color: var( --newspack-ui-color-neutral-90 );
 			cursor: pointer;
 
 			&:focus,
 			&:hover {
 				background: transparent;
-				color: var( --newspack-ui-color-text-med-contrast );
+				color: var( --newspack-ui-color-neutral-70 );
 			}
 			svg {
 				display: block;
@@ -165,8 +166,8 @@
 		}
 
 		&__footer {
-			background: var( --newspack-ui-color-gray-100 );
-			color: var( --newspack-ui-color-text-med-contrast );
+			background: var( --newspack-ui-color-neutral-5 );
+			color: var( --newspack-ui-color-neutral-60 );
 			font-size: var( --newspack-ui-font-size-extra-small );
 			line-height: var( --newspack-ui-line-height-small );
 			a {

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -126,16 +126,18 @@
 		}
 
 		&__header {
-			display: flex;
-			position: sticky;
 			align-items: center;
-			justify-content: space-between;
 			background: var( --newspack-ui-color-body-bg );
 			border-bottom: 1px solid var( --newspack-ui-color-border );
+			display: flex;
+			justify-content: space-between;
+			position: sticky;
+			top: 0;		
 
 			h2 {
 				font-family: var( --newspack-ui-font-family );
 				font-size: var( --newspack-ui-font-size-s );
+				line-height: var( --newspack-ui-line-height-s );
 				margin: 0;
 			}
 		}

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -87,7 +87,7 @@
 						bdi {
 							display: block;
 							font-weight: 600;
-							font-size: 32px; // TODO: create & replace w/ a variable.
+							font-size: var( --newspack-ui-font-size-xl );
 						}
 					}
 					.variation {

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -132,7 +132,7 @@
 			display: flex;
 			justify-content: space-between;
 			position: sticky;
-			top: 0;		
+			top: 0;
 
 			h2 {
 				font-family: var( --newspack-ui-font-family );
@@ -143,20 +143,7 @@
 		}
 
 		&__close {
-			margin: -2px -5px 0 0; // Offsets a padding in the SVG.
-			padding: 0 0 0 var( --newspack-ui-spacer-base );
-			background: transparent;
-			color: var( --newspack-ui-color-neutral-90 );
-			cursor: pointer;
-
-			&:focus,
-			&:hover {
-				background: transparent;
-				color: var( --newspack-ui-color-neutral-70 );
-			}
-			svg {
-				display: block;
-			}
+			margin: -6px -6px -6px 0; // Accounts for the header padding. TODO: Can this be improved to work w/variables?
 		}
 
 		&__content {

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -47,7 +47,7 @@
 				&__content {
 					padding: var( --newspack-ui-spacer-5 );
 					overflow: auto;
-					border-radius: var( --newspack-ui-border-radius-s );
+					border-radius: var( --newspack-ui-border-radius-m );
 					h3 {
 						font-size: var( --newspack-ui-font-size-s );
 						margin: 0;
@@ -166,7 +166,7 @@
 			background: var( --newspack-ui-color-neutral-5 );
 			color: var( --newspack-ui-color-neutral-60 );
 			font-size: var( --newspack-ui-font-size-xs );
-			line-height: var( --newspack-ui-line-height-s );
+			line-height: var( --newspack-ui-line-height-xs );
 			a {
 				text-decoration: underline;
 			}

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -110,10 +110,6 @@
 		}
 	}
 	&__modal {
-		// CSS Variables - update button background, with fallbacks to the Newspack UI defaults
-		--newspack-ui-color-button-bg: var( --newspack-ui-color-primary, var( --newspack-ui-color-neutral-90 ) );
-		--newspack-ui-color-button-text: var( --newspack-ui-color-against-primary, var( --newspack-ui-color-neutral-0 ) );
-
 		// Modal styles
 		background: var( --newspack-ui-color-body-bg );
 		border-radius: var( --newspack-ui-border-radius-m );

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -44,7 +44,7 @@
 				&__content {
 					padding: 24px;
 					overflow: auto;
-					border-radius: 5px;
+					border-radius: var( --newspack-ui-border-radius-small );
 					h3 {
 						font-size: 16px;
 						margin: 0;
@@ -113,7 +113,7 @@
 
 		// Modal styles
 		background: var( --newspack-ui-color-body-bg );
-		border-radius: var( --newspack-ui-border-radius );
+		border-radius: var( --newspack-ui-border-radius-medium );
 		display: flex;
 		flex-direction: column;
 		max-height: 90vh;
@@ -168,7 +168,7 @@
 		&__footer {
 			background: var( --newspack-ui-color-neutral-5 );
 			color: var( --newspack-ui-color-neutral-60 );
-			font-size: var( --newspack-ui-font-size-extra-small );
+			font-size: var( --newspack-ui-font-size-small );
 			line-height: var( --newspack-ui-line-height-small );
 			a {
 				text-decoration: underline;

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -1,3 +1,5 @@
+@use 'mixins';
+
 .newspack-ui {
 	&__modal-container {
 		position: fixed;
@@ -14,8 +16,8 @@
 			z-index: 1;
 			inset: 0;
 			opacity: 0;
-			background: rgba( 0, 0, 0, 0.5 );
-			transition: opacity 0.1s linear;
+			background: rgba( 0, 0, 0, 0.7 );
+			transition: opacity 0.125s linear;
 		}
 		.newspack-ui__modal {
 			position: relative;
@@ -23,7 +25,8 @@
 			width: 100%;
 			transform: translateY( 50px );
 			opacity: 0;
-			transition: transform 0.1s linear, opacity 0.1s linear;
+			transition: transform 0.125s linear, opacity 0.125s linear;
+			@include mixins.newspack-ui-elevation(3);
 		}
 		&[data-state='open'] {
 			z-index: 99999;

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -47,13 +47,13 @@
 				&__content {
 					padding: var( --newspack-ui-spacer-5 );
 					overflow: auto;
-					border-radius: var( --newspack-ui-border-radius-small );
+					border-radius: var( --newspack-ui-border-radius-s );
 					h3 {
-						font-size: var( --newspack-ui-font-size-medium );
+						font-size: var( --newspack-ui-font-size-s );
 						margin: 0;
 					}
 					p {
-						font-size: 0.8em;
+						font-size: var( --newspack-ui-font-size-xs );
 					}
 				}
 			}
@@ -68,7 +68,7 @@
 
 				&__item {
 					border: 1px solid var(--newspack-ui-color-border );
-					border-radius: var( --newspack-ui-border-radius-medium );
+					border-radius: var( --newspack-ui-border-radius-m );
 					text-align: center;
 					flex: 1 1 100%;
 					@media ( min-width: 600px ) {
@@ -81,7 +81,7 @@
 						}
 					}
 					.summary {
-						font-size: var( --newspack-ui-font-size-small );
+						font-size: var( --newspack-ui-font-size-xs );
 						padding: var( --newspack-ui-spacer-2 );
 						border-bottom: 1px solid var( --newspack-ui-color-border );
 						bdi {
@@ -92,17 +92,17 @@
 					}
 					.variation {
 						padding: var( --newspack-ui-spacer-2 );
-						font-size: var( --newspack-ui-font-size-small );
+						font-size: var( --newspack-ui-font-size-xs );
 						line-height: 1.5;
 						border-bottom: 1px solid var(--newspack-ui-color-border );
 						font-weight: 600;
 					}
 					form {
-						padding: var( --newspack-ui-spacer-2 );
+						padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-2 ) 0;
 						button {
 							display: block;
 							width: 100%;
-							font-size: var( --newspack-ui-font-size-small );
+							font-size: var( --newspack-ui-font-size-xs );
 						}
 					}
 				}
@@ -116,11 +116,11 @@
 
 		// Modal styles
 		background: var( --newspack-ui-color-body-bg );
-		border-radius: var( --newspack-ui-border-radius-medium );
+		border-radius: var( --newspack-ui-border-radius-m );
 		display: flex;
 		flex-direction: column;
 		max-height: 90vh;
-		max-width: var( --newspack-ui-modal-width-medium );
+		max-width: var( --newspack-ui-modal-width-m );
 		overflow: auto;
 
 		// Modal header & footer
@@ -132,14 +132,14 @@
 		&__header {
 			display: flex;
 			position: sticky;
-			align-items: flex-start;
+			align-items: center;
 			justify-content: space-between;
 			background: var( --newspack-ui-color-body-bg );
 			border-bottom: 1px solid var( --newspack-ui-color-border );
 
 			h2 {
 				font-family: var( --newspack-ui-font-family );
-				font-size: var( --newspack-ui-font-size-medium );
+				font-size: var( --newspack-ui-font-size-s );
 				margin: 0;
 			}
 		}
@@ -162,8 +162,6 @@
 		}
 
 		&__content {
-			--newspack-ui-font-size-base: var( --newspack-ui-font-size-small );
-
 			backface-visibility: visible;
 			padding: var( --newspack-ui-spacer-5 );
 		}
@@ -171,8 +169,8 @@
 		&__footer {
 			background: var( --newspack-ui-color-neutral-5 );
 			color: var( --newspack-ui-color-neutral-60 );
-			font-size: var( --newspack-ui-font-size-small );
-			line-height: var( --newspack-ui-line-height-small );
+			font-size: var( --newspack-ui-font-size-xs );
+			line-height: var( --newspack-ui-line-height-s );
 			a {
 				text-decoration: underline;
 			}
@@ -180,12 +178,12 @@
 
 		// Narrow modal
 		&--small {
-			max-width: var( --newspack-ui-modal-width-small );
+			max-width: var( --newspack-ui-modal-width-s );
 		}
 
 		// Contents
 		h3 {
-			font-size: var( --newspack-ui-font-size-medium );
+			font-size: var( --newspack-ui-font-size-s );
 		}
 
 		&__footer,

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -42,11 +42,11 @@
 		.newspack-ui {
 			&__modal {
 				&__content {
-					padding: 24px;
+					padding: var( --newspack-ui-spacer-5 );
 					overflow: auto;
 					border-radius: var( --newspack-ui-border-radius-small );
 					h3 {
-						font-size: 16px;
+						font-size: var( --newspack-ui-font-size-medium );
 						margin: 0;
 					}
 					p {
@@ -59,13 +59,13 @@
 				list-style: none;
 				display: flex;
 				flex-wrap: wrap;
-				gap: 16px;
+				gap: var( --newspack-ui-spacer-3 );
 				margin: 0;
 				padding: 0;
 
 				&__item {
-					border: 1px solid #ddd;
-					border-radius: 6px;
+					border: 1px solid var(--newspack-ui-color-border );
+					border-radius: var( --newspack-ui-border-radius-medium );
 					text-align: center;
 					flex: 1 1 100%;
 					@media ( min-width: 600px ) {
@@ -78,28 +78,28 @@
 						}
 					}
 					.summary {
-						font-size: 14px;
-						padding: 12px;
-						border-bottom: 1px solid #ddd;
+						font-size: var( --newspack-ui-font-size-small );
+						padding: var( --newspack-ui-spacer-2 );
+						border-bottom: 1px solid var( --newspack-ui-color-border );
 						bdi {
 							display: block;
 							font-weight: 600;
-							font-size: 32px;
+							font-size: 32px; // TODO: create & replace w/ a variable.
 						}
 					}
 					.variation {
-						padding: 12px;
-						font-size: 14px;
+						padding: var( --newspack-ui-spacer-2 );
+						font-size: var( --newspack-ui-font-size-small );
 						line-height: 1.5;
-						border-bottom: 1px solid #ddd;
+						border-bottom: 1px solid var(--newspack-ui-color-border );
 						font-weight: 600;
 					}
 					form {
-						padding: 12px;
+						padding: var( --newspack-ui-spacer-2 );
 						button {
 							display: block;
 							width: 100%;
-							font-size: 14px;
+							font-size: var( --newspack-ui-font-size-small );
 						}
 					}
 				}
@@ -143,7 +143,7 @@
 
 		&__close {
 			margin: -2px -5px 0 0; // Offsets a padding in the SVG.
-			padding: 0 0 0 8px;
+			padding: 0 0 0 var( --newspack-ui-spacer-base );
 			background: transparent;
 			color: var( --newspack-ui-color-neutral-90 );
 			cursor: pointer;

--- a/assets/newspack-ui/scss/elements/_boxes.scss
+++ b/assets/newspack-ui/scss/elements/_boxes.scss
@@ -2,7 +2,7 @@
 	.newspack-ui {
 		&__box {
 			background: var( --newspack-ui-color-neutral-5 );
-			border-radius: var( --newspack-ui-border-radius );
+			border-radius: var( --newspack-ui-border-radius-medium );
 			margin-bottom: var( --newspack-ui-spacer-5 );
 			padding: var( --newspack-ui-spacer-5 );
 

--- a/assets/newspack-ui/scss/elements/_boxes.scss
+++ b/assets/newspack-ui/scss/elements/_boxes.scss
@@ -2,7 +2,7 @@
 	.newspack-ui {
 		&__box {
 			background: var( --newspack-ui-color-neutral-5 );
-			border-radius: var( --newspack-ui-border-radius-medium );
+			border-radius: var( --newspack-ui-border-radius-m );
 			margin-bottom: var( --newspack-ui-spacer-5 );
 			padding: var( --newspack-ui-spacer-5 );
 

--- a/assets/newspack-ui/scss/elements/_boxes.scss
+++ b/assets/newspack-ui/scss/elements/_boxes.scss
@@ -16,7 +16,7 @@
 			}
 
 			&--warning {
-				// TODO
+				background: var( --newspack-ui-color-warning-0 );
 			}
 
 			&--border {

--- a/assets/newspack-ui/scss/elements/_boxes.scss
+++ b/assets/newspack-ui/scss/elements/_boxes.scss
@@ -1,18 +1,18 @@
 .newspack-ui {
 	.newspack-ui {
 		&__box {
-			background: var( --newspack-ui-color-gray-100 );
+			background: var( --newspack-ui-color-neutral-5 );
 			border-radius: var( --newspack-ui-border-radius );
 			margin-bottom: var( --newspack-ui-spacer-5 );
 			padding: var( --newspack-ui-spacer-5 );
 
 			// Backgrounds & Borders
 			&--success {
-				background: var( --newspack-ui-color-alert-green-bg );
+				background: var( --newspack-ui-color-success-0 );
 			}
 
 			&--error {
-				background: var( --newspack-ui-color-alert-red-bg );
+				background: var( --newspack-ui-color-error-0 );
 			}
 
 			&--warning {

--- a/assets/newspack-ui/scss/elements/_icons.scss
+++ b/assets/newspack-ui/scss/elements/_icons.scss
@@ -10,17 +10,17 @@
 		width: var( --newspack-ui-spacer-7 );
 
 		&--success {
-			background: var( --newspack-ui-color-alert-green );
+			background: var( --newspack-ui-color-success-50 );
 			color: var( --newspack-ui-color-body-bg );
 		}
 
 		&--error {
-			background: var( --newspack-ui-color-alert-red );
+			background: var( --newspack-ui-color-error-50 );
 			color: var( --newspack-ui-color-body-bg );
 		}
 
 		&--warning {
-			background: var( --newspack-ui-color-alert-yellow );
+			background: var( --newspack-ui-color-warning-30 );
 			color: var( --newspack-ui-color-body-bg );
 		}
 	}

--- a/assets/newspack-ui/scss/elements/_icons.scss
+++ b/assets/newspack-ui/scss/elements/_icons.scss
@@ -4,10 +4,10 @@
 		align-items: center;
 		border-radius: 100%;
 		display: flex;
-		height: var( --newspack-ui-spacer-7 );
+		height: var( --newspack-ui-spacer-8 );
 		justify-content: center;
 		margin: 0 auto var( --newspack-ui-spacer-2 );
-		width: var( --newspack-ui-spacer-7 );
+		width: var( --newspack-ui-spacer-8 );
 
 		&--success {
 			background: var( --newspack-ui-color-success-50 );

--- a/assets/newspack-ui/scss/elements/_tables.scss
+++ b/assets/newspack-ui/scss/elements/_tables.scss
@@ -4,6 +4,7 @@
 		font-size: var( --newspack-ui-font-size-xs ); // Prevent relative font size
 		line-height: var( --newspack-ui-line-height-xs );
 		margin: calc( var( --newspack-ui-spacer-base ) / -2 ) 0; // Offset cell padding.
+		table-layout: fixed;
 		th,
 		td {
 			background: transparent;

--- a/assets/newspack-ui/scss/elements/_tables.scss
+++ b/assets/newspack-ui/scss/elements/_tables.scss
@@ -2,7 +2,7 @@
 	table {
 		border: 0;
 		font-size: var( --newspack-ui-font-size-xs ); // Prevent relative font size
-		line-height: var( --newspack-ui-line-height-l );
+		line-height: var( --newspack-ui-line-height-xs );
 		margin: calc( var( --newspack-ui-spacer-base ) / -2 ) 0; // Offset cell padding.
 		th,
 		td {

--- a/assets/newspack-ui/scss/elements/_tables.scss
+++ b/assets/newspack-ui/scss/elements/_tables.scss
@@ -1,15 +1,15 @@
 .newspack-ui {
 	table {
 		border: 0;
-		font-size: var( --newspack-ui-font-size-small ); // Prevent relative font size
-		line-height: var( --newspack-ui-line-height-large );
+		font-size: var( --newspack-ui-font-size-xs ); // Prevent relative font size
+		line-height: var( --newspack-ui-line-height-l );
 		margin: calc( var( --newspack-ui-spacer-base ) / -2 ) 0; // Offset cell padding.
 		th,
 		td {
 			background: transparent;
 			border-color: var( --newspack-ui-color-border );
 			border-width: 0 0 1px;
-			font-size: var( --newspack-ui-font-size-small ); // Prevent relative font size
+			font-size: var( --newspack-ui-font-size-xs ); // Prevent relative font size
 			padding: calc( var( --newspack-ui-spacer-base ) / 2 ) 0;
 			vertical-align: top;
 			> * {

--- a/assets/newspack-ui/scss/elements/_typography.scss
+++ b/assets/newspack-ui/scss/elements/_typography.scss
@@ -22,31 +22,56 @@
 
 	&__font--2xs {
 		font-size: var( --newspack-ui-font-size-2xs );
-		line-height: 1.3333;
+		line-height: var( --newspack-ui-line-height-2xs );
 	}
 
 	&__font--xs {
 		font-size: var( --newspack-ui-font-size-xs );
-		line-height: 1.4286;
+		line-height: var( --newspack-ui-line-height-xs );
 	}
 
 	&__font--s {
 		font-size: var( --newspack-ui-font-size-s );
-		line-height: 1.5;
+		line-height: var( --newspack-ui-line-height-s );
 	}
 
 	&__font--m {
 		font-size: var( --newspack-ui-font-size-m );
-		line-height: 1.6;
+		line-height: var( --newspack-ui-line-height-m );
 	}
 
 	&__font--l {
 		font-size: var( --newspack-ui-font-size-l );
-		line-height: 1.5;
+		line-height: var( --newspack-ui-line-height-l );
 	}
 
 	&__font--xl {
 		font-size: var( --newspack-ui-font-size-xl );
-		line-height: 1.375;
+		line-height: var( --newspack-ui-line-height-xl );
+	}
+
+	&__font--2xl {
+		font-size: var( --newspack-ui-font-size-2xl );
+		line-height: var( --newspack-ui-line-height-2xl );
+	}
+
+	&__font--3xl {
+		font-size: var( --newspack-ui-font-size-3xl );
+		line-height: var( --newspack-ui-line-height-3xl );
+	}
+
+	&__font--4xl {
+		font-size: var( --newspack-ui-font-size-4xl );
+		line-height: var( --newspack-ui-line-height-4xl );
+	}
+
+	&__font--5xl {
+		font-size: var( --newspack-ui-font-size-5xl );
+		line-height: var( --newspack-ui-line-height-5xl );
+	}
+
+	&__font--6xl {
+		font-size: var( --newspack-ui-font-size-6xl );
+		line-height: var( --newspack-ui-line-height-6xl );
 	}
 }

--- a/assets/newspack-ui/scss/elements/_typography.scss
+++ b/assets/newspack-ui/scss/elements/_typography.scss
@@ -1,6 +1,7 @@
 .newspack-ui {
 	font-family: var( --newspack-ui-font-family );
 	font-size: var( --newspack-ui-font-size-s );
+	line-height: var( --newspack-ui-line-height-s );
 	-webkit-font-smoothing: antialiased;
 
 	p {

--- a/assets/newspack-ui/scss/elements/_typography.scss
+++ b/assets/newspack-ui/scss/elements/_typography.scss
@@ -1,20 +1,52 @@
 .newspack-ui {
+	font-family: var( --newspack-ui-font-family );
+	font-size: var( --newspack-ui-font-size-s );
 	-webkit-font-smoothing: antialiased;
 
 	p {
 		margin: var( --newspack-ui-spacer-2 ) 0;
 	}
 
+	h1, h2, h3, h4, h5, h6 {
+		font-family: var( --newspack-ui-font-family );
+	}
+
 	strong,
-	&__font__bold {
+	&__font--bold {
 		font-weight: var( --newspack-ui-font-weight-strong );
 	}
 
-	&__font__normal {
+	&__font--normal {
 		font-weight: normal;
 	}
 
-	&__font--small {
-		font-size: var( --newspack-ui-font-size-small );
+	&__font--2xs {
+		font-size: var( --newspack-ui-font-size-2xs );
+		line-height: 1.3333;
+	}
+
+	&__font--xs {
+		font-size: var( --newspack-ui-font-size-xs );
+		line-height: 1.4286;
+	}
+
+	&__font--s {
+		font-size: var( --newspack-ui-font-size-s );
+		line-height: 1.5;
+	}
+
+	&__font--m {
+		font-size: var( --newspack-ui-font-size-m );
+		line-height: 1.6;
+	}
+
+	&__font--l {
+		font-size: var( --newspack-ui-font-size-l );
+		line-height: 1.5;
+	}
+
+	&__font--xl {
+		font-size: var( --newspack-ui-font-size-xl );
+		line-height: 1.375;
 	}
 }

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -138,7 +138,7 @@
 		// Icon-only
 		&--icon {
 			display: grid;
-			height: var( --newspack-ui-spacer-7 ); // This is the XS size, we will need S, and M
+			height: var( --newspack-ui-spacer-7 ); // TODO: This is the XS size, we will need S, and M
 			padding: 0;
 			place-items: center;
 			width: var( --newspack-ui-spacer-7 );

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -12,9 +12,12 @@
 		gap: var( --newspack-ui-spacer-2 );
 		justify-content: center;
 		line-height: var( --newspack-ui-line-height-l );
-		margin-bottom: var( --newspack-ui-spacer-2 );
 		padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-3 ); // TODO: correct this
 		transition: background-color 150ms ease-in-out;
+
+		&:not( :last-child ) {
+			margin-bottom: var( --newspack-ui-spacer-2 );
+		}
 
 		&:hover {
 			color: inherit;

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -30,11 +30,7 @@
 			outline-offset: 1px;
 		}
 
-		&--wide {
-			display: flex;
-			width: 100%;
-		}
-
+		// Styles
 		&--primary {
 			background: var( --newspack-ui-color-button-bg );
 			color: var( --newspack-ui-color-button-text );
@@ -130,6 +126,25 @@
 			&:disabled {
 				background: var( --newspack-ui-color-error-5 ) !important;
 				color: var( --newspack-ui-color-neutral-0 ) !important;
+			}
+		}
+
+		// Wide
+		&--wide {
+			display: flex;
+			width: 100%;
+		}
+
+		// Icon-only
+		&--icon {
+			display: grid;
+			height: var( --newspack-ui-spacer-7 ); // This is the XS size, we will need S, and M
+			padding: 0;
+			place-items: center;
+			width: var( --newspack-ui-spacer-7 );
+
+			svg {
+				fill: currentcolor;
 			}
 		}
 	}

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -26,7 +26,7 @@
 
 		&:focus {
 			outline: 2px solid var( --newspack-ui-color-button-bg );
-			outline-offset: 2px;
+			outline-offset: 1px;
 		}
 
 		&--wide {

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -1,6 +1,5 @@
 .newspack-ui {
 	// TODO: define some kind of size hierachy for buttons eg. small, medium, large.
-	// Buttons in modals are already set to font-size-s and border-radius-m.
 	&__button {
 		align-items: center;
 		border: 0;

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -4,14 +4,14 @@
 	&__button {
 		align-items: center;
 		border: 0;
-		border-radius: var( --newspack-ui-border-radius-small );
+		border-radius: var( --newspack-ui-border-radius-s );
 		display: inline-flex;
 		font-family: var( --newspack-ui-font-family );
-		font-size: var( --newspack-ui-font-size-small );
+		font-size: var( --newspack-ui-font-size-s );
 		font-weight: 600;
 		gap: var( --newspack-ui-spacer-2 );
 		justify-content: center;
-		line-height: var( --newspack-ui-line-height-large );
+		line-height: var( --newspack-ui-line-height-l );
 		margin-bottom: var( --newspack-ui-spacer-2 );
 		padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-3 ); // TODO: correct this
 		transition: background-color 150ms ease-in-out;
@@ -38,6 +38,16 @@
 		&--primary {
 			background: var( --newspack-ui-color-button-bg );
 			color: var( --newspack-ui-color-button-text );
+
+			&:hover {
+				background: var( --newspack-ui-color-button-bg-hover );
+				color: var( --newspack-ui-color-button-text-hover );
+			}
+		}
+
+		&--branded {
+			background: var( --newspack-ui-color-primary );
+			color: var( --newspack-ui-color-against-primary );
 
 			&:hover {
 				background: var( --newspack-ui-color-button-bg-hover );

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -12,7 +12,7 @@
 		justify-content: center;
 		line-height: var( --newspack-ui-line-height-s );
 		padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-4 );
-		transition: background-color 150ms ease-in-out;
+		transition: background-color 125ms ease-in-out, outline 125ms ease-in-out;
 
 		&:not( :last-child ) {
 			margin-bottom: var( --newspack-ui-spacer-2 );
@@ -22,6 +22,7 @@
 			background: var( --newspack-ui-color-neutral-10 ) !important;
 			color: var( --newspack-ui-color-neutral-70 ) !important;
 			cursor: default;
+			pointer-events: none;
 		}
 
 		&:focus {
@@ -42,6 +43,11 @@
 				background: var( --newspack-ui-color-button-bg-hover );
 				color: var( --newspack-ui-color-button-text-hover );
 			}
+
+			&:disabled {
+				background: var( --newspack-ui-color-neutral-30 ) !important;
+				color: var( --newspack-ui-color-neutral-0 ) !important;
+			}
 		}
 
 		&--branded {
@@ -49,34 +55,66 @@
 			color: var( --newspack-ui-color-against-primary );
 
 			&:hover {
-				background: var( --newspack-ui-color-button-bg-hover );
-				color: var( --newspack-ui-color-button-text-hover );
+				background: color-mix(in srgb, var( --newspack-ui-color-primary ) 80%, black);
+				color: var( --newspack-ui-color-against-primary );
 			}
 
 			&:focus {
 				outline-color: var( --newspack-ui-color-primary );
+			}
+
+			&:disabled {
+				background: color-mix(in srgb, var( --newspack-ui-color-primary ) 20%, white) !important;
+				color: var( --newspack-ui-color-against-primary ) !important;
 			}
 		}
 
 		&--secondary {
 			background: var( --newspack-ui-color-neutral-10 );
 			color: var( --newspack-ui-color-neutral-90 );
-			padding: calc( var( --newspack-ui-spacer-2 ) - 1px )
-				calc( var( --newspack-ui-spacer-3 ) - 1px );
 
 			&:hover {
 				background: var( --newspack-ui-color-neutral-30 );
 				color: var( --newspack-ui-color-neutral-90 );
 			}
+
+			&:disabled {
+				background: var( --newspack-ui-color-neutral-5 ) !important;
+				color: var( --newspack-ui-color-neutral-40 ) !important;
+			}
 		}
 
-		&--tertiary {
+		&--ghost {
 			background: transparent;
 			color: var( ---newspack-ui-color-neutral-90 );
 
 			&:hover {
-				background: var( --newspack-ui-color-neutral-10 );
+				background: var( --newspack-ui-color-neutral-5 );
 				color: var( --newspack-ui-color-neutral-90 );
+			}
+
+			&:disabled {
+				background: transparent !important;
+				color: var( --newspack-ui-color-neutral-30 ) !important;
+			}
+		}
+
+		&--destructive {
+			background: var( --newspack-ui-color-error-50 );
+			color: var( --newspack-ui-color-neutral-0 );
+
+			&:hover {
+				background: var( --newspack-ui-color-error-60 );
+				color: var( --newspack-ui-color-neutral-0 );
+			}
+
+			&:focus {
+				outline-color: var( --newspack-ui-color-error-50 );
+			}
+
+			&:disabled {
+				background: var( --newspack-ui-color-error-5 ) !important;
+				color: var( --newspack-ui-color-neutral-0 ) !important;
 			}
 		}
 	}

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -25,8 +25,8 @@
 		}
 
 		&:disabled {
-			background: var( --newspack-ui-color-gray-100 ) !important;
-			color: var( --newspack-ui-color-text-med-contrast ) !important;
+			background: var( --newspack-ui-color-neutral-10 ) !important;
+			color: var( --newspack-ui-color-neutral-70 ) !important; //
 			cursor: default;
 		}
 
@@ -46,25 +46,24 @@
 		}
 
 		&--secondary {
-			background: transparent;
-			border: 1px solid var( --newspack-ui-color-border );
-			color: var( --newspack-ui-color-text-high-contrast );
+			background: var( --newspack-ui-color-neutral-10 );
+			color: var( --newspack-ui-color-neutral-90 );
 			padding: calc( var( --newspack-ui-spacer-2 ) - 1px )
 				calc( var( --newspack-ui-spacer-3 ) - 1px );
 
 			&:hover {
-				background: var( --newspack-ui-color-gray-100 );
-				color: var( --newspack-ui-color-text-high-contrast );
+				background: var( --newspack-ui-color-neutral-30 );
+				color: var( --newspack-ui-color-neutral-90 );
 			}
 		}
 
 		&--tertiary {
 			background: transparent;
-			color: var( --newspack-ui-color-text-high-contrast );
+			color: var( ---newspack-ui-color-neutral-90 );
 
 			&:hover {
-				background: var( --newspack-ui-color-gray-100 );
-				color: var( --newspack-ui-color-text-high-contrast );
+				background: var( --newspack-ui-color-neutral-10 );
+				color: var( --newspack-ui-color-neutral-90 );
 			}
 		}
 	}

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -3,7 +3,7 @@
 	&__button {
 		align-items: center;
 		border: 0;
-		border-radius: var( --newspack-ui-border-radius-s );
+		border-radius: var( --newspack-ui-border-radius-m );
 		display: inline-flex;
 		font-family: var( --newspack-ui-font-family );
 		font-size: var( --newspack-ui-font-size-s );
@@ -12,7 +12,7 @@
 		justify-content: center;
 		line-height: var( --newspack-ui-line-height-s );
 		padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-4 );
-		transition: background-color 125ms ease-in-out, outline 125ms ease-in-out;
+		transition: background-color 125ms ease-in-out, border-color 125ms ease-in-out, outline 125ms ease-in-out;
 
 		&:not( :last-child ) {
 			margin-bottom: var( --newspack-ui-spacer-2 );
@@ -84,7 +84,8 @@
 			}
 		}
 
-		&--ghost {
+		&--ghost,
+		&--outline {
 			background: transparent;
 			color: var( ---newspack-ui-color-neutral-90 );
 
@@ -96,6 +97,20 @@
 			&:disabled {
 				background: transparent !important;
 				color: var( --newspack-ui-color-neutral-30 ) !important;
+			}
+		}
+
+		&--outline {
+			border: 1px solid var( --newspack-ui-color-neutral-30 );
+			padding: calc( var( --newspack-ui-spacer-2 ) - 1px )
+				calc( var( --newspack-ui-spacer-4 ) - 1px );
+
+			&:hover {
+				border-color: var( --newspack-ui-color-neutral-40 );
+			}
+
+			&:disabled {
+				border-color: var( --newspack-ui-color-neutral-10 );
 			}
 		}
 

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -12,7 +12,7 @@
 		gap: var( --newspack-ui-spacer-2 );
 		justify-content: center;
 		line-height: var( --newspack-ui-line-height-large );
-		margin-bottom: var( --newspack-ui-spacer-base );
+		margin-bottom: var( --newspack-ui-spacer-2 );
 		padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-3 ); // TODO: correct this
 		transition: background-color 150ms ease-in-out;
 

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -19,18 +19,15 @@
 			margin-bottom: var( --newspack-ui-spacer-2 );
 		}
 
-		&:hover {
-			color: inherit;
-		}
-
-		&:focus {
-			// TODO
-		}
-
 		&:disabled {
 			background: var( --newspack-ui-color-neutral-10 ) !important;
 			color: var( --newspack-ui-color-neutral-70 ) !important;
 			cursor: default;
+		}
+
+		&:focus {
+			outline: 2px solid var( --newspack-ui-color-button-bg );
+			outline-offset: 2px;
 		}
 
 		&--wide {
@@ -55,6 +52,10 @@
 			&:hover {
 				background: var( --newspack-ui-color-button-bg-hover );
 				color: var( --newspack-ui-color-button-text-hover );
+			}
+
+			&:focus {
+				outline-color: var( --newspack-ui-color-primary );
 			}
 		}
 

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -26,7 +26,7 @@
 
 		&:disabled {
 			background: var( --newspack-ui-color-neutral-10 ) !important;
-			color: var( --newspack-ui-color-neutral-70 ) !important; //
+			color: var( --newspack-ui-color-neutral-70 ) !important;
 			cursor: default;
 		}
 

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -1,6 +1,6 @@
 .newspack-ui {
-	// TODO: define some kind of size hierachy for buttons eg. small, medium, large;
-	// not needed for RAS, but likely for My Account.
+	// TODO: define some kind of size hierachy for buttons eg. small, medium, large.
+	// Buttons in modals are already set to font-size-s and border-radius-m.
 	&__button {
 		align-items: center;
 		border: 0;
@@ -11,8 +11,8 @@
 		font-weight: 600;
 		gap: var( --newspack-ui-spacer-2 );
 		justify-content: center;
-		line-height: var( --newspack-ui-line-height-l );
-		padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-3 ); // TODO: correct this
+		line-height: var( --newspack-ui-line-height-s );
+		padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-4 );
 		transition: background-color 150ms ease-in-out;
 
 		&:not( :last-child ) {

--- a/assets/newspack-ui/scss/elements/forms/_checkbox-radio.scss
+++ b/assets/newspack-ui/scss/elements/forms/_checkbox-radio.scss
@@ -28,6 +28,10 @@
 		&:focus {
 			outline: 1.5px solid var( --newspack-ui-color-neutral-90 );
 			outline-offset: 1px;
+
+			&:not( :checked ) {
+				border: 0;
+			}
 		}
 
 		&:disabled {

--- a/assets/newspack-ui/scss/elements/forms/_checkbox-radio.scss
+++ b/assets/newspack-ui/scss/elements/forms/_checkbox-radio.scss
@@ -3,15 +3,15 @@
 	input[type='radio'] {
 		appearance: none;
 		background: white;
-		border: solid 1px var( --newspack-ui-color-border );
+		border: solid 1px var( --newspack-ui-color-input-border );
 		color: white;
 		cursor: pointer;
 		display: inline-grid;
 		font: inherit;
-		height: var( --newspack-ui-spacer-5 ) !important;
+		height: var( --newspack-ui-spacer-4 ) !important;
 		margin: 0;
 		place-content: center;
-		width: var( --newspack-ui-spacer-5 ) !important;
+		width: var( --newspack-ui-spacer-4 ) !important;
 
 		&::before {
 			content: '';
@@ -26,7 +26,7 @@
 		}
 
 		&:focus {
-			outline: 1.5px solid var( --newspack-ui-color-radio-bg );
+			outline: 1.5px solid var( --newspack-ui-color-neutral-90 );
 			outline-offset: 1px;
 		}
 
@@ -37,7 +37,7 @@
 	}
 
 	input[type='checkbox'] {
-		border-radius: var( --newspack-ui-border-radius );
+		border-radius: var( --newspack-ui-border-radius-extra-small );
 
 		&::before {
 			background: transparent
@@ -48,7 +48,7 @@
 		}
 
 		&:checked {
-			background: var( --newspack-ui-color-radio-bg );
+			background: var( --newspack-ui-color-neutral-90 );
 			border-color: transparent;
 		}
 	}
@@ -57,15 +57,15 @@
 		border-radius: 100%;
 
 		&::before {
-			background: var( --newspack-ui-color-radio-bg );
+			background: var( --newspack-ui-color-neutral-0 );
 			border-radius: 100%;
-			height: var( --newspack-ui-spacer-3 );
-			margin: 4px;
-			width: var( --newspack-ui-spacer-3 );
+			height: var( --newspack-ui-spacer-base );
+			width: var( --newspack-ui-spacer-base );
 		}
 
 		&:checked {
-			border-color: var( --newspack-ui-color-radio-bg );
+			background: var( --newspack-ui-color-neutral-90 );
+			border-color: var( --newspack-ui-color-neutral-90 );
 		}
 	}
 }

--- a/assets/newspack-ui/scss/elements/forms/_checkbox-radio.scss
+++ b/assets/newspack-ui/scss/elements/forms/_checkbox-radio.scss
@@ -41,7 +41,7 @@
 	}
 
 	input[type='checkbox'] {
-		border-radius: var( --newspack-ui-border-radius-extra-small );
+		border-radius: var( --newspack-ui-border-radius-xs );
 
 		&::before {
 			background: transparent

--- a/assets/newspack-ui/scss/elements/forms/_checkbox-radio.scss
+++ b/assets/newspack-ui/scss/elements/forms/_checkbox-radio.scss
@@ -11,6 +11,7 @@
 		height: var( --newspack-ui-spacer-4 ) !important;
 		margin: 0;
 		place-content: center;
+		transition: background-color 125ms ease-in-out, border-color 125ms ease-in-out, outline 125ms ease-in-out;
 		width: var( --newspack-ui-spacer-4 ) !important;
 
 		&::before {
@@ -25,12 +26,13 @@
 			}
 		}
 
-		&:focus {
-			outline: 1.5px solid var( --newspack-ui-color-neutral-90 );
+		&:focus-visible {
+			outline: 2px solid var( --newspack-ui-color-neutral-90 );
 			outline-offset: 1px;
 
 			&:not( :checked ) {
 				border: 0;
+				outline-offset: -1px;
 			}
 		}
 

--- a/assets/newspack-ui/scss/elements/forms/_index.scss
+++ b/assets/newspack-ui/scss/elements/forms/_index.scss
@@ -42,7 +42,7 @@
 	// Form response inline error text.
 	&__inline-error,
 	&__inline-info {
-		font-size: var( --newspack-ui-font-size-s );
+		font-size: var( --newspack-ui-font-size-xs );
 		line-height: var( --newspack-ui-line-height-s );
 		margin: var( --newspack-ui-spacer-base ) 0 var( --newspack-ui-spacer-5 );
 		a {

--- a/assets/newspack-ui/scss/elements/forms/_index.scss
+++ b/assets/newspack-ui/scss/elements/forms/_index.scss
@@ -42,7 +42,7 @@
 	// Form response inline error text.
 	&__inline-error,
 	&__inline-info {
-		font-size: var( --newspack-ui-font-size-xs );
+		font-size: var( --newspack-ui-font-size-s );
 		line-height: var( --newspack-ui-line-height-s );
 		margin: var( --newspack-ui-spacer-base ) 0 var( --newspack-ui-spacer-5 );
 		a {

--- a/assets/newspack-ui/scss/elements/forms/_index.scss
+++ b/assets/newspack-ui/scss/elements/forms/_index.scss
@@ -31,12 +31,16 @@
 	}
 
 	// Container for input description.
-	&__field-description {
+	&__helper-text {
 		color: var( --newspack-ui-color-neutral-60 );
 		display: block;
 		font-size: var( --newspack-ui-font-size-xs );
 		line-height: var( --newspack-ui-line-height-s );
 		margin: var( --newspack-ui-spacer-base ) 0 var( --newspack-ui-spacer-5 );
+
+		label & {
+			margin: 0;
+		}
 	}
 
 	// Form response inline error text.

--- a/assets/newspack-ui/scss/elements/forms/_index.scss
+++ b/assets/newspack-ui/scss/elements/forms/_index.scss
@@ -50,6 +50,6 @@
 	}
 
 	&__inline-error {
-		color: var( --newspack-ui-color-alert-red );
+		color: var( --newspack-ui-color-error-50 );
 	}
 }

--- a/assets/newspack-ui/scss/elements/forms/_index.scss
+++ b/assets/newspack-ui/scss/elements/forms/_index.scss
@@ -18,7 +18,7 @@
 
 	select {
 		font-family: var( --newspack-ui-font-family );
-		line-height: var( --newspack-ui-line-height-large );
+		line-height: var( --newspack-ui-line-height-l );
 	}
 
 	// Container for displaying grid of inputs.
@@ -32,17 +32,18 @@
 
 	// Container for input description.
 	&__field-description {
+		color: var( --newspack-ui-color-neutral-60 );
 		display: block;
-		font-size: var( --newspack-ui-font-size-small );
-		line-height: var( --newspack-ui-line-height-small );
+		font-size: var( --newspack-ui-font-size-xs );
+		line-height: var( --newspack-ui-line-height-s );
 		margin: var( --newspack-ui-spacer-base ) 0 var( --newspack-ui-spacer-5 );
 	}
 
 	// Form response inline error text.
 	&__inline-error,
 	&__inline-info {
-		font-size: var( --newspack-ui-font-size-small );
-		line-height: var( --newspack-ui-line-height-small );
+		font-size: var( --newspack-ui-font-size-xs );
+		line-height: var( --newspack-ui-line-height-s );
 		margin: var( --newspack-ui-spacer-base ) 0 var( --newspack-ui-spacer-5 );
 		a {
 			text-decoration: underline;

--- a/assets/newspack-ui/scss/elements/forms/_labels.scss
+++ b/assets/newspack-ui/scss/elements/forms/_labels.scss
@@ -26,8 +26,8 @@
 
 				// This selector isn't supported in Firefox yet.
 				&:has( input:checked ) {
-					background: var( --newspack-ui-color-gray-100 );
-					border-color: var( --newspack-ui-color-gray-900 );
+					background: var( --newspack-ui-color-neutral-5 );
+					border-color: var( --newspack-ui-color-neutral-90 );
 				}
 
 				+ .newspack-ui__input-list {

--- a/assets/newspack-ui/scss/elements/forms/_labels.scss
+++ b/assets/newspack-ui/scss/elements/forms/_labels.scss
@@ -20,9 +20,11 @@
 				align-items: flex-start;
 				border: 1px solid var( --newspack-ui-color-border );
 				border-radius: var( --newspack-ui-border-radius-m );
+				cursor: pointer;
 				font-weight: normal;
 				margin-bottom: var( --newspack-ui-spacer-5 );
 				padding: var( --newspack-ui-spacer-3 );
+				transition: background-color 125ms ease-in-out, border-color 125ms ease-in-out;
 
 				&:has( input:checked ) {
 					background: var( --newspack-ui-color-neutral-5 );

--- a/assets/newspack-ui/scss/elements/forms/_labels.scss
+++ b/assets/newspack-ui/scss/elements/forms/_labels.scss
@@ -3,9 +3,9 @@
 	label {
 		display: block;
 		font-family: var( --newspack-ui-font-family);
-		font-size: var( --newspack-ui-font-size-small ) !important; // !important to override Newspack Theme.
+		font-size: var( --newspack-ui-font-size-s ) !important; // !important to override Newspack Theme.
 		font-weight: 600;
-		line-height: var( --newspack-ui-line-height-small );
+		line-height: var( --newspack-ui-line-height-s );
 		margin: 0 0 var( --newspack-ui-spacer-base );
 
 		// For labels containing radio, checkbox inputs:
@@ -19,12 +19,11 @@
 			&.newspack-ui__input-list {
 				align-items: flex-start;
 				border: 1px solid var( --newspack-ui-color-border );
-				border-radius: var( --newspack-ui-border-radius-medium );
+				border-radius: var( --newspack-ui-border-radius-m );
 				font-weight: normal;
 				margin-bottom: var( --newspack-ui-spacer-5 );
 				padding: var( --newspack-ui-spacer-3 );
 
-				// This selector isn't supported in Firefox yet.
 				&:has( input:checked ) {
 					background: var( --newspack-ui-color-neutral-5 );
 					border-color: var( --newspack-ui-color-neutral-90 );

--- a/assets/newspack-ui/scss/elements/forms/_labels.scss
+++ b/assets/newspack-ui/scss/elements/forms/_labels.scss
@@ -19,7 +19,7 @@
 			&.newspack-ui__input-list {
 				align-items: flex-start;
 				border: 1px solid var( --newspack-ui-color-border );
-				border-radius: var( --newspack-ui-border-radius );
+				border-radius: var( --newspack-ui-border-radius-medium );
 				font-weight: normal;
 				margin-bottom: var( --newspack-ui-spacer-5 );
 				padding: var( --newspack-ui-spacer-3 );

--- a/assets/newspack-ui/scss/elements/forms/_spinner.scss
+++ b/assets/newspack-ui/scss/elements/forms/_spinner.scss
@@ -15,7 +15,7 @@
 		> span {
 			animation: spin 1s infinite linear;
 			border: 2px solid var( --newspack-ui-color-body-bg );
-			border-top-color: var( --newspack-ui-color-text-med-contrast );
+			border-top-color: var( --newspack-ui-color-neutral-70 );
 			border-radius: 50%;
 			height: 25px;
 			width: 25px;

--- a/assets/newspack-ui/scss/elements/forms/_text-inputs.scss
+++ b/assets/newspack-ui/scss/elements/forms/_text-inputs.scss
@@ -18,7 +18,7 @@
 	input[type='zip'],
 	input[type='color'],
 	textarea {
-		border-color: var( --newspack-ui-color-border );
+		border-color: var( --newspack-ui-color-input-border );
 		border-radius: var( --newspack-ui-border-radius );
 		display: block;
 		font-family: var( --newspack-ui-font-family);
@@ -28,11 +28,13 @@
 		width: 100%;
 
 		&:focus {
-			border-color: var( --newspack-ui-color-text-med-contrast );
+			border-color: var( --newspack-ui-color-input-border-focus );
+			border-width: 2px;
 		}
 
 		&:disabled {
-			// TODO.
+			background-color: var( --newspack-ui-color-input-background-disabled );
+			border-color: var( --newspack-ui-color-input-border-disabled );
 		}
 	}
 }

--- a/assets/newspack-ui/scss/elements/forms/_text-inputs.scss
+++ b/assets/newspack-ui/scss/elements/forms/_text-inputs.scss
@@ -19,11 +19,11 @@
 	input[type='color'],
 	textarea {
 		border-color: var( --newspack-ui-color-input-border );
-		border-radius: var( --newspack-ui-border-radius );
+		border-radius: var( --newspack-ui-border-radius-m );
 		display: block;
 		font-family: var( --newspack-ui-font-family);
-		font-size: var( --newspack-ui-font-size-small );
-		line-height: var( --newspack-ui-line-height-large );
+		font-size: var( --newspack-ui-font-size-s );
+		line-height: var( --newspack-ui-line-height-l );
 		padding: calc( var( --newspack-ui-spacer-2 ) - 1px ) calc( var( --newspack-ui-spacer-3 ) - 1px );
 		width: 100%;
 

--- a/assets/newspack-ui/scss/elements/forms/_text-inputs.scss
+++ b/assets/newspack-ui/scss/elements/forms/_text-inputs.scss
@@ -25,6 +25,7 @@
 		font-size: var( --newspack-ui-font-size-s );
 		line-height: var( --newspack-ui-line-height-l );
 		padding: calc( var( --newspack-ui-spacer-2 ) - 1px ) calc( var( --newspack-ui-spacer-3 ) - 1px );
+		transition: background-color 125ms ease-in-out, border-color 125ms ease-in-out, outline 125ms ease-in-out;
 		width: 100%;
 
 		&:focus {

--- a/assets/newspack-ui/scss/elements/forms/_text-inputs.scss
+++ b/assets/newspack-ui/scss/elements/forms/_text-inputs.scss
@@ -28,8 +28,8 @@
 		width: 100%;
 
 		&:focus {
-			border-color: var( --newspack-ui-color-input-border-focus );
-			border-width: 2px;
+			outline: 2px solid var( --newspack-ui-color-input-border-focus );
+			outline-offset: -1px;
 		}
 
 		&:disabled {

--- a/assets/newspack-ui/scss/elements/misc/_word-divider.scss
+++ b/assets/newspack-ui/scss/elements/misc/_word-divider.scss
@@ -1,7 +1,7 @@
 .newspack-ui__word-divider {
 	align-items: center;
 	display: flex;
-	font-size: var( --newspack-ui-font-size-small );
+	font-size: var( --newspack-ui-font-size-xs );
 	gap: var( --newspack-ui-spacer-2 );
 	justify-content: space-evenly;
 	margin: var( --newspack-ui-spacer-5 ) 0;

--- a/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -29,7 +29,7 @@
 	.woocommerce-additional-fields h3,
 	.woocommerce-checkout h3,
 	.woocommerce-form-coupon h3 {
-		font-size: var(--newspack-ui-font-size-medium);
+		font-size: var(--newspack-ui-font-size-s);
 		margin: 1rem 0 !important;
 	}
 
@@ -44,7 +44,7 @@
 			padding: 0;
 
 			p {
-				font-size: var(--newspack-ui-font-size-small);
+				font-size: var(--newspack-ui-font-size-xs);
 			}
 
 			ul.wc-saved-payment-methods {
@@ -65,7 +65,7 @@
 				}
 
 				p {
-					font-size: var(--newspack-ui-font-size-small);
+					font-size: var(--newspack-ui-font-size-xs);
 					margin-bottom: 0;
 
 					&.form-row {
@@ -88,7 +88,7 @@
 
 	// Override checkout form terms and condition text.
 	.woocommerce-terms-and-conditions-wrapper {
-		font-size: var(--newspack-ui-font-size-small);
+		font-size: var(--newspack-ui-font-size-xs);
 	}
 
 	// Override checkout form coupon field.

--- a/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -147,4 +147,33 @@
 			display: flex !important;
 		}
 	}
+
+	// Stripe inputs
+	.wc-credit-card-form {
+		.form-row-wide {
+			margin-bottom: var( --newspack-ui-spacer-base );
+		}
+		.wc-stripe-elements-field,
+		.wc-stripe-iban-element-field {
+			border: 1px solid var( --newspack-ui-color-input-border );
+			border-radius: var( --newspack-ui-border-radius-m );
+			display: block;
+			font-family: var( --newspack-ui-font-family);
+			font-size: var( --newspack-ui-font-size-s );
+			line-height: var( --newspack-ui-line-height-l );
+			padding: calc( var( --newspack-ui-spacer-2 ) - 1px ) calc( var( --newspack-ui-spacer-3 ) - 1px );
+		}
+	}
+
+	.wc_payment_methods label[for="payment_method_stripe"].newspack-ui__input-list {
+		padding: var( --newspack-ui-spacer-5 ) !important;
+	}
+
+	// Errors
+	.woocommerce-invalid {
+		input,
+		textarea {
+			border-color: var( --newspack-ui-color-error-50 );
+		}
+	}
 }

--- a/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -40,6 +40,7 @@
 		}
 
 		.payment_box {
+			background: transparent;
 			font-weight: normal;
 			padding: 0;
 
@@ -49,7 +50,7 @@
 
 			ul.wc-saved-payment-methods {
 				li {
-					margin-bottom: 16px;
+					margin-bottom: var(--newspack-ui-spacer-3);
 
 					input {
 						margin-right: 8px;
@@ -58,7 +59,7 @@
 			}
 
 			fieldset {
-				margin-bottom: 12px;
+				margin-bottom: var(--newspack-ui-spacer-2);
 
 				&:last-child {
 					margin-bottom: 0;
@@ -73,7 +74,7 @@
 						align-items: flex-start;
 
 						input {
-							margin-right: 12px;
+							margin-right: var(--newspack-ui-spacer-2);
 						}
 
 						label {
@@ -86,9 +87,39 @@
 		}
 	}
 
+	// Override billing details spacing.
+	.billing-details {
+		p {
+			margin: 0;
+		}
+
+		h3 {
+			margin-bottom: var(--newspack-ui-spacer-base);
+		}
+	}
+
+	// Order review table.
+	.woocommerce-checkout-review-order-table {
+		thead th,
+		.recurring-totals th {
+			background: transparent;
+		}
+
+		.cart-subtotal th,
+		.cart-subtotal td,
+		small {
+			font-size: var( --newspack-font-size-xs );
+		}
+	}
+
+	.woocommerce .first-payment-date {
+		font-family: var( --newspack-ui-font-family );
+	}
+
 	// Override checkout form terms and condition text.
 	.woocommerce-terms-and-conditions-wrapper {
 		font-size: var(--newspack-ui-font-size-xs);
+		margin-bottom: 0;
 	}
 
 	// Override checkout form coupon field.
@@ -99,7 +130,7 @@
 			margin: var(--newspack-ui-spacer-2) 0;
 
 			input {
-				margin-right: 8px;
+				margin-right: var(--newspack-ui-spacer-base);
 			}
 
 			button {

--- a/assets/newspack-ui/scss/variables/_colors.scss
+++ b/assets/newspack-ui/scss/variables/_colors.scss
@@ -1,39 +1,82 @@
 :root {
-	// Grays - notes from the Gutenberg styles.
-	// TODO: Import from 'wordpress/base-styles/colors' ?
-	--newspack-ui-color-black: #000;		// Use only when you truly need pure black. For UI, use $gray-900.
-	--newspack-ui-color-gray-900: #1e1e1e;
-	--newspack-ui-color-gray-800: #2f2f2f;
-	--newspack-ui-color-gray-700: #757575;	// Meets 4.6:1 text contrast against white.
-	--newspack-ui-color-gray-600: #949494;	// Meets 3:1 UI or large text contrast against white.
-	--newspack-ui-color-gray-400: #ccc;
-	--newspack-ui-color-gray-300: #ddd;		// Used for most borders.
-	--newspack-ui-color-gray-200: #e0e0e0;	// Used sparingly for light borders.
-	--newspack-ui-color-gray-100: #f0f0f0;	// Used for light gray backgrounds.
-	--newspack-ui-color-white: #fff;
+	// Neutral:
+	--newspack-ui-color-neutral-0: #fff;
+	--newspack-ui-color-neutral-5: #f7f7f7;
+	--newspack-ui-color-neutral-10: #f0f0f0;
+	--newspack-ui-color-neutral-20: #e0e0e0;
+	--newspack-ui-color-neutral-30: #ddd;
+	--newspack-ui-color-neutral-40: #ccc;
+	--newspack-ui-color-neutral-50: #949494;
+	--newspack-ui-color-neutral-60: #6c6c6c;
+	--newspack-ui-color-neutral-70: #00000070;
+	--newspack-ui-color-neutral-80: #3e3e3e;
+	--newspack-ui-color-neutral-90: #1e1e1e;
+	--newspack-ui-color-neutral-100: #000;
 
-	// Alert colors
-	--newpsack-ui-color-alert-yellow: #f0b849;
-	--newspack-ui-color-alert-green: #4ab866;
-	--newspack-ui-color-alert-red: #cc1818;
-	// --newpsack-ui-color-alert-yellow-bg: TBD
-	--newspack-ui-color-alert-green-bg: #edfaef;
-	--newpsack-ui-color-alert-red-bg: #fcf0f1;
+	// Primary:
+	--newspack-ui-color-primary-0: #f5fdff;
+	--newspack-ui-color-primary-5: #d6f6ff;
+	--newspack-ui-color-primary-10: #b4e4ff;
+	--newspack-ui-color-primary-20: #93ccfd;
+	--newspack-ui-color-primary-30: #72affb;
+	--newspack-ui-color-primary-40: #528dfc;
+	--newspack-ui-color-primary-50: #36f;
+	--newspack-ui-color-primary-60: #2240d5;
+	--newspack-ui-color-primary-70: #1522af;
+	--newspack-ui-color-primary-80: #0b0b8d;
+	--newspack-ui-color-primary-90: #0d046e;
+	--newspack-ui-color-primary-100: #0e0052;
+
+	// Secondary:
+	--newspack-ui-color-secondary-30: #fffff0;
+	--newspack-ui-color-secondary-40: #ffffd3;
+	--newspack-ui-color-secondary-50: #ff0;
+	--newspack-ui-color-secondary-60: #f2f200;
+	--newspack-ui-color-secondary-70: #e4e400;
+
+	// Success:
+	--newspack-ui-color-success-0: #edfaef;
+	--newspack-ui-color-success-5: #b8e6bf;
+	--newspack-ui-color-success-50: #008a20;
+	--newspack-ui-color-success-60: #007017;
+
+	// Error:
+	--newspack-ui-color-error-0: #fcf0f1;
+	--newspack-ui-color-error-5: #facfd2;
+	--newspack-ui-color-error-50: #d63638;
+	--newspack-ui-color-error-60: #b32d2e;
+
+	//Warning:
+	--newspack-ui-color-warning-0: #fcf9e8;
+	--newspack-ui-color-warning-5: #f5e6ab;
+	--newspack-ui-color-warning-30: #dba617;
+	--newspack-ui-color-warning-40: #bd8600;
 
 	// Theme variables - from the classic theme; overridden in class-newspack-ui.php for block theme.
 	--newspack-ui-color-primary: var( --newspack-theme-color-primary );
 	--newspack-ui-color-against-primary: var( --newspack-theme-color-against-primary );
 
 	// Specific assignments - general:
-	--newspack-ui-color-text-high-contrast: var( --newspack-ui-color-gray-900 );
-	--newspack-ui-color-text-med-contrast: var( --newspack-ui-color-gray-700 );
-	--newspack-ui-color-border: var( --newspack-ui-color-gray-300 );
-	--newspack-ui-color-body-bg: var( --newspack-ui-color-white );
+	--newspack-ui-color-border: var( --newspack-ui-color-neutral-30 );
+	--newspack-ui-color-body-bg: var( --newspack-ui-color-neutral-0 );
 
-	// Specific assignments - form elements
-	--newspack-ui-color-button-bg: var( --newspack-ui-color-gray-900 );
-	--newspack-ui-color-button-bg-hover: var( --newspack-ui-color-gray-800 ); // TODO: Replace w/correct value.
-	--newspack-ui-color-button-text: var( --newspack-ui-color-white );
-	--newspack-ui-color-button-text-hover: var( --newspack-ui-color-white );
-	--newspack-ui-color-radio-bg: var( --newspack-ui-color-gray-900 );
+	// Specific assignments - form elements - buttons:
+	--newspack-ui-color-button-bg: var( --newspack-ui-color-neutral-90 );
+	--newspack-ui-color-button-bg-hover: var( --newspack-ui-color-neutral-60 );
+	--newspack-ui-color-button-text: var( --newspack-ui-color-neutral-0 );
+	--newspack-ui-color-button-text-hover: var( --newspack-ui-color-neutral-0 );
+
+	// Specific assignments - form elements - inputs:
+	--newspack-ui-color-input-border: var( --newspack-ui-color-neutral-40 );
+	--newspack-ui-color-input-border-focus: var( --newspack-ui-color-neutral-60 );
+	--newspack-ui-color-input-border-disabled: var( --newspack-ui-color-neutral-40 );
+	--newspack-ui-color-input-background-disabled: var( --newspack-ui-color-neutral-10 );
+
+	// Alternatives for when prefers-contrast is set to 'more':
+	@media ( prefers-contrast: more ) {
+		--newspack-ui-color-input-border: var( --newspack-ui-color-neutral-60 );
+		--newspack-ui-color-input-border-focus: var( --newspack-ui-color-neutral-90 );
+		--newspack-ui-color-input-border-disabled: var( --newspack-ui-color-neutral-50 );
+		--newspack-ui-color-input-background-disabled: var( --newspack-ui-color-neutral-30 );
+	}
 }

--- a/assets/newspack-ui/scss/variables/_colors.scss
+++ b/assets/newspack-ui/scss/variables/_colors.scss
@@ -53,8 +53,11 @@
 	--newspack-ui-color-warning-40: #bd8600;
 
 	// Theme variables - from the classic theme; overridden in class-newspack-ui.php for block theme.
-	--newspack-ui-color-primary: var( --newspack-theme-color-primary );
-	--newspack-ui-color-against-primary: var( --newspack-theme-color-against-primary );
+	// TODO: commented out for now with the assumption all should be blue when used.
+	// --newspack-ui-color-primary: var( --newspack-theme-color-primary, var( --newspack-ui-color-neutral-90 ) );
+	// --newspack-ui-color-against-primary: var( --newspack-theme-color-against-primary, var( --newspack-ui-color-neutral-0 ) );
+	--newspack-ui-color-primary: var( --newspack-ui-color-primary-60 );
+	--newspack-ui-color-against-primary: var( --newspack-ui-color-neutral-0 );
 
 	// Specific assignments - general:
 	--newspack-ui-color-border: var( --newspack-ui-color-neutral-30 );

--- a/assets/newspack-ui/scss/variables/_colors.scss
+++ b/assets/newspack-ui/scss/variables/_colors.scss
@@ -71,14 +71,13 @@
 
 	// Specific assignments - form elements - inputs:
 	--newspack-ui-color-input-border: var( --newspack-ui-color-neutral-40 );
-	--newspack-ui-color-input-border-focus: var( --newspack-ui-color-neutral-60 );
+	--newspack-ui-color-input-border-focus: var( --newspack-ui-color-neutral-90 );
 	--newspack-ui-color-input-border-disabled: var( --newspack-ui-color-neutral-40 );
 	--newspack-ui-color-input-background-disabled: var( --newspack-ui-color-neutral-10 );
 
 	// Alternatives for when prefers-contrast is set to 'more':
 	@media ( prefers-contrast: more ) {
 		--newspack-ui-color-input-border: var( --newspack-ui-color-neutral-60 );
-		--newspack-ui-color-input-border-focus: var( --newspack-ui-color-neutral-90 );
 		--newspack-ui-color-input-border-disabled: var( --newspack-ui-color-neutral-50 );
 		--newspack-ui-color-input-background-disabled: var( --newspack-ui-color-neutral-30 );
 	}

--- a/assets/newspack-ui/scss/variables/_fonts.scss
+++ b/assets/newspack-ui/scss/variables/_fonts.scss
@@ -5,7 +5,7 @@
 	// TODO: the base size for the modals is 16px, with small text/labels at 14px;
 	// The My Account designs appear to use 16px for most labels
 	// Should we have a in-modal vs. non-modal set of font sizes?
-	--newspack-ui-font-size-large: 20px;
+	--newspack-ui-font-size-large: clamp(1.125rem, 0.929rem + 0.402vw, 1.25rem);
 	--newspack-ui-font-size-medium: 16px; // modal baseline
 	--newspack-ui-font-size-small: 14px; // modal small
 	--newspack-ui-font-size-extra-small: 12px; // modal extra small

--- a/assets/newspack-ui/scss/variables/_fonts.scss
+++ b/assets/newspack-ui/scss/variables/_fonts.scss
@@ -1,19 +1,23 @@
 :root {
-	// Fonts
+	// Fonts - general
 	--newspack-ui-font-family: system-ui, sans-serif;
-
-	// TODO: the base size for the modals is 16px, with small text/labels at 14px;
-	// The My Account designs appear to use 16px for most labels
-	// Should we have a in-modal vs. non-modal set of font sizes?
-	--newspack-ui-font-size-large: clamp(1.125rem, 0.929rem + 0.402vw, 1.25rem);
-	--newspack-ui-font-size-medium: 16px; // modal baseline
-	--newspack-ui-font-size-small: 14px; // modal small
-	--newspack-ui-font-size-extra-small: 12px; // modal extra small
-	--newspack-ui-font-size-base: var( --newspack-ui-font-size-medium );
 	--newspack-ui-font-weight-strong: 600;
 
-	// Line heights - TODO: sort this out:
-	--newspack-ui-line-height-large: 1.7143; // inputs, buttons
-	--newspack-ui-line-height-medium: 1.5; // 16px font size
-	--newspack-ui-line-height-small: 1.4286; // 14px font sizes
+	// Fonts - sizes
+	--newspack-ui-font-size-2xs: 12px; // line-height: 1.3333
+	--newspack-ui-font-size-xs: 14px; // line-height: 1.4286
+	--newspack-ui-font-size-s: 16px; // line-height: 1.5
+	--newspack-ui-font-size-m: clamp(1.125rem, 0.929rem + 0.402vw, 1.25rem); // line-height: 1.6
+	--newspack-ui-font-size-l: clamp( 1.25rem, 0.857rem + 0.803vw, 1.5rem ); // line-height: 1.5
+	--newspack-ui-font-size-xl: clamp( 1.375rem, 0.394rem + 2.008vw, 2rem ); // line-height: 1.375
+	--newspack-ui-font-size-2xl: clamp( 1.625rem, 0.055rem + 3.213vw, 2.625rem ); // line-height: 1.3333
+	--newspack-ui-font-size-3xl: clamp( 1.75rem, -0.213rem + 4.016vw, 3rem ); // line-height: 1.25
+	--newspack-ui-font-size-4xl: clamp( 2rem, -1.141rem + 6.426vw, 4rem ); // line-height: 1.125
+	--newspack-ui-font-size-5xl: clamp( 2.125rem, -2.39rem + 9.237vw, 5rem ); // line-height: 1.1
+	--newspack-ui-font-size-6xl: clamp( 2.25rem, -3.639rem + 12.048vw, 6rem ); // line-height: 1.0833
+
+	// Fonts - line heights. TODO: sort this out:
+	--newspack-ui-line-height-l: 1.7143; // inputs, buttons
+	--newspack-ui-line-height-m: 1.5; // 16px font size
+	--newspack-ui-line-height-s: 1.4286; // 14px font sizes
 }

--- a/assets/newspack-ui/scss/variables/_fonts.scss
+++ b/assets/newspack-ui/scss/variables/_fonts.scss
@@ -7,14 +7,14 @@
 	--newspack-ui-font-size-2xs: 12px;
 	--newspack-ui-font-size-xs: 14px;
 	--newspack-ui-font-size-s: 16px;
-	--newspack-ui-font-size-m: clamp(1.125rem, 0.929rem + 0.402vw, 1.25rem);
-	--newspack-ui-font-size-l: clamp( 1.25rem, 0.857rem + 0.803vw, 1.5rem );
-	--newspack-ui-font-size-xl: clamp( 1.375rem, 0.394rem + 2.008vw, 2rem );
-	--newspack-ui-font-size-2xl: clamp( 1.625rem, 0.055rem + 3.213vw, 2.625rem );
-	--newspack-ui-font-size-3xl: clamp( 1.75rem, -0.213rem + 4.016vw, 3rem );
-	--newspack-ui-font-size-4xl: clamp( 2rem, -1.141rem + 6.426vw, 4rem );
-	--newspack-ui-font-size-5xl: clamp( 2.125rem, -2.39rem + 9.237vw, 5rem );
-	--newspack-ui-font-size-6xl: clamp( 2.25rem, -3.639rem + 12.048vw, 6rem );
+	--newspack-ui-font-size-m: clamp(1.125rem, 0.929rem + 0.402vw, 1.25rem); // 18px - 20px
+	--newspack-ui-font-size-l: clamp( 1.25rem, 0.857rem + 0.803vw, 1.5rem ); // 20px - 24px
+	--newspack-ui-font-size-xl: clamp( 1.375rem, 0.394rem + 2.008vw, 2rem ); // 22px - 32px
+	--newspack-ui-font-size-2xl: clamp( 1.625rem, 0.055rem + 3.213vw, 2.625rem ); // 26px - 42px
+	--newspack-ui-font-size-3xl: clamp( 1.75rem, -0.213rem + 4.016vw, 3rem ); // 28px - 48px
+	--newspack-ui-font-size-4xl: clamp( 2rem, -1.141rem + 6.426vw, 4rem ); // 32px - 64px
+	--newspack-ui-font-size-5xl: clamp( 2.125rem, -2.39rem + 9.237vw, 5rem ); // 34px - 80px
+	--newspack-ui-font-size-6xl: clamp( 2.25rem, -3.639rem + 12.048vw, 6rem ); // 36px - 96px
 
 	// Fonts - line heights
 	// TODO: would this make more sense as mixins with the accompanying font sizes?

--- a/assets/newspack-ui/scss/variables/_fonts.scss
+++ b/assets/newspack-ui/scss/variables/_fonts.scss
@@ -4,20 +4,29 @@
 	--newspack-ui-font-weight-strong: 600;
 
 	// Fonts - sizes
-	--newspack-ui-font-size-2xs: 12px; // line-height: 1.3333
-	--newspack-ui-font-size-xs: 14px; // line-height: 1.4286
-	--newspack-ui-font-size-s: 16px; // line-height: 1.5
-	--newspack-ui-font-size-m: clamp(1.125rem, 0.929rem + 0.402vw, 1.25rem); // line-height: 1.6
-	--newspack-ui-font-size-l: clamp( 1.25rem, 0.857rem + 0.803vw, 1.5rem ); // line-height: 1.5
-	--newspack-ui-font-size-xl: clamp( 1.375rem, 0.394rem + 2.008vw, 2rem ); // line-height: 1.375
-	--newspack-ui-font-size-2xl: clamp( 1.625rem, 0.055rem + 3.213vw, 2.625rem ); // line-height: 1.3333
-	--newspack-ui-font-size-3xl: clamp( 1.75rem, -0.213rem + 4.016vw, 3rem ); // line-height: 1.25
-	--newspack-ui-font-size-4xl: clamp( 2rem, -1.141rem + 6.426vw, 4rem ); // line-height: 1.125
-	--newspack-ui-font-size-5xl: clamp( 2.125rem, -2.39rem + 9.237vw, 5rem ); // line-height: 1.1
-	--newspack-ui-font-size-6xl: clamp( 2.25rem, -3.639rem + 12.048vw, 6rem ); // line-height: 1.0833
+	--newspack-ui-font-size-2xs: 12px;
+	--newspack-ui-font-size-xs: 14px;
+	--newspack-ui-font-size-s: 16px;
+	--newspack-ui-font-size-m: clamp(1.125rem, 0.929rem + 0.402vw, 1.25rem);
+	--newspack-ui-font-size-l: clamp( 1.25rem, 0.857rem + 0.803vw, 1.5rem );
+	--newspack-ui-font-size-xl: clamp( 1.375rem, 0.394rem + 2.008vw, 2rem );
+	--newspack-ui-font-size-2xl: clamp( 1.625rem, 0.055rem + 3.213vw, 2.625rem );
+	--newspack-ui-font-size-3xl: clamp( 1.75rem, -0.213rem + 4.016vw, 3rem );
+	--newspack-ui-font-size-4xl: clamp( 2rem, -1.141rem + 6.426vw, 4rem );
+	--newspack-ui-font-size-5xl: clamp( 2.125rem, -2.39rem + 9.237vw, 5rem );
+	--newspack-ui-font-size-6xl: clamp( 2.25rem, -3.639rem + 12.048vw, 6rem );
 
-	// Fonts - line heights. TODO: sort this out:
-	--newspack-ui-line-height-l: 1.7143; // inputs, buttons
-	--newspack-ui-line-height-m: 1.5; // 16px font size
-	--newspack-ui-line-height-s: 1.4286; // 14px font sizes
+	// Fonts - line heights
+	// TODO: would this make more sense as mixins with the accompanying font sizes?
+	--newspack-ui-line-height-2xs: 1.3333;
+	--newspack-ui-line-height-xs: 1.4286;
+	--newspack-ui-line-height-s: 1.5;
+	--newspack-ui-line-height-m: 1.6;
+	--newspack-ui-line-height-l: 1.5;
+	--newspack-ui-line-height-xl: 1.375;
+	--newspack-ui-line-height-2xl: 1.3333;
+	--newspack-ui-line-height-3xl: 1.25;
+	--newspack-ui-line-height-4xl: 1.125;
+	--newspack-ui-line-height-5xl: 1.1;
+	--newspack-ui-line-height-6xl: 1.0833;
 }

--- a/assets/newspack-ui/scss/variables/_index.scss
+++ b/assets/newspack-ui/scss/variables/_index.scss
@@ -6,12 +6,11 @@
 :root {
 	// Modal widths
 	--newspack-ui-modal-width-large: 964px;
-	--newspack-ui-modal-width-medium: 600px;
-	--newspack-ui-modal-width-small: 368px;
+	--newspack-ui-modal-width-medium: 632px;
+	--newspack-ui-modal-width-small: 410px;
 
 	// Border radius - not ems because the font size of the element itself caused a cascade.
-	// TODO: give these better names.
-	--newspack-ui-border-radius: 6px;
+	--newspack-ui-border-radius-medium: 6px;
 	--newspack-ui-border-radius-small: 5px;
 	--newspack-ui-border-radius-extra-small: 2px;
 }

--- a/assets/newspack-ui/scss/variables/_index.scss
+++ b/assets/newspack-ui/scss/variables/_index.scss
@@ -5,12 +5,12 @@
 // TODO: Some misc styles that need a home!
 :root {
 	// Modal widths
-	--newspack-ui-modal-width-large: 964px;
-	--newspack-ui-modal-width-medium: 632px;
-	--newspack-ui-modal-width-small: 410px;
+	--newspack-ui-modal-width-l: 964px;
+	--newspack-ui-modal-width-m: 632px;
+	--newspack-ui-modal-width-s: 410px;
 
 	// Border radius - not ems because the font size of the element itself caused a cascade.
-	--newspack-ui-border-radius-medium: 6px;
-	--newspack-ui-border-radius-small: 5px;
-	--newspack-ui-border-radius-extra-small: 2px;
+	--newspack-ui-border-radius-m: 6px;
+	--newspack-ui-border-radius-s: 5px;
+	--newspack-ui-border-radius-xs: 2px;
 }

--- a/assets/newspack-ui/scss/variables/_index.scss
+++ b/assets/newspack-ui/scss/variables/_index.scss
@@ -10,7 +10,9 @@
 	--newspack-ui-modal-width-small: 368px;
 
 	// Border radius - not ems because the font size of the element itself caused a cascade.
+	// TODO: give these better names.
 	--newspack-ui-border-radius: 6px;
 	--newspack-ui-border-radius-small: 5px;
+	--newspack-ui-border-radius-extra-small: 2px;
 
 }

--- a/assets/newspack-ui/scss/variables/_index.scss
+++ b/assets/newspack-ui/scss/variables/_index.scss
@@ -11,6 +11,6 @@
 
 	// Border radius - not ems because the font size of the element itself caused a cascade.
 	--newspack-ui-border-radius-m: 6px;
-	--newspack-ui-border-radius-s: 5px;
+	--newspack-ui-border-radius-s: 4px;
 	--newspack-ui-border-radius-xs: 2px;
 }

--- a/assets/newspack-ui/scss/variables/_index.scss
+++ b/assets/newspack-ui/scss/variables/_index.scss
@@ -14,5 +14,4 @@
 	--newspack-ui-border-radius: 6px;
 	--newspack-ui-border-radius-small: 5px;
 	--newspack-ui-border-radius-extra-small: 2px;
-
 }

--- a/assets/newspack-ui/scss/variables/_spacing.scss
+++ b/assets/newspack-ui/scss/variables/_spacing.scss
@@ -6,7 +6,8 @@
 	--newspack-ui-spacer-4: calc( var( --newspack-ui-spacer-base ) * 2.5 ); // 20px
 	--newspack-ui-spacer-5: calc( var( --newspack-ui-spacer-base ) * 3 ); // 24px
 	--newspack-ui-spacer-6: calc( var( --newspack-ui-spacer-base ) * 4 ); // 32px - TODO: clamp?
-	--newspack-ui-spacer-7: calc( var( --newspack-ui-spacer-base ) * 5 ); // 40px - TODO: clamp?
-	--newspack-ui-spacer-8: calc( var( --newspack-ui-spacer-base ) * 6 ); // 48px - TODO: clamp?
-	--newspack-ui-spacer-9: calc( var( --newspack-ui-spacer-base ) * 8 ); // 64px - TODO: clamp?
+	--newspack-ui-spacer-7: calc( var( --newspack-ui-spacer-base ) * 4.5 ); // 36px - TODO: clamp?
+	--newspack-ui-spacer-8: calc( var( --newspack-ui-spacer-base ) * 5 ); // 40px - TODO: clamp?
+	--newspack-ui-spacer-9: calc( var( --newspack-ui-spacer-base ) * 6 ); // 48px - TODO: clamp?
+	--newspack-ui-spacer-10: calc( var( --newspack-ui-spacer-base ) * 8 ); // 64px - TODO: clamp?
 }

--- a/assets/newspack-ui/style.scss
+++ b/assets/newspack-ui/style.scss
@@ -8,7 +8,7 @@
 
 	// Need better spot for this
 	&__color-text-gray {
-		color: var( --newspack-ui-color-text-med-contrast );
+		color: var( --newspack-ui-color-neutral-70 );
 	}
 
 	// Overrides for theme styles -- to move to theme?

--- a/assets/newspack-ui/style.scss
+++ b/assets/newspack-ui/style.scss
@@ -3,8 +3,6 @@
 @use 'scss/modals';
 
 .newspack-ui {
-	font-family: var( --newspack-ui-font-family );
-	font-size: var( --newspack-ui-font-size-base );
 
 	// Need better spot for this
 	&__color-text-gray {
@@ -14,7 +12,7 @@
 	// Overrides for theme styles -- to move to theme?
 	h2,
 	h3 {
-		font-size: var( --newspack-ui-font-size-medium );
+		font-size: var( --newspack-ui-font-size-s );
 	}
 
 	a,

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -576,7 +576,7 @@ class Newspack_UI {
 			<button id="open-modal-example" class="newspack-ui__button newspack-ui__button--primary">Open Modal</button>
 			<div id="newspack-modal-example" class="newspack-ui__modal-container">
 				<div class="newspack-ui__modal-container__overlay"></div>
-				<div class="newspack-ui__modal newspack-ui__modal__small">
+				<div class="newspack-ui__modal newspack-ui__modal--small">
 						<header class="newspack-ui__modal__header">
 							<h2>Auth Modal Contents Default</h2>
 

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -64,9 +64,12 @@ class Newspack_UI {
 		<div class="newspack-ui">
 			<h2>Temporary Razzak Component Demo</h2>
 
-			<p>Regular text (16px)</p>
-
-			<p class="newspack-ui__font--small">Small text (14px).</p>
+			<p class="newspack-ui__font--xl">X-Large text</p>
+			<p class="newspack-ui__font--l">Large text</p>
+			<p class="newspack-ui__font--m">Medium text</p>
+			<p>Small text (default)</p>
+			<p class="newspack-ui__font--xs">X-Small text</p>
+			<p class="newspack-ui__font--2xs">2X-Small text</p>
 
 			<hr>
 
@@ -101,7 +104,7 @@ class Newspack_UI {
 					<strong>Success box style, plus icon + <code>newspack-ui__box--text-center</code> class.</strong>
 				</p>
 
-				<p class="newspack-ui__font--small">Plus a little bit of text below it.</p>
+				<p>Plus a little bit of text below it.</p>
 			</div>
 
 			<hr>
@@ -223,9 +226,10 @@ class Newspack_UI {
 			<hr>
 
 			<h2>Buttons</h2>
-			<p><code>newspack-ui__button--primary</code>, <code>--secondary</code>, and <code>--tertiary</code> classes for colours/borders, and <code>newspack-ui__button--wide</code> for being 100% wide</p>
+			<p><code>newspack-ui__button--primary</code>, <code>--branded</code>, <code>--secondary</code>, and <code>--tertiary</code> classes for colours/borders, and <code>newspack-ui__button--wide</code> for being 100% wide</p>
 			<button class="newspack-ui__button">Default Theme Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--primary">Primary Button</button><br>
+			<button class="newspack-ui__button newspack-ui__button--branded">Branded Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--secondary">Secondary Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--tertiary">Tertiary Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--tertiary" disabled>Disabled</button><br>
@@ -242,6 +246,7 @@ class Newspack_UI {
 			</button>
 			<button class="newspack-ui__button newspack-ui__button--wide">Default Theme Button</button>
 			<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Primary Button</button>
+			<button class="newspack-ui__button newspack-ui__button--branded newspack-ui__button--wide">Branded Button</button>
 			<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">Secondary Button</button>
 			<button class="newspack-ui__button newspack-ui__button--tertiary newspack-ui__button--wide">Tertiary Button</button>
 			<button class="newspack-ui__button newspack-ui__button--tertiary newspack-ui__button--wide" disabled>Disabled</button>
@@ -361,7 +366,7 @@ class Newspack_UI {
 								</div>
 							</p>
 
-							<p class="newspack-ui__font--small">Sign in by entering the code sent to email@address.com, or by clicking the magic link in the email.</p>
+							<p class="newspack-ui__font--xs">Sign in by entering the code sent to email@address.com, or by clicking the magic link in the email.</p>
 
 							<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Continue</button>
 							<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">Resend Code</button>
@@ -397,7 +402,7 @@ class Newspack_UI {
 								<strong>Success! Your account was created and you're signed in.</strong>
 							</p>
 
-							<p class="newspack-ui__font--small">In the future, you'll sign in with a code sent to your email. If you'd rather use a password, you can set one in <a href="#">My Account</a>.</p>
+							<p>In the future, you'll sign in with a code sent to your email. If you'd rather use a password, you can set one in <a href="#">My Account</a>.</p>
 						</div>
 
 
@@ -474,7 +479,7 @@ class Newspack_UI {
 
 					<section class="newspack-ui__modal__content">
 
-						<p class="newspack-ui__font--small">Get the best of The News Paper directly to your email inbox.<br>
+						<p>Get the best of The News Paper directly to your email inbox.<br>
 						<span class="newspack-ui__color-text-gray">Sending to: email@address.</span></p>
 
 						<label class="newspack-ui__input-list">

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -173,7 +173,7 @@ class Newspack_UI {
 				<input type="checkbox" name="checkbox-option-1">
 				<span>
 					<strong>The Weekly</strong><br>
-					Friday roundup of the most relevant stories.
+					<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 				</span>
 			</label>
 
@@ -181,7 +181,7 @@ class Newspack_UI {
 				<input type="checkbox" name="checkbox-option-2">
 				<span>
 					<strong>The Weekly</strong><br>
-					Friday roundup of the most relevant stories.
+					<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 				</span>
 			</label>
 			<br>
@@ -189,7 +189,7 @@ class Newspack_UI {
 				<input type="radio" name="list-radio-option">
 				<span>
 					<strong>The Weekly</strong><br>
-					Friday roundup of the most relevant stories.
+					<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 				</span>
 			</label>
 
@@ -197,7 +197,7 @@ class Newspack_UI {
 				<input type="radio" name="list-radio-option">
 				<span>
 					<strong>The Weekly</strong><br>
-					Friday roundup of the most relevant stories.
+					<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 				</span>
 			</label>
 
@@ -341,7 +341,7 @@ class Newspack_UI {
 				<div class="newspack-ui__modal">
 					<header class="newspack-ui__modal__header">
 						<h2>This is a header</h2>
-						<button class="newspack-ui__modal__close">
+						<button class="newspack-ui__button newspack-ui__button--icon newspack-ui__button--ghost newspack-ui__modal__close">
 							<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-plugin' ); ?></span>
 							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 								<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
@@ -366,7 +366,7 @@ class Newspack_UI {
 					<header class="newspack-ui__modal__header">
 						<h2>Auth Modal Contents Default</h2>
 
-						<button class="newspack-ui__modal__close">
+						<button class="newspack-ui__button newspack-ui__button--icon newspack-ui__button--ghost newspack-ui__modal__close">
 							<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-plugin' ); ?></span>
 							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 								<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
@@ -414,7 +414,7 @@ class Newspack_UI {
 					<header class="newspack-ui__modal__header">
 						<h2>Auth Modal Contents OTP</h2>
 
-						<button class="newspack-ui__modal__close">
+						<button class="newspack-ui__button newspack-ui__button--icon newspack-ui__button--ghost newspack-ui__modal__close">
 							<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-plugin' ); ?></span>
 							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 								<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
@@ -451,7 +451,7 @@ class Newspack_UI {
 					<header class="newspack-ui__modal__header">
 						<h2>Auth Modal Contents Success</h2>
 
-						<button class="newspack-ui__modal__close">
+						<button class="newspack-ui__button newspack-ui__button--icon newspack-ui__button--ghost newspack-ui__modal__close">
 							<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-plugin' ); ?></span>
 							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 								<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
@@ -487,7 +487,7 @@ class Newspack_UI {
 					<header class="newspack-ui__modal__header">
 						<h2>Auth Modal Contents Success + PW</h2>
 
-						<button class="newspack-ui__modal__close">
+						<button class="newspack-ui__button newspack-ui__button--icon newspack-ui__button--ghost newspack-ui__modal__close">
 							<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-plugin' ); ?></span>
 							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 								<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
@@ -513,7 +513,7 @@ class Newspack_UI {
 							<p>
 								<label>Set a display name</label>
 								<input type="text">
-								<span class="newspack-ui__field-description">This will be used to address you in emails, and when you leave comments.</span>
+								<span class="newspack-ui__helper-text">This will be used to address you in emails, and when you leave comments.</span>
 							</p>
 
 							<p>
@@ -523,7 +523,7 @@ class Newspack_UI {
 							<p>
 								<label>Confirm Password</label>
 								<input type="password">
-								<span class="newspack-ui__field-description">If you don't set a password, you can always log in with a magic link or one-time code sent to your email.</span>
+								<span class="newspack-ui__helper-text">If you don't set a password, you can always log in with a magic link or one-time code sent to your email.</span>
 							</p>
 						</form>
 
@@ -539,7 +539,7 @@ class Newspack_UI {
 					<header class="newspack-ui__modal__header">
 						<h2>Auth Modal Newsletter Sign Up</h2>
 
-						<button class="newspack-ui__modal__close">
+						<button class="newspack-ui__button newspack-ui__button--icon newspack-ui__button--ghost newspack-ui__modal__close">
 							<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-plugin' ); ?></span>
 							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 								<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
@@ -556,7 +556,7 @@ class Newspack_UI {
 							<input type="checkbox" name="checkbox-option-1">
 							<span>
 								<strong>The Weekly</strong><br>
-								Friday roundup of the most relevant stories.
+								<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 							</span>
 						</label>
 
@@ -564,7 +564,7 @@ class Newspack_UI {
 							<input type="checkbox" name="checkbox-option-2">
 							<span>
 								<strong>The Weekly</strong><br>
-								Friday roundup of the most relevant stories.
+								<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 							</span>
 						</label>
 
@@ -580,7 +580,7 @@ class Newspack_UI {
 						<header class="newspack-ui__modal__header">
 							<h2>Auth Modal Contents Default</h2>
 
-							<button class="newspack-blocks-modal__close newspack-ui__modal__close">
+							<button class="newspack-ui__button newspack-ui__button--icon newspack-ui__button--ghost newspack-ui__modal__close">
 								<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-plugin' ); ?></span>
 								<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 									<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
@@ -613,7 +613,7 @@ class Newspack_UI {
 								</p>
 
 								<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Sign In</button>
-								<button class="newspack-ui__button newspack-ui__button--tertiary newspack-ui__button--wide">Sign in to existing account</button>
+								<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">Sign in to existing account</button>
 							</form>
 						</section>
 

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -99,11 +99,33 @@ class Newspack_UI {
 						<path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z" />
 					</svg>
 				</span>
-
 				<p>
 					<strong>Success box style, plus icon + <code>newspack-ui__box--text-center</code> class.</strong>
 				</p>
+				<p>Plus a little bit of text below it.</p>
+			</div>
 
+			<div class="newspack-ui__box newspack-ui__box--warning newspack-ui__box--text-center">
+				<span class="newspack-ui__icon newspack-ui__icon--warning">
+					<svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z" />
+					</svg>
+				</span>
+				<p>
+					<strong>Warning box style, plus icon + <code>newspack-ui__box--text-center</code> class.</strong>
+				</p>
+				<p>Plus a little bit of text below it.</p>
+			</div>
+
+			<div class="newspack-ui__box newspack-ui__box--error newspack-ui__box--text-center">
+				<span class="newspack-ui__icon newspack-ui__icon--error">
+					<svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z" />
+					</svg>
+				</span>
+				<p>
+					<strong>Error box style, plus icon + <code>newspack-ui__box--text-center</code> class.</strong>
+				</p>
 				<p>Plus a little bit of text below it.</p>
 			</div>
 

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -248,13 +248,18 @@ class Newspack_UI {
 			<hr>
 
 			<h2>Buttons</h2>
-			<p><code>newspack-ui__button--primary</code>, <code>--branded</code>, <code>--secondary</code>, and <code>--tertiary</code> classes for colours/borders, and <code>newspack-ui__button--wide</code> for being 100% wide</p>
+			<p><code>newspack-ui__button--primary</code>, <code>--branded</code>, <code>--secondary</code>, <code>--ghost</code>, and <code>--destructive</code> classes for colours/borders, and <code>newspack-ui__button--wide</code> for being 100% wide</p>
 			<button class="newspack-ui__button">Default Theme Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--primary">Primary Button</button><br>
+			<button class="newspack-ui__button newspack-ui__button--primary" disabled>Primary Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--branded">Branded Button</button><br>
+			<button class="newspack-ui__button newspack-ui__button--branded" disabled>Branded Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--secondary">Secondary Button</button><br>
-			<button class="newspack-ui__button newspack-ui__button--tertiary">Tertiary Button</button><br>
-			<button class="newspack-ui__button newspack-ui__button--tertiary" disabled>Disabled</button><br>
+			<button class="newspack-ui__button newspack-ui__button--secondary" disabled>Secondary Button Disabled</button><br>
+			<button class="newspack-ui__button newspack-ui__button--ghost">Ghost Button</button><br>
+			<button class="newspack-ui__button newspack-ui__button--ghost" disabled>Ghost Button Disabled</button><br>
+			<button class="newspack-ui__button newspack-ui__button--destructive">Destructive Button</button><br>
+			<button class="newspack-ui__button newspack-ui__button--destructive" disabled>Destructive Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--secondary">
 				<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
 					<path fill-rule="evenodd" clip-rule="evenodd" d="M19.6 10.227C19.6 9.51801 19.536 8.83701 19.418 8.18201H10V12.05H15.382C15.2706 12.6619 15.0363 13.2448 14.6932 13.7635C14.3501 14.2822 13.9054 14.726 13.386 15.068V17.578H16.618C18.509 15.836 19.6 13.273 19.6 10.228V10.227Z" fill="#4285F4"></path>
@@ -270,8 +275,8 @@ class Newspack_UI {
 			<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Primary Button</button>
 			<button class="newspack-ui__button newspack-ui__button--branded newspack-ui__button--wide">Branded Button</button>
 			<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">Secondary Button</button>
-			<button class="newspack-ui__button newspack-ui__button--tertiary newspack-ui__button--wide">Tertiary Button</button>
-			<button class="newspack-ui__button newspack-ui__button--tertiary newspack-ui__button--wide" disabled>Disabled</button>
+			<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">Ghost Button</button>
+			<button class="newspack-ui__button newspack-ui__button--destructive newspack-ui__button--wide">Destructive Button</button>
 			<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">
 				<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
 					<path fill-rule="evenodd" clip-rule="evenodd" d="M19.6 10.227C19.6 9.51801 19.536 8.83701 19.418 8.18201H10V12.05H15.382C15.2706 12.6619 15.0363 13.2448 14.6932 13.7635C14.3501 14.2822 13.9054 14.726 13.386 15.068V17.578H16.618C18.509 15.836 19.6 13.273 19.6 10.228V10.227Z" fill="#4285F4"></path>

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -294,6 +294,46 @@ class Newspack_UI {
 
 			<hr>
 
+			<h2>Buttons Icon</h2>
+			<p>Uses the same classes as the <code>newspack-ui__button</code> but we add an extra class to it <code>newspack-ui__button--icon</code></p>
+			<button class="newspack-ui__button newspack-ui__button--icon">
+				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+					<path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z"/>
+				</svg>
+			</button>
+			<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--icon">
+				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+					<path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z"/>
+				</svg>
+			</button>
+			<button class="newspack-ui__button newspack-ui__button--branded newspack-ui__button--icon">
+				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+					<path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z"/>
+				</svg>
+			</button>
+			<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--icon">
+				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+					<path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z"/>
+				</svg>
+			</button>
+			<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--icon">
+				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+					<path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z"/>
+				</svg>
+			</button>
+			<button class="newspack-ui__button newspack-ui__button--outline newspack-ui__button--icon">
+				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+					<path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z"/>
+				</svg>
+			</button>
+			<button class="newspack-ui__button newspack-ui__button--destructive newspack-ui__button--icon">
+				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+					<path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z"/>
+				</svg>
+			</button>
+
+			<hr>
+
 			<h2>Modals</h2>
 
 			<div class="newspack-ui__box">

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -359,7 +359,7 @@ class Newspack_UI {
 							</p>
 
 							<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Sign In</button>
-							<button class="newspack-ui__button newspack-ui__button--tertiary newspack-ui__button--wide">Sign in to existing account</button>
+							<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">Sign in to existing account</button>
 						</form>
 					</section>
 
@@ -400,7 +400,7 @@ class Newspack_UI {
 
 							<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Continue</button>
 							<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">Resend Code</button>
-							<button class="newspack-ui__button newspack-ui__button--tertiary newspack-ui__button--wide">Go Back</button>
+							<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">Go Back</button>
 						</form>
 					</section>
 				</div><!-- .newspack-ui__modal--small -->
@@ -488,7 +488,7 @@ class Newspack_UI {
 						</form>
 
 						<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Continue</button>
-						<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">Skip for now</button>
+						<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">Skip for now</button>
 					</section>
 				</div><!-- .newspack-ui__modal--small -->
 			</div><!-- .newspack-ui__box -->

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -258,6 +258,8 @@ class Newspack_UI {
 			<button class="newspack-ui__button newspack-ui__button--secondary" disabled>Secondary Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--ghost">Ghost Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--ghost" disabled>Ghost Button Disabled</button><br>
+			<button class="newspack-ui__button newspack-ui__button--outline">Outline Button</button><br>
+			<button class="newspack-ui__button newspack-ui__button--outline" disabled>Outline Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--destructive">Destructive Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--destructive" disabled>Destructive Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--secondary">
@@ -276,6 +278,7 @@ class Newspack_UI {
 			<button class="newspack-ui__button newspack-ui__button--branded newspack-ui__button--wide">Branded Button</button>
 			<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">Secondary Button</button>
 			<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">Ghost Button</button>
+			<button class="newspack-ui__button newspack-ui__button--outline newspack-ui__button--wide">Outline Button</button>
 			<button class="newspack-ui__button newspack-ui__button--destructive newspack-ui__button--wide">Destructive Button</button>
 			<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">
 				<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1125,9 +1125,9 @@ final class Reader_Activation {
 				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary" data-action="otp" data-send-code><?php \esc_html_e( 'Resend code', 'newspack-plugin' ); ?></button>
 				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary" data-action="pwd" data-send-code><?php \esc_html_e( 'Email me a one-time code instead', 'newspack-plugin' ); ?></button>
 				<a class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary" data-action="pwd" href="<?php echo \esc_url( \wp_lostpassword_url() ); ?>"><?php \esc_html_e( 'Forgot password', 'newspack-plugin' ); ?></a>
-				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--tertiary newspack-ui__last-child" data-action="signin" data-set-action="register"><?php \esc_html_e( 'Create an account', 'newspack-plugin' ); ?></button>
-				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--tertiary newspack-ui__last-child" data-action="register" data-set-action="signin"><?php \esc_html_e( 'Sign in to an existing account', 'newspack-plugin' ); ?></button>
-				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--tertiary newspack-ui__last-child" data-action="otp pwd"  data-back><?php \esc_html_e( 'Go back', 'newspack-plugin' ); ?></button>
+				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--ghost newspack-ui__last-child" data-action="signin" data-set-action="register"><?php \esc_html_e( 'Create an account', 'newspack-plugin' ); ?></button>
+				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--ghost newspack-ui__last-child" data-action="register" data-set-action="signin"><?php \esc_html_e( 'Sign in to an existing account', 'newspack-plugin' ); ?></button>
+				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--ghost newspack-ui__last-child" data-action="otp pwd"  data-back><?php \esc_html_e( 'Go back', 'newspack-plugin' ); ?></button>
 			</form>
 			<a href="#" class="auth-callback newspack-ui__button newspack-ui__button--wide newspack-ui__button--primary" data-action="success"><?php \esc_html_e( 'Continue', 'newspack-plugin' ); ?></a>
 			<a href="#" class="set-password newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary" data-action="success"><?php \esc_html_e( 'Set a password (optional)', 'newspack-plugin' ); ?></a>
@@ -1159,7 +1159,7 @@ final class Reader_Activation {
 			<div class="newspack-ui__modal newspack-ui__modal--small">
 				<div class="newspack-ui__modal__header">
 					<h2><?php _e( 'Sign In', 'newspack-plugin' ); ?></h2>
-					<button class="newspack-ui__modal__close">
+					<button class="newspack-ui__button newspack-ui__button--icon newspack-ui__button--ghost newspack-ui__modal__close">
 						<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-plugin' ); ?></span>
 						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 							<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1073,7 +1073,7 @@ final class Reader_Activation {
 				<p>
 					<strong class="success-title"></strong>
 				</p>
-				<p class="newspack-ui__font--small success-description"></p>
+				<p class="newspack-ui__font--xs success-description"></p>
 			</div>
 			<form method="post" target="_top">
 				<div data-action="signin register">

--- a/includes/templates/reader-activation/login-form.php
+++ b/includes/templates/reader-activation/login-form.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div class="newspack-ui">
 	<?php Reader_Activation::render_auth_form(); ?>
-	<p><?php echo wp_kses_post( Reader_Activation::get_auth_footer() ); ?></p>
+	<p class="newspack-ui__font--xs"><?php echo wp_kses_post( Reader_Activation::get_auth_footer() ); ?></p>
 </div>
 <?php
 \do_action( 'woocommerce_after_customer_login_form' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is pretty big, but it mostly changes CSS variable values and names. Specifically:
* It updates the colour variable values to match the new component Figma file, and updates the names to match.
* It updates the font size variables, and updates their names to match. 
* It updates the variable names and values of the border-radius & modal widths.
* It updates the variable names throughout the SCSS files.
* It adds a couple more examples to the UI Demo page, for warnings, font sizes, and the branded buttons.

Outside of that, it also:
* Updates the styles of the radio button, checkbox, and text inputs to match the components (changes include adjusting the border radius, padding, and focus styles.
* Builds out the WooCommerce overrides styles, to make sure the checkout is picking up the new input and font sizing styles.

In the non-SCSS, non-demo files, the PR also updates a couple CSS classes in the reader-activation success message and the reader activation login form.

Still to do:
* Set up the different button size styles.
* Updating the ‘checkbox + label + container’ element.
* Update the label element to incorporate the error styles.

See: 1205234045751551-as-1206899964006422

### How to test the changes in this Pull Request:

1. Start on a test site running RAS.
2. Add a donate block to a page.
3. Create a variable product, and add a checkout button block for it to the same page. 
4. Apply the PR and run `npm run build`. 
5. While logged into a test site, append `?ui-demo` to any page’s URL; review that against the Figma file for font sizes, padding, spacing. 
6. Focus on inputs, and click radio buttons. 
7. Click the ‘Open Modal’ button at the bottom and review its appearance. 
8. View the site in “incognito mode”/as a reader. 
9. Run through the Donate process, and spot check the appearance of the modals.
10. Run through the checkout process using the Checkout button, adn spot check the appearance of the variable modal. 
11. Click the Sign In button in the header, and spot-check the appearance of the modal.
12. Test the 'prefers contrast' colours. In Chrome, you can do this by opening the Developer tools, enabling the Rendering tab, and finding the "Emulate CSS media feature prefers-contrast". Change this to prefers-contrast: more:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/ccb1c1b0-dee8-4023-8a86-90dfa91a2fa2)



### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->