### PR TITLE
fix(ras-acc): fix focus, Google button styles

### DIFF
--- a/assets/newspack-ui/scss/elements/forms/_checkbox-radio.scss
+++ b/assets/newspack-ui/scss/elements/forms/_checkbox-radio.scss
@@ -26,6 +26,10 @@
 			}
 		}
 
+		&:focus {
+			outline: unset;
+		}
+
 		&:focus-visible {
 			outline: 2px solid var( --newspack-ui-color-neutral-90 );
 			outline-offset: 1px;

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1424,12 +1424,14 @@ final class Reader_Activation {
 			return;
 		}
 		?>
-		<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary newspack-ui__button--google-oauth">
-			<?php \Newspack\Newspack_UI_Icons::print_svg( 'google' ); ?>
-			<?php echo \esc_html__( 'Sign in with Google', 'newspack-plugin' ); ?>
-		</button>
-		<div class="newspack-ui__word-divider">
-			<?php echo \esc_html__( 'Or', 'newspack-plugin' ); ?>
+		<div class="newspack-ui">
+			<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary newspack-ui__button--google-oauth">
+				<?php \Newspack\Newspack_UI_Icons::print_svg( 'google' ); ?>
+				<?php echo \esc_html__( 'Sign in with Google', 'newspack-plugin' ); ?>
+			</button>
+			<div class="newspack-ui__word-divider">
+				<?php echo \esc_html__( 'Or', 'newspack-plugin' ); ?>
+			</div>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a couple smaller display issues I noticed while working on RAS-ACC:

* It fixes the checkbox/radio button focus style, which was getting overridden by the theme.
* It fixes the Google button in the registration block, which I broke by making the Newspack UI button styles more specific 😅 

See: 1205234045751551-as-1207417756735456 and 1205234045751551-as-1207417756735446

### How to test the changes in this Pull Request:

_To test, you need to be on a test site with Google OAuth set up._ 

1. If not already, navigate to Customizer > Colors, and set your colours to a non-default colour -- ideally something bright but darker so it's not switched to grey by the theme's contrast logic. 
2. Edit a page, and add the reader registration block; publish and append the `?ui-demo` query string at the end of the URL.
3. Check the registration block and note the funky appearance of the Google button; the size will be all wrong and it will be using the site's secondary colour:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/343d221f-259f-4e4b-844a-79d89497b18e)

4. Navigate down to the checkboxes and click them to see the focus style - rather than using the dark grey from Newspack UI, it'll use the theme's secondary colour:

<img width="432" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/177561/d86ff7c6-44b9-441d-84db-0aa4ef707075">

5. Apply this PR and run `npm run build`.
6. Confirm that the Google button in the reader registration block is full width and light grey:

![image](https://github.com/Automattic/newspack-plugin/assets/177561/d7897d98-52d7-469f-bfc1-153ff12b0b8a)

7. Confirm that the 'focus' style isn't applied when the checkboxes are clicked, but it is applied when you tab-focus on them. The focus style should be 2px and black; when the checkbox is selected it should have a slight gap between the outline and the background, but when they're not it should be right on the line:

<img width="436" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/177561/aadc00c1-8828-4783-9542-f088df257131">

<img width="423" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/177561/c8497100-7c37-4d7d-8466-45c34151d671">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->