### PR TITLE
feat(cli-co-authors-plus): ensure correct author slug is set

### DIFF
--- a/includes/cli/class-co-authors-plus.php
+++ b/includes/cli/class-co-authors-plus.php
@@ -294,7 +294,7 @@ class Co_Authors_Plus {
 				WP_CLI::warning( sprintf( 'No term found for user %d.', $user_id ) );
 			}
 
-			$author_slug = str_replace( 'cap-', '', $guest_term->slug );
+			$author_slug = preg_replace( '/^cap-/', '', $guest_term->slug );
 
 			if ( self::$live ) {
 				if ( $wp_user_term ) {

--- a/includes/cli/class-co-authors-plus.php
+++ b/includes/cli/class-co-authors-plus.php
@@ -294,6 +294,8 @@ class Co_Authors_Plus {
 				WP_CLI::warning( sprintf( 'No term found for user %d.', $user_id ) );
 			}
 
+			$author_slug = str_replace( 'cap-', '', $guest_term->slug );
+
 			if ( self::$live ) {
 				if ( $wp_user_term ) {
 					// If the WP User term exists, delete the Guest Author term and reassign the posts.
@@ -326,7 +328,7 @@ class Co_Authors_Plus {
 				}
 			}
 
-			self::assign_user_props( $guest_author_data, $user_id );
+			self::assign_user_props( $guest_author_data, $user_id, $author_slug );
 			self::assign_user_meta( $guest_author, $user_id );
 
 			// Add the Non-Editing Contributor role.
@@ -355,11 +357,12 @@ class Co_Authors_Plus {
 	/**
 	 * Assign user props from guest author post's data.
 	 *
-	 * @param array $guest_author_data The guest author post's data.
-	 * @param int   $user_id The user ID to update the avatar for.
+	 * @param array  $guest_author_data The guest author post's data.
+	 * @param int    $user_id The user ID to update the avatar for.
+	 * @param string $author_slug Intended author slug. Must match the of the Guest Author slug (w/o "cap-" prefix).
 	 * @return bool True if the user meta was updated, false otherwise.
 	 */
-	private static function assign_user_props( $guest_author_data, $user_id ) {
+	private static function assign_user_props( $guest_author_data, $user_id, $author_slug ) {
 		$display_name = $guest_author_data['cap-display_name'][0];
 		$user_login = $guest_author_data['cap-user_login'][0];
 
@@ -371,7 +374,7 @@ class Co_Authors_Plus {
 				[
 					'ID'            => $user_id,
 					'display_name'  => $display_name,
-					'user_nicename' => $display_name,
+					'user_nicename' => $author_slug,
 				]
 			);
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

With the way CoAuthors-Plus works, the term corresponding to the author must have `slug` (with `'cap-'` prefix) set to the linked WP User's `slug` (aka `user_nicename`). This change ensures that this is always the case. 

### How to test the changes in this Pull Request:

1. Create a CAP Guest Author and link them to an existing WP User, take note of the Guest Author slug and archive URL
2. Run the migration: `wp newspack migrate-co-authors-guest-authors --verbose --live` 
3. Observe the author archive still works and that the term slug (the term ID will be printed in the output) matches the WP User's `user_nicename` (`wp user get <ID> --field=user_nicename`). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->