### PR TITLE
feat(ras-acc): add option to reset ras acc transactional email templates

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -20,6 +20,7 @@ import {
 	TextControl,
 	Waiting,
 	withWizardScreen,
+	utils,
 } from '../../../../components/src';
 import Prerequisite from '../../components/prerequisite';
 import ActiveCampaign from '../../components/active-campaign';
@@ -297,7 +298,18 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 									href={ email.edit_link }
 									description={ email.description }
 									actionText={ __( 'Edit', 'newspack-plugin' ) }
-									onSecondaryActionClick={ () => resetEmail( email.post_id ) }
+									onSecondaryActionClick={ () => {
+										if (
+											utils.confirmAction(
+												__(
+													'Are you sure you want to reset the contents of this email?',
+													'newspack-plugin'
+												)
+											)
+										) {
+											resetEmail( email.post_id );
+										}
+									} }
 									secondaryActionText={ __( 'Reset', 'newspack-plugin' ) }
 									secondaryDestructive={ true }
 									isSmall

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -2,10 +2,10 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
+import { ExternalLink } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -39,6 +39,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 	const [ prerequisites, setPrerequisites ] = useState( null );
 	const [ missingPlugins, setMissingPlugins ] = useState( [] );
 	const [ showAdvanced, setShowAdvanced ] = useState( false );
+
 	const updateConfig = ( key, val ) => {
 		setConfig( { ...config, [ key ]: val } );
 	};
@@ -70,6 +71,18 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 				setConfig( fetchedConfig );
 				setMembershipsConfig( memberships );
 			} )
+			.catch( setError )
+			.finally( () => setInFlight( false ) );
+	};
+	const resetEmail = postId => {
+		setError( false );
+		setInFlight( true );
+		wizardApiFetch( {
+			path: `/newspack/v1/wizard/newspack-engagement-wizard/reader-activation/emails/${ postId }`,
+			method: 'DELETE',
+			quiet: true,
+		} )
+			.then( emails => setConfig( { ...config, emails } ) )
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
 	};
@@ -284,6 +297,9 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 									href={ email.edit_link }
 									description={ email.description }
 									actionText={ __( 'Edit', 'newspack-plugin' ) }
+									onSecondaryActionClick={ () => resetEmail( email.post_id ) }
+									secondaryActionText={ __( 'Reset', 'newspack-plugin' ) }
+									secondaryDestructive={ true }
 									isSmall
 								/>
 							) ) }

--- a/assets/wizards/readerRevenue/views/emails/index.js
+++ b/assets/wizards/readerRevenue/views/emails/index.js
@@ -47,6 +47,18 @@ const Emails = () => {
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
 	};
