### PR TITLE
feat(wc-memberships): update two and three tiers patterns with checkout-button border radius

### DIFF
--- a/includes/plugins/wc-memberships/block-patterns/pay-wall-three-tiers-alt.php
+++ b/includes/plugins/wc-memberships/block-patterns/pay-wall-three-tiers-alt.php
@@ -87,7 +87,7 @@ $vip_features = [
 					</div>
 					<!-- /wp:group -->
 
-					<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Become a Member', 'newspack' ); ?>","width":100,"className":"is-style-outline"} /-->
+					<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Become a Member', 'newspack' ); ?>","width":100,"className":"is-style-outline","style":{"border":{"radius":"3px"}}} /-->
 				</div>
 				<!-- /wp:group -->
 
@@ -144,7 +144,7 @@ $vip_features = [
 					</div>
 					<!-- /wp:group -->
 
-					<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Become a Patron', 'newspack' ); ?>","width":100} /-->
+					<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Become a Patron', 'newspack' ); ?>","width":100,"style":{"border":{"radius":"3px"}}} /-->
 				</div>
 				<!-- /wp:group -->
 
@@ -190,7 +190,7 @@ $vip_features = [
 					</div>
 					<!-- /wp:group -->
 
-					<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Become a VIP', 'newspack' ); ?>","width":100,"className":"is-style-outline"} /-->
+					<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Become a VIP', 'newspack' ); ?>","width":100,"className":"is-style-outline","style":{"border":{"radius":"3px"}}} /-->
 				</div>
 				<!-- /wp:group -->
 

--- a/includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers-alt.php
+++ b/includes/plugins/wc-memberships/block-patterns/pay-wall-two-tiers-alt.php
@@ -79,7 +79,7 @@ $patron_features = [
 				</div>
 				<!-- /wp:group -->
 
-				<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Become a Member', 'newspack' ); ?>","width":100,"className":"is-style-outline"} /-->
+				<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Become a Member', 'newspack' ); ?>","width":100,"className":"is-style-outline","style":{"border":{"radius":"3px"}}} /-->
 			</div>
 			<!-- /wp:group -->
 
@@ -136,7 +136,7 @@ $patron_features = [
 				</div>
 				<!-- /wp:group -->
 
-				<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Become a Patron', 'newspack' ); ?>","width":100} /-->
+				<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Become a Patron', 'newspack' ); ?>","width":100,"style":{"border":{"radius":"3px"}}} /-->
 			</div>
 			<!-- /wp:group -->
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x]  Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a very quick PR where I simply set the border-radius of the checkout buttons to 3px as opposed to the default border-radius (Block Theme-only)

Patterns:

* Paywall with Two Tiers (Alt)
* Paywall with Three Tiers (Alt)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Switch to the Block Theme
3. Add the  patterns to a page, publish
4. Check if the correct border-radius is applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->