### PR TITLE
Auto-disable ESP sync on staging sites and clone sites

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -90,6 +90,8 @@ final class Reader_Activation {
 			\add_action( 'lostpassword_post', [ __CLASS__, 'set_password_reset_mail_content_type' ] );
 			\add_filter( 'lostpassword_errors', [ __CLASS__, 'rate_limit_lost_password' ], 10, 2 );
 		}
+
+		\add_filter( 'newspack_reader_activation_setting', [ __CLASS__, 'disable_esp_sync_on_staging_sites' ], 10, 2 );
 	}
 
 	/**
@@ -241,7 +243,7 @@ final class Reader_Activation {
 		if ( is_bool( $config[ $name ] ) ) {
 			$value = (bool) $value;
 		}
-		return $value;
+		return apply_filters( 'newspack_reader_activation_setting', $value, $name );
 	}
 
 	/**
@@ -2001,6 +2003,42 @@ final class Reader_Activation {
 			\update_user_meta( $user_data->ID, self::LAST_EMAIL_DATE, time() );
 		}
 		return $errors;
+	}
+
+	/**
+	 * Automatically force deactivate the ESP sync on staging sites to prevent polluting the data in ESPs.
+	 *
+	 * @param mixed  $value Setting value.
+	 * @param string $setting Setting name.
+	 * @return mixed Possibly modified $value.
+	 */
+	public static function disable_esp_sync_on_staging_sites( $value, $setting ) {
+		if ( 'sync_esp' !== $setting ) {
+			return $value;
+		}
+
+		if ( defined( 'NEWSPACK_FORCE_ALLOW_ESP_SYNC' ) && NEWSPACK_FORCE_ALLOW_ESP_SYNC ) {
+			return $value;
+		}
+
+		$site_url = strtolower( untrailingslashit( get_site_url() ) );
+		if ( false !== stripos( $site_url, '.newspackstaging.com' ) ) {
+			return false;
+		}
+
+		// Neither WCS_Staging::is_duplicate_site() nor is_plugin_active() are initialized early enough for all situations.
+		// So we need to re-create the logic from both.
+		if ( in_array( 'woocommerce-subscriptions/woocommerce-subscriptions.php', (array) get_option( 'active_plugins', [] ), true ) ) {
+			$subscriptions_site_url = \get_option( 'wc_subscriptions_siteurl', false );
+			if ( $subscriptions_site_url ) {
+				$cleaned_subscriptions_site_url = strtolower( untrailingslashit( str_ireplace( '_[wc_subscriptions_siteurl]_', '', $subscriptions_site_url ) ) );
+				if ( $cleaned_subscriptions_site_url !== $site_url ) {
+					return false;
+				}
+			}
+		}
+
+		return $value;
 	}
 }
 Reader_Activation::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue we run into occasionally where a clone/staging site will pollute live ESP data because there are multiple sites connected to the same ESP and syncing data.

**Note**: This is a hotfix.

### How to test the changes in this Pull Request:

1. Unit tests should prove the case for `newspackstaging.com` sites, but you can also actually test on one of those sites.

Locally:
1. `get option wc_subscriptions_siteurl` should return something like `http://newspack_[wc_subscriptions_siteurl]_dev.local` (with your local site URL and that thing in the middle of it). Update it to some other URL (keep the thing in the middle of it). This will automatically put WC Subscriptions into staging mode.
2. Before applying this patch, update the status of a subscription. Observe the status change IS reflected in the `NP_Membership Status` data synced up to the ESP.
3. Apply the patch, update the status of a subscription. Observe the status change is NOT reflected in the data synced up to the ESP.
4. Add `define( 'NEWSPACK_FORCE_ALLOW_ESP_SYNC', true );` to your wp-config. Update a subscription status again and observe the change IS reflected at the ESP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->