### PR TITLE
fix(oauth): prevent false warning when opening Google OAuth

### DIFF
--- a/assets/reader-activation/auth.js
+++ b/assets/reader-activation/auth.js
@@ -631,12 +631,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 						} else if ( authWindow ) {
 							authWindow.location = data;
 							const interval = setInterval( () => {
-								if ( ! googleOAuthSuccess ) {
+								if ( ! googleOAuthSuccess && authWindow.closed ) {
 									if ( googleLoginForm?.endLoginFlow ) {
 										googleLoginForm.endLoginFlow( newspack_reader_auth_labels.login_canceled, 401 );
 									}
+									clearInterval( interval );
 								}
-								clearInterval( interval );
 							}, 500 );
 						} else if ( googleLoginForm?.endLoginFlow ) {
 							googleLoginForm.endLoginFlow( newspack_reader_auth_labels.blocked_popup );

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -92,9 +92,15 @@ class Google_Login {
 	 * @return WP_REST_Response Response with the URL.
 	 */
 	public static function api_google_auth_get_url() {
+		$csrf_token = OAuth::generate_csrf_token( self::CSRF_TOKEN_NAMESPACE );
+		if ( $csrf_token === false ) {
+			/* translators: %s is the unique id of the visitor. */
+			self::handle_error( sprintf( __( 'Failed to save the CSRF token for id: %s', 'newspack-plugin' ), OAuth::get_unique_id() ) );
+			return new WP_Error( 'newspack_google_login', __( 'Failed to save the CSRF token.', 'newspack-plugin' ) );
+		}
 		$url = Google_OAuth::google_auth_get_url(
 			[
-				'csrf_token'     => OAuth::generate_csrf_token( self::CSRF_TOKEN_NAMESPACE ),
+				'csrf_token'     => $csrf_token,
 				'scope'          => implode( ' ', self::REQUIRED_SCOPES ),
 				'redirect_after' => add_query_arg( self::AUTH_CALLBACK, wp_create_nonce( self::AUTH_CALLBACK ), get_home_url() ),
 			]

--- a/includes/oauth/class-oauth.php
+++ b/includes/oauth/class-oauth.php
@@ -46,7 +46,7 @@ class OAuth {
 	 * @return string CSRF token.
 	 */
 	public static function generate_csrf_token( $namespace ) {
-		$csrf_token = sha1( openssl_random_pseudo_bytes( 1024 ) );
+		$csrf_token = wp_generate_password( 40, false );
 		$transient_scope = self::CSRF_TOKEN_TRANSIENT_SCOPE_PREFIX . $namespace;
 		return OAuth_Transients::set( self::get_unique_id(), $transient_scope, $csrf_token );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced in #3117 and adds two things:

1. Switch to `wp_generate_password` for CSRF token generation (kinda shot in the dark, kinda let's use core WP where applicable for better readability)
2. Handle failure to save the CSRF token in the DB error

### How to test the changes in this Pull Request:

1. On `release`, initiate the Google OAuth flow
3. Observe the "Login canceled" appearing below the login button
4. Close the pop-up window, observe the UI is still greyed-out
5. Switch to this branch, repeat, observe the UI is reactivated and "Login canceled" displayed only after closing the popup window

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->