### PR TITLE
fix: avoid resetting modal config via #register_modal hash from inside auth modal

### DIFF
--- a/assets/reader-activation-auth/auth-form.js
+++ b/assets/reader-activation-auth/auth-form.js
@@ -37,6 +37,16 @@ window.newspackRAS.push( function ( readerActivation ) {
 			const messageContentElement = container.querySelector( '.response' );
 
 			/**
+			 * Set action listener on the given item.
+			 */
+			const setActionListener = item => {
+				item.addEventListener( 'click', function ( ev ) {
+					ev.preventDefault();
+					container.setFormAction( ev.target.getAttribute( 'data-set-action' ), true );
+				} );
+			};
+
+			/**
 			 * Handle auth form action selection.
 			 */
 			let formAction;
@@ -193,12 +203,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				} );
 			}
 
-			container.querySelectorAll( '[data-set-action]' ).forEach( item => {
-				item.addEventListener( 'click', function ( ev ) {
-					ev.preventDefault();
-					container.setFormAction( ev.target.getAttribute( 'data-set-action' ), true );
-				} );
-			} );
+			container.querySelectorAll( '[data-set-action]' ).forEach( setActionListener );
 
 			form.startLoginFlow = () => {
 				container.removeAttribute( 'data-form-status' );
@@ -220,6 +225,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 					messageNode.innerHTML = message;
 					messageContentElement.style.display = 'block';
 					messageContentElement.appendChild( messageNode );
+					messageContentElement
+						.querySelectorAll( '[data-set-action]' )
+						.forEach( setActionListener );
 				}
 				if ( status === 200 ) {
 					if ( data ) {

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1541,7 +1541,7 @@ final class Reader_Activation {
 
 		$user = \get_user_by( 'email', $email );
 		if ( ( ! $user && 'register' !== $action ) || ( $user && ! self::is_user_reader( $user ) ) ) {
-			return self::send_auth_form_response( new \WP_Error( 'unauthorized', wp_kses_post( __( 'Account not found. <a href="#register_modal">Create an account</a> instead?', 'newspack-plugin' ) ) ) );
+			return self::send_auth_form_response( new \WP_Error( 'unauthorized', wp_kses_post( __( 'Account not found. <a data-set-action="register" href="#register_modal">Create an account</a> instead?', 'newspack-plugin' ) ) ) );
 		}
 
 		$payload = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug in the modal checkout flow. When entering the checkout flow in an unauthenticated state, it will pop up the auth/register modal to prompt you to sign in or register first, instantiated with config data to ensure that a successful login or registration will seamlessly pass you onto the modal checkout flow. If you attempt to sign in with a non-existent account email from this auth modal, the sign-in flow will throw an error containing a `#register_modal` hash link. If you then click on that link, it will reinstantiate the auth modal, which causes the config data to proceed to the checkout flow to be lost.

### How to test the changes in this Pull Request:

1. On the epic branch, start a checkout from a Donate or Checkout Button block.
2. In the "Sign in to complete transaction" modal, enter an email address not associated with any account and click "Continue" to try logging in. You should get an error like this:

<img width="567" alt="Screenshot 2024-05-23 at 5 01 28 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/3b8f094c-e937-4b4d-9977-63385d533d82">

3. Click "Create an account" from inside the error message (instead of from the button below "Continue") and then click "Continue".
4. Observe that the modal then shows the usual "Success" post-registration message and does not proceed to the modal checkout flow.
5. Check out this branch and repeat in a new session with a new email address. This time, confirm that you are passed onto the checkout flow after registering in step 3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->