### PR TITLE
Add "is modified" check before saving parent donation product

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -373,21 +373,27 @@ class Donations {
 			if ( $parent_product ) {
 				$suggested_amounts         = $parent_product->get_meta( 'newspack_donation_suggested_amount', true );
 				$untiered_suggested_amount = $parent_product->get_meta( 'newspack_donation_untiered_suggested_amount', true );
+				$parent_product_modified   = false;
 				if ( $suggested_amounts ) {
 					$legacy_settings['suggestedAmounts'] = $suggested_amounts;
 					$parent_product->delete_meta_data( 'newspack_donation_suggested_amount' );
+					$parent_product_modified = true;
 				}
 				if ( $untiered_suggested_amount ) {
 					$legacy_settings['suggestedAmountUntiered'] = $untiered_suggested_amount;
 					$parent_product->delete_meta_data( 'newspack_donation_untiered_suggested_amount' );
+					$parent_product_modified = true;
 				}
 				$tiered = $parent_product->get_meta( 'newspack_donation_is_tiered', true );
 
 				if ( ! empty( $tiered ) && is_int( intval( $tiered ) ) ) {
 					$legacy_settings['tiered'] = $tiered;
 					$parent_product->delete_meta_data( 'newspack_donation_is_tiered' );
+					$parent_product_modified = true;
 				}
-				$parent_product->save();
+				if ( $parent_product_modified ) {
+					$parent_product->save();
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes `/0/1200550061930446/1207545316537448`

This PR fixes an issue I noticed while doing performance debugging/profiling. On a page with a donate block or any time the donation settings are retrieved, the parent product gets saved on every single request, which generates some volume of `UPDATE` sql queries and makes the product un-cacheable (since the data is always changing).

This PR fixes that issue by adding a check to only save the parent product if it was modified as part of some backwards compatibility handling.

### How to test the changes in this Pull Request:

1. Before applying this PR, have a page with a Donate block on it and Query Monitor active.
2. Visit the page. Filter Query Monitor by SQL `UPDATE` statements. Observe the post modified of the parent product has been updated, as well as possible other product-related updates:

<img width="1406" alt="Screenshot 2024-06-14 at 8 43 37 AM" src="https://github.com/Automattic/newspack-plugin/assets/7317227/b1afa026-ff7f-40ff-b35d-3b9a93461748">

3. Apply this PR. `wp cache flush` to clear out any possible cached queries. Refresh the page. Observe the `UPDATE` statements don't appear any more:

<img width="1331" alt="Screenshot 2024-06-14 at 8 45 48 AM" src="https://github.com/Automattic/newspack-plugin/assets/7317227/826cc0c2-84e7-42f2-a4d8-dd701612814f">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->