### PR TITLE
fix(ras-acc): re-add webpack wizard entrypoints

### DIFF
--- a/src/blocks/reader-registration/editor.scss
+++ b/src/blocks/reader-registration/editor.scss
@@ -1,5 +1,5 @@
 @use "./style";
-@use "../../reader-activation/auth";
+@use "../../reader-activation-auth/style.scss" as auth;
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .newspack-registration {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,6 +56,17 @@ const entry = {
 	admin: path.join( __dirname, 'src', 'admin', 'index.js' ),
 	'memberships-gate': path.join( __dirname, 'src', 'memberships-gate', 'gate.js' ),
 	'memberships-gate-metering': path.join( __dirname, 'src', 'memberships-gate', 'metering.js' ),
+
+	// Newspack wizard assets.
+	...wizardsScriptFiles,
+	blocks: path.join( __dirname, 'src', 'blocks', 'index.js' ),
+	'memberships-gate-editor': path.join( __dirname, 'src', 'memberships-gate', 'editor.js' ),
+	'memberships-gate-block-patterns': path.join(
+		__dirname,
+		'src',
+		'memberships-gate',
+		'block-patterns.js'
+	),
 	'newspack-ui': path.join( __dirname, 'src', 'newspack-ui', 'index.js' ),
 };
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue where the latest `trunk` merge omitted wizard scripts from webpack entrypoints which causes the wizards menu to break in wp admin.

### How to test the changes in this Pull Request:

1. With these changes checked out, confirm the wizards load in wpadmin.
2. Confirm reader registration editor block styles aren't broken

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->