### PR TITLE
fix: fatal error when checking memberships for users with no memberships

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -844,7 +844,7 @@ class Memberships {
 		if ( function_exists( 'wc_memberships_get_user_membership' ) ) {
 			$membership = \wc_memberships_get_user_membership( $membership_id );
 			$plan       = $membership->get_plan();
-			if ( $plan && method_exists( $plan, 'get_access_length_type' ) && 'subscription' === $plan->get_access_length_type() && method_exists( $membership, 'get_subscription_id' ) && function_exists( 'wcs_get_subscription' ) ) {
+			if ( $membership && $plan && method_exists( $plan, 'get_access_length_type' ) && 'subscription' === $plan->get_access_length_type() && method_exists( $membership, 'get_subscription_id' ) && function_exists( 'wcs_get_subscription' ) ) {
 				$subscription = \wcs_get_subscription( $membership->get_subscription_id() );
 				if ( $subscription && in_array( $subscription->get_status(), self::$active_subscription_statuses, true ) ) {
 					return true;

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -844,7 +844,7 @@ class Memberships {
 		if ( function_exists( 'wc_memberships_get_user_membership' ) ) {
 			$membership = \wc_memberships_get_user_membership( $membership_id );
 			$plan       = $membership->get_plan();
-			if ( method_exists( $plan, 'get_access_length_type' ) && 'subscription' === $plan->get_access_length_type() && method_exists( $membership, 'get_subscription_id' ) && function_exists( 'wcs_get_subscription' ) ) {
+			if ( $plan && method_exists( $plan, 'get_access_length_type' ) && 'subscription' === $plan->get_access_length_type() && method_exists( $membership, 'get_subscription_id' ) && function_exists( 'wcs_get_subscription' ) ) {
 				$subscription = \wcs_get_subscription( $membership->get_subscription_id() );
 				if ( $subscription && in_array( $subscription->get_status(), self::$active_subscription_statuses, true ) ) {
 					return true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3050 introduced a fatal error when manually creating a new membership. This fixes the fatal.

### How to test the changes in this Pull Request:

1. On `release`, in WooCommerce > Memberships click "Add Member" to manually assign a membership to a user. Select a user and click "Add Member" in the modal. Observe a White Screen of Death and a fatal error in the logs:

```
PHP Fatal error:  Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, bool given in /newspack-repos/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php:847
```

2. Check out this branch, repeat, and confirm there's no error and that you're able to complete creating the membership and can edit it after the fact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->