### PR TITLE
fix(ras-acc): respect transactional email social icons alignment

### DIFF
--- a/includes/util.php
+++ b/includes/util.php
@@ -563,7 +563,7 @@ function newspack_get_social_markup( $color = 'white' ) {
 	$cm          = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'wordpress_seo' );
 	$social_urls = [];
 	$markup      = [
-		'block_markup' => '<!-- wp:social-links {"iconColor":"primary-text","iconColorValue":"primary-text","className":"is-style-filled-primary-text","layout":{"type":"flex","flexWrap":"nowrap"}} --><ul class="wp-block-social-links has-icon-color is-style-filled-primary-text">',
+		'block_markup' => '<!-- wp:social-links {"iconColor":"primary-text","iconColorValue":"primary-text","className":"is-style-filled-primary-text","style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} --><ul class="wp-block-social-links has-icon-color is-style-filled-primary-text" style="padding-right:0;padding-left:0">',
 		'html_markup'  => '',
 	];
 

--- a/includes/util.php
+++ b/includes/util.php
@@ -560,10 +560,11 @@ function newspack_get_theme_colors() {
  * @return array An array containing block and html markup for social media services.
  */
 function newspack_get_social_markup( $color = 'white' ) {
-	$cm          = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'wordpress_seo' );
-	$social_urls = [];
-	$markup      = [
-		'block_markup' => '<!-- wp:social-links {"iconColor":"primary-text","iconColorValue":"primary-text","className":"is-style-filled-primary-text","style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} --><ul class="wp-block-social-links has-icon-color is-style-filled-primary-text" style="padding-right:0;padding-left:0">',
+	$cm               = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'wordpress_seo' );
+	$has_social_icons = false;
+	$social_urls      = [];
+	$markup           = [
+		'block_markup' => '<!-- wp:social-links {"iconColor":"primary-text","iconColorValue":"primary-text","className":"is-style-filled-primary-text","style":{"spacing":{"padding":{"right":"0","left":"4px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} --><ul class="wp-block-social-links has-icon-color is-style-filled-primary-text" style="padding-right:0;padding-left:4px">',
 		'html_markup'  => '',
 	];
 
@@ -584,11 +585,11 @@ function newspack_get_social_markup( $color = 'white' ) {
 				<table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
 					<tbody>
 						<tr class="social-element">
-							<td style="padding:4px;vertical-align:middle;">
+							<td style="padding:0;vertical-align:middle;">
 								<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:transparent;border-radius:999px;width:24px;">
 									<tbody>
 										<tr>
-											<td style="padding:7px;font-size:0;height:24px;vertical-align:middle;width:24px;">
+											<td style="padding:8px;padding-left:' . ( $has_social_icons ? '8px' : '0px' ) . ';font-size:0;height:24px;vertical-align:middle;width:24px;">
 												<a href="' . esc_url( $url ) . '" target="_blank"><img alt="" height="24" src="*SITE_URL*/wp-content/plugins/newspack-newsletters/assets/' . $color . '-' . $service . '.png" style="border-radius:999px;display:block;" width="24"></a>
 											</td>
 										</tr>
@@ -599,6 +600,7 @@ function newspack_get_social_markup( $color = 'white' ) {
 					</tbody>
 				</table>
 				<!--[if mso | IE]></td><td><![endif]-->';
+			$has_social_icons = true;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207990881852220/f

This PR fixes an issue where the alignment of the transactional email social icons did not line up with the rest of the email content. This PR addresses this by adding a left and right padding of 0 to the social icons:

![Screenshot 2024-08-14 at 14 58 26](https://github.com/user-attachments/assets/26ee56ae-0122-4961-a536-9dd2a833244c)


### How to test the changes in this Pull Request:

To test this PR, be sure to also check out the following newsletters PR first: https://github.com/Automattic/newspack-newsletters/pull/1615

1. Be sure you have Yoast installed and active and have some socials added via Newspack > SEO
2. Reset any of the transactional emails via Newspack > Engagement > Show Advanced Settings > Transactional Email Content
3. Select edit for the corresponding email template and confirm the alignment of the social icons as pictured above
4. Send a test email, or trigger the email as a reader and confirm the alignment in the actual email.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->