+	const resetEmail = postId => {
+		setError( false );
+		setInFlight( true );
+		apiFetch( {
+			path: `/newspack/v1/wizard/newspack-reader-revenue-wizard/donations/emails/${ postId }`,
+			method: 'DELETE',
+			quiet: true,
+		} )
+			.then( result => setEmails( values( result ) ) )
+			.catch( setError )
+			.finally( () => setInFlight( false ) );
+	};
 
 	if ( false === pluginsReady ) {
 		return (
@@ -84,6 +96,9 @@ const Emails = () => {
 						href={ email.edit_link }
 						description={ email.description }
 						actionText={ __( 'Edit', 'newspack' ) }
+						secondaryActionText={ __( 'Reset', 'newspack' ) }
+						onSecondaryActionClick={ () => resetEmail( email.post_id ) }
+						secondaryDestructive={ true }
 						toggleChecked={ isActive }
 						toggleOnChange={ value => updateStatus( email.post_id, value ? 'publish' : 'draft' ) }
 						{ ...( isActive

--- a/assets/wizards/readerRevenue/views/emails/index.js
+++ b/assets/wizards/readerRevenue/views/emails/index.js
@@ -15,7 +15,7 @@ import values from 'lodash/values';
 /**
  * Internal dependencies
  */
-import { PluginInstaller, ActionCard, Notice } from '../../../../components/src';
+import { PluginInstaller, ActionCard, Notice, utils } from '../../../../components/src';
 
 const EMAILS = values( newspack_reader_revenue.emails );
 const postType = newspack_reader_revenue.email_cpt;
@@ -97,7 +97,18 @@ const Emails = () => {
 						description={ email.description }
 						actionText={ __( 'Edit', 'newspack' ) }
 						secondaryActionText={ __( 'Reset', 'newspack' ) }
-						onSecondaryActionClick={ () => resetEmail( email.post_id ) }
+						onSecondaryActionClick={ () => {
+							if (
+								utils.confirmAction(
+									__(
+										'Are you sure you want to reset the contents of this email?',
+										'newspack-plugin'
+									)
+								)
+							) {
+								resetEmail( email.post_id );
+							}
+						} }
 						secondaryDestructive={ true }
 						toggleChecked={ isActive }
 						toggleOnChange={ value => updateStatus( email.post_id, value ? 'publish' : 'draft' ) }

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -110,6 +110,15 @@ class Engagement_Wizard extends Wizard {
 		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/reader-activation/emails/(?P<id>\d+)',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'api_reset_reader_activation_email' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/newsletters',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
@@ -251,6 +260,44 @@ class Engagement_Wizard extends Wizard {
 				'memberships'          => self::get_memberships_settings(),
 			]
 		);
+	}
+
+	/**
+	 * Reset reader activation email template.
+	 * We acheive this by trashing the email template post.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function api_reset_reader_activation_email( $request ) {
+		$params = $request->get_params();
+		$id     = $params['id'];
+		$email  = get_post( $id );
+
+		if ( $email === null || $email->post_type !== Emails::POST_TYPE ) {
+			return new WP_Error(
+				'newspack_reset_reader_activation_email_invalid_arg',
+				esc_html__( 'Invalid argument: no email template matches the provided id.', 'newspack-plugin' ),
+				[
+					'status' => 400,
+					'level'  => 'notice',
+				]
+			);
+		}
+
+		if ( ! \wp_trash_post( $id ) ) {
+			return new WP_Error(
+				'newspack_reset_reader_activation_email_reset_failed',
+				esc_html__( 'Reset failed: unable to reset email template.', 'newspack-plugin' ),
+				[
+					'status' => 400,
+					'level'  => 'notice',
+				]
+			);
+		}
+
+		return rest_ensure_response( Emails::get_emails( array_values( Reader_Activation_Emails::EMAIL_TYPES ), false ) );
 	}
 
 	/**

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -268,6 +268,16 @@ class Reader_Revenue_Wizard extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/donations/emails/(?P<id>\d+)',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'api_reset_donation_email' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
 	}
 
 	/**
@@ -518,6 +528,46 @@ class Reader_Revenue_Wizard extends Wizard {
 
 		return rest_ensure_response( Donations::get_donation_settings() );
 	}
+
+
+	/**
+	 * Reset reader activation email template.
+	 * We acheive this by trashing the email template post.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function api_reset_donation_email( $request ) {
+		$params = $request->get_params();
+		$id     = $params['id'];
+		$email  = get_post( $id );
+
+		if ( $email === null || $email->post_type !== Emails::POST_TYPE ) {
+			return new WP_Error(
+				'newspack_reset_donation_email_invalid_arg',
+				esc_html__( 'Invalid argument: no email template matches the provided id.', 'newspack-plugin' ),
+				[
+					'status' => 400,
+					'level'  => 'notice',
+				]
+			);
+		}
+
+		if ( ! \wp_trash_post( $id ) ) {
+			return new WP_Error(
+				'newspack_reset_donation_email_reset_failed',
+				esc_html__( 'Reset failed: unable to reset email template.', 'newspack-plugin' ),
+				[
+					'status' => 400,
+					'level'  => 'notice',
+				]
+			);
+		}
+
+		return rest_ensure_response( Emails::get_emails( [ Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'] ], false ) );
+	}
+
 
 	/**
 	 * Check whether WooCommerce is installed and active.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds an option to reset transactional and donation email templates:

![Screenshot 2024-04-08 at 17 13 29](https://github.com/Automattic/newspack-plugin/assets/17905991/803b2488-dc56-4bf2-a09a-7eae20fb6296)

### How to test the changes in this Pull Request:

1. Go to Newspack > Engagement > Show Advanced Settings
2. If you've never made changes to any of the templates, select edit next to any of the transactional emails and make some changes (anything is fine)
3. Save your changes then head back to the Engagement advanced settings section and for the same email template that you just edited select the reset link
4. Select edit for the same template again and confirm your changes have been reset and the email template post has reverted to the default design:
![Screenshot 2024-04-09 at 10 56 29](https://github.com/Automattic/newspack-plugin/assets/17905991/6885a61e-2cda-45fd-971b-8125bbe6a5e6)
5. Repeat the above steps for the donation email template at Newspack > Reader Revenue > Email

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->