### PR TITLE
feat(ia): added reusable Wizard tab and section components

### DIFF
--- a/assets/wizards/newspack/views/settings/connections/index.tsx
+++ b/assets/wizards/newspack/views/settings/connections/index.tsx
@@ -13,58 +13,40 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 import Webhooks from './webhooks';
 import CustomEvents from './custom-events';
-import { SectionHeader } from '../../../../../components/src';
-
-function Section( {
-	title,
-	description,
-	children = null,
-}: {
-	title?: string;
-	description?: string;
-	children: React.ReactNode;
-} ) {
-	return (
-		<div className="newspack-wizard__section">
-			{ title && <SectionHeader heading={ 3 } title={ title } description={ description } /> }
-			{ children }
-		</div>
-	);
-}
+import WizardsTab from '../../../../wizards-tab';
+import WizardSection from '../../../../wizards-section';
 
 function Connections() {
 	return (
-		<div className="newspack-wizard__sections">
-			<h1>{ __( 'Connections', 'newspack-plugin' ) }</h1>
-
+		<WizardsTab title={ __( 'Connections', 'newspack-plugin' ) }>
 			{ /* Plugins */ }
-			<Section title={ __( 'Plugins', 'newspack-plugin' ) }>
+			<WizardSection title={ __( 'Plugins', 'newspack-plugin' ) }>
 				<div className="newspack-card">Coming soon</div>
 				<div className="newspack-card">Coming soon</div>
-			</Section>
+			</WizardSection>
 
 			{ /* APIs; google */ }
-			<Section title={ __( 'APIs', 'newspack-plugin' ) }>
+			<WizardSection title={ __( 'APIs', 'newspack-plugin' ) }>
 				<div className="newspack-card">Coming soon</div>
-			</Section>
+			</WizardSection>
 
 			{ /* reCAPTCHA */ }
-			<Section title={ __( 'reCAPTCHA v3', 'newspack-plugin' ) }>
+			<WizardSection title={ __( 'reCAPTCHA v3', 'newspack-plugin' ) }>
 				<div className="newspack-card">Coming soon</div>
-			</Section>
+			</WizardSection>
 
 			{ /* Webhooks */ }
-			<Section>
+			<WizardSection>
 				<Webhooks />
-			</Section>
+			</WizardSection>
 
 			{ /* Analytics */ }
-			<Section title={ __( 'Analytics', 'newspack-plugin' ) }>
+			<WizardSection title={ __( 'Analytics', 'newspack-plugin' ) }>
 				<div className="newspack-card">Coming soon</div>
-			</Section>
+			</WizardSection>
 
 			{ /* Custom Events */ }
-			<Section
+			<WizardSection
 				title={ __( 'Activate Newspack Custom Events', 'newspack-plugin' ) }
 				description={ __(
 					'Allows Newspack to send enhanced custom event data to your Google Analytics.',
@@ -72,8 +54,8 @@ function Connections() {
 				) }
 			>
 				<CustomEvents />
-			</Section>
-		</div>
+			</WizardSection>
+		</WizardsTab>
 	);
 }
 

--- a/assets/wizards/wizards-section.tsx
+++ b/assets/wizards/wizards-section.tsx
@@ -1,0 +1,35 @@
+/**
+ * Wizards Section component.
+ */
+
+/**
+ * Internal dependencies.
+ */
+import { SectionHeader } from '../components/src';
+
+/**
+ * Section component.
+ *
+ * @param props Component props.
+ * @param props.title Section title.
+ * @param props.description Section description.
+ * @param props.children Section children.
+ *
+ * @return Component.
+ */
+export default function WizardSection( {
+	title,
+	description,
+	children = null,
+}: {
+	title?: string;
+	description?: string;
+	children: React.ReactNode;
+} ) {
+	return (
+		<div className="newspack-wizard__section">
+			{ title && <SectionHeader heading={ 3 } title={ title } description={ description } /> }
+			{ children }
+		</div>
+	);
+}

--- a/assets/wizards/wizards-tab.tsx
+++ b/assets/wizards/wizards-tab.tsx
@@ -1,0 +1,19 @@
+/**
+ * Wizards Tab component.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+function WizardsTab( { title, children }: { title: string; children: React.ReactNode } ) {
+	return (
+		<div className="newspack-wizard__sections">
+			<h1>{ title }</h1>
+			{ children }
+		</div>
+	);
+}
+
+export default WizardsTab;

--- a/assets/wizards/wizards-tab.tsx
+++ b/assets/wizards/wizards-tab.tsx
@@ -2,11 +2,6 @@
  * Wizards Tab component.
  */
 
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
 function WizardsTab( { title, children }: { title: string; children: React.ReactNode } ) {
 	return (
 		<div className="newspack-wizard__sections">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added reusable Section & Tab components to obfuscate required boilerplate.

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets.
2. Navigate to Newspack > Settings i.e. _/wp-admin/admin.php?page=newspack-settings_
3. Observe Connections tab and sections load correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?