### PR TITLE
Improved approach to comment metering fix

### DIFF
--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -36,7 +36,7 @@ class Metering {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
-		add_action( 'wp', [ __CLASS__, 'handle_restriction' ], 11 );
+		add_action( 'wp', [ __CLASS__, 'handle_restriction' ], 9 );
 		add_action( 'wp_footer', [ __CLASS__, 'enqueue_scripts' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'get_article_view' ], 20 );
 	}
@@ -131,7 +131,8 @@ class Metering {
 		// Remove the default restriction handler from 'SkyVerge\WooCommerce\Memberships\Restrictions\Posts::restrict_post'.
 		if ( self::is_metering() ) {
 			$restriction_instance = \wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance();
-			\remove_action( 'the_post', spl_object_hash( $restriction_instance ) . 'restrict_post', 0 );
+			\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes' );
+			\add_filter( 'wc_memberships_restrictable_comment_types', '__return_empty_array' );
 		}
 
 		// Add inline gate to the footer so it can be handled by the frontend.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix**

A different approach than https://github.com/Automattic/newspack-plugin/pull/3057 for the same issue. This should have much smaller potential side effects than modifying the global `$wp_query` object.

### How to test the changes in this Pull Request:

Basically the same testing instructions as #3057 

1. Add a membership plan and set it to restrict all posts. Set up a metered wall that gives anonymous readers 1 pageview and registered readers 1 pageview. Make one or more comments on a post.
2. Before applying this patch, visit the post as an anonymous reader and/or free registered user. Observe no comments are shown on the post.
3. Apply this patch. 
4. Visit the post as an anonymous reader and confirm comments are shown. Visit a different post as an anonymous reader and confirm you're stopped by the wall.
5. Visit the post as a free registered reader and confirm comments are shown. Visit a different post as a free registered reader and confirm you're stopped by the wall.
6. Visit multiple posts as a paid reader and confirm you have access to all articles.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->