### PR TITLE
feat(ia): advertising > display ads

### DIFF
--- a/assets/admin/style.scss
+++ b/assets/admin/style.scss
@@ -79,13 +79,6 @@ h1 {
 	p {
 		margin-block: 0 1.5rem;
 	}
-
-	.newspack-section-header {
-		font-size: 2rem;
-		font-weight: 400;
-		line-height: 1.25;
-		margin-block: 0 2.5rem;
-	}
 }
 
 .newspack-dashboard__section {

--- a/assets/admin/style.scss
+++ b/assets/admin/style.scss
@@ -32,7 +32,6 @@ h1 {
 .gray-700 {
 	color: var(--np-color-wp-gray-700);
 }
-
 .newspack-wizard {
 
 	.newspack-wizard__loader {

--- a/assets/admin/style.scss
+++ b/assets/admin/style.scss
@@ -13,10 +13,32 @@
 	/* node_modules/@wordpress/base-styles/_colors.scss */
 	--np-color-wp-gray-700: #757575;
 	--np-color-wp-gray-900: #1e1e1e;
+
+	/**
+	 * Dimensions
+	 */
+	--np-wizard-tabs-height: 60px;
+
+	/**
+	 * WP Admin
+	 */
+	--wp-adminbar-height: 32px;
 }
 
 html {
 	font-size: 16px;
+	scroll-padding-top: calc(var(--wp-adminbar-height) + var(--np-wizard-tabs-height));
+	
+	@media (max-width: 782px) {
+		--wp-adminbar-height: 46px;
+		--np-wizard-tabs-height: 48px;
+
+		scroll-padding-top: calc(var(--wp-adminbar-height) + var(--np-wizard-tabs-height) + 1rem);
+	}
+
+	@media screen and (max-width: 600px) {
+		scroll-padding-top: 1rem;
+	}
 }
 
 h1 {
@@ -118,6 +140,10 @@ h1 {
 
 .newspack-card.newspack-action-card+.newspack-card.newspack-action-card {
 	margin-top: 0;
+}
+
+.newspack-card.newspack-action-card.is-small + .newspack-card.newspack-action-card.is-small {
+	margin-block: 0 1rem;
 }
 
 .newspack-card {

--- a/assets/admin/style.scss
+++ b/assets/admin/style.scss
@@ -32,6 +32,7 @@ h1 {
 .gray-700 {
 	color: var(--np-color-wp-gray-700);
 }
+
 .newspack-wizard {
 
 	.newspack-wizard__loader {
@@ -77,6 +78,13 @@ h1 {
 
 	p {
 		margin-block: 0 1.5rem;
+	}
+
+	.newspack-section-header {
+		font-size: 2rem;
+		font-weight: 400;
+		line-height: 1.25;
+		margin-block: 0 2.5rem;
 	}
 }
 

--- a/assets/components/src/action-card/index.js
+++ b/assets/components/src/action-card/index.js
@@ -102,7 +102,7 @@ class ActionCard extends Component {
 		const isDisplayingSecondaryAction = secondaryActionText && onSecondaryActionClick;
 		const badges = ! Array.isArray( badge ) && badge ? [ badge ] : badge;
 		return (
-			<Card className={ classes } onClick={ simple && onClick }>
+			<Card className={ classes } onClick={ simple && onClick } id={ this.props.id ?? null }>
 				<div className="newspack-action-card__region newspack-action-card__region-top">
 					{ toggleOnChange && (
 						<ToggleControl

--- a/assets/components/src/plugin-settings/SettingsSection.js
+++ b/assets/components/src/plugin-settings/SettingsSection.js
@@ -89,6 +89,7 @@ const SettingsSection = props => {
 	}
 	return (
 		<ActionCard
+			id={ props.id ?? null }
 			isMedium
 			disabled={ disabled }
 			title={ title }

--- a/assets/components/src/plugin-settings/index.js
+++ b/assets/components/src/plugin-settings/index.js
@@ -187,6 +187,7 @@ class PluginSettings extends Component {
 						<SettingsSection
 							key={ sectionKey }
 							disabled={ inFlight }
+							id={ `plugin-settings-${ sectionKey }` }
 							sectionKey={ sectionKey }
 							title={ this.getSectionTitle( sectionKey ) }
 							description={ this.getSectionDescription( sectionKey ) }

--- a/assets/components/src/plugin-toggle/index.js
+++ b/assets/components/src/plugin-toggle/index.js
@@ -97,6 +97,7 @@ class PluginToggle extends Component {
 					description={ description }
 					actionText={ this.actionTextForPlugin( plugin ) }
 					handoff={ handoff }
+					onClick={ plugin.onClick ?? null }
 					href={ href }
 					toggle
 					toggleChecked={ this.isPluginInstalledAndActive( plugin ) }

--- a/assets/components/src/section-header/style.scss
+++ b/assets/components/src/section-header/style.scss
@@ -25,12 +25,12 @@
 		text-align: center;
 	}
 
-	&:not( #{&}--no-margin ) + *:not( #{&} ) {
+	&:not(#{&}--no-margin)+*:not(#{&}) {
 		margin-top: -16px !important;
 	}
 
 	&#{&}--is-white {
-		> * {
+		>* {
 			color: white;
 		}
 	}

--- a/assets/components/src/section-header/style.scss
+++ b/assets/components/src/section-header/style.scss
@@ -25,12 +25,12 @@
 		text-align: center;
 	}
 
-	&:not(#{&}--no-margin)+*:not(#{&}) {
+	&:not( #{&}--no-margin ) + *:not( #{&} ) {
 		margin-top: -16px !important;
 	}
 
 	&#{&}--is-white {
-		>* {
+		> * {
 			color: white;
 		}
 	}

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -151,16 +151,6 @@
 				margin: 64px 0;
 			}
 		}
-
-		.newspack-section-header__container {
-
-			.heading-1 * {
-				font-size: 2rem;
-				font-weight: 400;
-				line-height: 1.25;
-				margin-block: 0 2.5rem;
-			}
-		}
 	}
 
 	&__above-header {

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -29,16 +29,16 @@
 
 	// Links
 	a {
-		color: var(--wp-admin-theme-color);
+		color: var( --wp-admin-theme-color );
 
 		&:active,
 		&:focus,
 		&:hover {
-			color: var(--wp-admin-theme-color-darker-10);
+			color: var( --wp-admin-theme-color-darker-10 );
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) var( --wp-admin-theme-color );
 			outline: 3px solid transparent;
 		}
 	}
@@ -57,7 +57,7 @@
 			padding: 0;
 		}
 
-		>div {
+		> div {
 			align-items: baseline;
 			display: flex;
 			padding: 0 24px;
@@ -67,7 +67,7 @@
 				display: none;
 				margin-left: 8px;
 
-				@media screen and (min-width: 744px) {
+				@media screen and ( min-width: 744px ) {
 					display: block;
 				}
 			}
@@ -82,7 +82,7 @@
 				margin-bottom: -1px !important;
 			}
 
-			&:not(.newspack-icon) {
+			&:not( .newspack-icon ) {
 				background: colors.$primary-500;
 				left: 50%;
 				margin: -28px 0 0 -28px !important;
@@ -124,7 +124,7 @@
 		max-width: 1208px;
 		padding: 0 16px;
 
-		@media screen and (min-width: 744px) {
+		@media screen and ( min-width: 744px ) {
 			padding: 40px 84px;
 		}
 
@@ -147,7 +147,7 @@
 			height: 1px;
 			margin: 48px 0;
 
-			@media screen and (min-width: 744px) {
+			@media screen and ( min-width: 744px ) {
 				margin: 64px 0;
 			}
 		}

--- a/assets/components/src/with-wizard-screen/style.scss
+++ b/assets/components/src/with-wizard-screen/style.scss
@@ -29,16 +29,16 @@
 
 	// Links
 	a {
-		color: var( --wp-admin-theme-color );
+		color: var(--wp-admin-theme-color);
 
 		&:active,
 		&:focus,
 		&:hover {
-			color: var( --wp-admin-theme-color-darker-10 );
+			color: var(--wp-admin-theme-color-darker-10);
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) var( --wp-admin-theme-color );
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			outline: 3px solid transparent;
 		}
 	}
@@ -57,7 +57,7 @@
 			padding: 0;
 		}
 
-		> div {
+		>div {
 			align-items: baseline;
 			display: flex;
 			padding: 0 24px;
@@ -67,7 +67,7 @@
 				display: none;
 				margin-left: 8px;
 
-				@media screen and ( min-width: 744px ) {
+				@media screen and (min-width: 744px) {
 					display: block;
 				}
 			}
@@ -82,7 +82,7 @@
 				margin-bottom: -1px !important;
 			}
 
-			&:not( .newspack-icon ) {
+			&:not(.newspack-icon) {
 				background: colors.$primary-500;
 				left: 50%;
 				margin: -28px 0 0 -28px !important;
@@ -124,8 +124,8 @@
 		max-width: 1208px;
 		padding: 0 16px;
 
-		@media screen and ( min-width: 744px ) {
-			padding: 32px 84px;
+		@media screen and (min-width: 744px) {
+			padding: 40px 84px;
 		}
 
 		// Typography
@@ -147,8 +147,18 @@
 			height: 1px;
 			margin: 48px 0;
 
-			@media screen and ( min-width: 744px ) {
+			@media screen and (min-width: 744px) {
 				margin: 64px 0;
+			}
+		}
+
+		.newspack-section-header__container {
+
+			.heading-1 * {
+				font-size: 2rem;
+				font-weight: 400;
+				line-height: 1.25;
+				margin-block: 0 2.5rem;
 			}
 		}
 	}

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -7,9 +7,11 @@
 
 // Reset Padding of the Admin Page
 
-.toplevel_page_newspack-dashboard:not( .menu-top ),
-.toplevel_page_newspack:not( .menu-top ),
+.toplevel_page_newspack-dashboard:not(.menu-top),
+.toplevel_page_newspack:not(.menu-top),
+body[class*='toplevel_page_newspack-']:not(.menu-top),
 body[class*='newspack_page_newspack-'],
+body[class*='toplevel_page_advertising-'],
 body[class*='admin_page_newspack-'] {
 	background: white;
 
@@ -21,11 +23,11 @@ body[class*='admin_page_newspack-'] {
 		padding-bottom: 220px;
 		min-height: 100vh;
 
-		@media screen and ( min-width: 783px ) {
+		@media screen and (min-width: 783px) {
 			padding-bottom: 202px;
 		}
 
-		@media screen and ( min-width: 1128px ) {
+		@media screen and (min-width: 1128px) {
 			padding-bottom: 168px;
 		}
 	}
@@ -34,8 +36,9 @@ body[class*='admin_page_newspack-'] {
 svg {
 	&.newspack--error {
 		fill: wp-colors.$alert-red;
-		transform: rotate( 180deg );
+		transform: rotate(180deg);
 	}
+
 	&.newspack--success {
 		fill: wp-colors.$alert-green;
 	}
@@ -81,7 +84,7 @@ svg {
 	inset: 0;
 	position: absolute;
 
-	> * {
+	>* {
 		display: none !important;
 	}
 
@@ -108,18 +111,18 @@ svg {
 		height: 24px;
 		margin: 68px auto 0;
 		max-width: 1040px;
-		width: calc( 100% - ( 32px * 2 ) );
+		width: calc(100% - (32px * 2));
 
-		@media screen and ( min-width: 744px ) {
+		@media screen and (min-width: 744px) {
 			box-shadow: inset -400px 0 0 0 white, 0 64px 0 0 wp-colors.$gray-700, 200px 96px 0 0 white,
 				0 96px 0 0 wp-colors.$gray-700;
-			width: calc( 100% - ( 64px * 2 ) );
+			width: calc(100% - (64px * 2));
 		}
 
-		@media screen and ( min-width: 1224px ) {
+		@media screen and (min-width: 1224px) {
 			box-shadow: inset -600px 0 0 0 white, 0 64px 0 0 wp-colors.$gray-700, 512px 96px 0 0 white,
 				0 96px 0 0 wp-colors.$gray-700;
-			width: calc( 100% - ( 64px * 2 ) );
+			width: calc(100% - (64px * 2));
 		}
 	}
 
@@ -159,7 +162,7 @@ svg {
 			position: fixed;
 			top: 46px;
 
-			@media screen and ( min-width: 783px ) {
+			@media screen and (min-width: 783px) {
 				top: 32px;
 				margin-left: 160px;
 
@@ -168,7 +171,7 @@ svg {
 				}
 			}
 
-			@media screen and ( min-width: 961px ) {
+			@media screen and (min-width: 961px) {
 				body.auto-fold & {
 					margin-left: 160px;
 				}
@@ -188,7 +191,7 @@ svg {
 		}
 
 		&::after {
-			background: rgba( white, 0.7 );
+			background: rgba(white, 0.7);
 			bottom: 0;
 			right: 0;
 			z-index: 9998;
@@ -201,7 +204,7 @@ svg {
 	cursor: wait;
 	min-height: 150px;
 
-	> * {
+	>* {
 		display: none !important;
 	}
 
@@ -217,12 +220,12 @@ svg {
 		max-width: 1040px;
 		width: 100%;
 
-		@media screen and ( min-width: 744px ) {
+		@media screen and (min-width: 744px) {
 			box-shadow: inset -400px 0 0 0 white, 0 64px 0 0 wp-colors.$gray-700, 200px 96px 0 0 white,
 				0 96px 0 0 wp-colors.$gray-700;
 		}
 
-		@media screen and ( min-width: 1224px ) {
+		@media screen and (min-width: 1224px) {
 			box-shadow: inset -600px 0 0 0 white, 0 64px 0 0 wp-colors.$gray-700, 520px 96px 0 0 white,
 				0 96px 0 0 wp-colors.$gray-700;
 		}

--- a/assets/components/src/with-wizard/style.scss
+++ b/assets/components/src/with-wizard/style.scss
@@ -23,11 +23,11 @@ body[class*='admin_page_newspack-'] {
 		padding-bottom: 220px;
 		min-height: 100vh;
 
-		@media screen and (min-width: 783px) {
+		@media screen and ( min-width: 783px ) {
 			padding-bottom: 202px;
 		}
 
-		@media screen and (min-width: 1128px) {
+		@media screen and ( min-width: 1128px ) {
 			padding-bottom: 168px;
 		}
 	}
@@ -36,9 +36,8 @@ body[class*='admin_page_newspack-'] {
 svg {
 	&.newspack--error {
 		fill: wp-colors.$alert-red;
-		transform: rotate(180deg);
+		transform: rotate( 180deg );
 	}
-
 	&.newspack--success {
 		fill: wp-colors.$alert-green;
 	}
@@ -84,7 +83,7 @@ svg {
 	inset: 0;
 	position: absolute;
 
-	>* {
+	> * {
 		display: none !important;
 	}
 
@@ -111,18 +110,18 @@ svg {
 		height: 24px;
 		margin: 68px auto 0;
 		max-width: 1040px;
-		width: calc(100% - (32px * 2));
+		width: calc( 100% - ( 32px * 2 ) );
 
-		@media screen and (min-width: 744px) {
+		@media screen and ( min-width: 744px ) {
 			box-shadow: inset -400px 0 0 0 white, 0 64px 0 0 wp-colors.$gray-700, 200px 96px 0 0 white,
 				0 96px 0 0 wp-colors.$gray-700;
-			width: calc(100% - (64px * 2));
+			width: calc( 100% - ( 64px * 2 ) );
 		}
 
-		@media screen and (min-width: 1224px) {
+		@media screen and ( min-width: 1224px ) {
 			box-shadow: inset -600px 0 0 0 white, 0 64px 0 0 wp-colors.$gray-700, 512px 96px 0 0 white,
 				0 96px 0 0 wp-colors.$gray-700;
-			width: calc(100% - (64px * 2));
+			width: calc( 100% - ( 64px * 2 ) );
 		}
 	}
 
@@ -162,7 +161,7 @@ svg {
 			position: fixed;
 			top: 46px;
 
-			@media screen and (min-width: 783px) {
+			@media screen and ( min-width: 783px ) {
 				top: 32px;
 				margin-left: 160px;
 
@@ -171,7 +170,7 @@ svg {
 				}
 			}
 
-			@media screen and (min-width: 961px) {
+			@media screen and ( min-width: 961px ) {
 				body.auto-fold & {
 					margin-left: 160px;
 				}
@@ -191,7 +190,7 @@ svg {
 		}
 
 		&::after {
-			background: rgba(white, 0.7);
+			background: rgba( white, 0.7 );
 			bottom: 0;
 			right: 0;
 			z-index: 9998;
@@ -204,7 +203,7 @@ svg {
 	cursor: wait;
 	min-height: 150px;
 
-	>* {
+	> * {
 		display: none !important;
 	}
 
@@ -220,12 +219,12 @@ svg {
 		max-width: 1040px;
 		width: 100%;
 
-		@media screen and (min-width: 744px) {
+		@media screen and ( min-width: 744px ) {
 			box-shadow: inset -400px 0 0 0 white, 0 64px 0 0 wp-colors.$gray-700, 200px 96px 0 0 white,
 				0 96px 0 0 wp-colors.$gray-700;
 		}
 
-		@media screen and (min-width: 1224px) {
+		@media screen and ( min-width: 1224px ) {
 			box-shadow: inset -600px 0 0 0 white, 0 64px 0 0 wp-colors.$gray-700, 520px 96px 0 0 white,
 				0 96px 0 0 wp-colors.$gray-700;
 		}

--- a/assets/wizards/advertising/components/ad-refresh-control/index.js
+++ b/assets/wizards/advertising/components/ad-refresh-control/index.js
@@ -132,6 +132,7 @@ export default function AdRefreshControlSettings() {
 	return (
 		<PluginSettings.Section
 			error={ error }
+			id="ad-refresh-control"
 			disabled={ inFlight }
 			sectionKey="ad-refresh-control"
 			title={ __( 'Ad Refresh Control', 'newspack-plugin' ) }

--- a/assets/wizards/advertising/components/add-ons/index.js
+++ b/assets/wizards/advertising/components/add-ons/index.js
@@ -20,21 +20,23 @@ export default function AddOns() {
 				'super-cool-ad-inserter': {
 					actionText: __( 'Configure', 'newspack-plugin' ),
 					href: '#/settings/scaip',
+					shouldRefreshAfterUpdate: true,
 					onClick() {
 						document.getElementById( 'plugin-settings-scaip' ).scrollIntoView();
 					},
 				},
 				'ad-refresh-control': {
 					actionText: __( 'Configure', 'newspack-plugin' ),
+					href: '#/settings/ad-refresh-control',
+					shouldRefreshAfterUpdate: true,
 					onClick() {
 						document.getElementById( 'ad-refresh-control' ).scrollIntoView();
 					},
-					href: '#/settings/ad-refresh-control',
 				},
 				'publisher-media-kit': {
-					shouldRefreshAfterUpdate: true,
 					actionText: __( 'Edit Media Kit', 'newspack-plugin' ),
 					href: newspack_ads_wizard.mediakit_edit_url ? newspack_ads_wizard.mediakit_edit_url : '',
+					shouldRefreshAfterUpdate: true,
 				},
 			} }
 		/>

--- a/assets/wizards/advertising/components/add-ons/index.js
+++ b/assets/wizards/advertising/components/add-ons/index.js
@@ -19,11 +19,17 @@ export default function AddOns() {
 			plugins={ {
 				'super-cool-ad-inserter': {
 					actionText: __( 'Configure', 'newspack-plugin' ),
-					href: '#/settings',
+					href: '#/settings/scaip',
+					onClick() {
+						document.getElementById( 'plugin-settings-scaip' ).scrollIntoView();
+					},
 				},
 				'ad-refresh-control': {
 					actionText: __( 'Configure', 'newspack-plugin' ),
-					href: '#/settings',
+					onClick() {
+						document.getElementById( 'ad-refresh-control' ).scrollIntoView();
+					},
+					href: '#/settings/ad-refresh-control',
 				},
 				'publisher-media-kit': {
 					shouldRefreshAfterUpdate: true,

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { withWizard, utils } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { AdUnit, AdUnits, Providers, Settings, Placements, Suppression, AddOns } from './views';
+import { AdUnit, AdUnits, Providers, Settings, Placements } from './views';
 import { getSizes } from './components/ad-unit-size-control';
 import './style.scss';
 
@@ -158,14 +158,14 @@ class AdvertisingWizard extends Component {
 				label: __( 'Settings', 'newspack-plugin' ),
 				path: '/settings',
 			},
-			{
-				label: __( 'Suppression', 'newspack-plugin' ),
-				path: '/suppression',
-			},
-			{
-				label: __( 'Add-Ons', 'newspack-plugin' ),
-				path: '/addons',
-			},
+			// {
+			// 	label: __( 'Suppression', 'newspack-plugin' ),
+			// 	path: '/suppression',
+			// },
+			// {
+			// 	label: __( 'Add-Ons', 'newspack-plugin' ),
+			// 	path: '/addons',
+			// },
 		];
 		return (
 			<Fragment>
@@ -206,11 +206,7 @@ class AdvertisingWizard extends Component {
 							path="/settings"
 							render={ () => (
 								<Settings
-									headerText={ __( 'Advertising', 'newspack-plugin' ) }
-									subHeaderText={ __(
-										'Configure display and advanced settings for your ads',
-										'newspack-plugin'
-									) }
+									headerText={ __( 'Advertising / Display Ads', 'newspack-plugin' ) }
 									tabbedNavigation={ tabs }
 								/>
 							) }
@@ -292,31 +288,6 @@ class AdvertisingWizard extends Component {
 								);
 							} }
 						/>
-						<Route
-							path="/suppression"
-							render={ () => (
-								<Suppression
-									headerText={ __( 'Advertising', 'newspack-plugin' ) }
-									subHeaderText={ __(
-										'Allows you to manage site-wide ad suppression',
-										'newspack-plugin'
-									) }
-									tabbedNavigation={ tabs }
-									config={ advertisingData.suppression }
-									onChange={ config => this.updateAdSuppression( config ) }
-								/>
-							) }
-						/>
-						<Route
-							path="/addons"
-							render={ () => (
-								<AddOns
-									headerText={ __( 'Advertising', 'newspack-plugin' ) }
-									subHeaderText={ __( 'Add-ons for enhanced advertising', 'newspack-plugin' ) }
-									tabbedNavigation={ tabs }
-								/>
-							) }
-						/>
 						<Redirect to="/" />
 					</Switch>
 				</HashRouter>
@@ -327,5 +298,5 @@ class AdvertisingWizard extends Component {
 
 render(
 	createElement( withWizard( AdvertisingWizard, [ 'newspack-ads' ] ) ),
-	document.getElementById( 'newspack-advertising-wizard' )
+	document.getElementById( 'advertising-display-ads' )
 );

--- a/assets/wizards/advertising/index.js
+++ b/assets/wizards/advertising/index.js
@@ -158,14 +158,6 @@ class AdvertisingWizard extends Component {
 				label: __( 'Settings', 'newspack-plugin' ),
 				path: '/settings',
 			},
-			// {
-			// 	label: __( 'Suppression', 'newspack-plugin' ),
-			// 	path: '/suppression',
-			// },
-			// {
-			// 	label: __( 'Add-Ons', 'newspack-plugin' ),
-			// 	path: '/addons',
-			// },
 		];
 		return (
 			<Fragment>
@@ -177,11 +169,7 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ () => (
 								<Providers
-									headerText="Advertising"
-									subHeaderText={ __(
-										'Manage ad providers and their settings.',
-										'newspack-plugin'
-									) }
+									headerText={ __( 'Advertising / Display Ads', 'newspack-plugin' ) }
 									services={ services }
 									toggleService={ this.toggleService }
 									fetchAdvertisingData={ this.fetchAdvertisingData }
@@ -193,11 +181,7 @@ class AdvertisingWizard extends Component {
 							path="/placements"
 							render={ () => (
 								<Placements
-									headerText={ __( 'Advertising', 'newspack-plugin' ) }
-									subHeaderText={ __(
-										'Define global advertising placements to serve ad units on your site',
-										'newspack-plugin'
-									) }
+									headerText={ __( 'Advertising / Display Ads', 'newspack-plugin' ) }
 									tabbedNavigation={ tabs }
 								/>
 							) }

--- a/assets/wizards/advertising/style.scss
+++ b/assets/wizards/advertising/style.scss
@@ -12,20 +12,19 @@
 	}
 
 	.newspack-grid {
-
 		&__thead,
 		&__tbody {
 			align-items: center;
-			grid-template-columns: repeat(3, calc(33.33% - 24px)) 36px;
+			grid-template-columns: repeat( 3, calc( 33.33% - 24px ) ) 36px;
 		}
 
-		.newspack-button.has-icon:not(.has-text) {
+		.newspack-button.has-icon:not( .has-text ) {
 			height: 48px;
 			min-width: 48px;
 			width: 48px;
 		}
 
-		+.newspack-card__header-actions {
+		+ .newspack-card__header-actions {
 			margin-top: 64px;
 		}
 	}
@@ -49,5 +48,4 @@
 			margin-bottom: 64px;
 		}
 	}
-
 }

--- a/assets/wizards/advertising/style.scss
+++ b/assets/wizards/advertising/style.scss
@@ -29,4 +29,25 @@
 			margin-top: 64px;
 		}
 	}
+
+	.newspack-section-header {
+		margin: 0;
+	}
+
+	.newspack-section-header__container {
+		margin-bottom: 40px;
+
+		.heading-1 :is(h1, h2, h3, h4, h5, h6) {
+			font-size: 2rem;
+			font-weight: 400;
+			line-height: 1.25;
+		}
+	}
+
+	.newspack-plugin-settings {
+		:nth-last-child(1 of .newspack-card) {
+			margin-bottom: 64px;
+		}
+	}
+
 }

--- a/assets/wizards/advertising/style.scss
+++ b/assets/wizards/advertising/style.scss
@@ -1,4 +1,4 @@
-.newspack-advertising-wizard {
+.advertising-display-ads {
 	.newspack-button-card .newspack-notice {
 		margin: 24px 0 0;
 	}
@@ -12,19 +12,20 @@
 	}
 
 	.newspack-grid {
+
 		&__thead,
 		&__tbody {
 			align-items: center;
-			grid-template-columns: repeat( 3, calc( 33.33% - 24px ) ) 36px;
+			grid-template-columns: repeat(3, calc(33.33% - 24px)) 36px;
 		}
 
-		.newspack-button.has-icon:not( .has-text ) {
+		.newspack-button.has-icon:not(.has-text) {
 			height: 48px;
 			min-width: 48px;
 			width: 48px;
 		}
 
-		+ .newspack-card__header-actions {
+		+.newspack-card__header-actions {
 			margin-top: 64px;
 		}
 	}

--- a/assets/wizards/advertising/views/index.js
+++ b/assets/wizards/advertising/views/index.js
@@ -3,5 +3,3 @@ export { default as Placements } from './placements';
 export { default as Settings } from './settings';
 export { default as AdUnits } from './ad-units';
 export { default as AdUnit } from './ad-unit';
-export { default as Suppression } from './suppression';
-export { default as AddOns } from './add-ons';

--- a/assets/wizards/advertising/views/placements/index.js
+++ b/assets/wizards/advertising/views/placements/index.js
@@ -131,6 +131,7 @@ const Placements = () => {
 
 	return (
 		<Fragment>
+			<h1>{ __( 'Placements', 'newspack-plugin' ) }</h1>
 			{ ! inFlight && ! providers.length && (
 				<Notice
 					isWarning

--- a/assets/wizards/advertising/views/providers/index.js
+++ b/assets/wizards/advertising/views/providers/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { ExternalLink } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -77,7 +77,8 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 	}
 
 	return (
-		<>
+		<Fragment>
+			<h1>{ __( 'Providers', 'newspack-plugin' ) }</h1>
 			<ActionCard
 				title={ __( 'Google Ad Manager', 'newspack-plugin' ) }
 				description={ __(
@@ -139,7 +140,7 @@ const Providers = ( { services, fetchAdvertisingData, toggleService } ) => {
 					</Card>
 				</Modal>
 			) }
-		</>
+		</Fragment>
 	);
 };
 

--- a/assets/wizards/advertising/views/settings/index.js
+++ b/assets/wizards/advertising/views/settings/index.js
@@ -7,8 +7,7 @@ import { Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { PluginSettings, withWizardScreen } from '../../../../components/src';
-import WizardSection from '../../../wizards-section';
+import { PluginSettings, SectionHeader, withWizardScreen } from '../../../../components/src';
 import AdRefreshControlSettings from '../../components/ad-refresh-control';
 import AddOns from '../../components/add-ons';
 import Suppression from '../suppression';
@@ -20,16 +19,13 @@ function Settings() {
 	return (
 		<Fragment>
 			<h1>{ __( 'Settings', 'newspack-plugin' ) }</h1>
-			<PluginSettings pluginSlug="newspack-ads" title={ null } />
-			<WizardSection heading={ 2 }>
+			<PluginSettings pluginSlug="newspack-ads" title={ null }>
 				<AdRefreshControlSettings />
-			</WizardSection>
-			<WizardSection heading={ 2 } title={ __( 'Suppression', 'newspack-plugin' ) }>
+				<SectionHeader className="heading-1" title={ __( 'Suppression', 'newspack-plugin' ) } />
 				<Suppression />
-			</WizardSection>
-			<WizardSection heading={ 2 } title={ __( 'Plugins', 'newspack-plugin' ) }>
+				<SectionHeader className="heading-1" title={ __( 'Plugins', 'newspack-plugin' ) } />
 				<AddOns />
-			</WizardSection>
+			</PluginSettings>
 		</Fragment>
 	);
 }

--- a/assets/wizards/advertising/views/settings/index.js
+++ b/assets/wizards/advertising/views/settings/index.js
@@ -1,21 +1,36 @@
 /**
  * Ad Settings view.
  */
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { PluginSettings, withWizardScreen } from '../../../../components/src';
+import WizardSection from '../../../wizards-section';
 import AdRefreshControlSettings from '../../components/ad-refresh-control';
+import AddOns from '../../components/add-ons';
+import Suppression from '../suppression';
 
 /**
  * Advertising management screen.
  */
 function Settings() {
 	return (
-		<PluginSettings pluginSlug="newspack-ads" title={ null }>
-			<AdRefreshControlSettings />
-		</PluginSettings>
+		<Fragment>
+			<h1>{ __( 'Settings', 'newspack-plugin' ) }</h1>
+			<PluginSettings pluginSlug="newspack-ads" title={ null } />
+			<WizardSection heading={ 2 }>
+				<AdRefreshControlSettings />
+			</WizardSection>
+			<WizardSection heading={ 2 } title={ __( 'Suppression', 'newspack-plugin' ) }>
+				<Suppression />
+			</WizardSection>
+			<WizardSection heading={ 2 } title={ __( 'Plugins', 'newspack-plugin' ) }>
+				<AddOns />
+			</WizardSection>
+		</Fragment>
 	);
 }
 

--- a/assets/wizards/advertising/views/settings/index.js
+++ b/assets/wizards/advertising/views/settings/index.js
@@ -21,10 +21,14 @@ function Settings() {
 			<h1>{ __( 'Settings', 'newspack-plugin' ) }</h1>
 			<PluginSettings pluginSlug="newspack-ads" title={ null }>
 				<AdRefreshControlSettings />
-				<SectionHeader className="heading-1" title={ __( 'Suppression', 'newspack-plugin' ) } />
-				<Suppression />
-				<SectionHeader className="heading-1" title={ __( 'Plugins', 'newspack-plugin' ) } />
-				<AddOns />
+				<div className="newspack-wizard__section">
+					<SectionHeader className="heading-1" title={ __( 'Suppression', 'newspack-plugin' ) } />
+					<Suppression />
+				</div>
+				<div className="newspack-wizard__section">
+					<SectionHeader className="heading-1" title={ __( 'Plugins', 'newspack-plugin' ) } />
+					<AddOns />
+				</div>
 			</PluginSettings>
 		</Fragment>
 	);

--- a/assets/wizards/advertising/views/suppression/index.js
+++ b/assets/wizards/advertising/views/suppression/index.js
@@ -18,7 +18,6 @@ import {
 	CategoryAutocomplete,
 	SectionHeader,
 	Waiting,
-	withWizardScreen,
 } from '../../../../components/src';
 
 const Suppression = () => {
@@ -70,6 +69,7 @@ const Suppression = () => {
 			{ error && <Notice isError noticeText={ error.message } /> }
 			<SectionHeader
 				title={ __( 'Post Types', 'newspack-plugin' ) }
+				heading={ 3 }
 				description={ __( 'Suppress ads on specific post types.', 'newspack-plugin' ) }
 			/>
 			<Grid columns={ 3 } gutter={ 16 }>
@@ -92,6 +92,7 @@ const Suppression = () => {
 			</Grid>
 			<SectionHeader
 				title={ __( 'Tags', 'newspack-plugin' ) }
+				heading={ 3 }
 				description={ __(
 					'Suppress ads on specific tags and their archive pages.',
 					'newspack-plugin'
@@ -118,6 +119,7 @@ const Suppression = () => {
 			/>
 			<SectionHeader
 				title={ __( 'Categories', 'newspack-plugin' ) }
+				heading={ 3 }
 				description={ __(
 					'Suppress ads on specific categories and their archive pages.',
 					'newspack-plugin'
@@ -143,6 +145,7 @@ const Suppression = () => {
 			/>
 			<SectionHeader
 				title={ __( 'Author Archive Pages', 'newspack-plugin' ) }
+				heading={ 3 }
 				description={ __(
 					'Suppress ads on automatically generated pages displaying a list of posts by an author.',
 					'newspack-plugin'
@@ -165,4 +168,4 @@ const Suppression = () => {
 	);
 };
 
-export default withWizardScreen( Suppression );
+export default Suppression;

--- a/assets/wizards/wizards-section.tsx
+++ b/assets/wizards/wizards-section.tsx
@@ -21,22 +21,14 @@ export default function WizardSection( {
 	title,
 	description,
 	children = null,
-	heading = 3,
-	className = '',
-	titleClassName = '',
 }: {
 	title?: string;
 	description?: string;
 	children: React.ReactNode;
-	heading?: number;
-	className?: string;
-	titleClassName?: string;
 } ) {
 	return (
-		<div className={ `${ className } newspack-wizard__section` }>
-			{ title && (
-				<SectionHeader { ...{ title, description, heading } } className={ titleClassName } />
-			) }
+		<div className="newspack-wizard__section">
+			{ title && <SectionHeader heading={ 3 } title={ title } description={ description } /> }
 			{ children }
 		</div>
 	);

--- a/assets/wizards/wizards-section.tsx
+++ b/assets/wizards/wizards-section.tsx
@@ -21,14 +21,22 @@ export default function WizardSection( {
 	title,
 	description,
 	children = null,
+	heading = 3,
+	className = '',
+	titleClassName = '',
 }: {
 	title?: string;
 	description?: string;
 	children: React.ReactNode;
+	heading?: number;
+	className?: string;
+	titleClassName?: string;
 } ) {
 	return (
-		<div className="newspack-wizard__section">
-			{ title && <SectionHeader heading={ 3 } title={ title } description={ description } /> }
+		<div className={ `${ className } newspack-wizard__section` }>
+			{ title && (
+				<SectionHeader { ...{ title, description, heading } } className={ titleClassName } />
+			) }
 			{ children }
 		</div>
 	);

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -122,17 +122,20 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-wizard-section.php';
 
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
+		
 		// Newspack Wizards and Sections.
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-dashboard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-settings.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-custom-events-section.php';
-
-		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
-		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
+		
+		// Advertising Wizard. 
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/advertising/class-advertising-display-ads.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/advertising/class-advertising-sponsors.php';
 
 		/* Unified Wizards */
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-settings.php';
-		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-advertising-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-analytics-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-engagement-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-reader-revenue-wizard.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -255,7 +255,11 @@ final class Newspack {
 		$screen = get_current_screen();
 
 		$is_newspack_screen = str_contains( $screen->base, 'newspack_page_' );
-		if ( ! $screen || ! $is_newspack_screen ) {
+		$is_advertising_screen = str_contains( $screen->base, 'toplevel_page_advertising' );
+
+		$is_wizard = $is_newspack_screen || $is_advertising_screen;
+
+		if ( ! $screen || ! $is_wizard ) {
 			return;
 		}
 		remove_all_actions( current_action() );

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -29,28 +29,30 @@ class Wizards {
 	 */
 	public static function init() {
 		self::$wizards = [
-			'setup'              => new Setup_Wizard(),
-			'site-design'        => new Site_Design_Wizard(),
-			'reader-revenue'     => new Reader_Revenue_Wizard(),
-			'advertising'        => new Advertising_Wizard(),
-			'syndication'        => new Syndication_Wizard(),
-			'analytics'          => new Analytics_Wizard(),
-			'components-demo'    => new Components_Demo(),
-			'seo'                => new SEO_Wizard(),
-			'health-check'       => new Health_Check_Wizard(),
-			'engagement'         => new Engagement_Wizard(),
-			'popups'             => new Popups_Wizard(),
-			'connections'        => new Connections_Wizard(),
-			'settings'           => new Settings(),
+			'setup'                   => new Setup_Wizard(),
+			'site-design'             => new Site_Design_Wizard(),
+			'reader-revenue'          => new Reader_Revenue_Wizard(),
+			'advertising'             => new Advertising_Wizard(),
+			'syndication'             => new Syndication_Wizard(),
+			'analytics'               => new Analytics_Wizard(),
+			'components-demo'         => new Components_Demo(),
+			'seo'                     => new SEO_Wizard(),
+			'health-check'            => new Health_Check_Wizard(),
+			'engagement'              => new Engagement_Wizard(),
+			'popups'                  => new Popups_Wizard(),
+			'connections'             => new Connections_Wizard(),
+			'settings'                => new Settings(),
 			// v2 Information Architecture.
-			'newspack-dashboard' => new Newspack_Dashboard(),
-			'newspack-settings'  => new Newspack_Settings( 
+			'newspack-dashboard'      => new Newspack_Dashboard(),
+			'newspack-settings'       => new Newspack_Settings( 
 				[
 					'sections' => [
 						'custom-events' => 'Newspack\Wizards\Newspack\Custom_Events_Section',
 					],
 				] 
 			),
+			'advertising-display-ads' => new Advertising_Display_Ads(),
+			'advertising-sponsors'    => new Advertising_Sponsors(),
 		];
 	}
 

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -411,7 +411,7 @@ class Advertising_Display_Ads extends Wizard {
 			$ad_units = $configuration_manager->get_ad_units();
 		} catch ( \Exception $error ) {
 			$message = $error->getMessage();
-			$error   = new WP_Error( 'newspack_ad_units', $message ? $message : __( 'Ad Units failed to fetch.', 'newspack' ) );
+			$error   = new WP_Error( 'newspack_ad_units', $message ? $message : __( 'Ad Units failed to fetch.', 'newspack-plugin' ) );
 		}
 
 		if ( \is_wp_error( $ad_units ) ) {

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -1,0 +1,561 @@
+<?php
+/**
+ * Newspack's Advertising Wizard
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use WP_Error;
+
+use Newspack_Ads\Providers\GAM_Model;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Easy interface for setting up general store info.
+ */
+class Advertising_Display_Ads extends Wizard {
+
+	const NEWSPACK_ADVERTISING_SERVICE_PREFIX = '_newspack_advertising_service_';
+
+	const SERVICE_ACCOUNT_CREDENTIALS_OPTION_NAME = '_newspack_ads_gam_credentials';
+
+	// Legacy network code manually inserted.
+	const OPTION_NAME_LEGACY_NETWORK_CODE = '_newspack_ads_service_google_ad_manager_network_code';
+
+	// GAM network code pulled from user credentials.
+	const OPTION_NAME_GAM_NETWORK_CODE = '_newspack_ads_gam_network_code';
+
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'advertising-display-ads';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Supported services.
+	 *
+	 * @var array
+	 */
+	protected $services = array(
+		'google_ad_manager' => array(
+			'label' => 'Google Ad Manager',
+		),
+	);
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return \esc_html__( 'Advertising', 'newspack' );
+	}
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public function register_api_endpoints() {
+
+		// Get all Newspack advertising data.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/billboard/',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'api_get_advertising' ),
+				'permission_callback' => array( $this, 'api_permissions_check' ),
+			)
+		);
+
+		// Enable one service.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/billboard/service/(?P<service>[\a-z]+)',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'api_enable_service' ),
+				'permission_callback' => array( $this, 'api_permissions_check' ),
+				'args'                => array(
+					'service' => array(
+						'sanitize_callback' => array( $this, 'sanitize_service' ),
+					),
+				),
+			)
+		);
+
+		// Disable one service.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/billboard/service/(?P<service>[\a-z]+)',
+			array(
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'api_disable_service' ),
+				'permission_callback' => array( $this, 'api_permissions_check' ),
+				'args'                => array(
+					'service' => array(
+						'sanitize_callback' => array( $this, 'sanitize_service' ),
+					),
+				),
+			)
+		);
+
+		// Update GAM credentials.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/billboard/credentials',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'api_update_gam_credentials' ),
+				'permission_callback' => array( $this, 'api_permissions_check' ),
+				'args'                => array(
+					'onboarding'  => array(
+						'type'              => 'boolean',
+						'sanitize_callback' => 'rest_sanitize_boolean',
+						'default'           => false,
+					),
+					'credentials' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'type'                        => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'project_id'                  => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'private_key_id'              => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'private_key'                 => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'client_email'                => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'client_id'                   => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'auth_uri'                    => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'token_uri'                   => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'auth_provider_x509_cert_url' => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'client_x509_cert_url'        => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Remove GAM credentials.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/billboard/credentials',
+			array(
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'api_remove_gam_credentials' ),
+				'permission_callback' => array( $this, 'api_permissions_check' ),
+			)
+		);
+
+		// Save a ad unit.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/billboard/ad_unit/(?P<id>\d+)',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'api_update_adunit' ),
+				'permission_callback' => array( $this, 'api_permissions_check' ),
+				'args'                => array(
+					'id'         => array(
+						'sanitize_callback' => 'absint',
+					),
+					'name'       => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'sizes'      => array(
+						'sanitize_callback' => array( $this, 'sanitize_sizes' ),
+					),
+					'fluid'      => array(
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					),
+					'ad_service' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+
+		// Delete a ad unit.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/billboard/ad_unit/(?P<id>\d+)',
+			array(
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'api_delete_adunit' ),
+				'permission_callback' => array( $this, 'api_permissions_check' ),
+				'args'                => array(
+					'id' => array(
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		// Update network code.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/billboard/network_code',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'api_update_network_code' ),
+				'permission_callback' => array( $this, 'api_permissions_check' ),
+				'args'                => array(
+					'network_code' => array(
+						'sanitize_callback' => function ( $value ) {
+							$raw_codes       = explode( ',', $value );
+							$sanitized_codes = array_reduce(
+								$raw_codes,
+								function ( $acc, $code ) {
+									$sanitized_code = absint( trim( $code ) );
+									if ( ! empty( $sanitized_code ) ) {
+										$acc[] = $sanitized_code;
+									}
+									return $acc;
+								},
+								array()
+							);
+
+							return implode( ',', $sanitized_codes );
+						},
+					),
+					'is_gam'       => array(
+						'sanitize_callback' => 'rest_sanitize_boolean',
+						'default'           => false,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Update network code.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response containing ad units info.
+	 */
+	public function api_update_network_code( $request ) {
+		// Update GAM or legacy network code.
+		$option_name = $request['is_gam'] ? GAM_Model::OPTION_NAME_GAM_NETWORK_CODE : GAM_Model::OPTION_NAME_LEGACY_NETWORK_CODE;
+		update_option( $option_name, $request['network_code'] );
+		return \rest_ensure_response( array() );
+	}
+
+	/**
+	 * Get advertising data.
+	 *
+	 * @return WP_REST_Response containing ad units info.
+	 */
+	public function api_get_advertising() {
+		return \rest_ensure_response( $this->retrieve_data() );
+	}
+
+	/**
+	 * Enable one service
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response containing ad units info.
+	 */
+	public function api_enable_service( $request ) {
+		$service = $request['service'];
+		update_option( self::NEWSPACK_ADVERTISING_SERVICE_PREFIX . $service, true );
+		return \rest_ensure_response( $this->retrieve_data() );
+	}
+
+	/**
+	 * Disable one service
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response containing ad units info.
+	 */
+	public function api_disable_service( $request ) {
+		$service = $request['service'];
+		update_option( self::NEWSPACK_ADVERTISING_SERVICE_PREFIX . $service, false );
+		return \rest_ensure_response( $this->retrieve_data() );
+	}
+
+	/**
+	 * Update GAM credentials.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response containing current GAM status.
+	 */
+	public function api_update_gam_credentials( $request ) {
+		$params = $request->get_params();
+		update_option( self::SERVICE_ACCOUNT_CREDENTIALS_OPTION_NAME, $params['credentials'] );
+		if ( isset( $params['onboarding'] ) && $params['onboarding'] ) {
+			return \rest_ensure_response( true );
+		}
+		return \rest_ensure_response( $this->retrieve_data() );
+	}
+
+	/**
+	 * Remove GAM credentials.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response containing current GAM status.
+	 */
+	public function api_remove_gam_credentials( $request ) {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+		$response              = $configuration_manager->remove_gam_credentials();
+
+		if ( \is_wp_error( $response ) ) {
+			return \rest_ensure_response( $response );
+		}
+		return \rest_ensure_response( $this->retrieve_data() );
+	}
+
+	/**
+	 * Update or create an ad unit.
+	 *
+	 * @param WP_REST_Request $request Ad unit info.
+	 * @return WP_REST_Response Updated ad unit info.
+	 */
+	public function api_update_adunit( $request ) {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+
+		$params = $request->get_params();
+		$adunit = array(
+			'id'         => 0,
+			'name'       => '',
+			'sizes'      => array(),
+			'ad_service' => '',
+		);
+		$args   = \wp_parse_args( $params, $adunit );
+		// Update and existing or add a new ad unit.
+		$adunit = ( 0 === $args['id'] )
+			? $configuration_manager->add_ad_unit( $args )
+			: $configuration_manager->update_ad_unit( $args );
+
+		if ( \is_wp_error( $adunit ) ) {
+			return \rest_ensure_response( $adunit );
+		}
+
+		return \rest_ensure_response( $this->retrieve_data() );
+	}
+
+	/**
+	 * Delete an ad unit.
+	 *
+	 * @param WP_REST_Request $request Request with ID of ad unit to delete.
+	 * @return WP_REST_Response Boolean Delete success.
+	 */
+	public function api_delete_adunit( $request ) {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+
+		$params = $request->get_params();
+		$id     = $params['id'];
+
+		$configuration_manager->delete_ad_unit( $id );
+
+		return \rest_ensure_response( $this->retrieve_data() );
+	}
+
+	/**
+	 * Retrieve all advertising data.
+	 *
+	 * @return array Advertising data.
+	 */
+	private function retrieve_data() {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+
+		$services = $this->get_services();
+		$error    = false;
+		try {
+			$ad_units = $configuration_manager->get_ad_units();
+		} catch ( \Exception $error ) {
+			$message = $error->getMessage();
+			$error   = new WP_Error( 'newspack_ad_units', $message ? $message : __( 'Ad Units failed to fetch.', 'newspack' ) );
+		}
+
+		if ( \is_wp_error( $ad_units ) ) {
+			$error = $ad_units;
+		}
+
+		return array(
+			'services' => $services,
+			'ad_units' => \is_wp_error( $ad_units ) ? array() : $ad_units,
+			'error'    => $error,
+		);
+	}
+
+	/**
+	 * Retrieve state and information for each service.
+	 *
+	 * @return array Information about services.
+	 */
+	private function get_services() {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+
+		$services = array();
+		foreach ( $this->services as $service => $data ) {
+			$services[ $service ] = array(
+				'label'     => $data['label'],
+				'enabled'   => $configuration_manager->is_service_enabled( $service ),
+				'available' => true,
+			);
+		}
+
+		// Verify GAM connection and run initial setup.
+		$gam_connection_status = $configuration_manager->get_gam_connection_status();
+		if ( \is_wp_error( $gam_connection_status ) ) {
+			$error_type = $gam_connection_status->get_error_code();
+			if ( 'newspack_ads_gam_api_fatal_error' === $error_type ) {
+				$services['google_ad_manager']['available'] = false;
+			}
+			$services['google_ad_manager']['status']['error'] = $gam_connection_status->get_error_message();
+		} else {
+			$services['google_ad_manager']['status']             = $gam_connection_status;
+			$services['google_ad_manager']['available_networks'] = $configuration_manager->get_gam_available_networks();
+			if ( true === $gam_connection_status['connected'] && ! isset( $gam_connection_status['error'] ) ) {
+				$services['google_ad_manager']['network_code'] = $gam_connection_status['network_code'];
+				$gam_setup_results                             = $configuration_manager->setup_gam();
+				if ( ! \is_wp_error( $gam_setup_results ) ) {
+					$services['google_ad_manager']['created_targeting_keys'] = $gam_setup_results['created_targeting_keys'];
+				} else {
+					$services['google_ad_manager']['status']['error'] = $gam_setup_results->get_error_message();
+				}
+			}
+		}
+
+		return $services;
+	}
+
+	/**
+	 * Sanitize the service name.
+	 *
+	 * @param string $service The service name.
+	 * @return string
+	 */
+	public function sanitize_service( $service ) {
+		return sanitize_title( $service );
+	}
+
+	/**
+	 * Enqueue Subscriptions Wizard scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		parent::enqueue_scripts_and_styles();
+
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $this->slug ) {
+			return;
+		}
+
+		\wp_enqueue_script(
+			'advertising-display-ads',
+			Newspack::plugin_url() . '/dist/billboard.js',
+			$this->get_script_dependencies(),
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+
+		\wp_register_style(
+			'advertising-display-ads',
+			Newspack::plugin_url() . '/dist/billboard.css',
+			$this->get_style_dependencies(),
+			NEWSPACK_PLUGIN_VERSION
+		);
+		\wp_style_add_data( 'advertising-display-ads', 'rtl', 'replace' );
+		\wp_enqueue_style( 'advertising-display-ads' );
+
+		\wp_localize_script(
+			'advertising-display-ads',
+			'newspack_ads_wizard',
+			array(
+				'iab_sizes'          => function_exists( '\Newspack_Ads\get_iab_sizes' ) ? \Newspack_Ads\get_iab_sizes() : array(),
+				'mediakit_edit_url'  => get_option( 'pmk-page' ) ? get_edit_post_link( get_option( 'pmk-page' ) ) : '',
+				'can_connect_google' => OAuth::is_proxy_configured( 'google' ),
+			)
+		);
+	}
+
+	/**
+	 * Sanitize array of ad unit sizes.
+	 *
+	 * @param array $sizes Array of sizes to sanitize.
+	 * @return array Sanitized array.
+	 */
+	public static function sanitize_sizes( $sizes ) {
+		$sizes     = is_array( $sizes ) ? $sizes : array();
+		$sanitized = array();
+		foreach ( $sizes as $size ) {
+			$size    = is_array( $size ) && 2 === count( $size ) ? $size : array( 0, 0 );
+			$size[0] = absint( $size[0] );
+			$size[1] = absint( $size[1] );
+
+			$sanitized[] = $size;
+		}
+		return $sanitized;
+	}
+
+	/**
+	 * Add an admin page for the wizard to live on.
+	 */
+	public function add_page() {
+		// SVG generated via https://boxy-svg.com/ with path width/height 20px.
+		$icon = 'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="none" stroke="none" d="M 2 12 C 2 4.313 10.333 -0.491 17 3.352 C 20.094 5.136 22 8.433 22 12 C 22 19.686 13.667 24.49 7 20.647 C 3.906 18.863 2 15.567 2 12 Z M 12 3.727 C 5.622 3.727 1.635 10.621 4.824 16.136 C 6.304 18.696 9.04 20.273 12 20.273 C 18.378 20.273 22.365 13.378 19.176 7.863 C 17.696 5.304 14.96 3.727 12 3.727 Z M 10.471 9.292 C 10.112 9.543 10 9.808 10 10.003 C 10 10.198 10.112 10.463 10.471 10.714 C 10.827 10.962 11.366 11.144 12 11.144 C 12.943 11.144 13.834 11.41 14.512 11.883 C 15.186 12.356 15.714 13.089 15.714 13.997 C 15.714 14.904 15.187 15.637 14.512 16.11 C 14.043 16.436 13.475 16.664 12.857 16.774 L 12.857 17.135 C 12.857 17.793 12.143 18.205 11.571 17.876 C 11.306 17.723 11.143 17.44 11.143 17.135 L 11.143 16.774 C 10.55 16.675 9.985 16.448 9.488 16.11 C 8.814 15.637 8.286 14.904 8.286 13.997 C 8.286 13.338 9 12.926 9.571 13.255 C 9.837 13.408 10 13.691 10 13.997 C 10 14.192 10.112 14.456 10.471 14.707 C 10.827 14.956 11.366 15.138 12 15.138 C 12.634 15.138 13.173 14.956 13.529 14.707 C 13.888 14.456 14 14.192 14 13.997 C 14 13.801 13.888 13.537 13.529 13.286 C 13.173 13.037 12.634 12.855 12 12.855 C 11.057 12.855 10.166 12.59 9.488 12.116 C 8.814 11.644 8.286 10.91 8.286 10.003 C 8.286 9.095 8.813 8.362 9.488 7.889 C 9.985 7.552 10.55 7.324 11.143 7.225 L 11.143 6.865 C 11.143 6.206 11.857 5.794 12.429 6.123 C 12.694 6.276 12.857 6.559 12.857 6.865 L 12.857 7.225 C 13.474 7.335 14.045 7.563 14.512 7.889 C 15.186 8.362 15.714 9.095 15.714 10.003 C 15.714 10.661 15 11.073 14.429 10.744 C 14.163 10.591 14 10.308 14 10.003 C 14 9.808 13.888 9.543 13.529 9.292 C 13.173 9.043 12.634 8.862 12 8.862 C 11.366 8.862 10.827 9.043 10.471 9.292 Z"></path></svg>' );
+		add_menu_page(
+			$this->get_name(),
+			$this->get_name(),
+			$this->capability,
+			$this->slug,
+			array( $this, 'render_wizard' ),
+			$icon,
+			3.5
+		);
+		add_submenu_page(
+			$this->slug,
+			__( 'Advertising / Display Ads', 'newspack-plugin' ),
+			__( 'Display Ads', 'newspack-plugin' ),
+			$this->capability,
+			$this->slug,
+			array( $this, 'render_wizard' )
+		);
+	}
+}

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -69,7 +69,7 @@ class Advertising_Display_Ads extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return \esc_html__( 'Advertising', 'newspack' );
+		return \esc_html__( 'Advertising', 'newspack-plugin' );
 	}
 
 	/**

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -44,7 +44,7 @@ class Advertising_Sponsors extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return esc_html__( 'Sponsors', 'newspack' );
+		return \esc_html__( 'Sponsors', 'newspack-plugin' );
 	}
 
 	/**

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Newspack's Advertising Wizard
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Easy interface for setting up general store info.
+ */
+class Advertising_Sponsors extends Wizard {
+
+	/**
+	 * The slug of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'advertising-sponsors';
+
+
+	/**
+	 * Parent Wizard slug
+	 *
+	 * @var string
+	 */
+	protected $parent_slug = 'advertising-display-ads';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return esc_html__( 'Sponsors', 'newspack' );
+	}
+
+	/**
+	 * Add an admin page for the wizard to live on.
+	 */
+	public function add_page() {
+		add_submenu_page(
+			$this->parent_slug,
+			__( 'Advertising / Sponsors', 'newspack-plugin' ),
+			__( 'Sponsors', 'newspack-plugin' ),
+			$this->capability,
+			$this->slug,
+			array( $this, 'render_wizard' )
+		);
+	}
+}

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -118,7 +118,7 @@ class Newspack_Dashboard extends Wizard {
 						'icon'  => 'ad',
 						'title' => __( 'Display Ads', 'newspack-plugin' ),
 						'desc'  => __( 'Sell programmatic advertising on your site to drive revenue.', 'newspack-plugin' ),
-						'href'  => admin_url( 'admin.php?page=newspack-advertising-wizard#/' ),
+						'href'  => admin_url( 'admin.php?page=advertising-display-ads#/' ),
 					],
 					[
 						'icon'  => 'currencyDollar',
@@ -256,7 +256,7 @@ class Newspack_Dashboard extends Wizard {
 					],
 					'endpoint'         => '/newspack/v1/wizard/billboard',
 					'isPreflightValid' => ( new Newspack_Ads_Configuration_Manager() )->is_gam_connected(),
-					'configLink'       => admin_url( 'admin.php?page=newspack-advertising-wizard' ),
+					'configLink'       => admin_url( 'admin.php?page=advertising-display-ads' ),
 					'dependencies'     => [
 						'newspack-ads' => [
 							'label'    => __( 'Newspack Ads', 'newspack-plugin' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

* New Advertising admin page.
* New sub menu pages; Display Ads (Full) & Sponsors (Initial).
* Migrate legacy advertising wizard to new IA location. 
* Migrated Add-Ons tab to Settings tab.
* Migrated Suppressions tab to Settings tab.
* Added titles to each tab and section.
* CSS changes to accommodate title additions and tighten up component spacing.

### How to test the changes in this Pull Request:

1. Checkout this code and build assets.
2. Navigate to _/wp-admin/admin.php?page=advertising-display-ads#/_
3. Observe each tab; Providers, Placement and Settings all load as expected.
4. On Settings tab confirm Suppressions and Plugins (previously Add-Ons) are present.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->