### PR TITLE
feat(ras): skip campaign setup

### DIFF
--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -93,9 +93,7 @@ export default function Prerequisite( {
 									: sprintf(
 											// Translators: Save or Update settings.
 											__( '%s settings', 'newspack-plugin' ),
-											isValid
-												? __( 'Update', 'newspack-plugin' )
-												: __( 'Save', 'newspack-plugin' )
+											isValid ? __( 'Update', 'newspack-plugin' ) : __( 'Save', 'newspack-plugin' )
 									  ) }
 							</Button>
 						</div>

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -23,10 +23,11 @@ export default function Prerequisite( {
 	saveConfig,
 }: PrequisiteProps ) {
 	const { href } = prerequisite;
+	const isValid = Boolean( prerequisite.active || prerequisite.is_skipped );
 
 	// If the prerequisite is active but has empty fields, show a warning.
 	const hasEmptyFields = () => {
-		if ( prerequisite.active && prerequisite.fields && prerequisite.warning ) {
+		if ( isValid && prerequisite.fields && prerequisite.warning ) {
 			const emptyValues = Object.keys( prerequisite.fields ).filter(
 				fieldName => '' === config[ fieldName as keyof Config ]
 			);
@@ -93,7 +94,7 @@ export default function Prerequisite( {
 									: sprintf(
 											// Translators: Save or Update settings.
 											__( '%s settings', 'newspack-plugin' ),
-											prerequisite.active
+											isValid
 												? __( 'Update', 'newspack-plugin' )
 												: __( 'Save', 'newspack-plugin' )
 									  ) }
@@ -138,7 +139,7 @@ export default function Prerequisite( {
 									} }
 								>
 									{ /* eslint-disable no-nested-ternary */ }
-									{ ( prerequisite.active
+									{ ( isValid
 										? __( 'Update ', 'newspack-plugin' )
 										: prerequisite.fields
 										? __( 'Save ', 'newspack-plugin' )
@@ -158,8 +159,10 @@ export default function Prerequisite( {
 	);
 
 	let status = __( 'Pending', 'newspack-plugin' );
-	if ( prerequisite.active ) {
-		status = __( 'Ready', 'newspack-plugin' );
+	if ( isValid ) {
+		status = `${ __( 'Ready', 'newspack-plugin' ) } ${
+			prerequisite.is_skipped ? `(${ __( 'Skipped', 'newspack-plugin' ) })` : ''
+		}`;
 	}
 	if ( prerequisite.is_unavailable ) {
 		status = __( 'Unavailable', 'newspack-plugin' );
@@ -170,14 +173,14 @@ export default function Prerequisite( {
 			className="newspack-ras-wizard__prerequisite"
 			isMedium
 			expandable={ ! prerequisite.is_unavailable }
-			collapse={ prerequisite.active }
+			collapse={ isValid }
 			title={ prerequisite.label }
 			description={ sprintf(
 				/* translators: %s: Prerequisite status */
 				__( 'Status: %s', 'newspack-plugin' ),
 				status
 			) }
-			checkbox={ prerequisite.active ? 'checked' : 'unchecked' }
+			checkbox={ isValid ? 'checked' : 'unchecked' }
 			notificationLevel="info"
 			notification={ hasEmptyFields() }
 		>

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -80,9 +80,8 @@ export default function Prerequisite( {
 								onClick={ () => {
 									const dataToSave: Partial< Config > = {};
 									fieldKeys.forEach( fieldName => {
-										if ( config[ fieldName ] ) {
-											// @ts-ignore - not sure what's the issue here.
-											dataToSave[ fieldName ] = config[ fieldName ];
+										if ( typeof config[ fieldName ] !== 'undefined' ) {
+											dataToSave[ fieldName ] = config[ fieldName ] as any;
 										}
 									} );
 									saveConfig( dataToSave );

--- a/assets/wizards/engagement/components/prerequisite.tsx
+++ b/assets/wizards/engagement/components/prerequisite.tsx
@@ -80,8 +80,9 @@ export default function Prerequisite( {
 								onClick={ () => {
 									const dataToSave: Partial< Config > = {};
 									fieldKeys.forEach( fieldName => {
-										if ( typeof config[ fieldName ] !== 'undefined' ) {
-											dataToSave[ fieldName ] = config[ fieldName ] as any;
+										if ( config[ fieldName ] ) {
+											// @ts-ignore - not sure what's the issue here.
+											dataToSave[ fieldName ] = config[ fieldName ];
 										}
 									} );
 									saveConfig( dataToSave );

--- a/assets/wizards/engagement/components/types.ts
+++ b/assets/wizards/engagement/components/types.ts
@@ -127,6 +127,7 @@ export type PrequisiteProps = {
 		action_enabled?: boolean;
 		disabled_text?: string;
 		is_unavailable?: boolean;
+		is_skipped?: boolean;
 	};
 };
 

--- a/assets/wizards/engagement/views/reader-activation/campaign.js
+++ b/assets/wizards/engagement/views/reader-activation/campaign.js
@@ -19,10 +19,7 @@ import {
 	utils,
 } from '../../../../components/src';
 import Prompt from '../../components/prompt';
-import Router from '../../../../components/src/proxied-imports/router';
 import './style.scss';
-
-const { useHistory } = Router;
 
 export default withWizardScreen( () => {
 	const { is_skipped_campaign_setup, reader_activation_url } = newspack_engagement_wizard;
@@ -35,8 +32,6 @@ export default withWizardScreen( () => {
 		status: '',
 		isSkipped: is_skipped_campaign_setup === '1',
 	} );
-
-	const history = useHistory();
 
 	const fetchPrompts = () => {
 		setError( false );
@@ -76,7 +71,6 @@ export default withWizardScreen( () => {
 			} );
 			setSkipped( { isSkipped: Boolean( request ), status: '' } );
 			newspack_engagement_wizard.is_skipped_campaign_setup = '1';
-			history.push( '/reader-activation' );
 		} catch ( err ) {
 			setSkipped( { isSkipped: false, status: '' } );
 		}
@@ -126,16 +120,20 @@ export default withWizardScreen( () => {
 				) ) }
 			<div className="newspack-buttons-card">
 				<Button
-					disabled={ skipped.isSkipped || skipped.status === 'pending' }
+					isTertiary
+					disabled={ inFlight || skipped.isSkipped || skipped.status === 'pending' }
 					onClick={ onSkipCampaignSetup }
 				>
-					{ skipped.status === ''
-						? __( 'Skip', 'newspack-plugin' )
-						: __( 'Skipping…', 'newspack-plugin' ) }
+					{ /* eslint-disable-next-line no-nested-ternary */ }
+					{ skipped.status === 'pending'
+						? __( 'Skipping…', 'newspack-plugin' )
+						: skipped.isSkipped
+						? __( 'Skipped', 'newspack-plugin' )
+						: __( 'Skip', 'newspack-plugin' ) }
 				</Button>
 				<Button
 					isPrimary
-					disabled={ inFlight || ! allReady }
+					disabled={ inFlight || ( ! allReady && ! skipped.isSkipped ) }
 					href={ `${ reader_activation_url }/complete` }
 				>
 					{ __( 'Continue', 'newspack-plugin' ) }

--- a/assets/wizards/engagement/views/reader-activation/campaign.js
+++ b/assets/wizards/engagement/views/reader-activation/campaign.js
@@ -63,15 +63,23 @@ export default withWizardScreen( () => {
 		) {
 			return;
 		}
+		setError( false );
 		setSkipped( { ...skipped, status: 'pending' } );
 		try {
 			const request = await apiFetch( {
 				path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation/skip-campaign-setup',
 				method: 'POST',
+				data: { skip: ! skipped.isSkipped },
 			} );
-			setSkipped( { isSkipped: Boolean( request ), status: '' } );
-			newspack_engagement_wizard.is_skipped_campaign_setup = '1';
+			if ( ! request.updated ) {
+				setError( { message: __( 'Server not updated', 'newspack-plugin' ) } );
+				setSkipped( { isSkipped: false, status: '' } );
+				return;
+			}
+			setSkipped( { isSkipped: Boolean( request.skipped ), status: '' } );
+			newspack_engagement_wizard.is_skipped_campaign_setup = request.skipped ? '1' : '';
 		} catch ( err ) {
+			setError( err );
 			setSkipped( { isSkipped: false, status: '' } );
 		}
 	}

--- a/assets/wizards/engagement/views/reader-activation/campaign.js
+++ b/assets/wizards/engagement/views/reader-activation/campaign.js
@@ -19,7 +19,10 @@ import {
 	utils,
 } from '../../../../components/src';
 import Prompt from '../../components/prompt';
+import Router from '../../../../components/src/proxied-imports/router';
 import './style.scss';
+
+const { useHistory } = Router;
 
 export default withWizardScreen( () => {
 	const { is_skipped_campaign_setup, reader_activation_url } = newspack_engagement_wizard;
@@ -32,6 +35,7 @@ export default withWizardScreen( () => {
 		status: '',
 		isSkipped: is_skipped_campaign_setup === '1',
 	} );
+	const history = useHistory();
 
 	const fetchPrompts = () => {
 		setError( false );
@@ -78,6 +82,7 @@ export default withWizardScreen( () => {
 			}
 			setSkipped( { isSkipped: Boolean( request.skipped ), status: '' } );
 			newspack_engagement_wizard.is_skipped_campaign_setup = request.skipped ? '1' : '';
+			history.push( '/reader-activation/complete' );
 		} catch ( err ) {
 			setError( err );
 			setSkipped( { isSkipped: false, status: '' } );

--- a/assets/wizards/engagement/views/reader-activation/complete.js
+++ b/assets/wizards/engagement/views/reader-activation/complete.js
@@ -22,18 +22,26 @@ import {
 } from '../../../../components/src';
 
 const listItems = [
-	__(
-		'Your <strong>current segments and prompts</strong> will be deactivated and archived.',
-		'newspack-plugin'
-	),
-	__(
-		'<strong>Reader registration</strong> will be activated to enable better targeting for driving engagement and conversations.',
-		'newspack-plugin'
-	),
-	__(
-		'The <strong>Reader Activation campaign</strong> will be activated with default segments and settings.',
-		'newspack-plugin'
-	),
+	{
+		text: __(
+			'Your <strong>current segments and prompts</strong> will be deactivated and archived.',
+			'newspack-plugin'
+		),
+		isSkipped: '<span class="is-skipped">[skipped]</span>',
+	},
+	{
+		text: __(
+			'<strong>Reader registration</strong> will be activated to enable better targeting for driving engagement and conversations.',
+			'newspack-plugin'
+		),
+	},
+	{
+		text: __(
+			'The <strong>Reader Activation campaign</strong> will be activated with default segments and settings.',
+			'newspack-plugin'
+		),
+		isSkipped: '<span class="is-skipped">[skipped]</span>',
+	},
 ];
 
 const activationSteps = [
@@ -65,8 +73,25 @@ export default withWizardScreen( () => {
 	const { reader_activation_url, is_skipped_campaign_setup = '' } = newspack_engagement_wizard;
 	const isSkippedCampaignSetup = is_skipped_campaign_setup === '1';
 
+	/**
+	 * If skipped, remove first item.
+	 */
 	if ( isSkippedCampaignSetup && activationSteps.length !== activationStepsCount - 1 ) {
 		activationSteps.shift();
+	}
+
+	/**
+	 * Generate step list strings
+	 */
+	for ( const listItemIndex in listItems ) {
+		if ( ! listItems[ listItemIndex ].text ) {
+			continue;
+		}
+		const suffix = isSkippedCampaignSetup ? ` ${ listItems[ listItemIndex ].isSkipped ?? '' }` : '';
+		listItems[ listItemIndex ] = `${ listItems[ listItemIndex ].text }${ suffix }`;
+		if ( isSkippedCampaignSetup ) {
+			listItems[ listItemIndex ] += ` ${ listItems[ listItemIndex ].isSkipped ?? '' }`;
+		}
 	}
 
 	useEffect( () => {
@@ -87,7 +112,7 @@ export default withWizardScreen( () => {
 			setProgressLabel( __( 'Done!', 'newspack-plugin' ) );
 			setTimeout( () => {
 				setInFlight( false );
-				window.location = reader_activation_url;
+				// window.location = reader_activation_url;
 			}, 3000 );
 		}
 	}, [ completed, progress ] );

--- a/assets/wizards/engagement/views/reader-activation/complete.js
+++ b/assets/wizards/engagement/views/reader-activation/complete.js
@@ -42,6 +42,8 @@ const activationSteps = [
 	__( 'Activating Reader Activation Campaign…', 'newspack-plugin' ),
 ];
 
+const activationStepsCount = activationSteps.length;
+
 /**
  * Get a random number between min and max.
  *
@@ -60,7 +62,12 @@ export default withWizardScreen( () => {
 	const [ progressLabel, setProgressLabel ] = useState( false );
 	const [ completed, setCompleted ] = useState( false );
 	const timer = useRef();
-	const { reader_activation_url } = newspack_engagement_wizard;
+	const { reader_activation_url, is_skipped_campaign_setup = '' } = newspack_engagement_wizard;
+	const isSkippedCampaignSetup = is_skipped_campaign_setup === '1';
+
+	if ( isSkippedCampaignSetup && activationSteps.length !== activationStepsCount - 1 ) {
+		activationSteps.shift();
+	}
 
 	useEffect( () => {
 		if ( timer.current ) {
@@ -95,6 +102,9 @@ export default withWizardScreen( () => {
 				await apiFetch( {
 					path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation/activate',
 					method: 'post',
+					data: {
+						skip_activation: isSkippedCampaignSetup,
+					},
 				} )
 			);
 		} catch ( err ) {

--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -96,7 +96,9 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 		const _allReady =
 			! missingPlugins.length &&
 			prerequisites &&
-			Object.keys( prerequisites ).every( key => prerequisites[ key ]?.active );
+			Object.keys( prerequisites ).every(
+				key => prerequisites[ key ]?.active || prerequisites[ key ]?.skipped
+			);
 
 		setAllReady( _allReady );
 

--- a/assets/wizards/engagement/views/reader-activation/style.scss
+++ b/assets/wizards/engagement/views/reader-activation/style.scss
@@ -4,6 +4,10 @@
 	margin-top: 0 !important;
 }
 
+span.is-skipped {
+	color: wp-colors.$gray-700;
+}
+
 .newspack-ras-campaign {
 	&__prompt-wizard,
 	&__completed {

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -500,6 +500,7 @@ final class Reader_Activation {
 			],
 			'ras_campaign'     => [
 				'active'         => self::is_ras_campaign_configured(),
+				'is_skipped'     => get_option( Engagement_Wizard::SKIP_CAMPAIGN_SETUP_OPTION, '' ) === '1',
 				'plugins'        => [
 					'newspack-popups' => class_exists( '\Newspack_Popups_Model' ),
 				],

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -407,7 +407,7 @@ final class Reader_Activation {
 	 * TODO: Make this dynamic once the third UI screen to generate the prompts is built.
 	 */
 	public static function is_ras_campaign_configured() {
-		return self::is_enabled();
+		return self::is_enabled() || get_option( Engagement_Wizard::SKIP_CAMPAIGN_SETUP_OPTION, '' ) === '1';
 	}
 
 	/**

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -7,7 +7,10 @@
 
 namespace Newspack;
 
+use TypeError;
 use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -276,10 +279,12 @@ class Engagement_Wizard extends Wizard {
 	/**
 	 * Activate reader activation and publish RAS prompts/segments.
 	 *
+	 * @param WP_REST_Request $request WP Rest Request object.
 	 * @return WP_REST_Response
 	 */
-	public function api_activate_reader_activation() {
-		$response = Reader_Activation::activate();
+	public function api_activate_reader_activation( WP_REST_Request $request ) {
+		$skip_activation = $request->get_param( 'skip_activation' ) ?? false;
+		$response = $skip_activation ? true : Reader_Activation::activate();
 
 		if ( \is_wp_error( $response ) ) {
 			return new \WP_REST_Response( [ 'message' => $response->get_error_message() ], 400 );

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -115,9 +115,15 @@ class Engagement_Wizard extends Wizard {
 			'/wizard/' . $this->slug . '/reader-activation/skip-campaign-setup',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => function() {
-					$skip_campaign_setup = update_option( static::SKIP_CAMPAIGN_SETUP_OPTION, true );
-					return rest_ensure_response( $skip_campaign_setup );
+				'callback'            => function( $request ) {
+					$skip = $request->get_param( 'skip' );
+					$skip_campaign_setup = update_option( static::SKIP_CAMPAIGN_SETUP_OPTION, $skip );
+					return rest_ensure_response( 
+						[ 
+							'skipped' => $skip,
+							'updated' => $skip_campaign_setup,
+						]
+					);
 				},
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -7,7 +7,7 @@
 
 namespace Newspack;
 
-use WP_Error, WP_Query;
+use WP_Error;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -17,6 +17,8 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
  * Easy interface for setting up general store info.
  */
 class Engagement_Wizard extends Wizard {
+
+	const SKIP_CAMPAIGN_SETUP_OPTION = '_newspack_ras_skip_campaign_setup';
 
 	/**
 	 * The slug of this wizard.
@@ -105,6 +107,18 @@ class Engagement_Wizard extends Wizard {
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_activate_reader_activation' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/reader-activation/skip-campaign-setup',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => function() {
+					$skip_campaign_setup = update_option( static::SKIP_CAMPAIGN_SETUP_OPTION, true );
+					return rest_ensure_response( $skip_campaign_setup );
+				},
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
@@ -422,6 +436,8 @@ class Engagement_Wizard extends Wizard {
 			$data['preview_post']       = $newspack_popups->preview_post();
 			$data['preview_archive']    = $newspack_popups->preview_archive();
 		}
+
+		$data['is_skipped_campaign_setup'] = get_option( static::SKIP_CAMPAIGN_SETUP_OPTION, '' );
 
 		\wp_localize_script(
 			'newspack-engagement-wizard',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Ability to allow editors to skip "Reader Activation Campaign" setup.

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets i.e. `git checkout origin/feat/skip-ras-campaign-setup && npm run build`
2. Ensure you've completed the first 5 Reader Activation settings, example below:
![Screenshot 2024-04-09 at 15 28 39](https://github.com/Automattic/newspack-plugin/assets/3676975/0e2dbc70-0355-4d9d-a110-cf4da360d7bc)
3. Expand "Reader Activation Campaign" and click "Update Reader Activation campaign" or navigate to - /wp-admin/admin.php?page=newspack-engagement-wizard#/reader-activation/campaign.
4. Click (newly added) "Skip" button, at the bottom-right of the screen. Confirm prompt.
5. Observe once response is received from server the "Continue" button is enabled.
6. Navigate back to Newspack / Engagement or /wp-admin/admin.php?page=newspack-engagement-wizard#/reader-activation and confirm "Reader Activation Campaign" has status "Ready (Skipped)"
![Screenshot 2024-04-09 at 10 44 14](https://github.com/Automattic/newspack-plugin/assets/3676975/865d863f-b451-40d6-a9ac-5eeef6a5d598)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?