### PR TITLE
refactor: slightly update UI for donation + billing field settings page

### DIFF
--- a/assets/components/src/section-header/index.js
+++ b/assets/components/src/section-header/index.js
@@ -21,7 +21,7 @@ import classnames from 'classnames';
 const SectionHeader = ( {
 	centered = false,
 	className = null,
-	description,
+	description = '',
 	heading = 2,
 	isWhite = false,
 	noMargin = false,
@@ -56,7 +56,7 @@ const SectionHeader = ( {
 			<Grid columns={ 1 } gutter={ 8 } className={ classes }>
 				{ typeof title === 'string' && <HeadingTag>{ title }</HeadingTag> }
 				{ typeof title === 'function' && <HeadingTag>{ title() }</HeadingTag> }
-				{ typeof description === 'string' && <p>{ description }</p> }
+				{ description && typeof description === 'string' && <p>{ description }</p> }
 				{ typeof description === 'function' && <p>{ description() }</p> }
 			</Grid>
 		</div>

--- a/assets/wizards/readerRevenue/components/money-input/style.scss
+++ b/assets/wizards/readerRevenue/components/money-input/style.scss
@@ -44,8 +44,11 @@
 		}
 
 		&-container {
-			p {
-				margin: 0 0 8px;
+			.input-label {
+				font-size: 11px;
+				font-weight: 500;
+				line-height: 1.4;
+				text-transform: uppercase;
 			}
 		}
 

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -10,6 +10,7 @@ import { ToggleControl, CheckboxControl } from '@wordpress/components';
  */
 import { MoneyInput } from '../../components';
 import {
+	ActionCard,
 	Button,
 	Card,
 	Grid,
@@ -78,7 +79,6 @@ type WizardData = {
 
 export const DonationAmounts = () => {
 	const wizardData = Wizard.useWizardData( 'reader-revenue' ) as WizardData;
-
 	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
 
 	if ( ! wizardData.donation_data || 'errors' in wizardData.donation_data ) {
@@ -110,20 +110,20 @@ export const DonationAmounts = () => {
 		<>
 			<Card headerActions noBorder>
 				<SectionHeader
-					title={ __( 'Suggested Donations', 'newspack' ) }
+					title={ __( 'Suggested Donations', 'newspack-plugin' ) }
 					description={ __(
 						'Set suggested donation amounts. These will be the default settings for the Donate block.',
-						'newspack'
+						'newspack-plugin'
 					) }
 					noMargin
 				/>
 				{ canUseNameYourPrice && (
 					<SelectControl
-						label={ __( 'Donation Type', 'newspack' ) }
+						label={ __( 'Donation Type', 'newspack-plugin' ) }
 						onChange={ () => changeHandler( [ 'tiered' ] )( ! tiered ) }
 						buttonOptions={ [
-							{ value: true, label: __( 'Tiered', 'newspack' ) },
-							{ value: false, label: __( 'Untiered', 'newspack' ) },
+							{ value: true, label: __( 'Tiered', 'newspack-plugin' ) },
+							{ value: false, label: __( 'Untiered', 'newspack-plugin' ) },
 						] }
 						buttonSmall
 						value={ tiered }
@@ -160,7 +160,7 @@ export const DonationAmounts = () => {
 													amounts[ section.key ][ 0 ] < minimumDonationFloat
 														? __(
 																'Warning: suggested donations should be at least the minimum donation amount.',
-																'newspack'
+																'newspack-plugin'
 														  )
 														: null
 												}
@@ -175,7 +175,7 @@ export const DonationAmounts = () => {
 													amounts[ section.key ][ 1 ] < minimumDonationFloat
 														? __(
 																'Warning: suggested donations should be at least the minimum donation amount.',
-																'newspack'
+																'newspack-plugin'
 														  )
 														: null
 												}
@@ -190,7 +190,7 @@ export const DonationAmounts = () => {
 													amounts[ section.key ][ 2 ] < minimumDonationFloat
 														? __(
 																'Warning: suggested donations should be at least the minimum donation amount.',
-																'newspack'
+																'newspack-plugin'
 														  )
 														: null
 												}
@@ -235,7 +235,7 @@ export const DonationAmounts = () => {
 												amounts[ section.key ][ 3 ] < minimumDonationFloat
 													? __(
 															'Warning: suggested donations should be at least the minimum donation amount.',
-															'newspack'
+															'newspack-plugin'
 													  )
 													: null
 											}
@@ -249,30 +249,25 @@ export const DonationAmounts = () => {
 					</Grid>
 				</Card>
 			) }
-			<Card headerActions noBorder>
-				<SectionHeader
-					title={ __( 'Minimum Donation', 'newspack' ) }
-					description={ __(
-						'Set minimum donation amount. Setting a reasonable minimum donation amount can help protect your site from bot attacks.',
-						'newspack'
-					) }
-					noMargin
-				/>
+			<Grid columns={ 2 } rowGap={ 16 }>
 				<TextControl
-					label={ __( 'Minimum donation', 'newspack' ) }
+					label={ __( 'Minimum donation', 'newspack-plugin' ) }
+					help={ __(
+						'Set minimum donation amount. Setting a reasonable minimum donation amount can help protect your site from bot attacks.',
+						'newspack-plugin'
+					) }
 					type="number"
 					min={ 1 }
 					value={ minimumDonationFloat }
 					onChange={ ( value: string ) => changeHandler( [ 'minimumDonation' ] )( value ) }
 				/>
-			</Card>
+			</Grid>
 		</>
 	);
 };
 
 const BillingFields = () => {
 	const wizardData = Wizard.useWizardData( 'reader-revenue' ) as WizardData;
-
 	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
 
 	if ( ! wizardData.donation_data || 'errors' in wizardData.donation_data ) {
@@ -299,10 +294,10 @@ const BillingFields = () => {
 		<>
 			<Card noBorder headerActions>
 				<SectionHeader
-					title={ __( 'Billing Fields', 'newspack' ) }
+					title={ __( 'Billing Fields', 'newspack-plugin' ) }
 					description={ __(
-						'Configure which billing fields should be rendered on the donation form.',
-						'newspack'
+						'Configure the billing fields shown in the modal checkout form.',
+						'newspack-plugin'
 					) }
 					noMargin
 				/>
@@ -332,7 +327,6 @@ const BillingFields = () => {
 
 const Donation = () => {
 	const wizardData = Wizard.useWizardData( 'reader-revenue' ) as WizardData;
-
 	const { saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
 	const onSaveDonationSettings = () =>
 		saveWizardSettings( {
@@ -350,50 +344,61 @@ const Donation = () => {
 
 	return (
 		<>
-			{ wizardData.donation_page && (
-				<>
-					<Card noBorder headerActions>
-						<h2>{ __( 'Donations Landing Page', 'newspack' ) }</h2>
-						<Button
-							variant="secondary"
-							isSmall
-							href={ wizardData.donation_page.editUrl }
-							onClick={ undefined }
-						>
-							{ __( 'Edit Page' ) }
-						</Button>
-					</Card>
-					{ 'publish' === wizardData.donation_page.status ? (
-						<Notice
-							isSuccess
-							noticeText={ __(
-								'Your donations landing page is set up and published.',
-								'newspack'
-							) }
-						/>
-					) : (
-						<Notice
-							isError
-							noticeText={ __(
-								"Your donations landing page has been created, but is not yet published. You can now edit it and publish when you're ready.",
-								'newspack'
-							) }
-						/>
-					) }
-				</>
-			) }
-			<DonationAmounts />
-			<div className="newspack-buttons-card">
-				<Button variant="primary" onClick={ onSaveDonationSettings } href={ undefined }>
-					{ __( 'Save Donation Settings' ) }
-				</Button>
-			</div>
-			<BillingFields />
-			<div className="newspack-buttons-card">
-				<Button variant="primary" onClick={ onSaveBillingFields } href={ undefined }>
-					{ __( 'Save Billing Fields' ) }
-				</Button>
-			</div>
+			<ActionCard
+				description={ __( 'Configure options for donations.', 'newspack-plugin' ) }
+				hasGreyHeader={ true }
+				isMedium
+				title={ __( 'Donation Settings', 'newspack-plugin' ) }
+				actionContent={
+					<Button variant="primary" onClick={ onSaveDonationSettings }>
+						{ __( 'Save Donation Settings', 'newspack-plugin' ) }
+					</Button>
+				}
+			>
+				{ wizardData.donation_page && (
+					<>
+						<Card noBorder headerActions>
+							<SectionHeader title={ __( 'Donations Landing Page', 'newspack-plugin' ) } noMargin />
+							<Button
+								variant="secondary"
+								isSmall
+								href={ wizardData.donation_page.editUrl }
+								onClick={ undefined }
+							>
+								{ __( 'Edit Page' ) }
+							</Button>
+						</Card>
+						{ 'publish' === wizardData.donation_page.status ? (
+							<Notice
+								isSuccess
+								noticeText={ __( 'Your donations landing page is published.', 'newspack-plugin' ) }
+							/>
+						) : (
+							<Notice
+								isError
+								noticeText={ __(
+									'Your donations landing page is not yet published.',
+									'newspack-plugin'
+								) }
+							/>
+						) }
+					</>
+				) }
+				<DonationAmounts />
+			</ActionCard>
+			<ActionCard
+				description={ __( 'Configure options for modal checkouts.', 'newspack-plugin' ) }
+				hasGreyHeader={ true }
+				isMedium
+				title={ __( 'Modal Checkout Settings', 'newspack-plugin' ) }
+				actionContent={
+					<Button variant="primary" onClick={ onSaveBillingFields }>
+						{ __( 'Save Modal Checkout Settings', 'newspack-plugin' ) }
+					</Button>
+				}
+			>
+				<BillingFields />
+			</ActionCard>
 		</>
 	);
 };

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -237,7 +237,7 @@ export const DonationAmounts = () => {
 														? __(
 																'Warning: suggested donations should be at least the minimum donation amount.',
 																'newspack-plugin'
-														)
+														  )
 														: null
 												}
 												onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }

--- a/assets/wizards/readerRevenue/views/donation/index.tsx
+++ b/assets/wizards/readerRevenue/views/donation/index.tsx
@@ -132,15 +132,15 @@ export const DonationAmounts = () => {
 				) }
 			</Card>
 			{ tiered ? (
-				<Grid columns={ 1 } gutter={ 16 }>
+				<Grid columns={ 1 }>
 					{ availableFrequencies.map( section => {
 						const isFrequencyDisabled = disabledFrequencies[ section.key ];
 						const isOneFrequencyActive =
 							Object.values( disabledFrequencies ).filter( Boolean ).length ===
 							FREQUENCY_SLUGS.length - 1;
 						return (
-							<Card isMedium key={ section.key }>
-								<Grid columns={ 1 } gutter={ 16 }>
+							<Card noBorder key={ section.key }>
+								<Grid columns={ 1 } gutter={ 8 }>
 									<ToggleControl
 										checked={ ! isFrequencyDisabled }
 										onChange={ () =>
@@ -206,50 +206,52 @@ export const DonationAmounts = () => {
 					} ) }
 				</Grid>
 			) : (
-				<Card isMedium>
-					<Grid columns={ 3 } rowGap={ 16 }>
-						{ availableFrequencies.map( section => {
-							const isFrequencyDisabled = disabledFrequencies[ section.key ];
-							const isOneFrequencyActive =
-								Object.values( disabledFrequencies ).filter( Boolean ).length ===
-								FREQUENCY_SLUGS.length - 1;
-							return (
-								<Grid columns={ 1 } gutter={ 16 } key={ section.key }>
-									<ToggleControl
-										checked={ ! isFrequencyDisabled }
-										onChange={ () =>
-											changeHandler( [ 'disabledFrequencies', section.key ] )(
-												! isFrequencyDisabled
-											)
-										}
-										label={ section.tieredLabel }
-										disabled={ ! isFrequencyDisabled && isOneFrequencyActive }
-									/>
-									{ ! isFrequencyDisabled && (
-										<MoneyInput
-											currencySymbol={ currencySymbol }
-											label={ section.staticLabel }
-											value={ amounts[ section.key ][ 3 ] }
-											min={ minimumDonationFloat }
-											error={
-												amounts[ section.key ][ 3 ] < minimumDonationFloat
-													? __(
-															'Warning: suggested donations should be at least the minimum donation amount.',
-															'newspack-plugin'
-													  )
-													: null
+				<Grid columns={ 1 }>
+					<Card noBorder>
+						<Grid columns={ 3 } rowGap={ 16 }>
+							{ availableFrequencies.map( section => {
+								const isFrequencyDisabled = disabledFrequencies[ section.key ];
+								const isOneFrequencyActive =
+									Object.values( disabledFrequencies ).filter( Boolean ).length ===
+									FREQUENCY_SLUGS.length - 1;
+								return (
+									<Grid columns={ 1 } gutter={ 16 } key={ section.key }>
+										<ToggleControl
+											checked={ ! isFrequencyDisabled }
+											onChange={ () =>
+												changeHandler( [ 'disabledFrequencies', section.key ] )(
+													! isFrequencyDisabled
+												)
 											}
-											onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
-											key={ section.key }
+											label={ section.tieredLabel }
+											disabled={ ! isFrequencyDisabled && isOneFrequencyActive }
 										/>
-									) }
-								</Grid>
-							);
-						} ) }
-					</Grid>
-				</Card>
+										{ ! isFrequencyDisabled && (
+											<MoneyInput
+												currencySymbol={ currencySymbol }
+												label={ section.staticLabel }
+												value={ amounts[ section.key ][ 3 ] }
+												min={ minimumDonationFloat }
+												error={
+													amounts[ section.key ][ 3 ] < minimumDonationFloat
+														? __(
+																'Warning: suggested donations should be at least the minimum donation amount.',
+																'newspack-plugin'
+														)
+														: null
+												}
+												onChange={ changeHandler( [ 'amounts', section.key, 3 ] ) }
+												key={ section.key }
+											/>
+										) }
+									</Grid>
+								);
+							} ) }
+						</Grid>
+					</Card>
+				</Grid>
 			) }
-			<Grid columns={ 2 } rowGap={ 16 }>
+			<Grid columns={ 3 }>
 				<TextControl
 					label={ __( 'Minimum donation', 'newspack-plugin' ) }
 					help={ __(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3140 splits the Donation settings page into two separate sections. This proposal slightly updates the UI to visually emphasize the separation, and clarifies that the billing fields configuration affects _all modal checkouts_ (not just donations).

### How to test the changes in this Pull Request:

Visit **Newspack > Reader Revenue > Donations** to see the new UI, and follow testing steps from #3140.

<img width="1100" alt="Screenshot 2024-05-31 at 12 02 35 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/ae30857f-c579-43a1-9016-f7a847110571">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->