### PR TITLE
feat: ensure regenerator-runtime is available (for WP 6.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "newspack",
-	"version": "3.8.8",
+	"version": "4.3.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "newspack",
-			"version": "3.8.8",
+			"version": "4.3.3",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@babel/plugin-transform-runtime": "^7.24.3",
@@ -33,16 +33,13 @@
 				"@types/wordpress__block-editor": "^11.5.14",
 				"@types/wordpress__blocks": "^12.5.14",
 				"@types/wordpress__components": "^23.0.12",
-<<<<<<< HEAD
 				"@wordpress/browserslist-config": "^5.40.0",
-=======
-				"@wordpress/browserslist-config": "^5.39.0",
->>>>>>> origin/release
 				"eslint": "^7.32.0",
 				"lint-staged": "^15.2.2",
 				"newspack-scripts": "^5.3.0",
 				"postcss-scss": "^4.0.9",
 				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
+				"regenerator-runtime": "^0.14.1",
 				"stylelint": "^16.5.0"
 			},
 			"engines": {
@@ -223,6 +220,7 @@
 		},
 		"node_modules/@babel/core": {
 			"version": "7.16.7",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.16.7",
@@ -251,6 +249,7 @@
 		},
 		"node_modules/@babel/core/node_modules/semver": {
 			"version": "6.3.0",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -260,6 +259,7 @@
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
 			"integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.22.5",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -591,6 +591,7 @@
 		},
 		"node_modules/@babel/helpers": {
 			"version": "7.16.7",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.16.7",
@@ -1967,6 +1968,17 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"dev": true
+		},
+		"node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+		},
 		"node_modules/@babel/template": {
 			"version": "7.24.0",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
@@ -1984,6 +1996,7 @@
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
 			"integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.22.5",
 				"@babel/generator": "^7.22.5",
@@ -3848,6 +3861,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3861,6 +3875,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3869,6 +3884,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3876,12 +3892,14 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -7528,15 +7546,9 @@
 			"dev": true
 		},
 		"node_modules/@wordpress/browserslist-config": {
-<<<<<<< HEAD
 			"version": "5.40.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.40.0.tgz",
 			"integrity": "sha512-DkTk/B5Qf32ZQ8HfWZWqC85w8VEv/YoAc+BZyXty/FIFJ5QCy6ddIwuysJtCRghyLPjTI+BOSaRo8poiQvyYfg==",
-=======
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.39.0.tgz",
-			"integrity": "sha512-oy5CRWS3WsaFN/KAgOUIE6mmyuFu5qmKZZhQ+voCN+ifXTsj1J6ypR3RyY03Cbojy6kidyVYl3qRyMxbbUwWSQ==",
->>>>>>> origin/release
 			"dev": true,
 			"engines": {
 				"node": ">=14"
@@ -9813,26 +9825,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/array.prototype.filter": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
-			"integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/array.prototype.find": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.1.tgz",
@@ -10739,188 +10731,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/cheerio": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"cheerio-select": "^2.1.0",
-				"dom-serializer": "^2.0.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"htmlparser2": "^8.0.1",
-				"parse5": "^7.0.0",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-select": "^5.1.0",
-				"css-what": "^6.1.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/css-select": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-what": "^6.1.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"nth-check": "^2.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/css-what": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/cheerio-select/node_modules/domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/nth-check": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/nth-check?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/cheerio/node_modules/domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/parse5": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
 		"node_modules/chokidar": {
 			"version": "3.5.2",
 			"dev": true,
@@ -11605,6 +11415,7 @@
 		},
 		"node_modules/convert-source-map": {
 			"version": "1.8.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.1"
@@ -12612,13 +12423,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"dev": true,
@@ -12704,35 +12508,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0"
-			},
-			"engines": {
-				"node": ">= 4"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domhandler?sponsor=1"
-			}
-		},
-		"node_modules/domhandler/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
 		},
 		"node_modules/domutils": {
 			"version": "1.7.0",
@@ -12891,19 +12666,6 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
 		"node_modules/env-ci": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
@@ -12936,40 +12698,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/enzyme": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"array.prototype.flat": "^1.2.3",
-				"cheerio": "^1.0.0-rc.3",
-				"enzyme-shallow-equal": "^1.0.1",
-				"function.prototype.name": "^1.1.2",
-				"has": "^1.0.3",
-				"html-element-map": "^1.2.0",
-				"is-boolean-object": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-number-object": "^1.0.4",
-				"is-regex": "^1.0.5",
-				"is-string": "^1.0.5",
-				"is-subset": "^0.1.1",
-				"lodash.escape": "^4.0.1",
-				"lodash.isequal": "^4.5.0",
-				"object-inspect": "^1.7.0",
-				"object-is": "^1.0.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1",
-				"object.values": "^1.1.1",
-				"raf": "^3.4.1",
-				"rst-selector-parser": "^2.2.3",
-				"string.prototype.trim": "^1.2.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/enzyme-matchers": {
@@ -13016,13 +12744,6 @@
 			"version": "16.13.1",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/enzyme/node_modules/lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/equivalent-key-map": {
 			"version": "0.2.2",
@@ -13100,13 +12821,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/es-define-property": {
 			"version": "1.0.0",
@@ -14647,6 +14361,7 @@
 		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -15307,20 +15022,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/html-element-map": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"array.prototype.filter": "^1.0.0",
-				"call-bind": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "2.0.1",
 			"dev": true,
@@ -15347,69 +15048,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/htmlparser2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/fb55/htmlparser2?sponsor=1",
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"entities": "^4.4.0"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/htmlparser2/node_modules/domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -16114,13 +15752,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/is-subset": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/is-symbol": {
 			"version": "1.0.4",
@@ -19108,6 +18739,7 @@
 		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
@@ -19158,6 +18790,7 @@
 		},
 		"node_modules/json5": {
 			"version": "2.2.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5"
@@ -19745,25 +19378,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
 		},
-		"node_modules/lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true
-		},
-		"node_modules/lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/lodash.isarguments": {
 			"version": "3.1.0",
@@ -20584,13 +20203,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -20655,36 +20267,6 @@
 			"version": "1.4.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"bin": {
-				"nearley-railroad": "bin/nearley-railroad.js",
-				"nearley-test": "bin/nearley-test.js",
-				"nearley-unparse": "bin/nearley-unparse.js",
-				"nearleyc": "bin/nearleyc.js"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://nearley.js.org/#give-to-nearley"
-			}
-		},
-		"node_modules/nearley/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -21685,43 +21267,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/react": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/react-dom": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"scheduler": "^0.23.0"
-			},
-			"peerDependencies": {
-				"react": "^18.2.0"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/scheduler": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-			"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0"
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/semver": {
@@ -25025,33 +24570,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/parse5-htmlparser2-tree-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domhandler": "^5.0.2",
-				"parse5": "^7.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
-		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
 		"node_modules/pascal-case": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -27015,27 +26533,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"node_modules/railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"dev": true,
@@ -27177,6 +26674,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
@@ -27767,9 +27265,10 @@
 			}
 		},
 		"node_modules/regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true
 		},
 		"node_modules/regenerator-transform": {
 			"version": "0.15.2",
@@ -28213,17 +27712,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/rst-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
-			}
-		},
 		"node_modules/rsvp": {
 			"version": "4.8.5",
 			"dev": true,
@@ -28335,6 +27823,7 @@
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/safe-regex": {
@@ -28711,6 +28200,7 @@
 		},
 		"node_modules/scheduler": {
 			"version": "0.20.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
@@ -29535,6 +29025,7 @@
 		},
 		"node_modules/source-map": {
 			"version": "0.5.7",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -30547,21 +30038,6 @@
 			},
 			"engines": {
 				"node": ">=14.18"
-			}
-		},
-		"node_modules/stylelint/node_modules/typescript": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-			"integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
 			}
 		},
 		"node_modules/stylelint/node_modules/which": {
@@ -32751,6 +32227,7 @@
 		},
 		"@babel/core": {
 			"version": "7.16.7",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.16.7",
 				"@babel/generator": "^7.16.7",
@@ -32770,7 +32247,8 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.3.0"
+					"version": "6.3.0",
+					"dev": true
 				}
 			}
 		},
