### PR TITLE
feat(cli): enable running the setup with a site import

### DIFF
--- a/includes/cli/class-setup.php
+++ b/includes/cli/class-setup.php
@@ -92,7 +92,7 @@ class Setup {
 	 * Populates the site with initial content
 	 *
 	 * @param array $assoc_args Assoc args passed to the CLI invocation.
-	 * @return void
+	 * @return void|WP_Error Error on failure.
 	 */
 	private function initial_content( $assoc_args ) {
 		WP_CLI::line( 'Creating Initial Content' );

--- a/includes/cli/class-setup.php
+++ b/includes/cli/class-setup.php
@@ -41,7 +41,7 @@ class Setup {
 
 		$this->plugins();
 
-		$this->initial_content();
+		$this->initial_content( $assoc_args );
 
 		WP_CLI::success( 'Done!' );
 	}
@@ -91,12 +91,20 @@ class Setup {
 	/**
 	 * Populates the site with initial content
 	 *
+	 * @param array $assoc_args Assoc args passed to the CLI invocation.
 	 * @return void
 	 */
-	private function initial_content() {
+	private function initial_content( $assoc_args ) {
 		WP_CLI::line( 'Creating Initial Content' );
 		$request = new WP_REST_Request( 'POST', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-setup-wizard/starter-content/init' );
-		$request->set_query_params( [ 'type' => 'generated' ] );
+		if ( isset( $assoc_args['site'] ) && ! empty( $assoc_args['site'] ) ) {
+			$assoc_args['type'] = 'import';
+		}
+		$init_query_params = wp_parse_args(
+			$assoc_args,
+			[ 'type' => 'generated' ]
+		);
+		$request->set_query_params( $init_query_params );
 		$response = rest_do_request( $request );
 
 		WP_CLI::line( 'Creating Posts' );

--- a/includes/cli/class-setup.php
+++ b/includes/cli/class-setup.php
@@ -99,6 +99,10 @@ class Setup {
 		$request = new WP_REST_Request( 'POST', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-setup-wizard/starter-content/init' );
 		if ( isset( $assoc_args['site'] ) && ! empty( $assoc_args['site'] ) ) {
 			$assoc_args['type'] = 'import';
+			// Prepend HTTPS protocol if missing.
+			if ( ! preg_match( '/^https?:\/\//', $assoc_args['site'] ) ) {
+				$assoc_args['site'] = 'https://' . $assoc_args['site'];
+			}
 		}
 		$init_query_params = wp_parse_args(
 			$assoc_args,
@@ -106,6 +110,9 @@ class Setup {
 		);
 		$request->set_query_params( $init_query_params );
 		$response = rest_do_request( $request );
+		if ( $response->status !== 200 ) {
+			return WP_CLI::error( $response->data['message'] );
+		}
 
 		WP_CLI::line( 'Creating Posts' );
 		for ( $i = 0; $i < 40; $i++ ) {

--- a/includes/starter_content/class-starter-content-wordpress.php
+++ b/includes/starter_content/class-starter-content-wordpress.php
@@ -88,7 +88,7 @@ class Starter_Content_WordPress extends Starter_Content_Provider {
 			);
 		}
 
-		$relevant_info = array_map( 
+		$relevant_info = array_map(
 			function( $post_data ) use ( $site_url ) {
 				return [
 					'title'          => $post_data['title']['rendered'],
@@ -98,7 +98,7 @@ class Starter_Content_WordPress extends Starter_Content_Provider {
 					'site_url'       => $site_url,
 				];
 			},
-			$response_json 
+			$response_json
 		);
 
 		update_option( self::$existing_content_raw_data_option, $relevant_info );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Enables running the `wp newspack setup` command a `--site` param to specify a (WP) site to import initial posts from. 

### How to test the changes in this Pull Request:

1. Run `wp newspack setup --site=<wordpress-site-url>` and observe the initial posts are not auto-generated, but fetched from the site

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->