### PR TITLE
fix(ras): handle newsletters subscribe form selector

### DIFF
--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -307,7 +307,9 @@ function attachAuthCookiesListener() {
  * Set the reader as newsletter subscriber once a newsletter form is submitted.
  */
 function attachNewsletterFormListener() {
-	const forms = document.querySelectorAll( '.newspack-subscribe-form,.mc4wp-form' );
+	const forms = document.querySelectorAll(
+		'.newspack-newsletters-subscribe,.newspack-subscribe-form,.mc4wp-form'
+	);
 	if ( ! forms.length ) {
 		return;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug that causes a newsletters subscription to not set RAS data (used by Newspack Campaigns' segmentation).

### How to test the changes in this Pull Request:

1. On `release`,
1. Ensure RAS is not enabled*
2. Create a prompt** with a Newsletter Subscribe form, set the prompt to be segmented to readers who did not sign up for a newsletter
3. View the front-end, subscribe using the form in the prompt
4. Browse to another page, observe the prompt is still there – despite the segmentation
5. Switch to this branch, retest – observe the prompt is not visible after signing up for a newsletter 

\* delete `newspack_reader_activation_enabled` option
\** make sure it displays on every pageview

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207384626833881