### PR TITLE
fix(data-events): ensure get_last_successful_order returns WC_Order

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -200,7 +200,7 @@ class WooCommerce_Connection {
 		// Prioritize any currently active subscriptions.
 		$active_subscriptions = self::get_active_subscriptions_for_user( $user_id );
 		if ( ! empty( $active_subscriptions ) ) {
-			return reset( $active_subscriptions );
+			return \wcs_get_subscription( reset( $active_subscriptions ) );
 		}
 
 		// If no active subscriptions, get the most recent completed order.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue introduced in #3268, as discovered by @miguelpeixe. The value of `Newspack\WooCommerce_Connection::get_last_successful_order()` should be a `WC_Order` or `WC_Subscription` instance, but changes in #3268 caused it to sometimes return an integer, which breaks data events handling.

Opened against `alpha` because the issue doesn't exist in `trunk` or `release` yet.

### How to test the changes in this Pull Request:

1. On `alpha`, run `wp shell` then `Newspack\WooCommerce_Connection::get_last_successful_order( new WC_Customer( $user_id ) )` where `$user_id` is the ID for a subscriber with at least one active subscription.
2. Observe that the returned value is an integer (the ID of the active subscription).
3. Check out this branch, repeat, and confirm that the value returned is an instance of `WC_Subscription` (the subscription itself, not just the ID).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->