### PR TITLE
Fallback to subscription for sync data when customer has no orders

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -283,6 +283,14 @@ class WooCommerce_Connection {
 
 		if ( ! $order ) {
 			$order = self::get_last_successful_order( $customer );
+
+			// If customer has no order, they might still have a Subscription.
+			if ( ! $order ) {
+				$user_subscriptions = wcs_get_users_subscriptions( $customer->get_id() );
+				if ( $user_subscriptions ) {
+					$order = reset( $user_subscriptions );
+				}
+			}
 		}
 
 		if ( $order ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: this is a hotfix.**

This PR adds fallback handling to the ESP sync for the case where a user has an active subscription but hasn't made any payments yet, so doesn't have a latest order. This is super common after a subscription migration, where there are a ton of subscriptions that haven't renewed yet on a site. In this scenario we can get a lot of the info we need from the subscription since it's technically an Order object.

### How to test the changes in this Pull Request:

1. Manually create a Subscription for a user in WP Admin. This should be a user that has not made any transactions yet.
2. Before applying this patch: `wp newspack woo resync --user-ids={user_id_from_above_user}`. Observe in MailChimp or ActiveCampaign that none of the product/subscription-status info synchronizes to the ESP.
3. Apply this patch. `wp newspack woo resync --user-ids={user_id_from_above_user}`. Observe that the product/subscription-status info synchronizes to the ESP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->