### PR TITLE
fix(ras-acc): update auth modal button spacing

### DIFF
--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -86,8 +86,9 @@
 			color: var( --newspack-ui-color-neutral-90 );
 			padding: var( --newspack-ui-spacer-5 );
 
-			// Make sure there's enough space above the first button in modals
-			.newspack-ui__button:not( :first-child ):first-of-type {
+			// Make sure there's enough space above the first button in modals.
+			// Ignore a tag buttons as they will never be first.
+			.newspack-ui__button:not( :first-child, a.newspack-ui__button ):first-of-type {
 				margin-top: var( --newspack-ui-spacer-5 );
 			}
 		}

--- a/assets/newspack-ui/scss/elements/misc/_reader-auth.scss
+++ b/assets/newspack-ui/scss/elements/misc/_reader-auth.scss
@@ -1,7 +1,8 @@
 // Re-adds some modal-like spacing for when the sign up form ends up embedded in a page.
+// Ignore a tag buttons as they will never be first..
 .newspack-ui {
 	&.newspack-reader-auth {
-		.newspack-ui__button:not( :first-child ):first-of-type {
+		.newspack-ui__button:not( :first-child, a.newspack-ui__button ):first-of-type {
 			margin-top: var( --newspack-ui-spacer-5 );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207817094376812

This PR fixes the button spacing above the anchor elements disguised as buttons:

Before:
![1207878733150098 JRDhiCpUZMvurp1KYS3G_height640](https://github.com/user-attachments/assets/de6380d5-975d-431d-891d-9abe9ff0c108)

After:
![Screenshot 2024-07-23 at 16 33 25](https://github.com/user-attachments/assets/bb7cf3db-9275-44f3-947e-f76d8c124ea7)

### How to test the changes in this Pull Request:

1. Create a new reader account and set up a password
2. Log out
3. Trigger the sign in modal via the sign in button
4. Input the reader email and select Continue
5. Confirm the spacing is consistent between the buttons as pictured above

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->