### PR TITLE
feat(ras): add flag to setup CLI command to skip default campaign setup

### DIFF
--- a/includes/cli/class-initializer.php
+++ b/includes/cli/class-initializer.php
@@ -42,19 +42,31 @@ class Initializer {
 		// Utility commands for managing RAS data via WP CLI.
 		WP_CLI::add_command(
 			'newspack ras setup',
-			[ 'Newspack\CLI\RAS', 'cli_setup_ras' ]
+			[ 'Newspack\CLI\RAS', 'cli_setup_ras' ],
+			[
+				'shortdesc' => 'Enable Reader Activation features.',
+				'synopsis'  => [
+					[
+						'type'        => 'flag',
+						'name'        => 'skip-campaigns',
+						'default'     => false,
+						'description' => 'Skip the creation of default campaign prompts and segments.',
+						'optional'    => true,
+					],
+				],
+			]
 		);
 
 		WP_CLI::add_command(
 			'newspack verify-reader',
 			[ 'Newspack\CLI\RAS', 'cli_verify_reader' ],
 			[
-				'shortdesc' => 'Verify a reader account . ',
+				'shortdesc' => 'Verify a reader account.',
 				'synopsis'  => [
 					[
 						'type'        => 'positional',
 						'name'        => 'user',
-						'description' => 'ID or email of the user account . ',
+						'description' => 'ID or email of the user account.',
 						'optional'    => false,
 						'repeating'   => false,
 					],

--- a/includes/cli/class-ras.php
+++ b/includes/cli/class-ras.php
@@ -8,6 +8,8 @@
 namespace Newspack\CLI;
 
 use WP_CLI;
+use Newspack\Engagement_Wizard;
+use Newspack\Plugin_Manager;
 use Newspack\Reader_Activation;
 
 defined( 'ABSPATH' ) || exit;
@@ -17,34 +19,45 @@ defined( 'ABSPATH' ) || exit;
  */
 class RAS {
 	/**
-	 * Verify the given user, bypassing the need to complete the email-based verification flow.
+	 * Enable Reader Activation features without having to complete the onboarding wizard.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
 	 */
-	public static function cli_setup_ras() {
-		if ( Reader_Activation::is_ras_campaign_configured() ) {
+	public static function cli_setup_ras( $args, $assoc_args ) {
+		$skip_campaigns = ! empty( $assoc_args['skip-campaigns'] );
+		if ( ! $skip_campaigns && Reader_Activation::is_ras_campaign_configured() ) {
 			WP_CLI::error( __( 'RAS is already configured for this site.', 'newspack-plugin' ) );
 		}
 
-		if ( ! class_exists( '\Newspack_Popups_Presets' ) ) {
-			WP_CLI::error( __( 'Newspack Campaigns plugin not found.', 'newspack-plugin' ) );
+		if ( ! $skip_campaigns && ! class_exists( '\Newspack_Popups_Presets' ) ) {
+			WP_CLI::warning( __( 'Newspack Campaigns plugin not found. Activating...', 'newspack-plugin' ) );
+			Plugin_Manager::install( 'newspack-popups' );
+			Plugin_Manager::activate( 'newspack-popups' );
 		}
 
-		
 		if ( ! class_exists( '\Newspack_Newsletters_Subscription' ) ) {
-			WP_CLI::error( __( 'Newspack Newsletters plugin not found.', 'newspack-plugin' ) );
+			WP_CLI::warning( __( 'Newspack Newsletters plugin not found. Activating...', 'newspack-plugin' ) );
+			Plugin_Manager::activate( 'newspack-newsletters' );
 		}
 
 		if ( \is_wp_error( \Newspack_Newsletters_Subscription::get_lists() ) ) {
 			WP_CLI::error( __( 'Newspack Newsletters provider not set.', 'newspack-plugin' ) );
 		}
 
-		$result = \Newspack_Popups_Presets::activate_ras_presets();
-		
+		$result = $skip_campaigns ? Reader_Activation::update_setting( 'enabled', true ) : \Newspack_Popups_Presets::activate_ras_presets();
 		if ( ! $result ) {
 			WP_CLI::error( __( 'Something went wrong. Please check for required plugins and try again.', 'newspack-plugin' ) );
 			exit;
 		}
 
-		WP_CLI::success( __( 'RAS enabled with default prompts.', 'newspack-plugin' ) );
+		WP_CLI::success(
+			sprintf(
+				// Translators: 'with' or 'without' default prompts.
+				__( 'RAS enabled %s default prompts.', 'newspack-plugin' ),
+				$skip_campaigns ? 'without' : 'with'
+			)
+		);
 	}
 
 	/**

--- a/includes/cli/class-ras.php
+++ b/includes/cli/class-ras.php
@@ -30,9 +30,9 @@ class RAS {
 			WP_CLI::error( __( 'RAS is already configured for this site.', 'newspack-plugin' ) );
 		}
 
-		if ( ! $skip_campaigns && ! class_exists( '\Newspack_Popups_Presets' ) ) {
+		if ( ! class_exists( '\Newspack_Popups_Presets' ) ) {
 			WP_CLI::warning( __( 'Newspack Campaigns plugin not found. Activating...', 'newspack-plugin' ) );
-			Plugin_Manager::install( 'newspack-popups' );
+			Plugin_Manager::install( 'newspack-popups' ); // Must be installed before being activated to avoid a fatal.
 			Plugin_Manager::activate( 'newspack-popups' );
 		}
 
@@ -41,7 +41,7 @@ class RAS {
 			Plugin_Manager::activate( 'newspack-newsletters' );
 		}
 
-		if ( \is_wp_error( \Newspack_Newsletters_Subscription::get_lists() ) ) {
+		if ( ! $skip_campaigns && \is_wp_error( \Newspack_Newsletters_Subscription::get_lists() ) ) {
 			WP_CLI::error( __( 'Newspack Newsletters provider not set.', 'newspack-plugin' ) );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3051 added the option to skip Campaigns default prompt + segment setup during RAS onboarding. This adds the same option to the `wp newspack ras setup` CLI command. It also tweaks that command so that if a required plugin isn't installed, the script will just install it instead of failing with an error.

### How to test the changes in this Pull Request:

1. On a fresh test site, install this version of the plugin and run `wp newspack setup` to complete the initial site setup.
2. After setup, complete the following steps which currently can't be automated:
  - Enable an ESP and at least one subscription list in **Newspack > Engagement > Newsletters**
  - Install and activate WooCommerce and WooCommerce Subscriptions
3. Run `wp newspack ras setup --skip-campaigns`. After it completes, visit **Newspack > Engagement > Reader Activation** in the admin and confirm that it's enabled and that you can view/edit advanced settings despite skipping the prerequisites.

<img width="1067" alt="Screenshot 2024-05-23 at 11 20 18 AM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/6a4036cf-d527-47f3-9231-ebd62f0c40e0">

4. Also make sure that RAS sign-in and My Account features are enabled on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->