### PR TITLE
feat(ga): add custom parameters to FE-originating GA requests

### DIFF
--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -160,30 +160,15 @@ class GA4 {
 	}
 
 	/**
-	 * Filters the event body before dispatching it.
-	 *
-	 * @param array  $body The event body.
-	 * @param string $event_name The event name.
-	 * @return array
+	 * Get custom parameters for a GA configuration or event body.
 	 */
-	public static function filter_event_body( $body, $event_name ) {
-		if ( ! in_array( $event_name, self::$watched_events, true ) ) {
-			return $body;
-		}
-		if ( ! self::can_use_ga4() ) {
-			return $body;
-		}
-
-		$body['data']['ga_client_id'] = self::extract_cid_from_cookies();
-
-		// Default params added to all events will go here.
-		$body['data']['ga_params'] = [
+	public static function get_custom_parameters() {
+		$parms = [
 			'logged_in' => is_user_logged_in() ? 'yes' : 'no',
 		];
-
 		$session_id = self::extract_sid_from_cookies();
 		if ( $session_id ) {
-			$body['data']['ga_params']['ga_session_id'] = $session_id;
+			$params['ga_session_id'] = $session_id;
 		}
 
 		// Get current post author name.
@@ -206,7 +191,7 @@ class GA4 {
 			}
 		}
 		if ( ! empty( $author_name ) ) {
-			$body['data']['ga_params']['author'] = $author_name;
+			$params['author'] = $author_name;
 		}
 
 		// Get current post categories.
@@ -217,26 +202,45 @@ class GA4 {
 			get_the_category()
 		);
 		if ( ! empty( $category_names ) ) {
-			$body['data']['ga_params']['categories'] = implode( ', ', $category_names );
+			$params['categories'] = implode( ', ', $category_names );
 		}
 
-		$body['data']['ga_params']['is_reader'] = 'no';
+		$params['is_reader'] = 'no';
 		if ( is_user_logged_in() ) {
 			$current_user                            = wp_get_current_user();
-			$body['data']['ga_params']['is_reader']  = Reader_Activation::is_user_reader( $current_user ) ? 'yes' : 'no';
-			$body['data']['ga_params']['email_hash'] = md5( $current_user->user_email );
+			$params['is_reader']  = Reader_Activation::is_user_reader( $current_user ) ? 'yes' : 'no';
+			$params['email_hash'] = md5( $current_user->user_email );
 
 			if ( method_exists( 'Newspack\Reader_Data', 'get_data' ) ) {
 				$reader_data = \Newspack\Reader_Data::get_data( get_current_user_id() );
 				// If the reader is signed up for any newsletters.
-				$body['data']['ga_params']['is_newsletter_subscriber'] = empty( $reader_data['is_newsletter_subscriber'] ) ? 'no' : 'yes';
+				$params['is_newsletter_subscriber'] = empty( $reader_data['is_newsletter_subscriber'] ) ? 'no' : 'yes';
 				// If reader has donated.
-				$body['data']['ga_params']['is_donor'] = empty( $reader_data['is_donor'] ) ? 'no' : 'yes';
+				$params['is_donor'] = empty( $reader_data['is_donor'] ) ? 'no' : 'yes';
 				// If reader has any currently active non-donation subscriptions.
-				$body['data']['ga_params']['is_subscriber'] = empty( $reader_data['active_subscriptions'] ) ? 'no' : 'yes';
+				$params['is_subscriber'] = empty( $reader_data['active_subscriptions'] ) ? 'no' : 'yes';
 			}
 		}
 
+		return $params;
+	}
+
+	/**
+	 * Filters the event body before dispatching it.
+	 *
+	 * @param array  $body The event body.
+	 * @param string $event_name The event name.
+	 * @return array
+	 */
+	public static function filter_event_body( $body, $event_name ) {
+		if ( ! in_array( $event_name, self::$watched_events, true ) ) {
+			return $body;
+		}
+		if ( ! self::can_use_ga4() ) {
+			return $body;
+		}
+		$body['data']['ga_client_id'] = self::extract_cid_from_cookies();
+		$body['data']['ga_params'] = self::get_custom_parameters();
 		return $body;
 	}
 

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -207,8 +207,8 @@ class GA4 {
 
 		$params['is_reader'] = 'no';
 		if ( is_user_logged_in() ) {
-			$current_user                            = wp_get_current_user();
-			$params['is_reader']  = Reader_Activation::is_user_reader( $current_user ) ? 'yes' : 'no';
+			$current_user = wp_get_current_user();
+			$params['is_reader'] = Reader_Activation::is_user_reader( $current_user ) ? 'yes' : 'no';
 			$params['email_hash'] = md5( $current_user->user_email );
 
 			if ( method_exists( 'Newspack\Reader_Data', 'get_data' ) ) {

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -163,7 +163,7 @@ class GA4 {
 	 * Get custom parameters for a GA configuration or event body.
 	 */
 	public static function get_custom_parameters() {
-		$parms = [
+		$params = [
 			'logged_in' => is_user_logged_in() ? 'yes' : 'no',
 		];
 		$session_id = self::extract_sid_from_cookies();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the [set of GA custom parameters](https://github.com/Automattic/newspack-plugin/blob/d1af9bbc3d57f4460f1e9d4fb4dee74f5ffb77a4/includes/data-events/connectors/ga4/README.md#L21-L22) appended to server-originating custom events to the front-end-originating events (incl. pageviews). 

The values of these parameters are cookie-dependent, which means it might have adverse effects of caching. A `NEWSPACK_GA_DISABLE_CUSTOM_FE_PARAMS` environment variable is added enable disabling this feature.

#### Alternative solution

If the caching degradation is a concern, another way to accomplish this is to hijack the triggering of the GA setup (see `Google\Site_Kit\Modules\Analytics_4\Web_Tag::enqueue_gtag_script` in `google-site-kit`) and only set up GA after an additional REST API request returning to cookie-dependent data. We've tried this before though (with `newspack-popups`) and it proved to be a brittle idea, resulting in some data loss. 

### How to test the changes in this Pull Request:

1. Ensure Google Site Kit is enabled and GA configured
2. View source, find the `Google Analytics snippet added by Site Kit` part and observe custom parameters added in the `gtag("config" …` call – as outlined on [this list](https://github.com/Automattic/newspack-plugin/blob/d1af9bbc3d57f4460f1e9d4fb4dee74f5ffb77a4/includes/data-events/connectors/ga4/README.md#L21-L22)  
3. Test as a logged-in reader user to, to verify the logged-in-only parameters are also appended
4. To observe the parameters actually being sent to GA, filter the Network tab for a `collect` request and inspect the payload params – the params pefixed with `ep.` are the custom parameters. You can also visit the GA dashboard to verify.
5. Set the `NEWSPACK_GA_DISABLE_CUSTOM_FE_PARAMS` environment variable to `true`, observe the parameters are not appended

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207498314266239