### PR TITLE
fix(ras): sync purchase data only for most recent order/subscription

### DIFF
--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -29,32 +29,7 @@ class Newspack_Newsletters {
 	 *
 	 * @var array
 	 */
-	public static $metadata_keys = [
-		'account'              => 'Account',
-		'registration_date'    => 'Registration Date',
-		'connected_account'    => 'Connected Account',
-		'signup_page'          => 'Signup Page',
-		'signup_page_utm'      => 'Signup UTM: ',
-		'newsletter_selection' => 'Newsletter Selection',
-		'referer'              => 'Referrer Path',
-		'registration_page'    => 'Registration Page',
-		'current_page_url'     => 'Registration Page',
-		'registration_method'  => 'Registration Method',
-
-		// Payment-related.
-		'membership_status'    => 'Membership Status',
-		'payment_page'         => 'Payment Page',
-		'payment_page_utm'     => 'Payment UTM: ',
-		'sub_start_date'       => 'Current Subscription Start Date',
-		'sub_end_date'         => 'Current Subscription End Date',
-		'billing_cycle'        => 'Billing Cycle',
-		'recurring_payment'    => 'Recurring Payment',
-		'last_payment_date'    => 'Last Payment Date',
-		'last_payment_amount'  => 'Last Payment Amount',
-		'product_name'         => 'Product Name',
-		'next_payment_date'    => 'Next Payment Date',
-		'total_paid'           => 'Total Paid',
-	];
+	public static $metadata_keys = [];
 
 	/**
 	 * Initialize hooks and filters.
@@ -65,13 +40,64 @@ class Newspack_Newsletters {
 		 *
 		 * @param array $metadata_keys The list of key/value pairs for metadata fields to be synced to the connected ESP.
 		 */
-		self::$metadata_keys = \apply_filters( 'newspack_ras_metadata_keys', self::$metadata_keys );
+		self::$metadata_keys = \apply_filters( 'newspack_ras_metadata_keys', self::get_all_metadata_fields() );
 
 		\add_filter( 'newspack_newsletters_contact_data', [ __CLASS__, 'normalize_contact_data' ] );
 
 		if ( self::should_sync_ras_metadata() ) {
 			\add_filter( 'newspack_newsletters_contact_lists', [ __CLASS__, 'add_activecampaign_master_list' ], 10, 3 );
 		}
+	}
+
+	/**
+	 * Get basic contact metadata fields.
+	 *
+	 * @return array List of fields.
+	 */
+	public static function get_basic_metadata_fields() {
+		return [
+			'account'              => 'Account',
+			'registration_date'    => 'Registration Date',
+			'connected_account'    => 'Connected Account',
+			'signup_page'          => 'Signup Page',
+			'signup_page_utm'      => 'Signup UTM: ',
+			'newsletter_selection' => 'Newsletter Selection',
+			'referer'              => 'Referrer Path',
+			'registration_page'    => 'Registration Page',
+			'current_page_url'     => 'Registration Page',
+			'registration_method'  => 'Registration Method',
+		];
+	}
+
+	/**
+	 * Get payment-related metadata fields.
+	 *
+	 * @return array List of fields.
+	 */
+	public static function get_payment_metadata_fields() {
+		return [
+			'membership_status'   => 'Membership Status',
+			'payment_page'        => 'Payment Page',
+			'payment_page_utm'    => 'Payment UTM: ',
+			'sub_start_date'      => 'Current Subscription Start Date',
+			'sub_end_date'        => 'Current Subscription End Date',
+			'billing_cycle'       => 'Billing Cycle',
+			'recurring_payment'   => 'Recurring Payment',
+			'last_payment_date'   => 'Last Payment Date',
+			'last_payment_amount' => 'Last Payment Amount',
+			'product_name'        => 'Product Name',
+			'next_payment_date'   => 'Next Payment Date',
+			'total_paid'          => 'Total Paid',
+		];
+	}
+
+	/**
+	 * Get all metdata fields.
+	 *
+	 * @return array List of fields.
+	 */
+	public static function get_all_metadata_fields() {
+		return array_merge( self::get_basic_metadata_fields(), self::get_payment_metadata_fields() );
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -203,13 +203,15 @@ class WooCommerce_Connection {
 
 		$metadata = [];
 
-		$referer_from_order = $order->get_meta( '_newspack_referer' );
-		if ( empty( $referer_from_order ) ) {
-			$payment_page_url = \wc_get_checkout_url();
-		} else {
-			$payment_page_url = $referer_from_order;
+		if ( empty( $payment_page_url ) ) {
+			$referer_from_order = $order->get_meta( '_newspack_referer' );
+			if ( empty( $referer_from_order ) ) {
+				$payment_page_url = \wc_get_checkout_url();
+			} else {
+				$payment_page_url = $referer_from_order;
+			}
 		}
-		$metadata['payment_page'] = $payment_page_url;
+		$metadata[ Newspack_Newsletters::get_metadata_key( 'payment_page' ) ] = $payment_page_url;
 
 		$utm = $order->get_meta( 'utm' );
 		if ( ! empty( $utm ) ) {
@@ -362,7 +364,7 @@ class WooCommerce_Connection {
 			}
 		}
 
-		$metadata = array_merge( $metadata, $order_metadata );
+		$metadata = array_merge( $order_metadata, $metadata );
 
 		$first_name = $customer->get_billing_first_name();
 		$last_name  = $customer->get_billing_last_name();

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -297,6 +297,21 @@ class WooCommerce_Connection {
 			}
 		}
 
+		// Clear out any payment-related fields that don't relate to the current order.
+		$payment_fields = array_keys( Newspack_Newsletters::get_payment_metadata_fields() );
+		foreach ( $payment_fields as $meta_key ) {
+			$meta_field = Newspack_Newsletters::get_metadata_key( $meta_key );
+			if ( ! isset( $metadata[ $meta_field ] ) ) {
+				if ( 'payment_page_utm' === $meta_key ) {
+					foreach ( WooCommerce_Order_UTM::$params as $param ) {
+						$metadata[ $meta_field . $param ] = '';
+					}
+				} else {
+					$metadata[ $meta_field ] = '';
+				}
+			}
+		}
+
 		return $metadata;
 	}
 
@@ -317,28 +332,34 @@ class WooCommerce_Connection {
 
 		$metadata       = [];
 		$order_metadata = [];
+		$last_order     = self::get_last_successful_order( $customer );
 
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'account' ) ]           = $customer->get_id();
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_date' ) ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ]        = \wc_format_localized_price( $customer->get_total_spent() );
 
