### PR TITLE
fix(ras-acc): only trigger update_checkout event when cover fees option selected

### DIFF
--- a/src/other-scripts/wc-cover-fees/index.js
+++ b/src/other-scripts/wc-cover-fees/index.js
@@ -23,7 +23,9 @@
 		} );
 		// Trigger checkout update on payment method change so it updates the fee.
 		$( document ).on( 'payment_method_selected', function () {
-			$body.trigger( 'update_checkout', { update_shipping_method: false } );
+			if ( checked ) {
+				$body.trigger( 'update_checkout', { update_shipping_method: false } );
+			}
 		} );
 	} );
 } )( jQuery );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://github.com/Automattic/newspack-blocks/pull/1823/files for details.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-blocks/pull/1823/files for testing instructions.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->