### PR TITLE
fix(ras-acc): remove html markup from transaction fee order review table entry

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -76,11 +76,7 @@ class WooCommerce_Cover_Fees {
 			return;
 		}
 		$cart->add_fee(
-			sprintf(
-				// Translators: %s is the fee percentage.
-				__( 'Transaction fee (%s)', 'newspack-plugin' ),
-				self::get_cart_fee_display_value()
-			),
+			__( 'Transaction fee', 'newspack-plugin' ),
 			self::get_cart_fee_value()
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207836618927981/f

This PR removes the HTML markup from the Stripe transaction fee name. We need to do this because Woo will run the name string through an escaping function that causes the HTML markup to render in the WC order review table.

Before:
![Screenshot 2024-07-25 at 10 56 34](https://github.com/user-attachments/assets/4238d04a-aafe-4446-9afb-5b8b8e97bd41)

After:
![Screenshot 2024-07-25 at 10 57 05](https://github.com/user-attachments/assets/9f1ba6df-57f1-4532-abcb-f3505df2cf1b)

### How to test the changes in this Pull Request:

1. Make sure stripe is enabled and the `Allow donors to cover transaction fees` checkbox is checked via the Newspack > Reader Revenue > Stripe menu
2. As a reader, go to any page with a donate block and initiate checkout
3. On the payment step of the modal, choose stripe as the payment method and check the "cover fees" checkbox
4. Look for the transaction table (pictured above), and confirm the Transaction Fee entry is added and there is no stray HTML markup

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->