### PR TITLE
fix(ia): Settings / Connections - Legacy Wizard

### DIFF
--- a/assets/wizards/index.tsx
+++ b/assets/wizards/index.tsx
@@ -23,6 +23,8 @@ import '../shared/js/public-path';
 const pageParam = new URLSearchParams( window.location.search ).get( 'page' ) ?? '';
 const rootElement = document.getElementById( pageParam );
 
+const ALLOWED_PAGES = [ 'newspack-dashboard', 'newspack-settings' ];
+
 const components: Record< string, any > = {
 	/**
 	 * `page` param with `newspack-*`.
@@ -38,10 +40,6 @@ const components: Record< string, any > = {
 		component: lazy(
 			() => import( /* webpackChunkName: "newspack-wizards" */ './newspack/views/settings' )
 		),
-	},
-	default: {
-		label: __( 'Error: Not Found!', 'newspack-plugin' ),
-		component: <h2>Not Found: { pageParam }</h2>,
 	},
 } as const;
 
@@ -65,20 +63,16 @@ const AdminPageLoader = ( { label }: { label: string } ) => {
 };
 
 const AdminPages = () => {
-	const PageComponent = components[ pageParam ].component ?? components.default.component;
+	const PageComponent = components[ pageParam ].component;
 	return (
-		<Suspense
-			fallback={
-				<AdminPageLoader label={ components[ pageParam ].label ?? components.default.label } />
-			}
-		>
+		<Suspense fallback={ <AdminPageLoader label={ components[ pageParam ].label } /> }>
 			<PageComponent />
 		</Suspense>
 	);
 };
 
-if ( rootElement ) {
+if ( rootElement && ALLOWED_PAGES.includes( pageParam ) ) {
 	render( <AdminPages />, rootElement );
 } else {
-	console.error( `rootElement (${ pageParam }) not found!` );
+	console.error( `${ pageParam } not found!` );
 }

--- a/includes/wizards/class-newspack-dashboard.php
+++ b/includes/wizards/class-newspack-dashboard.php
@@ -346,11 +346,10 @@ class Newspack_Dashboard extends Wizard {
 		 * JavaScript
 		 */
 		wp_localize_script(
-			$this->slug, 
+			'newspack-wizards', 
 			'newspackDashboard',
 			$this->get_local_data()
 		);
-		wp_enqueue_script( $this->slug );
-		wp_style_add_data( $this->slug, 'rtl', 'replace' );
+		wp_enqueue_script( 'newspack-wizards' );
 	}
 }

--- a/includes/wizards/class-newspack-settings.php
+++ b/includes/wizards/class-newspack-settings.php
@@ -115,10 +115,10 @@ class Newspack_Settings extends Wizard {
 		 * JavaScript
 		 */
 		wp_localize_script(
-			$this->slug, 
+			'newspack-wizards', 
 			'newspackSettings',
 			$this->get_local_data()
 		);
-		wp_enqueue_script( $this->slug );
+		wp_enqueue_script( 'newspack-wizards' );
 	}
 }

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -150,7 +150,7 @@ abstract class Wizard {
 		 */
 		$asset_file = include plugin_dir_path( __FILE__ ) . 'build/wizards.asset.php';
 		wp_register_script(
-			$this->slug,
+			'newspack-wizards',
 			Newspack::plugin_url() . '/dist/wizards.js',
 			$this->get_script_dependencies(),
 			$asset_file['version'] ?? NEWSPACK_PLUGIN_VERSION,


### PR DESCRIPTION
## Upon approval & merge of #3163 this PRs branch destination will be updated to `epic/ia`

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Includes fix, for `wp_enqueue_script` handle, necessary to allow legacy Wizards to function as normal. 

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets.
2. Navigate to _/wp-admin/admin.php?page=newspack-connections-wizard_
3. Observe that the page loads as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->