### PR TITLE
feat(ras-acc): migrate transactional emails to updated templates

### DIFF
--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -240,7 +240,7 @@ class Emails {
 		}
 
 		// Migrate to RAS-ACC email templates if migration option is not set AND there have been no manual updates to the templates.
-		if ( ! get_option( 'newspack_email_templates_migrated', false ) ) {
+		if ( get_option( 'newspack_email_templates_migrated', '' ) !== 'v1' ) {
 			$migrated  = true;
 			$templates = get_posts(
 				[
@@ -263,7 +263,9 @@ class Emails {
 				}
 			}
 
-			update_option( 'newspack_email_templates_migrated', $migrated );
+			if ( $migrated ) {
+				update_option( 'newspack_email_templates_migrated', 'v1' );
+			}
 		}
 
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR migrates any unmodified transactional email templates by trashing email template posts that have not been updated since the publish date.

### How to test the changes in this Pull Request:

There will be no visual changes to the emails after a migration since the transactional email redesign lives in another PR, but we can test this by checking the post IDs:

1. First, make sure you have unmodified transactional emails. If you have already modified all of these templates, you can "reset" them by deleting them all using something like the following wp cli command: `wp post delete $(wp post list --post_type='newspack_rr_email' --format=ids) --force`
2. Go to Newspack > Engagement > Show Advanced Settings
3. Take note of the post ids for the transactional emails. You can get these by hovering over the edit link of each email and finding the post ID in the link that appears at the bottom of the browser:
![Screenshot 2024-04-09 at 15 50 58](https://github.com/Automattic/newspack-plugin/assets/17905991/8bff5e3b-34d3-4e54-bd61-f43febb7a289)
4. Pick one or two email templates and make some changes then update them (You should leave one or more untouched).
5. On the frontend, logged in as a reader, trigger any transactional email. You can do this by creating a new reader account for example.
6. Back as an admin, go to the engagement transactional email settings page and recheck the post IDs for the transactional emails.
7. Confirm the edited templates have retained their post IDs, while the untouched templates now have new post IDs.
8. Again as a reader, trigger another transactional email.
9. Back as admin again, recheck email template post IDs and confirm none have changed (the migration should only occur once)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->