### PR TITLE
fix(reader-revenue): prevent sending duplicate receipt emails

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -530,6 +530,9 @@ class WooCommerce_Connection {
 		if ( ! is_a( $order, 'WC_Order' ) || ! Emails::can_send_email( Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'] ) ) {
 			return $enable;
 		}
+		if ( $order->get_meta( '_newspack_receipt_email_sent', true ) ) {
+			return $enable;
+		}
 
 		$frequencies = [
 			'month' => __( 'Monthly', 'newspack-plugin' ),
@@ -591,8 +594,11 @@ class WooCommerce_Connection {
 			$order->get_billing_email(),
 			$placeholders
 		);
-
-		return false;
+		if ( $sent ) {
+			$order->add_meta_data( '_newspack_receipt_email_sent', true, true );
+			return false;
+		}
+		return $enable;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Disabled a possibility of sending a custom receipt email more than once. 

### How to test the changes in this Pull Request:

1. On `trunk`,
2. Make a recurring donation and note the order ID
3. Observe the custom receipt email is sent
4. Open `wp shell` and proceed with the following:
    - `$em = new \WC_Email_Customer_Completed_Order()`
    - `$em->object = wc_get_order(<order-id-here>)`
    - `$em->is_enabled()`
5. You should now get a duplicate custom receipt email
6. Switch to this branch, repeat, observe the duplicate email cannot be sent 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205840492953313