### PR TITLE
fix(data-events): handle no ga_client_id in data

### DIFF
--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -114,7 +114,7 @@ class GA4 {
 		}
 
 		$params    = $data['ga_params'];
-		$client_id = $data['ga_client_id'];
+		$client_id = isset( $data['ga_client_id'] ) ? $data['ga_client_id'] : null;
 
 		if ( empty( $client_id ) ) {
 			$client_id = 'AnonymousUser-' . md5( $user_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Speaks for itself :) On a test site I saw:

```
PHP Warning:  Undefined array key "ga_client_id" in /wordpress/plugins/newspack-plugin/3.8.1/includes/data-events/connectors/ga4/class-ga4.php on line 117
```

### How to test the changes in this Pull Request:

Smoke test or eye test

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->