### PR TITLE
Refactor/mailchimp connector

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -38,7 +38,7 @@ final class Blocks {
 			'newspack-blocks',
 			'newspack_blocks',
 			[
-				'has_newsletters'         => method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ),
+				'has_newsletters'         => class_exists( 'Newspack_Newsletters_Subscription' ),
 				'has_reader_activation'   => Reader_Activation::is_enabled(),
 				'newsletters_url'         => Wizards::get_wizard( 'engagement' )->newsletters_settings_url(),
 				'has_google_oauth'        => Google_OAuth::is_oauth_configured(),

--- a/includes/configuration_managers/class-newspack-newsletters-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-newsletters-configuration-manager.php
@@ -112,8 +112,9 @@ class Newspack_Newsletters_Configuration_Manager extends Configuration_Manager {
 	 * @return array Lists.
 	 */
 	public function add_contact( $contact, $list_id ) {
+		__deprecated_function( __METHOD__, '4.4.3', 'Newspack_Newsletters_Contacts::upsert' );
 		if ( $this->is_configured() ) {
-			return \Newspack_Newsletters_Subscription::add_contact( $contact, $list_id );
+			return \Newspack_Newsletters_Contacts::upsert( $contact, $list_id );
 		}
 	}
 

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -56,7 +56,7 @@ class ActiveCampaign extends Connector {
 		if ( ! $master_list_id ) {
 			return;
 		}
-		return \Newspack_Newsletters_Subscription::add_contact( $contact, $master_list_id );
+		return \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id );
 	}
 
 	/**

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -75,123 +75,6 @@ class Mailchimp extends Connector {
 	}
 
 	/**
-	 * Get merge field type.
-	 *
-	 * @param mixed $value Value to check.
-	 *
-	 * @return string Merge field type.
-	 */
-	private static function get_merge_field_type( $value ) {
-		if ( is_numeric( $value ) ) {
-			return 'number';
-		}
-		if ( is_bool( $value ) ) {
-			return 'boolean';
-		}
-		return 'text';
-	}
-
-	/**
-	 * Get merge fields given data.
-	 *
-	 * @param string $audience_id Audience ID.
-	 * @param array  $data        Data to check.
-	 *
-	 * @return array Merge fields.
-	 */
-	private static function get_merge_fields( $audience_id, $data ) {
-		$merge_fields = [];
-
-		// Strip arrays.
-		$data = array_filter(
-			$data,
-			function( $value ) {
-				return ! is_array( $value );
-			}
-		);
-
-		// Get and match existing merge fields.
-		$merge_fields_res = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" );
-		if ( \is_wp_error( $merge_fields_res ) ) {
-			Logger::log(
-				sprintf(
-					// Translators: %1$s is the error message.
-					__( 'Error getting merge fields: %1$s', 'newspack-plugin' ),
-					$merge_fields_res->get_error_message()
-				)
-			);
-			return [];
-		}
-		$existing_fields = $merge_fields_res['merge_fields'];
-		usort(
-			$existing_fields,
-			function( $a, $b ) {
-				return $a['merge_id'] - $b['merge_id'];
-			}
-		);
-
-		$list_merge_fields = [];
-
-		// Handle duplicate fields.
-		foreach ( $existing_fields as $field ) {
-			if ( ! isset( $list_merge_fields[ $field['name'] ] ) ) {
-				$list_merge_fields[ $field['name'] ] = $field['tag'];
-			} else {
-				Logger::log(
-					sprintf(
-						// Translators: %1$s is the merge field name, %2$s is the field's unique tag.
-						__( 'Warning: Duplicate merge field %1$s found with tag %2$s.', 'newspack-plugin' ),
-						$field['name'],
-						$field['tag']
-					)
-				);
-			}
-		}
-
-		foreach ( $data as $field_name => $field_value ) {
-			// If field already exists, add it to the payload.
-			if ( isset( $list_merge_fields[ $field_name ] ) ) {
-				$merge_fields[ $list_merge_fields[ $field_name ] ] = $data[ $field_name ];
-				unset( $data[ $field_name ] );
-			}
-		}
-
-		// Create remaining fields.
-		$remaining_fields = array_keys( $data );
-		foreach ( $remaining_fields as $field_name ) {
-			$created_field = Mailchimp_API::post(
-				"lists/$audience_id/merge-fields",
-				[
-					'name' => $field_name,
-					'type' => self::get_merge_field_type( $data[ $field_name ] ),
-				]
-			);
-			// Skip field if it failed to create.
-			if ( is_wp_error( $created_field ) ) {
-				Logger::log(
-					sprintf(
-					// Translators: %1$s is the merge field key, %2$s is the error message.
-						__( 'Failed to create merge field %1$s. Error response: %2$s', 'newspack-plugin' ),
-						$field_name,
-						$created_field->get_error_message() ?? __( 'The connected ESP could not create this merge field.', 'newspack-plugin' )
-					)
-				);
-				continue;
-			}
-			Logger::log(
-				sprintf(
-					// Translators: %1$s is the merge field key, %2$s is the error message.
-					__( 'Created merge field %1$s.', 'newspack-plugin' ),
-					$field_name
-				)
-			);
-			$merge_fields[ $created_field['tag'] ] = $data[ $field_name ];
-		}
-
-		return $merge_fields;
-	}
-
-	/**
 	 * Update a Mailchimp contact
 	 *
 	 * @param array $contact Contact info to sync to ESP without lists.
@@ -203,31 +86,14 @@ class Mailchimp extends Connector {
 		if ( ! $audience_id ) {
 			return;
 		}
-		$hash    = md5( strtolower( $contact['email'] ) );
-		$payload = [
-			'email_address' => $contact['email'],
-			'status_if_new' => self::get_default_reader_status(),
-		];
 
-		// Normalize contact metadata.
-		$contact = Newspack_Newsletters::normalize_contact_data( $contact );
-		if ( ! empty( $contact['metadata'] ) ) {
-			$merge_fields = self::get_merge_fields( $audience_id, $contact['metadata'] );
-			if ( ! empty( $merge_fields ) ) {
-				$payload['merge_fields'] = $merge_fields;
-			}
+		if ( empty( $contact['metadata'] ) ) {
+			$contact['metadata'] = [];
 		}
 
-		Logger::log(
-			'Syncing contact with metadata key(s): ' . implode( ', ', array_keys( $contact['metadata'] ) ) . '.',
-			Data_Events::LOGGER_HEADER
-		);
+		$contact['metadata']['status'] = self::get_default_reader_status();
 
-		// Upsert the contact.
-		return Mailchimp_API::put(
-			"lists/$audience_id/members/$hash",
-			$payload
-		);
+		return \Newspack_Newsletters_Contacts::upsert( $contact, $audience_id );
 	}
 }
 new Mailchimp();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Refactors the Mailchimp data connector to use the methods on Newsletters plugin instead.

Move the merge fields strategy to the Newsletters plugin. (It was already there, we just updated it)

There should be no functional changes

### How to test the changes in this Pull Request:

Make sure data sync via Mailchimp Data Events API connector has the same results on `trunk` and on this branch.

Suggestion, you can inspect the payload of the request [here](https://github.com/Automattic/newspack-plugin/blob/trunk/includes/data-events/connectors/class-mailchimp.php#L227) when running on trunk and then inspect the payload [here](https://github.com/Automattic/newspack-newsletters/blob/refactor%2Fmailchimp-data-connector/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php#L1421) when running on this branch.

Also check in Mailchimp's dashboard to see if the contacts have the same fields in both situation.

When testing on this branch, you need to checkout https://github.com/Automattic/newspack-newsletters/pull/1568

In order to test, trigger a data event API that will sync a contact to mailchimp. For example, making a donation.

Also test if merge fields are created when they are missing (on this branch):
* On MC dashboard, delete one (or many) merge fields
* Make sure local mailchimp cache is refreshed:
```
SQL -> delete from wp_options where option_name like 'newspack_nl_mailchimp_cache%';
wp cache flush
```
Make sure the merge fields you deleted are no longer in cache:
```
$x = Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $audience_id );
foreach ( $x as $k => $v ) echo "$k -> " . $v['tag'] . "\n";
```

Trigger the user sync and confirm that the merge fields are re-created and correctly populated for the contact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->