### PR TITLE
feat: add heading to inline sign-in form

### DIFF
--- a/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/assets/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -30,4 +30,9 @@
 			margin-right: auto;
 			max-width: var( --newspack-ui-modal-width-s );
 	}
+
+	.newspack-reader-auth__inline-wrapper h2 {
+		font-size: var(--newspack-ui-font-size-m);
+		font-weight: 600;
+	}
 }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1237,7 +1237,7 @@ final class Reader_Activation {
 		}
 		?>
 		<div class="newspack-ui newspack-reader-auth">
-			<?php if ( false === $in_modal ) { ?>
+			<?php if ( ! $in_modal ) { ?>
 				<h2 data-action="signin"><?php echo wp_kses_post( self::get_reader_activation_labels( 'title' ) ); ?></h2>
 				<h2 data-action="register"><?php echo wp_kses_post( self::get_reader_activation_labels( 'create_account' ) ); ?></h2>
 			<?php } ?>

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1204,8 +1204,10 @@ final class Reader_Activation {
 
 	/**
 	 * Renders reader authentication form.
+	 *
+	 * @param boolean $in_modal Whether the form is rendiner in a modal; defaults to true.
 	 */
-	public static function render_auth_form() {
+	public static function render_auth_form( $in_modal = true ) {
 		/**
 		 * Filters whether to render reader auth form.
 		 *
@@ -1235,6 +1237,10 @@ final class Reader_Activation {
 		}
 		?>
 		<div class="newspack-ui newspack-reader-auth">
+			<?php if ( false === $in_modal ) { ?>
+				<h2 data-action="signin"><?php echo wp_kses_post( self::get_reader_activation_labels( 'title' ) ); ?></h2>
+				<h2 data-action="register"><?php echo wp_kses_post( self::get_reader_activation_labels( 'create_account' ) ); ?></h2>
+			<?php } ?>
 			<div class="newspack-ui__box newspack-ui__box--success newspack-ui__box--text-center" data-action="success">
 				<span class="newspack-ui__icon newspack-ui__icon--success">
 					<?php \Newspack\Newspack_UI_Icons::print_svg( 'check' ); ?>

--- a/includes/templates/reader-activation/login-form.php
+++ b/includes/templates/reader-activation/login-form.php
@@ -15,9 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 \do_action( 'woocommerce_before_customer_login_form' );
+
+$in_modal = false;
 ?>
 <div class="newspack-ui newspack-reader-auth__inline-wrapper">
-	<?php Reader_Activation::render_auth_form(); ?>
+	<?php Reader_Activation::render_auth_form( $in_modal ); ?>
 	<p class="newspack-ui__font--xs"><?php echo wp_kses_post( Reader_Activation::get_auth_footer() ); ?></p>
 </div>
 <?php

--- a/includes/templates/reader-activation/login-form.php
+++ b/includes/templates/reader-activation/login-form.php
@@ -15,11 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 \do_action( 'woocommerce_before_customer_login_form' );
-
-$in_modal = false;
 ?>
 <div class="newspack-ui newspack-reader-auth__inline-wrapper">
-	<?php Reader_Activation::render_auth_form( $in_modal ); ?>
+	<?php Reader_Activation::render_auth_form( false ); ?>
 	<p class="newspack-ui__font--xs"><?php echo wp_kses_post( Reader_Activation::get_auth_footer() ); ?></p>
 </div>
 <?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a heading to the inline login form that appears on the /my-account page, and follows the pattern used for the buttons so that it will toggle between Sign In and Create an Account.

See 1207817176293825-as-1207817176293836

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. In an incognito window, navigate to /my-account.
3. Confirm that the form has a Sign In heading.

![image](https://github.com/user-attachments/assets/23f71c1d-0fe7-4d68-a151-203f078bf938)

4. Click "Create an account".
5. Confirm that the header changes to Create an account.

![image](https://github.com/user-attachments/assets/63a327f1-1ceb-430d-afda-efc085e05787)

6. Click "Sign in to an existing account".
7. Confirm that the header changes back to Sign In.
8. Repeat steps 4-7 as many times as you'd like.

![sign-in-create-account](https://github.com/user-attachments/assets/fcc10398-b033-43c7-9e13-5d5cb6c2b244)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->