### PR TITLE
feat: custom role for assignable authors who don't edit posts

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -158,6 +158,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-co-authors-plus.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';

--- a/includes/plugins/class-co-authors-plus.php
+++ b/includes/plugins/class-co-authors-plus.php
@@ -86,7 +86,7 @@ class Co_Authors_Plus {
 		if ( get_role( self::CONTRIBUTOR_NO_EDIT_ROLE_NAME ) === null ) {
 			add_role( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.custom_role_add_role
 				self::CONTRIBUTOR_NO_EDIT_ROLE_NAME,
-				__( 'Not Editing Contributor', 'newspack-plugin' ),
+				__( 'Non-Editing Contributor', 'newspack-plugin' ),
 				[
 					self::ASSIGNABLE_TO_POSTS_CAPABILITY_NAME => true,
 				]

--- a/includes/plugins/class-co-authors-plus.php
+++ b/includes/plugins/class-co-authors-plus.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Co_Authors_Plus integration class.
+ * https://wordpress.org/plugins/co-authors-plus
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Co_Authors_Plus {
+	/**
+	 * Custom capability name.
+	 */
+	const ASSIGNABLE_TO_POSTS_CAPABILITY_NAME = 'edit_cap_posts';
+
+	/**
+	 * Custom role name for users who are assignable as post authors but aren't allowed to edit posts.
+	 */
+	const CONTRIBUTOR_NO_EDIT_ROLE_NAME = 'contributor_no_edit';
+
+	/**
+	 * Option name to mark the version of the settings. If the implementation details
+	 * change, the expected option value should be updated to trigger a reset of the settings.
+	 */
+	const SETTINGS_VERSION_OPTION_NAME = 'newspack_coauthors_plus_settings_version';
+
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_filter( 'coauthors_edit_author_cap', [ __CLASS__, 'coauthors_edit_author_cap' ] );
+		add_action( 'admin_init', [ __CLASS__, 'setup_custom_role_and_capability' ] );
+		add_action( 'template_redirect', [ __CLASS__, 'prevent_myaccount_update' ] );
+	}
+
+	/**
+	 * Override the capability required to assign a user as a co-author.
+	 *
+	 * @param string $edit_cap Capability required for a user to be assigned as a co-author.
+	 */
+	public static function coauthors_edit_author_cap( $edit_cap ) {
+		return self::ASSIGNABLE_TO_POSTS_CAPABILITY_NAME;
+	}
+
+	/**
+	 * Prevent users from updating their account details in My Account, if they have the custom role.
+	 */
+	public static function prevent_myaccount_update() {
+		$action = filter_input( INPUT_POST, 'action', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		if ( empty( $action ) || 'save_account_details' !== $action ) {
+			return;
+		}
+
+		$user_id = \get_current_user_id();
+		if ( $user_id <= 0 ) {
+			return;
+		}
+		$user = \get_user_by( 'id', $user_id );
+
+		$is_contributor_no_edit = in_array( self::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $user->roles );
+		if ( $is_contributor_no_edit ) {
+			if ( function_exists( 'wc_add_notice' ) ) {
+				/* translators: %s is the custom role name. */
+				\wc_add_notice( sprintf( __( 'Can\'t update details of a "%s" user.', 'newspack-plugin' ), self::CONTRIBUTOR_NO_EDIT_ROLE_NAME ), 'error' );
+			}
+			return;
+		}
+	}
+
+	/**
+	 * Create the custom role and then add custom capability.
+	 */
+	public static function setup_custom_role_and_capability() {
+		$current_settings_version = '1';
+		if ( \get_option( self::SETTINGS_VERSION_OPTION_NAME ) === $current_settings_version ) {
+			return;
+		}
+
+		// Create the custom role if it doesn't exist.
+		if ( get_role( self::CONTRIBUTOR_NO_EDIT_ROLE_NAME ) === null ) {
+			add_role( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.custom_role_add_role
+				self::CONTRIBUTOR_NO_EDIT_ROLE_NAME,
+				__( 'Not Editing Contributor', 'newspack-plugin' ),
+				[
+					self::ASSIGNABLE_TO_POSTS_CAPABILITY_NAME => true,
+				]
+			);
+		}
+
+		$wp_roles = wp_roles();
+		foreach ( $wp_roles->roles as $role_name => $role ) {
+			$role = $wp_roles->get_role( $role_name );
+			if ( $role->has_cap( 'edit_posts' ) || $role_name === self::CONTRIBUTOR_NO_EDIT_ROLE_NAME ) {
+				$role->add_cap( self::ASSIGNABLE_TO_POSTS_CAPABILITY_NAME );
+			}
+		}
+
+		\update_option( self::SETTINGS_VERSION_OPTION_NAME, $current_settings_version );
+	}
+}
+Co_Authors_Plus::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some publishers want to assign authorship of posts to users, but don't want these users to be able to log in. User stories:

> 👉 As a publisher, I want to assign a user as post author, without this author being able to edit site content
> 👉 As a publisher, I want to be able to update an existing subscriber, so that they can be assigned as a post author, without them being able to edit site content

See 1200550061930446-as-1206481527608031/f

### How to test the changes in this Pull Request:

1. Ensure `co-authors-plus` and `woocommerce` plugins are installed & activated
2. Create a new user and assign the new "Not Editing Contributor" role to them
3. Assign the user as a post author 
4. View the post on the front-end and confirm the user is assigned as the post author and has an author archive page
5. Log in as the user, observe you don't have access to `/wp-admin` pages
6. Visit the "My Account" page, try to change the name and observe it's not allowed for this kind of user
7. Log in as a site reader, observe the name on the "My Account" page can be updated 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206481527608031