### PR TITLE
feat(co-authors-plus): option to block the Guest Authors menu item

### DIFF
--- a/includes/plugins/class-co-authors-plus.php
+++ b/includes/plugins/class-co-authors-plus.php
@@ -37,6 +37,7 @@ class Co_Authors_Plus {
 		add_filter( 'coauthors_edit_author_cap', [ __CLASS__, 'coauthors_edit_author_cap' ] );
 		add_action( 'admin_init', [ __CLASS__, 'setup_custom_role_and_capability' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'prevent_myaccount_update' ] );
+		add_action( 'admin_menu', [ __CLASS__, 'remove_guest_authors_menu_item' ], PHP_INT_MAX );
 	}
 
 	/**
@@ -102,6 +103,33 @@ class Co_Authors_Plus {
 		}
 
 		\update_option( self::SETTINGS_VERSION_OPTION_NAME, $current_settings_version );
+	}
+
+	/**
+	 * Remove the Guest Authors menu item from the admin menu.
+	 */
+	public static function remove_guest_authors_menu_item() {
+		if ( ! defined( 'NEWSPACK_DISABLE_GUEST_AUTHORS' ) || ! NEWSPACK_DISABLE_GUEST_AUTHORS ) {
+			return;
+		}
+		remove_submenu_page( 'users.php', 'view-guest-authors' );
+		add_submenu_page(
+			'users.php',
+			__( 'Guest Authors', 'newspack-plugin' ),
+			__( 'Guest Authors', 'newspack-plugin' ),
+			'list_users',
+			'newspack-view-guest-authors',
+			[ __CLASS__, 'render_page' ]
+		);
+	}
+
+	/**
+	 * Render the replacement Guest Authors page.
+	 */
+	public static function render_page() {
+		?>
+			<h1><?php echo esc_html__( 'Please use regular WP Users with "Non-Editing Contributor" role.', 'newspack-plugin' ); ?></h1>
+		<?php
 	}
 }
 Co_Authors_Plus::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Newspack discourages the use of Co-Authors Plus' Guest Authors feature and offers a way to migrate them to WP Users (#3068). This PR adds an optional (behind `NEWSPACK_DISABLE_GUEST_AUTHORS` feature flag) blocking of the "Guest Authors" menu item.

### How to test the changes in this Pull Request:

1. Install Co-Authors Plus and visit the Users -> Guest Authors link, observe that Guest Authors can be added
2. Set `NEWSPACK_DISABLE_GUEST_AUTHORS` environment variable to true
3. Refresh the page, observe that the Users -> Guest Authors link leads to this message and Guest Authors can't be added here:

<img width="822" alt="image" src="https://github.com/Automattic/newspack-plugin/assets/7383192/b5111ac6-f769-43d6-85d0-f7d199911e7e">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->