### PR TITLE
fix: minor bugs in reCAPTCHA + Campaigns admin UIs

### DIFF
--- a/assets/wizards/connections/views/main/recaptcha.js
+++ b/assets/wizards/connections/views/main/recaptcha.js
@@ -45,14 +45,13 @@ const Recaptcha = () => {
 		setError( null );
 		setIsLoading( true );
 		try {
-			setSettings(
-				await apiFetch( {
-					path: '/newspack/v1/recaptcha',
-					method: 'POST',
-					data,
-				} )
-			);
-			setSettingsToUpdate( {} );
+			const newSettings = await apiFetch( {
+				path: '/newspack/v1/recaptcha',
+				method: 'POST',
+				data,
+			} );
+			setSettings( newSettings );
+			setSettingsToUpdate( newSettings );
 		} catch ( e ) {
 			setError( e?.message || __( 'Error updating settings.', 'newspack-plugin' ) );
 		} finally {
@@ -129,7 +128,7 @@ const Recaptcha = () => {
 								step="0.05"
 								min="0"
 								max="1"
-								value={ settingsToUpdate?.threshold || '' }
+								value={ parseFloat( settingsToUpdate?.threshold || '' ) }
 								label={ __( 'Threshold', 'newspack-plugin' ) }
 								onChange={ value =>
 									setSettingsToUpdate( { ...settingsToUpdate, threshold: value } )

--- a/assets/wizards/popups/components/segment-group/SegmentGroup.test.js
+++ b/assets/wizards/popups/components/segment-group/SegmentGroup.test.js
@@ -307,12 +307,12 @@ describe( 'A segment with conflicting prompts', () => {
 		};
 	} );
 
-	it( 'renders a conflict notice for uncategorized overlays in the same segment', async () => {
+	it( 'renders a conflict notice for mutliple overlays in the same segment', async () => {
 		SEGMENT.prompts = PROMPTS.overlaysUncategorized;
 
 		// Expected warning text.
 		const noticeText =
-			'If multiple uncategorized overlays share the same segment, only the most recent one will be displayed.';
+			'If multiple overlays are rendered on the same pageview, only the most recent one will be displayed.';
 		const props = {
 			campaignData: CAMPAIGN.campaignData,
 			campaign: CAMPAIGN.campaignId,
@@ -331,36 +331,12 @@ describe( 'A segment with conflicting prompts', () => {
 		);
 	} );
 
-	it( 'renders a conflict notice for categorized overlays in the same segment', async () => {
-		SEGMENT.prompts = PROMPTS.overlaysCategorized;
-
-		// Expected warning text.
-		const noticeText =
-			'If multiple overlays share the same segment and category filtering, only the most recent one will be displayed.';
-		const props = {
-			campaignData: CAMPAIGN.campaignData,
-			campaign: CAMPAIGN.campaignId,
-			segment: SEGMENT,
-		};
-		const { getByTestId } = render( <SegmentGroup { ...props } /> );
-		const notice1 = getByTestId( 'conflict-warning-3' );
-		const notice2 = getByTestId( 'conflict-warning-4' );
-
-		// Notice text has expected shape.
-		expect( notice1.textContent ).toEqual(
-			`${ PROMPTS.overlaysCategorized[ 1 ].title }: ${ noticeText }`
-		);
-		expect( notice2.textContent ).toEqual(
-			`${ PROMPTS.overlaysCategorized[ 0 ].title }: ${ noticeText }`
-		);
-	} );
-
-	it( 'renders a conflict notice for uncategorized above-header prompts in the same segment', async () => {
+	it( 'renders a conflict notice for multiple above-header prompts in the same segment', async () => {
 		SEGMENT.prompts = PROMPTS.aboveHeadersUncategorized;
 
 		// Expected warning text.
 		const noticeText =
-			'If multiple uncategorized above-header prompts share the same segment, only the most recent one will be displayed.';
+			'If multiple above-header prompts are rendered on the same pageview, only the most recent one will be displayed.';
 		const props = {
 			campaignData: CAMPAIGN.campaignData,
 			campaign: CAMPAIGN.campaignId,
@@ -379,36 +355,12 @@ describe( 'A segment with conflicting prompts', () => {
 		);
 	} );
 
-	it( 'renders a conflict notice for above-header prompts in the same segment', async () => {
-		SEGMENT.prompts = PROMPTS.aboveHeadersCategorized;
-
-		// Expected warning text.
-		const noticeText =
-			'If multiple above-header prompts share the same segment and category filtering, only the most recent one will be displayed.';
-		const props = {
-			campaignData: CAMPAIGN.campaignData,
-			campaign: CAMPAIGN.campaignId,
-			segment: SEGMENT,
-		};
-		const { getByTestId } = render( <SegmentGroup { ...props } /> );
-		const notice1 = getByTestId( 'conflict-warning-7' );
-		const notice2 = getByTestId( 'conflict-warning-8' );
-
-		// Notice text has expected shape.
-		expect( notice1.textContent ).toEqual(
-			`${ PROMPTS.aboveHeadersCategorized[ 1 ].title }: ${ noticeText }`
-		);
-		expect( notice2.textContent ).toEqual(
-			`${ PROMPTS.aboveHeadersCategorized[ 0 ].title }: ${ noticeText }`
-		);
-	} );
-
-	it( 'renders a conflict notice for uncategorized prompts in the same custom placement and segment', async () => {
+	it( 'renders a conflict notice for multiple prompts in the same custom placement and segment', async () => {
 		SEGMENT.prompts = PROMPTS.customPlacementsUncategorized;
 
 		// Expected warning text.
 		const noticeText =
-			'If multiple uncategorized prompts in the same custom placement share the same segment, only the most recent one will be displayed.';
+			'If multiple prompts are rendered in the same custom placement, only the most recent one will be displayed.';
 		const props = {
 			campaignData: CAMPAIGN.campaignData,
 			campaign: CAMPAIGN.campaignId,
@@ -427,30 +379,6 @@ describe( 'A segment with conflicting prompts', () => {
 		);
 	} );
 
-	it( 'renders a conflict notice for categorized prompts in the same custom placement and segment', async () => {
-		SEGMENT.prompts = PROMPTS.customPlacementsCategorized;
-
-		// Expected warning text.
-		const noticeText =
-			'If multiple prompts in the same custom placement share the same segment and category filtering, only the most recent one will be displayed.';
-		const props = {
-			campaignData: CAMPAIGN.campaignData,
-			campaign: CAMPAIGN.campaignId,
-			segment: SEGMENT,
-		};
-		const { getByTestId } = render( <SegmentGroup { ...props } /> );
-		const notice1 = getByTestId( 'conflict-warning-11' );
-		const notice2 = getByTestId( 'conflict-warning-12' );
-
-		// Notice text has expected shape.
-		expect( notice1.textContent ).toEqual(
-			`${ PROMPTS.customPlacementsCategorized[ 1 ].title }: ${ noticeText }`
-		);
-		expect( notice2.textContent ).toEqual(
-			`${ PROMPTS.customPlacementsCategorized[ 0 ].title }: ${ noticeText }`
-		);
-	} );
-
 	it( 'renders a conflict notice for conflicting prompts that have no segment', async () => {
 		const everyone = {
 			configuration: {},
@@ -464,7 +392,7 @@ describe( 'A segment with conflicting prompts', () => {
 
 		// Expected warning text.
 		const noticeText =
-			'If multiple uncategorized overlays share the same segment, only the most recent one will be displayed.';
+			'If multiple overlays are rendered on the same pageview, only the most recent one will be displayed.';
 		const props = {
 			campaignData: CAMPAIGN.campaignData,
 			campaign: CAMPAIGN.campaignId,

--- a/assets/wizards/popups/utils.js
+++ b/assets/wizards/popups/utils.js
@@ -380,31 +380,24 @@ const sharesSegments = ( segmentsA, segmentsB ) => {
 	);
 };
 
-export const buildWarning = ( prompt, promptCategories ) => {
+export const buildWarning = prompt => {
 	if ( isOverlay( prompt ) || isAboveHeader( prompt ) ) {
 		return sprintf(
-			// Translators: %1: 'uncetegorized' if no categories. %2: 'above-header prompts' if above header, 'overlays' otherwise. %3: 'and category filtering' if categories.
+			// Translators: %s is prompt type (above-header or overlay).
 			__(
-				'If multiple%1$s %2$s share the same segment%3$s, only the most recent one will be displayed.',
+				'If multiple %s are rendered on the same pageview, only the most recent one will be displayed.',
 				'newspack-plugin'
 			),
-			0 === promptCategories.length ? __( ' uncategorized', 'newspack-plugin' ) : '',
 			isAboveHeader( prompt )
 				? __( 'above-header prompts', 'newspack-plugin' )
-				: __( 'overlays', 'newspack-plugin' ),
-			0 < promptCategories.length ? __( ' and category filtering', 'newspack-plugin' ) : ''
+				: __( 'overlays', 'newspack-plugin' )
 		);
 	}
 
 	if ( isCustomPlacement( prompt ) ) {
-		return sprintf(
-			// Translators: %1: 'uncetegorized' if no categories. %2: 'and category filtering' if categories.
-			__(
-				'If multiple%1$s prompts in the same custom placement share the same segment%2$s, only the most recent one will be displayed.',
-				'newspack-plugin'
-			),
-			0 === promptCategories.length ? __( ' uncategorized', 'newspack-plugin' ) : '',
-			0 < promptCategories.length ? __( ' and category filtering', 'newspack-plugin' ) : ''
+		return __(
+			'If multiple prompts are rendered in the same custom placement, only the most recent one will be displayed.',
+			'newspack-plugin'
 		);
 	}
 

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -194,10 +194,15 @@ final class Recaptcha {
 			return null;
 		}
 		$value = \get_option( self::OPTIONS_PREFIX . $key, $config[ $key ] );
+
 		// Use default value type for casting bool option value.
 		if ( is_bool( $config[ $key ] ) ) {
 			$value = (bool) $value;
+		} elseif ( empty( $value ) ) {
+			// If the stored value is empty, use the default value.
+			$value = $config[ $key ];
 		}
+
 		return $value;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Two minor fixes for admin UIs.

### How to test the changes in this Pull Request:

#### reCAPTCHA fix

1. On `release,`, visit **Newspack > Connections** in WP admin.
2. Under the reCAPTCA v3 section, change some values and save. Observe how the fields become empty after saving (but if you refresh, you'll see the values you entered were persisted).
3. Check out this branch and repeat, and confirm that the values remain filled as saved and are persisted after refreshing.

#### Campaigns conflict warning

Simplifies the conflict warning message shown when more than one overlay/above-header/custom placement prompt is eligible to be shown at the same time.

1. Visit **Newspack > Campaigns** and publish two overlays (or two above-header prompts) with the same segment, and confirm the new message:

<img width="1046" alt="Screenshot 2024-04-18 at 4 46 31 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/d2654a35-ba3a-47ad-953b-2ef1d52f4464">

2. Publish two inline prompts with the same segment and assign to the same Custom Placement, and confirm the new message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206985224104282
  - https://app.asana.com/0/0/1206956078334328