### PR TITLE
feat(ras-acc): additional component updates

### DIFF
--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -149,6 +149,11 @@
 		&__content {
 			backface-visibility: visible;
 			padding: var( --newspack-ui-spacer-5 );
+
+			// Make sure there's enough space above the first button in modals
+			.newspack-ui__button:not( :first-child ):first-of-type {
+				margin-top: var( --newspack-ui-spacer-5 );
+			}
 		}
 
 		&__footer {

--- a/assets/newspack-ui/scss/elements/_typography.scss
+++ b/assets/newspack-ui/scss/elements/_typography.scss
@@ -1,4 +1,5 @@
 .newspack-ui {
+	color: var( --newspack-ui-color-neutral-90 );
 	font-family: var( --newspack-ui-font-family );
 	font-size: var( --newspack-ui-font-size-s );
 	line-height: var( --newspack-ui-line-height-s );

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -1,6 +1,6 @@
 .newspack-ui {
 	// TODO: define some kind of size hierachy for buttons eg. small, medium, large.
-	&__button {
+	.newspack-ui__button {
 		align-items: center;
 		background: var( --newspack-ui-color-neutral-10 );
 		border: 0;

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -2,8 +2,10 @@
 	// TODO: define some kind of size hierachy for buttons eg. small, medium, large.
 	&__button {
 		align-items: center;
+		background: var( --newspack-ui-color-neutral-10 );
 		border: 0;
 		border-radius: var( --newspack-ui-border-radius-m );
+		color: var( --newspack-ui-color-neutral-90 );
 		display: inline-flex;
 		font-family: var( --newspack-ui-font-family );
 		font-size: var( --newspack-ui-font-size-s );
@@ -18,9 +20,14 @@
 			margin-bottom: var( --newspack-ui-spacer-2 );
 		}
 
+		&:hover {
+			background: var( --newspack-ui-color-neutral-30 );
+			color: var( --newspack-ui-color-neutral-90 );
+		}
+
 		&:disabled {
-			background: var( --newspack-ui-color-neutral-10 ) !important;
-			color: var( --newspack-ui-color-neutral-70 ) !important;
+			background: var( --newspack-ui-color-neutral-5 ) !important;
+			color: var( --newspack-ui-color-neutral-40 ) !important;
 			cursor: default;
 			pointer-events: none;
 		}

--- a/assets/newspack-ui/scss/elements/forms/_index.scss
+++ b/assets/newspack-ui/scss/elements/forms/_index.scss
@@ -57,7 +57,7 @@
 	}
 
 	// Error class to apply to specific fields.
-	&__error,
+	&__field-error,
 	[data-form-status="400"] { // Attribute added to sign-up modal form on failure.
 		--newspack-ui-color-input-border: var( --newspack-ui-color-error-50 );
 		--newspack-ui-color-input-border-focus: var( --newspack-ui-color-error-50 );

--- a/assets/newspack-ui/scss/elements/forms/_index.scss
+++ b/assets/newspack-ui/scss/elements/forms/_index.scss
@@ -30,31 +30,41 @@
 		}
 	}
 
-	// Container for input description.
-	&__helper-text {
+	// Form inline text - helper and error.
+	&__helper-text,
+	&__inline-error {
 		color: var( --newspack-ui-color-neutral-60 );
 		display: block;
 		font-size: var( --newspack-ui-font-size-xs );
-		line-height: var( --newspack-ui-line-height-s );
-		margin: var( --newspack-ui-spacer-base ) 0 var( --newspack-ui-spacer-5 );
+		font-weight: normal;
+		line-height: var( --newspack-ui-line-height-xs );
+		margin: var( --newspack-ui-spacer-base ) 0 0;
+		a {
+			text-decoration: underline;
+		}
+
+		& + & {
+			margin-top: 0;
+		}
 
 		label & {
 			margin: 0;
 		}
 	}
 
-	// Form response inline error text.
-	&__inline-error,
-	&__inline-info {
-		font-size: var( --newspack-ui-font-size-xs );
-		line-height: var( --newspack-ui-line-height-s );
-		margin: var( --newspack-ui-spacer-base ) 0 var( --newspack-ui-spacer-5 );
-		a {
-			text-decoration: underline;
-		}
-	}
-
 	&__inline-error {
 		color: var( --newspack-ui-color-error-50 );
+	}
+
+	// Error class to apply to specific fields.
+	&__error,
+	[data-form-status="400"] { // Attribute added to sign-up modal form on failure.
+		--newspack-ui-color-input-border: var( --newspack-ui-color-error-50 );
+		--newspack-ui-color-input-border-focus: var( --newspack-ui-color-error-50 );
+		--newspack-ui-label-color: var( --newspack-ui-color-error-50 );
+
+		.newspack-ui__label-optional {
+			color: inherit;
+		}
 	}
 }

--- a/assets/newspack-ui/scss/elements/forms/_labels.scss
+++ b/assets/newspack-ui/scss/elements/forms/_labels.scss
@@ -12,7 +12,7 @@
 		&:has( input[type='checkbox'] ),
 		&:has( input[type='radio'] ) {
 			display: grid;
-			gap: 0 var( --newspack-ui-spacer-3 );
+			gap: 0 var( --newspack-ui-spacer-base );
 			grid-template-columns: var( --newspack-ui-spacer-4 ) 1fr;
 
 			> *:not( input ) {
@@ -29,6 +29,7 @@
 				border-radius: var( --newspack-ui-border-radius-m );
 				cursor: pointer;
 				font-weight: normal;
+				gap: 0 var( --newspack-ui-spacer-3 );
 				margin-bottom: var( --newspack-ui-spacer-5 );
 				padding: var( --newspack-ui-spacer-3 );
 				transition: background-color 125ms ease-in-out, border-color 125ms ease-in-out;

--- a/assets/newspack-ui/scss/elements/forms/_labels.scss
+++ b/assets/newspack-ui/scss/elements/forms/_labels.scss
@@ -12,7 +12,7 @@
 		&:has( input[type='checkbox'] ),
 		&:has( input[type='radio'] ) {
 			display: grid;
-			gap: 0 var( --newspack-ui-spacer-base );
+			gap: 0 var( --newspack-ui-spacer-3 );
 			grid-template-columns: var( --newspack-ui-spacer-4 ) 1fr;
 
 			> *:not( input ) {
@@ -33,7 +33,7 @@
 				padding: var( --newspack-ui-spacer-3 );
 				transition: background-color 125ms ease-in-out, border-color 125ms ease-in-out;
 
-				&:has( input:checked ) {
+				&:has( > input:checked ) {
 					background: var( --newspack-ui-color-neutral-5 );
 					border-color: var( --newspack-ui-color-neutral-90 );
 				}

--- a/assets/newspack-ui/scss/elements/forms/_labels.scss
+++ b/assets/newspack-ui/scss/elements/forms/_labels.scss
@@ -1,6 +1,6 @@
 .newspack-ui {
-	// TODO: In the current My Account mockups, these are 16px.
 	label {
+		color: var( --newspack-ui-label-color );
 		display: block;
 		font-family: var( --newspack-ui-font-family);
 		font-size: var( --newspack-ui-font-size-s ) !important; // !important to override Newspack Theme.
@@ -11,13 +11,20 @@
 		// For labels containing radio, checkbox inputs:
 		&:has( input[type='checkbox'] ),
 		&:has( input[type='radio'] ) {
-			align-items: center;
-			display: flex;
-			gap: var( --newspack-ui-spacer-2 );
+			display: grid;
+			gap: 0 var( --newspack-ui-spacer-base );
+			grid-template-columns: var( --newspack-ui-spacer-4 ) 1fr;
+
+			> *:not( input ) {
+				grid-column: 2 / span 1;
+			}
+
+			input {
+				margin-top: 0.125em; // TODO: improve the way alignment is being achieved here.
+			}
 
 			// For creating a bordered 'list' of radio, checkbox inputs:
-			&.newspack-ui__input-list {
-				align-items: flex-start;
+			&.newspack-ui__input-card {
 				border: 1px solid var( --newspack-ui-color-border );
 				border-radius: var( --newspack-ui-border-radius-m );
 				cursor: pointer;
@@ -31,10 +38,42 @@
 					border-color: var( --newspack-ui-color-neutral-90 );
 				}
 
-				+ .newspack-ui__input-list {
+				+ .newspack-ui__input-card {
 					margin-top: calc( var( --newspack-ui-spacer-2 ) * -1 );
 				}
 			}
+
+			// 'Selected' label
+			&:has( .newspack_ui__input-card__selected ) {
+				grid-template-columns: var( --newspack-ui-spacer-4 ) 1fr min-content;
+			}
+
+			.newspack_ui__input-card__selected {
+				align-self: start;
+				background: var( --newspack-ui-color-neutral-90 );
+				border-radius: var( --newspack-ui-border-radius-xs );
+				color: var( --newspack-ui-color-neutral-0 );
+				font-size: var( --newspack-ui-font-size-xs );
+				font-weight: 600;
+				grid-column-start: 3;
+				grid-row-start: 1;
+				line-height: var( --newspack-ui-line-height-xs );
+				padding: 2px 6px; // TODO: replace with variables; they only go down to 8px, rethink?
+				text-transform: uppercase;
+			}
+		}
+	}
+
+	&__label-optional {
+		color: var( --newspack-ui-color-neutral-60 );
+		font-weight: 400;
+	}
+
+	&__required {
+		color: var( --newspack-ui-color-error-50 );
+
+		&[title] {
+			text-decoration: none;
 		}
 	}
 }

--- a/assets/newspack-ui/scss/elements/forms/_labels.scss
+++ b/assets/newspack-ui/scss/elements/forms/_labels.scss
@@ -44,11 +44,11 @@
 			}
 
 			// 'Selected' badge
-			&:has( .newspack_ui__badge ) {
+			&:has( .newspack-ui__badge ) {
 				grid-template-columns: var( --newspack-ui-spacer-4 ) 1fr min-content;
 			}
 
-			.newspack_ui__badge {
+			.newspack-ui__badge {
 				align-self: start;
 				grid-column-start: 3;
 				grid-row-start: 1;

--- a/assets/newspack-ui/scss/elements/forms/_labels.scss
+++ b/assets/newspack-ui/scss/elements/forms/_labels.scss
@@ -43,23 +43,15 @@
 				}
 			}
 
-			// 'Selected' label
-			&:has( .newspack_ui__input-card__selected ) {
+			// 'Selected' badge
+			&:has( .newspack_ui__badge ) {
 				grid-template-columns: var( --newspack-ui-spacer-4 ) 1fr min-content;
 			}
 
-			.newspack_ui__input-card__selected {
+			.newspack_ui__badge {
 				align-self: start;
-				background: var( --newspack-ui-color-neutral-90 );
-				border-radius: var( --newspack-ui-border-radius-xs );
-				color: var( --newspack-ui-color-neutral-0 );
-				font-size: var( --newspack-ui-font-size-xs );
-				font-weight: 600;
 				grid-column-start: 3;
 				grid-row-start: 1;
-				line-height: var( --newspack-ui-line-height-xs );
-				padding: 2px 6px; // TODO: replace with variables; they only go down to 8px, rethink?
-				text-transform: uppercase;
 			}
 		}
 	}

--- a/assets/newspack-ui/scss/elements/misc/_badge.scss
+++ b/assets/newspack-ui/scss/elements/misc/_badge.scss
@@ -1,7 +1,5 @@
-.newspack_ui__badge {
-	background: var( --newspack-ui-color-neutral-90 );
+.newspack-ui__badge {
 	border-radius: var( --newspack-ui-border-radius-xs );
-	color: var( --newspack-ui-color-neutral-0 );
 	display: inline-grid;
 	font-size: var( --newspack-ui-font-size-xs );
 	font-weight: 600;
@@ -9,4 +7,35 @@
 	padding: 2px 6px; // TODO: replace with variables; they only go down to 8px, perhaps they need to be rethought?
 	place-items: center;
 	text-transform: uppercase;
+
+	&--primary {
+		background: var( --newspack-ui-color-neutral-90 );
+		color: var( --newspack-ui-color-neutral-0 );
+	}
+
+	&--secondary {
+		background: var( --newspack-ui-color-neutral-10 );
+		color: var( --newspack-ui-color-neutral-90 );
+	}
+
+	&--outline {
+		background: var( --newspack-ui-color-neutral-0 );
+		border: 1px solid var( --newspack-ui-color-neutral-30 );
+		color: var( --newspack-ui-color-neutral-60 );
+	}
+
+	&--success {
+		background: var( --newspack-ui-color-success-0 );
+		color: var( --newspack-ui-color-neutral-90 );
+	}
+
+	&--error {
+		background: var( --newspack-ui-color-error-0 );
+		color: var( --newspack-ui-color-neutral-90 );
+	}
+
+	&--warning {
+		background: var( --newspack-ui-color-warning-0 );
+		color: var( --newspack-ui-color-neutral-90 );
+	}
 }

--- a/assets/newspack-ui/scss/elements/misc/_badge.scss
+++ b/assets/newspack-ui/scss/elements/misc/_badge.scss
@@ -1,5 +1,7 @@
 .newspack-ui__badge {
+	background: var( --newspack-ui-color-neutral-0 );
 	border-radius: var( --newspack-ui-border-radius-xs );
+	color: var( --newspack-ui-color-neutral-90 );
 	display: inline-grid;
 	font-size: var( --newspack-ui-font-size-xs );
 	font-weight: 600;
@@ -15,27 +17,23 @@
 
 	&--secondary {
 		background: var( --newspack-ui-color-neutral-10 );
-		color: var( --newspack-ui-color-neutral-90 );
 	}
 
 	&--outline {
-		background: var( --newspack-ui-color-neutral-0 );
-		border: 1px solid var( --newspack-ui-color-neutral-30 );
 		color: var( --newspack-ui-color-neutral-60 );
+		outline: 1px solid var( --newspack-ui-color-neutral-30 );
+		outline-offset: -1px;
 	}
 
 	&--success {
 		background: var( --newspack-ui-color-success-0 );
-		color: var( --newspack-ui-color-neutral-90 );
 	}
 
 	&--error {
 		background: var( --newspack-ui-color-error-0 );
-		color: var( --newspack-ui-color-neutral-90 );
 	}
 
 	&--warning {
 		background: var( --newspack-ui-color-warning-0 );
-		color: var( --newspack-ui-color-neutral-90 );
 	}
 }

--- a/assets/newspack-ui/scss/elements/misc/_badge.scss
+++ b/assets/newspack-ui/scss/elements/misc/_badge.scss
@@ -1,0 +1,12 @@
+.newspack_ui__badge {
+	background: var( --newspack-ui-color-neutral-90 );
+	border-radius: var( --newspack-ui-border-radius-xs );
+	color: var( --newspack-ui-color-neutral-0 );
+	display: inline-grid;
+	font-size: var( --newspack-ui-font-size-xs );
+	font-weight: 600;
+	line-height: var( --newspack-ui-line-height-xs );
+	padding: 2px 6px; // TODO: replace with variables; they only go down to 8px, perhaps they need to be rethought?
+	place-items: center;
+	text-transform: uppercase;
+}

--- a/assets/newspack-ui/scss/elements/misc/_badge.scss
+++ b/assets/newspack-ui/scss/elements/misc/_badge.scss
@@ -20,6 +20,7 @@
 	}
 
 	&--outline {
+		background: var( --newspack-ui-color-neutral-0 );
 		color: var( --newspack-ui-color-neutral-60 );
 		outline: 1px solid var( --newspack-ui-color-neutral-30 );
 		outline-offset: -1px;

--- a/assets/newspack-ui/scss/elements/misc/_index.scss
+++ b/assets/newspack-ui/scss/elements/misc/_index.scss
@@ -1,1 +1,2 @@
 @use 'word-divider';
+@use 'badge';

--- a/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -1,17 +1,25 @@
 // Some general overrides for WooCommerce styles.
 .newspack-ui {
-	form p {
-		margin: 0 0 var( --newspack-ui-spacer-5 );
-	}
-
 	label .optional {
 		color: var( --newspack-ui-color-neutral-60 );
 		font-weight: 400;
 	}
 
+	form p {
+		margin: 0 0 var( --newspack-ui-spacer-5 );
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
 	&__modal--small {
 		form p {
 			margin: 0 0 var( --newspack-ui-spacer-2 );
+
+			&:last-child {
+				margin-bottom: 0;
+			}
 		}
 	}
 

--- a/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -48,8 +48,17 @@
 
 	// Override checkout payment method box.
 	.wc_payment_method {
+
+		+ .wc_payment_method {
+			margin-top: calc( var(--newspack-ui-spacer-5) / -2 );
+		}
+
 		span {
 			font-weight: var( --newspack-ui-font-weight-strong );
+		}
+
+		> label:first-of-type {
+			margin: unset;
 		}
 
 		.payment_box {
@@ -58,6 +67,7 @@
 			padding: 0;
 
 			p {
+				color: var( --newspack-ui-color-neutral-60 );
 				font-size: var(--newspack-ui-font-size-xs);
 			}
 
@@ -72,7 +82,8 @@
 			}
 
 			fieldset {
-				margin-bottom: var(--newspack-ui-spacer-2);
+				margin: 0 0 var(--newspack-ui-spacer-2);
+				padding: 0 !important; // To override inline styles.
 
 				&:last-child {
 					margin-bottom: 0;
@@ -99,10 +110,19 @@
 			}
 		}
 
+		// Override a style coming from the theme to hide the radio -- we need this when there's more than one option.
+		input.input-radio[name="payment_method"] {
+			display: inherit;
+		}
+
 		// If the only payment option, we're hiding the radio selection so we don't need a grid.
 		&:first-child:last-child .newspack-ui__input-card {
 			grid-template-columns: none;
 			gap: 0;
+
+			input.input-radio[name="payment_method"] {
+				display: none;
+			}
 		}
 	}
 
@@ -142,8 +162,17 @@
 		}
 	}
 
-	.wc_payment_methods label[for="payment_method_stripe"].newspack-ui__input-card {
-		padding: var( --newspack-ui-spacer-5 ) !important;
+	.wc_payment_methods label[for="payment_method_stripe"] {
+		&.newspack-ui__input-card {
+			padding: var( --newspack-ui-spacer-3 ) !important;
+		}
+	}
+
+	// Woo Payments inputs
+	#wcpay-upe-element,
+	.wcpay-upe-element {
+		margin: var(--newspack-ui-spacer-5) 0;
+		padding: 0;
 	}
 
 	// Override billing details spacing.
@@ -227,5 +256,15 @@
 		label {
 			color: var( --newspack-ui-color-error-50 );
 		}
+	}
+
+	// Buttons - adjust spacing
+	#place-order {
+		margin-bottom: 0;
+	}
+
+	// stylelint-disable-next-line selector-id-pattern
+	#checkout_back {
+		margin-top: 0;
 	}
 }

--- a/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -4,6 +4,11 @@
 		margin: 0 0 var( --newspack-ui-spacer-5 );
 	}
 
+	label .optional {
+		color: var( --newspack-ui-color-neutral-60 );
+		font-weight: 400;
+	}
+
 	&__modal--small {
 		form p {
 			margin: 0 0 var( --newspack-ui-spacer-2 );
@@ -107,6 +112,25 @@
 			font-size: var( --newspack-ui-font-size-s );
 			line-height: var( --newspack-ui-line-height-l );
 			padding: calc( var( --newspack-ui-spacer-2 ) - 1px ) calc( var( --newspack-ui-spacer-3 ) - 1px );
+		}
+
+		&:has( div.stripe-source-errors[role="alert"]:not( :empty ) ) {
+			.wc-stripe-elements-field,
+			.wc-stripe-iban-element-field {
+				border-color: var( --newspack-ui-color-error-50 );
+			}
+
+			label {
+				color: var( --newspack-ui-color-error-50 );
+			}
+
+			.woocommerce_error {
+				background: transparent;
+				color: var( --newspack-ui-color-error-50 );
+				font-family: var( --newspack-ui-font-family );
+				font-size: var( --newspack-ui-font-size-xs );
+				padding: 0;
+			}
 		}
 	}
 

--- a/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -10,7 +10,7 @@
 		}
 	}
 
-	.newspack-ui__input-list {
+	.newspack-ui__input-card {
 		label {
 			display: block;
 		}
@@ -85,6 +85,33 @@
 				}
 			}
 		}
+
+		// If the only payment option, we're hiding the radio selection so we don't need a grid.
+		&:first-child:last-child .newspack-ui__input-card {
+			grid-template-columns: none;
+			gap: 0;
+		}
+	}
+
+	// Stripe inputs
+	.wc-credit-card-form {
+		.form-row-wide {
+			margin-bottom: var( --newspack-ui-spacer-base );
+		}
+		.wc-stripe-elements-field,
+		.wc-stripe-iban-element-field {
+			border: 1px solid var( --newspack-ui-color-input-border );
+			border-radius: var( --newspack-ui-border-radius-m );
+			display: block;
+			font-family: var( --newspack-ui-font-family);
+			font-size: var( --newspack-ui-font-size-s );
+			line-height: var( --newspack-ui-line-height-l );
+			padding: calc( var( --newspack-ui-spacer-2 ) - 1px ) calc( var( --newspack-ui-spacer-3 ) - 1px );
+		}
+	}
+
+	.wc_payment_methods label[for="payment_method_stripe"].newspack-ui__input-card {
+		padding: var( --newspack-ui-spacer-5 ) !important;
 	}
 
 	// Override billing details spacing.
@@ -148,32 +175,25 @@
 		}
 	}
 
