### PR TITLE
fix(ras-acc): reset otp flow on sign in modal close

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -375,6 +375,38 @@ final class Magic_Link {
 	}
 
 	/**
+	 * Check for active magic link tokens.
+	 *
+	 * @param \WP_User $user User to check the active magic link token for.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public static function has_active_token( $user ) {
+		if ( ! self::can_magic_link( $user->ID ) ) {
+			return new \WP_Error( 'newspack_magic_link_invalid_user', __( 'Invalid user.', 'newspack' ) );
+		}
+
+		$now    = time();
+		$tokens = \get_user_meta( $user->ID, self::TOKENS_META, true );
+
+		$expire = $now - MINUTE_IN_SECONDS;
+		if ( ! empty( $tokens ) ) {
+			foreach ( $tokens as $index => $token_data ) {
+				/** Clear expired tokens. */
+				if ( $token_data['time'] < $expire ) {
+					unset( $tokens[ $index ] );
+				}
+			}
+		}
+
+		if ( empty( $tokens ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Generate a magic link.
 	 *
 	 * @param \WP_User $user User to generate the magic link for.

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -375,7 +375,7 @@ final class Magic_Link {
 	}
 
 	/**
-	 * Check for active magic link tokens.
+	 * Check for magic link tokens generated within the last 60 seconds.
 	 *
 	 * @param \WP_User $user User to check the active magic link token for.
 	 *

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1299,7 +1299,7 @@ final class Reader_Activation {
 					?>
 				</p>
 				<button type="submit" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--primary" data-action="register signin pwd otp"><?php echo \esc_html( $labels['continue'] ); ?></button>
-				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary" data-action="otp" data-send-code><?php echo \esc_html( $labels['resend_code'] ); ?></button>
+				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary" data-action="otp" data-resend-code><?php echo \esc_html( $labels['resend_code'] ); ?></button>
 				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary" data-action="pwd" data-send-code><?php echo \esc_html( $labels['otp'] ); ?></button>
 				<a class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary" data-action="pwd" href="<?php echo \esc_url( \wp_lostpassword_url() ); ?>"><?php echo \esc_html( $labels['forgot_password'] ); ?></a>
 				<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--ghost newspack-ui__last-child" data-action="signin" data-set-action="register"><?php echo \esc_html( $labels['create_account'] ); ?></button>

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -226,6 +226,7 @@ final class Reader_Activation {
 				'invalid_password'         => __( 'Please enter a password.', 'newspack-plugin' ),
 				'invalid_display'          => __( 'Display name cannot match your email address. Please choose a different display name.', 'newspack-plugin' ),
 				'blocked_popup'            => __( 'The popup has been blocked. Allow popups for the site and try again.', 'newspack-plugin' ),
+				'code_sent'                => __( 'Code sent! Check your inbox.', 'newspack-plugin' ),
 				'code_resent'              => __( 'Code resent! Check your inbox.', 'newspack-plugin' ),
 				'create_account'           => __( 'Create an account', 'newspack-plugin' ),
 				'signin'                   => [

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1684,6 +1684,7 @@ final class Reader_Activation {
 		if ( ! isset( $_POST[ self::AUTH_FORM_ACTION ] ) ) {
 			return;
 		}
+
 		$action           = isset( $_POST['action'] ) ? \sanitize_text_field( $_POST['action'] ) : '';
 		$referer          = isset( $_POST['referer'] ) ? \sanitize_text_field( $_POST['referer'] ) : '';
 		$current_page_url = \wp_parse_url( \wp_get_raw_referer() ); // Referer is the current page URL because the form is submitted via AJAX.
@@ -1739,6 +1740,10 @@ final class Reader_Activation {
 
 		switch ( $action ) {
 			case 'signin':
+				if ( Magic_Link::has_active_token( $user ) ) {
+					$payload['action'] = 'otp';
+					return self::send_auth_form_response( $payload, false );
+				}
 				if ( self::is_reader_without_password( $user ) ) {
 					$sent = Magic_Link::send_email( $user, $current_page_url );
 					if ( true !== $sent ) {

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -116,6 +116,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 			backButtons.forEach( backButton => {
 				backButton.addEventListener( 'click', function ( ev ) {
 					ev.preventDefault();
+					form.setMessageContent();
 					container.setFormAction( 'signin', true );
 				} );
 			} );
@@ -208,7 +209,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 			container.querySelectorAll( '[data-set-action]' ).forEach( setActionListener );
 
 			form.startLoginFlow = () => {
-				form.setMessageContent();
 				container.removeAttribute( 'data-form-status' );
 				submitButtons.forEach( button => {
 					button.disabled = true;
@@ -354,7 +354,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 			 */
 			form.addEventListener( 'submit', ev => {
 				ev.preventDefault();
-				form.setMessageContent();
 				form.startLoginFlow();
 
 				const action = form.action?.value;

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -57,6 +57,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 				}
 				if ( 'otp' === action ) {
 					if ( ! readerActivation.getOTPHash() ) {
+						form.setMessageContent();
+						container.setFormAction( 'signin', true );
 						return;
 					}
 					const emailAddressElements = container.querySelectorAll( '.email-address' );

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -414,7 +414,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 											if ( data.action ) {
 												container.setFormAction( data.action, true );
 												if ( data.action === 'otp' ) {
-													readerActivation.setOTPTimer();
+													if ( ! readerActivation.getOTPTimeRemaining() ) {
+														readerActivation.setOTPTimer();
+													}
 													handleOTPTimer();
 												}
 											} else {

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -418,6 +418,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 														readerActivation.setOTPTimer();
 													}
 													handleOTPTimer();
+													form.setMessageContent( newspack_reader_activation_labels.code_sent );
 												}
 											} else {
 												form.endLoginFlow( message, status, data );

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -117,6 +117,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				backButton.addEventListener( 'click', function ( ev ) {
 					ev.preventDefault();
 					form.setMessageContent();
+					resetOTPTimer();
 					container.setFormAction( 'signin', true );
 				} );
 			} );
@@ -149,6 +150,24 @@ window.newspackRAS.push( function ( readerActivation ) {
 						button.otpTimerInterval = setInterval( updateButton, 1000 );
 						updateButton();
 					}
+				} );
+			};
+
+			/**
+			 * Reset OTP Timer.
+			 */
+			const resetOTPTimer = () => {
+				if ( ! sendCodeButtons.length ) {
+					return;
+				}
+				sendCodeButtons.forEach( button => {
+					button.buttonText = button.textContent;
+					if ( button.otpTimerInterval ) {
+						clearInterval( button.otpTimerInterval );
+					}
+
+					// If the button text has a countdown, remove it.
+					button.textContent = button.buttonText.replace( /\s\(\d{1,}:\d{2}\)/, '' );
 				} );
 			};
 
