### PR TITLE
fix: hourly cron job to check for prematurely expired memberships

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -16,7 +16,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class Memberships {
 
-	const GATE_CPT = 'np_memberships_gate';
+	const GATE_CPT  = 'np_memberships_gate';
+	const CRON_HOOK = 'np_memberships_fix_expired_memberships';
 
 	/**
 	 * Whether the gate has been rendered in this execution.
@@ -63,6 +64,10 @@ class Memberships {
 		add_filter( 'newspack_gate_content', 'wp_filter_content_tags' );
 		add_filter( 'newspack_gate_content', 'wp_replace_insecure_home_url' );
 		add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
+
+		// Scheduled fix for prematurely expired memberships.
+		add_action( 'init', [ __CLASS__, 'cron_init' ] );
+		add_action( self::CRON_HOOK, [ __CLASS__, 'fix_expired_memberships_for_active_subscriptions' ] );
 
 		include __DIR__ . '/class-block-patterns.php';
 		include __DIR__ . '/class-metering.php';
@@ -868,6 +873,82 @@ class Memberships {
 		}
 
 		return $has_access;
+	}
+
+	/**
+	 * Schedule an hourly cron job to check for and fix expired memberships linked to active subscriptions.
+	 */
+	public static function cron_init() {
+		\register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );
+
+		if ( function_exists( 'wc_memberships' ) && ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			\wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Ensure that memberships tied to active subscriptions haven't expired prematurely.
+	 * Will loop through all active subscriptions on the site and check all memberships associated with it.
+	 */
+	public static function fix_expired_memberships_for_active_subscriptions() {
+		if ( ! function_exists( 'wc_memberships' ) ) {
+			return;
+		}
+
+
+		$max_per_batch           = 100;
+		$processed_batches       = 0;
+		$reactivated_memberships = 0;
+		$active_subscriptions    = WooCommerce_Connection::get_batch_of_active_subscriptions( $max_per_batch, $processed_batches );
+		if ( empty( $active_subscriptions ) ) {
+			return;
+		}
+
+		Logger::log( __( 'Checking for expired memberships linked to active subscriptions...', 'newspack-plugin' ) );
+
+		$active_membership_statuses = \wc_memberships()->get_user_memberships_instance()->get_active_access_membership_statuses();
+		while ( ! empty( $active_subscriptions ) ) {
+			$subscription = array_shift( $active_subscriptions );
+			try {
+				$memberships = \wc_memberships_get_memberships_from_subscription( $subscription );
+				if ( $memberships ) {
+					foreach ( $memberships as $membership ) {
+						// If the membership is not active and has an end date in the past, reactivate it.
+						if ( $membership && ! $membership->has_status( $active_membership_statuses ) && $membership->has_end_date() && $membership->get_end_date( 'timestamp' ) < time() ) {
+							$membership->set_end_date(); // Clear the end date.
+							$membership->update_status( 'active' ); // Reactivate the membership.
+							$reactivated_memberships++;
+						}
+					}
+				}
+			} catch ( Exception $e ) {
+				// Log the error.
+				Logger::log(
+					sprintf(
+						// Translators: %1$d is the membership ID, %2$s is the subscription ID.
+						__( 'Failed to reactivate membership %1$d linked to active subscription %2$s.', 'newspack-plugin' ),
+						$membership->get_id(),
+						$subscription->get_id()
+					)
+				);
+			}
+
+			// Get the next batch of active subscriptions.
+			if ( empty( $active_subscriptions ) ) {
+				$processed_batches++;
+				$active_subscriptions = WooCommerce_Connection::get_batch_of_active_subscriptions( $max_per_batch, $processed_batches * $max_per_batch );
+			}
+		}
+
+		if ( 0 < $reactivated_memberships ) {
+			Logger::log(
+				sprintf(
+					// Translators: %d is the number of reactivated memberships.
+					__( 'Reactivated %d memberships linked to active subscriptions.', 'newspack-plugin' ),
+					$reactivated_memberships
+				)
+			);
+		}
 	}
 }
 Memberships::init();

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -876,12 +876,25 @@ class Memberships {
 	}
 
 	/**
+	 * Deactivate the cron job.
+	 */
+	public static function cron_deactivate() {
+		\wp_clear_scheduled_hook( self::CRON_HOOK );
+	}
+
+	/**
 	 * Schedule an hourly cron job to check for and fix expired memberships linked to active subscriptions.
 	 */
 	public static function cron_init() {
 		\register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );
 
-		if ( function_exists( 'wc_memberships' ) && ! wp_next_scheduled( self::CRON_HOOK ) ) {
+		// No need to run the cron job if Memberships isn't active.
+		if ( ! function_exists( 'wc_memberships' ) ) {
+			self::cron_deactivate();
+			return;
+		}
+
+		if ( wp_next_scheduled( self::CRON_HOOK ) ) {
 			\wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
 		}
 	}

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -888,13 +888,7 @@ class Memberships {
 	public static function cron_init() {
 		\register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );
 
-		// No need to run the cron job if Memberships isn't active.
-		if ( ! function_exists( 'wc_memberships' ) ) {
-			self::cron_deactivate();
-			return;
-		}
-
-		if ( wp_next_scheduled( self::CRON_HOOK ) ) {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
 			\wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
 		}
 	}

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -109,6 +109,30 @@ class WooCommerce_Connection {
 	}
 
 	/**
+	 * Get a batch of active Woo Subscriptions.
+	 *
+	 * @param int $batch_size Max number of subscriptions to get.
+	 * @param int $offset     Number to skip.
+	 *
+	 * @return array|false Array of subscription objects, or false if no more to fetch.
+	 */
+	public static function get_batch_of_active_subscriptions( $batch_size = 100, $offset = 0 ) {
+		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
+			return false;
+		}
+
+		$subscriptions = \wcs_get_subscriptions(
+			[
+				'status'                 => [ 'active', 'pending', 'pending-cancel' ],
+				'subscriptions_per_page' => $batch_size,
+				'offset'                 => $offset,
+			]
+		);
+
+		return ! empty( $subscriptions ) ? array_values( $subscriptions ) : false;
+	}
+
+	/**
 	 * Get the last successful order for a given customer.
 	 *
 	 * @param \WC_Customer $customer Customer object.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Addresses the same issue as in #3050, but with a more performant approach.

Rather than filtering data at the moment any membership/subscription is fetched, this implements an hour cron job that iterates through all active subscriptions on the site, checks any memberships associated with those subscriptions, and reactivates memberships that aren't in an active state. This should ensure that anyone with an active subscription should have access to the memberships their subscription(s) grant them.

### How to test the changes in this Pull Request:

Follow the same testing instructions as in #3050, but also note that if you have `define( 'NEWSPACK_LOG_LEVEL', 2 );` defined in wp-config.php, you'll see some additional logging showing that the cron job is working:

```
[11-Apr-2024 16:51:00 UTC] [325]  [NEWSPACK][Newspack\Memberships::fix_expired_memberships_for_active_subscriptions]: Checking for expired memberships linked to active subscriptions...
[11-Apr-2024 16:51:02 UTC] [325]  [NEWSPACK][Newspack\Memberships::fix_expired_memberships_for_active_subscriptions]: Reactivated 5 memberships linked to active subscriptions.
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->