### PR TITLE
fix: add extra wrapper around inline login form

### DIFF
--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -17,6 +17,7 @@
 		margin-bottom: var( --newspack-ui-spacer-2 );
 		min-height: var( --newspack-ui-spacer-9 );
 		padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-5 );
+		text-decoration: none;
 		transition: background-color 125ms ease-in-out, border-color 125ms ease-in-out, outline 125ms ease-in-out;
 
 		&:last-child {

--- a/includes/templates/reader-activation/login-form.php
+++ b/includes/templates/reader-activation/login-form.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 \do_action( 'woocommerce_before_customer_login_form' );
 ?>
-<div class="newspack-ui">
+<div class="newspack-ui newspack-reader-auth__inline-wrapper">
 	<?php Reader_Activation::render_auth_form(); ?>
 	<p class="newspack-ui__font--xs"><?php echo wp_kses_post( Reader_Activation::get_auth_footer() ); ?></p>
 </div>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Testing instructions for this issue are in https://github.com/Automattic/newspack-theme/pull/2351.

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->