@@ -32778,6 +32256,7 @@
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
 			"integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.22.5",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -33019,6 +32498,7 @@
 		},
 		"@babel/helpers": {
 			"version": "7.16.7",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.16.7",
@@ -33090,8 +32570,7 @@
 		"@babel/plugin-proposal-private-property-in-object": {
 			"version": "7.21.0-placeholder-for-preset-env.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-			"integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-			"requires": {}
+			"integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w=="
 		},
 		"@babel/plugin-syntax-async-generators": {
 			"version": "7.8.4",
@@ -33879,6 +33358,13 @@
 			"integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
 			"requires": {
 				"regenerator-runtime": "^0.13.11"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.11",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+					"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+				}
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -33887,6 +33373,14 @@
 			"requires": {
 				"core-js-pure": "^3.20.2",
 				"regenerator-runtime": "^0.13.4"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.11",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+					"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/template": {
@@ -33903,6 +33397,7 @@
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
 			"integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.22.5",
 				"@babel/generator": "^7.22.5",
@@ -34331,8 +33826,7 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.1.tgz",
 			"integrity": "sha512-ubEkAaTfVZa+WwGhs5jbo5Xfqpeaybr/RvWzvFxRs4jfq16wH8l8Ty/QEEpINxll4xhuGfdMbipRyz5QZh9+FA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@csstools/css-tokenizer": {
 			"version": "2.2.4",
@@ -34344,15 +33838,13 @@
 			"version": "2.1.9",
 			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.9.tgz",
 			"integrity": "sha512-qqGuFfbn4rUmyOB0u8CVISIp5FfJ5GAR3mBrZ9/TKndHakdnm6pY0L/fbLcpPnrzwCyyTEZl1nUcXAYHEWneTA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@csstools/selector-specificity": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
 			"integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.5",
@@ -34530,8 +34022,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
 			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@emotion/utils": {
 			"version": "1.0.0",
@@ -35197,6 +34688,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -35206,22 +34698,26 @@
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -35397,8 +34893,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
 			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "6.7.0",
@@ -37507,8 +37002,7 @@
 		},
 		"@webpack-cli/configtest": {
 			"version": "1.1.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.0",
@@ -37519,8 +37013,7 @@
 		},
 		"@webpack-cli/serve": {
 			"version": "1.6.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wojtekmaj/enzyme-adapter-react-17": {
 			"version": "0.6.5",
@@ -37580,8 +37073,7 @@
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "3.1.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "6.5.0",
@@ -38053,15 +37545,9 @@
 			}
 		},
 		"@wordpress/browserslist-config": {
-<<<<<<< HEAD
 			"version": "5.40.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.40.0.tgz",
 			"integrity": "sha512-DkTk/B5Qf32ZQ8HfWZWqC85w8VEv/YoAc+BZyXty/FIFJ5QCy6ddIwuysJtCRghyLPjTI+BOSaRo8poiQvyYfg==",
-=======
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.39.0.tgz",
-			"integrity": "sha512-oy5CRWS3WsaFN/KAgOUIE6mmyuFu5qmKZZhQ+voCN+ifXTsj1J6ypR3RyY03Cbojy6kidyVYl3qRyMxbbUwWSQ==",
->>>>>>> origin/release
 			"dev": true
 		},
 		"@wordpress/components": {
@@ -39689,13 +39175,11 @@
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-walk": {
 			"version": "7.2.0",
@@ -39753,8 +39237,7 @@
 		},
 		"ajv-keywords": {
 			"version": "3.5.2",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -39881,20 +39364,6 @@
 		"array-unique": {
 			"version": "0.3.2",
 			"dev": true
-		},
-		"array.prototype.filter": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
-			"integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			}
 		},
 		"array.prototype.find": {
 			"version": "2.2.1",
@@ -40507,144 +39976,6 @@
 			"version": "0.7.0",
 			"dev": true
 		},
-		"cheerio": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"cheerio-select": "^2.1.0",
-				"dom-serializer": "^2.0.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"htmlparser2": "^8.0.1",
-				"parse5": "^7.0.0",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-					"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.3"
-					}
-				},
-				"parse5": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-					"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"entities": "^4.4.0"
-					}
-				}
-			}
-		},
-		"cheerio-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"boolbase": "^1.0.0",
-				"css-select": "^5.1.0",
-				"css-what": "^6.1.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1"
-			},
-			"dependencies": {
-				"css-select": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-					"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"boolbase": "^1.0.0",
-						"css-what": "^6.1.0",
-						"domhandler": "^5.0.2",
-						"domutils": "^3.0.1",
-						"nth-check": "^2.0.1"
-					}
-				},
-				"css-what": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-					"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-					"dev": true,
-					"peer": true
-				},
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-					"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.3"
-					}
-				},
-				"nth-check": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-					"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"boolbase": "^1.0.0"
-					}
-				}
-			}
-		},
 		"chokidar": {
 			"version": "3.5.2",
 			"dev": true,
@@ -41156,6 +40487,7 @@
 		},
 		"convert-source-map": {
 			"version": "1.8.0",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -41202,8 +40534,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
 			"integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"create-react-class": {
 			"version": "15.6.3",
@@ -41823,13 +41154,6 @@
 			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
 			"dev": true
 		},
