### PR TITLE
fix(ras-acc): correct password reset email typo

### DIFF
--- a/includes/templates/reader-activation-emails/password-reset.php
+++ b/includes/templates/reader-activation-emails/password-reset.php
@@ -59,7 +59,7 @@ $post_content =
 
 	$social_links .
 
-	'<!-- wp:paragraph ==>
+	'<!-- wp:paragraph -->
 	<p class="has-small-font-size">' . sprintf( /* Translators: 1: site title 2: site base address. */ __( '%1$s - %2$s', 'newspack-plugin' ), '<strong>*SITE_TITLE*</strong>', '*SITE_ADDRESS*' ) . '<br>' . sprintf( /* Translators: 1: link to site url. */ __( 'You received this email because you requested to reset your password to %s', 'newspack-plugin' ), '<a href="*SITE_URL*">*SITE_URL*</a>' ) . '</p>
 	<!-- /wp:paragraph -->
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I randomly noticed this while testing https://github.com/Automattic/newspack-plugin/pull/3326: the Reset Password email editor copy has a minor typo, which causes an error.

### How to test the changes in this Pull Request:

1. On epic/ras-acc, navigate to Reader Activation > Advanced Settings.
2. Click "Reset" and then "Edit" for the "Set a New Password" email.
3. Note the block error:

![CleanShot 2024-08-09 at 17 27 14](https://github.com/user-attachments/assets/c6b6488b-b203-4688-a165-b8935a814d35)

4. Apply this PR, and run `npm run build`. 
5. Repeat step 2 and confirm the error is now gone:

![CleanShot 2024-08-09 at 17 26 16](https://github.com/user-attachments/assets/0dfa353c-ea86-4a91-aa3b-f5076dda37aa)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->