### PR TITLE
fix: variable name > constant

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -433,7 +433,7 @@ final class Reader_Data {
 		$active_subscriptions = \wcs_get_subscriptions(
 			[
 				'customer_id'         => $data['user_id'],
-				'subscription_status' => WooCommerce_Connection::$active_subscription_statuses,
+				'subscription_status' => WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES,
 			]
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an error I noticed while testing something else.

### How to test the changes in this Pull Request:

1. On `release`, `NEWSPACK_LOG_LEVEL` set to `2` in wp-config.php, log in as a reader. In your debug.log, observe a warning:

```
[26-Jun-2024 20:54:56 UTC] [4875] [NEWSPACK-DATA-EVENTS][Newspack\Data_Events::handle][ERROR]: Access to undeclared static property Newspack\WooCommerce_Connection::$active_subscription_statuses
```

2. Check out this branch, repeat, and confirm no error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->