### PR TITLE
feat(memberships): add memberships-related body classes

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -59,6 +59,7 @@ class Memberships {
 		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
 		add_filter( 'get_post_status', [ __CLASS__, 'check_membership_status' ], 10, 2 );
 		add_action( 'wp', [ __CLASS__, 'remove_unnecessary_content_restriction' ], 11 );
+		add_filter( 'body_class', [ __CLASS__, 'add_body_class' ] );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -1120,6 +1121,32 @@ class Memberships {
 		return array_slice( $settings, 0, $position_of_show_excerpts_setting, true ) +
 			[ $setting['id'] => $setting ] +
 			array_slice( $settings, $position_of_show_excerpts_setting, null, true );
+	}
+
+	/**
+	 * Add relevant body CSS classnames.
+	 *
+	 * @param array $classes Array of body class names.
+	 */
+	public static function add_body_class( $classes ) {
+		// If a user has a paid membership, add a body class.
+		if ( ! function_exists( 'wc_memberships_get_user_active_memberships' ) ) {
+			return $classes;
+		}
+
+		$user_active_memberships = \wc_memberships_get_user_active_memberships();
+		foreach ( $user_active_memberships as $membership ) {
+			$plan = $membership->plan;
+			if ( $plan ) {
+				$plan_products = $membership->get_plan()->get_product_ids();
+				$classes[] = 'is-member-' . $plan->slug;
+				$paid_plan_classname = 'is-paid-plan-member';
+				if ( ! empty( $plan_products ) && ! in_array( $paid_plan_classname, $classes ) ) {
+					$classes[] = $paid_plan_classname;
+				}
+			}
+		}
+		return $classes;
 	}
 }
 Memberships::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds appending membership-related body classes. This will enable publishers to e.g. hide a "become a member" button for paying members.

### How to test the changes in this Pull Request:

1. Add an unpaid (unlinked to a product purchase) membership to a user
2. Log in as the user, observe the body has a `is-member-<plan-slug>` classname
3. Add a paid membership to the user
4. Observe that for this user, body has a second `is-member-<plan-slug>` classname, and a `is-paid-plan-member` classname

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207261739214821