### PR TITLE
feat(ras-acc): make auth flow UI text filterable

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -173,14 +173,15 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Get filtered labels.
+	 * Get reader activation auth flow labels.
 	 *
 	 * @param string|null $key Key of the label to return (optional).
 	 *
-	 * @return mixed[] Labels keyed by name.
+	 * @return mixed[]|string The label string or an array of labels keyed by string.
 	 */
 	private static function get_reader_auth_labels( $key = null ) {
 		$default_labels = [
+			'title'                   => __( 'Sign in', 'newspack-plugin' ),
 			'invalid_email'           => __( 'Please enter a valid email address.', 'newspack-plugin' ),
 			'invalid_password'        => __( 'Please enter a password.', 'newspack-plugin' ),
 			'invalid_display'         => __( 'Display name cannot match your email address. Please choose a different display name.', 'newspack-plugin' ),
@@ -194,6 +195,7 @@ final class Reader_Activation {
 				'continue'        => __( 'Continue', 'newspack-plugin' ),
 				'resend_code'     => __( 'Resend code', 'newspack-plugin' ),
 				'otp'             => __( 'Email me a one-time code instead', 'newspack-plugin' ),
+				'otp_title'       => __( 'Enter the code sent to your email.', 'newspack-plugin' ),
 				'forgot_password' => __( 'Forgot password', 'newspack-plugin' ),
 				'create_account'  => __( 'Create an account', 'newspack-plugin' ),
 				'register'        => __( 'Sign in to an existing account', 'newspack-plugin' ),
@@ -1135,7 +1137,7 @@ final class Reader_Activation {
 				<input type="hidden" name="action" />
 				<p data-action="otp">
 					<strong>
-						<?php esc_html_e( 'Enter the code sent to your email.', 'newspack-plugin' ); ?>
+						<?php echo esc_html( $labels['otp_title'] ); ?>
 					</strong>
 				</p>
 				<div data-action="signin register">
@@ -1202,12 +1204,13 @@ final class Reader_Activation {
 		}
 
 		$terms = self::get_auth_footer();
+		$label = self::get_reader_auth_labels( 'title' );
 		?>
 		<div class="newspack-ui newspack-ui__modal-container newspack-reader-auth-modal">
 			<div class="newspack-ui__modal-container__overlay"></div>
 			<div class="newspack-ui__modal newspack-ui__modal--small">
 				<div class="newspack-ui__modal__header">
-					<h2><?php _e( 'Sign In', 'newspack-plugin' ); ?></h2>
+					<h2><?php echo \esc_html( $label ); ?></h2>
 					<button class="newspack-ui__modal__close">
 						<span class="screen-reader-text"><?php esc_html_e( 'Close', 'newspack-plugin' ); ?></span>
 						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -180,57 +180,72 @@ final class Reader_Activation {
 	 * @return mixed[]|string The label string or an array of labels keyed by string.
 	 */
 	private static function get_reader_auth_labels( $key = null ) {
-		$default_labels = [
-			'title'                   => __( 'Sign in', 'newspack-plugin' ),
-			'invalid_email'           => __( 'Please enter a valid email address.', 'newspack-plugin' ),
-			'invalid_password'        => __( 'Please enter a password.', 'newspack-plugin' ),
-			'invalid_display'         => __( 'Display name cannot match your email address. Please choose a different display name.', 'newspack-plugin' ),
-			'blocked_popup'           => __( 'The popup has been blocked. Allow popups for the site and try again.', 'newspack-plugin' ),
-			'code_resent'             => __( 'Code resent! Check your inbox.', 'newspack-plugin' ),
-			'create_account'          => __( 'Create an account', 'newspack-plugin' ),
-			'signin'                  => [
-				'title'           => __( 'Sign in', 'newspack-plugin' ),
-				'success_title'   => __( 'Success! You’re signed in.', 'newspack-plugin' ),
-				'success_message' => __( 'Login successful!', 'newspack-plugin' ),
-				'continue'        => __( 'Continue', 'newspack-plugin' ),
-				'resend_code'     => __( 'Resend code', 'newspack-plugin' ),
-				'otp'             => __( 'Email me a one-time code instead', 'newspack-plugin' ),
-				'otp_title'       => __( 'Enter the code sent to your email.', 'newspack-plugin' ),
-				'forgot_password' => __( 'Forgot password', 'newspack-plugin' ),
-				'create_account'  => __( 'Create an account', 'newspack-plugin' ),
-				'register'        => __( 'Sign in to an existing account', 'newspack-plugin' ),
-				'go_back'         => __( 'Go back', 'newspack-plugin' ),
-				'set_password'    => __( 'Set a password (optional)', 'newspack-plugin' ),
-			],
-			'register'                => [
-				'title'               => __( 'Create an account', 'newspack-plugin' ),
-				'success_title'       => __( 'Success! Your account was created and you’re signed in.', 'newspack-plugin' ),
-				'success_description' => __( 'In the future, you’ll sign in with a magic link, or a code sent to your email. If you’d rather use a password, you can set one below.', 'newspack-plugin' ),
-			],
-			'verify'                  => __( 'Thank you for verifying your account!', 'newspack-plugin' ),
-			'magic_link'              => __( 'Please check your inbox for an authentication link.', 'newspack-plugin' ),
-			'password_reset_interval' => __( 'Please wait a moment before requesting another password reset email.', 'newspack-plugin' ),
-			'account_link'            => [
-				'signedin'  => __( 'My Account', 'newspack-plugin' ),
-				'signedout' => __( 'Sign In', 'newspack-plugin' ),
-			],
-			'newsletters'             => __( 'Subscribe to our newsletter', 'newspack-plugin' ),
-		];
-
 		if ( empty( self::$reader_auth_labels ) ) {
+			$default_labels = [
+				'title'                   => __( 'Sign in', 'newspack-plugin' ),
+				'invalid_email'           => __( 'Please enter a valid email address.', 'newspack-plugin' ),
+				'invalid_password'        => __( 'Please enter a password.', 'newspack-plugin' ),
+				'invalid_display'         => __( 'Display name cannot match your email address. Please choose a different display name.', 'newspack-plugin' ),
+				'blocked_popup'           => __( 'The popup has been blocked. Allow popups for the site and try again.', 'newspack-plugin' ),
+				'code_resent'             => __( 'Code resent! Check your inbox.', 'newspack-plugin' ),
+				'create_account'          => __( 'Create an account', 'newspack-plugin' ),
+				'signin'                  => [
+					'title'           => __( 'Sign in', 'newspack-plugin' ),
+					'success_title'   => __( 'Success! You’re signed in.', 'newspack-plugin' ),
+					'success_message' => __( 'Login successful!', 'newspack-plugin' ),
+					'continue'        => __( 'Continue', 'newspack-plugin' ),
+					'resend_code'     => __( 'Resend code', 'newspack-plugin' ),
+					'otp'             => __( 'Email me a one-time code instead', 'newspack-plugin' ),
+					'otp_title'       => __( 'Enter the code sent to your email.', 'newspack-plugin' ),
+					'forgot_password' => __( 'Forgot password', 'newspack-plugin' ),
+					'create_account'  => __( 'Create an account', 'newspack-plugin' ),
+					'register'        => __( 'Sign in to an existing account', 'newspack-plugin' ),
+					'go_back'         => __( 'Go back', 'newspack-plugin' ),
+					'set_password'    => __( 'Set a password (optional)', 'newspack-plugin' ),
+				],
+				'register'                => [
+					'title'               => __( 'Create an account', 'newspack-plugin' ),
+					'success_title'       => __( 'Success! Your account was created and you’re signed in.', 'newspack-plugin' ),
+					'success_description' => __( 'In the future, you’ll sign in with a magic link, or a code sent to your email. If you’d rather use a password, you can set one below.', 'newspack-plugin' ),
+				],
+				'verify'                  => __( 'Thank you for verifying your account!', 'newspack-plugin' ),
+				'magic_link'              => __( 'Please check your inbox for an authentication link.', 'newspack-plugin' ),
+				'password_reset_interval' => __( 'Please wait a moment before requesting another password reset email.', 'newspack-plugin' ),
+				'account_link'            => [
+					'signedin'  => __( 'My Account', 'newspack-plugin' ),
+					'signedout' => __( 'Sign In', 'newspack-plugin' ),
+				],
+				'newsletters'             => __( 'Subscribe to our newsletter', 'newspack-plugin' ),
+			];
+
 			/**
 			* Filters the global labels for reader activation auth flow.
 			*
 			* @param mixed[] $labels Labels keyed by name.
 			*/
-			self::$reader_auth_labels = apply_filters( 'newspack_reader_activation_auth_labels', $default_labels );
+			$filtered_labels = apply_filters( 'newspack_reader_activation_auth_labels', $default_labels );
+
+			foreach ( $default_labels as $key => $label ) {
+				if ( isset( $filtered_labels[ $key ] ) ) {
+					if ( is_array( $label ) && is_array( $filtered_labels[ $key ] ) ) {
+						self::$reader_auth_labels[ $key ] = array_merge( $label, $filtered_labels[ $key ] );
+					} elseif ( is_string( $label ) && is_string( $filtered_labels[ $key ] ) ) {
+						self::$reader_auth_labels[ $key ] = $filtered_labels[ $key ];
+					} else {
+						// If filtered label type doesn't match, fallback to default.
+						self::$reader_auth_labels[ $key ] = $label;
+					}
+				} else {
+					self::$reader_auth_labels[ $key ] = $label;
+				}
+			}
 		}
 
 		if ( ! $key ) {
-			return array_merge( $default_labels, self::$reader_auth_labels );
+			return self::$reader_auth_labels;
 		}
 
-		return self::$reader_auth_labels[ $key ] ?? $default_labels[ $key ] ?? '';
+		return self::$reader_auth_labels[ $key ] ?? '';
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -154,23 +154,7 @@ final class Reader_Activation {
 			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
-		$labels = [
-			'invalid_email'    => __( 'Please enter a valid email address.', 'newspack-plugin' ),
-			'invalid_password' => __( 'Please enter a password.', 'newspack-plugin' ),
-			'blocked_popup'    => __( 'The popup has been blocked. Allow popups for the site and try again.', 'newspack-plugin' ),
-			'code_resent'      => __( 'Code resent! Check your inbox.', 'newspack-plugin' ),
-			'create_account'   => __( 'Create an account', 'newspack-plugin' ),
-			'signin'           => [
-				'title'         => __( 'Sign in', 'newspack-plugin' ),
-				'success_title' => __( 'Success! You’re signed in.', 'newspack-plugin' ),
-			],
-			'register'         => [
-				'title'               => __( 'Create an account', 'newspack-plugin' ),
-				'success_title'       => __( 'Success! Your account was created and you’re signed in.', 'newspack-plugin' ),
-				'success_description' => __( 'In the future, you’ll sign in with a magic link, or a code sent to your email. If you’d rather use a password, you can set one below.', 'newspack-plugin' ),
-			],
-		];
-		\wp_localize_script( self::AUTH_SCRIPT_HANDLE, 'newspack_reader_auth_labels', $labels );
+		\wp_localize_script( self::AUTH_SCRIPT_HANDLE, 'newspack_reader_auth_labels', self::get_reader_auth_labels() );
 		\wp_script_add_data( self::AUTH_SCRIPT_HANDLE, 'async', true );
 		\wp_script_add_data( self::AUTH_SCRIPT_HANDLE, 'amp-plus', true );
 		\wp_enqueue_style(
@@ -182,16 +166,58 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Get filtered labels.
+	 *
+	 * @return mixed[] Labels keyed by name.
+	 */
+	private static function get_reader_auth_labels() {
+		$labels = [
+			'invalid_email'           => __( 'Please enter a valid email address.', 'newspack-plugin' ),
+			'invalid_password'        => __( 'Please enter a password.', 'newspack-plugin' ),
+			'invalid_display'         => __( 'Display name cannot match your email address. Please choose a different display name.', 'newspack-plugin' ),
+			'blocked_popup'           => __( 'The popup has been blocked. Allow popups for the site and try again.', 'newspack-plugin' ),
+			'code_resent'             => __( 'Code resent! Check your inbox.', 'newspack-plugin' ),
+			'create_account'          => __( 'Create an account', 'newspack-plugin' ),
+			'signin'                  => [
+				'title'           => __( 'Sign in', 'newspack-plugin' ),
+				'success_title'   => __( 'Success! You’re signed in.', 'newspack-plugin' ),
+				'success_message' => __( 'Login successful!', 'newspack-plugin' ),
+			],
+			'register'                => [
+				'title'               => __( 'Create an account', 'newspack-plugin' ),
+				'success_title'       => __( 'Success! Your account was created and you’re signed in.', 'newspack-plugin' ),
+				'success_description' => __( 'In the future, you’ll sign in with a magic link, or a code sent to your email. If you’d rather use a password, you can set one below.', 'newspack-plugin' ),
+			],
+			'verify'                  => __( 'Thank you for verifying your account!', 'newspack-plugin' ),
+			'magic_link'              => __( 'Please check your inbox for an authentication link.', 'newspack-plugin' ),
+			'password_reset_interval' => __( 'Please wait a moment before requesting another password reset email.', 'newspack-plugin' ),
+			'account_link'            => [
+				'signedin'  => __( 'My Account', 'newspack-plugin' ),
+				'signedout' => __( 'Sign In', 'newspack-plugin' ),
+			],
+			'newsletters'             => __( 'Subscribe to our newsletter', 'newspack-plugin' ),
+		];
+
+		/**
+		 * Filters the global labels for reader activation auth flow.
+		 *
+		 * @param mixed[] $labels Labels keyed by name.
+		 */
+		return apply_filters( 'newspack_reader_activation_auth_labels', $labels );
+	}
+
+	/**
 	 * Get settings config with default values.
 	 *
 	 * @return mixed[] Settings default values keyed by their name.
 	 */
 	private static function get_settings_config() {
+		$labels          = self::get_reader_auth_labels();
 		$settings_config = [
 			'enabled'                         => false,
 			'enabled_account_link'            => true,
 			'account_link_menu_locations'     => [ 'tertiary-menu' ],
-			'newsletters_label'               => __( 'Subscribe to our newsletters:', 'newspack-plugin' ),
+			'newsletters_label'               => $labels['newsletters'],
 			'use_custom_lists'                => false,
 			'newsletter_lists'                => [],
 			'terms_text'                      => '',
@@ -752,7 +778,9 @@ final class Reader_Activation {
 
 		\update_user_meta( $user->ID, self::EMAIL_VERIFIED, true );
 
-		WooCommerce_Connection::add_wc_notice( __( 'Thank you for verifying your account!', 'newspack-plugin' ), 'success' );
+		$labels = self::get_reader_auth_labels();
+
+		WooCommerce_Connection::add_wc_notice( $labels['verify'], 'success' );
 
 		/**
 		 * Fires after a reader's email address is verified.
@@ -994,10 +1022,8 @@ final class Reader_Activation {
 			return self::get_element_class_name( $parts );
 		};
 
-		$labels = [
-			'signedin'  => \__( 'My Account', 'newspack-plugin' ),
-			'signedout' => \__( 'Sign In', 'newspack-plugin' ),
-		];
+		$labels = self::get_reader_auth_labels();
+		$labels = $labels['account_link'];
 		$label  = \is_user_logged_in() ? 'signedin' : 'signedout';
 
 		$link  = '<a class="' . \esc_attr( $class() ) . '" data-labels="' . \esc_attr( htmlspecialchars( \wp_json_encode( $labels ), ENT_QUOTES, 'UTF-8' ) ) . '" href="' . \esc_url_raw( $account_url ?? '#' ) . '" data-newspack-reader-account-link>';
@@ -1213,7 +1239,8 @@ final class Reader_Activation {
 	private static function send_auth_form_response( $data = [], $message = false ) {
 		$is_error = \is_wp_error( $data );
 		if ( empty( $message ) ) {
-			$message = $is_error ? $data->get_error_message() : __( 'Login successful!', 'newspack-plugin' );
+			$labels  = self::get_reader_auth_labels();
+			$message = $is_error ? $data->get_error_message() : $labels['signin']['success_message'];
 		}
 		\wp_send_json( compact( 'message', 'data' ), \is_wp_error( $data ) ? 400 : 200 );
 	}
@@ -1238,12 +1265,13 @@ final class Reader_Activation {
 	 * }
 	 */
 	public static function render_subscription_lists_inputs( $lists = [], $checked = [], $config = [] ) {
+		$labels = self::get_reader_auth_labels();
 		$config = \wp_parse_args(
 			$config,
 			[
 				'title'            => '',
 				'name'             => 'lists',
-				'single_label'     => __( 'Subscribe to our newsletter', 'newspack-plugin' ),
+				'single_label'     => $labels['newsletters'],
 				'show_description' => true,
 			]
 		);
@@ -1418,6 +1446,8 @@ final class Reader_Activation {
 			'authenticated' => 0,
 		];
 
+		$labels = self::get_reader_auth_labels();
+
 		switch ( $action ) {
 			case 'signin':
 				if ( self::is_reader_without_password( $user ) ) {
@@ -1447,7 +1477,7 @@ final class Reader_Activation {
 				if ( true !== $sent ) {
 					return self::send_auth_form_response( new \WP_Error( 'unauthorized', \is_wp_error( $sent ) ? $sent->get_error_message() : __( 'We encountered an error sending an authentication link. Please try again.', 'newspack-plugin' ) ) );
 				}
-				return self::send_auth_form_response( $payload, __( 'Please check your inbox for an authentication link.', 'newspack-plugin' ) );
+				return self::send_auth_form_response( $payload, $labels['magic_link'] );
 			case 'register':
 				$metadata = [ 'registration_method' => 'auth-form' ];
 				if ( ! empty( $lists ) ) {
@@ -1739,7 +1769,8 @@ final class Reader_Activation {
 	 */
 	public static function better_display_name_error( $message ) {
 		if ( 'Display name cannot be changed to email address due to privacy concern.' === $message ) {
-			return __( 'Display name cannot match your email address. Please choose a different display name.', 'newspack-plugin' );
+			$labels = self::get_reader_auth_labels();
+			return $labels['invalid_display'];
 		}
 
 		return $message;
@@ -1938,7 +1969,8 @@ final class Reader_Activation {
 	 */
 	public static function rate_limit_lost_password( $errors, $user_data ) {
 		if ( $user_data && self::is_reader_email_rate_limited( $user_data ) ) {
-			$errors->add( 'newspack_password_reset_interval', __( 'Please wait a moment before requesting another password reset email.', 'newspack-plugin' ) );
+			$labels = self::get_reader_auth_labels();
+			$errors->add( 'newspack_password_reset_interval', $labels['password_reset_interval'] );
 		} else {
 			\update_user_meta( $user_data->ID, self::LAST_EMAIL_DATE, time() );
 		}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206943664367847/1205669646691019/f 

This PR makes the previously hard-coded reader activation auth flow text filterable:

![Screenshot 2024-04-17 at 13 01 39](https://github.com/Automattic/newspack-plugin/assets/17905991/d7ae6ff4-dcd6-4ffa-add3-983f0debf1dd)

Note: I have not made any of the errors, basic input labels and placeholders, or Google signin related text filterable. Let me know if you think any of these should be added.

### How to test the changes in this Pull Request:

1. Go through the sign in and registration flows and confirm none of the text is broken
2. Add the following filter and test the sign in and registration flows again. Confirm all of the text has been replaced as expected:

```
add_filter( 'newspack_reader_activation_auth_labels', function( $labels ) {
	return [
		'invalid_email'           => 'banana',
		'invalid_password'        => 'banana',
		'invalid_display'         => 'banana',
		'blocked_popup'           => 'banana',
		'code_resent'             => 'banana',
		'create_account'          => 'banana',
		'signin'                  => [
			'title'           => 'banana',
			'success_title'   => 'banana',
			'success_message' => 'banana',
			'continue'        => 'banana',
			'resend_code'     => 'banana',
			'otp'             => 'banana',
			'forgot_password' => 'banana',
			'create_account'  => 'banana',
			'register'        => 'banana',
			'go_back'         => 'banana',
			'set_password'    => 'banana',
		],
		'register'                => [
			'title'               => 'banana',
			'success_title'       => 'banana',
			'success_description' => 'banana',
		],
		'verify'                  => 'banana',
		'magic_link'              => 'banana',
		'password_reset_interval' => 'banana',
		'account_link'            => [
			'signedin'  => 'banana',
			'signedout' => 'banana',
		],
		'newsletters'             => 'banana',
	];
} );
```
3. Replace the above filter with the following and test the sign in and registration flows one more time. This time confirm all of the default text appears as expected:
```
add_filter( 'newspack_reader_activation_auth_labels', function( $labels ) {
	return [];
} );

```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->