### PR TITLE
feat: add phpcs sniff for newsletter methods

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -48,3 +48,4 @@ node_modules
 .cache
 codecov
 __mocks__
+phpcsSniffs

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,9 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-VIP-Go" />
 
+	<!-- Newspack Plugin rules -->
+	<rule ref="phpcsSniffs" />
+
 	<rule ref="WordPress">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />

--- a/phpcsSniffs/Sniffs/NewspackNewslettersMethodsSniff.php
+++ b/phpcsSniffs/Sniffs/NewspackNewslettersMethodsSniff.php
@@ -1,0 +1,126 @@
+<?php // phpcs:ignore WordPress.Files.FileName
+/**
+ * Newspack Newsletters Methods Sniff
+ *
+ * @package newspack-newsletters
+ */
+
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+/**
+ * Sniff for catching classes not marked as abstract or final
+ */
+class NewspackNewslettersMethodsSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * The error code.
+	 */
+	const ERROR_CODE = 'ForbiddenContactsMethods';
+
+	/**
+	 * The error message.
+	 */
+	const ERROR_MESSAGE = 'Method %s is reserved for internal use and should not be called from this scope. Use methods in Newspack_Newsletters_Contacts class instead to manipulate contacts.';
+
+	/**
+	 * The Warning code.
+	 */
+	const WARNING_CODE = 'PossibleForbiddenContactsMethods';
+
+	/**
+	 * The Warning message.
+	 */
+	const WARNING_MESSAGE = 'Possible forbidden Newsletters method detected. Method %s from the email provider classes is reserved for internal use and should not be called from this scope. Use methods in Newspack_Newsletters_Contacts class instead to manipulate contacts.';
+
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * @return array(int)
+	 */
+	public function register() {
+		return array( T_STRING );
+	}
+
+	/**
+	 * The methods we are looking for.
+	 *
+	 * These methods can only be called from the allowed classes or the service provider directory.
+	 *
+	 * @var array
+	 */
+	private $methods = [
+		'add_contact',
+		'add_esp_local_list_to_contact',
+		'remove_esp_local_list_from_contact',
+		'add_tag_to_contact',
+		'remove_tag_from_contact',
+		'update_contact_local_lists',
+		'update_contact_lists_handling_local',
+		'add_contact_handling_local_list',
+		'add_contact_with_groups_and_tags',
+		'update_contact_lists',
+		'add_contact',
+		'delete_user_subscription',
+		'update_contact_lists',
+	];
+
+	/**
+	 * The classes where forbidden static methods live.
+	 *
+	 * @var array
+	 */
+	private $static_classes = [
+		'Newspack_Newsletters_Subscription',
+	];
+
+	/**
+	 * The current class name.
+	 *
+	 * @var string
+	 */
+	private $current_class = '';
+
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * Will look for calls of the methods defined in $this->methods and check if they are called from the allowed classes.
+	 * They are also allowed to be called from within the service-providers directory.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcs_file The file where the token was found.
+	 * @param int                  $stack_ptr The position in the stack where the token was found.
+	 */
+	public function process( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
+
+		$tokens = $phpcs_file->getTokens();
+		$token = $tokens[ $stack_ptr ];
+
+		if ( in_array( $token['content'], $this->methods, true ) ) {
+			$operator = $tokens[ $stack_ptr - 1 ];
+
+			if ( $operator['type'] === 'T_DOUBLE_COLON' ) {
+
+
+				$class_name = $tokens[ $stack_ptr - 2 ]['content'];
+				if ( in_array( $class_name, $this->static_classes, true ) ) {
+
+					$method_name = $class_name . '::' . $token['content'] . '()';
+
+					$phpcs_file->addError(
+						sprintf( self::ERROR_MESSAGE, $method_name ),
+						$stack_ptr,
+						self::ERROR_CODE
+					);
+				}
+			} elseif ( $operator['type'] === 'T_OBJECT_OPERATOR' ) {
+
+				$method_name = $token['content'];
+
+				$phpcs_file->addWarning(
+					sprintf( self::WARNING_MESSAGE, $method_name ),
+					$stack_ptr,
+					self::WARNING_CODE
+				);
+			}
+		}
+	}
+}

--- a/phpcsSniffs/Sniffs/NewspackNewslettersMethodsSniff.php
+++ b/phpcsSniffs/Sniffs/NewspackNewslettersMethodsSniff.php
@@ -99,7 +99,6 @@ class NewspackNewslettersMethodsSniff implements PHP_CodeSniffer_Sniff {
 
 			if ( $operator['type'] === 'T_DOUBLE_COLON' ) {
 
-
 				$class_name = $tokens[ $stack_ptr - 2 ]['content'];
 				if ( in_array( $class_name, $this->static_classes, true ) ) {
 

--- a/phpcsSniffs/ruleset.xml
+++ b/phpcsSniffs/ruleset.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset name="Newspack">
+    <description>Add Newspack specific rules.</description>
+</ruleset>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Anywhere in the code add a call to `Newspack_Newsletters_Subscription::add_contact`
2. Run `./vendor/bin/phpcs` and confirm it gets caught as an error
3. Add a call to `$object->update_contact_local_lists('asd')` (or any other method listed in the sniffer)
4. Run `./vendor/bin/phpcs` and confirm it gets caught as a Warning
5. Are the messages looking ok?
6. Thoughts?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->