### PR TITLE
fix (ras-acc): remove nowrap from tables

### DIFF
--- a/assets/newspack-ui/scss/elements/_tables.scss
+++ b/assets/newspack-ui/scss/elements/_tables.scss
@@ -13,9 +13,6 @@
 			font-size: var( --newspack-ui-font-size-xs ); // Prevent relative font size
 			padding: calc( var( --newspack-ui-spacer-base ) / 2 ) 0;
 			vertical-align: top;
-			> * {
-				white-space: nowrap;
-			}
 		}
 		th {
 			font-weight: 600;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This PR removes a `nowrap` on elements inside tables to fix an issue where the transactional details didn't actually wrap on mobile.

I'm not actually sure why this style was there, but I added it and we're only using tables for the transaction details so far 😅 I think it's safe to remove with what we have for now, but we'll probably want some kind of side-scrolling style for large tables down the road if we need to re-add it.

See: 1207817176293825-as-1207944985845163

### How to test the changes in this Pull Request:

1. Run through a checkout for a recurring donation on a mobile device or using a desktop browser with a mobile-sized screen.
2. On the second checkout screen in the modal, note that the frequency gets cut off/runs off screen.

![image](https://github.com/user-attachments/assets/13a4a717-67f5-4ab3-96bf-2c436842fe35)

3. Apply this PR and run `npm run build`.
4. Confirm that the transaction details now wrap nicely, and that nothing else looks weird:

![image](https://github.com/user-attachments/assets/3b513aca-c4c9-405c-9b53-0f91da95cf15)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->