### PR TITLE
feat(ras-acc): remain on current page after signin via account link

### DIFF
--- a/assets/reader-activation-auth/index.js
+++ b/assets/reader-activation-auth/index.js
@@ -59,10 +59,13 @@ window.newspackRAS.push( readerActivation => {
 					}
 				}
 			}
-			if ( redirect ) {
+			if ( redirect !== '#' ) {
 				callback = () => {
 					window.location.href = redirect;
 				};
+			} else {
+				// Set account URL after logging in.
+				ev.target.href = newspack_ras_config.account_url;
 			}
 			openAuthModal( { callback } );
 		}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1145,8 +1145,12 @@ final class Reader_Activation {
 		}
 
 		/** Do not render link for authenticated readers if account page doesn't exist. */
-		if ( empty( $account_url ) && \is_user_logged_in() ) {
-			return '';
+		if ( empty( $account_url ) ) {
+			if ( \is_user_logged_in() ) {
+				return '';
+			} else {
+				$account_url = '#';
+			}
 		}
 
 		$class = function( ...$parts ) {
@@ -1156,8 +1160,9 @@ final class Reader_Activation {
 
 		$labels = self::get_reader_activation_labels( 'account_link' );
 		$label  = \is_user_logged_in() ? 'signedin' : 'signedout';
+		$href   = \is_user_logged_in() ? $account_url : '#';
 
-		$link  = '<a class="' . \esc_attr( $class() ) . '" data-labels="' . \esc_attr( htmlspecialchars( \wp_json_encode( $labels ), ENT_QUOTES, 'UTF-8' ) ) . '" href="' . \esc_url_raw( $account_url ?? '#' ) . '" data-newspack-reader-account-link>';
+		$link  = '<a class="' . \esc_attr( $class() ) . '" data-labels="' . \esc_attr( htmlspecialchars( \wp_json_encode( $labels ), ENT_QUOTES, 'UTF-8' ) ) . '" href="' . \esc_url_raw( $href ) . '" data-newspack-reader-account-link>';
 		$link .= '<span class="' . \esc_attr( $class( 'icon' ) ) . '">';
 		$link .= \Newspack\Newspack_UI_Icons::get_svg( 'account' );
 		$link .= '</span>';


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207385073694413/1207579795350578/f

This PR updates the redirect behavior of the RAS-ACC account button so that readers remain on the same page they triggered the signin modal when logging in or creating an account:

![Screenshot 2024-06-25 at 16 26 50](https://github.com/Automattic/newspack-plugin/assets/17905991/e749b2e8-df25-48b2-8846-88aca1ec2895)

### How to test the changes in this Pull Request:

1. As a non-logged in reader, navigate to any post
2. Click the sign in button as pictured above to trigger the auth modal
3. Create a new account
4. On `epic/ras-acc`, you will be redirected to they My Account page. On this branch you will remain on the current page.
5. Click the my account button (which should have replaced the sign in button pictured above)
6. Confirm you are redirected to the my account page now.
7. Log out and repeat the above steps, this time signing into the existing account rather than creating a new one.
8. Repeat the above steps triggering from various other parts of the site (i.e. Page, Archive, Homepage, etc.)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->