### PR TITLE
fix(ras-acc): handle cancelled accounts with active subs

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -625,62 +625,64 @@ class WooCommerce_Connection {
 		}
 
 		$items = $subscription->get_items();
-		$item  = array_shift( $items );
-		$is_donation = Donations::is_donation_product( $item->get_product_id() );
 
-		// Replace content placeholders.
-		$placeholders = [
-			[
-				'template' => '*BILLING_NAME*',
-				'value'    => trim( $subscription->get_billing_first_name() . ' ' . $subscription->get_billing_last_name() ),
-			],
-			[
-				'template' => '*BILLING_FIRST_NAME*',
-				'value'    => $subscription->get_billing_first_name(),
-			],
-			[
-				'template' => '*BILLING_LAST_NAME*',
-				'value'    => $subscription->get_billing_last_name(),
-			],
-			[
-				'template' => '*BILLING_FREQUENCY*',
-				'value'    => $product_map[ $item->get_product_id() ] ?? __( 'One-time', 'newspack-plugin' ),
-			],
-			[
-				'template' => '*PRODUCT_NAME*',
-				'value'    => $item->get_name(),
-			],
-			[
-				'template' => '*END_DATE*',
-				'value'    => wcs_format_datetime( wcs_get_datetime_from( $subscription->get_date( 'end' ) ) ),
-			],
-			[
-				'template' => '*BUTTON_TEXT*',
-				'value'    => $is_donation ? __( 'Restart Donation', 'newspack-plugin' ) : __( 'Restart Subscription', 'newspack-plugin' ),
-			],
-			[
-				'template' => '*CANCELLATION_DATE*',
-				'value'    => wcs_format_datetime( wcs_get_datetime_from( $subscription->get_date( 'cancelled' ) ) ),
-			],
-			[
-				'template' => '*CANCELLATION_TITLE*',
-				'value'    => $is_donation ? __( 'Donation Cancelled', 'newspack-plugin' ) : __( 'Subscription Cancelled', 'newspack-plugin' ),
-			],
-			[
-				'template' => '*CANCELLATION_TYPE*',
-				'value'    => $is_donation ? __( 'recurring donation', 'newspack-plugin' ) : __( 'subscription', 'newspack-plugin' ),
-			],
-			[
-				'template' => '*SUBSCRIPTION_URL*',
-				'value'    => $subscription->get_view_order_url(),
-			],
-		];
+		if ( ! empty( $items ) ) {
+			$item         = array_shift( $items );
+			$is_donation  = Donations::is_donation_product( $item->get_product_id() );
+			// Replace content placeholders.
+			$placeholders = [
+				[
+					'template' => '*BILLING_NAME*',
+					'value'    => trim( $subscription->get_billing_first_name() . ' ' . $subscription->get_billing_last_name() ),
+				],
+				[
+					'template' => '*BILLING_FIRST_NAME*',
+					'value'    => $subscription->get_billing_first_name(),
+				],
+				[
+					'template' => '*BILLING_LAST_NAME*',
+					'value'    => $subscription->get_billing_last_name(),
+				],
+				[
+					'template' => '*BILLING_FREQUENCY*',
+					'value'    => $product_map[ $item->get_product_id() ] ?? __( 'One-time', 'newspack-plugin' ),
+				],
+				[
+					'template' => '*PRODUCT_NAME*',
+					'value'    => $item->get_name(),
+				],
+				[
+					'template' => '*END_DATE*',
+					'value'    => wcs_format_datetime( wcs_get_datetime_from( $subscription->get_date( 'end' ) ) ),
+				],
+				[
+					'template' => '*BUTTON_TEXT*',
+					'value'    => $is_donation ? __( 'Restart Donation', 'newspack-plugin' ) : __( 'Restart Subscription', 'newspack-plugin' ),
+				],
+				[
+					'template' => '*CANCELLATION_DATE*',
+					'value'    => wcs_format_datetime( wcs_get_datetime_from( $subscription->get_date( 'cancelled' ) ) ),
+				],
+				[
+					'template' => '*CANCELLATION_TITLE*',
+					'value'    => $is_donation ? __( 'Donation Cancelled', 'newspack-plugin' ) : __( 'Subscription Cancelled', 'newspack-plugin' ),
+				],
+				[
+					'template' => '*CANCELLATION_TYPE*',
+					'value'    => $is_donation ? __( 'recurring donation', 'newspack-plugin' ) : __( 'subscription', 'newspack-plugin' ),
+				],
+				[
+					'template' => '*SUBSCRIPTION_URL*',
+					'value'    => $subscription->get_view_order_url(),
+				],
+			];
 
-		$sent = Emails::send_email(
-			Reader_Revenue_Emails::EMAIL_TYPES['CANCELLATION'],
-			$subscription->get_billing_email(),
-			$placeholders
-		);
+			$sent = Emails::send_email(
+				Reader_Revenue_Emails::EMAIL_TYPES['CANCELLATION'],
+				$subscription->get_billing_email(),
+				$placeholders
+			);
+		}
 
 		return $enable;
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206943664367857/1207172937166966/f

This PR addresses a fatal that would appear when cancelling an account with an active subscription:

```
PHP Fatal error:  Uncaught Error: Call to a member function get_product_id() on null
```

Note: I was not able to replicate this error on my end since the hook is always triggered with a valid subscription being passed, but to be safe these changes should guard against cases in which we do not have any valid subscription items.

### How to test the changes in this Pull Request:

1. Create a new reader account and purchase either a recurring donation or a subscription product.
2. From my account (as reader still) delete your account via My Account > Account Details (you may need to go through the verification flow before the delete account link appears here)
3. Confirm there are no fatal errors and the account is deleted successfully

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->