### PR TITLE
fix: improve compatibility with Members plugin

### DIFF
--- a/includes/plugins/class-co-authors-plus.php
+++ b/includes/plugins/class-co-authors-plus.php
@@ -70,9 +70,9 @@ class Co_Authors_Plus {
 		\add_filter( 'allow_password_reset', [ __CLASS__, 'disable_feature' ], 10, 2 );
 		\add_filter( 'woocommerce_current_user_can_edit_customer_meta_fields', [ __CLASS__, 'disable_feature' ], 10, 2 );
 
-		// Add UI to the user profile to assign the custom role.
+		// Members plugin is active, and it has its own UI for roles.
 		if ( ! class_exists( 'Members_Plugin' ) ) {
-			// Members plugin is active, and it has its own UI for roles.
+			// Add UI to the user profile to assign the custom role.
 			add_action( 'edit_user_profile', [ __CLASS__, 'edit_user_profile' ] );
 			add_action( 'wp_update_user', [ __CLASS__, 'edit_user_profile_update' ] );
 		}

--- a/includes/plugins/class-co-authors-plus.php
+++ b/includes/plugins/class-co-authors-plus.php
@@ -70,7 +70,7 @@ class Co_Authors_Plus {
 		\add_filter( 'allow_password_reset', [ __CLASS__, 'disable_feature' ], 10, 2 );
 		\add_filter( 'woocommerce_current_user_can_edit_customer_meta_fields', [ __CLASS__, 'disable_feature' ], 10, 2 );
 
-		// Members plugin is active, and it has its own UI for roles.
+		// Only if Members plugin is not active, because it has its own UI for roles.
 		if ( ! class_exists( 'Members_Plugin' ) ) {
 			// Add UI to the user profile to assign the custom role.
 			add_action( 'edit_user_profile', [ __CLASS__, 'edit_user_profile' ] );

--- a/includes/plugins/class-co-authors-plus.php
+++ b/includes/plugins/class-co-authors-plus.php
@@ -71,8 +71,11 @@ class Co_Authors_Plus {
 		\add_filter( 'woocommerce_current_user_can_edit_customer_meta_fields', [ __CLASS__, 'disable_feature' ], 10, 2 );
 
 		// Add UI to the user profile to assign the custom role.
-		add_action( 'edit_user_profile', [ __CLASS__, 'edit_user_profile' ] );
-		add_action( 'wp_update_user', [ __CLASS__, 'edit_user_profile_update' ] );
+		if ( ! class_exists( 'Members_Plugin' ) ) {
+			// Members plugin is active, and it has its own UI for roles.
+			add_action( 'edit_user_profile', [ __CLASS__, 'edit_user_profile' ] );
+			add_action( 'wp_update_user', [ __CLASS__, 'edit_user_profile_update' ] );
+		}
 	}
 
 	/**

--- a/includes/plugins/class-co-authors-plus.php
+++ b/includes/plugins/class-co-authors-plus.php
@@ -95,7 +95,7 @@ class Co_Authors_Plus {
 	 * @return bool
 	 */
 	private static function is_guest_author( WP_User $user ) {
-		return 1 === count( $user->roles ) && self::CONTRIBUTOR_NO_EDIT_ROLE_NAME === array_shift( $user->roles );
+		return 1 === count( $user->roles ) && self::CONTRIBUTOR_NO_EDIT_ROLE_NAME === current( $user->roles );
 	}
 
 	/**
@@ -186,7 +186,7 @@ class Co_Authors_Plus {
 		 */
 	public static function user_profile_update_errors( $errors, $update, $user ) {
 
-		if ( self::CONTRIBUTOR_NO_EDIT_ROLE_NAME !== $user->role ) {
+		if ( ! isset( $user->role ) || self::CONTRIBUTOR_NO_EDIT_ROLE_NAME !== $user->role ) {
 			return $errors;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a few compatibility issues with the "Members" plugin

### How to test the changes in this Pull Request:

1. Install members plugin `wp plugin install members --activate`
2. on `release`, edit a user and try to change its role
3. Confirm you see some issues with the role selector, sometimes it erases the selection after save, even though the user is correctly assigned to the role
4. Checkout this branch and confirm things get back to normal


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->