### PR TITLE
Expand memberships performance tweaks to archives

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -52,7 +52,7 @@ class Memberships {
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
-		add_action( 'wp', [ __CLASS__, 'remove_frontpage_content_restriction' ], 11 );
+		add_action( 'wp', [ __CLASS__, 'remove_unnecessary_content_restriction' ], 11 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -985,10 +985,11 @@ class Memberships {
 	}
 
 	/**
-	 * Remove content restriction on the front page, to increase performance.
+	 * Remove content restriction on the front page and archives, to increase performance.
+	 * The only thing Memberships would really do on these pages is add a "You need a membership"-type message in excerpts.
 	 */
-	public static function remove_frontpage_content_restriction() {
-		if ( is_front_page() && function_exists( 'wc_memberships' ) ) {
+	public static function remove_unnecessary_content_restriction() {
+		if ( ( is_front_page() || is_archive() ) && function_exists( 'wc_memberships' ) ) {
 			$memberships = wc_memberships();
 			$restrictions_instance = $memberships->get_restrictions_instance();
 			$posts_restrictions_instance = $restrictions_instance->get_posts_restrictions_instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Expands the performance improvements from https://github.com/Automattic/newspack-plugin/pull/3136 to also work on archives. Memberships doesn't really do anything useful on archives except possibly display a "You need to purchase a membership to view this" message at the excerpt of some posts.

### How to test the changes in this Pull Request:

1. Have a site with Memberships set up. Visit a category/tag/author archive. Ensure things continue functioning as normal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->