### PR TITLE
fix: autocomplete orders only for virtual products

### DIFF
--- a/assets/other-scripts/custom-product-options/index.js
+++ b/assets/other-scripts/custom-product-options/index.js
@@ -4,7 +4,6 @@
 		return;
 	}
 	$( '#variable_product_options' ).on( 'change', 'input.variable_is_virtual', function ( e ) {
-		console.log( e.currentTarget, $( e.currentTarget ).is( ':checked' ) );
 		$( e.currentTarget )
 			.closest( '.woocommerce_variation' )
 			.find( '.show_if_variation_virtual' )

--- a/assets/other-scripts/custom-product-options/index.js
+++ b/assets/other-scripts/custom-product-options/index.js
@@ -1,0 +1,20 @@
+/* globals jQuery */
+( function ( $ ) {
+	if ( ! $ ) {
+		return;
+	}
+	$( '#variable_product_options' ).on( 'change', 'input.variable_is_virtual', function ( e ) {
+		console.log( e.currentTarget, $( e.currentTarget ).is( ':checked' ) );
+		$( e.currentTarget )
+			.closest( '.woocommerce_variation' )
+			.find( '.show_if_variation_virtual' )
+			.hide();
+
+		if ( $( e.currentTarget ).is( ':checked' ) ) {
+			$( e.currentTarget )
+				.closest( '.woocommerce_variation' )
+				.find( '.show_if_variation_virtual' )
+				.show();
+		}
+	} );
+} )( jQuery );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3072 introduced a new option to autocomplete orders. That was a bit overreaching; this PR modifies the logic so that the option (and its default behavior) only applies for virtual products instead of all products.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Follow instructions from #3072, and make sure that all products and variations are marked as "Virtual" but not "Downloadable". Confirm that the autocomplete behavior works as described in #3072.
3. Edit the products and variations and deselect the "Virtual" checkbox for each product/variation. Confirm that the "Autocomplete orders" option disappears when deselecting "Virtual". Save all products/variations.
4. Complete purchases for the non-virtual products and confirm that their orders DO NOT autocomplete.
5. Publish a non-subscription product with both "Virtual" and "Autocomplete orders" options ENABLED and purchase it using a check payment (see WooCommerce > Settings > Payments to enable check payments for one-time purchases). Confirm that the order DOES NOT complete (as the order must still be manually updated to Completed status for manual payment methods).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->