### PR TITLE
Feat/rss vs wc memberships

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -47,6 +47,7 @@ class Memberships {
 		add_filter( 'wc_memberships_notice_html', [ __CLASS__, 'wc_memberships_notice_html' ], 100, 4 );
 		add_filter( 'wc_memberships_restricted_content_excerpt', [ __CLASS__, 'wc_memberships_excerpt' ], 100, 3 );
 		add_filter( 'wc_memberships_message_excerpt_apply_the_content_filter', '__return_false' );
+		add_filter( 'wc_memberships_admin_screen_ids', [ __CLASS__, 'admin_screens' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
 		add_action( 'wp_footer', [ __CLASS__, 'render_js' ] );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
@@ -996,6 +997,30 @@ class Memberships {
 			remove_filter( 'the_content', [ $posts_restrictions_instance, 'handle_restricted_post_content_filtering' ], 999 );
 			remove_action( 'loop_start', [ $posts_restrictions_instance, 'display_restricted_taxonomy_term_notice' ], 1 );
 		}
+	}
+
+	/**
+	 * Admin meta boxes handling.
+	 *
+	 * @param array $screen_ids associative array organized by context.
+	 */
+	public static function admin_screens( $screen_ids ) {
+		$unrestrictable_post_types = [ 'partner_rss_feed' ];
+		$screen_ids['meta_boxes'] = array_filter(
+			$screen_ids['meta_boxes'],
+			function( $screen_id ) use ( $unrestrictable_post_types ) {
+				$allow_restrictions = true;
+				foreach ( $unrestrictable_post_types as $post_type ) {
+					// Use strpos instead of full string match, because each CPT get two items in this array:
+					// the `<CPT>` and `edit-<CPT>`.
+					if ( strpos( $screen_id, $post_type ) !== false ) {
+						$allow_restrictions = false;
+					}
+				}
+				return $allow_restrictions;
+			}
+		);
+		return $screen_ids;
 	}
 }
 Memberships::init();

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -1049,7 +1049,7 @@ class Memberships {
 			'id'      => self::SKIP_RESTRICTION_IN_RSS_OPTION_NAME,
 			'name'    => __( 'Skip content restriction in RSS feeds', 'newspack-plugin' ),
 			'desc'    =>
-				'<span class="show-if-hide-content-only-restriction-mode">' . __( 'If enabled, full content will be availabe in RSS feeds.', 'newspack-plugin' ) . '</span>',
+				'<span class="show-if-hide-content-only-restriction-mode">' . __( 'If enabled, full content will be available in RSS feeds.', 'newspack-plugin' ) . '</span>',
 			'default' => 'no',
 		];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds an option to skip WC Memberships' content restrictions in RSS feeds. This is needed for publication which want to restrict content on the website, but still distribute it in news aggregation services.

Also, removes the WC Memberships meta box while editing an RSS feed, to avoid confusion.

### How to test the changes in this Pull Request:

1. Set up a WC Memberships plan with content restriction*
2. Visit the `/feed`, observe that not whole post content is sent in the payload 
3. Go to WooCommerce -> Settings -> Memberships and enable the "Skip content restriction in RSS feeds" setting
4. Refresh the feed, observe the full post content is available
5. Enable the RSS module by running `wp eval "\Newspack\Settings::activate_optional_module('rss');"`
6. Create or edit an RSS feed, observe there's no WP Membership meta box

\* restrict all posts for ease of testing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205279243070215