### PR TITLE
fix(cli/migrate-co-authors-guest-authors): handle existing email address

### DIFF
--- a/includes/cli/class-co-authors-plus.php
+++ b/includes/cli/class-co-authors-plus.php
@@ -132,6 +132,18 @@ class Co_Authors_Plus {
 					$user_data['meta_input'][ $meta_key ] = $post_meta[ 'cap-' . $meta_key ];
 				}
 			}
+
+			// Check if a user with this email address already exists (they might be a Subscriber).
+			$user = get_user_by( 'email', $user_data['user_email'] );
+			if ( $user !== false ) {
+				if ( self::$verbose ) {
+					WP_CLI::line( sprintf( 'User with email %s already exists, email address will be updated.', $user_data['user_email'] ) );
+				}
+				// Update the new user (non-editing contributor) email address.
+				// Since they won't need to log in, this email address does not have to be real.
+				$user_data['user_email'] = '_migrated-' . $guest_author->ID . '-' . $user_data['user_email'];
+			}
+
 			if ( self::$live ) {
 				$user_id = \wp_insert_user( $user_data );
 				if ( is_wp_error( $user_id ) ) {

--- a/includes/cli/class-co-authors-plus.php
+++ b/includes/cli/class-co-authors-plus.php
@@ -136,12 +136,13 @@ class Co_Authors_Plus {
 			// Check if a user with this email address already exists (they might be a Subscriber).
 			$user = get_user_by( 'email', $user_data['user_email'] );
 			if ( $user !== false ) {
+				$new_email_address = '_migrated-' . $guest_author->ID . '-' . $user_data['user_email'];
 				if ( self::$verbose ) {
-					WP_CLI::line( sprintf( 'User with email %s already exists, email address will be updated.', $user_data['user_email'] ) );
+					WP_CLI::line( sprintf( 'User with email %s already exists, email address will be updated to %s.', $user_data['user_email'], $new_email_address ) );
 				}
 				// Update the new user (non-editing contributor) email address.
 				// Since they won't need to log in, this email address does not have to be real.
-				$user_data['user_email'] = '_migrated-' . $guest_author->ID . '-' . $user_data['user_email'];
+				$user_data['user_email'] = $new_email_address;
 			}
 
 			if ( self::$live ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The CAP migration script (https://github.com/Automattic/newspack-plugin/pull/3068) did not account for Guest Authors which have the same email address as an existing WP User (but are not linked to the user). This PR fixes that by adjusting the new WP User's (created from Guest Authors) email.

### How to test the changes in this Pull Request:

1. Create a WP User with a particular email and a Guest Author with the same email
2. Run `wp newspack migrate-co-authors-guest-authors --live --verbose` and observe a notice about the user's email being updated
3. Verify the Guest Author is no more and that a WP User with an email address prefixed with `_migrated-<guest-id>-` has been created

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->