### PR TITLE
fix(ras): handle RAS disabled in newsletters signup handling

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -271,6 +271,9 @@ final class Reader_Data {
 	 * @param array $data      Data.
 	 */
 	public static function update_newsletter_subscribed_lists( $timestamp, $data ) {
+		if ( ! isset( $data['user_id'] ) ) {
+			return;
+		}
 		if ( ! empty( $data['lists'] ) ) {
 			self::update_item( $data['user_id'], 'is_newsletter_subscriber', true );
 			self::update_item( $data['user_id'], 'newsletter_subscribed_lists', wp_json_encode( $data['lists'] ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a PHP Warning logged if RAS is disabled and newsletter subscription status changes.

Related to https://github.com/Automattic/newspack-plugin/pull/3127

### How to test the changes in this Pull Request:

1. On `trunk`
1. Disable RAS*
2. Sign up for a newsletter using the Newsletters Subscribe block
3. Observe a PHP Warning logged about `Undefined array key "user_id"`
4. Switch to this branch, repeat, observe no warning logged

\* delete `newspack_reader_activation_enabled` option

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->