### PR TITLE
fix(data-events): gate interaction for registration form

### DIFF
--- a/includes/data-events/class-memberships.php
+++ b/includes/data-events/class-memberships.php
@@ -41,7 +41,7 @@ final class Memberships {
 		add_action( 'init', [ __CLASS__, 'register_listeners' ] );
 		add_filter( 'newspack_blocks_modal_checkout_cart_item_data', [ __CLASS__, 'checkout_cart_item_data' ], 10, 2 );
 		add_action( 'woocommerce_checkout_create_order_line_item', [ __CLASS__, 'checkout_create_order_line_item' ], 10, 4 );
-		add_filter( 'newspack_register_reader_form_metadata', [ __CLASS__, 'register_reader_metadata' ], 10, 2 );
+		add_filter( 'newspack_register_reader_metadata', [ __CLASS__, 'register_reader_metadata' ], 10, 2 );
 	}
 
 	/**
@@ -97,12 +97,12 @@ final class Memberships {
 		 * Gate interaction: Registration membership
 		 */
 		Data_Events::register_listener(
-			'newspack_reader_registration_form_processed',
+			'newspack_registered_reader',
 			'gate_interaction',
 			[ __CLASS__, 'registration_submission' ]
 		);
 		Data_Events::register_listener(
-			'newspack_reader_registration_form_processed',
+			'newspack_registered_reader',
 			'gate_interaction',
 			[ __CLASS__, 'registration_submission_with_status' ]
 		);
@@ -141,12 +141,15 @@ final class Memberships {
 	 *
 	 * Will trigger the event with "form_submission" as action in all cases.
 	 *
-	 * @param string              $email   Email address of the reader.
-	 * @param int|false|\WP_Error $user_id The created user ID in case of registration, false if not created or a WP_Error object.
-	 * @param array               $metadata Array with metadata about the user being registered.
+	 * @param string         $email         Email address.
+	 * @param bool           $authenticate  Whether to authenticate after registering.
+	 * @param false|int      $user_id       The created user id.
+	 * @param false|\WP_User $existing_user The existing user object.
+	 * @param array          $metadata      Metadata.
+	 *
 	 * @return ?array
 	 */
-	public static function registration_submission( $email, $user_id, $metadata ) {
+	public static function registration_submission( $email, $authenticate, $user_id, $existing_user, $metadata ) {
 		if ( ! isset( $metadata[ self::METADATA_NAME ] ) ) {
 			return;
 		}
@@ -167,12 +170,15 @@ final class Memberships {
 	 *
 	 * Will trigger the event with "form_submission" as action in all cases.
 	 *
-	 * @param string              $email   Email address of the reader.
-	 * @param int|false|\WP_Error $user_id The created user ID in case of registration, false if not created or a WP_Error object.
-	 * @param array               $metadata Array with metadata about the user being registered.
+	 * @param string         $email         Email address.
+	 * @param bool           $authenticate  Whether to authenticate after registering.
+	 * @param false|int      $user_id       The created user id.
+	 * @param false|\WP_User $existing_user The existing user object.
+	 * @param array          $metadata      Metadata.
+	 *
 	 * @return ?array
 	 */
-	public static function registration_submission_with_status( $email, $user_id, $metadata ) {
+	public static function registration_submission_with_status( $email, $authenticate, $user_id, $existing_user, $metadata ) {
 		if ( ! isset( $metadata[ self::METADATA_NAME ] ) ) {
 			return;
 		}

--- a/src/memberships-gate/gate.js
+++ b/src/memberships-gate/gate.js
@@ -31,7 +31,10 @@ function domReady( callback ) {
  * @param {HTMLElement} gate The gate element.
  */
 function addFormInputs( gate ) {
-	const forms = gate.querySelectorAll( 'form' );
+	const forms = [
+		...gate.querySelectorAll( 'form' ),
+		...document.querySelectorAll( '.newspack-reader-auth form' ),
+	];
 	forms.forEach( form => {
 		const input = document.createElement( 'input' );
 		input.type = 'hidden';
@@ -42,9 +45,12 @@ function addFormInputs( gate ) {
 }
 
 /**
- * Push gate 'seen' event to Google Analytics.
+ * Handle when the gate is seen.
  */
-function pushSeenEvent() {
+function handleSeen( gate ) {
+	// Add form inputs.
+	addFormInputs( gate );
+	// Push gate 'seen' event to Google Analytics.
 	const eventName = 'np_gate_interaction';
 	const payload = {
 		action: 'seen',
@@ -72,7 +78,7 @@ function initOverlay( gate ) {
 		if ( delta < 0 ) {
 			visible = true;
 			if ( ! seen ) {
-				pushSeenEvent();
+				handleSeen( gate );
 			}
 			seen = true;
 		}
@@ -87,16 +93,17 @@ domReady( function () {
 	if ( ! gate ) {
 		return;
 	}
-	addFormInputs( gate );
 
 	if ( gate.classList.contains( 'newspack-memberships__overlay-gate' ) ) {
 		initOverlay( gate );
 	} else {
 		// Seen event for inline gate.
 		const detectSeen = () => {
-			const delta = ( gate?.getBoundingClientRect().top || 0 ) - window.innerHeight / 2;
+			const delta =
+				( gate?.getBoundingClientRect().top || 0 ) -
+				window.innerHeight / 2;
 			if ( delta < 0 ) {
-				pushSeenEvent();
+				handleSeen( gate );
 				document.removeEventListener( 'scroll', detectSeen );
 			}
 		};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1207615072285532

#2740 introduced tracking capabilities for forms inside the gate, which covers the Reader Registration Block and Checkout Button Block.

There's the unhandled case of registrations initiated via a hash link on the gate, which triggers the RAS' global auth form:

<img width="810" alt="image" src="https://github.com/user-attachments/assets/ece43a94-68dc-49d1-9a2f-32fe7669248e">

To handle those cases, this PR proposes that the tracking input be added to RAS' auth form when visiting gated content.

This means registrations made on gated content, but initiated outside of the gate (like the header "Sign In" button), will also be treated as a gate interaction. To improve accuracy, the tracking input should now only be added once the gate is **seen** on the page. With that strategy, once the page loads the reader may register through the header "Sign In" and never realize that they are on gated content, which will not be a gate interaction. Once they scroll down and hit the gate, they may scroll back up, register from "Sign In", and it will be a gate interaction.

### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have RAS, Woo Memberships and a configured content gate
2. Edit your content gate to use the "Paywall with One Tier and Metering" pattern (Patterns -> Newspack Memberships)
3. In a fresh session, visit a gated article and, without scrolling down, register through the header "Sign In"
4. Confirm the registration goes through with the `registration_method` metadata as `auth-form`
5. Reset your session and visit a gated article
6. Scroll down to the gate and register through the "Register for free" link
7. Confirm the registration goes through with `registration_method` metadata as `registration-block-content-gate`
8. Also confirm the GA events goes through with the following:
```json
{"name":"np_gate_interaction","action":"form_submission_received","action_type":"registration"}
```
```json
{"name":"np_gate_interaction","action":"form_submission_success","action_type":"registration"}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->