### PR TITLE
fix: display transaction fee as an amount instead of a percentage

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -242,8 +242,9 @@ class WooCommerce_Cover_Fees {
 	public static function get_fee_display_value( $subtotal ) {
 		$total = self::get_total_with_fee( $subtotal );
 		if ( ! function_exists( 'wc_price' ) ) {
+			$donation_settings = Donations::get_donation_settings();
 			// Just one decimal place, please.
-			return ( (float) number_format( ( ( $total - $subtotal ) * 100 ) / $subtotal, 1 ) ) . '%';
+			return $donation_settings['currencySymbol'] . ( (float) number_format( $total - $subtotal, 2 ) );
 		}
 		return \wc_price( $total - $subtotal );
 	}

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -175,7 +175,7 @@ class WooCommerce_Cover_Fees {
 								'I’d like to cover the %1$s transaction fee to ensure my full donation goes towards %2$s mission.',
 								'newspack-plugin'
 							),
-							esc_html( self::get_cart_fee_display_value() ),
+							wp_kses_post( self::get_cart_fee_display_value() ),
 							esc_html( self::get_possessive( get_option( 'blogname' ) ) )
 						);
 					}
@@ -241,9 +241,11 @@ class WooCommerce_Cover_Fees {
 	 */
 	public static function get_fee_display_value( $subtotal ) {
 		$total = self::get_total_with_fee( $subtotal );
-		// Just one decimal place, please.
-		$flat_percentage = (float) number_format( ( ( $total - $subtotal ) * 100 ) / $subtotal, 1 );
-		return $flat_percentage . '%';
+		if ( ! function_exists( 'wc_price' ) ) {
+			// Just one decimal place, please.
+			return ( (float) number_format( ( ( $total - $subtotal ) * 100 ) / $subtotal, 1 ) ) . '%';
+		}
+		return \wc_price( $total - $subtotal );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Displays the transaction fee as an amount instead of a percentage in the Donate modal checkout flow.

### How to test the changes in this Pull Request:

1. Check out this branch
2. While using the Newspack Reader Revenue platform, in **Newspack > Reader Revenue > Stripe Settings**, enable the "Allow donors to cover transaction fees" option but leave the custom message field blank.
3. As a reader, start a donation transaction and proceed to the payment part of the modal.
4. Confirm that the default message shows the fee in an absolute currency amount instead of as a percentage:

<img width="499" alt="Screenshot 2024-06-27 at 4 21 55 PM" src="https://github.com/Automattic/newspack-plugin/assets/2230142/0af32ef2-224d-4b47-9055-0f1e3e12165e">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207669785215348