### PR TITLE
Fix/donation settings vs billing fields

### DIFF
--- a/assets/components/src/section-header/index.js
+++ b/assets/components/src/section-header/index.js
@@ -21,7 +21,7 @@ import classnames from 'classnames';
 const SectionHeader = ( {
 	centered = false,
 	className = null,
-	description,
+	description = '',
 	heading = 2,
 	isWhite = false,
 	noMargin = false,
@@ -56,7 +56,7 @@ const SectionHeader = ( {
 			<Grid columns={ 1 } gutter={ 8 } className={ classes }>
 				{ typeof title === 'string' && <HeadingTag>{ title }</HeadingTag> }
 				{ typeof title === 'function' && <HeadingTag>{ title() }</HeadingTag> }
-				{ typeof description === 'string' && <p>{ description }</p> }
+				{ description && typeof description === 'string' && <p>{ description }</p> }
 				{ typeof description === 'function' && <p>{ description() }</p> }
 			</Grid>
 		</div>

--- a/assets/components/src/wizard/store/index.js
+++ b/assets/components/src/wizard/store/index.js
@@ -59,17 +59,24 @@ const actions = {
 	setError: createAction( 'SET_ERROR' ),
 
 	// Async actions. These will not show up in Redux devtools.
-	*saveWizardSettings( { slug, section = '', payloadPath = false, updatePayload = null } ) {
+	*saveWizardSettings( {
+		slug,
+		section = '',
+		payloadPath = false,
+		auxData = {},
+		updatePayload = null,
+	} ) {
 		// Optionally data can be updated before saving - an immediate update case
 		// (without an explicit "save" action).
 		if ( updatePayload ) {
 			yield actions.updateWizardSettings( { slug, ...updatePayload } );
 		}
 		const wizardState = select( WIZARD_STORE_NAMESPACE ).getWizardAPIData( slug );
+		const data = payloadPath ? get( wizardState, payloadPath ) : wizardState;
 		const updatedData = yield actions.fetchFromAPI( {
 			path: `/newspack/v1/wizard/${ slug }/${ section }`,
 			method: 'POST',
-			data: payloadPath ? get( wizardState, payloadPath ) : wizardState,
+			data: { ...data, ...auxData },
 			isQuietFetch: true,
 		} );
 		if ( ! isEmpty( updatedData ) && ! updatedData.error ) {

--- a/assets/wizards/readerRevenue/components/money-input/style.scss
+++ b/assets/wizards/readerRevenue/components/money-input/style.scss
@@ -44,8 +44,11 @@
 		}
 
 		&-container {
-			p {
-				margin: 0 0 8px;
+			.input-label {
+				font-size: 11px;
+				font-weight: 500;
+				line-height: 1.4;
+				text-transform: uppercase;
 			}
 		}
 

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -10,6 +10,7 @@ import { ToggleControl, CheckboxControl } from '@wordpress/components';
  */
 import { MoneyInput } from '../../components';
 import {
+	ActionCard,
 	Button,
 	Card,
 	Grid,
@@ -78,7 +79,6 @@ type WizardData = {
 
 export const DonationAmounts = () => {
 	const wizardData = Wizard.useWizardData( 'reader-revenue' ) as WizardData;
-
 	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
 
 	if ( ! wizardData.donation_data || 'errors' in wizardData.donation_data ) {
@@ -110,20 +110,20 @@ export const DonationAmounts = () => {
 		<>
 			<Card headerActions noBorder>
 				<SectionHeader
-					title={ __( 'Suggested Donations', 'newspack' ) }
+					title={ __( 'Suggested Donations', 'newspack-plugin' ) }
 					description={ __(
 						'Set suggested donation amounts. These will be the default settings for the Donate block.',
-						'newspack'
+						'newspack-plugin'
 					) }
 					noMargin
 				/>
 				{ canUseNameYourPrice && (
 					<SelectControl
-						label={ __( 'Donation Type', 'newspack' ) }
+						label={ __( 'Donation Type', 'newspack-plugin' ) }
 						onChange={ () => changeHandler( [ 'tiered' ] )( ! tiered ) }
 						buttonOptions={ [
-							{ value: true, label: __( 'Tiered', 'newspack' ) },
-							{ value: false, label: __( 'Untiered', 'newspack' ) },
+							{ value: true, label: __( 'Tiered', 'newspack-plugin' ) },
+							{ value: false, label: __( 'Untiered', 'newspack-plugin' ) },
 						] }
 						buttonSmall
 						value={ tiered }
@@ -132,15 +132,15 @@ export const DonationAmounts = () => {
 				) }
 			</Card>
 			{ tiered ? (
-				<Grid columns={ 1 } gutter={ 16 }>
+				<Grid columns={ 1 }>
 					{ availableFrequencies.map( section => {
 						const isFrequencyDisabled = disabledFrequencies[ section.key ];
 						const isOneFrequencyActive =
 							Object.values( disabledFrequencies ).filter( Boolean ).length ===
 							FREQUENCY_SLUGS.length - 1;
 						return (
-							<Card isMedium key={ section.key }>
-								<Grid columns={ 1 } gutter={ 16 }>
+							<Card noBorder key={ section.key }>
+								<Grid columns={ 1 } gutter={ 8 }>
 									<ToggleControl
 										checked={ ! isFrequencyDisabled }
 										onChange={ () =>
@@ -160,7 +160,7 @@ export const DonationAmounts = () => {
 													amounts[ section.key ][ 0 ] < minimumDonationFloat
 														? __(
 																'Warning: suggested donations should be at least the minimum donation amount.',
-																'newspack'
+																'newspack-plugin'
 														  )
 														: null
 												}
@@ -175,7 +175,7 @@ export const DonationAmounts = () => {
 													amounts[ section.key ][ 1 ] < minimumDonationFloat
 														? __(
 																'Warning: suggested donations should be at least the minimum donation amount.',
-																'newspack'
+																'newspack-plugin'
 														  )
 														: null
 												}
@@ -190,7 +190,7 @@ export const DonationAmounts = () => {
 													amounts[ section.key ][ 2 ] < minimumDonationFloat
 														? __(
 																'Warning: suggested donations should be at least the minimum donation amount.',
-																'newspack'
+																'newspack-plugin'
 														  )
 														: null
 												}
@@ -206,73 +206,70 @@ export const DonationAmounts = () => {
 					} ) }
 				</Grid>
 			) : (
-				<Card isMedium>
-					<Grid columns={ 3 } rowGap={ 16 }>
-						{ availableFrequencies.map( section => {
-							const isFrequencyDisabled = disabledFrequencies[ section.key ];
-							const isOneFrequencyActive =
-								Object.values( disabledFrequencies ).filter( Boolean ).length ===
-								FREQUENCY_SLUGS.length - 1;
-							return (
-								<Grid columns={ 1 } gutter={ 16 } key={ section.key }>
-									<ToggleControl
-										checked={ ! isFrequencyDisabled }
-										onChange={ () =>
-											changeHandler( [ 'disabledFrequencies', section.key ] )(
-												! isFrequencyDisabled
-											)
-										}
-										label={ section.tieredLabel }
-										disabled={ ! isFrequencyDisabled && isOneFrequencyActive }
-									/>
-									{ ! isFrequencyDisabled && (
-										<MoneyInput
-											currencySymbol={ currencySymbol }
-											label={ section.staticLabel }
-											value={ amounts[ section.key ][ 3 ] }
-											min={ minimumDonationFloat }
-											error={
-												amounts[ section.key ][ 3 ] < minimumDonationFloat
-													? __(
-															'Warning: suggested donations should be at least the minimum donation amount.',
-															'newspack'
-													  )
-													: null
+				<Grid columns={ 1 }>
+					<Card noBorder>
+						<Grid columns={ 3 } rowGap={ 16 }>
+							{ availableFrequencies.map( section => {
+								const isFrequencyDisabled = disabledFrequencies[ section.key ];
+								const isOneFrequencyActive =
+									Object.values( disabledFrequencies ).filter( Boolean ).length ===
+									FREQUENCY_SLUGS.length - 1;
+								return (
+									<Grid columns={ 1 } gutter={ 16 } key={ section.key }>
+										<ToggleControl
+											checked={ ! isFrequencyDisabled }
+											onChange={ () =>
+												changeHandler( [ 'disabledFrequencies', section.key ] )(
+													! isFrequencyDisabled
+												)
 											}
-											onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
-											key={ section.key }
+											label={ section.tieredLabel }
+											disabled={ ! isFrequencyDisabled && isOneFrequencyActive }
 										/>
-									) }
-								</Grid>
-							);
-						} ) }
-					</Grid>
-				</Card>
+										{ ! isFrequencyDisabled && (
+											<MoneyInput
+												currencySymbol={ currencySymbol }
+												label={ section.staticLabel }
+												value={ amounts[ section.key ][ 3 ] }
+												min={ minimumDonationFloat }
+												error={
+													amounts[ section.key ][ 3 ] < minimumDonationFloat
+														? __(
+																'Warning: suggested donations should be at least the minimum donation amount.',
+																'newspack-plugin'
+														  )
+														: null
+												}
+												onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
+												key={ section.key }
+											/>
+										) }
+									</Grid>
+								);
+							} ) }
+						</Grid>
+					</Card>
+				</Grid>
 			) }
-			<Card headerActions noBorder>
-				<SectionHeader
-					title={ __( 'Minimum Donation', 'newspack' ) }
-					description={ __(
-						'Set minimum donation amount. Setting a reasonable minimum donation amount can help protect your site from bot attacks.',
-						'newspack'
-					) }
-					noMargin
-				/>
+			<Grid columns={ 3 }>
 				<TextControl
-					label={ __( 'Minimum donation', 'newspack' ) }
+					label={ __( 'Minimum donation', 'newspack-plugin' ) }
+					help={ __(
+						'Set minimum donation amount. Setting a reasonable minimum donation amount can help protect your site from bot attacks.',
+						'newspack-plugin'
+					) }
 					type="number"
 					min={ 1 }
 					value={ minimumDonationFloat }
 					onChange={ ( value: string ) => changeHandler( [ 'minimumDonation' ] )( value ) }
 				/>
-			</Card>
+			</Grid>
 		</>
 	);
 };
 
 const BillingFields = () => {
 	const wizardData = Wizard.useWizardData( 'reader-revenue' ) as WizardData;
-
 	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
 
 	if ( ! wizardData.donation_data || 'errors' in wizardData.donation_data ) {
@@ -299,10 +296,10 @@ const BillingFields = () => {
 		<>
 			<Card noBorder headerActions>
 				<SectionHeader
-					title={ __( 'Billing Fields', 'newspack' ) }
+					title={ __( 'Billing Fields', 'newspack-plugin' ) }
 					description={ __(
-						'Configure which billing fields should be rendered on the donation form.',
-						'newspack'
+						'Configure the billing fields shown in the modal checkout form.',
+						'newspack-plugin'
 					) }
 					noMargin
 				/>
@@ -332,7 +329,6 @@ const BillingFields = () => {
 
 const Donation = () => {
 	const wizardData = Wizard.useWizardData( 'reader-revenue' ) as WizardData;
-
 	const { saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
 	const onSaveDonationSettings = () =>
 		saveWizardSettings( {
@@ -350,50 +346,61 @@ const Donation = () => {
 
 	return (
 		<>
-			{ wizardData.donation_page && (
-				<>
-					<Card noBorder headerActions>
-						<h2>{ __( 'Donations Landing Page', 'newspack' ) }</h2>
-						<Button
-							variant="secondary"
-							isSmall
-							href={ wizardData.donation_page.editUrl }
-							onClick={ undefined }
-						>
-							{ __( 'Edit Page' ) }
-						</Button>
-					</Card>
-					{ 'publish' === wizardData.donation_page.status ? (
-						<Notice
-							isSuccess
-							noticeText={ __(
-								'Your donations landing page is set up and published.',
-								'newspack'
-							) }
-						/>
-					) : (
-						<Notice
-							isError
-							noticeText={ __(
-								"Your donations landing page has been created, but is not yet published. You can now edit it and publish when you're ready.",
-								'newspack'
-							) }
-						/>
-					) }
-				</>
-			) }
-			<DonationAmounts />
-			<div className="newspack-buttons-card">
-				<Button variant="primary" onClick={ onSaveDonationSettings } href={ undefined }>
-					{ __( 'Save Donation Settings' ) }
-				</Button>
-			</div>
-			<BillingFields />
-			<div className="newspack-buttons-card">
-				<Button variant="primary" onClick={ onSaveBillingFields } href={ undefined }>
-					{ __( 'Save Billing Fields' ) }
-				</Button>
-			</div>
+			<ActionCard
+				description={ __( 'Configure options for donations.', 'newspack-plugin' ) }
+				hasGreyHeader={ true }
+				isMedium
+				title={ __( 'Donation Settings', 'newspack-plugin' ) }
+				actionContent={
+					<Button variant="primary" onClick={ onSaveDonationSettings }>
+						{ __( 'Save Donation Settings', 'newspack-plugin' ) }
+					</Button>
+				}
+			>
+				{ wizardData.donation_page && (
+					<>
+						<Card noBorder headerActions>
+							<SectionHeader title={ __( 'Donations Landing Page', 'newspack-plugin' ) } noMargin />
+							<Button
+								variant="secondary"
+								isSmall
+								href={ wizardData.donation_page.editUrl }
+								onClick={ undefined }
+							>
+								{ __( 'Edit Page' ) }
+							</Button>
+						</Card>
+						{ 'publish' === wizardData.donation_page.status ? (
+							<Notice
+								isSuccess
+								noticeText={ __( 'Your donations landing page is published.', 'newspack-plugin' ) }
+							/>
+						) : (
+							<Notice
+								isError
+								noticeText={ __(
+									'Your donations landing page is not yet published.',
+									'newspack-plugin'
+								) }
+							/>
+						) }
+					</>
+				) }
+				<DonationAmounts />
+			</ActionCard>
+			<ActionCard
+				description={ __( 'Configure options for modal checkouts.', 'newspack-plugin' ) }
+				hasGreyHeader={ true }
+				isMedium
+				title={ __( 'Modal Checkout Settings', 'newspack-plugin' ) }
+				actionContent={
+					<Button variant="primary" onClick={ onSaveBillingFields }>
+						{ __( 'Save Modal Checkout Settings', 'newspack-plugin' ) }
+					</Button>
+				}
+			>
+				<BillingFields />
+			</ActionCard>
 		</>
 	);
 };

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -334,7 +334,14 @@ const Donation = () => {
 	const wizardData = Wizard.useWizardData( 'reader-revenue' ) as WizardData;
 
 	const { saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
-	const onSave = () =>
+	const onSaveDonationSettings = () =>
+		saveWizardSettings( {
+			slug: READER_REVENUE_WIZARD_SLUG,
+			section: 'donations',
+			payloadPath: [ 'donation_data' ],
+			auxData: { saveDonationProduct: true },
+		} );
+	const onSaveBillingFields = () =>
 		saveWizardSettings( {
 			slug: READER_REVENUE_WIZARD_SLUG,
 			section: 'donations',
@@ -376,10 +383,15 @@ const Donation = () => {
 				</>
 			) }
 			<DonationAmounts />
+			<div className="newspack-buttons-card">
+				<Button variant="primary" onClick={ onSaveDonationSettings } href={ undefined }>
+					{ __( 'Save Donation Settings' ) }
+				</Button>
+			</div>
 			<BillingFields />
 			<div className="newspack-buttons-card">
-				<Button variant="primary" onClick={ onSave } href={ undefined }>
-					{ __( 'Save Settings' ) }
+				<Button variant="primary" onClick={ onSaveBillingFields } href={ undefined }>
+					{ __( 'Save Billing Fields' ) }
 				</Button>
 			</div>
 		</>

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -363,11 +363,6 @@ class Donations {
 				return $ready;
 			}
 
-			$is_donation_product_valid = self::validate_donation_product();
-			if ( is_wp_error( $is_donation_product_valid ) ) {
-				return $is_donation_product_valid;
-			}
-
 			// Migrate legacy WC settings, stored as product meta.
 			$parent_product = self::get_parent_donation_product();
 			if ( $parent_product ) {
@@ -428,11 +423,6 @@ class Donations {
 			$parsed_settings['amounts'][ $frequency ] = array_map( 'floatval', $amounts );
 		}
 
-		// Ensure a minimum donation amount is set.
-		if ( ! isset( $saved_settings['minimumDonation'] ) && self::is_platform_wc() ) {
-			self::update_donation_product( [ 'minimumDonation' => $settings['minimumDonation'] ] );
-		}
-
 		$parsed_settings['platform']      = self::get_platform_slug();
 		$parsed_settings['billingFields'] = self::get_billing_fields();
 
@@ -460,10 +450,14 @@ class Donations {
 			if ( is_wp_error( $ready ) ) {
 				return $ready;
 			}
-			self::update_donation_product( $configuration );
+			$existing_configuration = self::get_donation_settings();
+
+			if ( isset( $args['saveDonationProduct'] ) && $args['saveDonationProduct'] === true ) {
+				self::update_donation_product( $configuration );
+			}
 
 			// Update the billing fields.
-			$billing_fields = $args['billingFields'];
+			$billing_fields = isset( $args['billingFields'] ) ? $args['billingFields'] : [];
 			if ( ! empty( $billing_fields ) ) {
 				$billing_fields = array_map( 'sanitize_text_field', $billing_fields );
 				self::update_billing_fields( $billing_fields );

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -286,16 +286,15 @@ class Reader_Revenue_Wizard extends Wizard {
 	 * @return WP_REST_Response Boolean success.
 	 */
 	public function api_update( $request ) {
-		$params   = $request->get_params();
-		$platform = $params['platform'];
-		Donations::set_platform_slug( $platform );
+		$params = $request->get_params();
+		Donations::set_platform_slug( $params['platform'] );
 
 		// Update NRH settings.
-		if ( 'nrh' === $platform ) {
+		if ( Donations::is_platform_nrh() ) {
 			NRH::update_settings( $params );
 		}
 
-		// Ensure that any Reader Revenue settings changed while the platform wasn't WC are persisted to WC products .
+		// Ensure that any Reader Revenue settings changed while the platform wasn't WC are persisted to WC products.
 		if ( Donations::is_platform_wc() ) {
 			Donations::update_donation_product( Donations::get_donation_settings() );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In Reader Revenue Wizard, saving the donation settings updates the donation products. However, if a user does not wish to use the products, but wants to update the "Billing Fields" section, they'll get the donation products anyway. This PR fixes it so that donation settings and billing fields are in separate sections:

| Before | After | 
|--------------|-----------|
| <img width="940" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/266806c0-17af-46de-b353-417cecf8ba67"> | <img width="962" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/47b8ee12-33e5-43af-a69e-ab24114905fb"> |

@Automattic/newspack-design – since this UI is in the process of getting an overhaul, I'm not sure if much design attention is needed here. Please advise.

### How to test the changes in this Pull Request:

1. On `trunk`
1. Set up a site with Newspack as the RR platform
2. Remove the WC donation products
3. Update "Billing Fields" section and save the settings – observe the donation products have been restored
4. Switch to this branch, delete the products again, update "Billing Fields" section and observe the products have not been restored
5. Update the donation settings section, observe the products have been restored

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207128165866630