### PR TITLE
fix: ensure only admins can reset starter content and newspack options

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -207,6 +207,9 @@ final class Newspack {
 	 * Handle resetting of various options and content.
 	 */
 	public function handle_resets() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
 		$redirect_url   = admin_url( 'admin.php?page=newspack' );
 		$newspack_reset = filter_input( INPUT_GET, 'newspack_reset', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( 'starter-content' === $newspack_reset ) {

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -111,7 +111,7 @@ abstract class Wizard {
 
 		$screen = get_current_screen();
 
-		if ( Starter_Content::has_created_starter_content() ) {
+		if ( Starter_Content::has_created_starter_content() && current_user_can( 'manage_options' ) ) {
 			$urls['remove_starter_content'] = esc_url(
 				add_query_arg(
 					array(
@@ -122,7 +122,7 @@ abstract class Wizard {
 			);
 		}
 
-		if ( Newspack::is_debug_mode() ) {
+		if ( Newspack::is_debug_mode() && current_user_can( 'manage_options' ) ) {
 			$urls['components_demo'] = esc_url( admin_url( 'admin.php?page=newspack-components-demo' ) );
 			$urls['setup_wizard']    = esc_url( admin_url( 'admin.php?page=newspack-setup-wizard' ) );
 			$urls['reset_url']       = esc_url(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As it says on the tin!

### How to test the changes in this Pull Request:

1. Ensure you have starter content generated
1. On `trunk`, create an Author user and log in as them
2. Visit the `/wp-admin/admin.php?newspack_reset=starter-content` page and observe the starter content has been deleted
3. Switch to this branch, repeat, observe the Author user cannot reset the starter content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->