### PR TITLE
fix(ras-acc): redirect to homepage when accessing my account in logged out state

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1152,12 +1152,8 @@ final class Reader_Activation {
 		}
 
 		/** Do not render link for authenticated readers if account page doesn't exist. */
-		if ( empty( $account_url ) ) {
-			if ( \is_user_logged_in() ) {
-				return '';
-			} else {
-				$account_url = '#';
-			}
+		if ( empty( $account_url ) && \is_user_logged_in() ) {
+			return '';
 		}
 
 		$class = function( ...$parts ) {
@@ -1230,8 +1226,13 @@ final class Reader_Activation {
 		}
 		// phpcs:enable
 
-		$referer = \wp_parse_url( \wp_get_referer() );
-		$labels  = self::get_reader_activation_labels( 'signin' );
+		$referer           = \wp_parse_url( \wp_get_referer() );
+		$labels            = self::get_reader_activation_labels( 'signin' );
+		$auth_callback_url = '#';
+		// If we are already on the my account page, set the my account URL so the page reloads on submit.
+		if ( function_exists( 'wc_get_page_permalink' ) && function_exists( 'is_account_page' ) && \is_account_page() ) {
+			$auth_callback_url = \wc_get_page_permalink( 'myaccount' );
+		}
 		?>
 		<div class="newspack-ui newspack-reader-auth">
 			<div class="newspack-ui__box newspack-ui__box--success newspack-ui__box--text-center" data-action="success">
@@ -1298,7 +1299,7 @@ final class Reader_Activation {
 				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--ghost newspack-ui__last-child" data-action="register" data-set-action="signin"><?php echo \esc_html( $labels['register'] ); ?></button>
 				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--ghost newspack-ui__last-child" data-action="otp pwd"  data-back><?php echo \esc_html( $labels['go_back'] ); ?></button>
 			</form>
-			<a href="#" class="auth-callback newspack-ui__button newspack-ui__button--wide newspack-ui__button--primary" data-action="success"><?php echo \esc_html( $labels['continue'] ); ?></a>
+			<a href="<?php echo \esc_url( $auth_callback_url ); ?>" class="auth-callback newspack-ui__button newspack-ui__button--wide newspack-ui__button--primary" data-action="success"><?php echo \esc_html( $labels['continue'] ); ?></a>
 			<a href="#" class="set-password newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary" data-action="success"><?php echo \esc_html( $labels['set_password'] ); ?></a>
 		</div>
 		<?php

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -42,7 +42,6 @@ class WooCommerce_My_Account {
 			\add_action( 'template_redirect', [ __CLASS__, 'handle_delete_account' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'handle_magic_link_request' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'redirect_to_account_details' ] );
-			\add_action( 'template_redirect', [ __CLASS__, 'redirect_to_home' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'edit_account_prevent_email_update' ] );
 			\add_action( 'init', [ __CLASS__, 'restrict_account_content' ], 100 );
 			\add_filter( 'woocommerce_save_account_details_required_fields', [ __CLASS__, 'remove_required_fields' ] );
@@ -356,21 +355,6 @@ class WooCommerce_My_Account {
 			$logout_url                = \wc_get_account_endpoint_url( 'customer-logout' );
 			if ( \trailingslashit( $current_url ) === \trailingslashit( $my_account_page_permalink ) ) {
 				\wp_safe_redirect( \wc_get_account_endpoint_url( 'edit-account' ) );
-				exit;
-			}
-		}
-	}
-
-	/**
-	 * Redirect to "Home" if accessing "My Account" directly when not logged in.
-	 */
-	public static function redirect_to_home() {
-		if ( ! \is_user_logged_in() && Reader_Activation::is_enabled() && function_exists( 'wc_get_page_permalink' ) ) {
-			global $wp;
-			$current_url               = \home_url( $wp->request );
-			$my_account_page_permalink = \wc_get_page_permalink( 'myaccount' );
-			if ( \trailingslashit( $current_url ) === \trailingslashit( $my_account_page_permalink ) ) {
-				\wp_safe_redirect( \get_home_url() );
 				exit;
 			}
 		}

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -42,12 +42,12 @@ class WooCommerce_My_Account {
 			\add_action( 'template_redirect', [ __CLASS__, 'handle_delete_account' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'handle_magic_link_request' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'redirect_to_account_details' ] );
+			\add_action( 'template_redirect', [ __CLASS__, 'redirect_to_home' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'edit_account_prevent_email_update' ] );
 			\add_action( 'init', [ __CLASS__, 'restrict_account_content' ], 100 );
 			\add_filter( 'woocommerce_save_account_details_required_fields', [ __CLASS__, 'remove_required_fields' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'verify_saved_account_details' ] );
-			\add_action( 'logout_redirect', [ __CLASS__, 'add_param_after_logout' ] );
-			\add_action( 'template_redirect', [ __CLASS__, 'show_message_after_logout' ] );
+			\add_action( 'logout_redirect', [ __CLASS__, 'redirect_to_home_after_logout' ] );
 			\add_action( 'woocommerce_account_subscriptions_endpoint', [ __CLASS__, 'append_membership_table' ], 11 );
 			\add_filter( 'wcs_my_account_redirect_to_single_subscription', [ __CLASS__, 'redirect_to_single_subscription' ] );
 			\add_filter( 'wc_memberships_members_area_my-memberships_actions', [ __CLASS__, 'hide_cancel_button_from_memberships_table' ] );
@@ -362,6 +362,21 @@ class WooCommerce_My_Account {
 	}
 
 	/**
+	 * Redirect to "Home" if accessing "My Account" directly when not logged in.
+	 */
+	public static function redirect_to_home() {
+		if ( ! \is_user_logged_in() && Reader_Activation::is_enabled() && function_exists( 'wc_get_page_permalink' ) ) {
+			global $wp;
+			$current_url               = \home_url( $wp->request );
+			$my_account_page_permalink = \wc_get_page_permalink( 'myaccount' );
+			if ( \trailingslashit( $current_url ) === \trailingslashit( $my_account_page_permalink ) ) {
+				\wp_safe_redirect( \get_home_url() );
+				exit;
+			}
+		}
+	}
+
+	/**
 	 * Remove WC's required fields.
 	 *
 	 * @param array $required_fields Required fields.
@@ -520,34 +535,22 @@ class WooCommerce_My_Account {
 	}
 
 	/**
-	 * Append a logout param after a reader logs out from My Account.
+	 * Modify redurect url to home after a reader logs out from My Account.
 	 *
 	 * @param string $redirect_to The redirect destination URL.
 	 *
 	 * @return string The filtered destination URL.
 	 */
-	public static function add_param_after_logout( $redirect_to ) {
+	public static function redirect_to_home_after_logout( $redirect_to ) {
 		if ( ! function_exists( 'wc_get_page_permalink' ) ) {
 			return;
 		}
 
 		if ( \wc_get_page_permalink( 'myaccount' ) === $redirect_to ) {
-			$redirect_to = \add_query_arg(
-				[ 'logged_out' => 1 ],
-				$redirect_to
-			);
+			$redirect_to = \get_home_url();
 		}
 
 		return $redirect_to;
-	}
-
-	/**
-	 * Show a logout success message to readers after logging out via My Account.
-	 */
-	public static function show_message_after_logout() {
-		if ( isset( $_GET['logged_out'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			WooCommerce_Connection::add_wc_notice( __( 'You have successfully logged out.', 'newspack-plugin' ), 'success' );
-		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207836618077219/f

This PR redirects readers to the homepage after logging out via my account. This is because we now provide a signin option from every other page and it's not necessary to visit the my-account page to login anymore when RAS is setup:

https://github.com/user-attachments/assets/a150fcc9-f6d6-4931-97f3-e6b1ddefa998

This also handles cases where folks are logging in from the my account page, forcing a redirect to trigger the updated my account dashboard.

### How to test the changes in this Pull Request:

1. Log in as a reader
2. Visit the my account page via the my account button or appending `/my-account` to the site url
3. Log in and confirm the page redirects to the my account dashboard 
4. Log out and confirm you redirected to the home page

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->