### PR TITLE
fix: revert #3050 due to performance issues

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -34,14 +34,6 @@ class Memberships {
 	public static $active_statuses = [ 'active', 'complimentary', 'free-trial', 'pending' ];
 
 	/**
-	 * WooCommerce Subscription statuses that should be considered active.
-	 * See: https://woo.com/document/subscriptions/statuses/
-	 *
-	 * @var array
-	 */
-	public static $active_subscription_statuses = [ 'active', 'pending', 'pending-cancel' ];
-
-	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
@@ -59,8 +51,6 @@ class Memberships {
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
-		add_filter( 'get_post_metadata', [ __CLASS__, 'ensure_no_expire_date_for_active_subscriptions' ], 10, 4 );
-		add_filter( 'get_post_status', [ __CLASS__, 'ensure_active_status_for_active_subscriptions' ], 10, 2 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -831,62 +821,6 @@ class Memberships {
 		}
 
 		return $all_caps;
-	}
-
-	/**
-	 * Is the given user membership tied to a currently active subscription?
-	 *
-	 * @param int $membership_id User membership ID.
-	 *
-	 * @return bool
-	 */
-	public static function membership_is_tied_to_active_subscription( $membership_id ) {
-		if ( function_exists( 'wc_memberships_get_user_membership' ) ) {
-			$membership = \wc_memberships_get_user_membership( $membership_id );
-			$plan       = $membership->get_plan();
-			if ( $membership && $plan && method_exists( $plan, 'get_access_length_type' ) && 'subscription' === $plan->get_access_length_type() && method_exists( $membership, 'get_subscription_id' ) && function_exists( 'wcs_get_subscription' ) ) {
-				$subscription = \wcs_get_subscription( $membership->get_subscription_id() );
-				if ( $subscription && in_array( $subscription->get_status(), self::$active_subscription_statuses, true ) ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Ensure that WC User Memberships that are tied to an active subscription do not have an Expire date.
-	 *
-	 * @param mixed  $value     The value get_metadata() should return - a single metadata value, or an array of values.
-	 * @param int    $object_id ID of the object metadata is for.
-	 * @param string $meta_key  Metadata key.
-	 * @param bool   $single    Whether to return a single value.
-	 *
-	 * @return mixed
-	 */
-	public static function ensure_no_expire_date_for_active_subscriptions( $value, $object_id, $meta_key, $single ) {
-		if ( ( '_cancelled_date' === $meta_key || '_end_date' === $meta_key ) && self::membership_is_tied_to_active_subscription( $object_id ) ) {
-			$value = '';
-		}
-		return $value;
-	}
-
-	/**
-	 * Ensuer that WC User Memberships that are tied to an active subscription have an active status.
-	 *
-	 * @param string  $status The status of the membership.
-	 * @param WP_Post $post The post object.
-	 *
-	 * @return string
-	 */
-	public static function ensure_active_status_for_active_subscriptions( $status, $post ) {
-		if ( 'wc_user_membership' === $post->post_type && 'wcm-active' !== $post->post_status && self::membership_is_tied_to_active_subscription( $post->ID ) ) {
-			$status     = 'wcm-active';
-			$membership = \wc_memberships_get_user_membership( $post->ID );
-			$membership->update_status( 'active' );
-		}
-		return $status;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Reverts #3050 due to performance issues on sites with many memberships.

### How to test the changes in this Pull Request:

Nothing to test—simply reverts problematic changes from v3.6.0.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->