### PR TITLE
feat(ras-acc): use newsletters subscription lists setting to manage post-checkout newsletter signup

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/index.js
+++ b/assets/wizards/engagement/views/reader-activation/index.js
@@ -332,9 +332,12 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 
 					<SectionHeader title={ __( 'Newsletter Subscription Lists', 'newspack-plugin' ) } />
 					<ActionCard
-						title={ __( 'Custom newsletter lists on registration', 'newspack-plugin' ) }
+						title={ __(
+							'Present newsletter signup after checkout and registration',
+							'newspack-plugin'
+						) }
 						description={ __(
-							"Choose which of the Newspack Newsletters's subscription lists should be available upon registration.",
+							'Ask readers to sign up for newsletters after creating an account or completing a purchase.',
 							'newspack-plugin'
 						) }
 						toggleChecked={ config.use_custom_lists }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -446,7 +446,7 @@ final class Reader_Activation {
 			}
 
 			// Skip any premium lists since the reader has already made a purchase at this stage.
-			if ( method_exists( '\Newspack_Newsletters\Plugins\Woocommerce_Memberships', 'is_membership_list' ) && \Newspack_Newsletters\Plugins\Woocommerce_Memberships::is_membership_list( $list['db_id'] ) ) {
+			if ( method_exists( '\Newspack_Newsletters\Plugins\Woocommerce_Memberships', 'is_subscription_list_tied_to_plan' ) && \Newspack_Newsletters\Plugins\Woocommerce_Memberships::is_subscription_list_tied_to_plan( $list['db_id'] ) ) {
 				continue;
 			}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -445,7 +445,10 @@ final class Reader_Activation {
 				continue;
 			}
 
-			// TODO: Check and filter if the list is a premium list.
+			// Skip any premium lists since the reader has already made a purchase at this stage.
+			if ( method_exists( '\Newspack_Newsletters\Plugins\Woocommerce_Memberships', 'is_membership_list' ) && \Newspack_Newsletters\Plugins\Woocommerce_Memberships::is_membership_list( $list['db_id'] ) ) {
+				continue;
+			}
 
 			$registration_lists[ $list_id ] = $list;
 		}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -405,6 +405,65 @@ final class Reader_Activation {
 	 * @return array
 	 */
 	public static function get_registration_newsletter_lists() {
+		if ( ! class_exists( '\Newspack_Newsletters_Subscription' ) ) {
+			return [];
+		}
+
+		$registration_lists = self::get_available_newsletter_lists();
+
+		/**
+		 * Filters the newsletters lists that should be rendered during registration.
+		 *
+		 * @param array $registration_lists Array of newsletter lists.
+		 */
+		return apply_filters( 'newspack_registration_newsletters_lists', $registration_lists );
+	}
+
+	/**
+	 * Get the newsletter lists that should be rendered after checkout.
+	 *
+	 * @param string $email Email address.
+	 *
+	 * @return array
+	 */
+	public static function get_post_checkout_newsletter_lists( $email ) {
+		$available_lists    = self::get_available_newsletter_lists();
+		$registration_lists = [];
+
+		if ( empty( $available_lists ) || ! method_exists( '\Newspack_Newsletters_Subscription', 'get_contact_lists' ) ) {
+			return [];
+		}
+
+		$current_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $email );
+		if ( \is_wp_error( $current_lists ) || ! is_array( $current_lists ) ) {
+			return [];
+		}
+
+		foreach ( $available_lists as $list_id => $list ) {
+			// Skip any lists the reader is already signed up for.
+			if ( in_array( $list_id, $current_lists, true ) ) {
+				continue;
+			}
+
+			// TODO: Check and filter if the list is a premium list.
+
+			$registration_lists[ $list_id ] = $list;
+		}
+
+		/**
+		 * Filters the newsletters lists that should be rendered after checkout.
+		 *
+		 * @param array $registration_lists Array of newsletter lists.
+		 */
+		return apply_filters( 'newspack_post_registration_newsletters_lists', $registration_lists );
+	}
+
+	/**
+	 * Get all available newsletter lists.
+	 *
+	 * @return array
+	 */
+	public static function get_available_newsletter_lists() {
 		if ( ! method_exists( 'Newspack_Newsletters_Subscription', 'get_lists' ) ) {
 			return [];
 		}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206943664367857/1205992141743582/f

These changes are paired with https://github.com/Automattic/newspack-blocks/pull/1727 and https://github.com/Automattic/newspack-newsletters/pull/1502

This PR:

Updates the Newsletter Subscription List setting copy to reflect the setting will also apply to checkout:

![Screenshot 2024-05-09 at 14 36 08](https://github.com/Automattic/newspack-plugin/assets/17905991/d024afed-eaf3-41f8-a3a6-1de61303b9ef)

Filters the post-checkout newsletter lists to include only lists that the reader is not signed up for and are not premium.

![Screenshot 2024-05-09 at 14 37 43](https://github.com/Automattic/newspack-plugin/assets/17905991/eb570960-cd2a-4672-a1ac-19e909fccb8a)

NOTE: Post-checkout newsletter signup form styles are being worked on in https://github.com/Automattic/newspack-plugin/pull/3091

### How to test the changes in this Pull Request:

Be sure to check out https://github.com/Automattic/newspack-blocks/pull/1727 and https://github.com/Automattic/newspack-newsletters/pull/1502 before testing.

1. Be sure to have at least two subscriptions lists, one that is associated with a WC membership plan, and one that is not.
2. Go to the Engagement reader activation wizard and disable the newsletter subscription lists setting: Newspack > Reader Revenue > Show Advanced Settings > Newsletter Subscription Lists
3. Create a new reader account using an email address that is NOT subscribed to your ESP.
4. Go through the checkout flow via the checkout block (either making a donation or purchasing a product via the checkout button block)
5. In the thank you modal, post-checkout, confirm there is no newsletter signup form
6. Go back to the engagement reader activation wizard and enable Newsletter Subscription Lists, and enable the lists set up in step 1.
7. Repeat checkout, but this time confirm the newsletter signup form is present in the thank you modal. Also confirm the newsletter list associated with the membership plan is not present
8. Sign up for the non-membership newsletter list via the signup form
9. Repeat checkout one more time, this time verifying neither the list associated with a membership plan as well as the list not associated with a membership plan are present in the form. (If you only had these two lists set up, then there should be no form)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->