### PR TITLE
fix(ras-setup): redirect to init screen after setup

### DIFF
--- a/assets/wizards/engagement/views/reader-activation/complete.js
+++ b/assets/wizards/engagement/views/reader-activation/complete.js
@@ -44,13 +44,11 @@ const listItems = [
 	},
 ];
 
-const activationSteps = [
-	__( 'Setting up new segments…', 'newspack-plugin' ),
-	__( 'Activating reader registration…', 'newspack-plugin' ),
-	__( 'Activating Reader Activation Campaign…', 'newspack-plugin' ),
-];
-
-const activationStepsCount = activationSteps.length;
+const DEFAULT_ACTIVATION_STEPS = {
+	campaignsSegments: __( 'Setting up new segments…', 'newspack-plugin' ),
+	readerRegistration: __( 'Activating reader registration…', 'newspack-plugin' ),
+	campaignsPrompts: __( 'Activating Reader Activation Campaign…', 'newspack-plugin' ),
+};
 
 /**
  * Get a random number between min and max.
@@ -70,15 +68,17 @@ export default withWizardScreen( () => {
 	const [ progressLabel, setProgressLabel ] = useState( false );
 	const [ completed, setCompleted ] = useState( false );
 	const timer = useRef();
+	const [ activationSteps, setActivationSteps ] = useState(
+		Object.values( DEFAULT_ACTIVATION_STEPS )
+	);
 	const { reader_activation_url, is_skipped_campaign_setup = '' } = newspack_engagement_wizard;
 	const isSkippedCampaignSetup = is_skipped_campaign_setup === '1';
 
-	/**
-	 * If skipped, remove first item.
-	 */
-	if ( isSkippedCampaignSetup && activationSteps.length !== activationStepsCount - 1 ) {
-		activationSteps.shift();
-	}
+	useEffect( () => {
+		if ( isSkippedCampaignSetup ) {
+			setActivationSteps( [ DEFAULT_ACTIVATION_STEPS.readerRegistration ] );
+		}
+	}, [ isSkippedCampaignSetup ] );
 
 	/**
 	 * Generate step list strings
@@ -107,12 +107,12 @@ export default withWizardScreen( () => {
 				setProgress( _progress => _progress + 1 );
 			}, generateRandomNumber( 1000, 2000 ) );
 		}
-		if ( progress === activationSteps.length && completed ) {
+		if ( progress >= activationSteps.length && completed ) {
 			setProgress( activationSteps.length + 1 ); // Plus one to account for the "Done!" step.
 			setProgressLabel( __( 'Done!', 'newspack-plugin' ) );
 			setTimeout( () => {
 				setInFlight( false );
-				// window.location = reader_activation_url;
+				window.location = reader_activation_url;
 			}, 3000 );
 		}
 	}, [ completed, progress ] );

--- a/assets/wizards/engagement/views/reader-activation/complete.js
+++ b/assets/wizards/engagement/views/reader-activation/complete.js
@@ -112,7 +112,7 @@ export default withWizardScreen( () => {
 			setProgressLabel( __( 'Done!', 'newspack-plugin' ) );
 			setTimeout( () => {
 				setInFlight( false );
-				window.location = reader_activation_url;
+				window.location.replace( reader_activation_url );
 			}, 3000 );
 		}
 	}, [ completed, progress ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In RAS setup, skipping the Campaigns (#3051) does not redirect to the initial screen after setup is complete, and displays activation steps erroneously. This PR fixes that.

### How to test the changes in this Pull Request:

1. On `trunk`
1. Walk through the RAS setup step-by-step
1. Skip the last step, setting up the Campaign.
1. Click Enable Reader Activation
1. Notice that the page refreshes but nothing changes
1. Click the Reader Activation tab and see that Reader Activation is enabled. 
2. Switch to this branch, repeat*, observe the setup completion redirects to the Engagement Wizard -> Reader Activation

\* Reset by running `wp option delete newspack_reader_activation_enabled newspack_popups_ras_prompts_last_updated _newspack_ras_skip_campaign_setup`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207381872737380