### PR TITLE
fix: reader registration empty styles applying outside block

### DIFF
--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -390,13 +390,13 @@ export default function ReaderRegistrationEdit( {
 				) }
 				{ editedState === 'registration' && (
 					<>
-						<div className="newspack-registration__icon" />
+						<span className="newspack-registration__icon" />
 						<div { ...innerBlocksProps } />
 					</>
 				) }
 				{ editedState === 'login' && (
 					<>
-						<div className="newspack-registration__icon" />
+						<span className="newspack-registration__icon" />
 						<RichText
 							align="center"
 							onChange={ value => setAttributes( { signedInLabel: value } ) }

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -201,7 +201,7 @@ function render_block( $attrs, $content ) {
 	<div class="newspack-registration <?php echo esc_attr( get_block_classes( $attrs ) ); ?>">
 		<?php if ( $registered ) : ?>
 			<div class="newspack-registration__registration-success">
-				<div class="newspack-registration__icon"></div>
+				<span class="newspack-registration__icon"></span>
 				<?php echo $success_registration_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
 		<?php else : ?>
@@ -314,11 +314,11 @@ function render_block( $attrs, $content ) {
 				</div>
 			</form>
 			<div class="newspack-registration__registration-success newspack-registration--hidden">
-				<div class="newspack-registration__icon"></div>
+				<span class="newspack-registration__icon"></span>
 				<?php echo $success_registration_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
 			<div class="newspack-registration__login-success newspack-registration--hidden">
-				<div class="newspack-registration__icon"></div>
+				<span class="newspack-registration__icon"></span>
 				<?php echo \wp_kses_post( $success_login_markup ); ?>
 			</div>
 		<?php endif; ?>

--- a/assets/blocks/reader-registration/style.scss
+++ b/assets/blocks/reader-registration/style.scss
@@ -234,7 +234,7 @@
 	}
 
 	&--hidden,
-	+ div:empty {
+	div:empty {
 		display: none;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1205234045751551/1207733530705589/f

This PR fixes an issue where styles for empty divs were affecting blocks outside of the reader registration block. As a result, a spacer added after the RR block would be hidden, while empty divs within the block would not:

Before:
![Screenshot 2024-07-16 at 14 41 33](https://github.com/user-attachments/assets/71176b64-0d9e-4de5-b5bc-3fb2f487bf90)

After:
![Screenshot 2024-07-16 at 14 46 03](https://github.com/user-attachments/assets/226955af-b714-4bfb-9140-5f7da51957ce)



### How to test the changes in this Pull Request:

1. Insert a Reader Registration block on any page or post
2. Right after it, place a Spacer block
3. Publish and visit the front-end, confirm the Spacer block is hidden on `epic/ras-acc` but not on this branch.
4. Go back to the editor and add a spacer WITHIN the registration block.
5. Publish and visit the front-end, confirm the Spacer block within the reader registration block is hidden.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->