### PR TITLE
fix(data-events): race condition between `order_completed` and `subscription_updated`

### DIFF
--- a/includes/data-events/connectors/class-connector.php
+++ b/includes/data-events/connectors/class-connector.php
@@ -89,6 +89,12 @@ abstract class Connector {
 			return;
 		}
 
+		// If order is a subscription renewal, ignore it here as it's handled by
+		// the subscription_updated event.
+		if ( ! empty( $data['is_renewal'] ) ) {
+			return;
+		}
+
 		$order_id = $data['platform_data']['order_id'];
 		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, $data['referer'], true );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There are 3 updates made to the ESP's contact metadata during a subscription renewal:
 1. Once the subscription expires, it's set to `on-hold` via `subscription_updated`
 2. When the renewal process is completed, the renewal order also updates the contact via `order_completed`
 3. The subscription status is then changed from `on-hold` to `active`, triggering another update via `subscription_updated`

Given the asynchronous nature of data events, there can be a race condition between 2 and 3. Because the subscription status hasn't yet been updated, the `order_completed` payload may overwrite the Membership Status to `on-hold`.

Redacted logs from a live site:

```
[05-Aug-2024 15:24:12 UTC] [23005][NEWSPACK-DATA-EVENTS]: Dispatching action "product_subscription_changed".
[05-Aug-2024 15:24:13 UTC] [34773][NEWSPACK-DATA-EVENTS]: Executing global action handlers for "product_subscription_changed".
[05-Aug-2024 15:24:13 UTC] [34773][NEWSPACK-DATA-EVENTS]: Executing action handlers for "product_subscription_changed".
[05-Aug-2024 15:24:13 UTC] [34773][NEWSPACK-NEWSLETTERS]: Adding contact to list(s): 1. Provider is active_campaign.
[05-Aug-2024 15:24:16 UTC] [34773][NEWSPACK]: Normalizing contact data for reader ESP sync:
[05-Aug-2024 15:24:16 UTC] [34773][NEWSPACK]: {
    "email": "john@doe.com",
    "metadata": {
        "NP_Membership Status": "on-hold",
    },
    "existing_contact_data": {
        "cdate": "2023-09-05T10:24:37-05:00",
        "email": "john@doe.com",
    }
}
[05-Aug-2024 15:24:16 UTC] [34773][NEWSPACK-NEWSLETTERS]: Adding contact with metadata key(s): NP_Payment Page, NP_Membership Status, NP_Current Subscription Start Date, NP_Current Subscription End Date, NP_Billing Cycle, NP_Recurring Payment, NP_Next Payment Date, NP_Product Name, NP_Payment UTM: source, NP_Payment UTM: medium, NP_Payment UTM: campaign, NP_Payment UTM: term, NP_Payment UTM: content, NP_Last Payment Date, NP_Last Payment Amount, NP_Total Paid, NP_Account, NP_Registration Date.
[05-Aug-2024 15:24:16 UTC] [23005][NEWSPACK-DATA-EVENTS]: Dispatching action "order_completed".
[05-Aug-2024 15:24:17 UTC] [35577][NEWSPACK-DATA-EVENTS]: Executing global action handlers for "order_completed".
[05-Aug-2024 15:24:17 UTC] [35577][NEWSPACK-DATA-EVENTS]: Executing action handlers for "order_completed".
[05-Aug-2024 15:24:17 UTC] [35577][NEWSPACK-NEWSLETTERS]: Adding contact to list(s): 1. Provider is active_campaign.
[05-Aug-2024 15:24:18 UTC] [23005][NEWSPACK-DATA-EVENTS]: Dispatching action "product_subscription_changed".
[05-Aug-2024 15:24:19 UTC] [35925][NEWSPACK-DATA-EVENTS]: Executing global action handlers for "product_subscription_changed".
[05-Aug-2024 15:24:19 UTC] [35925][NEWSPACK-DATA-EVENTS]: Executing action handlers for "product_subscription_changed".
[05-Aug-2024 15:24:19 UTC] [35925][NEWSPACK-NEWSLETTERS]: Adding contact to list(s): 1. Provider is active_campaign.
[05-Aug-2024 15:24:19 UTC] [35577][NEWSPACK]: Normalizing contact data for reader ESP sync:
[05-Aug-2024 15:24:19 UTC] [35577][NEWSPACK]: {
    "email": "john@doe.com",
    "metadata": {
        "NP_Membership Status": "on-hold",
    },
    "existing_contact_data": {
        "cdate": "2023-09-05T10:24:37-05:00",
        "email": "john@doe.com",
    }
}
[05-Aug-2024 15:24:19 UTC] [35577][NEWSPACK-NEWSLETTERS]: Adding contact with metadata key(s): NP_Payment Page, NP_Membership Status, NP_Current Subscription Start Date, NP_Current Subscription End Date, NP_Billing Cycle, NP_Recurring Payment, NP_Last Payment Amount, NP_Last Payment Date, NP_Next Payment Date, NP_Product Name, NP_Payment UTM: source, NP_Payment UTM: medium, NP_Payment UTM: campaign, NP_Payment UTM: term, NP_Payment UTM: content, NP_Total Paid, NP_Account, NP_Registration Date.
[05-Aug-2024 15:24:21 UTC] [35925][NEWSPACK]: Normalizing contact data for reader ESP sync:
[05-Aug-2024 15:24:21 UTC] [35925][NEWSPACK]: {
    "email": "john@doe.com",
    "metadata": {
        "NP_Membership Status": "active",
    },
    "existing_contact_data": {
        "cdate": "2023-09-05T10:24:37-05:00",
        "email": "john@doe.com",
    }
}
[05-Aug-2024 15:24:21 UTC] [35925][NEWSPACK-NEWSLETTERS]: Adding contact with metadata key(s): NP_Payment Page, NP_Membership Status, NP_Current Subscription Start Date, NP_Current Subscription End Date, NP_Billing Cycle, NP_Recurring Payment, NP_Next Payment Date, NP_Product Name, NP_Payment UTM: source, NP_Payment UTM: medium, NP_Payment UTM: campaign, NP_Payment UTM: term, NP_Payment UTM: content, NP_Last Payment Date, NP_Last Payment Amount, NP_Total Paid, NP_Account, NP_Registration Date.
```

Notice the last 2 contact updates are executed in sequence.

This PR changes the `order_completed` handler so it doesn't run on renewal orders. These updates should now only be handled by `subscription_updated`.

### How to test the changes in this Pull Request:

1. Make sure you have RAS configured and Newspack Newsletters connected to an ESP
2. In a fresh reader account, purchase a non-donation subscription
3. From the dashboard, set the subscription to `on-hold`
4. Visit the contact page in the ESP and confirm the "Membership Status" is set to on hold
5. Use the "Subscription actions" metabox to process a renewal
6. Make sure the renewal order is processed and complete
7. Visit the contact page in the ESP and confirm the "Membership Status" is back to active

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->