### PR TITLE
fix: update newspack-scripts to v5.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"@wordpress/browserslist-config": "^5.40.0",
 				"eslint": "^7.32.0",
 				"lint-staged": "^15.2.2",
-				"newspack-scripts": "^5.3.0",
+				"newspack-scripts": "^5.5.1",
 				"postcss-scss": "^4.0.9",
 				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 				"regenerator-runtime": "^0.14.1",
@@ -20280,9 +20280,9 @@
 			"dev": true
 		},
 		"node_modules/newspack-scripts": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.3.0.tgz",
-			"integrity": "sha512-rzvctV0e2QCRZOlRNyudCIGOkcK5XiqXZODuqtICDIh+bNyARxCDfpjJZPT1UUTdDXIsM/McH68ItHy3aa08aQ==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.1.tgz",
+			"integrity": "sha512-0M6P1XNpHJ7tRVD3hLpOK8rFEzDzB93EkGweA7Q+HOb4ke+ZjoUmqDl0aBMesvtPA019KsYExIiOWlzs4S6kNg==",
 			"dev": true,
 			"dependencies": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -46437,9 +46437,9 @@
 			"dev": true
 		},
 		"newspack-scripts": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.3.0.tgz",
-			"integrity": "sha512-rzvctV0e2QCRZOlRNyudCIGOkcK5XiqXZODuqtICDIh+bNyARxCDfpjJZPT1UUTdDXIsM/McH68ItHy3aa08aQ==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.1.tgz",
+			"integrity": "sha512-0M6P1XNpHJ7tRVD3hLpOK8rFEzDzB93EkGweA7Q+HOb4ke+ZjoUmqDl0aBMesvtPA019KsYExIiOWlzs4S6kNg==",
 			"dev": true,
 			"requires": {
 				"@automattic/calypso-build": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@wordpress/browserslist-config": "^5.40.0",
 		"eslint": "^7.32.0",
 		"lint-staged": "^15.2.2",
-		"newspack-scripts": "^5.3.0",
+		"newspack-scripts": "^5.5.1",
 		"postcss-scss": "^4.0.9",
 		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 		"regenerator-runtime": "^0.14.1",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR bumps the `newspack-scripts` to 5.5.1, which [fixes an issue with generating alpha releases](https://github.com/Automattic/newspack-scripts/pull/212).

### How to test the changes in this Pull Request:

1. Confirm that npm run build looks okay!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
