### PR TITLE
fix(starter-content): make the starter content generation idempotent

### DIFF
--- a/includes/starter_content/class-starter-content-provider.php
+++ b/includes/starter_content/class-starter-content-provider.php
@@ -120,9 +120,9 @@ abstract class Starter_Content_Provider {
 	protected static function get_starter_post( $post_index ) {
 		global $wpdb;
 		$meta_key         = self::$starter_post_meta_prefix . $post_index;
-		$existing_post_id = $wpdb->get_row( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key=%s;", $meta_key ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$existing_post_id = $wpdb->get_row( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key=%s;", $meta_key ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		if ( $existing_post_id ) {
-			return $existing_post_id['post_id'];
+			return $existing_post_id->post_id;
 		}
 		return false;
 	}
@@ -135,9 +135,9 @@ abstract class Starter_Content_Provider {
 	protected static function get_starter_homepage() {
 		global $wpdb;
 		$meta_key         = self::$starter_homepage_meta;
-		$existing_post_id = $wpdb->get_row( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key=%s;", $meta_key ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$existing_post_id = $wpdb->get_row( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key=%s;", $meta_key ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		if ( $existing_post_id ) {
-			return $existing_post_id;
+			return $existing_post_id->post_id;
 		}
 		return false;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Makes the starter content generation idempotent by always removing the previously generated content before creating new content. 

### How to test the changes in this Pull Request:

1. Generate starter content by running `wp newspack setup`
2. Observe the content is generated as expected
3. Run the command again, observe starter content has been re-generated 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->