### PR TITLE
fix(ras-acc): correct linting error

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1475,7 +1475,7 @@ final class Reader_Activation {
 			return new \WP_Error( 'no_lists_selected', __( 'No lists selected.', 'newspack-plugin' ) );
 		}
 
-		$result = \Newspack_Newsletters_Subscription::add_contact(
+		$result = \Newspack_Newsletters_Contacts::subscribe(
 			[
 				'email'    => $email_address,
 				'metadata' => [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a linting error that came from merging trunk into epic/ras-acc, related to https://github.com/Automattic/newspack-plugin/pull/3337 being added to this branch.

It's a straightforward change, but I ran into errors until I ran `composer dump-autoload` and reinstalled composer, so I want to make sure it's not just working now due to weird luck 😅 

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Possibly run `composer dump-autoload && rm -r vendor && composer install` (but feel free to skip this step and see how things go).
3. Make sure the Newsletter coda is enabled after checkout under Newspack > Engagement > Reader Activation > Advanced Settings.
4. In an incognito window, run a checkout (donation block or checkout button block), and opt to sign up for a newsletter at the end.
5. Confirm there are no errors logged.
6. Confirm that the sign up actually went through, and appears in your ESP of choice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->