### PR TITLE
fix: revert 3057

### DIFF
--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -121,7 +121,6 @@ class Metering {
 	 * Custom handling of content restriction when using metering.
 	 */
 	public static function handle_restriction() {
-		global $wp_query;
 		if ( ! class_exists( 'WC_Memberships' ) ) {
 			return;
 		}
@@ -129,14 +128,8 @@ class Metering {
 			return;
 		}
 
+		// Remove the default restriction handler from 'SkyVerge\WooCommerce\Memberships\Restrictions\Posts::restrict_post'.
 		if ( self::is_metering() ) {
-			add_filter( 'wc_memberships_restrictable_comment_types', '__return_empty_array' );
-
-			// Fixes a bug in Memberships where comments get restricted on restricted posts even with the above filter.
-			$wp_query->comment_count   = get_comment_count( get_the_ID() );
-			$wp_query->current_comment = 0;
-
-			// Remove the default restriction handler from 'SkyVerge\WooCommerce\Memberships\Restrictions\Posts::restrict_post'.
 			$restriction_instance = \wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance();
 			\remove_action( 'the_post', spl_object_hash( $restriction_instance ) . 'restrict_post', 0 );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3057 in conjunction with some cron job seems to cause some sort of issue that fills up the logs with millions of notices a minute. This PR rolls that change back so we can re-approach the problem in some other way that should have less side-effects.

### How to test the changes in this Pull Request:

1. Stop after the second testing instruction at https://github.com/Automattic/newspack-plugin/pull/3057

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->