### PR TITLE
fix(woocommerce): prevent /shop redirect from author archives

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -159,6 +159,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-co-authors-plus.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
 		include_once NEWSPACK_ABSPATH . 'includes/polyfills/class-amp-polyfills.php';

--- a/includes/plugins/class-woocommerce.php
+++ b/includes/plugins/class-woocommerce.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * WooCommerce integration class.
+ * https://wordpress.org/plugins/woocommerce
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class WooCommerce {
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_action( 'wp_loaded', [ __CLASS__,'disable_wc_author_archive_override' ] );
+	}
+
+	/**
+	 * Prevent WC from redirecting to shop page from author archives of users who are customers (wc_disable_author_archives_for_customers).
+	 */
+	public static function disable_wc_author_archive_override() {
+		remove_action( 'template_redirect', 'wc_disable_author_archives_for_customers', 10 );
+	}
+}
+WooCommerce::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WooCommerce will redirect to the Shop page if visiting an author archive of a user who has the Customer role. These users can be non-editing contributors, though, and as such should have an archive available.

### How to test the changes in this Pull Request:

1. On `trunk`,
1. Create a user with two roles - Customer, Non-Editing Contributor, and assign them as an author to a post
2. Visit their author archive (`/author/user-slug`), observe it redirects to the WC Shop page
3. Switch to this branch, load the archive again, observe no redirect

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207784617698902