### PR TITLE
fix(ras-acc): correctly render auth modal response message and success button spacing

### DIFF
--- a/assets/reader-activation-auth/auth-form.js
+++ b/assets/reader-activation-auth/auth-form.js
@@ -72,8 +72,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 				formAction = action;
 				actionInput.value = action;
 				container.removeAttribute( 'data-form-status' );
-				messageContentElement.style.display = 'none';
-				messageContentElement.innerHTML = '';
 				container.querySelectorAll( '[data-action]' ).forEach( item => {
 					if ( 'none' !== item.style.display ) {
 						item.prevDisplay = item.style.display;
@@ -157,7 +155,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				handleOTPTimer();
 				sendCodeButtons.forEach( button => {
 					button.addEventListener( 'click', function ( ev ) {
-						messageContentElement.innerHTML = '';
+						form.setMessageContent();
 						ev.preventDefault();
 						form.startLoginFlow();
 						const body = new FormData();
@@ -184,8 +182,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 									body,
 								} )
 									.then( () => {
-										messageContentElement.style.display = 'block';
-										messageContentElement.innerHTML = newspack_reader_activation_labels.code_resent;
+										form.setMessageContent( newspack_reader_activation_labels.code_resent );
 										container.setFormAction( 'otp' );
 										readerActivation.setOTPTimer();
 									} )
@@ -211,7 +208,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				submitButtons.forEach( button => {
 					button.disabled = true;
 				} );
-				messageContentElement.innerHTML = '';
+				form.setMessageContent();
 				form.style.opacity = 0.5;
 			};
 
@@ -224,8 +221,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				if ( message ) {
 					const messageNode = document.createElement( 'p' );
 					messageNode.innerHTML = message;
-					messageContentElement.style.display = 'block';
-					messageContentElement.appendChild( messageNode );
+					form.setMessageContent( message, status !== 200 );
 					messageContentElement
 						.querySelectorAll( '[data-set-action]' )
 						.forEach( setActionListener );
@@ -282,6 +278,39 @@ window.newspackRAS.push( function ( readerActivation ) {
 							}
 						}
 					}
+				}
+			};
+
+			/**
+			 * Sets response message content.
+			 *
+			 * @param {string|HTMLElement} message Message content.
+			 * @param {boolean}            isError Whether the message is an error.
+			 *
+			 * @return {void}
+			 */
+			form.setMessageContent = ( message = '', isError = false ) => {
+				if ( message ) {
+					if ( typeof message === 'string' ) {
+						messageContentElement.innerHTML = message;
+					} else {
+						messageContentElement.appendChild( message );
+					}
+					if ( isError ) {
+						messageContentElement.classList.remove( 'newspack-ui__helper-text' );
+						messageContentElement.classList.add( 'newspack-ui__inline-error' );
+					} else {
+						messageContentElement.classList.remove( 'newspack-ui__inline-error' );
+						messageContentElement.classList.add( 'newspack-ui__helper-text' );
+					}
+					messageContentElement.style.display = 'block';
+				} else {
+					messageContentElement.style.display = 'none';
+					messageContentElement.innerHTML = '';
+					messageContentElement.classList.remove(
+						'newspack-ui__inline-error',
+						'newspack-ui__helper-text'
+					);
 				}
 			};
 

--- a/assets/reader-activation-auth/auth-form.js
+++ b/assets/reader-activation-auth/auth-form.js
@@ -221,10 +221,13 @@ window.newspackRAS.push( function ( readerActivation ) {
 				if ( message ) {
 					const messageNode = document.createElement( 'p' );
 					messageNode.innerHTML = message;
-					form.setMessageContent( message, status !== 200 );
-					messageContentElement
-						.querySelectorAll( '[data-set-action]' )
-						.forEach( setActionListener );
+
+					if ( status !== 200 ) {
+						form.setMessageContent( message, true );
+						messageContentElement
+							.querySelectorAll( '[data-set-action]' )
+							.forEach( setActionListener );
+					}
 				}
 				if ( status === 200 ) {
 					if ( data ) {
@@ -275,6 +278,10 @@ window.newspackRAS.push( function ( readerActivation ) {
 							} else {
 								setPasswordButton.style.display = 'none';
 								setPasswordButton.setAttribute( 'href', '#' );
+								const continueButton = container.querySelector( '.auth-callback' );
+								if ( continueButton ) {
+									continueButton.classList.add( 'newspack-ui__last-child' );
+								}
 							}
 						}
 					}

--- a/assets/reader-activation-auth/style.scss
+++ b/assets/reader-activation-auth/style.scss
@@ -7,6 +7,10 @@
 	input[type='email'].nphp {
 		@include mixins.visuallyHidden;
 	}
+
+	.response-container {
+		margin-bottom: 12px;
+	}
 }
 
 .entry-content .newspack-reader,
@@ -179,8 +183,4 @@ li.menu-item .newspack-reader__account-link {
  */
 .woocommerce-account .entry-header .entry-title {
 	display: none;
-}
-
-.response-container {
-	margin-bottom: 12px;
 }

--- a/assets/reader-activation-auth/style.scss
+++ b/assets/reader-activation-auth/style.scss
@@ -180,3 +180,7 @@ li.menu-item .newspack-reader__account-link {
 .woocommerce-account .entry-header .entry-title {
 	display: none;
 }
+
+.response-container {
+	margin-bottom: 12px;
+}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1273,7 +1273,7 @@ final class Reader_Activation {
 					<?php Recaptcha::render_recaptcha_v2_container(); ?>
 				<?php endif; ?>
 				<div class="response-container">
-					<div class="response newspack-ui__inline-error">
+					<div class="response">
 						<?php if ( ! empty( $message ) ) : ?>
 							<p><?php echo \esc_html( $message ); ?></p>
 						<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150134/f and https://app.asana.com/0/1207817176293825/1207878733150140/f

This PR ensures the auth modal response messages render correctly:

![Screenshot 2024-07-25 at 13 02 39](https://github.com/user-attachments/assets/2a6f428a-dc62-4295-bfe7-b789d0b9ed89)

It also removes extra padding from success modal Continue button when logging in with a password:

Before:
![Screenshot 2024-07-25 at 15 08 43](https://github.com/user-attachments/assets/eaae8804-8a25-42ef-9a9b-349940104198)

After:
![Screenshot 2024-07-25 at 15 05 55](https://github.com/user-attachments/assets/6f8702f1-8079-4b13-875b-1fe865e52731)


### How to test the changes in this Pull Request:

1. As a reader (with an account but without a password) trigger the auth modal via the Sign in button (top right navigation)
2. Enter an invalid OTP code and confirm an error message appears and the input label and message is styled red
3. Wait for the OTP resend button timer to run down, then click the Resend code button
4. Confirm helper text appears styled in gray letting you know the code has been resent (pictured above)
5. Close the auth form without logging in
6. As a reader (with an account that has a password set) trigger the auth modal again
7. Complete the sign in process and stop at the success modal
8. Confirm the Continue button does not have additional padding at the bottom

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->