### PR TITLE
fix(registration-block): prevent undefined variable warning

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -144,11 +144,11 @@ function render_block( $attrs, $content ) {
 	}
 
 	/** Setup list subscription */
+	$lists = [];
 	if ( $attrs['newsletterSubscription'] && method_exists( 'Newspack_Newsletters_Subscription', 'get_lists_config' ) ) {
 		$list_config = \Newspack_Newsletters_Subscription::get_lists_config();
 		if ( ! \is_wp_error( $list_config ) ) {
 			// get existing lists preserving the order.
-			$lists = [];
 			foreach ( $attrs['lists'] as $list_id ) {
 				if ( isset( $list_config[ $list_id ] ) ) {
 					$lists[ $list_id ] = $list_config[ $list_id ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

`$lists` is defined conditionally, but used unconditionally later. This PR fixes it.

### How to test the changes in this Pull Request:

1. On `trunk`,
1. Insert the Registration Block on a page, observe `PHP Warning:  Undefined variable $lists …` logged when the front-end is loaded
2. Switch to this branch, observe no warning logged 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->