### PR TITLE
Show comments on metered paywall posts

### DIFF
--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -121,6 +121,7 @@ class Metering {
 	 * Custom handling of content restriction when using metering.
 	 */
 	public static function handle_restriction() {
+		global $wp_query;
 		if ( ! class_exists( 'WC_Memberships' ) ) {
 			return;
 		}
@@ -128,8 +129,14 @@ class Metering {
 			return;
 		}
 
-		// Remove the default restriction handler from 'SkyVerge\WooCommerce\Memberships\Restrictions\Posts::restrict_post'.
 		if ( self::is_metering() ) {
+			add_filter( 'wc_memberships_restrictable_comment_types', '__return_empty_array' );
+
+			// Fixes a bug in Memberships where comments get restricted on restricted posts even with the above filter.
+			$wp_query->comment_count   = get_comment_count( get_the_ID() );
+			$wp_query->current_comment = 0;
+
+			// Remove the default restriction handler from 'SkyVerge\WooCommerce\Memberships\Restrictions\Posts::restrict_post'.
 			$restriction_instance = \wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance();
 			\remove_action( 'the_post', spl_object_hash( $restriction_instance ) . 'restrict_post', 0 );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**Note: This is a hotfix**

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue discovered around the metered wall functionality: when a metered wall is in place, comments always get hidden for anonymous users. 

### How to test the changes in this Pull Request:

1. Add a membership plan and set it to restrict all posts. Set up a metered wall that gives anonymous readers 1 pageview. Make one or more comments on a post.
2. Before applying this patch, visit the post in an incognito window. Observe no comments are shown:
<img width="955" alt="Screenshot 2024-04-10 at 12 14 21 PM" src="https://github.com/Automattic/newspack-plugin/assets/7317227/1a82b772-1b38-47d7-abe9-de533f7b2fd7">
4. Apply this patch. Refresh the page. Observe comments are shown:
<img width="894" alt="Screenshot 2024-04-10 at 12 14 36 PM" src="https://github.com/Automattic/newspack-plugin/assets/7317227/a24b53ad-091c-4538-af28-c0042a9ff5dd">
5. Visit a different post. Observe the registration wall continues to block you after you've exceeded your post quota.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->