### PR TITLE
fix (ras-acc): hide 'Create account' message when clicked

### DIFF
--- a/assets/reader-activation-auth/auth-form.js
+++ b/assets/reader-activation-auth/auth-form.js
@@ -315,6 +315,21 @@ window.newspackRAS.push( function ( readerActivation ) {
 						messageContentElement.classList.add( 'newspack-ui__helper-text' );
 					}
 					messageContentElement.style.display = 'block';
+
+					// If the message includes a registration toggle, hide the message when clicked.
+					messageContentElement
+						.querySelectorAll( 'a[data-set-action="register"], a[data-set-action="signin"]' )
+						.forEach( registerLink => {
+							registerLink.parentNode.setAttribute( 'data-action', 'signin' );
+
+							registerLink.addEventListener(
+								'click',
+								function () {
+									messageContentElement.innerHTML = '';
+								},
+								false
+							);
+						} );
 				} else {
 					messageContentElement.style.display = 'none';
 					messageContentElement.innerHTML = '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR hides the "Account not found. Create an account instead?" message when clicked. When it's clicked the modal is switched to the "Create an account" state already, and most of the error display goes away, but the message remaining makes it less clear that the form has changed.

See: 1207817176293825-as-1207817176293828

### How to test the changes in this Pull Request:

1. As a reader in an incognito window, click the Sign In link.
2. Enter a non-registered email address, but still click "Continue" on the "Sign in to complete transaction" window.
3. The modal should show an error like:

![image](https://github.com/user-attachments/assets/764d80bc-5c71-4c03-94a6-51f118e121cd)

4. Click the "Create an account" link inside of the error message. Note that the form switches to the "Register to complete transaction" state, and most of the error styling is removed, except the message:

![image](https://github.com/user-attachments/assets/097d0c04-56f0-4923-b0d4-c42f921aed1b)

5. Apply this PR and run `npm run build`.
6. Repeat steps 1-4 and confirm that the error message goes away when you click "Create an account".

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->