-		"discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"dev": true,
-			"peer": true
-		},
 		"doctrine": {
 			"version": "3.0.0",
 			"dev": true,
@@ -41888,25 +41212,6 @@
 				"webidl-conversions": {
 					"version": "5.0.0",
 					"dev": true
-				}
-			}
-		},
-		"domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
 				}
 			}
 		},
@@ -42034,13 +41339,6 @@
 				"ansi-colors": "^4.1.1"
 			}
 		},
-		"entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"peer": true
-		},
 		"env-ci": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
@@ -42061,46 +41359,6 @@
 		"envinfo": {
 			"version": "7.8.1",
 			"dev": true
-		},
-		"enzyme": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"array.prototype.flat": "^1.2.3",
-				"cheerio": "^1.0.0-rc.3",
-				"enzyme-shallow-equal": "^1.0.1",
-				"function.prototype.name": "^1.1.2",
-				"has": "^1.0.3",
-				"html-element-map": "^1.2.0",
-				"is-boolean-object": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-number-object": "^1.0.4",
-				"is-regex": "^1.0.5",
-				"is-string": "^1.0.5",
-				"is-subset": "^0.1.1",
-				"lodash.escape": "^4.0.1",
-				"lodash.isequal": "^4.5.0",
-				"object-inspect": "^1.7.0",
-				"object-is": "^1.0.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1",
-				"object.values": "^1.1.1",
-				"raf": "^3.4.1",
-				"rst-selector-parser": "^2.2.3",
-				"string.prototype.trim": "^1.2.1"
-			},
-			"dependencies": {
-				"lodash.isequal": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-					"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-					"dev": true,
-					"peer": true
-				}
-			}
 		},
 		"enzyme-matchers": {
 			"version": "7.1.2",
@@ -42198,13 +41456,6 @@
 				"unbox-primitive": "^1.0.2",
 				"which-typed-array": "^1.1.11"
 			}
