### PR TITLE
feat(ras-acc): update newsletters palette on theme primary color updates

### DIFF
--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -493,10 +493,8 @@ class Emails {
 				$theme_colors = newspack_get_theme_colors();
 				\Newspack_Newsletters::update_color_palette(
 					[
-						'primary'        => $theme_colors['primary_color'],
-						'secondary'      => $theme_colors['secondary_color'],
-						'primary-text'   => $theme_colors['primary_text_color'],
-						'secondary-text' => $theme_colors['secondary_text_color'],
+						'primary'      => $theme_colors['primary_color'],
+						'primary-text' => $theme_colors['primary_text_color'],
 					]
 				);
 			}
@@ -649,18 +647,16 @@ class Emails {
 		}
 
 		// Check for theme mod color settings in case a non-newspack theme is installed.
-		if ( ! isset( $previous_value['primary_color_hex'], $previous_value['secondary_color_hex'], $updated_value['primary_color_hex'], $updated_value['secondary_color_hex'] ) ) {
+		if ( ! isset( $previous_value['primary_color_hex'], $updated_value['primary_color_hex'] ) ) {
 			return;
 		}
 
-		if ( $previous_value['primary_color_hex'] !== $updated_value['primary_color_hex'] || $previous_value['secondary_color_hex'] !== $updated_value['secondary_color_hex'] ) {
+		if ( $previous_value['primary_color_hex'] !== $updated_value['primary_color_hex'] ) {
 			// Update the newsletters color palette.
 			$updated = \Newspack_Newsletters::update_color_palette(
 				[
-					'primary'        => $updated_value['primary_color_hex'],
-					'secondary'      => $updated_value['secondary_color_hex'],
-					'primary-text'   => newspack_get_color_contrast( $updated_value['primary_color_hex'] ),
-					'secondary-text' => newspack_get_color_contrast( $updated_value['secondary_color_hex'] ),
+					'primary'      => $updated_value['primary_color_hex'],
+					'primary-text' => newspack_get_color_contrast( $updated_value['primary_color_hex'] ),
 				]
 			);
 
@@ -683,15 +679,11 @@ class Emails {
 				$email_html = str_replace(
 					[
 						$previous_value['primary_color_hex'],
-						$previous_value['secondary_color_hex'],
 						newspack_get_color_contrast( $previous_value['primary_color_hex'] ),
-						newspack_get_color_contrast( $previous_value['secondary_color_hex'] ),
 					],
 					[
 						$updated_value['primary_color_hex'],
-						$updated_value['secondary_color_hex'],
 						newspack_get_color_contrast( $updated_value['primary_color_hex'] ),
-						newspack_get_color_contrast( $updated_value['secondary_color_hex'] ),
 					],
 					$email_html
 				);

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -489,7 +489,7 @@ class Emails {
 			return false;
 		} else {
 			// Make sure newsletters color palette is updated with latest theme colors.
-			if ( self::supports_emails() ) {
+			if ( self::supports_emails() && method_exists( '\Newspack_Newsletters', 'update_color_palette' ) ) {
 				$theme_colors = newspack_get_theme_colors();
 				\Newspack_Newsletters::update_color_palette(
 					[

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -28,7 +28,7 @@ class Emails {
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_filter( 'newspack_newsletters_email_editor_cpts', [ __CLASS__, 'register_email_cpt_with_email_editor' ] );
 		add_filter( 'newspack_newsletters_allowed_editor_actions', [ __CLASS__, 'register_scripts_enqueue_with_email_editor' ] );
-		add_action( 'update_option_theme_mods_' . get_template(), [ __CLASS__, 'maybe_update_email_templates' ], 10, 2 );
+		add_action( 'update_option_theme_mods_' . ( wp_get_theme()->parent() ? get_stylesheet() : get_template() ), [ __CLASS__, 'maybe_update_email_templates' ], 10, 2 );
 		add_action( 'admin_head', [ __CLASS__, 'inject_dynamic_email_template_styles' ] );
 	}
 

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -695,6 +695,7 @@ class Emails {
 
 		?>
 		<style type="text/css">
+			.is-style-filled-primary-text,
 			.<?php echo esc_html( self::POST_TYPE ); ?>-has-primary-text-color,
 			.<?php echo esc_html( self::POST_TYPE ); ?>-has-primary-text-color a {
 				color: <?php echo esc_attr( $primary_text_color ); ?> !important;

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -489,15 +489,17 @@ class Emails {
 			return false;
 		} else {
 			// Make sure newsletters color palette is updated with latest theme colors.
-			$theme_colors = newspack_get_theme_colors();
-			\Newspack_Newsletters::update_color_palette(
-				[
-					'primary'        => $theme_colors['primary_color'],
-					'secondary'      => $theme_colors['secondary_color'],
-					'primary-text'   => $theme_colors['primary_text_color'],
-					'secondary-text' => $theme_colors['secondary_text_color'],
-				]
-			);
+			if ( self::supports_emails() ) {
+				$theme_colors = newspack_get_theme_colors();
+				\Newspack_Newsletters::update_color_palette(
+					[
+						'primary'        => $theme_colors['primary_color'],
+						'secondary'      => $theme_colors['secondary_color'],
+						'primary-text'   => $theme_colors['primary_text_color'],
+						'secondary-text' => $theme_colors['secondary_text_color'],
+					]
+				);
+			}
 
 			$email_post_data = self::load_email_template( $type );
 			if ( ! $email_post_data ) {
@@ -695,9 +697,16 @@ class Emails {
 
 		?>
 		<style type="text/css">
-			.is-style-filled-primary-text,
 			.<?php echo esc_html( self::POST_TYPE ); ?>-has-primary-text-color,
 			.<?php echo esc_html( self::POST_TYPE ); ?>-has-primary-text-color a {
+				color: <?php echo esc_attr( $primary_text_color ); ?> !important;
+			}
+
+			.is-style-filled-primary-text li {
+				background: transparent !important;
+			}
+
+			.is-style-filled-primary-text li svg {
 				color: <?php echo esc_attr( $primary_text_color ); ?> !important;
 			}
 		</style>

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -678,6 +678,25 @@ class Emails {
 			);
 
 			foreach ( $templates as $template ) {
+				// Find/replace the old hex values with the new ones in the rendered email HTML.
+				$email_html = get_post_meta( $template->ID, \Newspack_Newsletters::EMAIL_HTML_META, true );
+				$email_html = str_replace(
+					[
+						$previous_value['primary_color_hex'],
+						$previous_value['secondary_color_hex'],
+						newspack_get_color_contrast( $previous_value['primary_color_hex'] ),
+						newspack_get_color_contrast( $previous_value['secondary_color_hex'] ),
+					],
+					[
+						$updated_value['primary_color_hex'],
+						$updated_value['secondary_color_hex'],
+						newspack_get_color_contrast( $updated_value['primary_color_hex'] ),
+						newspack_get_color_contrast( $updated_value['secondary_color_hex'] ),
+					],
+					$email_html
+				);
+				update_post_meta( $template->ID, \Newspack_Newsletters::EMAIL_HTML_META, $email_html );
+
 				wp_update_post( [ 'ID' => $template->ID ] );
 			}
 		}

--- a/includes/util.php
+++ b/includes/util.php
@@ -563,7 +563,7 @@ function newspack_get_social_markup( $color = 'white' ) {
 	$cm          = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'wordpress_seo' );
 	$social_urls = [];
 	$markup      = [
-		'block_markup' => '<!-- wp:social-links {"iconColor":"primary-text","iconColorValue":"primary-text","layout":{"type":"flex","flexWrap":"nowrap"}} --><ul class="wp-block-social-links has-icon-color">',
+		'block_markup' => '<!-- wp:social-links {"iconColor":"primary-text","iconColorValue":"primary-text","className":"is-style-filled-primary-text","layout":{"type":"flex","flexWrap":"nowrap"}} --><ul class="wp-block-social-links has-icon-color is-style-filled-primary-text">',
 		'html_markup'  => '',
 	];
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Part of https://app.asana.com/0/1206943664367847/1205668937699542/f

This PR is meant to be reviewed alongside these newsletters changes: https://github.com/Automattic/newspack-newsletters/pull/1487

These changes ensure we are updating the newsletter color palette option with the latest primary and secondary theme colors before creating transactional emails from templates OR before triggering an update to email HTML when updating a sites primary or secondary newspack theme colors.

### How to test the changes in this Pull Request:

1. With both the changes in the newsletters pr as well as this one checked out, go to Newspack > Engagement > Show advanced settings and reset the one time password email.
2. Go to the post editor for the OTP email by selecting the edit link
3. Confirm the social icons are filled either white or black depending on the color of the email footer (should be contrasting)
4. Send a test email to yourself
5. Confirm the social icons are also filled with the same color in the email
6. Go to Newspack > Site Design and change the sites primary color to something of the opposite darkness/lightness than it previously was and save
7. Go back to the OTP email edit page and confirm the social icons are now the opposite color than they were before (black or white)
8. Send another test email to yourself
9. Confirm the social icons are also filled with the same color in the email

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->