### PR TITLE
fix(ras-acc): handle content gate auth checkout flow

### DIFF
--- a/assets/reader-activation-auth/auth-form.js
+++ b/assets/reader-activation-auth/auth-form.js
@@ -236,7 +236,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 					}
 
 					let callback;
-					if ( container.authCallback && data?.registered ) {
+					if (
+						container.authCallback &&
+						data?.registered &&
+						! readerActivation.getCheckoutStatus()
+					) {
 						callback = ( authMessage, authData ) =>
 							openNewslettersSignupModal( {
 								callback: container.authCallback( authMessage, authData ),

--- a/assets/reader-activation/index.js
+++ b/assets/reader-activation/index.js
@@ -326,6 +326,26 @@ export function getAuthStrategy() {
 	}
 	return getCookie( 'np_auth_strategy' );
 }
+/**
+ * Set the reader checkout status.
+ *
+ * @param {boolean} status Checkout status. Default is false.
+ *
+ * @return {void}
+ */
+export function setCheckoutStatus( status = false ) {
+	setCookie( 'np_auth_checkout_status', status );
+	emit( EVENTS.reader, getReader() );
+	return status;
+}
+/**
+ * Get the reader checkout status.
+ *
+ * @return {boolean} Reader checkout status.
+ */
+export function getCheckoutStatus() {
+	return 'true' === getCookie( 'np_auth_checkout_status' );
+}
 
 /**
  * Ensure the client ID cookie is set.
@@ -424,6 +444,8 @@ const readerActivation = {
 	authenticateOTP,
 	setAuthStrategy,
 	getAuthStrategy,
+	setCheckoutStatus,
+	getCheckoutStatus,
 	getCaptchaV3Token: window.newspack_grecaptcha
 		? window.newspack_grecaptcha?.getCaptchaV3Token
 		: () => new Promise( res => res( '' ) ), // Empty promise.

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -717,7 +717,7 @@ class Memberships {
 			window.newspackRAS = window.newspackRAS || [];
 			window.newspackRAS.push( function( ras ) {
 				ras.on( 'reader', function( ev ) {
-					if ( ev.detail.authenticated ) {
+					if ( ev.detail.authenticated && ! window?.newspackReaderActivation?.getCheckoutStatus() ) {
 						if ( ras.overlays.get().length ) {
 							ras.on( 'overlay', function( ev ) {
 								if ( ! ev.detail.overlays.length ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207836897783913/f

This PR addresses an issue where the registration/login+checkout flow via content gate is cutoff after the auth step. This happens because the content gate is watching for the reader to be authenticated before reloading the page. However, in the case of auth+checkout, we don't want to reload until after checkout has been completed.

We fix this by adding a cookie flag to indicate auth checkout status, and only reload when that flag is no longer set (after checkout).

This PR addresses another smaller issue where the newsletters modal should not triggered by the auth modal when this checkout flag is set since the checkout flow will manage which modals should appear next.

![Screenshot 2024-07-30 at 12 49 45](https://github.com/user-attachments/assets/041d778c-cb12-417e-b21f-4c6eade6ff8a)

### How to test the changes in this Pull Request:

**Important**: You will also need to checkout the changes in https://github.com/Automattic/newspack-blocks/pull/1817 to test.

1. Set up a membership plan that restricts content to users who have made a recurring donation
2. Set up a content gate for this membership plan via Newspack > Engagement > Show Advanced Settings
3. Ensure the `Present newsletter signup after checkout and registration` toggle is active via this same menu
4. As a logged out reader, visit a restricted page and make a donation to gain access to the restricted content
5. Confirm you are able to sign in as well as complete checkout and the page does not reload until AFTER all modals have closed
6. Confirm the newsletters modal is the final modal that appeared in the flow
7. Confirm you have gained access to the content once the page has reloaded
8. Smoke test the normal donation checkout flow as a signed out and signed in user (Not the content gate donation block)
9. Smoke test the normal signin and registration flow via the RAS-ACC sign in button at the top right of the site navigation

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->