### PR TITLE
fix (ras-acc): update max-height for modal styles

### DIFF
--- a/assets/newspack-ui/scss/_modals.scss
+++ b/assets/newspack-ui/scss/_modals.scss
@@ -48,7 +48,7 @@
 		border-radius: var( --newspack-ui-border-radius-m );
 		display: flex;
 		flex-direction: column;
-		max-height: 90vh;
+		max-height: 90%;
 		max-width: var( --newspack-ui-modal-width-m );
 		overflow: auto;
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR goes with https://github.com/Automattic/newspack-blocks/pull/1834; the testing steps can be found there.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->