### PR TITLE
fix(guest-author): enqueue the guest author admin script selectively

### DIFF
--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -246,6 +246,9 @@ class Guest_Contributor_Role {
 	 */
 	public static function admin_footer() {
 		global $pagenow;
+		if ( ! in_array( $pagenow, [ 'user-edit.php','user-new.php' ] ) ) {
+			return;
+		}
 		\wp_enqueue_script(
 			'newspack-co-authors-plus',
 			Newspack::plugin_url() . '/dist/other-scripts/co-authors-plus.js',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The guest author script (#3277) should only be enqueued where applicable.

### How to test the changes in this Pull Request:

1. On `trunk`, observe the `newspack-plugin/dist/other-scripts/co-authors-plus.js` JS script is loaded for any admin request (e.g. editor) 
2. Switch to this branch, observe it's not anymore
3. Add or edit a user - observe the script is included there

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->