### PR TITLE
fix: add option to display subscriptionless memberships

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -263,6 +263,17 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 									toggleChecked={ membershipsConfig.require_all_plans }
 								/>
 							) }
+							<ActionCard
+								title={ __( 'Display memberships on the subscriptions tab', 'newspack-plugin' ) }
+								description={ __(
+									"Display memberships that don't have active subscriptions on the My Account Subscriptions tab, so readers can see information like expiration dates.",
+									'newspack-plugin'
+								) }
+								toggleOnChange={ value =>
+									setMembershipsConfig( { ...membershipsConfig, show_on_subscription_tab: value } )
+								}
+								toggleChecked={ membershipsConfig.show_on_subscription_tab }
+							/>
 							<hr />
 						</>
 					) : null }
@@ -384,6 +395,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 									mailchimp_reader_default_status: config.mailchimp_reader_default_status,
 									active_campaign_master_list: config.active_campaign_master_list,
 									memberships_require_all_plans: membershipsConfig.require_all_plans,
+									memberships_show_on_subscription_tab: membershipsConfig.show_on_subscription_tab,
 									use_custom_lists: config.use_custom_lists,
 									newsletter_lists: config.newsletter_lists,
 									sync_esp: config.sync_esp,

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -379,6 +379,27 @@ class Memberships {
 	}
 
 	/**
+	 * Get the current setting of the "Display memberships on the subscriptions tab" option.
+	 *
+	 * @return boolean
+	 */
+	public static function get_show_on_subscription_tab_setting() {
+		return \get_option( 'newspack_memberships_show_on_subscription_tab', false );
+	}
+
+	/**
+	 * Set the "Display memberships on the subscriptions tab" option.
+	 *
+	 * @param boolean $show False to show memberships without subscriptions on the subscriptions tab (default)
+	 *                      or true to display those memberships on the subscriptions tab..
+	 *
+	 * @return boolean
+	 */
+	public static function set_show_on_subscription_tab_setting( $show = false ) {
+		return \update_option( 'newspack_memberships_show_on_subscription_tab', $show );
+	}
+
+	/**
 	 * Whether the current user is a member of the given plan.
 	 *
 	 * @param int $plan_id Plan ID.

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -524,34 +524,6 @@ class WooCommerce_My_Account {
 	}
 
 	/**
-	 * Adds option to display memberships without subscriptions on the Subscriptions tab of My Account..
-	 *
-	 * @param array $settings WooCommerce Memberships settings.
-	 * @return array
-	 */
-	public static function option_display_memberships_without_subs( $settings ) {
-		$settings[] = [
-			'name' => __( 'Newspack Reader Activation', 'newspack-plugin' ),
-			'type' => 'title',
-			'id'   => 'wc_memberships_show_unsubbed_memberships',
-		];
-
-		$settings[] = [
-			'type'    => 'checkbox',
-			'id'      => 'wc_memberships_show_unsubbed_memberships',
-			'name'    => __( 'Memberships without subscriptions', 'newspack-plugin' ),
-			'desc'    => __( 'Display memberships that don\'t have active subscriptions on the My Account Subscriptions tab.', 'newspack-plugin' ),
-			'default' => 'no',
-		];
-
-		$settings[] = [
-			'type' => 'sectionend',
-		];
-
-		return $settings;
-	}
-
-	/**
 	 * Check if a reader has memberships that aren't associated with subscriptions.
 	 *
 	 * @return array
@@ -580,7 +552,7 @@ class WooCommerce_My_Account {
 	 */
 	public static function append_membership_table() {
 		// If this option is not enabled, stop.
-		if ( 'no' === \get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
+		if ( ! Memberships::get_show_on_subscription_tab_setting() ) {
 			return;
 		}
 
@@ -609,7 +581,7 @@ class WooCommerce_My_Account {
 	 */
 	public static function redirect_to_single_subscription() {
 		// If this option is not enabled, stop.
-		if ( 'no' === \get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
+		if ( ! Memberships::get_show_on_subscription_tab_setting() ) {
 			return true;
 		}
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -48,6 +48,7 @@ class WooCommerce_My_Account {
 			\add_action( 'template_redirect', [ __CLASS__, 'show_message_after_logout' ] );
 			\add_action( 'woocommerce_account_subscriptions_endpoint', [ __CLASS__, 'append_membership_table' ], 11 );
 			\add_filter( 'wc_memberships_general_settings', [ __CLASS__, 'option_display_memberships_without_subs' ] );
+			\add_filter( 'wcs_my_account_redirect_to_single_subscription', [ __CLASS__, 'redirect_to_single_subscription' ] );
 		}
 	}
 
@@ -520,46 +521,6 @@ class WooCommerce_My_Account {
 	}
 
 	/**
-	 * Optionally append a table of active memberships without subscriptions on the My Account Subscriptions tab.
-	 */
-	public static function append_membership_table() {
-		if ( function_exists( 'wc_memberships_get_user_active_memberships' ) ) {
-			$customer_id              = \get_current_user_id();
-			$memberships_info         = wc_memberships_get_user_active_memberships( $customer_id );
-			$memberships_without_subs = [];
-
-			// If this option is not enabled, don't return the table.
-			if ( 'no' === get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
-				return;
-			}
-
-			// Create an array of active memberships without active subscriptions.
-			if ( function_exists( 'wc_memberships_has_subscription_product_granted_access' ) ) {
-				foreach ( $memberships_info as $membership ) {
-					if ( ! wc_memberships_has_subscription_product_granted_access( $membership ) ) {
-						$memberships_without_subs[] = $membership;
-					}
-				}
-			}
-
-			// If there are active memberships without subscriptions, present them in a table.
-			if ( $memberships_without_subs ) {
-				echo '<div class="woocommerce-memberships-without-subs">';
-				echo '<h2>' . esc_html__( 'Active Memberships', 'newspack-plugin' ) . '</h2>';
-				echo '<p>' . esc_html__( 'These memberships are active, but don\'t have an associated subscription. They will need to be manually renewed when they expire.', 'newspack-plugin' ) . '</p>';
-				wc_get_template(
-					'myaccount/my-memberships.php',
-					array(
-						'customer_memberships' => $memberships_without_subs,
-						'user_id'              => get_current_user_id(),
-					)
-				);
-				echo '</div>';
-			}
-		}
-	}
-
-	/**
 	 * Adds option to display memberships without subscriptions on the Subscriptions tab of My Account..
 	 *
 	 * @param array $settings WooCommerce Memberships settings.
@@ -585,6 +546,83 @@ class WooCommerce_My_Account {
 		);
 
 		return $settings;
+	}
+
+	/**
+	 * Check if a reader has memberships that aren't associated with subscriptions.
+	 *
+	 * @return array
+	 */
+	public static function has_memberships_without_subs() {
+		if ( function_exists( 'wc_memberships_get_user_active_memberships' ) ) {
+			$customer_id              = \get_current_user_id();
+			$memberships_info         = wc_memberships_get_user_active_memberships( $customer_id );
+			$memberships_without_subs = [];
+
+			// If this option is not enabled, don't return the table.
+			if ( 'no' === get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
+				return;
+			}
+
+			// Create an array of active memberships without active subscriptions.
+			if ( function_exists( 'wc_memberships_has_subscription_product_granted_access' ) ) {
+				foreach ( $memberships_info as $membership ) {
+					if ( ! wc_memberships_has_subscription_product_granted_access( $membership ) ) {
+						$memberships_without_subs[] = $membership;
+					}
+				}
+			}
+
+			return $memberships_without_subs;
+		}
+	}
+
+	/**
+	 * Optionally append a table of active memberships without subscriptions on the My Account Subscriptions tab.
+	 */
+	public static function append_membership_table() {
+		// If this option is not enabled, don't return the table.
+		if ( 'no' === get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
+			return;
+		}
+
+		$memberships_without_subs = self::has_memberships_without_subs();
+
+		// If there are active memberships without subscriptions, present them in a table.
+		if ( $memberships_without_subs ) {
+			echo '<div class="woocommerce-memberships-without-subs">';
+			echo '<h2>' . esc_html__( 'Active Memberships', 'newspack-plugin' ) . '</h2>';
+			echo '<p>' . esc_html__( 'These memberships are active, but don\'t have an associated subscription. They will need to be manually renewed when they expire.', 'newspack-plugin' ) . '</p>';
+			wc_get_template(
+				'myaccount/my-memberships.php',
+				array(
+					'customer_memberships' => $memberships_without_subs,
+					'user_id'              => get_current_user_id(),
+				)
+			);
+			echo '</div>';
+		}
+	}
+
+	/**
+	 * Returns whether or not to redirect the Subscriptions link to a single subscription, or to the main Subscriptions screen.
+	 *
+	 * @return bool
+	 */
+	public static function redirect_to_single_subscription() {
+		// If this option is not enabled, we want to keep the default redirect - return true.
+		if ( 'no' === get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
+			return true;
+		}
+
+		$memberships_without_subs = self::has_memberships_without_subs();
+
+		// If there are memberships without subs, we want to remove the redirect and go to Subscriptions; otherwise, return true.
+		if ( $memberships_without_subs ) {
+			return false;
+		} else {
+			return true;
+		}
 	}
 }
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -134,8 +134,6 @@ class WooCommerce_My_Account {
 				}
 			}
 
-
-
 			$disabled_wc_menu_items = \apply_filters( 'newspack_my_account_disabled_pages', $default_disabled_items );
 			foreach ( $disabled_wc_menu_items as $key ) {
 				if ( isset( $items[ $key ] ) ) {

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -524,9 +524,9 @@ class WooCommerce_My_Account {
 	 */
 	public static function append_membership_table() {
 		if ( function_exists( 'wc_memberships_get_user_active_memberships' ) ) {
-			$customer_id            = \get_current_user_id();
-			$memberships_info       = wc_memberships_get_user_active_memberships( $customer_id );
-			$no_sub_memberships     = [];
+			$customer_id              = \get_current_user_id();
+			$memberships_info         = wc_memberships_get_user_active_memberships( $customer_id );
+			$memberships_without_subs = [];
 
 			// If this option is not enabled, don't return the table.
 			if ( 'no' === get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
@@ -537,20 +537,20 @@ class WooCommerce_My_Account {
 			if ( function_exists( 'wc_memberships_has_subscription_product_granted_access' ) ) {
 				foreach ( $memberships_info as $membership ) {
 					if ( ! wc_memberships_has_subscription_product_granted_access( $membership ) ) {
-						$no_sub_memberships[] = $membership;
+						$memberships_without_subs[] = $membership;
 					}
 				}
 			}
 
 			// If there are active memberships without subscriptions, present them in a table.
-			if ( $no_sub_memberships ) {
+			if ( $memberships_without_subs ) {
 				echo '<div class="woocommerce-memberships-without-subs">';
-				echo '<h4>' . esc_html__( 'Active Memberships', 'newspack-plugin' ) . '</h4>';
+				echo '<h2>' . esc_html__( 'Active Memberships', 'newspack-plugin' ) . '</h2>';
 				echo '<p>' . esc_html__( 'These memberships are active, but don\'t have an associated subscription. They will need to be manually renewed when they expire.', 'newspack-plugin' ) . '</p>';
 				wc_get_template(
 					'myaccount/my-memberships.php',
 					array(
-						'customer_memberships' => $no_sub_memberships,
+						'customer_memberships' => $memberships_without_subs,
 						'user_id'              => get_current_user_id(),
 					)
 				);

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -622,7 +622,7 @@ class WooCommerce_My_Account {
 	}
 
 	/**
-	 * Hides 'Cancel' button on main Membeships table to tidy it up.
+	 * Hides 'Cancel' button on main Memberships table to tidy it up.
 	 *
 	 * @param array $actions WooCommerce Memberships available actions.
 	 * @return array

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -554,16 +554,11 @@ class WooCommerce_My_Account {
 	 *
 	 * @return array
 	 */
-	public static function has_memberships_without_subs() {
+	public static function get_memberships_without_subs() {
 		if ( function_exists( 'wc_memberships_get_user_active_memberships' ) ) {
 			$customer_id              = \get_current_user_id();
 			$memberships_info         = wc_memberships_get_user_active_memberships( $customer_id );
 			$memberships_without_subs = [];
-
-			// If this option is not enabled, don't return the table.
-			if ( 'no' === get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
-				return;
-			}
 
 			// Create an array of active memberships without active subscriptions.
 			if ( function_exists( 'wc_memberships_has_subscription_product_granted_access' ) ) {
@@ -582,12 +577,12 @@ class WooCommerce_My_Account {
 	 * Optionally append a table of active memberships without subscriptions on the My Account Subscriptions tab.
 	 */
 	public static function append_membership_table() {
-		// If this option is not enabled, don't return the table.
+		// If this option is not enabled, stop.
 		if ( 'no' === get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
 			return;
 		}
 
-		$memberships_without_subs = self::has_memberships_without_subs();
+		$memberships_without_subs = self::get_memberships_without_subs();
 
 		// If there are active memberships without subscriptions, present them in a table.
 		if ( $memberships_without_subs ) {
@@ -611,12 +606,12 @@ class WooCommerce_My_Account {
 	 * @return bool
 	 */
 	public static function redirect_to_single_subscription() {
-		// If this option is not enabled, we want to keep the default redirect - return true.
+		// If this option is not enabled, stop.
 		if ( 'no' === get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
 			return true;
 		}
 
-		$memberships_without_subs = self::has_memberships_without_subs();
+		$memberships_without_subs = self::get_memberships_without_subs();
 
 		// If there are memberships without subs, we want to remove the redirect and go to Subscriptions; otherwise, return true.
 		if ( $memberships_without_subs ) {

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -50,6 +50,8 @@ class WooCommerce_My_Account {
 			\add_filter( 'wc_memberships_general_settings', [ __CLASS__, 'option_display_memberships_without_subs' ] );
 			\add_filter( 'wcs_my_account_redirect_to_single_subscription', [ __CLASS__, 'redirect_to_single_subscription' ] );
 			\add_filter( 'wc_memberships_members_area_my-memberships_actions', [ __CLASS__, 'hide_cancel_button_from_memberships_table' ] );
+			\add_filter( 'wc_memberships_my_memberships_column_names', [ __CLASS__, 'remove_next_bill_on' ], 21 );
+
 		}
 	}
 
@@ -630,6 +632,17 @@ class WooCommerce_My_Account {
 	public static function hide_cancel_button_from_memberships_table( $actions ) {
 		unset( $actions['cancel'] );
 		return $actions;
+	}
+
+	/**
+	 * Removes the 'Next Bill On' column in the main Memberships table to tidy it up.
+	 *
+	 * @param array $columns WooCommerce Memberships table columns.
+	 * @return array
+	 */
+	public static function remove_next_bill_on( $columns ) {
+		unset( $columns['membership-next-bill-on'] );
+		return $columns;
 	}
 }
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -342,7 +342,7 @@ class WooCommerce_My_Account {
 	 * Do not redirect if this request is a membership cancellation.
 	 */
 	public static function redirect_to_account_details() {
-		$resubscribe_request       = isset( $_REQUEST['resubscribe'] ) ? 'shop_subscription' === get_post_type( absint( $_REQUEST['resubscribe'] ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$resubscribe_request       = isset( $_REQUEST['resubscribe'] ) ? 'shop_subscription' === \get_post_type( absint( $_REQUEST['resubscribe'] ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$cancel_membership_request = isset( $_REQUEST['cancel_membership'] ) ? true : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( \is_user_logged_in() && Reader_Activation::is_enabled() && function_exists( 'wc_get_page_permalink' ) && ! $resubscribe_request && ! $cancel_membership_request ) {
@@ -530,23 +530,23 @@ class WooCommerce_My_Account {
 	 * @return array
 	 */
 	public static function option_display_memberships_without_subs( $settings ) {
-		$settings[] = array(
+		$settings[] = [
 			'name' => __( 'Newspack Reader Activation', 'newspack-plugin' ),
 			'type' => 'title',
 			'id'   => 'wc_memberships_show_unsubbed_memberships',
-		);
+		];
 
-		$settings[] = array(
+		$settings[] = [
 			'type'    => 'checkbox',
 			'id'      => 'wc_memberships_show_unsubbed_memberships',
 			'name'    => __( 'Memberships without subscriptions', 'newspack-plugin' ),
 			'desc'    => __( 'Display memberships that don\'t have active subscriptions on the My Account Subscriptions tab.', 'newspack-plugin' ),
 			'default' => 'no',
-		);
+		];
 
-		$settings[] = array(
+		$settings[] = [
 			'type' => 'sectionend',
-		);
+		];
 
 		return $settings;
 	}
@@ -559,13 +559,13 @@ class WooCommerce_My_Account {
 	public static function get_memberships_without_subs() {
 		if ( function_exists( 'wc_memberships_get_user_active_memberships' ) ) {
 			$customer_id              = \get_current_user_id();
-			$memberships_info         = wc_memberships_get_user_active_memberships( $customer_id );
+			$memberships_info         = \wc_memberships_get_user_active_memberships( $customer_id );
 			$memberships_without_subs = [];
 
 			// Create an array of active memberships without active subscriptions.
 			if ( function_exists( 'wc_memberships_has_subscription_product_granted_access' ) ) {
 				foreach ( $memberships_info as $membership ) {
-					if ( ! wc_memberships_has_subscription_product_granted_access( $membership ) ) {
+					if ( ! \wc_memberships_has_subscription_product_granted_access( $membership ) ) {
 						$memberships_without_subs[] = $membership;
 					}
 				}
@@ -580,7 +580,7 @@ class WooCommerce_My_Account {
 	 */
 	public static function append_membership_table() {
 		// If this option is not enabled, stop.
-		if ( 'no' === get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
+		if ( 'no' === \get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
 			return;
 		}
 
@@ -595,7 +595,7 @@ class WooCommerce_My_Account {
 				'myaccount/my-memberships.php',
 				array(
 					'customer_memberships' => $memberships_without_subs,
-					'user_id'              => get_current_user_id(),
+					'user_id'              => \get_current_user_id(),
 				)
 			);
 			echo '</div>';
@@ -609,7 +609,7 @@ class WooCommerce_My_Account {
 	 */
 	public static function redirect_to_single_subscription() {
 		// If this option is not enabled, stop.
-		if ( 'no' === get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
+		if ( 'no' === \get_option( 'wc_memberships_show_unsubbed_memberships', 'no' ) ) {
 			return true;
 		}
 
@@ -630,7 +630,9 @@ class WooCommerce_My_Account {
 	 * @return array
 	 */
 	public static function hide_cancel_button_from_memberships_table( $actions ) {
-		unset( $actions['cancel'] );
+		if ( ! empty( $actions['cancel'] ) ) {
+			unset( $actions['cancel'] );
+		}
 		return $actions;
 	}
 
@@ -641,7 +643,9 @@ class WooCommerce_My_Account {
 	 * @return array
 	 */
 	public static function remove_next_bill_on( $columns ) {
-		unset( $columns['membership-next-bill-on'] );
+		if ( ! empty( $columns['membership-next-bill-on'] ) ) {
+			unset( $columns['membership-next-bill-on'] );
+		}
 		return $columns;
 	}
 }

--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -84,6 +84,14 @@
 			vertical-align: middle;
 		}
 	}
+
+	.woocommerce-memberships-without-subs {
+		margin-top: 2rem;
+
+		p {
+			font-size: 0.8rem;
+		}
+	}
 }
 
 /* stylelint-disable-next-line */

--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -86,12 +86,22 @@
 	}
 
 	.woocommerce-memberships-without-subs {
-		margin-top: 2rem;
+		h2 {
+			font-size: 1em;
+			margin-top: 0;
+		}
 
 		p {
 			font-size: 0.8rem;
 		}
 	}
+
+	// Hide the 'You have no active subscriptions' message if memberships table is present.
+	.woocommerce_account_subscriptions:has( > .no_subscriptions ):has( ~ .woocommerce-memberships-without-subs ) {
+		display: none;
+	}
+
+
 }
 
 /* stylelint-disable-next-line */

--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -85,6 +85,7 @@
 		}
 	}
 
+	/* WooCommerce Membership styles */
 	.woocommerce-memberships-without-subs {
 		h2 {
 			font-size: 1em;
@@ -94,12 +95,28 @@
 		p {
 			font-size: 0.8rem;
 		}
+
+		.my_account_memberships {
+			table-layout: unset;
+
+			td {
+				width: 20%;
+
+				&:first-child {
+					width: 25%;
+				}
+
+				&:last-child {
+					width: 15%;
+				}
+			}
+		}
 	}
 
-	// Hide the 'You have no active subscriptions' message if memberships table is present.
 	.woocommerce_account_subscriptions:has( ~ .woocommerce-memberships-without-subs ) {
 		margin-bottom: 2rem;
 
+		// Hide the 'You have no active subscriptions' message if memberships table is present.
 		&:has( > .no_subscriptions ) {
 			display: none;
 		}

--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -97,8 +97,12 @@
 	}
 
 	// Hide the 'You have no active subscriptions' message if memberships table is present.
-	.woocommerce_account_subscriptions:has( > .no_subscriptions ):has( ~ .woocommerce-memberships-without-subs ) {
-		display: none;
+	.woocommerce_account_subscriptions:has( ~ .woocommerce-memberships-without-subs ) {
+		margin-bottom: 2rem;
+
+		&:has( > .no_subscriptions ) {
+			display: none;
+		}
 	}
 
 

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -204,10 +204,11 @@ class Engagement_Wizard extends Wizard {
 	 */
 	private static function get_memberships_settings() {
 		return [
-			'edit_gate_url'     => Memberships::get_edit_gate_url(),
-			'gate_status'       => get_post_status( Memberships::get_gate_post_id() ),
-			'plans'             => Memberships::get_plans(),
-			'require_all_plans' => Memberships::get_require_all_plans_setting(),
+			'edit_gate_url'            => Memberships::get_edit_gate_url(),
+			'gate_status'              => \get_post_status( Memberships::get_gate_post_id() ),
+			'plans'                    => Memberships::get_plans(),
+			'require_all_plans'        => Memberships::get_require_all_plans_setting(),
+			'show_on_subscription_tab' => Memberships::get_show_on_subscription_tab_setting(),
 		];
 	}
 
@@ -242,6 +243,11 @@ class Engagement_Wizard extends Wizard {
 		// Update Memberships options.
 		if ( isset( $args['memberships_require_all_plans'] ) ) {
 			Memberships::set_require_all_plans_setting( (bool) $args['memberships_require_all_plans'] );
+		}
+
+		// Update Memberships options.
+		if ( isset( $args['memberships_show_on_subscription_tab'] ) ) {
+			Memberships::set_show_on_subscription_tab_setting( (bool) $args['memberships_show_on_subscription_tab'] );
 		}
 
 		return rest_ensure_response(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is to work with an edge case where readers can have WooCommerce Memberships with expiration dates but without subscriptions. Because Newspack hides the Memberships tab in My Account, there's no way for readers to get information about these memberships.

In this specific case, we don't want to create associated subscriptions for these memberships because they'll send out a bunch of renewal emails. Instead, we just want a way for readers to be able to see when their memberships are expiring, so they can proactively renew them. 

See: 1200550061930446-as-1206901401819708

### How to test the changes in this Pull Request:

_I wrote these test steps as though you'd be using different browser sessions to act as the admin and reader, but you can also use the User Switching plugin._

1. Set up a test site with RAS set up, plus WooCommerce Memberships installed.
2. Create two membership plans:
     *  Make a membership plan that is not associated with a subscription. Set it to grant access upon "manual assignment only", and set the membership length to have a "specific length" (this can be any value, though one week, month, year is probably more realistic to test).
     * Make a membership plan that is associated with a subscription. Set up a Checkout Button block that allows you to purchase the associated subscription.
3. Create a test reader.
4. Manually assign the test reader the non-suscription membership plan.
5. In an incognito window, log in as this reader in an incognito window/different browser, and go to My Account. Note that you have no way to view your Memberships -- there's no Membership tab, and if you go to Subscriptions, it says you don't have any.

![image](https://github.com/Automattic/newspack-plugin/assets/177561/82651fbf-9bf8-4377-853b-c8e7d47bd57f)

6. Apply this PR and run `npm run build`.
7. As your WordPress Admin user, navigate to WP Admin > WooCommerce > Settings > Memberships, and scroll to the bottom; confirm you have a Reader Activation section, and a checkmark to show active Memberships that don't have associated Subscriptions. The checkmark should be unchecked.

![image](https://github.com/Automattic/newspack-plugin/assets/177561/4e0d08db-a68f-49c4-ad3c-c91ebad58655)

9. Check this option, and click Save.
10. Back in your reader browser session, refresh the Subscriptions tab.
11. Confirm that the 'No Subscriptions' message is gone, and you also get an extra table listing your non-subscription Memberships product with its expiry date:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/c4264751-cd7c-4453-a63a-759e062d933f)

12. Still logged in as this reader, navigate to where you set up your Checkout Button block for your subscription membership product, and purchase it.
13. Navigate back to My Account - confirm that 'Subscriptions' still says just 'Subscriptions' (and not 'My Subscription' -- normally the plugin will override that and link directly to your subscription if you have just one). 
14. Click on Subscriptions, and confirm you see your subscription listed, as well as the Memberships table:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/5c6ad982-1b02-4591-be3d-e5658fd23c50)

15. From the Subscription tab, click the 'View' tab next to your Membership, then click 'Manage' in the left column.
16. Click 'Cancel' to cancel your Membership.

![image](https://github.com/Automattic/newspack-plugin/assets/177561/04174b5c-d7ea-42a7-a3a9-a3c7147a7262)

17. Confirm that the Subscriptions tab now just says 'My Subscription' (because you don't have any active unsubscription-related memberships, it should be back at the default behaviour).
18. As your Admin user, manually re-assign the non-sub Membership to your reader. 
19. As your reader, refresh My Account; if you're still viewing the single Subscription detail, you might need to click out of that section and back to get to the main Subscriptions list view.
20. As the Admin user, navigate to WP Admin > WooCommerce > Settings > Memberships.
21. Uncheck "Display memberships that don't have active subscriptions on the My Account Subscriptions tab. " and click Save.
22. As your reader, refresh My Account and confirm the membership is gone again (to confirm it's still assigned, you can go to /my-account/members-area).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->