### PR TITLE
feat(ia): Newspack > Settings > Social - part 1

### DIFF
--- a/assets/wizards/newspack/views/settings/sections.tsx
+++ b/assets/wizards/newspack/views/settings/sections.tsx
@@ -8,13 +8,14 @@ import { __ } from '@wordpress/i18n';
 const settingsTabs = window.newspackSettings;
 
 import Connections from './connections';
+import Social from './social';
 
 type SectionKeys = keyof typeof settingsTabs;
 
 const sectionComponents: Record< SectionKeys | 'default', () => JSX.Element > = {
 	connections: Connections,
 	// emails: Emails,
-	// social: Social,
+	social: Social,
 	// syndication: Syndication,
 	// seo: Seo,
 	// 'theme-and-brand': ThemeAndBrand,

--- a/assets/wizards/newspack/views/settings/sections.tsx
+++ b/assets/wizards/newspack/views/settings/sections.tsx
@@ -16,7 +16,6 @@ type SectionKeys = keyof typeof settingsTabs;
 
 const sectionComponents: Record< SectionKeys | 'default', () => JSX.Element > = {
 	connections: Connections,
-	// emails: Emails,
 	social: Social,
 	emails: Emails,
 	// social: Social,

--- a/assets/wizards/newspack/views/settings/social/index.tsx
+++ b/assets/wizards/newspack/views/settings/social/index.tsx
@@ -1,0 +1,28 @@
+/**
+ * Newspack > Settings > Social
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Section from '../../../../wizards-section';
+import Publicize from './publicize';
+
+function Social() {
+	return (
+		<div className="newspack-wizard__sections">
+			<h1>{ __( 'Social', 'newspack-plugin' ) }</h1>
+
+			<Section>
+				<Publicize />
+			</Section>
+		</div>
+	);
+}
+
+export default Social;

--- a/assets/wizards/newspack/views/settings/social/publicize.tsx
+++ b/assets/wizards/newspack/views/settings/social/publicize.tsx
@@ -1,0 +1,29 @@
+/**
+ * Newspack > Settings > Social
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import WizardsPluginCard from '../../../../wizards-plugin-card';
+
+function Publicize() {
+	return (
+		<WizardsPluginCard
+			name={ __( 'Publicize', 'newspack-plugin' ) }
+			badge="Jetpack"
+			slug="jetpack"
+			path=""
+			description={ __(
+				"Publicize makes it easy to share your site's posts on several social media networks automatically when you publish a new post.",
+				'newspack-plugin'
+			) }
+			actionText={ __( 'Configure', 'newspack-plugin' ) }
+			// handoff="jetpack"
+			editLink="admin.php?page=jetpack#/sharing"
+		/>
+	);
+}
+
+export default Publicize;

--- a/assets/wizards/newspack/views/settings/social/publicize.tsx
+++ b/assets/wizards/newspack/views/settings/social/publicize.tsx
@@ -19,7 +19,6 @@ function Publicize() {
 				'newspack-plugin'
 			) }
 			actionText={ { complete: __( 'Configure', 'newspack-plugin' ) } }
-			// handoff="jetpack"
 			editLink="admin.php?page=jetpack#/sharing"
 		/>
 	);

--- a/assets/wizards/newspack/views/settings/social/publicize.tsx
+++ b/assets/wizards/newspack/views/settings/social/publicize.tsx
@@ -12,7 +12,7 @@ function Publicize() {
 	return (
 		<WizardsPluginCard
 			title={ __( 'Publicize', 'newspack-plugin' ) }
-			badge="Jetpack"
+			badge={ __( 'Jetpack', 'newspack-plugin' ) }
 			slug="jetpack"
 			description={ __(
 				"Publicize makes it easy to share your site's posts on several social media networks automatically when you publish a new post.",

--- a/assets/wizards/newspack/views/settings/social/publicize.tsx
+++ b/assets/wizards/newspack/views/settings/social/publicize.tsx
@@ -18,7 +18,10 @@ function Publicize() {
 				"Publicize makes it easy to share your site's posts on several social media networks automatically when you publish a new post.",
 				'newspack-plugin'
 			) }
-			actionText={ { complete: __( 'Configure', 'newspack-plugin' ) } }
+			actionText={ {
+				complete: __( 'Configure', 'newspack-plugin' ),
+				activate: __( 'Activate Jetpack', 'newspack-plugin' ),
+			} }
 			editLink="admin.php?page=jetpack#/sharing"
 		/>
 	);

--- a/assets/wizards/types/wizard-action-card.d.ts
+++ b/assets/wizards/types/wizard-action-card.d.ts
@@ -54,13 +54,6 @@ type PluginWizardApiFetchCallback = (
 	callbacks?: ApiFetchCallbacks< PluginResponse >
 ) => Promise< PluginResponse >;
 
-type PluginCardActionText = {
-	complete?: string;
-	configure?: string;
-	activate?: string;
-	install?: string;
-};
-
 /**
  * Plugin card action texts
  */

--- a/assets/wizards/types/wizard-action-card.d.ts
+++ b/assets/wizards/types/wizard-action-card.d.ts
@@ -16,7 +16,7 @@ type ActionCardProps = Partial< {
 	toggleChecked: boolean;
 	toggleOnChange: () => void;
 	actionContent: boolean | JSX.Element | null;
-	error: string | null;
+	error: Error | string | null;
 	handoff: string | null;
 	isErrorStatus: boolean;
 	isChecked: boolean;
@@ -31,17 +31,13 @@ type PluginCard = {
 	path: string;
 	slug: string;
 	editLink?: string;
-	description?: (
-		errorMessage: string | null,
-		isFetching: boolean,
-		status: string | null
-	) => string;
+	description?:
+		| string
+		| ( ( errorMessage: string | null, isFetching: boolean, status: string | null ) => string );
 	name: string;
 	url?: string;
 	status?: string;
 	badge?: string;
 	indent?: string;
-	error?: null | {
-		errorCode: string;
-	};
+	error?: string | null | Error;
 };

--- a/assets/wizards/wizards-section.tsx
+++ b/assets/wizards/wizards-section.tsx
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies.
+ */
+import { SectionHeader } from '../components/src';
+
+/**
+ * Section component.
+ *
+ * @param props Component props.
+ * @param props.title Section title.
+ * @param props.description Section description.
+ * @param props.children Section children.
+ *
+ * @return Component.
+ */
+export default function Section( {
+	title,
+	description,
+	children = null,
+}: {
+	title?: string;
+	description?: string;
+	children: React.ReactNode;
+} ) {
+	return (
+		<div className="newspack-wizard__section">
+			{ title && <SectionHeader heading={ 3 } title={ title } description={ description } /> }
+			{ children }
+		</div>
+	);
+}

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -251,7 +251,7 @@ final class Newspack {
 	public function remove_notifications() {
 		$screen = get_current_screen();
 
-		$is_newspack_screen = ( 'newspack' === $screen->parent_base ) || ( 'admin_page_newspack-' === substr( $screen->base, 0, 20 ) );
+		$is_newspack_screen = str_contains( $screen->base, 'newspack_page_' );
 		if ( ! $screen || ! $is_newspack_screen ) {
 			return;
 		}


### PR DESCRIPTION
## NB: Dependent on https://github.com/Automattic/newspack-plugin/pull/3249 merging first!
once #3249 is merged destination branch will update to `origin/epic/ia`

---

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

* Introduction of Publicize component, for managing social functionality within Jetpack, on Newspack Settings. The component uses `WizardsPluginCard`.

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets i.e. `git checkout origin/feat/is-settings-social && npm run build`
2. Deactivate Jetpack plugin i.e. `wp plugin deactivate jetpack`
3. Navigate to _/wp-admin/admin.php?page=newspack-settings#/social_
4. Confirm presence of Publicize component (with "Activate Jetpack" prompt):

![Screenshot 2024-07-19 at 10 01 16](https://github.com/user-attachments/assets/11829350-a2f8-487d-86b1-d1d294c2459b)

5. Click "Activate Jetpack" and observe page reloads and Jetpack is activate.

If you have Jetpack activated, but not connected, you should see the below. Clicking "Configure" will navigate user to _/wp-admin/admin.php?page=jetpack#/sharing_.

![Screenshot 2024-07-19 at 09 59 30](https://github.com/user-attachments/assets/378baf59-cc50-461e-8ef6-be8935c9956d)

If Jetpack is activate and connected you should see the following:

![Screenshot 2024-07-19 at 10 08 36](https://github.com/user-attachments/assets/1915ccc3-828f-456b-8118-293582dc5b53)



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?