### PR TITLE
Updating and reorganizing CAP tweaks

### DIFF
--- a/assets/other-scripts/co-authors-plus/index.js
+++ b/assets/other-scripts/co-authors-plus/index.js
@@ -1,0 +1,68 @@
+/* globals guestAuthorRole, jQuery */
+
+jQuery( document ).ready( function ( $ ) {
+	$( 'select#role' ).change( function () {
+		if ( guestAuthorRole.role !== $( this ).val() ) {
+			deactivateGuestAuthor();
+		} else {
+			activateGuestAuthor();
+		}
+	} );
+
+	const loginLabel = $( 'label[for="user_login"]' )[ 0 ].innerHTML;
+
+	function activateGuestAuthor() {
+		// Make email not required.
+		$( 'label[for="email"] > span.description' ).hide();
+		$( '#createuser input[name=email]' ).closest( 'tr' ).removeClass( 'form-required' );
+
+		// User login.
+		if ( 'new' === guestAuthorRole.screen ) {
+			$( 'label[for="user_login"]' )[ 0 ].innerHTML = guestAuthorRole.displayNameLabel;
+		} else {
+			$( 'label[for="user_login"]' ).parents( 'tr' ).hide();
+		}
+
+		// Password.
+		$( 'label[for="pass1"]' ).parents( 'tr' ).hide();
+
+		// Email notification.
+		$( 'input#send_user_notification' ).parents( 'tr' ).hide();
+
+		// User profile fields.
+		$( 'label[for="rich_editing"]' ).parents( 'tr' ).hide();
+		$( 'label[for="comment_shortcuts"]' ).parents( 'tr' ).hide();
+		$( 'label[for="admin_bar_front"]' ).parents( 'tr' ).hide();
+		$( 'label[for="locale"]' ).parents( 'tr' ).hide();
+		$( 'tr.user-admin-color-wrap' ).hide();
+	}
+
+	function deactivateGuestAuthor() {
+		// Make email required.
+		$( 'label[for="email"] > span.description' ).show();
+		$( '#createuser input[name=email]' ).closest( 'tr' ).addClass( 'form-required' );
+
+		// User login.
+		if ( 'new' === guestAuthorRole.screen ) {
+			$( 'label[for="user_login"]' )[ 0 ].innerHTML = loginLabel;
+		} else {
+			$( 'label[for="user_login"]' ).parents( 'tr' ).show();
+		}
+
+		// Password.
+		$( 'label[for="pass1"]' ).parents( 'tr' ).show();
+
+		// Email notification.
+		$( 'input#send_user_notification' ).parents( 'tr' ).show();
+
+		// User profile fields.
+		$( 'label[for="rich_editing"]' ).parents( 'tr' ).show();
+		$( 'label[for="comment_shortcuts"]' ).parents( 'tr' ).show();
+		$( 'label[for="admin_bar_front"]' ).parents( 'tr' ).show();
+		$( 'label[for="locale"]' ).parents( 'tr' ).show();
+		$( 'tr.user-admin-color-wrap' ).show();
+	}
+
+	// Trigger change event on page load.
+	$( 'select#role' ).change();
+} );

--- a/assets/other-scripts/co-authors-plus/index.js
+++ b/assets/other-scripts/co-authors-plus/index.js
@@ -63,6 +63,13 @@ jQuery( document ).ready( function ( $ ) {
 		$( 'tr.user-admin-color-wrap' ).show();
 	}
 
+	// Check for the role query argument for a quick link to add guest authors.
+	const urlParams = new URLSearchParams( window.location.search );
+	const role = urlParams.get( 'role' );
+	if ( role === guestAuthorRole.role ) {
+		$( 'select#role' ).val( role );
+	}
+
 	// Trigger change event on page load.
 	$( 'select#role' ).change();
 } );

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -157,7 +157,8 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
-		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-co-authors-plus.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-guest-author-role.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-coauthor-user-cap.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';

