### PR TITLE
fix: force active membership if the user has active subs

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -933,14 +933,14 @@ class Memberships {
 	 * @return string
 	 */
 	public static function check_membership_status( $post_status, $post ) {
-		if ( 'wc_user_membership' !== $post->post_type || ! self::has_memberships() || ! function_exists( 'wc_memberships_get_user_membership' ) ) {
+		if ( 'wc_user_membership' !== $post->post_type || 'wcm-active' !== $post->post_status || ! self::has_memberships() || ! function_exists( 'wc_memberships_get_user_membership' ) ) {
 			return $post_status;
 		}
 		$integrations = wc_memberships()->get_integrations_instance();
 		$integration  = $integrations ? $integrations->get_subscriptions_instance() : null;
 		$membership   = wc_memberships_get_user_membership( $post->ID );
 		$plan_id      = $membership->get_plan_id();
-		if ( ! $membership->has_status( 'active' ) && $integration && $integration->has_membership_plan_subscription( $plan_id ) ) {
+		if ( $integration && $integration->has_membership_plan_subscription( $plan_id ) ) {
 			$subscription_plan    = new \WC_Memberships_Integration_Subscriptions_Membership_Plan( $plan_id );
 			$required_products    = $subscription_plan->get_subscription_product_ids();
 			$active_subscriptions = WooCommerce_Connection::get_active_subscriptions_for_user( $membership->get_user_id(), $required_products );

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -933,7 +933,7 @@ class Memberships {
 	 * @return string
 	 */
 	public static function check_membership_status( $post_status, $post ) {
-		if ( 'wc_user_membership' !== $post->post_type || 'wcm-active' !== $post->post_status || ! self::has_memberships() || ! function_exists( 'wc_memberships_get_user_membership' ) ) {
+		if ( 'wc_user_membership' !== $post->post_type || 'wcm-active' === $post->post_status || ! self::has_memberships() || ! function_exists( 'wc_memberships_get_user_membership' ) ) {
 			return $post_status;
 		}
 		$integrations = wc_memberships()->get_integrations_instance();

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -83,7 +83,7 @@ class Memberships {
 	/**
 	 * Check if Memberships is available.
 	 */
-	public static function has_memberships() {
+	public static function is_active() {
 		return class_exists( 'WC_Memberships' ) && function_exists( 'wc_memberships' );
 	}
 
@@ -330,7 +330,7 @@ class Memberships {
 	 * @return string[] Plan names keyed by plan ID.
 	 */
 	private static function get_gate_plans( $gate_id ) {
-		if ( ! self::has_memberships() || ! function_exists( 'wc_memberships_get_membership_plan' ) ) {
+		if ( ! self::is_active() || ! function_exists( 'wc_memberships_get_membership_plan' ) ) {
 			return [];
 		}
 		$ids = get_post_meta( $gate_id, 'plans', true );
@@ -353,7 +353,7 @@ class Memberships {
 	 * @return array
 	 */
 	public static function get_plans() {
-		if ( ! self::has_memberships() || ! function_exists( 'wc_memberships_get_membership_plans' ) ) {
+		if ( ! self::is_active() || ! function_exists( 'wc_memberships_get_membership_plans' ) ) {
 			return [];
 		}
 		$membership_plans = wc_memberships_get_membership_plans();
@@ -424,7 +424,7 @@ class Memberships {
 		if ( ! \is_user_logged_in() ) {
 			return false;
 		}
-		if ( ! self::has_memberships() || ! function_exists( 'wc_memberships_is_user_active_or_delayed_member' ) ) {
+		if ( ! self::is_active() || ! function_exists( 'wc_memberships_is_user_active_or_delayed_member' ) ) {
 			return false;
 		}
 		return \wc_memberships_is_user_active_or_delayed_member( \get_current_user_id(), $plan_id );
@@ -489,7 +489,7 @@ class Memberships {
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
-		if ( ! self::has_memberships() || ! function_exists( 'wc_memberships_is_post_content_restricted' ) || ! \wc_memberships_is_post_content_restricted( $post_id ) ) {
+		if ( ! self::is_active() || ! function_exists( 'wc_memberships_is_post_content_restricted' ) || ! \wc_memberships_is_post_content_restricted( $post_id ) ) {
 			return false;
 		}
 		return ! is_user_logged_in() || ! current_user_can( 'wc_memberships_view_restricted_post_content', $post_id ); // phpcs:ignore WordPress.WP.Capabilities.Unknown
@@ -804,7 +804,7 @@ class Memberships {
 	 */
 	public static function user_has_cap( $all_caps, $caps, $args ) {
 		// Bail if Woo Memberships is not active.
-		if ( ! self::has_memberships() ) {
+		if ( ! self::is_active() ) {
 			return $all_caps;
 		}
 
@@ -933,7 +933,7 @@ class Memberships {
 	 * @return string
 	 */
 	public static function check_membership_status( $post_status, $post ) {
-		if ( 'wc_user_membership' !== $post->post_type || 'wcm-active' === $post->post_status || ! self::has_memberships() || ! function_exists( 'wc_memberships_get_user_membership' ) ) {
+		if ( 'wc_user_membership' !== $post->post_type || 'wcm-active' === $post->post_status || ! self::is_active() || ! function_exists( 'wc_memberships_get_user_membership' ) ) {
 			return $post_status;
 		}
 		$integrations = wc_memberships()->get_integrations_instance();

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -8,6 +8,7 @@
 namespace Newspack;
 
 use Newspack\Memberships\Metering;
+use Newspack\WooCommerce_Connection;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -56,6 +57,7 @@ class Memberships {
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
+		add_filter( 'get_post_status', [ __CLASS__, 'check_membership_status' ], 10, 2 );
 		add_action( 'wp', [ __CLASS__, 'remove_unnecessary_content_restriction' ], 11 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
@@ -76,6 +78,13 @@ class Memberships {
 
 		include __DIR__ . '/class-block-patterns.php';
 		include __DIR__ . '/class-metering.php';
+	}
+
+	/**
+	 * Check if Memberships is available.
+	 */
+	public static function has_memberships() {
+		return class_exists( 'WC_Memberships' ) && function_exists( 'wc_memberships' );
 	}
 
 	/**
@@ -321,7 +330,7 @@ class Memberships {
 	 * @return string[] Plan names keyed by plan ID.
 	 */
 	private static function get_gate_plans( $gate_id ) {
-		if ( ! function_exists( 'wc_memberships_get_membership_plan' ) ) {
+		if ( ! self::has_memberships() || ! function_exists( 'wc_memberships_get_membership_plan' ) ) {
 			return [];
 		}
 		$ids = get_post_meta( $gate_id, 'plans', true );
@@ -344,7 +353,7 @@ class Memberships {
 	 * @return array
 	 */
 	public static function get_plans() {
-		if ( ! function_exists( 'wc_memberships_get_membership_plans' ) ) {
+		if ( ! self::has_memberships() || ! function_exists( 'wc_memberships_get_membership_plans' ) ) {
 			return [];
 		}
 		$membership_plans = wc_memberships_get_membership_plans();
@@ -415,7 +424,7 @@ class Memberships {
 		if ( ! \is_user_logged_in() ) {
 			return false;
 		}
-		if ( ! function_exists( 'wc_memberships_is_user_active_or_delayed_member' ) ) {
+		if ( ! self::has_memberships() || ! function_exists( 'wc_memberships_is_user_active_or_delayed_member' ) ) {
 			return false;
 		}
 		return \wc_memberships_is_user_active_or_delayed_member( \get_current_user_id(), $plan_id );
@@ -480,7 +489,7 @@ class Memberships {
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
-		if ( ! function_exists( 'wc_memberships_is_post_content_restricted' ) || ! \wc_memberships_is_post_content_restricted( $post_id ) ) {
+		if ( ! self::has_memberships() || ! function_exists( 'wc_memberships_is_post_content_restricted' ) || ! \wc_memberships_is_post_content_restricted( $post_id ) ) {
 			return false;
 		}
 		return ! is_user_logged_in() || ! current_user_can( 'wc_memberships_view_restricted_post_content', $post_id ); // phpcs:ignore WordPress.WP.Capabilities.Unknown
@@ -795,7 +804,7 @@ class Memberships {
 	 */
 	public static function user_has_cap( $all_caps, $caps, $args ) {
 		// Bail if Woo Memberships is not active.
-		if ( ! class_exists( 'WC_Memberships' ) || ! function_exists( 'wc_memberships' ) ) {
+		if ( ! self::has_memberships() ) {
 			return $all_caps;
 		}
 
@@ -803,6 +812,18 @@ class Memberships {
 			foreach ( $caps as $cap ) {
 
 				switch ( $cap ) {
+					case 'wc_memberships_access_all_restricted_content':
+					case 'wc_memberships_view_restricted_product':
+					case 'wc_memberships_purchase_restricted_product':
+					case 'wc_memberships_view_restricted_product_taxonomy_term':
+					case 'wc_memberships_view_delayed_product_taxonomy_term':
+					case 'wc_memberships_view_restricted_taxonomy_term':
+					case 'wc_memberships_view_restricted_taxonomy':
+					case 'wc_memberships_view_restricted_post_type':
+					case 'wc_memberships_view_delayed_post_type':
+					case 'wc_memberships_view_delayed_taxonomy':
+					case 'wc_memberships_view_delayed_taxonomy_term':
+					case 'wc_memberships_view_delayed_post_content':
 					case 'wc_memberships_view_restricted_post_content':
 						if ( self::can_manage_woocommerce( $all_caps ) ) {
 							$all_caps[ $cap ] = true;
@@ -812,6 +833,10 @@ class Memberships {
 						// Allow user who can edit posts (by default: editors, authors, contributors).
 						if ( isset( $all_caps['edit_posts'] ) && true === $all_caps['edit_posts'] ) {
 							$all_caps[ $cap ] = true;
+							break;
+						}
+
+						if ( ! isset( $args[1] ) || ! isset( $args[2] ) ) {
 							break;
 						}
 
@@ -828,20 +853,8 @@ class Memberships {
 
 						break;
 
-					case 'wc_memberships_access_all_restricted_content':
-					case 'wc_memberships_view_restricted_product':
-					case 'wc_memberships_purchase_restricted_product':
-					case 'wc_memberships_view_restricted_product_taxonomy_term':
-					case 'wc_memberships_view_delayed_product_taxonomy_term':
-					case 'wc_memberships_view_restricted_taxonomy_term':
-					case 'wc_memberships_view_restricted_taxonomy':
-					case 'wc_memberships_view_restricted_post_type':
-					case 'wc_memberships_view_delayed_post_type':
-					case 'wc_memberships_view_delayed_taxonomy':
-					case 'wc_memberships_view_delayed_taxonomy_term':
-					case 'wc_memberships_view_delayed_post_content':
 					case 'wc_memberships_view_delayed_product':
-						// Allow user who can edit posts (by default: editors, authors, contributors).
+						// Allow users who can edit posts (by default: editors, authors, contributors).
 						if ( isset( $all_caps['edit_posts'] ) && true === $all_caps['edit_posts'] ) {
 							$all_caps[ $cap ] = true;
 							break;
@@ -876,10 +889,19 @@ class Memberships {
 			return true;
 		}
 
+		$integrations      = wc_memberships()->get_integrations_instance();
+		$integration       = $integrations ? $integrations->get_subscriptions_instance() : null;
 		$require_all_plans = self::get_require_all_plans_setting();
 		$has_access        = false;
+		$has_subscription  = false;
 
 		foreach ( $rules as $rule ) {
+			$membership_plan_id = $rule->get_membership_plan_id();
+			if ( $integration && $integration->has_membership_plan_subscription( $membership_plan_id ) ) {
+				$subscription_plan  = new \WC_Memberships_Integration_Subscriptions_Membership_Plan( $membership_plan_id );
+				$required_products  = $subscription_plan->get_subscription_product_ids();
+				$has_subscription   = ! empty( WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $required_products ) );
+			}
 
 			// If no object ID is provided, then we are looking at rules that apply to whole post types or taxonomies.
 			// In this case, rules that apply to specific objects should be skipped.
@@ -887,7 +909,7 @@ class Memberships {
 				continue;
 			}
 
-			if ( wc_memberships_is_user_active_or_delayed_member( $user_id, $rule->get_membership_plan_id() ) ) {
+			if ( $has_subscription || wc_memberships_is_user_active_or_delayed_member( $user_id, $rule->get_membership_plan_id() ) ) {
 				$has_access = true;
 				if ( ! $require_all_plans ) {
 					break;
@@ -899,6 +921,41 @@ class Memberships {
 		}
 
 		return $has_access;
+	}
+
+	/**
+	 * Check if a user has an active subscription with the required products when checking membership status.
+	 * If they have an active subscription, reset inactive memberships to active link to the active subscription.
+	 *
+	 * @param string  $post_status Post status.
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return string
+	 */
+	public static function check_membership_status( $post_status, $post ) {
+		if ( 'wc_user_membership' !== $post->post_type || ! self::has_memberships() || ! function_exists( 'wc_memberships_get_user_membership' ) ) {
+			return $post_status;
+		}
+		$integrations = wc_memberships()->get_integrations_instance();
+		$integration  = $integrations ? $integrations->get_subscriptions_instance() : null;
+		$membership   = wc_memberships_get_user_membership( $post->ID );
+		$plan_id      = $membership->get_plan_id();
+		if ( ! $membership->has_status( 'active' ) && $integration && $integration->has_membership_plan_subscription( $plan_id ) ) {
+			$subscription_plan    = new \WC_Memberships_Integration_Subscriptions_Membership_Plan( $plan_id );
+			$required_products    = $subscription_plan->get_subscription_product_ids();
+			$active_subscriptions = WooCommerce_Connection::get_active_subscriptions_for_user( $membership->get_user_id(), $required_products );
+			$has_subscription     = ! empty( $active_subscriptions );
+			if ( $has_subscription ) {
+				$post_status = 'wcm-active';
+				$membership  = new \WC_Memberships_Integration_Subscriptions_User_Membership( $post->ID );
+				$membership->unschedule_expiration_events();
+				$membership->set_subscription_id( $active_subscriptions[0] );
+				$membership->set_end_date(); // Clear the end date.
+				$membership->update_status( 'active' );
+			}
+		}
+
+		return $post_status;
 	}
 
 	/**
@@ -952,6 +1009,7 @@ class Memberships {
 					foreach ( $memberships as $membership ) {
 						// If the membership is not active and has an end date in the past, reactivate it.
 						if ( $membership && ! $membership->has_status( $active_membership_statuses ) && $membership->has_end_date() && $membership->get_end_date( 'timestamp' ) < time() ) {
+							$membership->unschedule_expiration_events();
 							$membership->set_end_date(); // Clear the end date.
 							$membership->update_status( 'active' ); // Reactivate the membership.
 							$reactivated_memberships++;

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -149,6 +149,39 @@ class WooCommerce_Connection {
 	}
 
 	/**
+	 * Does the given user have any subscriptions with an active status?
+	 * Can optionally pass an array of product IDs. If given, only subscriptions
+	 * that have all of the given product IDs will be returned.
+	 *
+	 * @param int   $user_id User ID.
+	 * @param array $product_ids Optional array of product IDs to filter by.
+	 *
+	 * @return int[] Array of active subscription IDs.
+	 */
+	public static function get_active_subscriptions_for_user( $user_id, $product_ids = [] ) {
+		$subcriptions = array_reduce(
+			array_keys( \wcs_get_users_subscriptions( $user_id ) ),
+			function( $acc, $subscription_id ) use ( $product_ids ) {
+				$subscription = \wcs_get_subscription( $subscription_id );
+				if ( $subscription->has_status( self::ACTIVE_SUBSCRIPTION_STATUSES ) ) {
+					if ( ! empty( $product_ids ) ) {
+						foreach ( $product_ids as $product_id ) {
+							if ( ! $subscription->has_product( $product_id ) ) {
+								return $acc;
+							}
+						}
+					}
+					$acc[] = $subscription_id;
+				}
+				return $acc;
+			},
+			[]
+		);
+
+		return $subcriptions;
+	}
+
+	/**
 	 * Get the most recent active subscription, or the last successful order for a given customer.
 	 *
 	 * @param \WC_Customer $customer Customer object.
@@ -160,20 +193,18 @@ class WooCommerce_Connection {
 			return false;
 		}
 
+		$user_id = $customer->get_id();
+
 		// Prioritize any currently active subscriptions.
-		$user_subscriptions = \wcs_get_users_subscriptions( $customer->get_id() );
-		if ( ! empty( $user_subscriptions ) ) {
-			foreach ( $user_subscriptions as $subscription ) {
-				if ( $subscription->has_status( self::ACTIVE_SUBSCRIPTION_STATUSES ) ) {
-					return $subscription;
-				}
-			}
+		$active_subscriptions = self::get_active_subscriptions_for_user( $user_id() );
+		if ( ! empty( $active_subscriptions ) ) {
+			return reset( $active_subscriptions );
 		}
 
 		// If no active subscriptions, get the most recent completed order.
 		// See https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query for query args.
 		$args = [
-			'customer_id' => $customer->get_id(),
+			'customer_id' => $user_id(),
 			'status'      => [ 'wc-completed' ],
 			'limit'       => 1,
 			'order'       => 'DESC',

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -171,8 +171,11 @@ class WooCommerce_Connection {
 								return $acc;
 							}
 						}
+					} else {
+						$acc[] = $subscription_id;
 					}
-					$acc[] = $subscription_id;
+
+					return $acc;
 				}
 				return $acc;
 			},

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -198,7 +198,7 @@ class WooCommerce_Connection {
 		$user_id = $customer->get_id();
 
 		// Prioritize any currently active subscriptions.
-		$active_subscriptions = self::get_active_subscriptions_for_user( $user_id() );
+		$active_subscriptions = self::get_active_subscriptions_for_user( $user_id );
 		if ( ! empty( $active_subscriptions ) ) {
 			return reset( $active_subscriptions );
 		}
@@ -206,7 +206,7 @@ class WooCommerce_Connection {
 		// If no active subscriptions, get the most recent completed order.
 		// See https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query for query args.
 		$args = [
-			'customer_id' => $user_id(),
+			'customer_id' => $user_id,
 			'status'      => [ 'wc-completed' ],
 			'limit'       => 1,
 			'order'       => 'DESC',

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -174,8 +174,6 @@ class WooCommerce_Connection {
 					} else {
 						$acc[] = $subscription_id;
 					}
-
-					return $acc;
 				}
 				return $acc;
 			},

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -151,7 +151,7 @@ class WooCommerce_Connection {
 	/**
 	 * Does the given user have any subscriptions with an active status?
 	 * Can optionally pass an array of product IDs. If given, only subscriptions
-	 * that have all of the given product IDs will be returned.
+	 * that have at least one of the given product IDs will be returned.
 	 *
 	 * @param int   $user_id User ID.
 	 * @param array $product_ids Optional array of product IDs to filter by.
@@ -166,7 +166,8 @@ class WooCommerce_Connection {
 				if ( $subscription->has_status( self::ACTIVE_SUBSCRIPTION_STATUSES ) ) {
 					if ( ! empty( $product_ids ) ) {
 						foreach ( $product_ids as $product_id ) {
-							if ( ! $subscription->has_product( $product_id ) ) {
+							if ( $subscription->has_product( $product_id ) ) {
+								$acc[] = $subscription_id;
 								return $acc;
 							}
 						}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is a third attempt at addressing the problem described in #3060 and #3050, where if a user has more than one subscription and not all are active, any of the user's memberships tied to the subscriptions' products could be incorrectly expired at any time.

This implements two new checks at runtime:

1. When checking the user membership's status
2. When checking whether the user has access to a restricted post

The first should run only for memberships with non-active statuses, and only if the membership's plan is tied to subscription product ownership. If it is and the user does have an active subscription with the required subscription product(s), it will update the membership to `active` status and relink the membership to the active subscription. 

The second check is a fallback of sorts at the point where the user is trying to view restricted content. It checks if the membership requires any subscription products and allows access as long as the user has an active subscription with one of those products. Since the membership updates from the first check could take longer than it takes for the restricted content to load in the browser, this second check should avoid a race condition the first time any affected users try to view restricted content, but maybe it's not needed since the first check should permanently fix the membership status.

The major piece that was missing from #3050 was `WC_Memberships_User_Membership::unschedule_expiration_events()`—without calling this, updating an expired membership to `active` will result in an infinite loop of active/expire actions that will severely impact site performance. If we call that method before updating the status to `active`, the check should run exactly once for any impacted memberships, so in theory this PR should have no negative effect on site performance.

### How to test the changes in this Pull Request:

1. Set up a membership plan that requires ownership of a subscription product(s) and set it to restrict content (e.g. of a post category).
3. As a reader, purchase the required subscription and confirm that you can view the restricted content.
4. As an admin, manually update the reader subscription to "Expired" status.
5. As the reader, confirm that you can no longer view the restricted content.
6. Still as the reader, purchase another subscription to the required product.
7. On `trunk`, observe that you still can't view restricted content despite owning an active subscription with the required product.
8. As an admin, observe that the reader's membership still shows "Expired" status and is tied to the reader's expired subscription, instead of the newer active one.
9. Check out this branch and refresh the membership either in the admin or the restricted content as the reader.
10. Confirm that the reader can now view restricted content, and that the membership is updated to "Active" status, relinked to the active subscription, and that it doesn't continually try to expire and reactivate itself in an infinite loop that eventually crashes your entire site.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207858308890295