### PR TITLE
fix(newsletters): missing UTM params passing

### DIFF
--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -279,7 +279,7 @@ class Newspack_Newsletters {
 						if ( 'utm' === substr( $param, 0, 3 ) ) {
 							$param = str_replace( 'utm_', '', $param );
 							$key   = self::get_metadata_key( $utm_key_prefix ) . $param;
-							if ( ! isset( $contact['metadata'][ $key ] ) ) {
+							if ( ! isset( $contact['metadata'][ $key ] ) || empty( $contact['metadata'][ $key ] ) ) {
 								$contact['metadata'][ $key ] = $value;
 							}
 						}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes missing (if using Apple Pay at least) UTM params when passing data to ESP. 

### How to test the changes in this Pull Request:

1. On `trunk`, set up WooCommerce Stripe Gateway with "Express checkouts" (`/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`)
2. Ensure AC is connected as the ESP, and "Sync contacts to ESP" settings enabled and configured in Enagement Wizard -> Reader Activation -> Advanced Settings
3. Make a donation using Apple Pay*, from a URL with UTM params (e.g. `?utm_source=website&utm_medium=homepage&utm_campaign=header`)
4. Observe the synced contact in AC does not have `NP_Payment UTM: <param-name>` meta fields set
5. Switch to this branch, repeat the test, observe that after the donation the UTM param metadata is passed to AC

\* Safari browser on an Apple device is required to make the Apple Pay link show up (BrowserStack can be used, too) 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206857261405656