### PR TITLE
Assorted small tweaks

### DIFF
--- a/includes/cli/class-setup.php
+++ b/includes/cli/class-setup.php
@@ -35,6 +35,13 @@ class Setup {
 			wp_set_current_user( $user_id );
 		}
 
+		// Set permalink structure to pretty links, unless already set.
+		if ( ! get_option( 'permalink_structure' ) ) {
+			global $wp_rewrite;
+			$wp_rewrite->set_permalink_structure( '/%year%/%monthnum%/%postname%/' );
+			$wp_rewrite->flush_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rules_flush_rules
+		}
+
 		$user_name = wp_get_current_user()->user_login;
 
 		WP_CLI::line( "Logged in as $user_name" );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -851,7 +851,9 @@ final class Reader_Activation {
 	 * Setup nav menu hooks.
 	 */
 	public static function setup_nav_menu() {
-		if ( ! self::get_setting( 'enabled_account_link' ) || ! self::is_woocommerce_active() ) {
+		// Not checking if the whole WC suite is active (self::is_woocommerce_active()),
+		// because only the main WooCommerce plugin is actually required for this to work.
+		if ( ! self::get_setting( 'enabled_account_link' ) || ! function_exists( 'WC' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Adds permalink structure update to the `wp newspack setup` command.
2. Enables the RAS auth nav link to be displayed if WooCommerce Subscriptions is not active. The main WC plugin is the only requirement. WC Subscriptions is a premium plugin, and won't be present in a minimal Newspack setup.

### How to test the changes in this Pull Request:

1. On a fresh site, delete `permalink_structure` option and flush rewrite rules (`wp option delete permalink_structure && wp rewrite flush`)
3. Run `wp newspack setup` and observe the permalink structure has been updated
4. Enable and configure RAS and deactivate the `woocommerce-subscriptions` plugin – observe the auth nav link is still rendered and working as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->