### PR TITLE
fix(ras-acc): fix order of elements in registration block

### DIFF
--- a/assets/blocks/reader-registration/edit.js
+++ b/assets/blocks/reader-registration/edit.js
@@ -345,6 +345,19 @@ export default function ReaderRegistrationEdit( {
 									</div>
 								) : null }
 								<div className="newspack-registration__main">
+									{ newspack_blocks.has_google_oauth && (
+										<div className="newspack-reader__logins">
+											<button className="newspack-reader__logins__google">
+												<span
+													dangerouslySetInnerHTML={ { __html: newspack_blocks.google_logo_svg } }
+												/>
+												<span>{ __( 'Sign in with Google', 'newspack-plugin' ) }</span>
+											</button>
+											<div className="newspack-ui__word-divider">
+												{ __( 'Or', 'newspack-plugin' ) }
+											</div>
+										</div>
+									) }
 									<div>
 										<div className="newspack-registration__inputs">
 											<input type="email" placeholder={ placeholder } />
@@ -358,21 +371,6 @@ export default function ReaderRegistrationEdit( {
 											</button>
 										</div>
 
-										{ newspack_blocks.has_google_oauth && (
-											<div className="newspack-reader__logins">
-												<div className="newspack-reader__logins__separator">
-													<div />
-													<div>{ __( 'OR', 'newspack-plugin' ) }</div>
-													<div />
-												</div>
-												<button className="newspack-reader__logins__google">
-													<span
-														dangerouslySetInnerHTML={ { __html: newspack_blocks.google_logo_svg } }
-													/>
-													<span>{ __( 'Sign in with Google', 'newspack-plugin' ) }</span>
-												</button>
-											</div>
-										) }
 										<div className="newspack-registration__response" />
 									</div>
 									<div className="newspack-registration__help-text">

--- a/assets/blocks/reader-registration/editor.scss
+++ b/assets/blocks/reader-registration/editor.scss
@@ -154,3 +154,20 @@
 		}
 	}
 }
+
+.newspack-ui__word-divider {
+	align-items: center;
+	display: flex;
+	font-size: 14px;
+	gap: 12px;
+	justify-content: space-evenly;
+	margin: 24px 0;
+
+	&::before,
+	&::after {
+		border-top: 1px solid #ddd;
+		content: '';
+		display: block;
+		width: 100%;
+	}
+}

--- a/assets/blocks/reader-registration/index.php
+++ b/assets/blocks/reader-registration/index.php
@@ -263,6 +263,7 @@ function render_block( $attrs, $content ) {
 							<?php if ( Recaptcha::can_use_captcha( 'v2' ) ) : ?>
 								<?php Recaptcha::render_recaptcha_v2_container(); ?>
 							<?php endif; ?>
+							<?php Reader_Activation::render_third_party_auth(); ?>
 							<div class="newspack-registration__inputs">
 								<input
 								<?php
@@ -285,7 +286,6 @@ function render_block( $attrs, $content ) {
 									<span class="submit"><?php echo \esc_html( $attrs['label'] ); ?></span>
 								</button>
 							</div>
-							<?php Reader_Activation::render_third_party_auth(); ?>
 							<div class="newspack-registration__response <?php echo ( empty( $message ) ) ? 'newspack-registration--hidden' : null; ?>">
 								<?php if ( ! empty( $message ) ) : ?>
 									<p><?php echo \esc_html( $message ); ?></p>

--- a/assets/reader-activation-auth/style.scss
+++ b/assets/reader-activation-auth/style.scss
@@ -120,24 +120,6 @@
 	&__logins {
 		font-size: 1rem;
 		margin-top: 0.8rem;
-		&__separator {
-			align-items: center;
-			display: flex;
-			margin: 0.8rem 0;
-			div {
-				text-align: center;
-				&:nth-child( 2 ) {
-					font-size: 0.8rem;
-					line-height: 1.5;
-					padding: 0 0.5em;
-				}
-				&:first-child,
-				&:last-child {
-					flex: 1;
-					border-top: 1px solid wp-colors.$gray-200;
-				}
-			}
-		}
 		&--disabled {
 			button {
 				opacity: 0.5;
@@ -184,3 +166,5 @@ li.menu-item .newspack-reader__account-link {
 .woocommerce-account .entry-header .entry-title {
 	display: none;
 }
+
+


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR moves the location of the Sign In with Google button in the Registration block, to fix a bug that came from changing the order for RAS-ACC, and to make it more consistent with the built-in RAS-ACC sign-in form. 

See 1205234045751551-as-1207882141458899.

### How to test the changes in this Pull Request:

1. Start on a test site running epic/ras-acc branch, with Google connected via Newspack Manager so the Sign In with Google button appears.
2. In an incognito window, click around until the campaign-based RAS sign up modal appears; this modal uses the Registration Block. Note the order:

![image](https://github.com/user-attachments/assets/c1122e81-2d42-440d-a57c-953e29c5ed3e)

3. Apply this PR.
4. Confirm that the order is fixed, and the spacing looks more normal:

![image](https://github.com/user-attachments/assets/1de9070f-474b-4b5a-8608-d0d117db7922)

5. Confirm that the order is also correct in the editor. (The styles there overall aren't 100% 1:1, but the block is also being reworked [here](https://github.com/Automattic/newspack-plugin/pull/3199), so I just focused on the Google button order):

![image](https://github.com/user-attachments/assets/bbef89e8-7e7a-4678-9971-f02156e3c747)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->