### PR TITLE
feat: add a UI to add the non editing contrib role

### DIFF
--- a/includes/plugins/class-co-authors-plus.php
+++ b/includes/plugins/class-co-authors-plus.php
@@ -37,6 +37,8 @@ class Co_Authors_Plus {
 		add_filter( 'coauthors_edit_author_cap', [ __CLASS__, 'coauthors_edit_author_cap' ] );
 		add_action( 'admin_init', [ __CLASS__, 'setup_custom_role_and_capability' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'prevent_myaccount_update' ] );
+		add_action( 'edit_user_profile', [ __CLASS__, 'edit_user_profile' ] );
+		add_action( 'wp_update_user', [ __CLASS__, 'edit_user_profile_update' ] );
 	}
 
 	/**
@@ -102,6 +104,62 @@ class Co_Authors_Plus {
 		}
 
 		\update_option( self::SETTINGS_VERSION_OPTION_NAME, $current_settings_version );
+	}
+
+	/**
+	 * Save custom fields.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public static function edit_user_profile_update( $user_id ) {
+		if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'update-user_' . $user_id ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_user', $user_id ) ) {
+			return false;
+		}
+
+		$user = get_userdata( $user_id );
+		if ( ! empty( $_POST['newspack_cap_custom_cap_option'] ) ) {
+			$user->add_role( self::CONTRIBUTOR_NO_EDIT_ROLE_NAME );
+		} else {
+			$user->remove_role( self::CONTRIBUTOR_NO_EDIT_ROLE_NAME );
+		}
+	}
+
+	/**
+	 * Add user profile fields.
+	 *
+	 * @param WP_User $user The current WP_User object.
+	 */
+	public static function edit_user_profile( $user ) {
+		$current_status = user_can( $user->ID, self::CONTRIBUTOR_NO_EDIT_ROLE_NAME );
+		?>
+		<div class="newspack-plugin-cap-options">
+
+			<h2><?php echo esc_html__( 'Co-Authors Plus Options', 'newspack-plugin' ); ?></h2>
+
+			<table class="form-table" role="presentation">
+				<tr class="user-newspack_cap_custom_cap_option-wrap">
+					<th scope="row">
+						<?php esc_html_e( 'Enable as coauthor', 'newspack-plugin' ); ?>
+					</th>
+					<td>
+						<label for="newspack_cap_custom_cap_option">
+							<input type="checkbox" name="newspack_cap_custom_cap_option" id="newspack_cap_custom_cap_option" value="1" <?php checked( $current_status ); ?> />
+							<?php esc_html_e( 'Allow this user to be assigned as a co-author of a post.', 'newspack-plugin' ); ?>
+						</label>
+						<p class="description">
+						<?php
+							esc_html_e( 'If this option is checked, this user will be able to be assigned as a co-author of a post even if they are not allowed to edit posts. For users with edit access, this option has no effect.', 'newspack-plugin' );
+						?>
+						</p>
+					</td>
+				</tr>
+			</table>
+		</div>
+		<?php
 	}
 }
 Co_Authors_Plus::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a UI to assign users to the custom Non-Editing Contributor role:

<img width="907" alt="image" src="https://github.com/user-attachments/assets/78e789f0-7b8c-4c0e-89ce-e31a1c850f0d">

### How to test the changes in this Pull Request:

1. Edit a user
2. See the new "Co-Authors Plus" section
3. Check the box to add the custom role save
4. Confirm the role is added to the user
5. Uncheck the box and save
6. Confirm the role is removed
7. Confirm you don't see this section when you edit your own profile

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->