### PR TITLE
fix(oauth-transients): remove redundant cleanup

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -612,6 +612,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 					'newspack_google_login',
 					'width=500,height=600'
 				);
+				let googleOAuthSuccess = false;
+				window.addEventListener( 'google-oauth-success', () => {
+					googleOAuthSuccess = true;
+					checkLoginStatus( metadata );
+				} );
+
 				fetch( '/wp-json/newspack/v1/login/google' )
 					.then( res => res.json().then( data => Promise.resolve( { data, status: res.status } ) ) )
 					.then( ( { data, status } ) => {
@@ -626,7 +632,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 							authWindow.location = data;
 							const interval = setInterval( () => {
 								if ( authWindow.closed ) {
-									checkLoginStatus( metadata );
+									if ( ! googleOAuthSuccess ) {
+										if ( googleLoginForm?.endLoginFlow ) {
+											googleLoginForm.endLoginFlow();
+										}
+									}
 									clearInterval( interval );
 								}
 							}, 500 );

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -130,7 +130,8 @@ class Google_Login {
 		$saved_csrf_token = OAuth::retrieve_csrf_token( self::CSRF_TOKEN_NAMESPACE );
 
 		if ( $_REQUEST['csrf_token'] !== $saved_csrf_token ) {
-			self::handle_error( __( 'CSRF token verification failed.', 'newspack-plugin' ) );
+			/* translators: %s is a unique user id */
+			self::handle_error( sprintf( __( 'CSRF token verification failed for id: %s', 'newspack-plugin' ), OAuth::get_unique_id() ) );
 			\wp_die( \esc_html__( 'Authentication failed.', 'newspack-plugin' ) );
 		}
 
@@ -154,7 +155,10 @@ class Google_Login {
 		/** Close window if it's a popup. */
 		?>
 		<script type="text/javascript" data-amp-plus-allowed>
-			if ( window.opener ) { window.close(); }
+			if ( window.opener ) {
+				window.opener.dispatchEvent( new Event('google-oauth-success') );
+				window.close();
+			}
 		</script>
 		<?php
 	}

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -177,8 +177,7 @@ class Google_Login {
 	public static function api_google_login_register( $request ) {
 		$uid = OAuth::get_unique_id();
 		// Retrieve the email address associated with the unique ID when the user was authenticated.
-		$email = OAuth_Transients::get( $uid, 'email' );
-		OAuth_Transients::delete( $uid, 'email' );
+		$email    = OAuth_Transients::get( $uid, 'email' );
 		$metadata = [];
 		if ( $request->get_param( 'metadata' ) ) {
 			try {

--- a/includes/oauth/class-oauth-transients.php
+++ b/includes/oauth/class-oauth-transients.php
@@ -123,6 +123,11 @@ class OAuth_Transients {
 			)
 		);
 
+		// Burn after reading.
+		if ( ! empty( $value ) && ( ! defined( 'NEWSPACK_OAUTH_TRANSIENTS_DEBUG' ) || ! NEWSPACK_OAUTH_TRANSIENTS_DEBUG ) ) {
+			self::delete( $id, $scope );
+		}
+
 		return $value ?? false;
 	}
 

--- a/includes/oauth/class-oauth-transients.php
+++ b/includes/oauth/class-oauth-transients.php
@@ -22,10 +22,10 @@ class OAuth_Transients {
 	 * Initialize hooks.
 	 */
 	public static function init() {
-		register_activation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'create_custom_table' ] );
-		add_action( 'init', [ __CLASS__, 'check_update_version' ] );
-		add_action( 'init', [ __CLASS__, 'cron_init' ] );
-		add_action( self::CRON_HOOK, [ __CLASS__, 'cleanup' ] );
+		\register_activation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'create_custom_table' ] );
+		\add_action( 'init', [ __CLASS__, 'check_update_version' ] );
+		\add_action( 'init', [ __CLASS__, 'cron_init' ] );
+		\add_action( self::CRON_HOOK, [ __CLASS__, 'cleanup' ] );
 	}
 
 	/**
@@ -34,8 +34,11 @@ class OAuth_Transients {
 	 */
 	public static function cron_init() {
 		\register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );
-		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-			\wp_schedule_event( time(), 'weekly', self::CRON_HOOK );
+
+		if ( defined( 'NEWSPACK_CRON_DISABLE' ) && is_array( NEWSPACK_CRON_DISABLE ) && in_array( self::CRON_HOOK, NEWSPACK_CRON_DISABLE, true ) ) {
+			self::cron_deactivate();
+		} elseif ( ! \wp_next_scheduled( self::CRON_HOOK ) ) {
+				\wp_schedule_event( time(), 'weekly', self::CRON_HOOK );
 		}
 	}
 
@@ -93,7 +96,7 @@ class OAuth_Transients {
 			) $charset_collate;";
 
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-			dbDelta( $sql );
+			\dbDelta( $sql );
 		}
 	}
 

--- a/includes/oauth/class-oauth-transients.php
+++ b/includes/oauth/class-oauth-transients.php
@@ -100,14 +100,13 @@ class OAuth_Transients {
 	/**
 	 * Get a value from the database.
 	 *
-	 * @param string  $id The reader's unique ID.
-	 * @param string  $scope The scope of the data to get.
-	 * @param string  $field_to_get The column to get. Defaults to 'value'.
-	 * @param boolean $cleanup If true, clean up old transients while getting.
+	 * @param string $id The reader's unique ID.
+	 * @param string $scope The scope of the data to get.
+	 * @param string $field_to_get The column to get. Defaults to 'value'.
 	 *
 	 * @return mixed The value of the data, or false if not found.
 	 */
-	public static function get( $id, $scope, $field_to_get = 'value', $cleanup = true ) {
+	public static function get( $id, $scope, $field_to_get = 'value' ) {
 		global $wpdb;
 		$table_name = self::get_table_name();
 
@@ -120,11 +119,6 @@ class OAuth_Transients {
 				$scope
 			)
 		);
-
-		// Prune old transients.
-		if ( $cleanup ) {
-			self::cleanup();
-		}
 
 		return $value ?? false;
 	}

--- a/includes/oauth/class-oauth.php
+++ b/includes/oauth/class-oauth.php
@@ -60,7 +60,6 @@ class OAuth {
 	public static function retrieve_csrf_token( $namespace ) {
 		$transient_scope = self::CSRF_TOKEN_TRANSIENT_SCOPE_PREFIX . $namespace;
 		$value = OAuth_Transients::get( self::get_unique_id(), $transient_scope );
-		OAuth_Transients::delete( self::get_unique_id(), $transient_scope );
 		return $value;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes a redundant cleanup call on `get`, and implements a way to let us temporarily disable and reenable cron jobs via an environment constant.

### How to test the changes in this Pull Request:

1. Check out this branch
2. On `wp cron event list`, confirm that `np_oauth_transients_cleanup` is scheduled for weekly execution
3. Add `define( 'NEWSPACK_CRON_DISABLE', [ 'np_oauth_transients_cleanup' ] );` to your wp-config.php
4. On `wp cron event list`, confirm that `np_oauth_transients_cleanup` is no longer scheduled
5. Remove `np_oauth_transients_cleanup` from the `NEWSPACK_CRON_DISABLE` array in wp-config.php and confirm that `np_oauth_transients_cleanup` job is scheduled again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->