### PR TITLE
feat(ras): helper method for ESP master list

### DIFF
--- a/includes/data-events/connectors/class-activecampaign.php
+++ b/includes/data-events/connectors/class-activecampaign.php
@@ -55,7 +55,7 @@ class ActiveCampaign extends Connector {
 	 * @param string $context Context of the update for logging purposes.
 	 */
 	protected static function put( $contact, $context ) {
-		$master_list_id = Reader_Activation::get_setting( 'active_campaign_master_list' );
+		$master_list_id = Reader_Activation::get_esp_master_list_id( 'active_campaign' );
 		if ( ! $master_list_id ) {
 			return;
 		}

--- a/includes/data-events/connectors/class-mailchimp.php
+++ b/includes/data-events/connectors/class-mailchimp.php
@@ -48,20 +48,6 @@ class Mailchimp extends Connector {
 	}
 
 	/**
-	 * Get audience ID.
-	 *
-	 * @return string|bool Audience ID or false if not set.
-	 */
-	private static function get_audience_id() {
-		$audience_id = Reader_Activation::get_setting( 'mailchimp_audience_id' );
-		/** Attempt to use list ID from "Mailchimp for WooCommerce" */
-		if ( ! $audience_id && function_exists( 'mailchimp_get_list_id' ) ) {
-			$audience_id = \mailchimp_get_list_id();
-		}
-		return ! empty( $audience_id ) ? $audience_id : false;
-	}
-
-	/**
 	 * Get default reader MailChimp status.
 	 *
 	 * @return string MailChimp status slug, 'transactional' or 'subscriber'. (Default: 'transactional').
@@ -83,7 +69,7 @@ class Mailchimp extends Connector {
 	 * @return array|WP_Error response body or error.
 	 */
 	protected static function put( $contact, $context ) {
-		$audience_id = self::get_audience_id();
+		$audience_id = Reader_Activation::get_esp_master_list_id( 'mailchimp' );
 		if ( ! $audience_id ) {
 			return;
 		}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -324,7 +324,7 @@ final class Reader_Activation {
 	 *
 	 * @param string $provider Optional ESP provider. Defaults to the configured ESP.
 	 *
-	 * @return string|bool Master list ID or false if not set or not available
+	 * @return string|bool Master list ID or false if not set or not available.
 	 */
 	public static function get_esp_master_list_id( $provider = '' ) {
 		if ( ! self::is_esp_configured() ) {
@@ -342,7 +342,7 @@ final class Reader_Activation {
 				if ( ! $audience_id && function_exists( 'mailchimp_get_list_id' ) ) {
 					$audience_id = \mailchimp_get_list_id();
 				}
-				return $audience_id;
+				return ! empty( $audience_id ) ? $audience_id : false;
 			default:
 				return false;
 		}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -320,6 +320,35 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Get the master list ID for the ESP.
+	 *
+	 * @param string $provider Optional ESP provider. Defaults to the configured ESP.
+	 *
+	 * @return string|bool Master list ID or false if not set or not available
+	 */
+	public static function get_esp_master_list_id( $provider = '' ) {
+		if ( ! self::is_esp_configured() ) {
+			return false;
+		}
+		if ( empty( $provider ) ) {
+			$provider = \Newspack_Newsletters::service_provider();
+		}
+		switch ( $provider ) {
+			case 'active_campaign':
+				return self::get_setting( 'active_campaign_master_list' );
+			case 'mailchimp':
+				$audience_id = self::get_setting( 'mailchimp_audience_id' );
+				/** Attempt to use list ID from "Mailchimp for WooCommerce" */
+				if ( ! $audience_id && function_exists( 'mailchimp_get_list_id' ) ) {
+					$audience_id = \mailchimp_get_list_id();
+				}
+				return $audience_id;
+			default:
+				return false;
+		}
+	}
+
+	/**
 	 * Get the newsletter lists that should be rendered during registration.
 	 *
 	 * @return array


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements a new helper method to get the master list ID for any provider.

### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have Mailchimp as your ESP
2. Donate using a reader account
3. Confirm the data is synced to the ESP using the selected audience ID
4. Switch to ActiveCampaign and repeat steps 2 and 3

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->