### PR TITLE
feat: remove 'Patterns' link from Appearance menu

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -20,6 +20,7 @@ class Patches {
 		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_patterns_menu_link' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_pattern_categories_menu_link' ] );
+		add_action( 'admin_menu', [ __CLASS__, 'remove_core_patterns_menu_link' ] );
 		add_action( 'manage_edit-wp_block_columns', [ __CLASS__, 'add_custom_columns' ] );
 		add_action( 'manage_edit-wp_block_sortable_columns', [ __CLASS__, 'add_sortable_columns' ] );
 		add_action( 'manage_wp_block_posts_custom_column', [ __CLASS__, 'custom_column_content' ], 10, 2 );
@@ -116,6 +117,13 @@ class Patches {
 	 */
 	public static function add_pattern_categories_menu_link() {
 		add_submenu_page( 'edit.php', 'manage_pattern_categories', __( 'Pattern Categories', 'newspack-plugin' ), 'edit_posts', 'edit-tags.php?taxonomy=wp_pattern_category', '', 3 );
+	}
+
+	/**
+	 * Remove the Core Patterns link, which redirects to the Site Editor as of WordPress 6.6.
+	 */
+	public static function remove_core_patterns_menu_link() {
+		remove_submenu_page( 'themes.php', 'site-editor.php?path=/patterns' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR reworks https://github.com/Automattic/newspack-plugin/pull/3221 as a hotfix.

WordPress 6.6 updates the Core link under WP Admin > Appearance > Patterns to point to the Site Editor. 

The Newspack Plugin already includes a link to Patterns and Pattern Categories under Posts, so the link from Core was already redundant. Now it has the possibility of being confusing -- we'll need to get publishers onboarded with the Site Editor when they're moved to block themes, but in the meantime it's unlikely they're using this link, and pushing them into the Site Editor at this point doesn't seem like it'd be a smooth introduction. 

Note: When a block theme is active, the Patterns link doesn't exist -- there's a Patterns section under Appearance > Editor instead. So adding this change to the Newspack Plugin won't affect the block theme, and keeps the code with the code adding the Patterns under the Posts menu. It also won't affect WP 6.5 because the link is different.

### How to test the changes in this Pull Request:

1. From the WordPress Dashboard, note that there's a Patterns link under the Appearance menu.
2. Apply this PR.
3. Confirm the Patterns link there is now gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->