@@ -266,7 +285,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 						}
 						if ( formAction === 'otp' ) {
 							// Reset OTP on successful OTP login.
-							window?.newspackReaderActivation?.resetOTP?.();
+							readerActivation.resetOTP();
 						}
 						container.setFormAction( 'success' );
 						container.querySelector( '.success-title' ).innerHTML = labels.success_title || '';

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -408,17 +408,18 @@ window.newspackRAS.push( function ( readerActivation ) {
 										.json()
 										.then( ( { message, data } ) => {
 											const status = res.status;
+											const prevEmail = readerActivation.getReader?.()?.email;
 											if ( status === 200 ) {
 												readerActivation.setReaderEmail( body.get( 'npe' ) );
 											}
 											if ( data.action ) {
 												container.setFormAction( data.action, true );
 												if ( data.action === 'otp' ) {
-													if ( ! readerActivation.getOTPTimeRemaining() ) {
+													form.setMessageContent( newspack_reader_activation_labels.code_sent );
+													if ( data.email !== prevEmail || ! readerActivation.getOTPTimeRemaining() ) {
 														readerActivation.setOTPTimer();
 													}
 													handleOTPTimer();
-													form.setMessageContent( newspack_reader_activation_labels.code_sent );
 												}
 											} else {
 												form.endLoginFlow( message, status, data );

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -57,8 +57,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 				}
 				if ( 'otp' === action ) {
 					if ( ! readerActivation.getOTPHash() ) {
-						form.setMessageContent();
-						container.setFormAction( 'signin', true );
 						return;
 					}
 					const emailAddressElements = container.querySelectorAll( '.email-address' );
@@ -184,7 +182,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 									body,
 								} )
 									.then( () => {
-										form.setMessageContent( newspack_reader_activation_labels.code_resent );
+										form.setMessageContent(
+											formAction === 'pwd'
+												? newspack_reader_activation_labels.code_sent
+												: newspack_reader_activation_labels.code_resent
+										);
 										container.setFormAction( 'otp' );
 										readerActivation.setOTPTimer();
 									} )
@@ -206,6 +208,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 			container.querySelectorAll( '[data-set-action]' ).forEach( setActionListener );
 
 			form.startLoginFlow = () => {
+				form.setMessageContent();
 				container.removeAttribute( 'data-form-status' );
 				submitButtons.forEach( button => {
 					button.disabled = true;
@@ -260,6 +263,10 @@ window.newspackRAS.push( function ( readerActivation ) {
 						let labels = newspack_reader_activation_labels.signin;
 						if ( data?.registered ) {
 							labels = newspack_reader_activation_labels.register;
+						}
+						if ( formAction === 'otp' ) {
+							// Reset OTP on successful OTP login.
+							window?.newspackReaderActivation?.resetOTP?.();
 						}
 						container.setFormAction( 'success' );
 						container.querySelector( '.success-title' ).innerHTML = labels.success_title || '';
@@ -347,6 +354,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 			 */
 			form.addEventListener( 'submit', ev => {
 				ev.preventDefault();
+				form.setMessageContent();
 				form.startLoginFlow();
 
 				const action = form.action?.value;

--- a/src/reader-activation-auth/auth-modal.js
+++ b/src/reader-activation-auth/auth-modal.js
@@ -45,7 +45,6 @@ export function openAuthModal( config = {} ) {
 	const close = () => {
 		container.config = {};
 		modal.setAttribute( 'data-state', 'closed' );
-		window?.newspackReaderActivation?.clearOTPRequest();
 		document.body.classList.remove( 'newspack-signin' );
 		document.body.style.overflow = 'auto';
 		if ( modal.overlayId && window.newspackReaderActivation?.overlays ) {
@@ -124,6 +123,14 @@ export function openAuthModal( config = {} ) {
 	}
 	container.setFormAction( initialFormAction, true );
 
+	// Default to signin action if otp and timer has expired.
+	if (
+		initialFormAction === 'otp' &&
+		window?.newspackReaderActivation?.getOTPTimeRemaining() <= 0
+	) {
+		container.setFormAction( 'signin' );
+		window?.newspackReaderActivation?.resetOTP();
+	}
 	document.body.classList.add( 'newspack-signin' );
 	document.body.style.overflow = 'hidden';
 	modal.setAttribute( 'data-state', 'open' );

--- a/src/reader-activation-auth/auth-modal.js
+++ b/src/reader-activation-auth/auth-modal.js
@@ -129,7 +129,6 @@ export function openAuthModal( config = {} ) {
 		window?.newspackReaderActivation?.getOTPTimeRemaining() <= 0
 	) {
 		container.setFormAction( 'signin' );
-		window?.newspackReaderActivation?.resetOTP();
 	}
 	document.body.classList.add( 'newspack-signin' );
 	document.body.style.overflow = 'hidden';

--- a/src/reader-activation-auth/auth-modal.js
+++ b/src/reader-activation-auth/auth-modal.js
@@ -45,6 +45,7 @@ export function openAuthModal( config = {} ) {
 	const close = () => {
 		container.config = {};
 		modal.setAttribute( 'data-state', 'closed' );
+		window?.newspackReaderActivation?.clearOTPRequest();
 		document.body.classList.remove( 'newspack-signin' );
 		document.body.style.overflow = 'auto';
 		if ( modal.overlayId && window.newspackReaderActivation?.overlays ) {

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -233,9 +233,9 @@ export function clearOTPTimer() {
 }
 
 /**
- * Clear the reader's OTP hash and timer for the current authentication request.
+ * Resets the reader's OTP hash and timer for the current authentication request.
  */
-export function clearOTPRequest() {
+export function resetOTP() {
 	setCookie( 'np_otp_hash', ' ', 0 );
 	clearOTPTimer();
 }
@@ -448,7 +448,7 @@ const readerActivation = {
 	getOTPHash,
 	setOTPTimer,
 	clearOTPTimer,
-	clearOTPRequest,
+	resetOTP,
 	getOTPTimeRemaining,
 	authenticateOTP,
 	setAuthStrategy,

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -233,6 +233,14 @@ export function clearOTPTimer() {
 }
 
 /**
+ * Clear the reader's OTP hash and timer for the current authentication request.
+ */
+export function clearOTPRequest() {
+	setCookie( 'np_otp_hash', ' ', 0 );
+	clearOTPTimer();
+}
+
+/**
  * Get the time remaining for the OTP timer.
  *
  * @return {number} Time remaining in seconds
@@ -440,6 +448,7 @@ const readerActivation = {
 	getOTPHash,
 	setOTPTimer,
 	clearOTPTimer,
+	clearOTPRequest,
 	getOTPTimeRemaining,
 	authenticateOTP,
 	setAuthStrategy,

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -233,14 +233,6 @@ export function clearOTPTimer() {
 }
 
 /**
- * Resets the reader's OTP hash and timer for the current authentication request.
- */
-export function resetOTP() {
-	setCookie( 'np_otp_hash', ' ', 0 );
-	clearOTPTimer();
-}
-
-/**
  * Get the time remaining for the OTP timer.
  *
  * @return {number} Time remaining in seconds
@@ -448,7 +440,6 @@ const readerActivation = {
 	getOTPHash,
 	setOTPTimer,
 	clearOTPTimer,
-	resetOTP,
 	getOTPTimeRemaining,
 	authenticateOTP,
 	setAuthStrategy,


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207922674964422/f

This PR "resets" the OTP state of the login form once the OTP timer runs out. Previously, if a reader opened the login form with an account with a password set, but then chose to sign in via OTP, the auth form would "remember" this OTP login state and prompt for OTP the next time the auth modal was opened.

This PR fixes this by resetting OTP cookies whenever the auth form is opened AND the OTP timer has run out and setting the auth form the the default signin state.

![Screenshot 2024-08-06 at 12 30 04](https://github.com/user-attachments/assets/ce856577-7c4d-4e06-b8c7-8bf085279e7e)

This PR also fixes a problem where the OTP code message always mentioned "resent" even when the code was sent for the first time:

### How to test the changes in this Pull Request:

1. Set up a reader account that has a password set, and a reader account that does not
2. As the reader account with a password:
  - Trigger the signin flow via the sign-in button
  - Enter the relevant email address and select continue
  - Choose to sign in via OTP via the OTP button
  - Confirm the auth modal transitions to the OTP view, the message says "code sent!...", and an OTP email was actually sent. DON'T login.
  - Wait 60 seconds for the resend code button timer to finish running down, then click the button
  - Confirm the auth modal message updates to say "code resent!..." and another OTP email was sent.
  - Confirm you are able to login with the OTP code
3. As the reader account WITHOUT a password:
  - Repeat the above steps. The only difference should be the auth form opens into the OTP screen by default after entering the relevant email address and selecting continue.
4. Smoke test the rest of the login form to confirm nothing seems broken

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->