### PR TITLE
feat: update variation styles

### DIFF
--- a/assets/newspack-ui/scss/_mixins.scss
+++ b/assets/newspack-ui/scss/_mixins.scss
@@ -1,3 +1,5 @@
+@use 'variables/breakpoints';
+
 @mixin newspack-ui-elevation($size: 1) {
     @if $size == 1 {
         box-shadow: 0 1px 10px rgba( 0, 0, 0, 0.07 );
@@ -6,4 +8,24 @@
     }  @else if $size == 3 {
         box-shadow: 0 3px 30px rgba( 0, 0, 0, 0.21 );
     }
+}
+
+@mixin media( $res ) {
+	@if mobile == $res {
+		@media only screen and ( min-width: breakpoints.$mobile_width ) {
+			@content;
+		}
+	}
+
+	@if tablet == $res {
+		@media only screen and ( min-width: breakpoints.$tablet_width ) {
+			@content;
+		}
+	}
+
+	@if desktop == $res {
+		@media only screen and ( min-width: breakpoints.$desktop_width ) {
+			@content;
+		}
+	}
 }

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -62,6 +62,7 @@
 			align-items: center;
 			background: var( --newspack-ui-color-body-bg );
 			border-bottom: 1px solid var( --newspack-ui-color-border );
+			color: var( --newspack-ui-color-neutral-90 );
 			display: flex;
 			justify-content: space-between;
 			position: sticky;
