### PR TITLE
fix(tracking): handling user role in pixel

### DIFF
--- a/includes/tracking/class-meta-pixel.php
+++ b/includes/tracking/class-meta-pixel.php
@@ -41,7 +41,7 @@ class Meta_Pixel extends Pixel {
 		$current_user = wp_get_current_user();
 		$event_params = [
 			'page_title' => get_the_title(),
-			'user_role'  => empty( $current_user->roles ) ? 'guest' : array_shift( $current_user->roles ),
+			'user_role'  => empty( $current_user->roles ) ? 'guest' : reset( $current_user->roles ),
 			'event_url'  => home_url( $wp->request ),
 		];
 

--- a/includes/tracking/class-meta-pixel.php
+++ b/includes/tracking/class-meta-pixel.php
@@ -24,6 +24,9 @@ class Meta_Pixel extends Pixel {
 	 * Print the pixels' codes.
 	 */
 	public function print_code_snippets() {
+		if ( ! $this->is_configured() ) {
+			return;
+		}
 		add_action( 'wp_head', [ $this, 'print_head_snippet' ], 100 );
 		add_action( 'wp_footer', [ $this, 'print_footer_snippet' ] );
 	}
@@ -38,7 +41,7 @@ class Meta_Pixel extends Pixel {
 		$current_user = wp_get_current_user();
 		$event_params = [
 			'page_title' => get_the_title(),
-			'user_role'  => empty( $current_user->roles ) ? 'guest' : $current_user->roles[0],
+			'user_role'  => empty( $current_user->roles ) ? 'guest' : array_shift( $current_user->roles ),
 			'event_url'  => home_url( $wp->request ),
 		];
 

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -72,12 +72,12 @@ abstract class Pixel {
 	}
 
 	/**
-	 * Checks if option is active
+	 * Checks if pixel should be printed.
 	 *
 	 * @return boolean
 	 */
-	public function is_active() {
-		return $this->get_option()['active'];
+	public function is_configured() {
+		return ! empty( $this->get_pixel_id() );
 	}
 
 	/**
@@ -86,7 +86,7 @@ abstract class Pixel {
 	 * @return string
 	 */
 	public function get_pixel_id() {
-		if ( ! $this->is_active() ) {
+		if ( ! $this->get_option()['active'] ) {
 			return '';
 		}
 		return $this->get_option()['pixel_id'];
@@ -145,14 +145,10 @@ abstract class Pixel {
 	 * @return void
 	 */
 	public function create_js_snippet( $payload ) {
-		if ( $this->is_amp() ) {
+		if ( $this->is_amp() || ! $this->is_configured() ) {
 			return;
 		}
-		$pixel_id = $this->get_pixel_id();
-		if ( empty( $pixel_id ) ) {
-			return;
-		}
-		echo str_replace( '__PIXEL_ID__', $pixel_id, $payload ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo str_replace( '__PIXEL_ID__', $this->get_pixel_id(), $payload ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -162,12 +158,11 @@ abstract class Pixel {
 	 * @return void
 	 */
 	public function create_noscript_snippet( $payload ) {
-		$pixel_id = $this->get_pixel_id();
-		if ( empty( $pixel_id ) ) {
+		if ( ! $this->is_configured() ) {
 			return;
 		}
 		// If AMP plugin is enabled, it will convert the image into a <amp-pixel> tag.
-		echo '<noscript>' . str_replace( '__PIXEL_ID__', $pixel_id, $payload ) . '</noscript>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<noscript>' . str_replace( '__PIXEL_ID__', $this->get_pixel_id(), $payload ) . '</noscript>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with how the user role was retrieved in the pixel tracking code. Also refactors the code to avoid unnecessary code execution.

### How to test the changes in this Pull Request:

1. On `trunk`
1. Create a new account via RAS and visit /my-account page
2. Observe a PHP Warning logged about retrieval of index `0` while there's none*
3. Switch to this branch, observe no issues logged

\* because `$current_user->roles` in `Meta_Pixel->get_event_params` is `[1] => 'subscriber'`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->