### PR TITLE
fix(oauth): prevent API call if login is abandoned

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -612,6 +612,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 					'newspack_google_login',
 					'width=500,height=600'
 				);
+				let googleOAuthSuccess = false;
+				window.addEventListener( 'google-oauth-success', () => {
+					googleOAuthSuccess = true;
+					checkLoginStatus( metadata );
+				} );
+
 				fetch( '/wp-json/newspack/v1/login/google' )
 					.then( res => res.json().then( data => Promise.resolve( { data, status: res.status } ) ) )
 					.then( ( { data, status } ) => {
@@ -626,7 +632,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 							authWindow.location = data;
 							const interval = setInterval( () => {
 								if ( authWindow.closed ) {
-									checkLoginStatus( metadata );
+									if ( ! googleOAuthSuccess ) {
+										if ( googleLoginForm?.endLoginFlow ) {
+											googleLoginForm.endLoginFlow();
+										}
+									}
 									clearInterval( interval );
 								}
 							}, 500 );

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -130,7 +130,8 @@ class Google_Login {
 		$saved_csrf_token = OAuth::retrieve_csrf_token( self::CSRF_TOKEN_NAMESPACE );
 
 		if ( $_REQUEST['csrf_token'] !== $saved_csrf_token ) {
-			self::handle_error( __( 'CSRF token verification failed.', 'newspack-plugin' ) );
+			/* translators: %s is a unique user id */
+			self::handle_error( sprintf( __( 'CSRF token verification failed for id: %s', 'newspack-plugin' ), OAuth::get_unique_id() ) );
 			\wp_die( \esc_html__( 'Authentication failed.', 'newspack-plugin' ) );
 		}
 
@@ -154,7 +155,10 @@ class Google_Login {
 		/** Close window if it's a popup. */
 		?>
 		<script type="text/javascript" data-amp-plus-allowed>
-			if ( window.opener ) { window.close(); }
+			if ( window.opener ) {
+				window.opener.dispatchEvent( new Event('google-oauth-success') );
+				window.close();
+			}
 		</script>
 		<?php
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If the Google OAuth login process is abandoned, currently an API call to register the user will be made anyway, triggering false-positive error events. This PR chagnes that, so if the process is abandoned, the `/newspack/v1/login/google/register` call is not made.

### How to test the changes in this Pull Request:

1. On `release`,
1. Set up `NEWSPACK_GOOGLE_OAUTH_PROXY` so sign in with Google is available
2. Using the Registration block, click "Sign in with Google", but close the pop-up window
3. Observe in the Network panel that the call to `/newspack/v1/login/google/register` endpoint is made, with `500` response code 
4. Switch to this branch, repeat, observe the API call is not made if the process is abandoned 
5. Test the happy path – observe that signing in with Google is possible 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->