### PR TITLE
fix: add credits meta attributes to image block effect hook dependencies array

### DIFF
--- a/assets/blocks/core-image/index.tsx
+++ b/assets/blocks/core-image/index.tsx
@@ -48,9 +48,21 @@ const AttributesLoader = ( { setAttributes, attributes }: ImageBlockTypes.Attrib
 		// Meta added, proceed
 		if ( Object.keys( meta ).length ) {
 			const { _media_credit, _media_credit_url, _navis_media_credit_org } = meta;
-			setAttributes( { meta: { _media_credit, _media_credit_url, _navis_media_credit_org } } );
+			// Only trigger if our meta has updated.
+			if (
+				_media_credit !== attributes?.meta?._media_credit ||
+				_media_credit_url !== attributes?.meta?._media_credit_url ||
+				_navis_media_credit_org !== attributes?.meta?._navis_media_credit_org
+			) {
+				setAttributes( { meta: { _media_credit, _media_credit_url, _navis_media_credit_org } } );
+			}
 		}
-	}, [ Object.keys( meta ).length ] );
+	}, [
+		meta,
+		attributes?.meta?._media_credit,
+		attributes?.meta?._media_credit_url,
+		attributes?.meta?._navis_media_credit_org,
+	] );
 
 	return <></>;
 };


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207720049982626/1207708215353147/f

This PR fixes a problem where adding our credits image block meta would cause an infinite render loop whenever a synced pattern was created.

We fix this by adding a check for updated meta attribute values to the effect hook as well as adding the attribute meta values to the hook dependencies.

![Screenshot 2024-07-08 at 15 25 02](https://github.com/Automattic/newspack-plugin/assets/17905991/b5167876-b6b9-47df-b8ad-8cc5a7ceea28)

### How to test the changes in this Pull Request:

1. Start on a site running WP 6.6 RC, and using Chrome.
2. Add an image block to the editor.
3. Create a synced pattern from the image block (From block options, select create pattern and make sure the synced toggle is on as pictured above)
4. On release Chrome will freeze up as the block is re-rendered infinitely. On this branch, there should be no problems.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->