### PR TITLE
fix(js): skip regenerator-runtime fix for some files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,25 +36,7 @@ wizardsScripts.forEach( function ( wizard ) {
 	);
 } );
 
-// Get files for other scripts.
-const otherScripts = fs
-	.readdirSync( path.join( __dirname, 'assets', 'other-scripts' ) )
-	.filter( script =>
-		fs.existsSync( path.join( __dirname, 'assets', 'other-scripts', script, 'index.js' ) )
-	);
-otherScripts.forEach( function ( script ) {
-	wizardsScriptFiles[ `other-scripts/${ script }` ] = path.join(
-		__dirname,
-		'assets',
-		'other-scripts',
-		script,
-		'index.js'
-	);
-} );
-
 const entry = {
-	...wizardsScriptFiles,
-	blocks: path.join( __dirname, 'assets', 'blocks', 'index.js' ),
 	'reader-activation': path.join( __dirname, 'assets', 'reader-activation', 'index.js' ),
 	'reader-auth': path.join( __dirname, 'assets', 'reader-activation', 'auth.js' ),
 	'reader-registration-block': path.join(
@@ -66,9 +48,31 @@ const entry = {
 	),
 	'my-account': path.join( __dirname, 'includes', 'reader-revenue', 'my-account', 'index.js' ),
 	admin: path.join( __dirname, 'assets', 'admin', 'index.js' ),
-	'memberships-gate-editor': path.join( __dirname, 'assets', 'memberships-gate', 'editor.js' ),
 	'memberships-gate': path.join( __dirname, 'assets', 'memberships-gate', 'gate.js' ),
 	'memberships-gate-metering': path.join( __dirname, 'assets', 'memberships-gate', 'metering.js' ),
+};
+
+// Get files for other scripts.
+const otherScripts = fs
+	.readdirSync( path.join( __dirname, 'assets', 'other-scripts' ) )
+	.filter( script =>
+		fs.existsSync( path.join( __dirname, 'assets', 'other-scripts', script, 'index.js' ) )
+	);
+otherScripts.forEach( function ( script ) {
+	entry[ `other-scripts/${ script }` ] = path.join(
+		__dirname,
+		'assets',
+		'other-scripts',
+		script,
+		'index.js'
+	);
+} );
+
+// These files will need `regenerator-runtime` as of WP 6.6.
+const wpAdminEntries = {
+	...wizardsScriptFiles,
+	blocks: path.join( __dirname, 'assets', 'blocks', 'index.js' ),
+	'memberships-gate-editor': path.join( __dirname, 'assets', 'memberships-gate', 'editor.js' ),
 	'memberships-gate-block-patterns': path.join(
 		__dirname,
 		'assets',
@@ -77,8 +81,8 @@ const entry = {
 	),
 };
 
-Object.keys( entry ).forEach( key => {
-	entry[ key ] = [ 'regenerator-runtime/runtime', entry[ key ] ];
+Object.keys( wpAdminEntries ).forEach( key => {
+	entry[ key ] = [ 'regenerator-runtime/runtime', wpAdminEntries[ key ] ];
 } );
 
 const webpackConfig = getBaseWebpackConfig(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced by https://github.com/Automattic/newspack-plugin/pull/3196. Some JS files in this plugin are not meant to be additionally processed.

Because https://github.com/Automattic/newspack-plugin/pull/3196 is already on `alpha`, this change will also have to land on `alpha` branch. 

### How to test the changes in this Pull Request:

1. On `trunk`, load the Newspack dashboard
2. Observe a `Cannot read properties of undefined (reading '__esModule')` error in the JS console 
3. Switch to this branch, rebuild, observe no error in the console

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->