-	// Stripe inputs
-	.wc-credit-card-form {
-		.form-row-wide {
-			margin-bottom: var( --newspack-ui-spacer-base );
-		}
-		.wc-stripe-elements-field,
-		.wc-stripe-iban-element-field {
-			border: 1px solid var( --newspack-ui-color-input-border );
-			border-radius: var( --newspack-ui-border-radius-m );
-			display: block;
-			font-family: var( --newspack-ui-font-family);
-			font-size: var( --newspack-ui-font-size-s );
-			line-height: var( --newspack-ui-line-height-l );
-			padding: calc( var( --newspack-ui-spacer-2 ) - 1px ) calc( var( --newspack-ui-spacer-3 ) - 1px );
-		}
-	}
-
-	.wc_payment_methods label[for="payment_method_stripe"].newspack-ui__input-list {
-		padding: var( --newspack-ui-spacer-5 ) !important;
+	// Required fields.
+	.woocommerce form .form-row .required {
+		color: var( --newspack-ui-color-error-50 );
 	}
 
 	// Errors
 	.woocommerce-invalid {
 		input,
-		textarea {
+		textarea,
+		.select2-container--default .select2-selection--single {
 			border-color: var( --newspack-ui-color-error-50 );
+
+			&:focus {
+				outline-color: var( --newspack-ui-color-error-50 );
+			}
+		}
+
+		label {
+			color: var( --newspack-ui-color-error-50 );
 		}
 	}
 }

--- a/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -258,6 +258,11 @@
 		}
 	}
 
