### PR TITLE
fix(ras-acc): qa testing design feedback

### DIFF
--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -72,7 +72,6 @@
 			h2 {
 				font-family: var( --newspack-ui-font-family );
 				font-size: var( --newspack-ui-font-size-s );
-				font-weight: 600;
 				line-height: var( --newspack-ui-line-height-s );
 				margin: 0;
 			}
@@ -122,6 +121,10 @@
 			> *:last-child {
 				margin-bottom: 0;
 			}
+		}
+
+		h1, h2, h3, h4, h5, h6, strong {
+			font-weight: 600;
 		}
 	}
 }

--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -72,6 +72,7 @@
 			h2 {
 				font-family: var( --newspack-ui-font-family );
 				font-size: var( --newspack-ui-font-size-s );
+				font-weight: 600;
 				line-height: var( --newspack-ui-line-height-s );
 				margin: 0;
 			}

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -9,6 +9,8 @@
 		font-family: var( --newspack-ui-font-family );
 		font-size: var( --newspack-ui-font-size-s );
 		font-weight: 600;
+		letter-spacing: initial;
+		text-transform: none;
 		gap: var( --newspack-ui-spacer-2 );
 		justify-content: center;
 		line-height: var( --newspack-ui-line-height-s );

--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -9,7 +9,7 @@
 		font-family: var( --newspack-ui-font-family );
 		font-size: var( --newspack-ui-font-size-s );
 		font-weight: 600;
-		gap: calc( var( --newspack-ui-spacer-base ) / 2 );
+		gap: var( --newspack-ui-spacer-2 );
 		justify-content: center;
 		line-height: var( --newspack-ui-line-height-s );
 		margin-bottom: var( --newspack-ui-spacer-2 );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150039, https://app.asana.com/0/1207817176293825/1207878733150043, and https://app.asana.com/0/1207817176293825/1207878733150047

This PR adds various style fixes to RAS-ACC auth form:

1. Spacing between google icon and button text should be 12px:

![Screenshot 2024-07-23 at 12 35 10](https://github.com/user-attachments/assets/5887a254-8e7d-4bd7-bb25-d46788d14a33)

2. Normalize button font styles in newspack ui:

![Screenshot 2024-07-23 at 12 36 07](https://github.com/user-attachments/assets/1bc454da-36dd-4782-b838-d7b204fa9cea)

3. Consistent font weights:

![Screenshot 2024-07-23 at 12 36 58](https://github.com/user-attachments/assets/9c581f14-9156-4639-8352-d7e7f7a81d22)

### How to test the changes in this Pull Request:

This PR should be tested with the following Blocks PR checked out as well: https://github.com/Automattic/newspack-blocks/pull/1807

1. On a test site, add the following additional CSS via the Appearance > Customize menu:

```
button {	
  border-radius: 0;
  font-size: 0.7rem;
  letter-spacing: 0.1em;
  padding: 1rem 2.5rem;
  text-transform: uppercase;
}
```
2. As a reader trigger the auth modal by clicking the Sign In button at the top right of the page.
3. Verify the 3 points above
  - Spacing between Google G and button text is 12px
  - Button text is not capitalized and custom letter spacing is not being used
  - All font weights for bolded text are 600 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->