### PR TITLE
fix(wizards): include path for `wizards.assets.php`

### DIFF
--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -148,7 +148,7 @@ abstract class Wizard {
 		/**
 		 * Register wizards.js with cache busting
 		 */
-		$asset_file = include plugin_dir_path( __FILE__ ) . 'build/wizards.asset.php';
+		$asset_file = include dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/wizards.asset.php';
 		wp_register_script(
 			'newspack-wizards',
 			Newspack::plugin_url() . '/dist/wizards.js',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes warning: "include(/Users/raz/Sites/newspack/plugin/includes/wizards/build/wizards.asset.php): Failed to open stream: No such file or directory in /Users/raz/Sites/newspack/plugin/includes/wizards/class-wizard.php on line 151"

### How to test the changes in this Pull Request:

1. 
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->