### PR TITLE
fix(woo): include all active statuses

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -390,7 +390,7 @@ final class Reader_Data {
 	/**
 	 * Data event handler to update a user's list of active non-donation subscriptions.
 	 * The active_subscriptions key stores an array of the user's active non-donation subscriptions.
-	 * 
+	 *
 	 * @param int   $timestamp Timestamp.
 	 * @param array $data      Data.
 	 */
@@ -401,7 +401,7 @@ final class Reader_Data {
 
 		$existing_subscriptions = self::get_data( $data['user_id'], 'active_subscriptions' );
 		$active_subscriptions   = $existing_subscriptions ? json_decode( $existing_subscriptions ) : [];
-		if ( 'active' === $data['status_after'] ) {
+		if ( WooCommerce_Connection::is_subscription_active( $data['status_after'] ) ) {
 			$active_subscriptions = array_merge( $active_subscriptions, $data['product_ids'] );
 		} else {
 			$active_subscriptions = array_values( array_diff( $active_subscriptions, $data['product_ids'] ) );
@@ -414,7 +414,7 @@ final class Reader_Data {
 	/**
 	 * Data event handler to check if the user has active subscriptions and
 	 * set the data item on login.
-	 * 
+	 *
 	 * @param int   $timestamp Timestamp.
 	 * @param array $data      Data.
 	 */
@@ -430,7 +430,7 @@ final class Reader_Data {
 		$active_subscriptions = \wcs_get_subscriptions(
 			[
 				'customer_id'         => $data['user_id'],
-				'subscription_status' => 'active',
+				'subscription_status' => WooCommerce_Connection::$active_subscription_statuses,
 			]
 		);
 
@@ -448,7 +448,7 @@ final class Reader_Data {
 
 	/**
 	 * Data event handler to update a user's list of active memberships.
-	 * 
+	 *
 	 * @param int   $timestamp Timestamp.
 	 * @param array $data      Data.
 	 */
@@ -472,7 +472,7 @@ final class Reader_Data {
 	/**
 	 * Data event handler to check if the user has active memberships and
 	 * set the data item on login.
-	 * 
+	 *
 	 * @param int   $timestamp Timestamp.
 	 * @param array $data      Data.
 	 */

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -7,14 +7,19 @@
 
 namespace Newspack;
 
-use WP_Error;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Connection with WooCommerce's features.
  */
 class WooCommerce_Connection {
+	/**
+	 * Statuses considered active subscriptions.
+	 *
+	 * @var array
+	 */
+	public static $active_subscription_statuses = [ 'active', 'pending', 'pending-cancel' ];
+
 	/**
 	 * Initialize.
 	 *
@@ -49,6 +54,18 @@ class WooCommerce_Connection {
 
 		\add_filter( 'page_template', [ __CLASS__, 'page_template' ] );
 		\add_filter( 'get_post_metadata', [ __CLASS__, 'get_post_metadata' ], 10, 3 );
+	}
+
+	/**
+	 * Check if the given status is considered active in Woo Subscriptions.
+	 *
+	 * @param string $status Subscription status.
+	 *
+	 * @return boolean
+	 */
+	public static function is_subscription_active( $status ) {
+		$status = str_replace( 'wc-', '', $status ); // Normalize status strings.
+		return in_array( $status, self::$active_subscription_statuses, true );
 	}
 
 	/**
@@ -123,7 +140,7 @@ class WooCommerce_Connection {
 
 		$subscriptions = \wcs_get_subscriptions(
 			[
-				'status'                 => [ 'active', 'pending', 'pending-cancel' ],
+				'status'                 => self::$active_subscription_statuses,
 				'subscriptions_per_page' => $batch_size,
 				'offset'                 => $offset,
 			]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Expands the definition of what we consider to be an "active" Woo subscription to match what [Woo Subscriptions itself considers active](https://woocommerce.com/document/subscriptions/statuses/).

### How to test the changes in this Pull Request:

1. Check out this branch.
2. As a reader, purchase a new non-donation subscription product.
3. Navigate to another page to trigger the reader data refresh.
4. In WP admin, manually update the subscription's status to "Pending" status.
5. Using `wp shell` in CLI, inspect the reader's data and confirm that the subscription is still listed in `active_subscriptions`:

```
wp> \Newspack\Reader_Data::get_data( 26 ); // User ID
=> array(3) {
  ["active_memberships"]=>
  string(14) "["266","1898"]"
  ["active_subscriptions"]=>
  string(7) "["508"]"
  ["pageviews"]=>
  string(124) "{"day":{"count":5,"start":1711663108627},"week":{"count":5,"start":1711663108627},"month":{"count":5,"start":1711663108627}}"
}
```

6. In WP admin, manually update the subscription to "Pending Cancellation" status. Repeat step 5 and confirm that the subscription is still listed in `active_subscriptions`.
7. In WP admin, manually update the subscription to "Cancelled" or "Expired" status. Repeat step 5 and confirm that the subscription is no longer listed in `active_subscriptions`.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->