### PR TITLE
feat: hide registration lists the user is already subscribed to

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -331,6 +331,10 @@ final class Reader_Activation {
 		}
 		$use_custom_lists = self::get_setting( 'use_custom_lists' );
 		$available_lists  = \Newspack_Newsletters_Subscription::get_lists_config();
+		$subscribed_lists = [];
+		if ( \is_user_logged_in() && self::is_user_reader( \wp_get_current_user() ) ) {
+			$subscribed_lists = \Newspack_Newsletters_Subscription::get_contact_lists( \wp_get_current_user()->user_email );
+		}
 		if ( \is_wp_error( $available_lists ) ) {
 			return [];
 		}
@@ -349,6 +353,14 @@ final class Reader_Activation {
 				}
 			}
 		}
+
+		// Filter out lists that the reader is already subscribed to.
+		$registration_lists = array_filter(
+			$registration_lists,
+			function( $list ) use ( $subscribed_lists ) {
+				return ! in_array( $list['id'], $subscribed_lists, true );
+			}
+		);
 
 		/**
 		 * Filters the newsletters lists that should be rendered during registration.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When showing newsletter lists that can be subscribed to, if the current user is logged in as a reader, don't show any lists that the reader is already subscribed to. 

This affects lists shown in the following contexts:

1. In the Registration block
2. In the auth modal after clicking "I don't have an account"
3. In the post-checkout newsletter signup modal (if `NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP` is defined in wp-config.php)

Because the first two contexts are only relevant for non-logged-in users, in practice this really only affects lists shown in the post-checkout modal.

Closes `1206943664367852/1207162723214827`.

### How to test the changes in this Pull Request:

1. Check out this branch
2. Add `define( 'NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP', true );` to wp-config.php
3. Set up a premium newsletter list via Memberships, tied to the purchase of a subscription product
5. As a reader, purchase the product and confirm that you're shown the newsletter signup form after completing checkout, and that it shows the premium list set up in step 2
6. Subscribe to the list and continue browsing
7. Purchase another product and confirm that you're shown the newsletter signup form after completing checkout again, but that the premium list you signed up to in step 6 is no longer shown as an option here.
8. Sign up for all available lists and complete another purchase, and this time confirm that the post-checkout newsletter signup list is not shown (because there are no more lists to show to this reader).
9. Visit My Account > Newsletters and verify as needed, and confirm that all lists are shown here and correctly indicate your signup status.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207162723214827