-		if ( ! $order ) {
-			$order = self::get_last_successful_order( $customer );
+		// If a more recent order exists, use it to sync.
+		if ( ! $order || ( $last_order && $order->get_id() !== $last_order->get_id() ) ) {
+			$order = $last_order;
+		}
 
-			// If customer has no order, they might still have a Subscription.
-			if ( ! $order ) {
-				$user_subscriptions = wcs_get_users_subscriptions( $customer->get_id() );
-				if ( $user_subscriptions ) {
-					$order = reset( $user_subscriptions );
-				}
+		// If customer has no order, they might still have a Subscription.
+		if ( ! $order ) {
+			$user_subscriptions = \wcs_get_users_subscriptions( $customer->get_id() );
+			if ( $user_subscriptions ) {
+				$order = reset( $user_subscriptions );
 			}
 		}
 
+		// Get the order metadata.
 		if ( $order ) {
 			$order_metadata = self::get_contact_order_metadata( $order, $payment_page_url, $is_new );
 		} else {
-			// If the customer has no successful orders, ensure their spend totals are correct.
-			$order_metadata[ Newspack_Newsletters::get_metadata_key( 'last_payment_amount' ) ] = \wc_format_localized_price( '0.00' );
+			// If the customer has no successful orders, clear out subscription-related fields.
+			$payment_fields = array_keys( Newspack_Newsletters::get_payment_metadata_fields() );
+			foreach ( $payment_fields as $meta_key ) {
+				$metadata[ Newspack_Newsletters::get_metadata_key( $meta_key ) ] = '';
+			}
 		}
 
 		$metadata = array_merge( $metadata, $order_metadata );
@@ -348,12 +369,12 @@ class WooCommerce_Connection {
 		$full_name  = trim( "$first_name $last_name" );
 		$contact    = [
 			'email'    => $customer->get_billing_email(),
-			'metadata' => array_filter( $metadata ),
+			'metadata' => $metadata,
 		];
 		if ( ! empty( $full_name ) ) {
 			$contact['name'] = $full_name;
 		}
-		return array_filter( $contact );
+		return $contact;
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-order-utm.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-order-utm.php
@@ -13,13 +13,12 @@ defined( 'ABSPATH' ) || exit;
  * WooCommerce Order UTM class.
  */
 class WooCommerce_Order_UTM {
-
 	/**
 	 * UTM parameters.
 	 *
 	 * @var string[]
 	 */
-	private static $params = [
+	public static $params = [
 		'source',
 		'medium',
 		'campaign',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks the reader data sync behavior so that any purchase-related fields only relate to the reader's most recent active order/subscription, if any. It's possible for a single reader to have more than one subscription in different states, so in this case an active one should take precedence when it comes to contact data in the connected ESP.

### How to test the changes in this Pull Request:

1. Publish three different non-donation subscription-type products with different attributes (name, price, billing period, etc.) so they're easily distinguished in the connected ESP data.
2. As a reader, purchase subscriptions for two of the products.
3. As an admin, force immediate cancellation of the older subscription (in WooCommerce > Subscriptions > Edit Subscription, change the status to "Cancelled" or "Expired").
4. On `release`, log in as the reader in a new session.
5. In the connected ESP, observe that the contact's metadata reflects a mix of data from both subscriptions: e.g. the `NP_Current Subscription End Date` will reflect the time you changed the status of the cancelled subscription in step 3, but the `NP_Membership Status`, `NP_Billing Cycle`, `* Payment Date` fields, etc. will all reflect the more recent active one.
6. Check out this branch and purchase a third subscription with the third product (so you should have one cancelled/expired sub and 2x active ones). Confirm that the contact data in the ESP now reflects only this most recent subscription, and that `NP_Current Subscription End Date` has been emptied out (because there's an active subscription, so there shouldn't be an end date).
7. As an admin, cancel the older active subscription. Confirm that the contact data in the ESP still reflects only the remaining active subscription.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207153288488122