### PR TITLE
Load optional modules after settings to fix fatal errors

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -115,9 +115,6 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/revisions-control/class-revisions-control.php';
 		include_once NEWSPACK_ABSPATH . 'includes/authors/class-authors-custom-fields.php';
 
-		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-rss.php';
-		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-media-partners.php';
-
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-provider.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-generated.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-wordpress.php';
@@ -166,6 +163,9 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
 		include_once NEWSPACK_ABSPATH . 'includes/polyfills/class-amp-polyfills.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-performance.php';
+
+		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-rss.php';
+		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-media-partners.php';
 
 		if ( Donations::is_platform_nrh() ) {
 			include_once NEWSPACK_ABSPATH . 'includes/class-nrh.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes a small issue that I keep running into and has been bugging me :) When you try and run a CLI command while in the directory of most of our plugins, a fatal error is thrown. This is because the optional modules use the Settings class, but the file for that class isn't loaded until after the optional modules file is loaded. This PR tweaks the file include order to fix this problem.


### How to test the changes in this Pull Request:

1. Before applying this patch, have Newspack Plugin and Newspack Blocks active.
2. SSH into your site. `cd newspack-blocks` then try any WP CLI command while in that directory e.g. `wp plugin list`. Observe you get:
```
Error: There has been a critical error on this website.Learn more about troubleshooting WordPress. There has been a critical error on this website.
```
With this stack trace:
```
[04-Jun-2024 15:20:07 UTC] PHP Fatal error:  Uncaught Error: Class 'Newspack\Settings' not found in /newspackdev/app/public/wp-content/plugins/newspack-plugin/includes/optional-modules/class-rss.php:24
Stack trace:
#0 /newspackdev/app/public/wp-content/plugins/newspack-plugin/includes/optional-modules/class-rss.php(731): Newspack\RSS::init()
...
```
3. `cd` to the `wp-content` directory. Try a CLI command again. It should work fine.
4. Apply this patch. `cd newspack-blocks`. Try a CLI command again. It should work fine.
5. Navigate to Syndication settings. Enable RSS Enhancements. Verify RSS Enhancements still works fine.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->