### PR TITLE
fix(ras-acc): disable body scroll when auth modal is open

### DIFF
--- a/assets/reader-activation-auth/auth-modal.js
+++ b/assets/reader-activation-auth/auth-modal.js
@@ -46,6 +46,7 @@ export function openAuthModal( config = {} ) {
 		container.config = {};
 		modal.setAttribute( 'data-state', 'closed' );
 		document.body.classList.remove( 'newspack-signin' );
+		document.body.style.overflow = 'auto';
 		if ( modal.overlayId && window.newspackReaderActivation?.overlays ) {
 			window.newspackReaderActivation.overlays.remove( modal.overlayId );
 		}
@@ -123,6 +124,7 @@ export function openAuthModal( config = {} ) {
 	container.setFormAction( initialFormAction, true );
 
 	document.body.classList.add( 'newspack-signin' );
+	document.body.style.overflow = 'hidden';
 	modal.setAttribute( 'data-state', 'open' );
 	if ( window.newspackReaderActivation?.overlays ) {
 		modal.overlayId = window.newspackReaderActivation.overlays.add();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206943664367857/1207328906416559/f

This PR disables scrolling from main body while the auth modal is open.

![Screenshot 2024-05-24 at 15 34 27](https://github.com/Automattic/newspack-plugin/assets/17905991/b8ed5f08-6816-4480-901d-2d7df98318bd)

### How to test the changes in this Pull Request:

- As a logged out user, select the sign in button
- When the modal appears, move your mouse so it is outside of the modal and scroll
- On `epic/ras-acc` the main content scrolls while the modal is open. On this branch it should not.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->