### PR TITLE
fix(data-events): remove `is_updating` check from `newsletter_subscribed` listener

### DIFF
--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -99,14 +99,11 @@ Data_Events::register_listener(
 Data_Events::register_listener(
 	'newspack_newsletters_contact_subscribed',
 	'newsletter_subscribed',
-	function( $provider, $contact, $lists, $result, $is_updating ) {
+	function( $provider, $contact, $lists, $result ) {
 		if ( empty( $lists ) ) {
 			return;
 		}
 		if ( is_wp_error( $result ) ) {
-			return;
-		}
-		if ( $is_updating ) {
 			return;
 		}
 		$user = get_user_by( 'email', $contact['email'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Before using the new `newspack_newsletters_contact_subscribed` hook for the `newsletter_subscribed` listener, we had to be more careful about this trigger. Now that the `::subscribe()`method exists, it should be called from intentional subscriptions and not contact metadata updates or lists preferences changes.

With the `is_updating` check, `newsletter_subscribed` is skipped for contacts that exist in the ESP as transactional or without a subscription.

### How to test the changes in this Pull Request:

1. While on the `epic/consolidate-data-flows` branch, setup Newspack Newsletters with Mailchimp
2. Use the reader registration block to register a new reader without subscribing to newsletters
3. Authenticated as the new registered reader, use the newsletter subscription form block to subscribe to newsletter lists
4. Confirm, via logs, that `newsletter_subscribed` is never triggered and the GA event for `np_newsletter_subscribed
` is never sent
5. Check out this branch and repeat steps 2 and 3 with a new email
6. Confirm the `newsletter_subscribed` is triggered and you can see the GA event for  `np_newsletter_subscribed`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->