### PR TITLE
Fix/epic status if new

### DIFF
--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -92,7 +92,7 @@ class Mailchimp extends Connector {
 			$contact['metadata'] = [];
 		}
 
-		$contact['metadata']['status'] = self::get_default_reader_status();
+		$contact['metadata']['status_if_new'] = self::get_default_reader_status();
 
 		return \Newspack_Newsletters_Contacts::upsert( $contact, $audience_id, $context );
 	}

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -320,6 +320,10 @@ class Newspack_Newsletters {
 			if ( isset( $contact['metadata']['status'] ) ) {
 				$normalized_metadata['status'] = $contact['metadata']['status'];
 			}
+			if ( isset( $contact['metadata']['status_if_new'] ) ) {
+				$normalized_metadata['status_if_new'] = $contact['metadata']['status_if_new'];
+			}
+
 			$contact['metadata'] = $normalized_metadata;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Redoing https://github.com/Automattic/newspack-plugin/pull/3321 that was left behind in the epic merge

Fixes how mailchimp handles `status` and `status_if_new` on data events sync

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-newsletters/pull/1603

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->