### PR TITLE
OAuth: use a custom table for transients

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -101,6 +101,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/my-account/class-woocommerce-my-account.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-revenue/class-reader-revenue-emails.php';
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-oauth.php';
+		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-oauth-transients.php';
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-google-oauth.php';
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-google-services-connection.php';
 		include_once NEWSPACK_ABSPATH . 'includes/oauth/class-mailchimp-api.php';

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -144,10 +144,9 @@ class Google_Login {
 		Logger::log( 'Got user email from Google: ' . $user_email );
 
 		// Associate the email address with the a unique ID for later retrieval.
-		$transient_expiration_time = 60 * 5; // 5 minutes.
-		$has_set_transient = set_transient( self::EMAIL_TRANSIENT_PREFIX . OAuth::get_unique_id(), $user_email, $transient_expiration_time );
+		$set_transient_result = OAuth_Transients::set( OAuth::get_unique_id(), 'email', $user_email );
 		// If transient setting failed, the email address will not be available for the registration endpoint.
-		if ( ! $has_set_transient ) {
+		if ( $set_transient_result === false ) {
 			self::handle_error( __( 'Failed setting transient.', 'newspack-plugin' ) );
 			\wp_die( \esc_html__( 'Authentication failed.', 'newspack-plugin' ) );
 		}
@@ -178,8 +177,8 @@ class Google_Login {
 	public static function api_google_login_register( $request ) {
 		$uid = OAuth::get_unique_id();
 		// Retrieve the email address associated with the unique ID when the user was authenticated.
-		$email = get_transient( self::EMAIL_TRANSIENT_PREFIX . $uid );
-		delete_transient( self::EMAIL_TRANSIENT_PREFIX . $uid ); // Burn after reading.
+		$email = OAuth_Transients::get( $uid, 'email' );
+		OAuth_Transients::delete( $uid, 'email' );
 		$metadata = [];
 		if ( $request->get_param( 'metadata' ) ) {
 			try {

--- a/includes/oauth/class-oauth-transients.php
+++ b/includes/oauth/class-oauth-transients.php
@@ -39,7 +39,7 @@ class OAuth_Transients {
 	 * Initialize hooks.
 	 */
 	public static function init() {
-		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'create_custom_table' ] );
+		register_activation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'create_custom_table' ] );
 		add_action( 'init', [ __CLASS__, 'check_update_version' ] );
 	}
 

--- a/includes/oauth/class-oauth-transients.php
+++ b/includes/oauth/class-oauth-transients.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Custom table for temporary data required by OAuth flows.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class OAuth_Transients {
+	/**
+	 * Name of the custom table. To be prefixed with WPDB prefix.
+	 */
+	const TABLE_NAME = 'newspack_oauth_transients';
+
+	/**
+	 * Installed version number of the custom table.
+	 */
+	const TABLE_VERSION = '1.0';
+
+	/**
+	 * Option name for the installed version number of the custom table.
+	 */
+	const TABLE_VERSION_OPTION = '_newspack_oauth_transients_version';
+
+	/**
+	 * How long to keep the data in the table. Any data older than this will be purged.
+	 *
+	 * @var int
+	 */
+	private $expiration = 30 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'create_custom_table' ] );
+		add_action( 'init', [ __CLASS__, 'check_update_version' ] );
+	}
+
+	/**
+	 * Get custom table name.
+	 */
+	public static function get_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . self::TABLE_NAME;
+	}
+
+	/**
+	 * Checks if the custom table has been created and is up-to-date.
+	 * If not, run the create_custom_table method.
+	 * See: https://codex.wordpress.org/Creating_Tables_with_Plugins
+	 */
+	public static function check_update_version() {
+		$current_version = \get_option( self::TABLE_VERSION_OPTION, false );
+
+		if ( self::TABLE_VERSION !== $current_version ) {
+			self::create_custom_table();
+			\update_option( self::TABLE_VERSION_OPTION, self::TABLE_VERSION );
+		}
+	}
+
+	/**
+	 * Create a custom DB table to store transient data needed for OAuth.
+	 * Avoids the use of slow post meta for query sorting purposes.
+	 * Only create the table if it doesn't already exist.
+	 */
+	public static function create_custom_table() {
+		global $wpdb;
+		$table_name = self::get_table_name();
+
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) != $table_name ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$charset_collate = $wpdb->get_charset_collate();
+			$sql             = "CREATE TABLE $table_name (
+				-- Reader's unique ID.
+				id varchar(100) NOT NULL,
+				-- Scope of the data.
+				scope varchar(30) NOT NULL,
+				-- Value of the data.
+				value varchar(100) NOT NULL,
+				-- Timestamp when data was created.
+				created_at datetime NOT NULL,
+				PRIMARY KEY (id, scope),
+				KEY (scope)
+			) $charset_collate;";
+
+			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+			dbDelta( $sql );
+		}
+	}
+
+	/**
+	 * Get a value from the database.
+	 *
+	 * @param string $id The reader's unique ID.
+	 * @param string $scope The scope of the data to get.
+	 * @param string $field_to_get The column to get. Defaults to 'value'.
+	 *
+	 * @return mixed The value of the data, or false if not found.
+	 */
+	public static function get( $id, $scope, $field_to_get = 'value' ) {
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+		$value      = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				'SELECT %1$s FROM %2$s WHERE id = %3$d AND scope = %4$s', // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
+				$field_to_get,
+				$table_name,
+				$id,
+				$scope
+			)
+		);
+
+		return $value ?? false;
+	}
+
+	/**
+	 * Set a value in the database.
+	 *
+	 * @param string $id The reader's unique ID.
+	 * @param string $scope The scope of the data to set.
+	 * @param string $value The value of the data to set.
+	 *
+	 * @return bool True if the value was set, false otherwise.
+	 */
+	public static function set( $id, $scope, $value ) {
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+		$result     = $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$table_name,
+			[
+				'id'         => $id,
+				'scope'      => $scope,
+				'value'      => $value,
+				'created_at' => \current_time( 'mysql' ),
+			],
+			[
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+			]
+		);
+
+		return $result;
+	}
+}
+
+OAuth_Transients::init();

