### PR TITLE
feat(cli): cap-migration tweaks

### DIFF
--- a/includes/cli/class-co-authors-plus.php
+++ b/includes/cli/class-co-authors-plus.php
@@ -132,7 +132,6 @@ class Co_Authors_Plus {
 				'user_url'        => isset( $post_meta['cap-website'] ) ? $post_meta['cap-website'] : '',
 				'user_pass'       => wp_generate_password(),
 				'role'            => \Newspack\Co_Authors_Plus::CONTRIBUTOR_NO_EDIT_ROLE_NAME,
-				'user_email'      => isset( $post_meta['cap-user_email'] ) ? $post_meta['cap-user_email'] : '',
 				'display_name'    => isset( $post_meta['cap-display_name'] ) ? $post_meta['cap-display_name'] : '',
 				'first_name'      => isset( $post_meta['cap-first_name'] ) ? $post_meta['cap-first_name'] : '',
 				'last_name'       => isset( $post_meta['cap-last_name'] ) ? $post_meta['cap-last_name'] : '',
@@ -142,6 +141,16 @@ class Co_Authors_Plus {
 					'_np_migrated_cap_guest_author' => $guest_author->ID,
 				],
 			];
+
+			if ( isset( $post_meta['cap-user_email'] ) && ! empty( $post_meta['cap-user_email'] ) ) {
+				$user_data['user_email'] = $post_meta['cap-user_email'];
+			} else {
+				$dummy_email = '_migrated-' . $guest_author->ID . '-' . $user_login . '@example.com';
+				$user_data['user_email'] = $dummy_email;
+				if ( self::$verbose ) {
+					WP_CLI::line( sprintf( 'Missing email for Guest Author, email address will be updated to %s.', $dummy_email ) );
+				}
+			}
 
 			$existing_user = get_user_by( 'login', $user_login );
 			if ( $existing_user !== false ) {

--- a/includes/cli/class-initializer.php
+++ b/includes/cli/class-initializer.php
@@ -63,5 +63,6 @@ class Initializer {
 		);
 
 		WP_CLI::add_command( 'newspack migrate-co-authors-guest-authors', [ 'Newspack\CLI\Co_Authors_Plus', 'migrate_guest_authors' ] );
+		WP_CLI::add_command( 'newspack backfill-non-editing-contributors', [ 'Newspack\CLI\Co_Authors_Plus', 'backfill_non_editing_contributor' ] );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Adds two arguments for more fine-grained control: `user_logins` and `guest_author_ids`
2. Ensures user email is always set when creating a WP User. Lack of an email causes issues with user avatar display. 
3. Fixes the liked WP Users migration – before, the `contributor_no_edit` role was not added, so the updated WP User would not be assignable to posts.
4. Adds a CLI script to backfill the WP Users who should have the `contributor_no_edit` role added (`subscriber`/`customer` with posts authored)

### How to test the changes in this Pull Request:

1. Create two Guest Authors – one linked to a WP User with `subscriber` role, and one not
2. Ensure the second one does not have an email address
5. Execute `wp newspack migrate-co-authors-guest-authors --user_logins=<login-of-the-WP-User> --verbose --live` and observe only the first Guest Author was processed 
6. Execute `wp newspack migrate-co-authors-guest-authors --guest_author_ids=<guest-author-ID-here> --verbose --live` and observe only the second Guest Author was processed
7. Observe the WP User created from the second Guest Author has a dummy email address assigned
8. Observe that same WP User has the `contributor_no_edit` role

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->