### PR TITLE
fix(google-login): get the email from the /tokeninfo endpoint

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -631,14 +631,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 						} else if ( authWindow ) {
 							authWindow.location = data;
 							const interval = setInterval( () => {
-								if ( authWindow.closed ) {
-									if ( ! googleOAuthSuccess ) {
-										if ( googleLoginForm?.endLoginFlow ) {
-											googleLoginForm.endLoginFlow();
-										}
+								if ( ! googleOAuthSuccess ) {
+									if ( googleLoginForm?.endLoginFlow ) {
+										googleLoginForm.endLoginFlow( newspack_reader_auth_labels.login_canceled, 401 );
 									}
-									clearInterval( interval );
 								}
+								clearInterval( interval );
 							}, 500 );
 						} else if ( googleLoginForm?.endLoginFlow ) {
 							googleLoginForm.endLoginFlow( newspack_reader_auth_labels.blocked_popup );

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -171,6 +171,7 @@ class Google_Login {
 	 * @param string $message The message to log.
 	 */
 	private static function handle_error( $message ) {
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
 		Logger::error(
 			sprintf(
 				// Translators: %1$s is the error message, %2$s is the user agent.
@@ -178,13 +179,15 @@ class Google_Login {
 				$message,
 				\wp_json_encode(
 					[
-						'user_agent' => isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ) : 'N/A', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-						'referrer'   => isset( $_SERVER['HTTP_REFERER'] ) ? esc_url( $_SERVER['HTTP_REFERER'] ) : 'N/A', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+						'user_agent'   => isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ) : 'N/A',
+						'referrer'     => isset( $_SERVER['HTTP_REFERER'] ) ? esc_url( $_SERVER['HTTP_REFERER'] ) : 'N/A',
+						'request_time' => isset( $_SERVER['REQUEST_TIME'] ) ? gmdate( 'Y-m-d\TH:i:s', intval( $_SERVER['REQUEST_TIME'] ) ) : 'N/A',
 					],
 					JSON_PRETTY_PRINT
 				)
 			)
 		);
+		// phpcs:enable
 		do_action( 'newspack_google_login_error', new WP_Error( 'newspack_google_login', $message ) );
 	}
 

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -145,10 +145,12 @@ class Google_Login {
 		Logger::log( 'Got user email from Google: ' . $user_email );
 
 		// Associate the email address with the a unique ID for later retrieval.
-		$set_transient_result = OAuth_Transients::set( OAuth::get_unique_id(), 'email', $user_email );
+		$uid = OAuth::get_unique_id();
+		$set_transient_result = OAuth_Transients::set( $uid, 'email', $user_email );
 		// If transient setting failed, the email address will not be available for the registration endpoint.
 		if ( $set_transient_result === false ) {
-			self::handle_error( __( 'Failed setting transient.', 'newspack-plugin' ) );
+			/* translators: %s is a unique user id */
+			self::handle_error( sprintf( __( 'Failed setting email transient for id: %s', 'newspack-plugin' ), $uid ) );
 			\wp_die( \esc_html__( 'Authentication failed.', 'newspack-plugin' ) );
 		}
 

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -171,7 +171,20 @@ class Google_Login {
 	 * @param string $message The message to log.
 	 */
 	private static function handle_error( $message ) {
-		Logger::error( $message );
+		Logger::error(
+			sprintf(
+				// Translators: %1$s is the error message, %2$s is the user agent.
+				__( '%1$s | Details: %2$s', 'newspack-plugin' ),
+				$message,
+				\wp_json_encode(
+					[
+						'user_agent' => isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ) : 'N/A', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+						'referrer'   => isset( $_SERVER['HTTP_REFERER'] ) ? esc_url( $_SERVER['HTTP_REFERER'] ) : 'N/A', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+					],
+					JSON_PRETTY_PRINT
+				)
+			)
+		);
 		do_action( 'newspack_google_login_error', new WP_Error( 'newspack_google_login', $message ) );
 	}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -158,6 +158,7 @@ final class Reader_Activation {
 				'invalid_email'    => __( 'Please enter a valid email address.', 'newspack-plugin' ),
 				'invalid_password' => __( 'Please enter a password.', 'newspack-plugin' ),
 				'blocked_popup'    => __( 'The popup has been blocked. Allow popups for the site and try again.', 'newspack-plugin' ),
+				'login_canceled'   => __( 'Login canceled.', 'newspack-plugin' ),
 			]
 		);
 		\wp_script_add_data( self::AUTH_SCRIPT_HANDLE, 'async', true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Improved error logging for transient setting failure
2. One request (to Google APIs) less in Google OAuth process, because the `/tokeninfo` endpoint already returns the email address

### How to test the changes in this Pull Request:

1. Use 'Sign in with Google' option in the Registration block 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->