### PR TITLE
fix(ras): prevent email address exposure via user login

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1727,9 +1727,7 @@ final class Reader_Activation {
 			return $user_data;
 		}
 
-		$user_login      = str_replace( '+', '_', \sanitize_user( $user_data['user_email'], true ) ); // Matches the email address, but replace + with _ to allow for Gmail aliases.
-		$random_password = \wp_generate_password();
-		$user_nicename   = self::generate_user_nicename( ! empty( $user_data['display_name'] ) ? $user_data['display_name'] : $user_data['user_email'] );
+		$user_nicename = self::generate_user_nicename( ! empty( $user_data['display_name'] ) ? $user_data['display_name'] : $user_data['user_email'] );
 
 		// If we don't have a display name, make it match the nicename.
 		if ( empty( $user_data['display_name'] ) ) {
@@ -1742,7 +1740,7 @@ final class Reader_Activation {
 				'user_login'    => $user_nicename,
 				'user_nicename' => $user_nicename,
 				'display_name'  => $user_nicename,
-				'user_pass'     => $random_password,
+				'user_pass'     => \wp_generate_password(),
 			]
 		);
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1739,8 +1739,9 @@ final class Reader_Activation {
 		$user_data = array_merge(
 			$user_data,
 			[
-				'user_login'    => $user_login,
+				'user_login'    => $user_nicename,
 				'user_nicename' => $user_nicename,
+				'display_name'  => $user_nicename,
 				'user_pass'     => $random_password,
 			]
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the possibility of reader email address exposure through comments. 

### How to test the changes in this Pull Request:

1. On `trunk`,
2. Install and activate `woocommerce-memberships-for-teams` plugin
3. Register using the Registration block
4. Find the new user in WP Admin Users view - observe the "Display name publicly as" field is set to the email address
5. Switch to this branch, repeat, observe the publicly displayed name is set to the part of the email before the `@`


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207301960751638