### PR TITLE
feat(ras-acc): handle checkout redirect params

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -450,8 +450,7 @@ final class Magic_Link {
 		if ( is_wp_error( $key ) ) {
 			return $key;
 		}
-
-		$url                = \add_query_arg(
+		$url = \add_query_arg(
 			[
 				'action' => self::AUTH_ACTION,
 				'email'  => urlencode( $user->user_email ),
@@ -469,7 +468,6 @@ final class Magic_Link {
 				'template' => '*SET_PASSWORD_LINK*',
 				'value'    => Emails::get_password_reset_url( $user, $key ),
 			],
-
 		];
 		if ( $use_otp && ! empty( $token_data['otp'] ) ) {
 			$email_type           = 'OTP_AUTH';
@@ -761,7 +759,7 @@ final class Magic_Link {
 
 		$redirect = \wp_validate_redirect(
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			\sanitize_text_field( \wp_unslash( $_GET['redirect'] ?? '' ) ),
+			\sanitize_url( \wp_unslash( $_GET['redirect'] ?? '' ) ),
 			\remove_query_arg( [ 'action', 'email', 'token' ] )
 		);
 

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -726,7 +726,7 @@ class Memberships {
 			window.newspackRAS = window.newspackRAS || [];
 			window.newspackRAS.push( function( ras ) {
 				ras.on( 'reader', function( ev ) {
-					if ( ev.detail.authenticated && ! window?.newspackReaderActivation?.getCheckoutStatus() ) {
+					if ( ev.detail.authenticated && ! window?.newspackReaderActivation?.isPendingCheckout() ) {
 						if ( ras.overlays.get().length ) {
 							ras.on( 'overlay', function( ev ) {
 								if ( ! ev.detail.overlays.length ) {

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1692,19 +1692,19 @@ final class Reader_Activation {
 
 		$action           = isset( $_POST['action'] ) ? \sanitize_text_field( $_POST['action'] ) : '';
 		$referer          = isset( $_POST['referer'] ) ? \sanitize_text_field( $_POST['referer'] ) : '';
+		$current_page_url = \wp_parse_url( \wp_get_raw_referer() ); // Referer is the current page URL because the form is submitted via AJAX.
 		$email            = isset( $_POST['npe'] ) ? \sanitize_email( $_POST['npe'] ) : '';
 		$password         = isset( $_POST['password'] ) ? \sanitize_text_field( $_POST['password'] ) : '';
 		$lists            = isset( $_POST['lists'] ) ? array_map( 'sanitize_text_field', $_POST['lists'] ) : [];
 		$honeypot         = isset( $_POST['email'] ) ? \sanitize_text_field( $_POST['email'] ) : '';
-		$redirect_url     = isset( $_POST['redirect_url'] ) ? \sanitize_text_field( $_POST['redirect_url'] ) : '';
-		$current_page_url = \wp_parse_url( \wp_get_raw_referer() ); // Referer is the current page URL because the form is submitted via AJAX.
+		$redirect_url     = isset( $_POST['redirect_url'] ) ? \esc_url_raw( $_POST['redirect_url'] ) : '';
 		// phpcs:enable
 
-		if ( ! $redirect_url ) {
-			if ( ! empty( $current_page_url['path'] ) ) {
-				$redirect_url = \esc_url( \home_url( $current_page_url['path'] ) );
-			}
+		if ( ! empty( $current_page_url['path'] ) ) {
+			$current_page_url = \esc_url( \home_url( $current_page_url['path'] ) );
 		}
+
+		$redirect = ! empty( $redirect_url ) ? $redirect_url : $current_page_url;
 
 		// Honeypot trap.
 		if ( ! empty( $honeypot ) ) {
@@ -1753,7 +1753,7 @@ final class Reader_Activation {
 					return self::send_auth_form_response( $payload, false );
 				}
 				if ( self::is_reader_without_password( $user ) ) {
-					$sent = Magic_Link::send_email( $user, $redirect_url );
+					$sent = Magic_Link::send_email( $user, $redirect );
 					if ( true !== $sent ) {
 						return self::send_auth_form_response( new \WP_Error( 'unauthorized', \is_wp_error( $sent ) ? $sent->get_error_message() : __( 'We encountered an error sending an authentication link. Please try again.', 'newspack-plugin' ) ) );
 					}
@@ -1775,7 +1775,7 @@ final class Reader_Activation {
 				$payload['authenticated'] = \is_wp_error( $authenticated ) ? 0 : 1;
 				return self::send_auth_form_response( $payload, false );
 			case 'link':
-				$sent = Magic_Link::send_email( $user, $redirect_url );
+				$sent = Magic_Link::send_email( $user, $redirect );
 				if ( true !== $sent ) {
 					return self::send_auth_form_response( new \WP_Error( 'unauthorized', \is_wp_error( $sent ) ? $sent->get_error_message() : __( 'We encountered an error sending an authentication link. Please try again.', 'newspack-plugin' ) ) );
 				}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1692,15 +1692,18 @@ final class Reader_Activation {
 
 		$action           = isset( $_POST['action'] ) ? \sanitize_text_field( $_POST['action'] ) : '';
 		$referer          = isset( $_POST['referer'] ) ? \sanitize_text_field( $_POST['referer'] ) : '';
-		$current_page_url = \wp_parse_url( \wp_get_raw_referer() ); // Referer is the current page URL because the form is submitted via AJAX.
 		$email            = isset( $_POST['npe'] ) ? \sanitize_email( $_POST['npe'] ) : '';
 		$password         = isset( $_POST['password'] ) ? \sanitize_text_field( $_POST['password'] ) : '';
 		$lists            = isset( $_POST['lists'] ) ? array_map( 'sanitize_text_field', $_POST['lists'] ) : [];
 		$honeypot         = isset( $_POST['email'] ) ? \sanitize_text_field( $_POST['email'] ) : '';
+		$redirect_url     = isset( $_POST['redirect_url'] ) ? \sanitize_text_field( $_POST['redirect_url'] ) : '';
+		$current_page_url = \wp_parse_url( \wp_get_raw_referer() ); // Referer is the current page URL because the form is submitted via AJAX.
 		// phpcs:enable
 
-		if ( ! empty( $current_page_url['path'] ) ) {
-			$current_page_url = \esc_url( \home_url( $current_page_url['path'] ) );
+		if ( ! $redirect_url ) {
+			if ( ! empty( $current_page_url['path'] ) ) {
+				$redirect_url = \esc_url( \home_url( $current_page_url['path'] ) );
+			}
 		}
 
 		// Honeypot trap.
@@ -1750,7 +1753,7 @@ final class Reader_Activation {
 					return self::send_auth_form_response( $payload, false );
 				}
 				if ( self::is_reader_without_password( $user ) ) {
-					$sent = Magic_Link::send_email( $user, $current_page_url );
+					$sent = Magic_Link::send_email( $user, $redirect_url );
 					if ( true !== $sent ) {
 						return self::send_auth_form_response( new \WP_Error( 'unauthorized', \is_wp_error( $sent ) ? $sent->get_error_message() : __( 'We encountered an error sending an authentication link. Please try again.', 'newspack-plugin' ) ) );
 					}
@@ -1772,7 +1775,7 @@ final class Reader_Activation {
 				$payload['authenticated'] = \is_wp_error( $authenticated ) ? 0 : 1;
 				return self::send_auth_form_response( $payload, false );
 			case 'link':
-				$sent = Magic_Link::send_email( $user, $current_page_url );
+				$sent = Magic_Link::send_email( $user, $redirect_url );
 				if ( true !== $sent ) {
 					return self::send_auth_form_response( new \WP_Error( 'unauthorized', \is_wp_error( $sent ) ? $sent->get_error_message() : __( 'We encountered an error sending an authentication link. Please try again.', 'newspack-plugin' ) ) );
 				}

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -98,9 +98,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 			container.setFormAction( 'signin' );
 
 			/**
-			 * Get the redirect URL.
+			 * Get the checkout redirect URL.
 			 */
-			const getRedirectUrl = () => {
+			const getCheckoutRedirectUrl = () => {
 				const checkoutType = readerActivation.getCheckoutData( 'type' );
 				if ( ! checkoutType ) {
 					return;
@@ -183,8 +183,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 						body.set( 'reader-activation-auth-form', 1 );
 						body.set( 'npe', emailInput.value );
 						body.set( 'action', 'link' );
-						if ( readerActivation.getCheckoutStatus() ) {
-							const redirectUrl = getRedirectUrl();
+						if ( readerActivation.isPendingCheckout() ) {
+							const redirectUrl = getCheckoutRedirectUrl();
 							if ( redirectUrl ) {
 								body.set( 'redirect_url', redirectUrl );
 							}
@@ -272,7 +272,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 					if (
 						container.authCallback &&
 						data?.registered &&
-						! readerActivation.getCheckoutStatus()
+						! readerActivation.isPendingCheckout()
 					) {
 						callback = ( authMessage, authData ) =>
 							openNewslettersSignupModal( {
@@ -414,8 +414,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 						if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 							return form.endLoginFlow( newspack_reader_activation_labels.invalid_email, 400 );
 						}
-						if ( readerActivation.getCheckoutStatus() ) {
-							const redirectUrl = getRedirectUrl();
+						if ( readerActivation.isPendingCheckout() ) {
+							const redirectUrl = getCheckoutRedirectUrl();
 							if ( redirectUrl ) {
 								body.set( 'redirect_url', redirectUrl );
 							}

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -384,12 +384,24 @@ window.newspackRAS.push( function ( readerActivation ) {
 						}
 						if ( readerActivation.getCheckoutStatus() ) {
 							const checkoutType = readerActivation.getCheckoutData( 'type' );
-							const buttonText = readerActivation.getCheckoutData( 'button_text' );
-							const redirectUrl = new URL( window.location.href );
-							redirectUrl.searchParams.set( 'modal_checkout', 1 );
-							redirectUrl.searchParams.set( 'type', checkoutType );
-							redirectUrl.searchParams.set( 'button_text', buttonText );
-							body.set( 'redirect_url', redirectUrl.href );
+							if ( checkoutType ) {
+								const redirectUrl = new URL( window.location.href );
+								redirectUrl.searchParams.set( 'newspack_modal_checkout', 1 );
+								redirectUrl.searchParams.set( 'type', checkoutType );
+								// Add checkout button params.
+								if ( checkoutType === 'checkout_button' ) {
+									redirectUrl.searchParams.set( 'product_id', readerActivation.getCheckoutData( 'productId' ) );
+									redirectUrl.searchParams.set( 'variation_id', readerActivation.getCheckoutData( 'variationId' ) );
+								}
+								// Add donate params.
+								if ( checkoutType === 'donate' ) {
+									redirectUrl.searchParams.set( 'layout', readerActivation.getCheckoutData( 'layout' ) );
+									redirectUrl.searchParams.set( 'frequency', readerActivation.getCheckoutData( 'frequency' ) );
+									redirectUrl.searchParams.set( 'amount', readerActivation.getCheckoutData( 'amount' ) );
+									redirectUrl.searchParams.set( 'other', readerActivation.getCheckoutData( 'other' ) );
+								}
+								body.set( 'redirect_url', redirectUrl.href );
+							}
 						}
 						if ( 'otp' === action ) {
 							readerActivation

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -4,6 +4,7 @@
  * Internal dependencies.
  */
 import { domReady, formatTime } from '../utils';
+import { getCheckoutRedirectUrl } from '../reader-activation/checkout';
 import { openNewslettersSignupModal } from '../reader-activation-newsletters/newsletters-modal';
 
 import './google-oauth';
@@ -96,32 +97,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 				}
 			};
 			container.setFormAction( 'signin' );
-
-			/**
-			 * Get the checkout redirect URL.
-			 */
-			const getCheckoutRedirectUrl = () => {
-				const checkoutType = readerActivation.getCheckoutData( 'type' );
-				if ( ! checkoutType ) {
-					return;
-				}
-				const redirectUrl = new URL( window.location.href );
-				redirectUrl.searchParams.set( 'newspack_modal_checkout', 1 );
-				redirectUrl.searchParams.set( 'type', checkoutType );
-				// Add checkout button params.
-				if ( checkoutType === 'checkout_button' ) {
-					redirectUrl.searchParams.set( 'product_id', readerActivation.getCheckoutData( 'product_id' ) ?? '' );
-					redirectUrl.searchParams.set( 'variation_id', readerActivation.getCheckoutData( 'variation_id' ) ?? '' );
-				}
-				// Add donate params.
-				if ( checkoutType === 'donate' ) {
-					redirectUrl.searchParams.set( 'layout', readerActivation.getCheckoutData( 'layout' ) ?? '' );
-					redirectUrl.searchParams.set( 'frequency', readerActivation.getCheckoutData( 'frequency' ?? '' ) );
-					redirectUrl.searchParams.set( 'amount', readerActivation.getCheckoutData( 'amount' ) ?? '' );
-					redirectUrl.searchParams.set( 'other', readerActivation.getCheckoutData( 'other' ) ?? '' );
-				}
-				return redirectUrl.href;
-			}
 
 			/**
 			 * Handle reader changes.

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -382,6 +382,15 @@ window.newspackRAS.push( function ( readerActivation ) {
 						if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 							return form.endLoginFlow( newspack_reader_activation_labels.invalid_email, 400 );
 						}
+						if ( readerActivation.getCheckoutStatus() ) {
+							const checkoutType = readerActivation.getCheckoutData( 'type' );
+							const buttonText = readerActivation.getCheckoutData( 'button_text' );
+							const redirectUrl = new URL( window.location.href );
+							redirectUrl.searchParams.set( 'modal_checkout', 1 );
+							redirectUrl.searchParams.set( 'type', checkoutType );
+							redirectUrl.searchParams.set( 'button_text', buttonText );
+							body.set( 'redirect_url', redirectUrl.href );
+						}
 						if ( 'otp' === action ) {
 							readerActivation
 								.authenticateOTP( body.get( 'otp_code' ) )

--- a/src/reader-activation/checkout.js
+++ b/src/reader-activation/checkout.js
@@ -1,0 +1,60 @@
+import { EVENTS, emit } from './events.js';
+
+import { getReader } from './index.js';
+import Store from './store.js';
+
+/**
+ * Reader Activation Library.
+ */
+export const store = Store();
+
+/**
+ * Get the current checkout.
+ *
+ * @return {Object} Checkout data.
+ */
+export function getCheckout() {
+	return store.get( 'checkout' ) || {};
+}
+
+/**
+ * Set the current checkout data.
+ *
+ * @param {Object} data Checkout data. Optional.
+ *                      If empty or not provided, the checkout data will be cleared.
+ */
+export function setCheckoutData( data = {} ) {
+	store.set( 'checkout', data, false );
+	emit( EVENTS.reader, getReader() );
+}
+
+/**
+ * Get the reader checkout data.
+ *
+ * @param {string} key Checkout data key. Optional.
+ *
+ * @return {any} Reader checkout data.
+ */
+export function getCheckoutData( key ) {
+	const checkout = getCheckout();
+	if ( ! key ) {
+		return checkout;
+	}
+	return checkout?.[ key ];
+}
+
+/**
+ * Whether checkout is pending.
+ *
+ * @return {boolean} Whether checkout is pending.
+ */
+export function isPendingCheckout() {
+	return getCheckoutData( 'is_pending_checkout' );
+}
+
+/**
+ * Reset the reader checkout data.
+ */
+export function resetCheckoutData() {
+	setCheckoutData();
+}

--- a/src/reader-activation/checkout.js
+++ b/src/reader-activation/checkout.js
@@ -58,3 +58,32 @@ export function isPendingCheckout() {
 export function resetCheckoutData() {
 	setCheckoutData();
 }
+
+/**
+ * Get a checkout redirect URL.
+ *
+ * @return {string} A checkout redirect URL if checkout data is present.
+ *                  Otherwise, an empty string
+ */
+export function getCheckoutRedirectUrl() {
+	const checkoutType = getCheckoutData( 'type' );
+	if ( ! checkoutType ) {
+		return '';
+	}
+	const redirectUrl = new URL( window.location.href );
+	redirectUrl.searchParams.set( 'newspack_modal_checkout', 1 );
+	redirectUrl.searchParams.set( 'type', checkoutType );
+	// Add checkout button params.
+	if ( checkoutType === 'checkout_button' ) {
+		redirectUrl.searchParams.set( 'product_id', getCheckoutData( 'product_id' ) ?? '' );
+		redirectUrl.searchParams.set( 'variation_id', getCheckoutData( 'variation_id' ) ?? '' );
+	}
+	// Add donate params.
+	if ( checkoutType === 'donate' ) {
+		redirectUrl.searchParams.set( 'layout', getCheckoutData( 'layout' ) ?? '' );
+		redirectUrl.searchParams.set( 'frequency', getCheckoutData( 'frequency' ?? '' ) );
+		redirectUrl.searchParams.set( 'amount', getCheckoutData( 'amount' ) ?? '' );
+		redirectUrl.searchParams.set( 'other', getCheckoutData( 'other' ) ?? '' );
+	}
+	return redirectUrl.href;
+}

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -328,26 +328,6 @@ export function getAuthStrategy() {
 	}
 	return getCookie( 'np_auth_strategy' );
 }
-/**
- * Set the reader checkout status.
- *
- * @param {boolean} status Checkout status. Default is false.
- *
- * @return {void}
- */
-export function setCheckoutStatus( status = false ) {
-	setCookie( 'np_auth_checkout_status', status );
-	emit( EVENTS.reader, getReader() );
-	return status;
-}
-/**
- * Get the reader checkout status.
- *
- * @return {boolean} Reader checkout status.
- */
-export function getCheckoutStatus() {
-	return 'true' === getCookie( 'np_auth_checkout_status' );
-}
 
 /**
  * Ensure the client ID cookie is set.
@@ -424,6 +404,71 @@ function attachNewsletterFormListener() {
 	} );
 }
 
+
+/**
+ * Checkout functions.
+ */
+
+/**
+ * Get the current checkout.
+ *
+ * @return {Object} Checkout data.
+ */
+export function getCheckout() {
+	return store.get( 'checkout' ) || {};
+}
+
+/**
+ * Set the current checkout data.
+ *
+ * @param {Object} data Optiona. Checkout data.
+ *                      If empty or not provided, the checkout data will be cleared.
+ */
+export function setCheckoutData( data = {} ) {
+	const checkout = getCheckout();
+	const update = Object.keys( data ).length ? { ...checkout, ...data } : data;
+	store.set( 'checkout', update, false );
+	emit( EVENTS.reader, getReader() );
+}
+
+/**
+ * Set the reader checkout status.
+ *
+ * @param {boolean} status Optional. Checkout status. Default is false.
+ */
+export function setCheckoutStatus( status = false ) {
+	setCheckoutData( { status } );
+}
+
+/**
+ * Get the reader checkout data.
+ * @param {string} key Checkout data key. Optional.
+ *
+ * @return {any} Reader checkout data.
+ */
+export function getCheckoutData( key ) {
+	const checkout = getCheckout();
+	if ( ! key ) {
+		return checkout;
+	}
+	return checkout?.[ key ];
+}
+
+/**
+ * Get the reader checkout status.
+ * @return {boolean} Reader checkout status.
+ */
+export function getCheckoutStatus() {
+	return getCheckoutData( 'status' );
+}
+
+/**
+ * Reset the reader checkout data.
+ */
+export function resetCheckoutData() {
+	setCheckoutData();
+}
+
 const readerActivation = {
 	store,
 	overlays,
@@ -446,8 +491,11 @@ const readerActivation = {
 	authenticateOTP,
 	setAuthStrategy,
 	getAuthStrategy,
+	setCheckoutData,
 	setCheckoutStatus,
+	getCheckoutData,
 	getCheckoutStatus,
+	resetCheckoutData,
 	getCaptchaV3Token: window.newspack_grecaptcha
 		? window.newspack_grecaptcha?.getCaptchaV3Token
 		: () => new Promise( res => res( '' ) ), // Empty promise.

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -425,19 +425,8 @@ export function getCheckout() {
  *                      If empty or not provided, the checkout data will be cleared.
  */
 export function setCheckoutData( data = {} ) {
-	const checkout = getCheckout();
-	const update = Object.keys( data ).length ? { ...checkout, ...data } : data;
-	store.set( 'checkout', update, false );
+	store.set( 'checkout', data, false );
 	emit( EVENTS.reader, getReader() );
-}
-
-/**
- * Set the reader checkout status.
- *
- * @param {boolean} status Optional. Checkout status. Default is false.
- */
-export function setCheckoutStatus( status = false ) {
-	setCheckoutData( { status } );
 }
 
 /**
@@ -492,7 +481,6 @@ const readerActivation = {
 	setAuthStrategy,
 	getAuthStrategy,
 	setCheckoutData,
-	setCheckoutStatus,
 	getCheckoutData,
 	getCheckoutStatus,
 	resetCheckoutData,

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -3,6 +3,7 @@
 window.newspack_ras_config = window.newspack_ras_config || {};
 
 import Store from './store.js';
+import { isPendingCheckout, setCheckoutData, getCheckoutData, resetCheckoutData } from './checkout.js';
 import { EVENTS, on, off, emit } from './events.js';
 import { getCookie, setCookie, generateID } from './utils.js';
 import overlays from './overlays.js';
@@ -404,60 +405,6 @@ function attachNewsletterFormListener() {
 	} );
 }
 
-
-/**
- * Checkout functions.
- */
-
-/**
- * Get the current checkout.
- *
- * @return {Object} Checkout data.
- */
-export function getCheckout() {
-	return store.get( 'checkout' ) || {};
-}
-
-/**
- * Set the current checkout data.
- *
- * @param {Object} data Optiona. Checkout data.
- *                      If empty or not provided, the checkout data will be cleared.
- */
-export function setCheckoutData( data = {} ) {
-	store.set( 'checkout', data, false );
-	emit( EVENTS.reader, getReader() );
-}
-
-/**
- * Get the reader checkout data.
- * @param {string} key Checkout data key. Optional.
- *
- * @return {any} Reader checkout data.
- */
-export function getCheckoutData( key ) {
-	const checkout = getCheckout();
-	if ( ! key ) {
-		return checkout;
-	}
-	return checkout?.[ key ];
-}
-
-/**
- * Get the reader checkout status.
- * @return {boolean} Reader checkout status.
- */
-export function getCheckoutStatus() {
-	return getCheckoutData( 'status' );
-}
-
-/**
- * Reset the reader checkout data.
- */
-export function resetCheckoutData() {
-	setCheckoutData();
-}
-
 const readerActivation = {
 	store,
 	overlays,
@@ -482,7 +429,7 @@ const readerActivation = {
 	getAuthStrategy,
 	setCheckoutData,
 	getCheckoutData,
-	getCheckoutStatus,
+	isPendingCheckout,
 	resetCheckoutData,
 	getCaptchaV3Token: window.newspack_grecaptcha
 		? window.newspack_grecaptcha?.getCaptchaV3Token


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207817176293828/f

This PR updates the magic link redirect url when auth is triggered during the checkout process. We do this so the blocks plugin can handle the magic link by opening into modal checkout.

### How to test the changes in this Pull Request:

Make sure to also checkout the changes in this Blocks PR before testing: https://github.com/Automattic/newspack-blocks/pull/1841

1. On one or more test page or post, set up the following:
  - A donate block
  - A checkout button block for a simple product
  - A checkout button block for a variable product, allowing the reader to choose variation
  - A checkout button block for a variable product, with a preset variation
  - A checkout button block for a simple subscription
  - A checkout button block for a variable subscription
![Screenshot 2024-08-19 at 16 45 15](https://github.com/user-attachments/assets/ec63b6b6-d5ae-4fc6-9004-c8e57fecf894)
2. As a logged out reader, visit the page and for each do the following:
  - Select the block to trigger modal checkout
  - When the auth modal appears, if otp isn't default, choose to receive an otp code via email
  - Check the email, but do not copy and use the OTP code. Instead click the magic link (or button) in the email
  - Confirm a new browser tab opens up to the test page and the checkout modal automatically opens to the same product choice:
![Screenshot 2024-08-19 at 16 48 00](https://github.com/user-attachments/assets/da002893-4178-49cc-a55f-ebbc1ec96431)
  - Either complete checkout or close the modal
  - Go to my account and log out
3. As admin, set the donation block layout to the other layout that was not yet tested (either frequency or tiered) and again, repeat the above test steps.
4. Finally, via Newspack > Reader Revenue > Donations, set the main donations page donation block to untiered
5. Visit the donations page as a logged out reader, and again repeat the test steps above

BONUS: Smoke test both modal checkout while logged in and the standalone auth form while logged out to make sure there are no regressions.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->