### PR TITLE
fix(esp-meta): handle state of the 'Woo Team' meta

### DIFF
--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -183,6 +183,23 @@ class Newspack_Newsletters {
 	}
 
 	/**
+	 * Get enabled fields which match provided keys.
+	 * Will return key-value pairs of enabled fields which match the keys provided.
+	 *
+	 * @param string[] $keys Array of keys to match.
+	 */
+	public static function get_applicable_fields( $keys ) {
+		$enabled_fields = self::get_metadata_fields();
+		return array_filter(
+			self::get_metadata_keys(),
+			function( $val, $key ) use ( $keys, $enabled_fields ) {
+				return in_array( $key, $keys ) && in_array( $val, $enabled_fields );
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+	}
+
+	/**
 	 * Update the list of fields to be synced to the connected ESP.
 	 *
 	 * @param array $fields List of fields to sync.

--- a/includes/plugins/class-newspack-newsletters.php
+++ b/includes/plugins/class-newspack-newsletters.php
@@ -188,7 +188,7 @@ class Newspack_Newsletters {
 	 *
 	 * @param string[] $keys Array of keys to match.
 	 */
-	public static function get_applicable_fields( $keys ) {
+	public static function filter_enabled_fields( $keys ) {
 		$enabled_fields = self::get_metadata_fields();
 		return array_filter(
 			self::get_metadata_keys(),

--- a/includes/plugins/class-teams-for-memberships.php
+++ b/includes/plugins/class-teams-for-memberships.php
@@ -14,8 +14,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class Teams_For_Memberships {
 
-	const METADATA_FIELD_LABEL = 'Woo Team';
-
 	/**
 	 * Initialize hooks and filters.
 	 */
@@ -41,7 +39,7 @@ class Teams_For_Memberships {
 	 */
 	public static function add_teams_metadata_keys( $metadata_keys ) {
 		if ( self::is_enabled() ) {
-			$metadata_keys['woo_team'] = self::METADATA_FIELD_LABEL;
+			$metadata_keys['woo_team'] = 'Woo Team';
 		}
 		return $metadata_keys;
 	}
@@ -57,8 +55,8 @@ class Teams_For_Memberships {
 			return $contact;
 		}
 
-		$enabled_fields = Newspack_Newsletters::get_metadata_fields();
-		if ( ! in_array( self::METADATA_FIELD_LABEL, $enabled_fields ) ) {
+		$applicable_fields = Newspack_Newsletters::get_applicable_fields( [ 'woo_team' ] );
+		if ( count( $applicable_fields ) === 0 ) {
 			return $contact;
 		}
 

--- a/includes/plugins/class-teams-for-memberships.php
+++ b/includes/plugins/class-teams-for-memberships.php
@@ -55,8 +55,8 @@ class Teams_For_Memberships {
 			return $contact;
 		}
 
-		$applicable_fields = Newspack_Newsletters::get_applicable_fields( [ 'woo_team' ] );
-		if ( count( $applicable_fields ) === 0 ) {
+		$filtered_enabled_fields = Newspack_Newsletters::filter_enabled_fields( [ 'woo_team' ] );
+		if ( count( $filtered_enabled_fields ) === 0 ) {
 			return $contact;
 		}
 

--- a/includes/plugins/class-teams-for-memberships.php
+++ b/includes/plugins/class-teams-for-memberships.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class Teams_For_Memberships {
 
+	const METADATA_FIELD_LABEL = 'Woo Team';
+
 	/**
 	 * Initialize hooks and filters.
 	 */
@@ -39,7 +41,7 @@ class Teams_For_Memberships {
 	 */
 	public static function add_teams_metadata_keys( $metadata_keys ) {
 		if ( self::is_enabled() ) {
-			$metadata_keys['woo_team'] = 'Woo Team';
+			$metadata_keys['woo_team'] = self::METADATA_FIELD_LABEL;
 		}
 		return $metadata_keys;
 	}
@@ -52,6 +54,11 @@ class Teams_For_Memberships {
 	 */
 	public static function normalize_contact( $contact ) {
 		if ( ! self::is_enabled() ) {
+			return $contact;
+		}
+
+		$enabled_fields = Newspack_Newsletters::get_metadata_fields();
+		if ( ! in_array( self::METADATA_FIELD_LABEL, $enabled_fields ) ) {
 			return $contact;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small issue with #3325.

### How to test the changes in this Pull Request:

1. On `trunk`, activate the Teams for Memberships plugin
2. In the Engagement wizard, ensure the "Woo Team" meta field is **deselected**
3. Add a user to a team, then log in as them and make a donation
4. Observe that the synced contact in the ESP has the "NP_Woo Team" field value set
5. Switch to this branch, repeat step 3 & 4 
6. Observe the ESP contact has the field value not set
7. Enable the field in the Engagement wizard and re-test – observe the field is now set

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->