-		},
-		"es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true,
-			"peer": true
 		},
 		"es-define-property": {
 			"version": "1.0.0",
@@ -42472,8 +41723,7 @@
 		},
 		"eslint-config-prettier": {
 			"version": "8.3.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -43244,7 +42494,8 @@
 			"dev": true
 		},
 		"gensync": {
-			"version": "1.0.0-beta.2"
+			"version": "1.0.0-beta.2",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -43707,17 +42958,6 @@
 			"version": "1.0.0",
 			"dev": true
 		},
-		"html-element-map": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"array.prototype.filter": "^1.0.0",
-				"call-bind": "^1.0.2"
-			}
-		},
 		"html-encoding-sniffer": {
 			"version": "2.0.1",
 			"dev": true,
@@ -43734,52 +42974,6 @@
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
 			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
 			"dev": true
-		},
-		"htmlparser2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"entities": "^4.4.0"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-					"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.3"
-					}
-				}
-			}
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
@@ -43819,8 +43013,7 @@
 		},
 		"icss-utils": {
 			"version": "5.1.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ignore": {
 			"version": "5.3.1",
@@ -44220,13 +43413,6 @@
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
-		},
-		"is-subset": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-			"dev": true,
-			"peer": true
 		},
 		"is-symbol": {
 			"version": "1.0.4",
@@ -45638,8 +44824,7 @@
 		},
 		"jest-pnp-resolver": {
 			"version": "1.2.2",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "27.4.0",
@@ -46229,7 +45414,8 @@
 			}
 		},
 		"jsesc": {
-			"version": "2.5.2"
+			"version": "2.5.2",
+			"dev": true
 		},
 		"json-buffer": {
 			"version": "3.0.1",
@@ -46267,6 +45453,7 @@
 		},
 		"json5": {
 			"version": "2.2.0",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -46651,25 +45838,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
 		},
