### PR TITLE
fix: set max width for in-page sign-in form

### DIFF
--- a/assets/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/assets/newspack-ui/scss/elements/forms/_buttons.scss
@@ -17,6 +17,7 @@
 		margin-bottom: var( --newspack-ui-spacer-2 );
 		min-height: var( --newspack-ui-spacer-9 );
 		padding: var( --newspack-ui-spacer-2 ) var( --newspack-ui-spacer-5 );
+		text-decoration: none;
 		transition: background-color 125ms ease-in-out, border-color 125ms ease-in-out, outline 125ms ease-in-out;
 
 		&:last-child {

--- a/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -21,3 +21,13 @@
 		}
 	}
 }
+
+.woocommerce-account {
+	// Inline sign up form max-width.
+	.woocommerce-notices-wrapper:has( + .newspack-reader-auth__inline-wrapper ),
+	.newspack-reader-auth__inline-wrapper {
+			margin-left: auto;
+			margin-right: auto;
+			max-width: var( --newspack-ui-modal-width-s );
+	}
+}

--- a/includes/templates/reader-activation/login-form.php
+++ b/includes/templates/reader-activation/login-form.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 \do_action( 'woocommerce_before_customer_login_form' );
 ?>
-<div class="newspack-ui">
+<div class="newspack-ui newspack-reader-auth__inline-wrapper">
 	<?php Reader_Activation::render_auth_form(); ?>
 	<p class="newspack-ui__font--xs"><?php echo wp_kses_post( Reader_Activation::get_auth_footer() ); ?></p>
 </div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR combines the changes from https://github.com/Automattic/newspack-theme/pull/2351 and https://github.com/Automattic/newspack-plugin/pull/3282 into one PR that keeps all the changes on the Newspack Plugin side. 

See 1205234045751551-as-1207890325042756

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Go to /my-account and confirm that the sign-up form appears roughly the same size as it does in the modal.
3. Try signing in, and confirm that the different screens (OTP, password) look okay.

![image](https://github.com/user-attachments/assets/321038fe-9906-4b6e-86c5-949e97944d80)

![image](https://github.com/user-attachments/assets/930435dc-ec40-4eac-bec8-9425e0971ca7)

![image](https://github.com/user-attachments/assets/7277707c-0d0f-42fb-86d9-a8f075a31e9b)

4. Log out and confirm the sign out message uses the max-width, too. 

![image](https://github.com/user-attachments/assets/c6c11d84-d8da-45a8-8fe9-919394234c89)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->