### PR TITLE
fix: inform status if new for data events esp sync in mailchimp

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -38,7 +38,7 @@ final class Blocks {
 			'newspack-blocks',
 			'newspack_blocks',
 			[
-				'has_newsletters'         => method_exists( 'Newspack_Newsletters_Subscription', 'add_contact' ),
+				'has_newsletters'         => class_exists( 'Newspack_Newsletters_Subscription' ),
 				'has_reader_activation'   => Reader_Activation::is_enabled(),
 				'newsletters_url'         => Wizards::get_wizard( 'engagement' )->newsletters_settings_url(),
 				'has_google_oauth'        => Google_OAuth::is_oauth_configured(),

--- a/includes/configuration_managers/class-newspack-newsletters-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-newsletters-configuration-manager.php
@@ -112,8 +112,9 @@ class Newspack_Newsletters_Configuration_Manager extends Configuration_Manager {
 	 * @return array Lists.
 	 */
 	public function add_contact( $contact, $list_id ) {
+		__deprecated_function( __METHOD__, '4.4.3', 'Newspack_Newsletters_Contacts::upsert' );
 		if ( $this->is_configured() ) {
-			return \Newspack_Newsletters_Subscription::add_contact( $contact, $list_id );
+			return \Newspack_Newsletters_Contacts::upsert( $contact, $list_id );
 		}
 	}
 

--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -319,7 +319,7 @@ Example with an array of strings to map the hook's arguments:
 
 ```php
 Newspack\Data_Events::register_listener(
-	'newspack_newsletters_add_contact',
+	'newspack_newsletters_contact_subscribed',
 	'newsletter_subscribed',
 	[ 'provider', 'contact', 'lists', 'result' ]
 );

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -44,6 +44,7 @@ class ActiveCampaign extends Connector {
 			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'product_subscription_changed' );
 			Data_Events::register_handler( [ __CLASS__, 'newsletter_updated' ], 'newsletter_subscribed' );
 			Data_Events::register_handler( [ __CLASS__, 'newsletter_updated' ], 'newsletter_updated' );
+			Data_Events::register_handler( [ __CLASS__, 'network_new_reader' ], 'network_new_reader' );
 		}
 	}
 

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -103,7 +103,7 @@ class ActiveCampaign extends Connector {
 			'email'    => $data['email'],
 			'metadata' => $metadata,
 		];
-		self::put( $contact, sprintf( 'Updating the account and newsletter_selection fields after a change in the subscription lists. User ID: %d', $data['user_id'] ) );
+		self::put( $contact, 'Updating the account and newsletter_selection fields after a change in the subscription lists.' );
 	}
 }
 new ActiveCampaign();

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -103,7 +103,7 @@ class ActiveCampaign extends Connector {
 			'email'    => $data['email'],
 			'metadata' => $metadata,
 		];
-		self::put( $contact, 'Updating the account and newsletter_selection fields after a change in the subscription lists' );
+		self::put( $contact, sprintf( 'Updating the account and newsletter_selection fields after a change in the subscription lists. User ID: %d', $data['user_id'] ) );
 	}
 }
 new ActiveCampaign();

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -37,6 +37,7 @@ class ActiveCampaign extends Connector {
 			'active_campaign' === \Newspack_Newsletters::service_provider()
 		) {
 			Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
+			Data_Events::register_handler( [ __CLASS__, 'reader_deleted' ], 'reader_deleted' );
 			Data_Events::register_handler( [ __CLASS__, 'reader_logged_in' ], 'reader_logged_in' );
 			Data_Events::register_handler( [ __CLASS__, 'order_completed' ], 'order_completed' );
 			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'donation_subscription_changed' );

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -51,14 +51,15 @@ class ActiveCampaign extends Connector {
 	/**
 	 * Upsert the contact.
 	 *
-	 * @param array $contact Contact info to sync to ESP.
+	 * @param array  $contact Contact info to sync to ESP.
+	 * @param string $context Context of the update for logging purposes.
 	 */
-	public static function put( $contact ) {
+	protected static function put( $contact, $context ) {
 		$master_list_id = Reader_Activation::get_setting( 'active_campaign_master_list' );
 		if ( ! $master_list_id ) {
 			return;
 		}
-		return \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id );
+		return \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, false, $context );
 	}
 
 	/**
@@ -102,7 +103,7 @@ class ActiveCampaign extends Connector {
 			'email'    => $data['email'],
 			'metadata' => $metadata,
 		];
-		self::put( $contact );
+		self::put( $contact, 'Updating the account and newsletter_selection fields after a change in the subscription lists' );
 	}
 }
 new ActiveCampaign();

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -59,7 +59,7 @@ class ActiveCampaign extends Connector {
 		if ( ! $master_list_id ) {
 			return;
 		}
-		return \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, false, $context );
+		return \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context );
 	}
 
 	/**

--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -56,7 +56,7 @@ class ActiveCampaign extends Connector {
 		if ( ! $master_list_id ) {
 			return;
 		}
-		return \Newspack_Newsletters_Subscription::add_contact( $contact, $master_list_id );
+		return \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id );
 	}
 
 	/**

--- a/includes/data-events/connectors/class-connector.php
+++ b/includes/data-events/connectors/class-connector.php
@@ -118,7 +118,7 @@ abstract class Connector {
 			return;
 		}
 
-		static::put( $contact, 'RAS Woo Subscription updated' );
+		static::put( $contact, sprintf( 'RAS Woo Subscription updated. Status changed from %s to %s', $data['status_before'], $data['status_after'] ) );
 	}
 
 	/**
@@ -162,6 +162,7 @@ abstract class Connector {
 
 		$contact['metadata']['network_registration_site'] = $registration_site;
 
-		static::put( $contact, 'RAS Newspack Network: user propagated from another site in the network' );
+		$site_url = get_site_url();
+		static::put( $contact, sprintf( 'RAS Newspack Network: User propagated from another site in the network. Propagated from %s to %s.', $registration_site, $site_url ) );
 	}
 }

--- a/includes/data-events/connectors/class-connector.php
+++ b/includes/data-events/connectors/class-connector.php
@@ -51,7 +51,7 @@ abstract class Connector {
 			'metadata' => $metadata,
 		];
 
-		static::put( $contact );
+		static::put( $contact, 'RAS Reader registration' );
 	}
 
 	/**
@@ -75,7 +75,7 @@ abstract class Connector {
 
 		$contact = WooCommerce_Connection::get_contact_from_customer( $customer );
 
-		static::put( $contact );
+		static::put( $contact, 'RAS Reader login' );
 	}
 
 	/**
@@ -97,7 +97,7 @@ abstract class Connector {
 			return;
 		}
 
-		static::put( $contact );
+		static::put( $contact, 'RAS Order completed' );
 	}
 
 	/**
@@ -118,7 +118,7 @@ abstract class Connector {
 			return;
 		}
 
-		static::put( $contact );
+		static::put( $contact, 'RAS Woo Subscription updated' );
 	}
 
 	/**
@@ -130,7 +130,7 @@ abstract class Connector {
 	 */
 	public static function reader_deleted( $timestamp, $data, $client_id ) {
 		if ( true === \Newspack\Reader_Activation::get_setting( 'sync_esp_delete' ) ) {
-			return Newspack_Newsletters_Contacts::delete( $data['user_id'] );
+			return Newspack_Newsletters_Contacts::delete( $data['user_id'], 'RAS Reader deleted' );
 		}
 	}
 
@@ -162,6 +162,6 @@ abstract class Connector {
 
 		$contact['metadata']['network_registration_site'] = $registration_site;
 
-		static::put( $contact );
+		static::put( $contact, 'RAS Newspack Network: user propagated from another site in the network' );
 	}
 }

--- a/includes/data-events/connectors/class-connector.php
+++ b/includes/data-events/connectors/class-connector.php
@@ -152,7 +152,8 @@ abstract class Connector {
 		}
 
 		// Ensure email is set as the user probably won't have a billing email.
-		if ( ! isset( $contact['email'] ) ) {
+		if ( empty( $contact['email'] ) ) {
+			$user = get_userdata( $user_id );
 			$contact['email'] = $user->user_email;
 		}
 

--- a/includes/data-events/connectors/class-connector.php
+++ b/includes/data-events/connectors/class-connector.php
@@ -119,4 +119,17 @@ abstract class Connector {
 
 		static::put( $contact );
 	}
+
+	/**
+	 * Handle a user deletion.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 */
+	public static function reader_deleted( $timestamp, $data, $client_id ) {
+		if ( true === \Newspack\Reader_Activation::get_setting( 'sync_esp_delete' ) ) {
+			return Newspack_Newsletters_Contacts::delete( $data['user_id'] );
+		}
+	}
 }

--- a/includes/data-events/connectors/class-connector.php
+++ b/includes/data-events/connectors/class-connector.php
@@ -132,4 +132,35 @@ abstract class Connector {
 			return Newspack_Newsletters_Contacts::delete( $data['user_id'] );
 		}
 	}
+
+	/**
+	 * Handle a a new network added in the Newspack Network plugin.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 * @param int   $client_id ID of the client that triggered the event.
+	 */
+	public static function network_new_reader( $timestamp, $data, $client_id ) {
+		$user_id = $data['user_id'];
+		$registration_site = $data['registration_site'];
+
+		$contact = WooCommerce_Connection::get_contact_from_customer( new \WC_Customer( $user_id ) );
+
+		if ( ! $contact ) {
+			return;
+		}
+
+		// Ensure email is set as the user probably won't have a billing email.
+		if ( ! isset( $contact['email'] ) ) {
+			$contact['email'] = $user->user_email;
+		}
+
+		if ( empty( $contact['metadata'] ) ) {
+			$contact['metadata'] = [];
+		}
+
+		$contact['metadata']['network_registration_site'] = $registration_site;
+
+		static::put( $contact );
+	}
 }

--- a/includes/data-events/connectors/class-connector.php
+++ b/includes/data-events/connectors/class-connector.php
@@ -9,6 +9,7 @@ namespace Newspack\Data_Events\Connectors;
 
 use Newspack\Newspack_Newsletters;
 use Newspack\WooCommerce_Connection;
+use Newspack_Newsletters_Contacts;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -44,6 +44,7 @@ class Mailchimp extends Connector {
 			Data_Events::register_handler( [ __CLASS__, 'order_completed' ], 'order_completed' );
 			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'donation_subscription_changed' );
 			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'product_subscription_changed' );
+			Data_Events::register_handler( [ __CLASS__, 'network_new_reader' ], 'network_new_reader' );
 		}
 	}
 

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -39,6 +39,7 @@ class Mailchimp extends Connector {
 			'mailchimp' === \Newspack_Newsletters::service_provider()
 		) {
 			Data_Events::register_handler( [ __CLASS__, 'reader_registered' ], 'reader_registered' );
+			Data_Events::register_handler( [ __CLASS__, 'reader_deleted' ], 'reader_deleted' );
 			Data_Events::register_handler( [ __CLASS__, 'reader_logged_in' ], 'reader_logged_in' );
 			Data_Events::register_handler( [ __CLASS__, 'order_completed' ], 'order_completed' );
 			Data_Events::register_handler( [ __CLASS__, 'subscription_updated' ], 'donation_subscription_changed' );

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -94,7 +94,7 @@ class Mailchimp extends Connector {
 
 		$contact['metadata']['status'] = self::get_default_reader_status();
 
-		return \Newspack_Newsletters_Contacts::upsert( $contact, $audience_id, false, $context );
+		return \Newspack_Newsletters_Contacts::upsert( $contact, $audience_id, $context );
 	}
 }
 new Mailchimp();

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -75,123 +75,6 @@ class Mailchimp extends Connector {
 	}
 
 	/**
-	 * Get merge field type.
-	 *
-	 * @param mixed $value Value to check.
-	 *
-	 * @return string Merge field type.
-	 */
-	private static function get_merge_field_type( $value ) {
-		if ( is_numeric( $value ) ) {
-			return 'number';
-		}
-		if ( is_bool( $value ) ) {
-			return 'boolean';
-		}
-		return 'text';
-	}
-
-	/**
-	 * Get merge fields given data.
-	 *
-	 * @param string $audience_id Audience ID.
-	 * @param array  $data        Data to check.
-	 *
-	 * @return array Merge fields.
-	 */
-	private static function get_merge_fields( $audience_id, $data ) {
-		$merge_fields = [];
-
-		// Strip arrays.
-		$data = array_filter(
-			$data,
-			function( $value ) {
-				return ! is_array( $value );
-			}
-		);
-
-		// Get and match existing merge fields.
-		$merge_fields_res = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" );
-		if ( \is_wp_error( $merge_fields_res ) ) {
-			Logger::log(
-				sprintf(
-					// Translators: %1$s is the error message.
-					__( 'Error getting merge fields: %1$s', 'newspack-plugin' ),
-					$merge_fields_res->get_error_message()
-				)
-			);
-			return [];
-		}
-		$existing_fields = $merge_fields_res['merge_fields'];
-		usort(
-			$existing_fields,
-			function( $a, $b ) {
-				return $a['merge_id'] - $b['merge_id'];
-			}
-		);
-
-		$list_merge_fields = [];
-
-		// Handle duplicate fields.
-		foreach ( $existing_fields as $field ) {
-			if ( ! isset( $list_merge_fields[ $field['name'] ] ) ) {
-				$list_merge_fields[ $field['name'] ] = $field['tag'];
-			} else {
-				Logger::log(
-					sprintf(
-						// Translators: %1$s is the merge field name, %2$s is the field's unique tag.
-						__( 'Warning: Duplicate merge field %1$s found with tag %2$s.', 'newspack-plugin' ),
-						$field['name'],
-						$field['tag']
-					)
-				);
-			}
-		}
-
-		foreach ( $data as $field_name => $field_value ) {
-			// If field already exists, add it to the payload.
-			if ( isset( $list_merge_fields[ $field_name ] ) ) {
-				$merge_fields[ $list_merge_fields[ $field_name ] ] = $data[ $field_name ];
-				unset( $data[ $field_name ] );
-			}
-		}
-
-		// Create remaining fields.
-		$remaining_fields = array_keys( $data );
-		foreach ( $remaining_fields as $field_name ) {
-			$created_field = Mailchimp_API::post(
-				"lists/$audience_id/merge-fields",
-				[
-					'name' => $field_name,
-					'type' => self::get_merge_field_type( $data[ $field_name ] ),
-				]
-			);
-			// Skip field if it failed to create.
-			if ( is_wp_error( $created_field ) ) {
-				Logger::log(
-					sprintf(
-					// Translators: %1$s is the merge field key, %2$s is the error message.
-						__( 'Failed to create merge field %1$s. Error response: %2$s', 'newspack-plugin' ),
-						$field_name,
-						$created_field->get_error_message() ?? __( 'The connected ESP could not create this merge field.', 'newspack-plugin' )
-					)
-				);
-				continue;
-			}
-			Logger::log(
-				sprintf(
-					// Translators: %1$s is the merge field key, %2$s is the error message.
-					__( 'Created merge field %1$s.', 'newspack-plugin' ),
-					$field_name
-				)
-			);
-			$merge_fields[ $created_field['tag'] ] = $data[ $field_name ];
-		}
-
-		return $merge_fields;
-	}
-
-	/**
 	 * Update a Mailchimp contact
 	 *
 	 * @param array $contact Contact info to sync to ESP without lists.
@@ -203,31 +86,14 @@ class Mailchimp extends Connector {
 		if ( ! $audience_id ) {
 			return;
 		}
-		$hash    = md5( strtolower( $contact['email'] ) );
-		$payload = [
-			'email_address' => $contact['email'],
-			'status_if_new' => self::get_default_reader_status(),
-		];
 
-		// Normalize contact metadata.
-		$contact = Newspack_Newsletters::normalize_contact_data( $contact );
-		if ( ! empty( $contact['metadata'] ) ) {
-			$merge_fields = self::get_merge_fields( $audience_id, $contact['metadata'] );
-			if ( ! empty( $merge_fields ) ) {
-				$payload['merge_fields'] = $merge_fields;
-			}
+		if ( empty( $contact['metadata'] ) ) {
+			$contact['metadata'] = [];
 		}
 
-		Logger::log(
-			'Syncing contact with metadata key(s): ' . implode( ', ', array_keys( $contact['metadata'] ) ) . '.',
-			Data_Events::LOGGER_HEADER
-		);
+		$contact['metadata']['status'] = self::get_default_reader_status();
 
-		// Upsert the contact.
-		return Mailchimp_API::put(
-			"lists/$audience_id/members/$hash",
-			$payload
-		);
+		return \Newspack_Newsletters_Contacts::upsert( $contact, $audience_id );
 	}
 }
 new Mailchimp();

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -92,7 +92,7 @@ class Mailchimp extends Connector {
 			$contact['metadata'] = [];
 		}
 
-		$contact['metadata']['status'] = self::get_default_reader_status();
+		$contact['metadata']['status_if_new'] = self::get_default_reader_status();
 
 		return \Newspack_Newsletters_Contacts::upsert( $contact, $audience_id, $context );
 	}

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -9,7 +9,6 @@ namespace Newspack\Data_Events\Connectors;
 
 use Newspack\Logger;
 use Newspack\Data_Events;
-use Newspack\Mailchimp_API;
 use Newspack\Newspack_Newsletters;
 use Newspack\Reader_Activation;
 
@@ -79,11 +78,11 @@ class Mailchimp extends Connector {
 	/**
 	 * Update a Mailchimp contact
 	 *
-	 * @param array $contact Contact info to sync to ESP without lists.
-	 *
+	 * @param array  $contact Contact info to sync to ESP without lists.
+	 * @param string $context Context of the update for logging purposes.
 	 * @return array|WP_Error response body or error.
 	 */
-	public static function put( $contact ) {
+	protected static function put( $contact, $context ) {
 		$audience_id = self::get_audience_id();
 		if ( ! $audience_id ) {
 			return;
@@ -95,7 +94,7 @@ class Mailchimp extends Connector {
 
 		$contact['metadata']['status'] = self::get_default_reader_status();
 
-		return \Newspack_Newsletters_Contacts::upsert( $contact, $audience_id );
+		return \Newspack_Newsletters_Contacts::upsert( $contact, $audience_id, false, $context );
 	}
 }
 new Mailchimp();

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -99,14 +99,11 @@ Data_Events::register_listener(
 Data_Events::register_listener(
 	'newspack_newsletters_contact_subscribed',
 	'newsletter_subscribed',
-	function( $provider, $contact, $lists, $result, $is_updating ) {
+	function( $provider, $contact, $lists, $result ) {
 		if ( empty( $lists ) ) {
 			return;
 		}
 		if ( is_wp_error( $result ) ) {
-			return;
-		}
-		if ( $is_updating ) {
 			return;
 		}
 		$user = get_user_by( 'email', $contact['email'] );

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -31,6 +31,23 @@ Data_Events::register_listener(
 );
 
 /**
+ * For when a reader is deleted.
+ */
+Data_Events::register_listener(
+	'delete_user',
+	'reader_deleted',
+	function( $user_id, $reassign, $user ) {
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			return;
+		}
+		return [
+			'user_id' => $user_id,
+			'user'    => $user,
+		];
+	}
+);
+
+/**
  * For when a reader registers via Woo.
  */
 Data_Events::register_listener(

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -97,7 +97,7 @@ Data_Events::register_listener(
  * For when a new contact is added to newsletter lists for the first time.
  */
 Data_Events::register_listener(
-	'newspack_newsletters_add_contact',
+	'newspack_newsletters_contact_subscribed',
 	'newsletter_subscribed',
 	function( $provider, $contact, $lists, $result, $is_updating ) {
 		if ( empty( $lists ) ) {

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -320,6 +320,10 @@ class Newspack_Newsletters {
 			if ( isset( $contact['metadata']['status'] ) ) {
 				$normalized_metadata['status'] = $contact['metadata']['status'];
 			}
+			if ( isset( $contact['metadata']['status_if_new'] ) ) {
+				$normalized_metadata['status_if_new'] = $contact['metadata']['status_if_new'];
+			}
+
 			$contact['metadata'] = $normalized_metadata;
 		}
 

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -35,6 +35,13 @@ class Newspack_Newsletters {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
+		\add_action( 'init', [ __CLASS__, 'setup_hooks' ] );
+	}
+
+	/**
+	 * Setup hooks.
+	 */
+	public static function setup_hooks() {
 		/**
 		 * Filters the list of key/value pairs for metadata fields to be synced to the connected ESP.
 		 *
@@ -42,7 +49,7 @@ class Newspack_Newsletters {
 		 */
 		self::$metadata_keys = \apply_filters( 'newspack_ras_metadata_keys', self::get_all_metadata_fields() );
 
-		\add_filter( 'newspack_newsletters_contact_data', [ __CLASS__, 'normalize_contact_data' ] );
+		\add_filter( 'newspack_newsletters_contact_data', [ __CLASS__, 'normalize_contact_data' ], 99 );
 
 		if ( self::should_sync_ras_metadata() ) {
 			\add_filter( 'newspack_newsletters_contact_lists', [ __CLASS__, 'add_activecampaign_master_list' ], 10, 3 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes how mailchimp handles `status` and `status_if_new` on data events sync

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-newsletters/pull/1603

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->