-		"lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-			"dev": true,
-			"peer": true
-		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true
-		},
-		"lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"peer": true
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -47208,13 +46381,6 @@
 				"moment": "^2.29.4"
 			}
 		},
-		"moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"dev": true,
-			"peer": true
-		},
 		"mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -47259,28 +46425,6 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"dev": true
-		},
-		"nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true,
-					"peer": true
-				}
-			}
 		},
 		"neo-async": {
 			"version": "2.6.2",
@@ -47808,8 +46952,7 @@
 				},
 				"eslint-plugin-react-hooks": {
 					"version": "4.3.0",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"espree": {
 					"version": "9.3.0",
@@ -47970,37 +47113,6 @@
 					"integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
 					"dev": true
 				},
-				"react": {
-					"version": "18.2.0",
-					"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-					"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0"
-					}
-				},
-				"react-dom": {
-					"version": "18.2.0",
-					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-					"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"scheduler": "^0.23.0"
-					}
-				},
-				"scheduler": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-					"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"dev": true
@@ -48085,8 +47197,7 @@
 							"version": "10.0.1",
 							"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
 							"integrity": "sha512-TQ4xQ48tW4QSlODcti7pgSRqBZcUaBzuh0jPpfiMhwJKBPkqzTIAU+IrSWL/7BgXlOM90DjB7YaNgFpx8QWhuA==",
-							"dev": true,
-							"requires": {}
+							"dev": true
 						}
 					}
 				},
@@ -50288,29 +49399,6 @@
 			"version": "6.0.1",
 			"dev": true
 		},
-		"parse5-htmlparser2-tree-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domhandler": "^5.0.2",
-				"parse5": "^7.0.0"
-			},
-			"dependencies": {
-				"parse5": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-					"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"entities": "^4.4.0"
-					}
-				}
-			}
-		},
 		"pascal-case": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -50925,8 +50013,7 @@
 		},
 		"postcss-modules-extract-imports": {
 			"version": "3.0.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -51323,15 +50410,13 @@
 		},
 		"postcss-safe-parser": {
 			"version": "6.0.0",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-scss": {
 			"version": "4.0.9",
 			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
 			"integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-selector-parser": {
 			"version": "6.0.16",
@@ -51573,24 +50658,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"dev": true,
-			"peer": true
-		},
-		"randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			}
-		},
 		"randombytes": {
 			"version": "2.1.0",
 			"dev": true,
@@ -51622,8 +50689,7 @@
 			"version": "6.9.9",
 			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
 			"integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"react": {
 			"version": "17.0.2",
@@ -51655,8 +50721,7 @@
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
 			"integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"react-daterange-picker": {
 			"version": "2.0.1",
@@ -51696,6 +50761,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -52031,8 +51097,7 @@
 			"version": "0.15.2",
 			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
 			"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"reakit-warning": {
 			"version": "0.6.2",
@@ -52135,9 +51200,10 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.15.2",
@@ -52438,17 +51504,6 @@
 				"glob": "^7.1.3"
 			}
 		},