+	// Privacy Policy
+	.woocommerce-privacy-policy-text {
+		color: var( --newspack-ui-color-neutral-60 );
+	}
+
 	// Buttons - adjust spacing
 	#place-order {
 		margin-bottom: 0;

--- a/assets/newspack-ui/scss/variables/_colors.scss
+++ b/assets/newspack-ui/scss/variables/_colors.scss
@@ -74,6 +74,7 @@
 	--newspack-ui-color-input-border-focus: var( --newspack-ui-color-neutral-90 );
 	--newspack-ui-color-input-border-disabled: var( --newspack-ui-color-neutral-40 );
 	--newspack-ui-color-input-background-disabled: var( --newspack-ui-color-neutral-10 );
+	--newspack-ui-label-color: var( --newspack-ui-color-neutral-90 );
 
 	// Alternatives for when prefers-contrast is set to 'more':
 	@media ( prefers-contrast: more ) {

--- a/assets/newspack-ui/style.scss
+++ b/assets/newspack-ui/style.scss
@@ -6,7 +6,7 @@
 
 	// Need better spot for this
 	&__color-text-gray {
-		color: var( --newspack-ui-color-neutral-70 );
+		color: var( --newspack-ui-color-neutral-60 );
 	}
 
 	// Overrides for theme styles -- to move to theme?

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -169,9 +169,9 @@ class Newspack_UI {
 					<span class="newspack-ui__helper-text">Some helper text.</span>
 				</p>
 
-				<p class="newspack-ui__error">
-					<label for="text-input-demo">Text input <span class="newspack-ui__label-optional">(additional text)</span></label>
-					<input type="text" placeholder="Regular text">
+				<p>
+					<label for="text-input-demo" class="newspack-ui__field-error">Text input <span class="newspack-ui__label-optional">(additional text)</span></label>
+					<input type="text" placeholder="Regular text" class="newspack-ui__field-error">
 					<span class="newspack-ui__helper-text">Some helper text.</span>
 					<span class="newspack-ui__helper-text newspack-ui__inline-error">An error message.</span>
 				</p>
@@ -191,8 +191,8 @@ class Newspack_UI {
 					</label>
 				</p>
 
-				<p class="newspack-ui__error">
-					<label>
+				<p>
+					<label class="newspack-ui__field-error">
 						<input type="radio" name="radio-control-demo">
 						This is a radio input.
 						<span class="newspack-ui__helper-text">Some helper text.</span>
@@ -207,8 +207,8 @@ class Newspack_UI {
 					</label>
 				</p>
 
-				<p class="newspack-ui__error">
-					<label>
+				<p>
+					<label class="newspack-ui__field-error">
 						<input type="checkbox">
 						This is a checkbox input.
 					</label>
@@ -313,7 +313,7 @@ class Newspack_UI {
 
 			<hr>
 
-			<h2 id="badges">Badges (more examples TK)</h2>
+			<h2 id="badges">Badges</h2>
 			<span class="newspack-ui__badge newspack-ui__badge--primary">Badge</span><br>
 			<span class="newspack-ui__badge newspack-ui__badge--secondary">Badge</span><br>
 			<span class="newspack-ui__badge newspack-ui__badge--outline">Badge</span><br>
@@ -326,7 +326,6 @@ class Newspack_UI {
 
 			<h2 id="buttons">Buttons</h2>
 			<p><code>newspack-ui__button--primary</code>, <code>--branded</code>, <code>--secondary</code>, <code>--ghost</code>, and <code>--destructive</code> classes for colours/borders, and <code>newspack-ui__button--wide</code> for being 100% wide</p>
-			<button class="newspack-ui__button">Default Theme Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--primary">Primary Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--primary" disabled>Primary Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--branded">Branded Button</button><br>
@@ -352,7 +351,6 @@ class Newspack_UI {
 			</button>
 
 			<h3>Wide buttons</h3>
-			<button class="newspack-ui__button newspack-ui__button--wide">Default Theme Button</button>
 			<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Primary Button</button>
 			<button class="newspack-ui__button newspack-ui__button--branded newspack-ui__button--wide">Branded Button</button>
 			<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">Secondary Button</button>

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -510,7 +510,7 @@ class Newspack_UI {
 								</div>
 							</p>
 
-							<p class="newspack-ui__font--xs">Sign in by entering the code sent to email@address.com, or by clicking the magic link in the email.</p>
+							<p class="newspack-ui__helper-text">Sign in by entering the code sent to email@address.com, or by clicking the magic link in the email.</p>
 
 							<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Continue</button>
 							<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">Resend Code</button>
@@ -599,10 +599,10 @@ class Newspack_UI {
 								<input type="password">
 								<span class="newspack-ui__helper-text">If you don't set a password, you can always log in with a magic link or one-time code sent to your email.</span>
 							</p>
-						</form>
 
-						<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Continue</button>
-						<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">Skip for now</button>
+							<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Continue</button>
+							<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">Skip for now</button>
+						</form>
 					</section>
 				</div><!-- .newspack-ui__modal--small -->
 			</div><!-- .newspack-ui__box -->

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -62,18 +62,38 @@ class Newspack_UI {
 		ob_start();
 		?>
 		<div class="newspack-ui">
-			<h2>Temporary Razzak Component Demo</h2>
+			<h1>Component Demo</h1>
 
-			<p class="newspack-ui__font--xl">X-Large text</p>
-			<p class="newspack-ui__font--l">Large text</p>
-			<p class="newspack-ui__font--m">Medium text</p>
-			<p>Small text (default)</p>
-			<p class="newspack-ui__font--xs">X-Small text</p>
-			<p class="newspack-ui__font--2xs">2X-Small text</p>
+			<ul>
+				<li><a href="?ui-demo#typography">Typography</a></li>
+				<li><a href="?ui-demo#boxes">Boxes</a></li>
+				<li><a href="?ui-demo#form-elements">Form Elements</a></li>
+				<li><a href="?ui-demo#checkbox-radio-lists">Checkbox/Radio Lists</a></li>
+				<li><a href="?ui-demo#order-table">Order table</a></li>
+				<li><a href="?ui-demo#buttons">Buttons</a></li>
+				<li><a href="#buttons-icon">Buttons Icon</a></li>
+				<li><a href="?ui-demo#modals">Modals</a></li>
+			</ul>
 
 			<hr>
 
-			<h2>Boxes</h2>
+			<h2 id="typography">Typography</h2>
+
+			<p class="newspack-ui__font--2xs">2X-Small text</p>
+			<p class="newspack-ui__font--xs">X-Small text</p>
+			<p>Small text (default)</p>
+			<p class="newspack-ui__font--m">Medium text</p>
+			<p class="newspack-ui__font--l">Large text</p>
+			<p class="newspack-ui__font--xl">X-Large text</p>
+			<p class="newspack-ui__font--2xl">2X-Large text</p>
+			<p class="newspack-ui__font--3xl">3X-Large text</p>
+			<p class="newspack-ui__font--4xl">4X-Large text</p>
+			<p class="newspack-ui__font--5xl">5X-Large text</p>
+			<p class="newspack-ui__font--6xl">6X-Large text</p>
+
+			<hr>
+
+			<h2 id="boxes">Boxes</h2> <?php // TODO: figure out correct name. ?>
 
 			<div class="newspack-ui__box">
 				<p>Default box style</p>
@@ -131,7 +151,7 @@ class Newspack_UI {
 
 			<hr>
 
-			<h2>Form elements</h2>
+			<h2 id="form-elements">Form elements</h2>
 			<form>
 				<p>
 					<label for="text-input-demo">Text input</label>
@@ -139,71 +159,117 @@ class Newspack_UI {
 				</p>
 
 				<p>
-					<label for="email-input-demo">Email input</label>
+					<label for="email-input-demo">Email input <abbr class="newspack-ui__required" title="required">*</abbr></label>
 					<input type="email" placeholder="Email Address">
+				</p>
+
+				<p>
+					<label for="text-input-demo">Text input <span class="newspack-ui__label-optional">(additional text)</span> <abbr class="newspack-ui__required" title="required">*</abbr></label>
+					<input type="text" placeholder="Regular text">
+					<span class="newspack-ui__helper-text">Some helper text.</span>
+				</p>
+
+				<p class="newspack-ui__error">
+					<label for="text-input-demo">Text input <span class="newspack-ui__label-optional">(additional text)</span></label>
+					<input type="text" placeholder="Regular text">
+					<span class="newspack-ui__helper-text">Some helper text.</span>
+					<span class="newspack-ui__helper-text newspack-ui__inline-error">An error message.</span>
+				</p>
+
+				<p>
+					<label>
+						<input type="radio" name="radio-control-demo">
+						This is a radio input.
+						<span class="newspack-ui__helper-text">Some helper text.</span>
+					</label>
+				</p>
+
+				<p>
+					<label>
+						<input type="radio" name="radio-control-demo">
+						This is a radio input.
+					</label>
+				</p>
+
+				<p class="newspack-ui__error">
+					<label>
+						<input type="radio" name="radio-control-demo">
+						This is a radio input.
+						<span class="newspack-ui__helper-text">Some helper text.</span>
+						<span class="newspack-ui__helper-text newspack-ui__inline-error">An error message.</span>
+					</label>
+				</p>
+
+				<p>
+					<label>
+						<input type="checkbox">
+						This is a checkbox input.
+					</label>
+				</p>
+
+				<p class="newspack-ui__error">
+					<label>
+						<input type="checkbox">
+						This is a checkbox input.
+					</label>
 				</p>
 			</form>
 
-			<p>
-				<label>
-					<input type="radio" name="radio-control-demo">
-					This is a radio input.
-				</label>
-			</p>
-
-			<p>
-				<label>
-					<input type="radio" name="radio-control-demo">
-					This is a radio input.
-				</label>
-			</p>
-
-			<p>
-				<label>
-					<input type="checkbox">
-					This is a checkbox input.
-				</label>
-			</p>
-
 
 			<hr>
 
-			<h2>Checkbox/Radio Lists</h2>
-			<label class="newspack-ui__input-list">
-				<input type="checkbox" name="checkbox-option-1">
-				<span>
-					<strong>The Weekly</strong><br>
-					<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
-				</span>
+			<h2 id="checkbox-radio-lists">Checkbox/Radio Lists</h2>
+
+			<label class="newspack-ui__input-card">
+				<input type="radio" name="list-radio-option" checked>
+				<strong>The Weekly</strong><br>
+				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
-			<label class="newspack-ui__input-list">
-				<input type="checkbox" name="checkbox-option-2">
-				<span>
-					<strong>The Weekly</strong><br>
-					<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
-				</span>
+			<label class="newspack-ui__input-card">
+				<input type="radio" name="list-radio-option">
+				<strong>The Weekly</strong><br>
+				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
+
 			<br>
-			<label class="newspack-ui__input-list">
-				<input type="radio" name="list-radio-option">
-				<span>
-					<strong>The Weekly</strong><br>
-					<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
-				</span>
+
+			<label class="newspack-ui__input-card">
+				<input type="checkbox" name="checkbox-option-1">
+				<strong>The Weekly</strong><br>
+				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
-			<label class="newspack-ui__input-list">
+			<label class="newspack-ui__input-card">
+				<input type="checkbox" name="checkbox-option-1">
+				<strong>The Weekly</strong><br>
+				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
+			</label>
+
+			<label class="newspack-ui__input-card">
+				<input type="checkbox" name="checkbox-option-2">
+				<strong>The Weekly</strong><br>
+				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
+			</label>
+
+			<br>
+
+			<label class="newspack-ui__input-card">
+				<input type="radio" name="list-radio-option" checked>
+				<strong>The Weekly</strong><br>
+				<span class="newspack_ui__input-card__selected">Current</span>
+				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
+			</label>
+
+			<label class="newspack-ui__input-card">
 				<input type="radio" name="list-radio-option">
-				<span>
-					<strong>The Weekly</strong><br>
-					<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
-				</span>
+				<strong>The Weekly</strong><br>
+				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
 			<hr>
 
-			<h2>Order table</h2>
+			<h2 id="order-table">Order table</h2>
 			<h3 id="order_review_heading">Transaction details</h3>
 			<div id="order_review" class="woocommerce-checkout-review-order newspack-ui__box">
 				<table class="shop_table woocommerce-checkout-review-order-table" style="position: static; zoom: 1;">
@@ -247,7 +313,7 @@ class Newspack_UI {
 
 			<hr>
 
-			<h2>Buttons</h2>
+			<h2 id="buttons">Buttons</h2>
 			<p><code>newspack-ui__button--primary</code>, <code>--branded</code>, <code>--secondary</code>, <code>--ghost</code>, and <code>--destructive</code> classes for colours/borders, and <code>newspack-ui__button--wide</code> for being 100% wide</p>
 			<button class="newspack-ui__button">Default Theme Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--primary">Primary Button</button><br>
@@ -262,17 +328,8 @@ class Newspack_UI {
 			<button class="newspack-ui__button newspack-ui__button--outline" disabled>Outline Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--destructive">Destructive Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--destructive" disabled>Destructive Button Disabled</button><br>
-			<button class="newspack-ui__button newspack-ui__button--secondary">
-				<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-					<path fill-rule="evenodd" clip-rule="evenodd" d="M19.6 10.227C19.6 9.51801 19.536 8.83701 19.418 8.18201H10V12.05H15.382C15.2706 12.6619 15.0363 13.2448 14.6932 13.7635C14.3501 14.2822 13.9054 14.726 13.386 15.068V17.578H16.618C18.509 15.836 19.6 13.273 19.6 10.228V10.227Z" fill="#4285F4"></path>
-					<path fill-rule="evenodd" clip-rule="evenodd" d="M9.99996 20C12.7 20 14.964 19.105 16.618 17.577L13.386 15.068C12.491 15.668 11.346 16.023 9.99996 16.023C7.39496 16.023 5.18996 14.263 4.40496 11.9H1.06396V14.49C1.89597 16.1468 3.17234 17.5395 4.7504 18.5126C6.32846 19.4856 8.14603 20.0006 9.99996 20Z" fill="#34A853"></path>
-					<path fill-rule="evenodd" clip-rule="evenodd" d="M4.405 11.9C4.205 11.3 4.091 10.66 4.091 10C4.091 9.34001 4.205 8.70001 4.405 8.10001V5.51001H1.064C0.364015 6.90321 -0.000359433 8.44084 2.66054e-07 10C2.66054e-07 11.614 0.386 13.14 1.064 14.49L4.404 11.9H4.405Z" fill="#FBBC05"></path>
-					<path fill-rule="evenodd" clip-rule="evenodd" d="M9.99996 3.977C11.468 3.977 12.786 4.482 13.823 5.473L16.691 2.605C14.959 0.99 12.695 0 9.99996 0C6.08996 0 2.70996 2.24 1.06396 5.51L4.40396 8.1C5.19196 5.736 7.39596 3.977 9.99996 3.977Z" fill="#EA4335"></path>
-				</svg>
-				<span>
-					Sign in with Google
-				</span>
-			</button>
+
+			<h3>Wide buttons</h3>
 			<button class="newspack-ui__button newspack-ui__button--wide">Default Theme Button</button>
 			<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Primary Button</button>
 			<button class="newspack-ui__button newspack-ui__button--branded newspack-ui__button--wide">Branded Button</button>
@@ -294,7 +351,7 @@ class Newspack_UI {
 
 			<hr>
 
-			<h2>Buttons Icon</h2>
+			<h2 id="buttons-icon">Buttons Icon</h2>
 			<p>Uses the same classes as the <code>newspack-ui__button</code> but we add an extra class to it <code>newspack-ui__button--icon</code></p>
 			<button class="newspack-ui__button newspack-ui__button--icon">
 				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
@@ -334,7 +391,7 @@ class Newspack_UI {
 
 			<hr>
 
-			<h2>Modals</h2>
+			<h2 id="modals">Modals</h2>
 
 			<div class="newspack-ui__box">
 
@@ -552,7 +609,7 @@ class Newspack_UI {
 						<p>Get the best of The News Paper directly to your email inbox.<br>
 						<span class="newspack-ui__color-text-gray">Sending to: email@address.</span></p>
 
-						<label class="newspack-ui__input-list">
+						<label class="newspack-ui__input-card">
 							<input type="checkbox" name="checkbox-option-1">
 							<span>
 								<strong>The Weekly</strong><br>
@@ -560,7 +617,7 @@ class Newspack_UI {
 							</span>
 						</label>
 
-						<label class="newspack-ui__input-list">
+						<label class="newspack-ui__input-card">
 							<input type="checkbox" name="checkbox-option-2">
 							<span>
 								<strong>The Weekly</strong><br>

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -328,6 +328,17 @@ class Newspack_UI {
 			<button class="newspack-ui__button newspack-ui__button--outline" disabled>Outline Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--destructive">Destructive Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--destructive" disabled>Destructive Button Disabled</button><br>
+			<button class="newspack-ui__button newspack-ui__button--secondary">
+				<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path fill-rule="evenodd" clip-rule="evenodd" d="M19.6 10.227C19.6 9.51801 19.536 8.83701 19.418 8.18201H10V12.05H15.382C15.2706 12.6619 15.0363 13.2448 14.6932 13.7635C14.3501 14.2822 13.9054 14.726 13.386 15.068V17.578H16.618C18.509 15.836 19.6 13.273 19.6 10.228V10.227Z" fill="#4285F4"></path>
+					<path fill-rule="evenodd" clip-rule="evenodd" d="M9.99996 20C12.7 20 14.964 19.105 16.618 17.577L13.386 15.068C12.491 15.668 11.346 16.023 9.99996 16.023C7.39496 16.023 5.18996 14.263 4.40496 11.9H1.06396V14.49C1.89597 16.1468 3.17234 17.5395 4.7504 18.5126C6.32846 19.4856 8.14603 20.0006 9.99996 20Z" fill="#34A853"></path>
+					<path fill-rule="evenodd" clip-rule="evenodd" d="M4.405 11.9C4.205 11.3 4.091 10.66 4.091 10C4.091 9.34001 4.205 8.70001 4.405 8.10001V5.51001H1.064C0.364015 6.90321 -0.000359433 8.44084 2.66054e-07 10C2.66054e-07 11.614 0.386 13.14 1.064 14.49L4.404 11.9H4.405Z" fill="#FBBC05"></path>
+					<path fill-rule="evenodd" clip-rule="evenodd" d="M9.99996 3.977C11.468 3.977 12.786 4.482 13.823 5.473L16.691 2.605C14.959 0.99 12.695 0 9.99996 0C6.08996 0 2.70996 2.24 1.06396 5.51L4.40396 8.1C5.19196 5.736 7.39596 3.977 9.99996 3.977Z" fill="#EA4335"></path>
+				</svg>
+				<span>
+					Sign in with Google
+				</span>
+			</button>
 
 			<h3>Wide buttons</h3>
 			<button class="newspack-ui__button newspack-ui__button--wide">Default Theme Button</button>

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -257,7 +257,7 @@ class Newspack_UI {
 			<label class="newspack-ui__input-card">
 				<input type="radio" name="list-radio-option" checked>
 				<strong>The Weekly</strong><br>
-				<span class="newspack_ui__badge">Badge</span>
+				<span class="newspack-ui__badge newspack-ui__badge--primary">Badge</span>
 				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
@@ -314,7 +314,12 @@ class Newspack_UI {
 			<hr>
 
 			<h2 id="badges">Badges (more examples TK)</h2>
-			<span class="newspack_ui__badge">Badge</span><br>
+			<span class="newspack-ui__badge newspack-ui__badge--primary">Badge</span><br>
+			<span class="newspack-ui__badge newspack-ui__badge--secondary">Badge</span><br>
+			<span class="newspack-ui__badge newspack-ui__badge--outline">Badge</span><br>
+			<span class="newspack-ui__badge newspack-ui__badge--success">Badge</span><br>
+			<span class="newspack-ui__badge newspack-ui__badge--error">Badge</span><br>
+			<span class="newspack-ui__badge newspack-ui__badge--warning">Badge</span><br>
 
 
 			<hr>

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -257,7 +257,7 @@ class Newspack_UI {
 			<label class="newspack-ui__input-card">
 				<input type="radio" name="list-radio-option" checked>
 				<strong>The Weekly</strong><br>
-				<span class="newspack_ui__input-card__selected">Current</span>
+				<span class="newspack_ui__badge">Badge</span>
 				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
@@ -310,6 +310,12 @@ class Newspack_UI {
 					</tfoot>
 				</table>
 			</div>
+
+			<hr>
+
+			<h2 id="badges">Badges (more examples TK)</h2>
+			<span class="newspack_ui__badge">Badge</span><br>
+
 
 			<hr>
 

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -222,13 +222,13 @@ class Newspack_UI {
 
 			<label class="newspack-ui__input-card">
 				<input type="radio" name="list-radio-option" checked>
-				<strong>The Weekly</strong><br>
+				<strong>The Weekly</strong>
 				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
 			<label class="newspack-ui__input-card">
 				<input type="radio" name="list-radio-option">
-				<strong>The Weekly</strong><br>
+				<strong>The Weekly</strong>
 				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
@@ -236,19 +236,19 @@ class Newspack_UI {
 
 			<label class="newspack-ui__input-card">
 				<input type="checkbox" name="checkbox-option-1">
-				<strong>The Weekly</strong><br>
+				<strong>The Weekly</strong>
 				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
 			<label class="newspack-ui__input-card">
 				<input type="checkbox" name="checkbox-option-1">
-				<strong>The Weekly</strong><br>
+				<strong>The Weekly</strong>
 				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
 			<label class="newspack-ui__input-card">
 				<input type="checkbox" name="checkbox-option-2">
-				<strong>The Weekly</strong><br>
+				<strong>The Weekly</strong>
 				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
@@ -256,14 +256,14 @@ class Newspack_UI {
 
 			<label class="newspack-ui__input-card">
 				<input type="radio" name="list-radio-option" checked>
-				<strong>The Weekly</strong><br>
+				<strong>The Weekly</strong>
 				<span class="newspack-ui__badge newspack-ui__badge--primary">Badge</span>
 				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
 			<label class="newspack-ui__input-card">
 				<input type="radio" name="list-radio-option">
-				<strong>The Weekly</strong><br>
+				<strong>The Weekly</strong>
 				<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 			</label>
 
@@ -296,7 +296,7 @@ class Newspack_UI {
 						</tr>
 
 						<tr class="tax-rate tax-rate-ca-bc-gst-5-1">
-							<th>GST 5%)</th>
+							<th>GST 5%</th>
 							<td><span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">$</span>9.00</span></td>
 						</tr>
 						<tr class="tax-rate tax-rate-ca-bc-pst-7-2">
@@ -632,7 +632,7 @@ class Newspack_UI {
 						<label class="newspack-ui__input-card">
 							<input type="checkbox" name="checkbox-option-1">
 							<span>
-								<strong>The Weekly</strong><br>
+								<strong>The Weekly</strong>
 								<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 							</span>
 						</label>
@@ -640,7 +640,7 @@ class Newspack_UI {
 						<label class="newspack-ui__input-card">
 							<input type="checkbox" name="checkbox-option-2">
 							<span>
-								<strong>The Weekly</strong><br>
+								<strong>The Weekly</strong>
 								<span class="newspack-ui__helper-text">Friday roundup of the most relevant stories.</span>
 							</span>
 						</label>

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1151,9 +1151,7 @@ final class Reader_Activation {
 				<?php endif; ?>
 				<input type="hidden" name="action" />
 				<p data-action="otp">
-					<strong>
-						<?php echo esc_html( $labels['otp_title'] ); ?>
-					</strong>
+					<label><?php echo esc_html( $labels['otp_title'] ); ?></label>
 				</p>
 				<div data-action="signin register">
 					<p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some more updates to the component styles to match the latest mockups. Specifically, it:

#### Adds an example of an error state, and applies those styles to the checkout and sign up modals. 

I approached this like we would add a CSS class around the field that has an error (`.newspack-ui__error`), and then used the existing behaviour (the `400` data-status on the sign-in/up modal and the classes WooCommerce adds) to apply those styles there rather than trying to work in the classes. I'd love to hear if this sounds okay, or terrible!

![image](https://github.com/Automattic/newspack-plugin/assets/177561/e5f6109a-d0a9-4095-8c9e-64863b9bce0d)

![image](https://github.com/Automattic/newspack-plugin/assets/177561/f76154e5-d0e0-4aa0-b0d1-272da92fec7f)

![image](https://github.com/Automattic/newspack-plugin/assets/177561/be01fd46-b24f-403c-a060-7bb14091d37d)

----

#### Reworked the checkbox/radio code to allow for helper text, status labels

Overall, this includes switching the checkbox labels to display as `grid`, and include helper/error text. 

![image](https://github.com/Automattic/newspack-plugin/assets/177561/9441f5c1-5a27-4066-824c-72d8ee1021aa)

I also added an example of a Badge, applied to a input card. This one is set up with the assumption that the badge text will be injected into the `label` when applicable + some `:has` CSS to adjust the grid if the status is there. That might be overkill though -- it can also be reworked to add a CSS class when a label should be applied. This component isn't used in the RAS-ACC styles, but I wanted to make sure it would work with the other checkbox changes:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/927a8077-c553-4561-9e3d-471cc94e4276)

As part of this, I also tweaked the Woo payment option styles to remove some extra space the above added - I basically used the assumption that if there's only one payment option we're hiding the radio button, but just let me know if that's not correct! 

#### Edited to add: updated the newsletter "coda" styles

![image](https://github.com/Automattic/newspack-plugin/assets/177561/fc926c22-1a74-4d43-bf0d-96abf0bfcc28)

----

#### And some small things:
* I set a base font colour and label colour to the styles.
* I renamed the `newspack-ui__input-list` to `newspack-ui__input-card`, which is closer to what it's referred to in Figma.
* I started beefing out the demo content a bit more, adding anchors and some more examples. 
* Reordered the Stripe styles a bit in the Woo overrides SCSS, to keep 'em together.
* Added a style for the 'required' asterisk, following how Woo approaches the markup (`abbr`).

See 1205234045751551-as-1206899964006422

### How to test the changes in this Pull Request:

1. Apply PR and https://github.com/Automattic/newspack-blocks/pull/1719, and run `npm run build`.
2. Turn on the newsletter 'coda' in the checkout by adding `define( 'NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP', true );` to the wp-config.php file.
3. Log into your test site, and append `?ui-demo` 
4. Review the appearance of the components, and their structure (primarily the changes around checkbox/radio buttons -- does this approach for errors & adding a badge make sense?). 
5. Set up a checkout button block or donate block, and run through the checkout. At each prompt, submit the form without doing anything, or by doing stuff wrong, to see the error styles:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/fcef54b1-fdc0-4c82-a015-021a813ea4cb)

![image](https://github.com/Automattic/newspack-plugin/assets/177561/bf10581d-dfb7-4373-85d4-0aac65fff573)

![image](https://github.com/Automattic/newspack-plugin/assets/177561/4c4f92f9-deac-4e24-a5a0-9084af41822a)

6. Confirm that the newsletter coda is picking up the input 'card' styles -- it's not split into two screens yet (success and newsletter):

![image](https://github.com/Automattic/newspack-plugin/assets/177561/c4cb2f78-d41d-48f4-b5c9-321f01c6dcd1)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->