### PR TITLE
fix(ras-acc): recognize active non release newspack plugins

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -392,6 +392,18 @@ class Plugin_Manager {
 		}
 		$status            = 'uninstalled';
 		$installed_plugins = self::get_installed_plugins();
+
+		// Also check for release, epic, or other non-release versions of newspack plugins.
+		if ( str_contains( $plugin_slug, 'newspack' ) ) {
+			foreach ( $installed_plugins as $slug => $path ) {
+				// If there is a non-release slug installed, inject the release slug/path into the installed plugins array.
+				// We need to do this because the `is_plugin_active` function only depends on the "standard" slug and path.
+				if ( $slug !== $plugin_slug && str_contains( $slug, $plugin_slug ) ) {
+					$installed_plugins[ $plugin_slug ] = $plugin_slug . '/' . $plugin_slug . '.php';
+				}
+			}
+		}
+
 		if ( isset( $installed_plugins[ $plugin_slug ] ) ) {
 			if ( \is_plugin_active( $installed_plugins[ $plugin_slug ] ) ) {
 				$status = 'active';

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -393,17 +393,6 @@ class Plugin_Manager {
 		$status            = 'uninstalled';
 		$installed_plugins = self::get_installed_plugins();
 
-		// Also check for release, epic, or other non-release versions of newspack plugins.
-		if ( str_contains( $plugin_slug, 'newspack' ) ) {
-			foreach ( $installed_plugins as $slug => $path ) {
-				// If there is a non-release slug installed, inject the release slug/path into the installed plugins array.
-				// We need to do this because the `is_plugin_active` function only depends on the "standard" slug and path.
-				if ( $slug !== $plugin_slug && str_contains( $slug, $plugin_slug ) ) {
-					$installed_plugins[ $plugin_slug ] = $plugin_slug . '/' . $plugin_slug . '.php';
-				}
-			}
-		}
-
 		if ( isset( $installed_plugins[ $plugin_slug ] ) ) {
 			if ( \is_plugin_active( $installed_plugins[ $plugin_slug ] ) ) {
 				$status = 'active';
@@ -416,6 +405,25 @@ class Plugin_Manager {
 		if ( 'wordpress-seo' === $plugin_slug && 'active' !== $status && isset( $installed_plugins['wordpress-seo-premium'] ) && $installed_plugins['wordpress-seo-premium'] ) {
 			if ( \is_plugin_active( $installed_plugins['wordpress-seo-premium'] ) ) {
 				$status = 'active';
+			}
+		}
+
+		// Also check for alpha or epic versions of newspack plugins.
+		if ( 'active' !== $status && str_contains( $plugin_slug, 'newspack' ) ) {
+			foreach ( $installed_plugins as $slug => $path ) {
+				if ( $slug !== $plugin_slug && str_contains( $slug, $plugin_slug ) ) {
+					$versions = [
+						'alpha',
+						'epic',
+					];
+
+					foreach ( $versions as $version ) {
+						if ( str_contains( $slug, $version ) && \is_plugin_active( $path ) ) {
+							$status = 'active';
+							break;
+						}
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1200550061930446/1207859936042301/f

This PR resolves an issue where our wizards don't recognize non-release versions of our plugins as active.

![Screenshot 2024-08-01 at 17 45 51](https://github.com/user-attachments/assets/6c7e18ba-e6d6-4474-b942-3230b108e9a8)


### How to test the changes in this Pull Request:

1. Be sure you DONT have the `WP_NEWSPACK_DEBUG` wp-config constant set.
2. Install an epic version of `newspack-blocks` or just change the directory name of the `newspack-blocks` plugin to something like `newspack-blocks-v3.7.0-epic-ras-acc.2` and make sure its active
3. As admin, visit the reader revenue wizard
4. On `epic/ras-acc` the wizard won't be available and will ask you to activate newspack blocks. On this branch the wizard will be available and will consider blocks active.
5. Smoke test the rest of the wizard to confirm no other sections have been broken

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->