-		"rst-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
-			}
-		},
 		"rsvp": {
 			"version": "4.8.5",
 			"dev": true
@@ -52520,7 +51575,8 @@
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.2"
+			"version": "5.1.2",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -52774,6 +51830,7 @@
 		},
 		"scheduler": {
 			"version": "0.20.2",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -53401,7 +52458,8 @@
 			"dev": true
 		},
 		"source-map": {
-			"version": "0.5.7"
+			"version": "0.5.7",
+			"dev": true
 		},
 		"source-map-js": {
 			"version": "1.2.0",
@@ -53882,8 +52940,7 @@
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.3.tgz",
 					"integrity": "sha512-KEPNw4+WW5AVEIyzC80rTbWEUatTW2lXpN8+8ILC8PiPeWPjwUzrPZDIOZ2wwqDmeqOYTdSGyL3+vE5GC3FB3Q==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"argparse": {
 					"version": "2.0.1",
@@ -54039,8 +53096,7 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
 					"integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"rimraf": {
 					"version": "5.0.5",
@@ -54112,14 +53168,6 @@
 						"has-flag": "^4.0.0",
 						"supports-color": "^7.0.0"
 					}
-				},
-				"typescript": {
-					"version": "5.4.2",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-					"integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
-					"dev": true,
-					"optional": true,
-					"peer": true
 				},
 				"which": {
 					"version": "1.3.1",
@@ -54970,8 +54018,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
 			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"use-lilius": {
 			"version": "2.0.5",
@@ -54994,15 +54041,13 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
 			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"use-sync-external-store": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
 			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -55409,8 +54454,7 @@
 		},
 		"ws": {
 			"version": "7.5.5",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"newspack-scripts": "^5.3.0",
 		"postcss-scss": "^4.0.9",
 		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
+		"regenerator-runtime": "^0.14.1",
 		"stylelint": "^16.5.0"
 	},
 	"browserslist": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ const wizardsScripts = fs
 const wizardsScriptFiles = {
 	'plugins-screen': path.join( __dirname, 'assets', 'plugins-screen', 'plugins-screen.js' ),
 };
-wizardsScripts.forEach( function( wizard ) {
+wizardsScripts.forEach( function ( wizard ) {
 	let wizardFileName = wizard;
 	if ( wizard === 'advertising' ) {
 		// "advertising.js" might be blocked by ad-blocking extensions.
@@ -42,7 +42,7 @@ const otherScripts = fs
 	.filter( script =>
 		fs.existsSync( path.join( __dirname, 'assets', 'other-scripts', script, 'index.js' ) )
 	);
-otherScripts.forEach( function( script ) {
+otherScripts.forEach( function ( script ) {
 	wizardsScriptFiles[ `other-scripts/${ script }` ] = path.join(
 		__dirname,
 		'assets',
@@ -68,12 +68,7 @@ const entry = {
 	admin: path.join( __dirname, 'assets', 'admin', 'index.js' ),
 	'memberships-gate-editor': path.join( __dirname, 'assets', 'memberships-gate', 'editor.js' ),
 	'memberships-gate': path.join( __dirname, 'assets', 'memberships-gate', 'gate.js' ),
-	'memberships-gate-metering': path.join(
-		__dirname,
-		'assets',
-		'memberships-gate',
-		'metering.js'
-	),
+	'memberships-gate-metering': path.join( __dirname, 'assets', 'memberships-gate', 'metering.js' ),
 	'memberships-gate-block-patterns': path.join(
 		__dirname,
 		'assets',
@@ -85,8 +80,6 @@ const entry = {
 Object.keys( entry ).forEach( key => {
 	entry[ key ] = [ 'regenerator-runtime/runtime', entry[ key ] ];
 } );
-
-console.log( entry );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ const wizardsScripts = fs
 const wizardsScriptFiles = {
 	'plugins-screen': path.join( __dirname, 'assets', 'plugins-screen', 'plugins-screen.js' ),
 };
-wizardsScripts.forEach( function ( wizard ) {
+wizardsScripts.forEach( function( wizard ) {
 	let wizardFileName = wizard;
 	if ( wizard === 'advertising' ) {
 		// "advertising.js" might be blocked by ad-blocking extensions.
@@ -42,7 +42,7 @@ const otherScripts = fs
 	.filter( script =>
 		fs.existsSync( path.join( __dirname, 'assets', 'other-scripts', script, 'index.js' ) )
 	);
-otherScripts.forEach( function ( script ) {
+otherScripts.forEach( function( script ) {
 	wizardsScriptFiles[ `other-scripts/${ script }` ] = path.join(
 		__dirname,
 		'assets',
@@ -52,38 +52,46 @@ otherScripts.forEach( function ( script ) {
 	);
 } );
 
+const entry = {
+	...wizardsScriptFiles,
+	blocks: path.join( __dirname, 'assets', 'blocks', 'index.js' ),
+	'reader-activation': path.join( __dirname, 'assets', 'reader-activation', 'index.js' ),
+	'reader-auth': path.join( __dirname, 'assets', 'reader-activation', 'auth.js' ),
+	'reader-registration-block': path.join(
+		__dirname,
+		'assets',
+		'blocks',
+		'reader-registration',
+		'view.js'
+	),
+	'my-account': path.join( __dirname, 'includes', 'reader-revenue', 'my-account', 'index.js' ),
+	admin: path.join( __dirname, 'assets', 'admin', 'index.js' ),
+	'memberships-gate-editor': path.join( __dirname, 'assets', 'memberships-gate', 'editor.js' ),
+	'memberships-gate': path.join( __dirname, 'assets', 'memberships-gate', 'gate.js' ),
+	'memberships-gate-metering': path.join(
+		__dirname,
+		'assets',
+		'memberships-gate',
+		'metering.js'
+	),
+	'memberships-gate-block-patterns': path.join(
+		__dirname,
+		'assets',
+		'memberships-gate',
+		'block-patterns.js'
+	),
+};
+
+Object.keys( entry ).forEach( key => {
+	entry[ key ] = [ 'regenerator-runtime/runtime', entry[ key ] ];
+} );
+
+console.log( entry );
+
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
-		entry: {
-			...wizardsScriptFiles,
-			blocks: path.join( __dirname, 'assets', 'blocks', 'index.js' ),
-			'reader-activation': path.join( __dirname, 'assets', 'reader-activation', 'index.js' ),
-			'reader-auth': path.join( __dirname, 'assets', 'reader-activation', 'auth.js' ),
-			'reader-registration-block': path.join(
-				__dirname,
-				'assets',
-				'blocks',
-				'reader-registration',
-				'view.js'
-			),
-			'my-account': path.join( __dirname, 'includes', 'reader-revenue', 'my-account', 'index.js' ),
-			admin: path.join( __dirname, 'assets', 'admin', 'index.js' ),
-			'memberships-gate-editor': path.join( __dirname, 'assets', 'memberships-gate', 'editor.js' ),
-			'memberships-gate': path.join( __dirname, 'assets', 'memberships-gate', 'gate.js' ),
-			'memberships-gate-metering': path.join(
-				__dirname,
-				'assets',
-				'memberships-gate',
-				'metering.js'
-			),
-			'memberships-gate-block-patterns': path.join(
-				__dirname,
-				'assets',
-				'memberships-gate',
-				'block-patterns.js'
-			),
-		},
+		entry,
 	}
 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WP 6.6 changes some things and `regenerator-runtime` is not available anymore. This PR adds it to every entry file processed by webpack. 

### How to test the changes in this Pull Request:

No functional changes—all should work as expected.

\* `6.6-beta2` to be exact

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->