### PR TITLE
fix: reCAPTCHA v2 + v3 for RAS-ACC flows

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -27,10 +27,6 @@ final class Recaptcha {
 	public static function init() {
 		\add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'register_scripts' ] );
-		\add_action( 'newspack_newsletters_subscribe_block_before_email_field', [ __CLASS__, 'render_recaptcha_v2_container' ] );
-
-		// Add reCAPTCHA to the Woo checkout form.
-		\add_action( 'woocommerce_review_order_before_submit', [ __CLASS__, 'add_recaptcha_v2_to_checkout' ] );
 
 		// Verify reCAPTCHA on checkout submission.
 		\add_action( 'woocommerce_checkout_process', [ __CLASS__, 'verify_recaptcha_on_checkout' ] );
@@ -428,25 +424,6 @@ final class Recaptcha {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Render a container for the reCAPTCHA v2 checkbox widget.
-	 */
-	public static function render_recaptcha_v2_container() {
-		if ( ! self::can_use_captcha( 'v2' ) ) {
-			return;
-		}
-		?>
-		<div id="<?php echo \esc_attr( 'newspack-recaptcha-' . uniqid() ); ?>" class="grecaptcha-container"></div>
-		<?php
-	}
-
-	/**
-	 * Add reCAPTCHA v2 to Woo checkout.
-	 */
-	public static function add_recaptcha_v2_to_checkout() {
-		self::render_recaptcha_v2_container();
 	}
 
 	/**

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -7,9 +7,6 @@
 
 namespace Newspack;
 
-use Error;
-use Google\Service\Docs\PinTableHeaderRowsRequest;
-
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -121,8 +121,6 @@ final class Recaptcha {
 				null, // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 				false
 			);
-			\wp_script_add_data( self::SCRIPT_HANDLE_API, 'async', true );
-			\wp_script_add_data( self::SCRIPT_HANDLE_API, 'defer', true );
 
 			\wp_enqueue_script(
 				self::SCRIPT_HANDLE,
@@ -131,8 +129,6 @@ final class Recaptcha {
 				NEWSPACK_PLUGIN_VERSION,
 				true
 			);
-			\wp_script_add_data( self::SCRIPT_HANDLE, 'async', true );
-			\wp_script_add_data( self::SCRIPT_HANDLE, 'defer', true );
 
 			\wp_localize_script(
 				self::SCRIPT_HANDLE,

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -232,7 +232,7 @@ final class Recaptcha {
 				)
 			) {
 			$legacy_key      = \get_option( self::OPTIONS_PREFIX . 'site_key', false );
-			$legacy_secret   = \get_option( self::OPTIONS_PREFIX . 'site_key', false );
+			$legacy_secret   = \get_option( self::OPTIONS_PREFIX . 'site_secret', false );
 
 			if ( ! empty( $legacy_key ) ) {
 				$settings['credentials'][ $current_version ]['site_key'] = $legacy_key;

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1256,7 +1256,7 @@ final class Reader_Activation {
 				</p>
 				<p class="newspack-ui__font--xs success-description"></p>
 			</div>
-			<form method="post" target="_top">
+			<form method="post" target="_top" data-recaptcha="register">
 				<div data-action="signin register">
 					<?php self::render_third_party_auth(); ?>
 				</div>
@@ -1717,7 +1717,7 @@ final class Reader_Activation {
 		}
 
 		// reCAPTCHA test on account registration only.
-		if ( 'register' === $action && Recaptcha::can_use_captcha() ) {
+		if ( 'register' === $action && Recaptcha::can_use_captcha( 'v3' ) ) {
 			$captcha_result = Recaptcha::verify_captcha();
 			if ( \is_wp_error( $captcha_result ) ) {
 				return self::send_auth_form_response( $captcha_result );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1256,7 +1256,7 @@ final class Reader_Activation {
 				</p>
 				<p class="newspack-ui__font--xs success-description"></p>
 			</div>
-			<form method="post" target="_top" data-recaptcha="register">
+			<form method="post" target="_top" data-newspack-recaptcha="register">
 				<div data-action="signin register">
 					<?php self::render_third_party_auth(); ?>
 				</div>

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -269,6 +269,7 @@ final class Reader_Activation {
 				),
 				'newsletters_success'      => __( 'Signup successful!', 'newspack-plugin' ),
 				'newsletters_title'        => __( 'Sign up for newsletters', 'newspack-plugin' ),
+				'auth_form_action'         => self::AUTH_FORM_ACTION,
 			];
 
 			/**
@@ -1256,7 +1257,7 @@ final class Reader_Activation {
 				</p>
 				<p class="newspack-ui__font--xs success-description"></p>
 			</div>
-			<form method="post" target="_top" data-newspack-recaptcha="register">
+			<form method="post" target="_top" data-newspack-recaptcha="<?php echo \esc_attr( self::AUTH_FORM_ACTION ); ?>">
 				<div data-action="signin register">
 					<?php self::render_third_party_auth(); ?>
 				</div>
@@ -1282,9 +1283,6 @@ final class Reader_Activation {
 					<label for="newspack-reader-auth-password-input"><?php esc_html_e( 'Enter your password', 'newspack-plugin' ); ?></label>
 					<input id="newspack-reader-auth-password-input" name="password" type="password" />
 				</p>
-				<?php if ( Recaptcha::can_use_captcha( 'v2' ) ) : ?>
-					<?php Recaptcha::render_recaptcha_v2_container(); ?>
-				<?php endif; ?>
 				<div class="response-container">
 					<div class="response">
 						<?php if ( ! empty( $message ) ) : ?>

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1257,7 +1257,7 @@ final class Reader_Activation {
 				</p>
 				<p class="newspack-ui__font--xs success-description"></p>
 			</div>
-			<form method="post" target="_top" data-newspack-recaptcha="<?php echo \esc_attr( self::AUTH_FORM_ACTION ); ?>">
+			<form method="post" target="_top" data-newspack-recaptcha="newspack_register">
 				<div data-action="signin register">
 					<?php self::render_third_party_auth(); ?>
 				</div>

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -205,7 +205,7 @@ function render_block( $attrs, $content ) {
 				<?php echo $success_registration_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
 		<?php else : ?>
-			<form id="<?php echo esc_attr( get_form_id() ); ?>" data-newspack-recaptcha="<?php echo \esc_attr( FORM_ACTION ); ?>">
+			<form id="<?php echo esc_attr( get_form_id() ); ?>" data-newspack-recaptcha="newspack_register">
 				<div class="newspack-registration__have-account">
 					<?php echo \wp_kses_post( $attrs['haveAccountLabel'] ); ?>
 					<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link>

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -205,7 +205,7 @@ function render_block( $attrs, $content ) {
 				<?php echo $success_registration_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
 		<?php else : ?>
-			<form id="<?php echo esc_attr( get_form_id() ); ?>" data-recaptcha="register">
+			<form id="<?php echo esc_attr( get_form_id() ); ?>" data-newspack-recaptcha="register">
 				<div class="newspack-registration__have-account">
 					<?php echo \wp_kses_post( $attrs['haveAccountLabel'] ); ?>
 					<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link>

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -205,7 +205,7 @@ function render_block( $attrs, $content ) {
 				<?php echo $success_registration_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
 		<?php else : ?>
-			<form id="<?php echo esc_attr( get_form_id() ); ?>" data-newspack-recaptcha="register">
+			<form id="<?php echo esc_attr( get_form_id() ); ?>" data-newspack-recaptcha="<?php echo \esc_attr( FORM_ACTION ); ?>">
 				<div class="newspack-registration__have-account">
 					<?php echo \wp_kses_post( $attrs['haveAccountLabel'] ); ?>
 					<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link>

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -260,9 +260,6 @@ function render_block( $attrs, $content ) {
 					?>
 					<div class="newspack-registration__main">
 						<div>
-							<?php if ( Recaptcha::can_use_captcha( 'v2' ) ) : ?>
-								<?php Recaptcha::render_recaptcha_v2_container(); ?>
-							<?php endif; ?>
 							<?php Reader_Activation::render_third_party_auth(); ?>
 							<div class="newspack-registration__inputs">
 								<input

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -205,7 +205,7 @@ function render_block( $attrs, $content ) {
 				<?php echo $success_registration_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
 		<?php else : ?>
-			<form id="<?php echo esc_attr( get_form_id() ); ?>">
+			<form id="<?php echo esc_attr( get_form_id() ); ?>" data-recaptcha="register">
 				<div class="newspack-registration__have-account">
 					<?php echo \wp_kses_post( $attrs['haveAccountLabel'] ); ?>
 					<a href="<?php echo \esc_url( $sign_in_url ); ?>" data-newspack-reader-account-link>
@@ -409,7 +409,7 @@ function process_form() {
 	}
 
 	// reCAPTCHA test.
-	if ( Recaptcha::can_use_captcha() ) {
+	if ( Recaptcha::can_use_captcha( 'v3' ) ) {
 		$captcha_result = Recaptcha::verify_captcha();
 		if ( \is_wp_error( $captcha_result ) ) {
 			return send_form_response( $captcha_result );

--- a/src/blocks/reader-registration/view.js
+++ b/src/blocks/reader-registration/view.js
@@ -98,46 +98,24 @@ window.newspackRAS.push( function( readerActivation ) {
 					return form.endLoginFlow( 'Please enter a vaild email address.', 400 );
 				}
 
-				readerActivation
-					.getCaptchaV3Token() // Get a token for reCAPTCHA v3, if needed.
-					.then( captchaToken => {
-						// If there's no token, we don't need to do anything.
-						if ( ! captchaToken ) {
-							return;
-						}
-						let tokenField = form[ 'g-recaptcha-response' ];
-						if ( ! tokenField ) {
-							tokenField = document.createElement( 'input' );
-							tokenField.setAttribute( 'type', 'hidden' );
-							tokenField.setAttribute( 'name', 'g-recaptcha-response' );
-							tokenField.setAttribute( 'autocomplete', 'off' );
-							form.appendChild( tokenField );
-						}
-						tokenField.value = captchaToken;
+				const body = new FormData( form );
+				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
+					return form.endFlow( 'Please enter a vaild email address.', 400 );
+				}
+				fetch( form.getAttribute( 'action' ) || window.location.pathname, {
+					method: 'POST',
+					headers: {
+						Accept: 'application/json',
+					},
+					body,
+				} )
+					.then( res => {
+						res
+							.json()
+							.then( ( { message, data } ) => form.endLoginFlow( message, res.status, data ) );
 					} )
 					.catch( e => {
 						form.endLoginFlow( e, 400 );
-					} )
-					.finally( () => {
-						const body = new FormData( form );
-						if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
-							return form.endFlow( 'Please enter a vaild email address.', 400 );
-						}
-						fetch( form.getAttribute( 'action' ) || window.location.pathname, {
-							method: 'POST',
-							headers: {
-								Accept: 'application/json',
-							},
-							body,
-						} )
-							.then( res => {
-								res
-									.json()
-									.then( ( { message, data } ) => form.endLoginFlow( message, res.status, data ) );
-							} )
-							.catch( e => {
-								form.endLoginFlow( e, 400 );
-							} );
 					} );
 			} );
 

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -214,4 +214,6 @@ function destroy( forms = [] ) {
 /**
  * Invoke only after reCAPTCHA API is ready.
  */
-domReady( () => grecaptcha.ready( render ) );
+domReady( function () {
+	grecaptcha.ready( render );
+} );

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -35,7 +35,7 @@ function refreshV3Token( field, action = 'submit' ) {
 function renderV3Captchas( forms = [] ) {
 	const formsToHandle = forms.length
 		? forms
-		: [ ...document.querySelectorAll( 'form[data-recaptcha]' ) ];
+		: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
 
 	formsToHandle.forEach( form => {
 		let field = form.querySelector( 'input[name="g-recaptcha-response"]' );
@@ -45,7 +45,7 @@ function renderV3Captchas( forms = [] ) {
 			field.name = 'g-recaptcha-response';
 			form.appendChild( field );
 
-			const action = form.getAttribute( 'data-recaptcha' ) || 'submit';
+			const action = form.getAttribute( 'data-newspack-recaptcha' ) || 'submit';
 			refreshV3Token( field, action );
 			setInterval( () => refreshV3Token( field, action ), 30000 ); // Refresh token every 30 seconds.
 		}
@@ -58,7 +58,7 @@ function renderV3Captchas( forms = [] ) {
 function destroyV3Captchas( forms = [] ) {
 	const formsToHandle = forms.length
 		? forms
-		: [ ...document.querySelectorAll( 'form[data-recaptcha]' ) ];
+		: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
 
 	formsToHandle.forEach( form => {
 		const field = form.querySelector( 'input[name="g-recaptcha-response"]' );

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -41,7 +41,7 @@ const isInvisible = 'v2_invisible' === newspack_recaptcha_data.version;
  * @param {HTMLElement} field  The hidden input field storing the token for a form.
  * @param {string}      action The action name to pass to reCAPTCHA.
  *
- * @return {Promise<void>}
+ * @return {Promise<void>|void} A promise that resolves when the token is refreshed.
  */
 function refresh( field, action = 'submit' ) {
 	if ( field ) {

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -139,7 +139,7 @@ function renderWidget( form ) {
 			callback,
 		} );
 		button.setAttribute( 'data-recaptcha-widget-id', widgetId );
-		setInterval( () => refreshWidget( button ), 30000 ); // Refresh widget every 30 seconds.
+		setInterval( () => refreshWidget( button ), 120000 ); // Refresh widget every 2 minutes.
 
 		// Refresh reCAPTCHAs on Woo checkout update and error.
 		( function ( $ ) {
@@ -155,8 +155,13 @@ function renderWidget( form ) {
 			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
 				callback();
 			} else {
-				e.preventDefault();
 				grecaptcha.execute( widgetId );
+
+				// For some reason, WooCommerce checkout forms don't properly pin the widget in a fixed location, so we need to scroll to the top of the page to ensure it's visible.
+				if ( 'newspack_modal_checkout_container' === document.body.getAttribute( 'id' ) ) {
+					document.body.scrollIntoView( { behavior: 'smooth' } );
+				}
+				e.preventDefault();
 			}
 		} );
 	} );

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -1,4 +1,4 @@
-/* globals newspack_reader_activation_labels, newspack_grecaptcha */
+/* globals newspack_reader_activation_labels */
 
 /**
  * Internal dependencies.
@@ -54,6 +54,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 			 */
 			let formAction;
 			container.setFormAction = ( action, shouldFocus = false ) => {
+				const newspack_grecaptcha = window.newspack_grecaptcha || {};
 				if ( ! FORM_ALLOWED_ACTIONS.includes( action ) ) {
 					action = 'signin';
 				}

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -1,4 +1,4 @@
-/* globals newspack_reader_activation_labels */
+/* globals newspack_reader_activation_labels, newspack_grecaptcha */
 
 /**
  * Internal dependencies.
@@ -56,6 +56,13 @@ window.newspackRAS.push( function ( readerActivation ) {
 			container.setFormAction = ( action, shouldFocus = false ) => {
 				if ( ! FORM_ALLOWED_ACTIONS.includes( action ) ) {
 					action = 'signin';
+				}
+				if ( 'v2_invisible' === newspack_grecaptcha?.version ) {
+					if ( 'register' === action ) {
+						submitButtons.forEach( button => button.removeAttribute( 'data-skip-recaptcha' ) );
+					} else {
+						submitButtons.forEach( button => button.setAttribute( 'data-skip-recaptcha', '' ) );
+					}
 				}
 				if ( 'otp' === action ) {
 					if ( ! readerActivation.getOTPHash() ) {

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -61,6 +61,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				if ( 'v2_invisible' === newspack_grecaptcha?.version ) {
 					if ( 'register' === action ) {
 						submitButtons.forEach( button => button.removeAttribute( 'data-skip-recaptcha' ) );
+						newspack_grecaptcha.render( [ form ] );
 					} else {
 						submitButtons.forEach( button => button.setAttribute( 'data-skip-recaptcha', '' ) );
 					}
@@ -179,7 +180,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 							},
 							body,
 						} )
-							.then( () => {
+							.then( response => {
+								if ( 200 !== response.status ) {
+									return response.json().then( ( { message } ) => {
+										form.endLoginFlow( message, response.status );
+									} );
+								}
 								form.setMessageContent(
 									formAction === 'pwd'
 										? newspack_reader_activation_labels.code_sent
@@ -189,9 +195,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 								if ( ! readerActivation.getOTPTimeRemaining() ) {
 									readerActivation.setOTPTimer();
 								}
-							} )
-							.catch( e => {
-								console.log( e ); // eslint-disable-line no-console
 							} )
 							.finally( () => {
 								handleOTPTimer();

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -436,9 +436,6 @@ const readerActivation = {
 	getCheckoutData,
 	isPendingCheckout,
 	resetCheckoutData,
-	getCaptchaV3Token: window.newspack_grecaptcha
-		? window.newspack_grecaptcha?.getCaptchaV3Token
-		: () => new Promise( res => res( '' ) ), // Empty promise.
 };
 
 /**

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -386,23 +386,28 @@ function attachAuthCookiesListener() {
  * Set the reader as newsletter subscriber once a newsletter form is submitted.
  */
 function attachNewsletterFormListener() {
-	const forms = document.querySelectorAll(
-		'.newspack-newsletters-subscribe,.newspack-subscribe-form,.mc4wp-form'
-	);
-	if ( ! forms.length ) {
+	const newspackForms = [ '.newspack-newsletters-subscribe', '.newspack-subscribe-form' ];
+	const thirdPartyForms = [ '.mc4wp-form' ];
+
+	if ( ! newspackForms.length && ! thirdPartyForms.length ) {
 		return;
 	}
-	forms.forEach( form => {
-		if ( form.tagName !== 'FORM' ) {
-			form = form.querySelector( 'form' );
-		}
+
+	const attachHandler = ( el, eventToListenTo = 'submit' ) => {
+		const form = 'FORM' === el.tagName ? el : el.querySelector( 'form' );
 		if ( ! form ) {
 			return;
 		}
-		form.addEventListener( 'submit', () => {
+		form.addEventListener( eventToListenTo, () => {
 			store.set( 'is_newsletter_subscriber', true );
 		} );
-	} );
+	};
+
+	// For third-party forms, set reader data on form submit. For first-party forms, listen for the custom event upon successful signup response.
+	document.querySelectorAll( thirdPartyForms.join( ',' ) ).forEach( el => attachHandler( el ) );
+	document
+		.querySelectorAll( newspackForms.join( ',' ) )
+		.forEach( el => attachHandler( el, 'newspack-newsletters-subscribe-success' ) );
 }
 
 const readerActivation = {

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -389,10 +389,6 @@ function attachNewsletterFormListener() {
 	const newspackForms = [ '.newspack-newsletters-subscribe', '.newspack-subscribe-form' ];
 	const thirdPartyForms = [ '.mc4wp-form' ];
 
-	if ( ! newspackForms.length && ! thirdPartyForms.length ) {
-		return;
-	}
-
 	const attachHandler = ( el, eventToListenTo = 'submit' ) => {
 		const form = 'FORM' === el.tagName ? el : el.querySelector( 'form' );
 		if ( ! form ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR (along with https://github.com/Automattic/newspack-blocks/pull/1811 and https://github.com/Automattic/newspack-newsletters/pull/1581) fixes reCAPTCHA v2 and v3 integrations for RAS-ACC flows, which are currently broken in `epic/ras-acc`. It also implements some improvements and standardizations to the reCAPTCHA implementations:

- All v3 token fetching now happens via the same JS methods, instead of requiring different methods for Woo checkout
- The API in `/assets/other-scripts/recaptcha` is a bit easier to follow now
- v2 widgets are rendered more intentionally only when needed, instead of `onload`
- a new `destroy` method (for v3) and `skip-recaptcha` data attributes (for v2) can now be used to skip reCAPTCHA verification on flows where it's not needed, but which share the same form and submit button elements as registration flows which do need verification
- In the admin, v2 and v3 credentials are now stored separately, so switching reCAPTCHA version won't cause you to lose stored credentials

Still not implemented in this PR, but maybe in a future PR: we should figure out a way to validate credentials in the admin based on the selected reCAPTCHA version.

### How to test the changes in this Pull Request:

1. On `epic/ras-acc`, connect reCAPTCHA v2 or v3 via **Newspack > Connections**. Observe that sign-in flows trigger unnecessary reCAPTCHA checks, and that not all sign-in, registration, subscribe, or donation flows can be completed due to reCAPTCHA errors.
2. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/1811 and https://github.com/Automattic/newspack-newsletters/pull/1581. Visit **Newspack > Connections** and confirm that your credentials are still there. Switch versions (from v2 to v3 or vice versa) and enter a new set of matching credentials, and save. After saving, confirm you can switch back and forth between versions and that the appropriate credentials for both are shown when switching.
3. Test the following flows with v3 enabled (set Threshold to `1.0` and save to ensure that verification fails, then to `0.1` to allow verification to pass):
  - Register via the Registration block (should trigger reCAPTCHA verification)
  - Sign up for newsletters via the Newsletter Subscription Form block (should trigger reCAPTCHA verification)
  - Sign in via the auth modal, using OTP and password (should NOT trigger reCAPTCHA verification)
  - Register for a new account via the auth modal (should trigger reCAPTCHA verification)
  - Complete a transaction via modal checkout
    - Continuing from Billing Details (screen 1) should NOT trigger reCAPTCHA verification
    - Submitting payment details (screen 2) SHOULD trigger verification
4. Switch to v2 and repeat all flows—verification should and shouldn't happen at the same points of all flows.
5. Turn off reCAPTCHA entirely and repeat all flows again—they should all be completable without reCAPTCHA-related errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207791057370559