### PR TITLE
fix(ras-acc): newspack ui heading font weights

### DIFF
--- a/assets/newspack-ui/scss/elements/_typography.scss
+++ b/assets/newspack-ui/scss/elements/_typography.scss
@@ -11,6 +11,7 @@
 
 	h1, h2, h3, h4, h5, h6 {
 		font-family: var( --newspack-ui-font-family );
+		font-weight: var( --newspack-ui-font-weight-strong );
 	}
 
 	strong,


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150043/f

Seems all bolded text, headings included, should have a font weight of 600 per the task above. This PR forces the 600 font weight on headings.

![Screenshot 2024-07-31 at 16 35 19](https://github.com/user-attachments/assets/2524136b-dc78-418f-bddd-ede53f03a3fa)

### How to test the changes in this Pull Request:

1. Open the checkout modal and confirm each heading has a font weight of 600 throughout the modal
2. Repeat the above step for the auth modal

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->