### PR TITLE
fix(ras-acc): adjust newsletters modal spacing and always display email text

### DIFF
--- a/assets/reader-activation-newsletters/newsletters-modal.js
+++ b/assets/reader-activation-newsletters/newsletters-modal.js
@@ -81,7 +81,13 @@ export function openNewslettersSignupModal( config = {} ) {
 	const emailInput = modal.querySelector( 'span.email' );
 	if ( emailInput && ! emailInput.innerText ) {
 		const reader = window?.newspackReaderActivation?.getReader();
-		emailInput.textContent = reader?.email || '';
+
+		if ( reader?.email ) {
+			emailInput.textContent = reader.email;
+		} else {
+			// Remove parent element of emailInput if no email is found.
+			emailInput.parentElement.remove();
+		}
 	}
 
 	modal.setAttribute( 'data-state', 'open' );

--- a/assets/reader-activation-newsletters/style.scss
+++ b/assets/reader-activation-newsletters/style.scss
@@ -5,11 +5,16 @@
 	}
 
 	p.details {
-		margin-bottom: 4px;
+		margin-bottom: 0;
 	}
 
 	p.recipient {
-		margin-top: 0;
+		margin-top: 4px;
+		margin-bottom: 0;
+	}
+
+	.newspack-newsletters-signup {
+		margin-top: var( --newspack-ui-spacer-5 );
 	}
 }
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1424,14 +1424,12 @@ final class Reader_Activation {
 					<p class="newspack-ui__font--xs details">
 						<?php echo \esc_html( self::get_reader_activation_labels( 'newsletters_details' ) ); ?>
 					</p>
-					<?php if ( ! empty( $email_address ) ) : ?>
-						<p class="newspack-ui__font--xs newspack-ui__color-text-gray recipient">
-							<?php echo esc_html( __( 'Sending to: ', 'newspack-plugin' ) ); ?>
-							<span class="email">
-								<?php echo esc_html( $email_address ); ?>
-							</span>
-						</p>
-					<?php endif; ?>
+					<p class="newspack-ui__font--xs newspack-ui__color-text-gray recipient">
+						<?php echo esc_html( __( 'Sending to: ', 'newspack-plugin' ) ); ?>
+						<span class="email">
+							<?php echo esc_html( $email_address ); ?>
+						</span>
+					</p>
 					<?php self::render_newsletters_signup_form( $email_address, $newsletters_lists ); ?>
 				</div>
 			</div>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150111/f

This PR does two things related to the newsletters signup modal:

1. Always populates with an email address. Before, if the newsletters modal triggered as part of a registration flow (i.e. checkout modal as logged out user), the email would not be populated. This was because the form markup is generated before the reader creates an account. This PR updates this email address in the markup dynamically via JS.

![Screenshot 2024-07-24 at 16 25 04](https://github.com/user-attachments/assets/6cdf95ee-4954-4bb9-9e6c-3a669ba2f466)

2. Updates the spacing of some of the text in the newsletters modal

![Screenshot 2024-07-24 at 16 25 56](https://github.com/user-attachments/assets/e11f1dd7-2a30-4407-aa17-7b606377cada)

### How to test the changes in this Pull Request:

1. As admin, ensure the `Present newsletter signup after checkout and registration` toggle is enabled with some newsletter lists selected via Newspack > Engagement > Show Advanced Settings
2. As a logged out reader, go to any page with a donation or checkout block
3. Go through the checkout flow until you get to the newsletters modal
4. Verify the email address text is present and the spacing between the text and the first newsletters list option as pictured above.
5. Repeat the process, but this time as a logged in reaeder

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->