### PR TITLE
feat(memberships): remove content restriction handling on the homepage

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -52,6 +52,7 @@ class Memberships {
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
+		add_action( 'wp', [ __CLASS__, 'remove_frontpage_content_restriction' ], 11 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -980,6 +981,20 @@ class Memberships {
 					$reactivated_memberships
 				)
 			);
+		}
+	}
+
+	/**
+	 * Remove content restriction on the front page, to increase performance.
+	 */
+	public static function remove_frontpage_content_restriction() {
+		if ( is_front_page() && function_exists( 'wc_memberships' ) ) {
+			$memberships = wc_memberships();
+			$restrictions_instance = $memberships->get_restrictions_instance();
+			$posts_restrictions_instance = $restrictions_instance->get_posts_restrictions_instance();
+			remove_action( 'the_post', [ $posts_restrictions_instance, 'restrict_post' ], 0 );
+			remove_filter( 'the_content', [ $posts_restrictions_instance, 'handle_restricted_post_content_filtering' ], 999 );
+			remove_action( 'loop_start', [ $posts_restrictions_instance, 'display_restricted_taxonomy_term_notice' ], 1 );
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Running WooCommerce Memeberships' content restriction on the homepage is not a valid use case, but content restriction handling takes a toll on performance. This PR removes handling of content restriction on the homepage.

Code contributed by @claudiulodro 

### How to test the changes in this Pull Request:

1. Set up WP Memberships with content restriction, ensure it functions as expected 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->