### PR TITLE
feat(ga): disable tracking for editors regardless of RA status

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -34,11 +34,8 @@ class GoogleSiteKit {
 	 * @param array $googlesitekit_analytics_settings GA settings.
 	 */
 	public static function filter_ga_settings( $googlesitekit_analytics_settings ) {
-		if ( Reader_Activation::is_enabled() ) {
-			// If RA is enabled, readers will become logged in users. They should still be tracked in GA.
-			if ( in_array( 'loggedinUsers', $googlesitekit_analytics_settings['trackingDisabled'] ) ) {
-				$googlesitekit_analytics_settings['trackingDisabled'] = [ 'contentCreators' ];
-			}
+		if ( in_array( 'loggedinUsers', $googlesitekit_analytics_settings['trackingDisabled'] ) ) {
+			$googlesitekit_analytics_settings['trackingDisabled'] = [ 'contentCreators' ];
 		}
 		return $googlesitekit_analytics_settings;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes the Reader Activation check when overriding Site Kit's tracking-disabled condition. With this change, tracking will be enabled for _all users except editors_ (as opposed to being disabled for _all logged-in users_).

#### Rationale

Regardless of Reader Activation status, sites might offer log-in for readers. These reader should be tracked in GA just like anonymous visitors. This change is based on the assumption that on a Newspack site, a logged-in users who can't edit post is a reader. 

### How to test the changes in this Pull Request:

1. Deactivate Reader Activation and visit Site Kit -> Settings -> Analytics view
1. Observe that the "Excluded from Analytics" setting is set to "Users that can write posts"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207899141354695