### PR TITLE
fix(ras-acc): handle invalid removechild js error

### DIFF
--- a/assets/blocks/reader-registration/view.js
+++ b/assets/blocks/reader-registration/view.js
@@ -83,7 +83,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 					messageElement.appendChild( messageNode );
 					messageElement.classList.remove( 'newspack-registration--hidden' );
 				}
-				submitElement.removeChild( spinner );
+				if ( submitElement.contains( spinner ) ) {
+					submitElement.removeChild( spinner );
+				}
 				submitElement.disabled = false;
 				container.classList.remove( 'newspack-registration--in-progress' );
 			};


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207836897783913/f

This resolves some js errors that appear whenever transitioning from the auth modal to the checkout modal. It looks like there is some logic that tries to remove a loading state spinner in the auth modal which throws an error since the modal is closed and transitioned to the checkout modal.

This fixes this by adding a check to confirm the spinner is a child of the submitted element before attempting to remove the spinner.

### How to test the changes in this Pull Request:

1. As a logged out reader go to any page with a donate block
2. Open dev tools and monitor console errors
3. Go through checkout, logging in via the auth modal first, and stopping at the checkout modal
4. Confirm none of the following errors are logged:

```
DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at n.endLoginFlow
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->