--- a/includes/oauth/class-oauth.php
+++ b/includes/oauth/class-oauth.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
  * Main class.
  */
 class OAuth {
-	const CSRF_TOKEN_TRANSIENT_NAME_BASE = '_newspack_google_oauth_csrf_';
+	const CSRF_TOKEN_TRANSIENT_SCOPE_PREFIX = 'csrf_';
 
 	/**
 	 * Get API key for proxies.
@@ -46,10 +46,9 @@ class OAuth {
 	 * @return string CSRF token.
 	 */
 	public static function generate_csrf_token( $namespace ) {
-		$csrf_token     = sha1( openssl_random_pseudo_bytes( 1024 ) );
-		$transient_name = self::CSRF_TOKEN_TRANSIENT_NAME_BASE . $namespace . self::get_unique_id();
-		set_transient( $transient_name, $csrf_token, 5 * MINUTE_IN_SECONDS );
-		return $csrf_token;
+		$csrf_token = sha1( openssl_random_pseudo_bytes( 1024 ) );
+		$transient_scope = self::CSRF_TOKEN_TRANSIENT_SCOPE_PREFIX . $namespace;
+		return OAuth_Transients::set( self::get_unique_id(), $transient_scope, $csrf_token );
 	}
 
 	/**
@@ -59,8 +58,10 @@ class OAuth {
 	 * @return string CSRF token.
 	 */
 	public static function retrieve_csrf_token( $namespace ) {
-		$csrf_token_transient_name = self::CSRF_TOKEN_TRANSIENT_NAME_BASE . $namespace . self::get_unique_id();
-		return get_transient( $csrf_token_transient_name );
+		$transient_scope = self::CSRF_TOKEN_TRANSIENT_SCOPE_PREFIX . $namespace;
+		$value = OAuth_Transients::get( self::get_unique_id(), $transient_scope );
+		OAuth_Transients::delete( self::get_unique_id(), $transient_scope );
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Transients are not reliable when used between requests. This PR adds use of a custom transient table for OAuth purposes.

### How to test the changes in this Pull Request:

1. Set up a test site to use a Google OAuth proxy by providing a `NEWSPACK_GOOGLE_OAUTH_PROXY` env. variable
2. Insert a Registration block somewhere, use it on the front-end to sign in as a reader using a Google account
3. Observe you're signed in
4. Now test the cleanup – click the "Sign in with Google" button but abandon the process by closing the popup window
5. Look at the DB – there should be one row in the `wp_newspack_oauth_transients` table
6. Copy this row, changing the datetime to something more than an hour ago
7. Run `wp cron event run np_oauth_transients_cleanup` to trigger the cleanup
8. Observe the older row was deleted

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207152636003149
  - https://app.asana.com/0/0/1206967355160163