### PR TITLE
Feat/increase search authors limit

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -157,7 +157,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
-		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-co-authors-plus.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-guest-contributor-role.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce.php';
 

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -158,6 +158,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-guest-contributor-role.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-search-authors-limit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce.php';
 

--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Co_Authors_Plus integration class.
+ * Guest_Contributor_Role class.
  * https://wordpress.org/plugins/co-authors-plus
  *
  * @package Newspack
@@ -21,7 +21,7 @@ use WP_User;
  * This role can also be assigned to users who have other roles, so they can be assigned as co-authors of a post without having the capability to edit posts.
  * This is done via a custom UI in the user profile.
  */
-class Co_Authors_Plus {
+class Guest_Contributor_Role {
 	/**
 	 * Custom capability name.
 	 */
@@ -434,4 +434,4 @@ class Co_Authors_Plus {
 		return $value;
 	}
 }
-Co_Authors_Plus::init();
+Guest_Contributor_Role::init();

--- a/includes/plugins/co-authors-plus/class-search-authors-limit.php
+++ b/includes/plugins/co-authors-plus/class-search-authors-limit.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Search Authors limit class.
+ * https://wordpress.org/plugins/co-authors-plus
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class increases the number of results returned by the search authors query.
+ *
+ * In some cases, when you have too many authors starting with the same string, user is never able to find the author they are looking for.
+ *
+ * Also, because the search is performed using the terms table, even if we underpromote a user, they will still appear in the search results.
+ */
+class Search_Authors_Limit {
+
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_filter( 'coauthors_search_authors_get_terms_args', [ __CLASS__, 'search_args' ] );
+	}
+
+	/**
+	 * Increase the number of results returned by the search authors query.
+	 *
+	 * @param array $args The arguments for the get_terms query.
+	 * @return array The modified arguments.
+	 */
+	public static function search_args( $args ) {
+		$args['number'] = 100;
+		return $args;
+	}
+}
+
+Search_Authors_Limit::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Increases the number of returned authors to 100 when performing a search.

Sometimes when you have too many authors whose names start with the same string, users are never able to get the author they want.

Also, when there are some users who are not in use anymore, and are underpromoted to a non-author role, they still show up in the search results, because searches are performed in the terms table. So there is no way to clear the users list to remove unusued users that are polluting the results.

### How to test the changes in this Pull Request:

1. Add many users with containing the same piece of string
2. Search for an Author in the Editor -> add co authors panel. 
3. Confirm that you get more than 10 results (it should go up until a 100)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->