### PR TITLE
fix: use percentage in cover fee name

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -79,7 +79,7 @@ class WooCommerce_Cover_Fees {
 			sprintf(
 				// Translators: %s is the fee percentage.
 				__( 'Transaction fee (%s)', 'newspack-plugin' ),
-				self::get_cart_fee_display_value()
+				self::get_cart_fee_percentage()
 			),
 			self::get_cart_fee_value()
 		);
@@ -262,9 +262,24 @@ class WooCommerce_Cover_Fees {
 	}
 
 	/**
+	 * Get the fee percentage.
+	 *
+	 * @param float $subtotal The subtotal to calculate the fee for.
+	 *
+	 * @return string
+	 */
+	public static function get_fee_percentage( $subtotal ) {
+		$total = self::get_total_with_fee( $subtotal );
+		// Just one decimal place, please.
+		$flat_percentage = (float) number_format( ( ( $total - $subtotal ) * 100 ) / $subtotal, 1 );
+		return $flat_percentage . '%';
+	}
+
+	/**
 	 * Calculate the adjusted total, taking the fee into account.
 	 *
 	 * @param float $subtotal The subtotal to calculate the total for.
+	 *
 	 * @return float
 	 */
 	public static function get_total_with_fee( $subtotal ) {
@@ -278,6 +293,15 @@ class WooCommerce_Cover_Fees {
 	 */
 	public static function get_cart_fee_value() {
 		return self::get_fee_value( WC()->cart->get_subtotal() );
+	}
+
+	/**
+	 * Get the fee percentage for the current cart.
+	 *
+	 * @return float
+	 */
+	public static function get_cart_fee_percentage() {
+		return self::get_fee_percentage( WC()->cart->get_subtotal() );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150175/f

This fixes an issue where we are using the cover fee display value in the cover fee name. Woo escapes HTML entities when outputting the cover fee name as a result, HTML tags are rendered on the frontend in the transaction order review table:

Before:
![Screenshot 2024-07-26 at 12 31 02](https://github.com/user-attachments/assets/a0fbd9eb-8f13-4d65-ba16-0f8fc61f7f4f)

After:
![Screenshot 2024-07-26 at 12 24 52](https://github.com/user-attachments/assets/e2aed963-f54c-4144-bc21-0e3f069b6868)


### How to test the changes in this Pull Request:

1. As a reader visit any page with the donate block
2. Go through modal checkout until you get to the payment method step
3. Select Stripe as your payment gateway and check the cover fees checkbox
4. Confirm the Transaction fee displays correctly in the transaction order review table as pictured in the after image above.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->