### PR TITLE
feat(everlit): added Everlit to plugins + refactor plugins in connections wizard

### DIFF
--- a/assets/wizards/connections/views/main/plugins.js
+++ b/assets/wizards/connections/views/main/plugins.js
@@ -47,6 +47,7 @@ const PLUGINS = {
 		editLink: 'admin.php?page=everlit_settings',
 		title: __( 'Everlit', 'newspack-plugin' ),
 		subTitle: __( 'AI-Generated Audio Stories', 'newspack-plugin' ),
+		hidden: window.newspack_connections_data.can_use_everlit !== '1',
 		description: (
 			<>
 				{ __(
@@ -193,7 +194,11 @@ const Plugins = ( { setError } ) => {
 	return (
 		<>
 			{ Object.entries( PLUGINS ).map( ( [ slug, plugin ] ) => {
-				return <Plugin key={ slug } plugin={ plugin } setError={ setError } />;
+				return (
+					! Boolean( plugin.hidden ) && (
+						<Plugin key={ slug } plugin={ plugin } setError={ setError } />
+					)
+				);
 			} ) }
 		</>
 	);

--- a/assets/wizards/connections/views/main/plugins.js
+++ b/assets/wizards/connections/views/main/plugins.js
@@ -144,7 +144,8 @@ const Plugin = ( { plugin, setError } ) => {
 		}
 		return (
 			<>
-				{ __( 'Status:', 'newspack-plugin' ) } { description } { descriptionSuffix }
+				{ __( 'Status:', 'newspack-plugin' ) } { description }{ ' ' }
+				{ ! isSetup ? descriptionSuffix : '' }
 			</>
 		);
 	};

--- a/assets/wizards/connections/views/main/plugins.js
+++ b/assets/wizards/connections/views/main/plugins.js
@@ -1,99 +1,198 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Handoff, hooks } from '../../../../components/src';
+import { ActionCard, Button, hooks, Waiting } from '../../../../components/src';
+
+async function fetchHandler( slug, action = '' ) {
+	const path = action
+		? `/newspack/v1/plugins/${ slug }/${ action }`
+		: `/newspack/v1/plugins/${ slug }`;
+	const method = action ? 'POST' : 'GET';
+	const result = await apiFetch( { path, method } );
+	return {
+		status: result.Status,
+		configured: result.Configured,
+	};
+}
 
 const PLUGINS = {
 	jetpack: {
 		pluginSlug: 'jetpack',
 		editLink: 'admin.php?page=jetpack#/settings',
-		name: 'Jetpack',
-		fetchStatus: () =>
-			apiFetch( { path: `/newspack/v1/plugins/jetpack` } ).then( result => ( {
-				jetpack: { status: result.Configured ? result.Status : 'inactive' },
-			} ) ),
+		title: 'Jetpack',
+		init: () => fetchHandler( 'jetpack' ),
+		activate: () => fetchHandler( 'jetpack', 'activate' ),
+		install: () => fetchHandler( 'jetpack', 'install' ),
 	},
 	'google-site-kit': {
 		pluginSlug: 'google-site-kit',
 		editLink: 'admin.php?page=googlesitekit-splash',
-		name: __( 'Site Kit by Google', 'newspack-plugin' ),
-		fetchStatus: () =>
-			apiFetch( { path: '/newspack/v1/plugins/google-site-kit' } ).then( result => ( {
-				'google-site-kit': { status: result.Configured ? result.Status : 'inactive' },
-			} ) ),
+		title: __( 'Site Kit by Google', 'newspack-plugin' ),
+		statusDescription: {
+			notConfigured: __( 'Not connected for this user', 'newspack-plugin' ),
+		},
+		init: () => fetchHandler( 'google-site-kit' ),
+		activate: () => fetchHandler( 'google-site-kit', 'activate' ),
+		install: () => fetchHandler( 'google-site-kit', 'install' ),
+	},
+	everlit: {
+		pluginSlug: 'everlit',
+		editLink: 'admin.php?page=everlit_settings',
+		title: __( 'Everlit', 'newspack-plugin' ),
+		subTitle: __( 'AI-Generated Audio Stories', 'newspack-plugin' ),
+		description: (
+			<>
+				{ __(
+					'Complete setup and licensing agreement to unlock 5 free audio stories per month.',
+					'newspack-plugin'
+				) }{ ' ' }
+				<a href="https://everlit.audio/" target="_blank" rel="noreferrer">
+					{ __( 'Learn more', 'newspack-plugin' ) }
+				</a>
+			</>
+		),
+		statusDescription: {
+			uninstalled: __( 'Not installed.', 'newspack-plugin' ),
+			inactive: __( 'Inactive.', 'newspack-plugin' ),
+			notConfigured: __( 'Pending.', 'newspack-plugin' ),
+		},
+		init: () => fetchHandler( 'everlit' ),
+		activate: () => fetchHandler( 'everlit', 'activate' ),
+		install: () => fetchHandler( 'everlit', 'install' ),
 	},
 };
 
-const pluginConnectButton = plugin => {
-	if ( plugin.pluginSlug ) {
-		return (
-			<Handoff plugin={ plugin.pluginSlug } editLink={ plugin.editLink } compact isLink>
-				{ __( 'Connect', 'newspack-plugin' ) }
-			</Handoff>
-		);
+const pluginConnectButton = ( {
+	isLoading,
+	isSetup,
+	isActive,
+	onActivate,
+	onInstall,
+	isInstalled,
+	...plugin
+} ) => {
+	if ( plugin.status === 'page-reload' ) {
+		return <span className="gray">{ __( 'Page reloading…', 'newspack-plugin' ) }</span>;
 	}
-	if ( plugin.url ) {
+	if ( isLoading ) {
+		return <Waiting />;
+	}
+	if ( ! isInstalled ) {
 		return (
-			<Button isLink href={ plugin.url } target="_blank">
-				{ __( 'Connect', 'newspack-plugin' ) }
+			<Button isLink onClick={ onInstall }>
+				{
+					/* translators: %s: Plugin name */
+					sprintf( __( 'Install %s', 'newspack-plugin' ), plugin.title )
+				}
 			</Button>
 		);
 	}
-	if ( plugin.error?.code === 'unavailable_site_id' ) {
+	if ( ! isActive ) {
 		return (
-			<span className="i newspack-error">
-				{ __( 'Jetpack connection required', 'newspack-plugin' ) }
-			</span>
+			<Button isLink onClick={ onActivate }>
+				{
+					/* translators: %s: Plugin name */
+					sprintf( __( 'Activate %s', 'newspack-plugin' ), plugin.title )
+				}
+			</Button>
 		);
+	}
+	if ( ! isSetup ) {
+		return <a href={ plugin.editLink }>{ __( 'Complete Setup', 'newspack-plugin' ) }</a>;
 	}
 };
 
-const Plugins = ( { setError } ) => {
-	const [ plugins, setPlugins ] = hooks.useObjectState( PLUGINS );
-	const pluginsArray = Object.values( plugins );
+const Plugin = ( { plugin, setError } ) => {
+	const [ pluginState, setPluginState ] = hooks.useObjectState( plugin );
+	const { title, subTitle } = pluginState;
+	const isActive = pluginState.status === 'active';
+	const isInstalled = pluginState.status !== 'uninstalled';
+	const isConfigured = pluginState.configured;
+	const isSetup = isActive && isConfigured;
+	const isLoading = ! pluginState.status;
+
 	useEffect( () => {
-		pluginsArray.forEach( async plugin => {
-			const update = await plugin.fetchStatus().catch( setError );
-			setPlugins( update );
-		} );
+		plugin
+			.init()
+			.then( update => setPluginState( update ) )
+			.catch( setError );
 	}, [] );
 
+	const getDescription = () => {
+		if ( isLoading ) {
+			return __( 'Loading…', 'newspack-plugin' );
+		}
+		const descriptionSuffix = plugin.description ?? '';
+		let description = '';
+		if ( ! isInstalled ) {
+			description =
+				pluginState.statusDescription?.uninstalled ?? __( 'Uninstalled.', 'newspack-plugin' );
+		} else if ( ! isActive ) {
+			description = pluginState.statusDescription?.inactive ?? __( 'Inactive.', 'newspack-plugin' );
+		} else if ( ! isConfigured ) {
+			description =
+				pluginState.statusDescription?.notConfigured ?? __( 'Not connected.', 'newspack-plugin' );
+		} else {
+			description = __( 'Connected', 'newspack-plugin' );
+		}
+		return (
+			<>
+				{ __( 'Status:', 'newspack-plugin' ) } { description } { descriptionSuffix }
+			</>
+		);
+	};
+
+	const onActivate = () => {
+		setPluginState( { status: '' } );
+		pluginState
+			.activate()
+			.then( () => setPluginState( { status: 'page-reload' } ) )
+			.finally( () => {
+				window.location.reload();
+			} );
+	};
+
+	const onInstall = () => {
+		setPluginState( { status: '' } );
+		pluginState.install().then( update => setPluginState( update ) );
+	};
+
+	return (
+		<ActionCard
+			title={ `${ title }${ subTitle ? `: ${ subTitle }` : '' }` }
+			description={ getDescription }
+			actionText={
+				! isSetup
+					? pluginConnectButton( {
+							isSetup,
+							isActive,
+							isLoading,
+							isInstalled,
+							onActivate,
+							onInstall,
+							...pluginState,
+					  } )
+					: null
+			}
+			disabled={ isLoading }
+			checkbox={ ! isSetup || isLoading ? 'unchecked' : 'checked' }
+			isMedium
+		/>
+	);
+};
+
+const Plugins = ( { setError } ) => {
 	return (
 		<>
-			{ pluginsArray.map( plugin => {
-				const isInactive = plugin.status === 'inactive';
-				const isLoading = ! plugin.status;
-				const getDescription = () => {
-					if ( isLoading ) {
-						return __( 'Loading…', 'newspack-plugin' );
-					}
-					if ( isInactive ) {
-						if ( plugin.pluginSlug === 'google-site-kit' ) {
-							return __( 'Not connected for this user', 'newspack-plugin' );
-						}
-						return __( 'Not connected', 'newspack-plugin' );
-					}
-					return __( 'Connected', 'newspack-plugin' );
-				};
-				return (
-					<ActionCard
-						key={ plugin.name }
-						title={ plugin.name }
-						description={ `${ __( 'Status:', 'newspack-plugin' ) } ${ getDescription() }` }
-						actionText={ isInactive ? pluginConnectButton( plugin ) : null }
-						checkbox={ isInactive || isLoading ? 'unchecked' : 'checked' }
-						badge={ plugin.badge }
-						indent={ plugin.indent }
-						isMedium
-					/>
-				);
+			{ Object.entries( PLUGINS ).map( ( [ slug, plugin ] ) => {
+				return <Plugin key={ slug } plugin={ plugin } setError={ setError } />;
 			} ) }
 		</>
 	);

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -331,12 +331,12 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 			],
 			'everlit'                     => [
-				'Name'        => \esc_html__( 'Everlit', 'newspack' ),
-				'Description' => \esc_html__( 'Using a new generation of ultra realistic, AI-driven speech synthesis, we are bringing a backlog of human interest stories, fiction, and knowledge to the present day.', 'newspack' ),
+				'Name'        => esc_html__( 'Everlit', 'newspack' ),
+				'Description' => esc_html__( 'Using a new generation of ultra realistic, AI-driven speech synthesis, we are bringing a backlog of human interest stories, fiction, and knowledge to the present day.', 'newspack' ),
 				'Author'      => 'Everlit',
-				'AuthorURI'   => \esc_url( 'https://everlit.audio' ),
-				'PluginURI'   => \esc_url( 'https://everlit.audio' ),
-				'Download'    => \esc_url( 'https://creator.everlit.audio/wordpress/everlit-wordpress.zip' ),
+				'AuthorURI'   => esc_url( 'https://everlit.audio' ),
+				'PluginURI'   => esc_url( 'https://everlit.audio' ),
+				'Download'    => esc_url( 'https://creator.everlit.audio/wordpress/everlit-wordpress.zip' ),
 				'EditPath'    => 'admin.php?page=everlit_settings',
 			],
 		];

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -330,6 +330,15 @@ class Plugin_Manager {
 				'PluginURI'   => \esc_url( 'https://wordpress.org/plugins/broadstreet/' ),
 				'Download'    => 'wporg',
 			],
+			'everlit'                     => [
+				'Name'        => \esc_html__( 'Everlit', 'newspack' ),
+				'Description' => \esc_html__( 'Using a new generation of ultra realistic, AI-driven speech synthesis, we are bringing a backlog of human interest stories, fiction, and knowledge to the present day.', 'newspack' ),
+				'Author'      => 'Everlit',
+				'AuthorURI'   => \esc_url( 'https://everlit.audio' ),
+				'PluginURI'   => \esc_url( 'https://everlit.audio' ),
+				'Download'    => \esc_url( 'https://creator.everlit.audio/wordpress/everlit-wordpress.zip' ),
+				'EditPath'    => 'admin.php?page=everlit_settings',
+			],
 		];
 
 		$default_info = [

--- a/includes/configuration_managers/class-configuration-managers.php
+++ b/includes/configuration_managers/class-configuration-managers.php
@@ -64,6 +64,10 @@ class Configuration_Managers {
 			'filename'   => 'class-parsely-configuration-manager.php',
 			'class_name' => 'Parsely_Configuration_Manager',
 		],
+		'everlit'               => [
+			'filename'   => 'class-everlit-configuration-manager.php',
+			'class_name' => 'Everlit_Configuration_Manager',
+		],
 	];
 
 	/**

--- a/includes/configuration_managers/class-everlit-configuration-manager.php
+++ b/includes/configuration_managers/class-everlit-configuration-manager.php
@@ -38,11 +38,23 @@ class Everlit_Configuration_Manager extends Configuration_Manager {
 	 * @return bool Plugin ready state.
 	 */
 	public function is_configured() {
+		if ( ! static::is_enabled() ) {
+			return false;
+		}
 		$toc = get_option( 'everlit_clickwrap_accepted', [] ) ?? [];
 		[ 'token' => $token ] = get_option( 'everlit_settings', [] ) ?? [];
 		if ( $this->is_active() && $token !== null && isset( $toc['timestamp'] ) ) {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Newspack Manager conditional check.
+	 *
+	 * @return bool If Newspack Manager is installed and connected.
+	 */
+	public static function is_enabled() {
+		return method_exists( 'Newspack_Manager', 'is_connected_to_manager' ) && \Newspack_Manager::is_connected_to_manager();
 	}
 }

--- a/includes/configuration_managers/class-everlit-configuration-manager.php
+++ b/includes/configuration_managers/class-everlit-configuration-manager.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Everlit plugin configuration manager.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/configuration_managers/class-configuration-manager.php';
+
+/**
+ * Provide an interface for configuring and querying the configuration of Everlit.
+ */
+class Everlit_Configuration_Manager extends Configuration_Manager {
+
+	/**
+	 * The slug of the plugin.
+	 *
+	 * @var string
+	 */
+	public $slug = 'everlit';
+
+	/**
+	 * Configure Everlit for Newspack use.
+	 *
+	 * @return bool Enforce configurability.
+	 */
+	public function configure() {
+		return true;
+	}
+
+	/**
+	 * Is Everlit installed and connected?
+	 *
+	 * @return bool Plugin ready state.
+	 */
+	public function is_configured() {
+		$toc = get_option( 'everlit_clickwrap_accepted', [] ) ?? [];
+		[ 'token' => $token ] = get_option( 'everlit_settings', [] ) ?? [];
+		if ( $this->is_active() && $token !== null && isset( $toc['timestamp'] ) ) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/includes/wizards/class-connections-wizard.php
+++ b/includes/wizards/class-connections-wizard.php
@@ -65,6 +65,7 @@ class Connections_Wizard extends Wizard {
 				'can_connect_google'   => OAuth::is_proxy_configured( 'google' ),
 				'can_connect_fivetran' => OAuth::is_proxy_configured( 'fivetran' ),
 				'can_use_webhooks'     => defined( 'NEWSPACK_EXPERIMENTAL_WEBHOOKS' ) && NEWSPACK_EXPERIMENTAL_WEBHOOKS,
+				'can_use_everlit'      => method_exists( 'Newspack_Manager', 'is_connected_to_manager' ) && \Newspack_Manager::is_connected_to_manager(),
 			]
 		);
 		\wp_enqueue_script( 'newspack-connections-wizard' );

--- a/includes/wizards/class-connections-wizard.php
+++ b/includes/wizards/class-connections-wizard.php
@@ -65,7 +65,7 @@ class Connections_Wizard extends Wizard {
 				'can_connect_google'   => OAuth::is_proxy_configured( 'google' ),
 				'can_connect_fivetran' => OAuth::is_proxy_configured( 'fivetran' ),
 				'can_use_webhooks'     => defined( 'NEWSPACK_EXPERIMENTAL_WEBHOOKS' ) && NEWSPACK_EXPERIMENTAL_WEBHOOKS,
-				'can_use_everlit'      => method_exists( 'Newspack_Manager', 'is_connected_to_manager' ) && \Newspack_Manager::is_connected_to_manager(),
+				'can_use_everlit'      => Everlit_Configuration_Manager::is_enabled(),
 			]
 		);
 		\wp_enqueue_script( 'newspack-connections-wizard' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Everlit plugin management. Due to the nature of the UX implementation of this feature it was necessary to do a rewrite of some of the logic within the `<Plugins />` component used within Connections Wizard, namely:
* Ability to activate plugin when inactive and reload browser when activated.
* Different status, per/plugin, functionality.
* HTML within `<ActionCard />` descriptions i.e. `<a>Learn more</a>`.
* Plugin Manager configuration for Everlit
* Configuration Manager Class for Everlit to request setup status.
* Abstracted individual Plugins into a separate component `<Plugin />` to avoid re-renders on all ActionCards when a single plugins state changes.
* Loading indicators during requests.

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets i.e. `git checkout origin/feat/wizard-everlit-plugin && npm run build`
2. Navigate to _/wp-admin/admin.php?page=newspack-connections-wizard_
3. Observer the new ActionCard for Everlit is present.

![Screenshot 2024-06-19 at 09 47 32](https://github.com/Automattic/newspack-plugin/assets/3676975/b8f24862-357e-431c-b76d-72c89ff0dacc)

4. Click "Install Everlit", once request has completed observe you see the following:

![Screenshot 2024-06-19 at 09 48 53](https://github.com/Automattic/newspack-plugin/assets/3676975/7e50070d-5151-49c5-838f-812aee56b48c)

5. Click "Activate Everlit". Observe:
   - Once request has completed, page will reload (Necessary for Everlit Plugin settings to show once activated) 
   - "Everlit" admin menu item exists after reload.
   - The Everlit plugin action card should resemble the below - prompting further setup. 

![Screenshot 2024-06-19 at 09 55 33](https://github.com/Automattic/newspack-plugin/assets/3676975/fcc01a79-9449-4c3a-b645-93a01e55724f)

6. Right click "Complete Setup" and open in a new tab, this will open a tab with Everlit initial setup. Add your details and click "Submit".

![Screenshot 2024-06-19 at 09 58 23](https://github.com/Automattic/newspack-plugin/assets/3676975/4194fbaa-8d8e-40c2-a778-6a6d2c9293c0)

7. Navigate back to Connections tab and refresh page. Observe that further setup is still necessary. 

![Screenshot 2024-06-19 at 09 55 33](https://github.com/Automattic/newspack-plugin/assets/3676975/fcc01a79-9449-4c3a-b645-93a01e55724f)

8. Navigate back to Everlit settings tab and refresh page. Observe that different configuration is now available e.g. "Everlit Token". Add a "Everlit Token" (for testing purposes this can be anything) and click "Save Changes"
9. Navigate back to Connections tab and refresh. You should now see a successfully configured Everlit plugin.

![Screenshot 2024-06-19 at 10 10 48](https://github.com/Automattic/newspack-plugin/assets/3676975/174a43b4-618d-4133-a9fb-825c12c71e87)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
