### PR TITLE
feat: show deprecation warning for CM in Engagement wizard

### DIFF
--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -14,7 +14,7 @@ import once from 'lodash/once';
 import { useEffect, useState, Fragment } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { sprintf, __ } from '@wordpress/i18n';
-import { CheckboxControl, TextareaControl, ExternalLink } from '@wordpress/components';
+import { CheckboxControl, TextareaControl, ExternalLink, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -187,6 +187,18 @@ export const NewspackNewsletters = ( {
 								{ __( 'Authorize', 'newspack-plugin' ) }
 							</Button>
 						</Card>
+					) }
+					{ 'campaign_monitor' ===
+						config?.settings?.newspack_newsletters_service_provider?.value && (
+						<Notice isWarning isDismissible={ false }>
+							<h2>{ __( 'Campaign Monitor support will be deprecated', 'newspack-plugin' ) }</h2>
+							<p>
+								{ __(
+									'Please connect a different service provider to ensure continued support.',
+									'newspack-'
+								) }
+							</p>
+						</Notice>
 					) }
 					{ values( config.settings )
 						.filter(

--- a/assets/wizards/engagement/views/newsletters/index.js
+++ b/assets/wizards/engagement/views/newsletters/index.js
@@ -190,7 +190,7 @@ export const NewspackNewsletters = ( {
 					) }
 					{ 'campaign_monitor' ===
 						config?.settings?.newspack_newsletters_service_provider?.value && (
-						<Notice isWarning isDismissible={ false }>
+						<Notice status="warning" isDismissible={ false }>
 							<h2>{ __( 'Campaign Monitor support will be deprecated', 'newspack-plugin' ) }</h2>
 							<p>
 								{ __(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a deprecation warning in the Engagement > Newsletters wizard if using Campaign Monitor as the connected ESP.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-newsletters/pull/1579 for testing instructions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->