@@ -82,6 +83,7 @@
 
 		&__content {
 			backface-visibility: visible;
+			color: var( --newspack-ui-color-neutral-90 );
 			padding: var( --newspack-ui-spacer-5 );
 
 			// Make sure there's enough space above the first button in modals
@@ -124,17 +126,27 @@
 
 	&__modal-variation {
 		.newspack-ui {
+			color: red;
+
 			&__selection {
-					> *:first-child {
-						margin-top: 0;
+				> *:first-child {
+					margin-top: 0;
+				}
+
+				h3 {
+					margin: 0;
+
+					+ p {
+						margin-top: calc( var( --newspack-ui-spacer-base ) / 2);
 					}
+				}
 			}
 
 			&__options {
 				list-style: none;
 				display: flex;
 				flex-wrap: wrap;
-				gap: var( --newspack-ui-spacer-3 );
+				gap: var( --newspack-ui-spacer-2 );
 				margin: var( --newspack-ui-spacer-5 ) 0 0;
 				padding: 0;
 
@@ -173,21 +185,22 @@
 							}
 
 							del {
-								position: absolute;
-								width: 100%;
+								color: var( --newspack-ui-color-neutral-60 );
 								left: 0;
-								top: var( --newspack-ui-spacer-base );
+								position: absolute;
+								top: calc( var( --newspack-ui-spacer-base ) * 0.75 );
+								width: 100%;
 							}
 						}
 					}
 
 					.variation {
+						border-top: 1px solid var(--newspack-ui-color-border );
+						font-size: var( --newspack-ui-font-size-xs );
+						font-weight: 600;
+						line-height: var( --newspack-ui-line-height-xs );
 						margin-top: auto;
 						padding: var( --newspack-ui-spacer-2 );
-						font-size: var( --newspack-ui-font-size-xs );
-						line-height: var( --newspack-ui-line-height-xs );
-						border-top: 1px solid var(--newspack-ui-color-border );
-						font-weight: 600;
 					}
 
 					form {

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -66,6 +66,7 @@
 			justify-content: space-between;
 			position: sticky;
 			top: 0;
+			z-index: 10;
 
 			h2 {
 				font-family: var( --newspack-ui-font-family );
@@ -153,14 +154,24 @@
 					.summary {
 						font-size: var( --newspack-ui-font-size-xs );
 						line-height: var( --newspack-ui-line-height-xs );
-						padding: var( --newspack-ui-spacer-2 );
+						padding: var( --newspack-ui-spacer-4 ) var( --newspack-ui-spacer-2 );
+						position: relative;
 
-						// Scale up just the primary price for a product, not the other fees:
-						.price > .amount > bdi,
-						.price > ins > .amount > bdi {
-							display: block;
-							font-weight: 600;
-							font-size: var( --newspack-ui-font-size-xl );
+						.price {
+							// Scale up just the primary price for a product, not the other fees:
+							> .amount > bdi,
+							> ins > .amount > bdi {
+								display: block;
+								font-weight: 600;
+								font-size: var( --newspack-ui-font-size-xl );
+							}
+
+							del {
+								position: absolute;
+								width: 100%;
+								left: 0;
+								top: var( --newspack-ui-spacer-base );
+							}
 						}
 					}
 

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -118,16 +118,10 @@
 
 	&__modal-variation {
 		.newspack-ui {
-			&__modal {
-				&__content {
-					h3 {
-						font-size: var( --newspack-ui-font-size-s );
-						margin: 0;
+			&__selection {
+					> *:first-child {
+						margin-top: 0;
 					}
-					p {
-						font-size: var( --newspack-ui-font-size-xs );
-					}
-				}
 			}
 
 			&__options {
@@ -146,7 +140,7 @@
 					flex: 1 1 100%;
 					text-align: center;
 
-					@media ( min-width: 600px ) {
+					@include mixins.media( mobile ) {
 						flex: 1 1 30%;
 						max-width: calc( 33.3333% - 10px );
 						&:first-child:nth-last-child( 2 ),
@@ -161,7 +155,7 @@
 						line-height: var( --newspack-ui-line-height-xs );
 						padding: var( --newspack-ui-spacer-2 );
 
-						// Scale up just the primary price for a product, not other fees:
+						// Scale up just the primary price for a product, not the other fees:
 						.price > .amount > bdi,
 						.price > ins > .amount > bdi {
 							display: block;

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -41,74 +41,7 @@
 			}
 		}
 	}
-	&__modal-variation {
-		.newspack-ui {
-			&__modal {
-				&__content {
-					padding: var( --newspack-ui-spacer-5 );
-					overflow: auto;
-					border-radius: var( --newspack-ui-border-radius-m );
-					h3 {
-						font-size: var( --newspack-ui-font-size-s );
-						margin: 0;
-					}
-					p {
-						font-size: var( --newspack-ui-font-size-xs );
-					}
-				}
-			}
 
-			&__options {
-				list-style: none;
-				display: flex;
-				flex-wrap: wrap;
-				gap: var( --newspack-ui-spacer-3 );
-				margin: 0;
-				padding: 0;
-
-				&__item {
-					border: 1px solid var(--newspack-ui-color-border );
-					border-radius: var( --newspack-ui-border-radius-m );
-					text-align: center;
-					flex: 1 1 100%;
-					@media ( min-width: 600px ) {
-						flex: 1 1 30%;
-						max-width: calc( 33.3333% - 10px );
-						&:first-child:nth-last-child( 2 ),
-						&:first-child:nth-last-child( 2 ) ~ li {
-							flex: 1 1 40%;
-							max-width: calc( 50% - 10px );
-						}
-					}
-					.summary {
-						font-size: var( --newspack-ui-font-size-xs );
-						padding: var( --newspack-ui-spacer-2 );
-						border-bottom: 1px solid var( --newspack-ui-color-border );
-						bdi {
-							display: block;
-							font-weight: 600;
-							font-size: var( --newspack-ui-font-size-xl );
-						}
-					}
-					.variation {
-						padding: var( --newspack-ui-spacer-2 );
-						font-size: var( --newspack-ui-font-size-xs );
-						line-height: 1.5;
-						border-bottom: 1px solid var(--newspack-ui-color-border );
-						font-weight: 600;
-					}
-					form {
-						padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-2 ) 0;
-						button {
-							display: block;
-							width: 100%;
-							font-size: var( --newspack-ui-font-size-xs );
-						}
-					}
-				}
-			}
-		}
-	}
 	&__modal {
 		// Modal styles
 		background: var( --newspack-ui-color-body-bg );
@@ -179,6 +112,82 @@
 
 			> *:last-child {
 				margin-bottom: 0;
+			}
+		}
+	}
+
+	&__modal-variation {
+		.newspack-ui {
+			&__modal {
+				&__content {
+					h3 {
+						font-size: var( --newspack-ui-font-size-s );
+						margin: 0;
+					}
+					p {
+						font-size: var( --newspack-ui-font-size-xs );
+					}
+				}
+			}
+
+			&__options {
+				list-style: none;
+				display: flex;
+				flex-wrap: wrap;
+				gap: var( --newspack-ui-spacer-3 );
+				margin: var( --newspack-ui-spacer-5 ) 0 0;
+				padding: 0;
+
+				&__item {
+					border: 1px solid var(--newspack-ui-color-border );
+					border-radius: var( --newspack-ui-border-radius-m );
+					display: flex;
+					flex-direction: column;
+					flex: 1 1 100%;
+					text-align: center;
+
+					@media ( min-width: 600px ) {
+						flex: 1 1 30%;
+						max-width: calc( 33.3333% - 10px );
+						&:first-child:nth-last-child( 2 ),
+						&:first-child:nth-last-child( 2 ) ~ li {
+							flex: 1 1 40%;
+							max-width: calc( 50% - 10px );
+						}
+					}
+
+					.summary {
+						font-size: var( --newspack-ui-font-size-xs );
+						line-height: var( --newspack-ui-line-height-xs );
+						padding: var( --newspack-ui-spacer-2 );
+
+						// Scale up just the primary price for a product, not other fees:
+						.price > .amount > bdi,
+						.price > ins > .amount > bdi {
+							display: block;
+							font-weight: 600;
+							font-size: var( --newspack-ui-font-size-xl );
+						}
+					}
+
+					.variation {
+						margin-top: auto;
+						padding: var( --newspack-ui-spacer-2 );
+						font-size: var( --newspack-ui-font-size-xs );
+						line-height: var( --newspack-ui-line-height-xs );
+						border-top: 1px solid var(--newspack-ui-color-border );
+						font-weight: 600;
+					}
+
+					form {
+						border-top: 1px solid var(--newspack-ui-color-border );
+						padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-2 ) 0;
+						button {
+							display: block;
+							width: 100%;
+						}
+					}
+				}
 			}
 		}
 	}

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -126,7 +126,6 @@
 
 	&__modal-variation {
 		.newspack-ui {
-			color: red;
 
 			&__selection {
 				> *:first-child {

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -159,7 +159,7 @@
 					.summary {
 						font-size: var( --newspack-ui-font-size-xs );
 						line-height: var( --newspack-ui-line-height-xs );
-						padding: var( --newspack-ui-spacer-4 ) var( --newspack-ui-spacer-2 );
+						padding: var( --newspack-ui-spacer-5 ) var( --newspack-ui-spacer-2 );
 						position: relative;
 
 						.price {
@@ -169,6 +169,7 @@
 								display: block;
 								font-weight: 600;
 								font-size: var( --newspack-ui-font-size-xl );
+								line-height: var( --newspack-ui-line-height-xl );
 							}
 
 							del {

--- a/assets/newspack-ui/scss/variables/_breakpoints.scss
+++ b/assets/newspack-ui/scss/variables/_breakpoints.scss
@@ -1,0 +1,3 @@
+$mobile_width: 600px;
+$tablet_width: 782px;
+$desktop_width: 1168px;

--- a/assets/newspack-ui/scss/variables/_index.scss
+++ b/assets/newspack-ui/scss/variables/_index.scss
@@ -1,3 +1,4 @@
+@use 'breakpoints';
 @use 'colors';
 @use 'fonts';
 @use 'spacing';

--- a/assets/newspack-ui/style.scss
+++ b/assets/newspack-ui/style.scss
@@ -13,6 +13,7 @@
 	h2,
 	h3 {
 		font-size: var( --newspack-ui-font-size-s );
+		line-height: var( --newspack-ui-line-height-s );	
 	}
 
 	a,


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR, along with https://github.com/Automattic/newspack-blocks/pull/1729, makes some tweaks to the variation styles:

* It reorders the SCSS a bit (moving the variations to the bottom of the modal CSS)
* It adjusts the styles to account for mixed height variations, for products that include fees, and products that are on sale.

See: 1205234045751551-as-1206482127342706

### How to test the changes in this Pull Request:

1. Apply this PR and https://github.com/Automattic/newspack-blocks/pull/1729, and run `npm run build` for both plugins.
2. Create two products with variations: one with a regular variable product, and one with variable subscriptions.
3. Of the variations, try adding some different price configurations: for either, add a sales price to at least one product, and for the subscription product, add an initial fee and a trial.
4. Assign each of those products to a checkout button block.
5. Do a visual review of the front-end and confirm things look okay -- primarily the additional info (sale price, fees)

![image](https://github.com/Automattic/newspack-plugin/assets/177561/69989721-4d59-48a3-ae66-a7e9c800fbe5)

![image](https://github.com/Automattic/newspack-plugin/assets/177561/f1d9aa42-9bb6-4079-bd14-ecf3e464a43c)

6. As an edge case, you can try to make one variation taller (usually by having a really long variation name, or two + variations applied) and confirm that the visual treatment of the taller variation makes sense: 

![image](https://github.com/Automattic/newspack-plugin/assets/177561/3952e02d-1a22-4676-90f1-f349934e2e95)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->