### PR TITLE
feat: add spinner to registration block submit button

### DIFF
--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -279,7 +279,7 @@ function render_block( $attrs, $content ) {
 									<?php endif; ?>
 									type="submit"
 								>
-									<?php echo \esc_attr( $attrs['label'] ); ?>
+									<span class="submit"><?php echo \esc_html( $attrs['label'] ); ?></span>
 								</button>
 							</div>
 							<?php Reader_Activation::render_third_party_auth(); ?>

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -271,15 +271,16 @@ function render_block( $attrs, $content ) {
 									placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
 								/>
 								<?php Reader_Activation::render_honeypot_field( $attrs['placeholder'] ); ?>
-								<input
+								<button
 								<?php
 								if ( $is_admin_preview ) :
 									?>
 									disabled
 									<?php endif; ?>
 									type="submit"
-									value="<?php echo \esc_attr( $attrs['label'] ); ?>"
-								/>
+								>
+									<?php echo \esc_attr( $attrs['label'] ); ?>
+								</button>
 							</div>
 							<?php Reader_Activation::render_third_party_auth(); ?>
 							<div class="newspack-registration__response <?php echo ( empty( $message ) ) ? 'newspack-registration--hidden' : null; ?>">

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -168,6 +168,31 @@
 		input {
 			pointer-events: none;
 		}
+
+		button[type='submit'] {
+			color: var( --newspack-cta-color );
+			position: relative;
+
+			span {
+				--animation-duration: 900ms;
+				--animation-timing-function: linear;
+				--color-spinner-primary: var( --newspack-cta-contrast-color );
+				--color-spinner-background: var( --newspack-cta-color );
+				--size: 18px;
+				--stroke-width: 1.5px;
+
+				animation: var(--animation-timing-function) var(--animation-duration) infinite spin;
+				border-color: var(--color-spinner-primary) var(--color-spinner-primary) var(--color-spinner-background) var(--color-spinner-background);
+				border-radius: 50%;
+				border-style: solid;
+				border-width: var(--stroke-width);
+				height: var(--size);
+				transform: rotate(0deg);
+				width: var(--size);
+				position: absolute;
+				left: calc( 50% - ( var(--size) / 2 ) );
+			}
+		}
 	}
 
 	&__icon {
@@ -265,4 +290,13 @@
 	100% {
 		transform: scale( 1 );
 	}
+}
+
+@keyframes spin {
+  from {
+    transform: rotate( 0deg );
+  }
+  to {
+    transform: rotate( 360deg );
+  }
 }

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -170,14 +170,17 @@
 		}
 
 		button[type='submit'] {
-			color: var( --newspack-cta-color );
 			position: relative;
 
-			span {
+			span.submit {
+				visibility: hidden;
+			}
+
+			span.spinner {
 				--animation-duration: 900ms;
 				--animation-timing-function: linear;
-				--color-spinner-primary: var( --newspack-cta-contrast-color );
-				--color-spinner-background: var( --newspack-cta-color );
+				--color-spinner-primary: transparent;
+				--color-spinner-background: currentcolor;
 				--size: 18px;
 				--stroke-width: 1.5px;
 

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -38,6 +38,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 			const messageElement = container.querySelector( '.newspack-registration__response' );
 			const submitElement = form.querySelector( 'button[type="submit"]' );
 			const spinner = document.createElement( 'span' );
+			spinner.classList.add( 'spinner' );
 			let successElement = container.querySelector(
 				'.newspack-registration__registration-success'
 			);

--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -36,7 +36,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 			}
 
 			const messageElement = container.querySelector( '.newspack-registration__response' );
-			const submitElement = form.querySelector( 'input[type="submit"]' );
+			const submitElement = form.querySelector( 'button[type="submit"]' );
+			const spinner = document.createElement( 'span' );
 			let successElement = container.querySelector(
 				'.newspack-registration__registration-success'
 			);
@@ -45,6 +46,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				messageElement.classList.add( 'newspack-registration--hidden' );
 				messageElement.innerHTML = '';
 				submitElement.disabled = true;
+				submitElement.appendChild( spinner );
 				container.classList.add( 'newspack-registration--in-progress' );
 			};
 
@@ -80,6 +82,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 					messageElement.appendChild( messageNode );
 					messageElement.classList.remove( 'newspack-registration--hidden' );
 				}
+				submitElement.removeChild( spinner );
 				submitElement.disabled = false;
 				container.classList.remove( 'newspack-registration--in-progress' );
 			};


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207385073694408/1206756862605997/f

The registration block can take a few seconds to complete and the current loading state is not entirely clear for all publishers. This PR adds a loading spinner to the registration form submit button when clicked to make it more clear the form is loading:

https://github.com/Automattic/newspack-plugin/assets/17905991/17048f71-7a3a-456b-be46-dc4ac3adecd5

### How to test the changes in this Pull Request:

1. On a test site, set up a registration wall content gate: https://help.newspack.com/engagement/reader-activation-system/content-gating/#getting-started
2. Activate the memberships plugin and create a membership plan for all new registrations, restricting all posts to members of this plan
3. Visit any post on your site as a logged out user and scroll until the registration wall triggers
4. Enter a valid email address and verify a loading spinner appears within the submit button as shown above


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->