--- a/includes/plugins/class-co-authors-plus.php
+++ b/includes/plugins/class-co-authors-plus.php
@@ -105,6 +105,10 @@ class Co_Authors_Plus {
 
 		$user_meta = get_userdata( $user_id );
 
+		if ( ! $user_meta ) {
+			return $caps;
+		}
+
 		if ( in_array( self::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $user_meta->roles, true ) ) {
 			$caps = [ 'do_not_allow' ];
 		}

--- a/includes/plugins/class-co-authors-plus.php
+++ b/includes/plugins/class-co-authors-plus.php
@@ -34,6 +34,7 @@ class Co_Authors_Plus {
 
 			if ( defined( 'NEWSPACK_DISABLE_CAP_GUEST_AUTHORS' ) && NEWSPACK_DISABLE_CAP_GUEST_AUTHORS ) {
 				\add_filter( 'coauthors_guest_authors_enabled', '__return_false' );
+				add_action( 'admin_menu', [ __CLASS__, 'guest_author_menu_replacement' ] );
 			}
 
 			// Register new role.
@@ -74,7 +75,7 @@ class Co_Authors_Plus {
 
 		\add_role( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.custom_role_add_role
 			self::CONTRIBUTOR_NO_EDIT_ROLE_NAME,
-			__( 'Non-Editing Contributor', 'newspack-plugin' ),
+			__( 'Guest Author', 'newspack-plugin' ),
 			[
 				'read' => true,
 				\apply_filters( 'coauthors_edit_author_cap', 'edit_posts' ) => true, // Make sure CAP considers this a role that can author posts.
@@ -235,6 +236,37 @@ class Co_Authors_Plus {
 		}
 
 		return $user;
+	}
+
+	/**
+	 * Adds a replacement Guest Authors menu item.
+	 */
+	public static function guest_author_menu_replacement() {
+		add_submenu_page(
+			'users.php',
+			__( 'Guest Authors', 'newspack-plugin' ),
+			__( 'Guest Authors', 'newspack-plugin' ),
+			'list_users',
+			'newspack-view-guest-authors',
+			[ __CLASS__, 'render_guest_authors_replacement_page' ]
+		);
+	}
+
+	/**
+	 * Render the replacement Guest Authors page.
+	 */
+	public static function render_guest_authors_replacement_page() {
+		?>
+			<div class="wrap">
+				<h1><?php echo esc_html__( 'Guest Authors', 'newspack-plugin' ); ?></h1>
+
+				<p><?php echo esc_html__( "Co-Authors-Plus' Guest Authors are disabled in this site. Use the Guest Author user role instead.", 'newspack-plugin' ); ?></p>
+				<p><?php echo esc_html__( 'You can use one of the shortcuts below:', 'newspack-plugin' ); ?></p>
+
+				<a href="<?php echo esc_url( admin_url( 'user-new.php?role=' . self::CONTRIBUTOR_NO_EDIT_ROLE_NAME ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add new Guest Author', 'newspack-plugin' ); ?></a>
+				<a href="<?php echo esc_url( admin_url( 'users.php?role=' . self::CONTRIBUTOR_NO_EDIT_ROLE_NAME ) ); ?>" class="page-title-action"><?php echo esc_html__( 'View all Guest Authors', 'newspack-plugin' ); ?></a>
+			</div>
+		<?php
 	}
 }
 

--- a/includes/plugins/co-authors-plus/class-coauthor-user-cap.php
+++ b/includes/plugins/co-authors-plus/class-coauthor-user-cap.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Co-Authors Plus integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class creates a new capability and adds it to all roles that have the edit_posts capability
+ *
+ * Then it filters the capability used by Co-Authors Plus to determine which users can be assigned as co-authors.
+ */
+class Coauthor_User_Cap {
+
+	/**
+	 * Custom capability name.
+	 */
+	const ASSIGNABLE_TO_POSTS_CAPABILITY_NAME = 'edit_cap_posts';
+
+	/**
+	 * Option name to mark the version of the settings. If the implementation details
+	 * change, the expected option value should be updated to trigger a reset of the settings.
+	 */
+	const SETTINGS_VERSION_OPTION_NAME = 'newsroomnz_coauthors_plus_tweaks_settings_version';
+
+	/**
+	 * Initializes the class.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_filter( 'coauthors_edit_author_cap', [ __CLASS__, 'coauthors_edit_author_cap' ] );
+		add_action( 'admin_init', [ __CLASS__, 'setup_custom_capability' ] );
+	}
+
+	/**
+	 * Override the capability required to assign a user as a co-author.
+	 *
+	 * @param string $edit_cap Capability required for a user to be assigned as a co-author.
+	 */
+	public static function coauthors_edit_author_cap( $edit_cap ) {
+		return self::ASSIGNABLE_TO_POSTS_CAPABILITY_NAME;
+	}
+
+	/**
+	 * Add custom capability to the roles that should be allowed to author posts.
+	 */
+	public static function setup_custom_capability() {
+		$current_settings_version = '1';
+		if ( \get_option( self::SETTINGS_VERSION_OPTION_NAME ) === $current_settings_version ) {
+			return;
+		}
+
+		$wp_roles = wp_roles();
+		foreach ( $wp_roles->roles as $role_name => $role ) {
+			$role = $wp_roles->get_role( $role_name );
+			if ( $role->has_cap( 'edit_posts' ) || $role_name === Guest_Author_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME ) {
+				$role->add_cap( self::ASSIGNABLE_TO_POSTS_CAPABILITY_NAME );
+			}
+		}
+
+		\update_option( self::SETTINGS_VERSION_OPTION_NAME, $current_settings_version );
+	}
+}
+
+Coauthor_User_Cap::init();

--- a/includes/plugins/co-authors-plus/class-coauthor-user-cap.php
+++ b/includes/plugins/co-authors-plus/class-coauthor-user-cap.php
@@ -25,7 +25,7 @@ class Coauthor_User_Cap {
 	 * Option name to mark the version of the settings. If the implementation details
 	 * change, the expected option value should be updated to trigger a reset of the settings.
 	 */
-	const SETTINGS_VERSION_OPTION_NAME = 'newsroomnz_coauthors_plus_tweaks_settings_version';
+	const SETTINGS_VERSION_OPTION_NAME = 'newspack_coauthors_plus_settings_version';
 
 	/**
 	 * Initializes the class.

--- a/includes/plugins/co-authors-plus/class-coauthor-user-cap.php
+++ b/includes/plugins/co-authors-plus/class-coauthor-user-cap.php
@@ -35,6 +35,7 @@ class Coauthor_User_Cap {
 	public static function init() {
 		add_filter( 'coauthors_edit_author_cap', [ __CLASS__, 'coauthors_edit_author_cap' ] );
 		add_action( 'admin_init', [ __CLASS__, 'setup_custom_capability' ] );
+		add_action( 'newspack_before_delete_account', [ __CLASS__, 'before_delete_account' ] );
 	}
 
 	/**
@@ -64,6 +65,27 @@ class Coauthor_User_Cap {
 		}
 
 		\update_option( self::SETTINGS_VERSION_OPTION_NAME, $current_settings_version );
+	}
+
+	/**
+	 * Prevents the Delete Account email to be sent and display an error message to the user
+	 *
+	 * @param int $user_id The user ID trying to delete the account.
+	 * @return void
+	 */
+	public static function before_delete_account( $user_id ) {
+		if ( user_can( $user_id, self::ASSIGNABLE_TO_POSTS_CAPABILITY_NAME ) ) {
+			\wp_safe_redirect(
+				\add_query_arg(
+					[
+						'message'  => __( 'It looks like you are an author on this site. Please contact a site adminstrator to get your account deactivated.', 'newspack-plugin' ),
+						'is_error' => true,
+					],
+					\remove_query_arg( WooCommerce_My_Account::DELETE_ACCOUNT_URL_PARAM )
+				)
+			);
+			exit;
+		}
 	}
 }
 

--- a/includes/plugins/co-authors-plus/class-guest-author-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-author-role.php
@@ -10,9 +10,9 @@ namespace Newspack;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Main class.
+ * This class implements a custom role called Guest Authors to be used instead of the regular CO-Authors Plus guest authors.
  */
-class Co_Authors_Plus {
+class Guest_Author_Role {
 	/**
 	 * Custom role name for users who are assignable as post authors but aren't allowed to edit posts.
 	 *
@@ -274,4 +274,4 @@ class Co_Authors_Plus {
 	}
 }
 
-Co_Authors_Plus::init();
+Guest_Author_Role::init();

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -204,6 +204,13 @@ class WooCommerce_My_Account {
 			return;
 		}
 
+		/**
+		 * Fires before the account deletion email is sent.
+		 *
+		 * @param int $user_id The user ID of the account being deleted.
+		 */
+		do_action( 'newspack_before_delete_account', $user_id );
+
 		$token      = \wp_generate_password( 43, false, false );
 		$form_nonce = \wp_create_nonce( self::DELETE_ACCOUNT_FORM );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves our implementation of an alternative to CAP Guest Authors.

### How to test the changes in this Pull Request:

1. Checkout this branch
2. Add `define( 'NEWSPACK_DISABLE_CAP_GUEST_AUTHORS', true );` to wp-config
3. Visit Users > Guest Authors and see the replacement page
4. Click Add new Guest Author and confirm you see the regular form to add a new user but with some modifications (no username, no password)
5. Create a user and confirm you can assign it as coauthor
6. Confirm you can not login as this user
7. Confirm the edit page for this user does not have a bunch of fields (username, password, application password, woo fields, profile colors, etc)
8. @adekbadek confirm that this transitions well from a site using the previous approach. (the user role has the same slug and the capability is no longer checked)

-- test author cap ---

Add the edit_cap_posts capability to a subscribe user and confirm you can assign them as coauthors. Remove the capability and make sure you no longer can.

Make sure all other roles that can edit posts still can be assigned as coauthors.

-- test user account deletion --

Login as subscriber with the special cap and try to delete its account. Confirm you get a message saying you can't

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->