### PR TITLE
Make email template fetching deterministic

### DIFF
--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -418,6 +418,8 @@ class Emails {
 				'post_status'    => 'any',
 				'meta_key'       => self::EMAIL_CONFIG_NAME_META,
 				'meta_value'     => $type, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
 			]
 		);
 		if ( $emails_query->post ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue I ran into on a client site. Under high traffic, it is possible for multiple of the same email template to be created if there are multiple requests at the same time, and this creates a tricky mess to clean up because (under high traffic) if you delete one of the duplicate templates, there will be an open request that returned that template in the WP Query, but since that post doesn't exist any more, it will create a new template (or 2). It's hard to explain, but this PR solves this problem. 

### How to test the changes in this Pull Request:

1. Visit the Engagement screen and edit any of the email templates there. Observe it continues working nicely.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->