### PR TITLE
fix: enable Memberships fix cron job only when environment constant is defined

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -909,8 +909,10 @@ class Memberships {
 	public static function cron_init() {
 		\register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );
 
-		if ( defined( 'NEWSPACK_ENABLE_MEMBERSHIPS_FIX_CRON' ) && NEWSPACK_ENABLE_MEMBERSHIPS_FIX_CRON && ! wp_next_scheduled( self::CRON_HOOK ) ) {
-			\wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
+		if ( defined( 'NEWSPACK_ENABLE_MEMBERSHIPS_FIX_CRON' ) && NEWSPACK_ENABLE_MEMBERSHIPS_FIX_CRON ) {
+			if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+				\wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
+			}
 		} else {
 			self::cron_deactivate();
 		}

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -909,8 +909,10 @@ class Memberships {
 	public static function cron_init() {
 		\register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );
 
-		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+		if ( defined( 'NEWSPACK_ENABLE_MEMBERSHIPS_FIX_CRON' ) && NEWSPACK_ENABLE_MEMBERSHIPS_FIX_CRON && ! wp_next_scheduled( self::CRON_HOOK ) ) {
 			\wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
+		} else {
+			self::cron_deactivate();
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3060 added an hourly cron job to fix an issue we've seen with the Memberships plugin. However, on sites with many active subscriptions, this cron job can cause out-of-memory (OOM) errors due to the large number of query results the cron job needs to process. It's possible that these OOM errors might interfere with other scheduled/automated behaviors on the site, and running this fix hourly is a bit heavy-handed, so instead of forcing the job to always run, this PR implements a check for a `NEWSPACK_ENABLE_MEMBERSHIPS_FIX_CRON` environment constant and only runs the fix jobs if present.

This will let us run the fix only for sites that need it (usually ones who have migrated or created a large number of subscriptions/memberships at a time) and turn it off when no longer needed.

### How to test the changes in this Pull Request:

1. Before checking out this branch, use CLI to run `wp cron event list` and observe that you see a `np_memberships_fix_expired_memberships` job scheduled hourly.
2. Check out this branch, re-run `wp cron event list` and confirm that the job is no longer listed as scheduled. Also confirm that if you run `wp cron event run np_memberships_fix_expired_memberships` WP CLI returns an error: `Error: Invalid cron event 'np_memberships_fix_expired_memberships'`
3. Add `define( 'NEWSPACK_ENABLE_MEMBERSHIPS_FIX_CRON', true );` to wp-config.php, repeat step 1 and confirm that the cron job is once again scheduled and can be run with `wp cron event run np_memberships_fix_expired_memberships`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->