### PR TITLE
Feat/ia settings connections  hooks  custom events

### DIFF
--- a/assets/wizards/newspack/views/settings/connections/custom-events.tsx
+++ b/assets/wizards/newspack/views/settings/connections/custom-events.tsx
@@ -69,7 +69,7 @@ function CustomEvents() {
 	function updateGa4Credentials() {
 		wizardApiFetch< Ga4Credentials >(
 			{
-				path: '/newspack/v1/wizard/analytics/ga4-credentials',
+				path: '/newspack/v2/wizard/analytics/ga4-credentials',
 				method: 'POST',
 				data: {
 					measurement_id: ga4Credentials.measurement_id,

--- a/assets/wizards/newspack/views/settings/connections/custom-events.tsx
+++ b/assets/wizards/newspack/views/settings/connections/custom-events.tsx
@@ -11,8 +11,21 @@ import { useState, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { WizardError } from '../../../../errors';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 import { Button, Grid, Notice, TextControl } from '../../../../../components/src';
+
+/**
+ * Validate GA4 Measurement ID.
+ *
+ * @link https://measureschool.com/ga4-measurement-id/
+ * @param measurementId Measurement ID to validate
+ * @return boolean True if the measurement ID is valid, false otherwise
+ */
+function isValidGA4MeasurementID( measurementId: string = '' ) {
+	const ga4Pattern = /^G-[A-Za-z0-9]{10,}$/;
+	return ga4Pattern.test( measurementId );
+}
 
 /**
  * Analytics Custom Events screen.
@@ -21,13 +34,37 @@ function CustomEvents() {
 	const [ ga4Credentials, setGa4Credentials ] = useState< Ga4Credentials >(
 		window.newspackSettings.connections.sections.customEvents
 	);
-	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch(
+	const { wizardApiFetch, errorMessage, resetError, setError } = useWizardApiFetch(
 		'newspack-settings/connections/custom-events'
 	);
 
 	useEffect( () => {
+		if ( ! isValidGA4MeasurementID( ga4Credentials.measurement_id ) ) {
+			setError(
+				new WizardError(
+					__(
+						'You need a valid Measurement ID (e.g. "G-ABCDE12345") to activate Newspack Custom Events.',
+						'newspack-plugin'
+					),
+					'ga4_invalid_measurement_id'
+				)
+			);
+			return;
+		}
+		if ( ! ga4Credentials.measurement_protocol_secret ) {
+			setError(
+				new WizardError(
+					__(
+						'You need a valid Measurement API Secret to activate Newspack Custom Events.',
+						'newspack-plugin'
+					),
+					'ga4_invalid_measurement_protocol_secret'
+				)
+			);
+			return;
+		}
 		resetError();
-	}, [] );
+	}, [ ga4Credentials.measurement_id, ga4Credentials.measurement_protocol_secret ] );
 
 	function updateGa4Credentials() {
 		wizardApiFetch< Ga4Credentials >(
@@ -41,12 +78,11 @@ function CustomEvents() {
 			},
 			{
 				onSuccess( fetchedData ) {
-					window.newspackSettings.connections.sections.analytics = {
-						...window.newspackSettings.connections.sections.analytics,
+					window.newspackSettings.connections.sections.customEvents = {
+						...window.newspackSettings.connections.sections.customEvents,
 						...fetchedData,
 					};
 					setGa4Credentials( fetchedData );
-					resetError();
 				},
 			}
 		);
@@ -69,7 +105,7 @@ function CustomEvents() {
 					value={ ga4Credentials.measurement_id }
 					label={ __( 'Measurement ID', 'newspack-plugin' ) }
 					help={ __(
-						'You can find this in Site Kit Settings, or in Google Analytics > Admin > Data Streams and clickng the data stream. Example: G-ABCD1234',
+						'You can find this in Site Kit Settings, or in Google Analytics > Admin > Data Streams and clickng the data stream. Example: G-ABCDE12345',
 						'newspack-plugin'
 					) }
 					onChange={ ( value: string ) =>
@@ -88,14 +124,14 @@ function CustomEvents() {
 					onChange={ ( value: string ) =>
 						setGa4Credentials( { ...ga4Credentials, measurement_protocol_secret: value } )
 					}
-					autoComplete="off"
+					autoComplete="one-time-code"
 				/>
 			</Grid>
 			<Button
 				className="newspack__analytics-newspack-custom-events__save-button"
 				variant="primary"
 				onClick={ updateGa4Credentials }
-				disabled={ ! ga4Credentials.measurement_id || ! ga4Credentials.measurement_protocol_secret }
+				disabled={ !! errorMessage }
 			>
 				{ __( 'Save', 'newspack-plugin' ) }
 			</Button>

--- a/assets/wizards/newspack/views/settings/connections/custom-events.tsx
+++ b/assets/wizards/newspack/views/settings/connections/custom-events.tsx
@@ -18,11 +18,12 @@ import { Button, Grid, Notice, TextControl } from '../../../../../components/src
 /**
  * Validate GA4 Measurement ID.
  *
- * @link https://measureschool.com/ga4-measurement-id/
+ * @see   https://measureschool.com/ga4-measurement-id/
+ *
  * @param measurementId Measurement ID to validate
- * @return boolean True if the measurement ID is valid, false otherwise
+ * @return boolean      True if the measurement ID is valid, false otherwise
  */
-function isValidGA4MeasurementID( measurementId: string = '' ) {
+function isValidGA4MeasurementID( measurementId = '' ) {
 	const ga4Pattern = /^G-[A-Za-z0-9]{10,}$/;
 	return ga4Pattern.test( measurementId );
 }

--- a/assets/wizards/newspack/views/settings/connections/custom-events.tsx
+++ b/assets/wizards/newspack/views/settings/connections/custom-events.tsx
@@ -1,0 +1,106 @@
+/**
+ * Settings Wizard: Connections > Custom Events
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
+import { Button, Grid, Notice, TextControl } from '../../../../../components/src';
+
+/**
+ * Analytics Custom Events screen.
+ */
+function CustomEvents() {
+	const [ ga4Credentials, setGa4Credentials ] = useState< Ga4Credentials >(
+		window.newspackSettings.connections.sections.customEvents
+	);
+	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch(
+		'newspack-settings/connections/custom-events'
+	);
+
+	useEffect( () => {
+		resetError();
+	}, [] );
+
+	function updateGa4Credentials() {
+		wizardApiFetch< Ga4Credentials >(
+			{
+				path: '/newspack/v1/wizard/analytics/ga4-credentials',
+				method: 'POST',
+				data: {
+					measurement_id: ga4Credentials.measurement_id,
+					measurement_protocol_secret: ga4Credentials.measurement_protocol_secret,
+				},
+			},
+			{
+				onSuccess( fetchedData ) {
+					window.newspackSettings.connections.sections.analytics = {
+						...window.newspackSettings.connections.sections.analytics,
+						...fetchedData,
+					};
+					setGa4Credentials( fetchedData );
+					resetError();
+				},
+			}
+		);
+	}
+
+	return (
+		<div className="newspack__analytics-configuration">
+			<div className="newspack__analytics-configuration__header">
+				<p>
+					{ __(
+						"Newspack already sends some custom event data to your GA account, but adding the credentials below enables enhanced events that are fired from your site's backend. For example, when a donation is confirmed or when a user successfully subscribes to a newsletter.",
+						'newspack-plugin'
+					) }
+				</p>
+			</div>
+
+			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
+			<Grid noMargin rowGap={ 16 }>
+				<TextControl
+					value={ ga4Credentials.measurement_id }
+					label={ __( 'Measurement ID', 'newspack-plugin' ) }
+					help={ __(
+						'You can find this in Site Kit Settings, or in Google Analytics > Admin > Data Streams and clickng the data stream. Example: G-ABCD1234',
+						'newspack-plugin'
+					) }
+					onChange={ ( value: string ) =>
+						setGa4Credentials( { ...ga4Credentials, measurement_id: value } )
+					}
+					autoComplete="off"
+				/>
+				<TextControl
+					type="password"
+					value={ ga4Credentials.measurement_protocol_secret }
+					label={ __( 'Measurement Protocol API Secret', 'newspack-plugin' ) }
+					help={ __(
+						'Generate an API secret from your GA dashboard in Admin > Data Streams and opening your data stream. Select "Measurement Protocol API secrets" under the Events section. Create a new secret.',
+						'newspack-plugin'
+					) }
+					onChange={ ( value: string ) =>
+						setGa4Credentials( { ...ga4Credentials, measurement_protocol_secret: value } )
+					}
+					autoComplete="off"
+				/>
+			</Grid>
+			<Button
+				className="newspack__analytics-newspack-custom-events__save-button"
+				variant="primary"
+				onClick={ updateGa4Credentials }
+				disabled={ ! ga4Credentials.measurement_id || ! ga4Credentials.measurement_protocol_secret }
+			>
+				{ __( 'Save', 'newspack-plugin' ) }
+			</Button>
+		</div>
+	);
+}
+
+export default CustomEvents;

--- a/assets/wizards/newspack/views/settings/connections/index.tsx
+++ b/assets/wizards/newspack/views/settings/connections/index.tsx
@@ -6,15 +6,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import CustomEvents from './custom-events';
 import { SectionHeader } from '../../../../../components/src';
-import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
-import { WIZARD_STORE_NAMESPACE } from '../../../../../components/src/wizard/store';
 
 function Section( {
 	title,
@@ -33,54 +30,11 @@ function Section( {
 	);
 }
 
-const CACHE_KEY = '/newspack-settings/connections';
-
 function Connections() {
-	const { wizardApiFetch, isFetching, error } = useWizardApiFetch( CACHE_KEY );
-
-	const wizardData: any = useSelect( select =>
-		select( WIZARD_STORE_NAMESPACE ).getWizardData( CACHE_KEY )
-	);
-
-	const [ status, setStatus ] = useState( 'idle' );
-	const [ statusTwo, setStatusTwo ] = useState( 'idle' );
-
-	useEffect( () => {
-		for ( const plugin of [ 'jetpack', 'jetpacks' ] ) {
-			const stateHandler = plugin === 'jetpack' ? setStatus : setStatusTwo;
-			wizardApiFetch(
-				{ path: `/newspack/v1/plugins/${ plugin }` },
-				{
-					onStart() {
-						stateHandler( 'Start' );
-					},
-					onSuccess() {
-						stateHandler( 'Success' );
-					},
-					onError() {
-						stateHandler( 'Error' );
-					},
-				}
-			);
-		}
-	}, [] );
-
 	return (
 		<div className="newspack-wizard__sections">
 			<h1>{ __( 'Connections', 'newspack-plugin' ) }</h1>
-			<pre>
-				{ JSON.stringify(
-					{
-						status,
-						statusTwo,
-						wizardData,
-						isFetching,
-						error,
-					},
-					null,
-					2
-				) }
-			</pre>
+
 			{ /* Plugins */ }
 			<Section title={ __( 'Plugins', 'newspack-plugin' ) }>
 				<div className="newspack-card">Coming soon</div>
@@ -115,7 +69,7 @@ function Connections() {
 					'newspack-plugin'
 				) }
 			>
-				<div className="newspack-card">Coming soon</div>
+				<CustomEvents />
 			</Section>
 		</div>
 	);

--- a/assets/wizards/newspack/views/settings/types.d.ts
+++ b/assets/wizards/newspack/views/settings/types.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Google Analytics 4 credentials Type.
+ */
+type Ga4Credentials = Record< string, string >;

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -120,9 +120,15 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-generated.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-wordpress.php';
 
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-wizard.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-wizard-section.php';
+
+		// Newspack Wizards and Sections.
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-dashboard.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-settings.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-custom-events-section.php';
+
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
-		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-newspack-dashboard.php';
-		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-newspack-settings.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
 
 		/* Unified Wizards */

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -7,6 +7,8 @@
 
 namespace Newspack;
 
+use Newspack\Wizards\Newspack\Newspack_Settings;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -42,7 +44,13 @@ class Wizards {
 			'settings'           => new Settings(),
 			// v2 Information Architecture.
 			'newspack-dashboard' => new Newspack_Dashboard(),
-			'newspack-settings'  => new Newspack_Settings(),
+			'newspack-settings'  => new Newspack_Settings( 
+				[
+					'sections' => [
+						'custom-events' => 'Newspack\Wizards\Newspack\Custom_Events_Section',
+					],
+				] 
+			),
 		];
 	}
 

--- a/includes/util.php
+++ b/includes/util.php
@@ -10,6 +10,7 @@ namespace Newspack;
 defined( 'ABSPATH' ) || exit;
 
 define( 'NEWSPACK_API_NAMESPACE', 'newspack/v1' );
+define( 'NEWSPACK_API_NAMESPACE_V2', 'newspack/v2' );
 define( 'NEWSPACK_API_URL', get_site_url() . '/wp-json/' . NEWSPACK_API_NAMESPACE );
 
 /**

--- a/includes/wizards/class-newspack-settings.php
+++ b/includes/wizards/class-newspack-settings.php
@@ -48,10 +48,14 @@ class Newspack_Settings extends Wizard {
 				'label'    => __( 'Connections', 'newspack-plugin' ),
 				'path'     => '/',
 				'sections' => [
-					'plugins'   => [],
-					'apis'      => [],
-					'recaptcha' => [],
-					'analytics' => [],
+					'plugins'      => [],
+					'apis'         => [],
+					'recaptcha'    => [],
+					'analytics'    => [],
+					'customEvents' => [
+						'measurement_id'              => get_option( 'ga4_measurement_id', '' ),
+						'measurement_protocol_secret' => get_option( 'ga4_measurement_protocol_secret', '' ),
+					],
 				],
 			],
 			'emails'            => [

--- a/includes/wizards/class-wizard-section.php
+++ b/includes/wizards/class-wizard-section.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Wizard Section Object, for inheritence.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Wizards;
+
+use WP_Error;
+
+/**
+ * Abstract class for wizard sections.
+ */
+abstract class Wizard_Section {
+	
+	/**
+	 * The WP capability required to access this section.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Initialize.
+	 */
+	public function __construct() {
+		// If inheriting class has method `register_rest_routes` bind method to action.
+		if ( method_exists( $this, 'register_rest_routes' ) ) {
+			add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+		}
+	}
+	
+	/**
+	 * Check capabilities for using API.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function api_permissions_check() {
+		if ( ! current_user_can( $this->capability ) ) {
+			return new WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				[
+					'status' => 403,
+				]
+			);
+		}
+		return true;
+	}
+}

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -8,6 +8,8 @@
 namespace Newspack;
 
 use Newspack\Starter_Content;
+use Newspack\Wizards\Section;
+
 defined( 'ABSPATH' ) || exit;
 
 define( 'NEWSPACK_WIZARD_COMPLETED_OPTION_PREFIX', 'newspack_wizard_completed_' );
@@ -46,11 +48,24 @@ abstract class Wizard {
 	protected $menu_priority = 2;
 
 	/**
-	 * Initialize.
+	 * Array to store instances of section objects.
+	 *
+	 * @var Wizards\Section[]
 	 */
-	public function __construct() {
+	protected $sections = [];
+
+	/**
+	 * Initialize.
+	 *
+	 * @param array $args Array of optional arguments. i.e. `sections`.
+	 * @return void 
+	 */
+	public function __construct( $args = [] ) {
 		add_action( 'admin_menu', [ $this, 'add_page' ], $this->menu_priority );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
+		if ( isset( $args['sections'] ) ) {
+			$this->load_wizard_sections( $args['sections'] );
+		}
 	}
 
 	/**
@@ -247,4 +262,15 @@ abstract class Wizard {
 	 * @return string The wizard name.
 	 */
 	abstract public function get_name();
+
+	/**
+	 * Load wizard sections.
+	 * 
+	 * @param Section[] $sections Array of Section objects.
+	 */
+	public function load_wizard_sections( $sections ) {
+		foreach ( $sections as $section_slug => $section_class ) {
+			$this->sections[ $section_slug ] = new $section_class();
+		}
+	}
 }

--- a/includes/wizards/newspack/class-custom-events-section.php
+++ b/includes/wizards/newspack/class-custom-events-section.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Custom Events Section Object.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Wizards\Newspack;
+
+/**
+ * WordPress dependencies
+ */
+use WP_Error, WP_REST_Server;
+
+/**
+ * Internal dependencies
+ */
+use Newspack\Wizards\Wizard_Section;
+
+/**
+ * Custom Events Section Object.
+ *
+ * @package Newspack\Wizards\Newspack
+ */
+class Custom_Events_Section extends Wizard_Section {
+
+	/**
+	 * Register Wizard Section specific endpoints.
+	 *
+	 * @return void 
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE_V2,
+			'/wizard/analytics/ga4-credentials',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_set_ga4_credentials' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'measurement_id'              => [
+						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => [ $this, 'validate_measurement_id' ],
+					],
+					'measurement_protocol_secret' => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Updates the GA4 crendetials
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function api_set_ga4_credentials( $request ) {
+		$measurement_id              = $request->get_param( 'measurement_id' );
+		$measurement_protocol_secret = $request->get_param( 'measurement_protocol_secret' );
+
+		if ( ! $measurement_protocol_secret ) {
+			return new WP_Error(
+				'newspack_analytics_wizard_invalid_params',
+				esc_html__( 'Invalid Measurement Protocol API Secret.', 'newspack' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		update_option( 'ga4_measurement_id', sanitize_text_field( $measurement_id ) );
+		update_option( 'ga4_measurement_protocol_secret', sanitize_text_field( $measurement_protocol_secret ) );
+
+		return rest_ensure_response( $this->get_data() );
+	}
+
+	/**
+	 * Gets the credentials for the GA4 API.
+	 *
+	 * @return array
+	 */
+	public static function get_data() {
+		return [
+			'measurement_id'              => esc_html( get_option( 'ga4_measurement_id', '' ) ),
+			'measurement_protocol_secret' => esc_html( get_option( 'ga4_measurement_protocol_secret', '' ) ),
+		];
+	}
+
+	/**
+	 * Validates the Measurement ID
+	 *
+	 * @link https://measureschool.com/ga4-measurement-id/
+	 * @param string $value The value to validate.
+	 * @return bool
+	 */
+	public function validate_measurement_id( $value ) {
+		return is_string( $value ) && preg_match( '/^G-[A-Za-z0-9]{10,}$/', $value );
+	}
+}

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -9,8 +9,6 @@ namespace Newspack;
 
 defined( 'ABSPATH' ) || exit;
 
-require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
-
 /**
  * Common functionality for admin wizards. Override this class.
  */

--- a/includes/wizards/newspack/class-newspack-settings.php
+++ b/includes/wizards/newspack/class-newspack-settings.php
@@ -5,11 +5,11 @@
  * @package Newspack
  */
 
-namespace Newspack;
+namespace Newspack\Wizards\Newspack;
+
+use Newspack\Wizard;
 
 defined( 'ABSPATH' ) || exit;
-
-require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 
 /**
  * Common functionality for admin wizards. Override this class.

--- a/includes/wizards/newspack/class-newspack-settings.php
+++ b/includes/wizards/newspack/class-newspack-settings.php
@@ -52,10 +52,7 @@ class Newspack_Settings extends Wizard {
 					'apis'         => [],
 					'recaptcha'    => [],
 					'analytics'    => [],
-					'customEvents' => [
-						'measurement_id'              => get_option( 'ga4_measurement_id', '' ),
-						'measurement_protocol_secret' => get_option( 'ga4_measurement_protocol_secret', '' ),
-					],
+					'customEvents' => $this->sections['custom-events']->get_data(),
 				],
 			],
 			'emails'            => [


### PR DESCRIPTION
### Upon approval & merge of #3170, #3163 this PRs branch destination will be updated to `epic/ia`

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

* Migrated from _/wp-admin/admin.php?page=newspack-connections-wizard_.
* Adds Custom Events section/component.
* Refactored API Fetch to use new `useWizardApiFetch` hook, introduced in #3163.
* Updated `autocomplete` attributes from `off` to `one-time-code` to avoid browser prompts to save password.
* Moved all Newspack related wizardry to a directory `./newspack`.
* Added new Section Class to provide server-side functionality on a section-by-section basis. This, for now, is mostly necessary when you need to add REST api endpoint(s) to a specific section. 
* Added `includes/wizards/class-wizard.php` include to `includes/class-newspack.php` `init` method to avoid including it on every `Wizard` inherited class.
* Added Measurement ID validation to Frontend (avoids invalid requests from hitting backend) and refactored server-side validation. Rules are must start with `"G-"` followed by 10 (we use `{10,}` to allow for future lengthening) alphanumeric characters. 
* Added more descriptive, and granular, error feedback.
* Replaced deprecated conditional props on  `<Button />` with preferred `variant` prop.

### How to test the changes in this Pull Request:

**Original location:**
* Newspack Custom Events: _/wp-admin/admin.php?page=newspack-analytics-wizard#/newspack-custom-events_

1. Checkout `feat/ia-settings-connections__custom-events` and build assets.
2. Navigate to _/wp-admin/admin.php?page=newspack-settings_
3. Scroll to the bottom where "Activate Newspack Custom Events" section is located.
4. Observe that saving/updating data works as expected.

![Screenshot 2024-06-06 at 14 10 14](https://github.com/Automattic/newspack-plugin/assets/3676975/925e5928-60cb-4bca-b130-57018200e49c)

5. Removing ID displays a notification and disables saving.

![Screenshot 2024-06-08 at 09 31 30](https://github.com/Automattic/newspack-plugin/assets/3676975/ca7b7cd7-b017-4e92-b292-467f94fc1faa)

**Additional steps:**
- Confirm stored data is persistent between tab changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
