### PR TITLE
Media Kit page handling

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -314,14 +314,6 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'options-general.php?page=adstxt-settings',
 			],
-			'publisher-media-kit'         => [
-				'Name'        => \esc_html__( 'Publisher Media Kit', 'newspack' ),
-				'Description' => \esc_html__( 'Quick and easy option for small to medium sized publishers to digitize their media kit.', 'newspack' ),
-				'Author'      => \esc_html__( '10up', 'newspack' ),
-				'AuthorURI'   => \esc_url( 'https://10up.com' ),
-				'PluginURI'   => \esc_url( 'https://wordpress.org/plugins/publisher-media-kit/' ),
-				'Download'    => 'wporg',
-			],
 			'broadstreet'                 => [
 				'Name'        => \esc_html__( 'Broadstreet', 'newspack' ),
 				'Description' => \esc_html__( 'Integrate Broadstreet’s business directory and ad-serving features into your site.', 'newspack' ),

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -208,6 +208,9 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 */
 	public function get_media_kit_page_edit_url() {
 		$raw_url = get_edit_post_link( $this->get_media_kit_page_id(), '' );
+		if ( ! $raw_url ) {
+			return false;
+		}
 		$parsed_url = wp_parse_url( $raw_url );
 		return $parsed_url['path'] . '?' . $parsed_url['query'];
 	}

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -191,6 +191,56 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Get Media Kit page ID.
+	 */
+	public static function get_media_kit_page_id() {
+		$page_id = false;
+		try {
+			$page_id = \Newspack_Ads\Media_Kit::get_existing_page_id();
+		} catch ( \Throwable $th ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Do nothing.
+		}
+		return $page_id;
+	}
+
+	/**
+	 * Get Media Kit page.
+	 */
+	public function get_media_kit_page_edit_url() {
+		return get_edit_post_link( $this->get_media_kit_page_id(), '' );
+	}
+
+	/**
+	 * Get Media Kit page status.
+	 */
+	public function get_media_kit_page_status() {
+		if ( method_exists( '\Newspack_Ads\Media_Kit', 'get_page_status' ) ) {
+			return \Newspack_Ads\Media_Kit::get_page_status();
+		}
+		return false;
+	}
+
+	/**
+	 * Create the Media Kit page.
+	 */
+	public function create_media_kit_page() {
+		if ( method_exists( '\Newspack_Ads\Media_Kit', 'create_media_kit_page' ) ) {
+			return \Newspack_Ads\Media_Kit::create_media_kit_page();
+		}
+		return false;
+	}
+
+	/**
+	 * Unpublish the Media Kit page.
+	 */
+	public function unpublish_media_kit_page() {
+		if ( method_exists( '\Newspack_Ads\Media_Kit', 'create_media_kit_page' ) ) {
+			return \Newspack_Ads\Media_Kit::create_media_kit_page();
+		}
+		return false;
+	}
+
+	/**
 	 * Configure Newspack Ads for Newspack use.
 	 *
 	 * @return bool || WP_Error Return true if successful, or WP_Error if not.

--- a/includes/configuration_managers/class-newspack-ads-configuration-manager.php
+++ b/includes/configuration_managers/class-newspack-ads-configuration-manager.php
@@ -207,7 +207,9 @@ class Newspack_Ads_Configuration_Manager extends Configuration_Manager {
 	 * Get Media Kit page.
 	 */
 	public function get_media_kit_page_edit_url() {
-		return get_edit_post_link( $this->get_media_kit_page_id(), '' );
+		$raw_url = get_edit_post_link( $this->get_media_kit_page_id(), '' );
+		$parsed_url = wp_parse_url( $raw_url );
+		return $parsed_url['path'] . '?' . $parsed_url['query'];
 	}
 
 	/**

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -272,6 +272,28 @@ class Advertising_Wizard extends Wizard {
 				],
 			]
 		);
+
+		// Create the Media Kit page.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/billboard/media-kit',
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'api_create_media_kit_page' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		// Unpublish the Media Kit page.
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/billboard/media-kit',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'api_unpublish_media_kit_page' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
 	}
 
 	/**
@@ -398,6 +420,48 @@ class Advertising_Wizard extends Wizard {
 	}
 
 	/**
+	 * Create the Media Kit page.
+	 */
+	public static function api_create_media_kit_page() {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+		$edit_url = $configuration_manager->get_media_kit_page_edit_url();
+		if ( ! $edit_url ) {
+			$configuration_manager->create_media_kit_page();
+		}
+		return \rest_ensure_response(
+			[
+				'edit_url'    => $configuration_manager->get_media_kit_page_edit_url(),
+				'page_status' => $configuration_manager->get_media_kit_page_status(),
+			]
+		);
+	}
+
+	/**
+	 * Unpublish (revert to draft) the Media Kit page.
+	 */
+	public static function api_unpublish_media_kit_page() {
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
+		$page_id = $configuration_manager->get_media_kit_page_id();
+		if ( $page_id ) {
+			$update = wp_update_post(
+				[
+					'ID'          => $page_id,
+					'post_status' => 'draft',
+				]
+			);
+			if ( $update === 0 || is_wp_error( $update ) ) {
+				return rest_ensure_response( new WP_Error( 'update_failed', __( 'Failed to update page status.', 'newspack' ) ) );
+			}
+		}
+		return \rest_ensure_response(
+			[
+				'edit_url'    => $configuration_manager->get_media_kit_page_edit_url(),
+				'page_status' => $configuration_manager->get_media_kit_page_status(),
+			]
+		);
+	}
+
+	/**
 	 * Retrieve all advertising data.
 	 *
 	 * @return array Advertising data.
@@ -504,12 +568,15 @@ class Advertising_Wizard extends Wizard {
 		\wp_style_add_data( 'newspack-advertising-wizard', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-advertising-wizard' );
 
+		$configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-ads' );
 		\wp_localize_script(
 			'newspack-advertising-wizard',
 			'newspack_ads_wizard',
 			array(
-				'iab_sizes'          => function_exists( '\Newspack_Ads\get_iab_sizes' ) ? \Newspack_Ads\get_iab_sizes() : [],
-				'can_connect_google' => OAuth::is_proxy_configured( 'google' ),
+				'iab_sizes'               => function_exists( '\Newspack_Ads\get_iab_sizes' ) ? \Newspack_Ads\get_iab_sizes() : [],
+				'media_kit_page_edit_url' => $configuration_manager->get_media_kit_page_edit_url(),
+				'media_kit_page_status'   => $configuration_manager->get_media_kit_page_status(),
+				'can_connect_google'      => OAuth::is_proxy_configured( 'google' ),
 			)
 		);
 	}

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -509,7 +509,6 @@ class Advertising_Wizard extends Wizard {
 			'newspack_ads_wizard',
 			array(
 				'iab_sizes'          => function_exists( '\Newspack_Ads\get_iab_sizes' ) ? \Newspack_Ads\get_iab_sizes() : [],
-				'mediakit_edit_url'  => get_option( 'pmk-page' ) ? get_edit_post_link( get_option( 'pmk-page' ) ) : '',
 				'can_connect_google' => OAuth::is_proxy_configured( 'google' ),
 			)
 		);

--- a/src/components/src/action-card/index.js
+++ b/src/components/src/action-card/index.js
@@ -72,6 +72,7 @@ class ActionCard extends Component {
 			hasWhiteHeader,
 			isPending,
 			expandable = false,
+			isButtonEnabled = false
 		} = this.props;
 
 		const { expanded } = this.state;
@@ -173,7 +174,7 @@ class ActionCard extends Component {
 									</Handoff>
 								) : onClick || hasInternalLink ? (
 									<Button
-										disabled={ disabled }
+										disabled={ disabled && ! isButtonEnabled }
 										isLink
 										href={ href }
 										onClick={ onClick }

--- a/src/wizards/advertising/components/add-ons/index.js
+++ b/src/wizards/advertising/components/add-ons/index.js
@@ -1,4 +1,3 @@
-/* globals newspack_ads_wizard */
 /**
  * Ad Add-ons component
  */
@@ -24,11 +23,6 @@ export default function AddOns() {
 				'ad-refresh-control': {
 					actionText: __( 'Configure', 'newspack-plugin' ),
 					href: '#/settings',
-				},
-				'publisher-media-kit': {
-					shouldRefreshAfterUpdate: true,
-					actionText: __( 'Edit Media Kit', 'newspack-plugin' ),
-					href: newspack_ads_wizard.mediakit_edit_url ? newspack_ads_wizard.mediakit_edit_url : '',
 				},
 			} }
 		/>

--- a/src/wizards/advertising/components/add-ons/index.js
+++ b/src/wizards/advertising/components/add-ons/index.js
@@ -25,11 +25,13 @@ const MediaKitToggle = () => {
 		newspack_ads_wizard.media_kit_page_status
 	);
 
+	const isPagePublished = pageStatus === 'publish';
+
 	const toggleMediaKit = () => {
 		setInFlight( true );
 		apiFetch( {
 			path: '/newspack/v1/wizard/billboard/media-kit',
-			method: pageStatus === 'publish' ? 'DELETE' : 'POST',
+			method: isPagePublished ? 'DELETE' : 'POST',
 		} )
 			.then( ( { edit_url, page_status } ) => {
 				setEditURL( edit_url );
@@ -41,12 +43,14 @@ const MediaKitToggle = () => {
 	const props = editURL
 		? {
 				href: editURL,
-				actionText: __( 'Edit Media Kit page', 'newspack-plugin' ),
+				actionText: isPagePublished
+					? __( 'Edit Media Kit page', 'newspack-plugin' )
+					: __( 'Review draft page', 'newspack-plugin' ),
 		  }
 		: {};
 
 	let description = __(
-		'Media Kit page is not published. Click the link to edit and publish it.',
+		'Media kit page is created but unpublished, click the link to review and publish.',
 		'newspack-plugin'
 	);
 	let toggleEnabled = false;
@@ -70,10 +74,11 @@ const MediaKitToggle = () => {
 	return (
 		<ActionCard
 			disabled={ isInFlight || ! toggleEnabled }
+			isButtonEnabled={ true }
 			title={ __( 'Media Kit', 'newspack-plugin' ) }
 			description={ description }
 			toggle
-			toggleChecked={ Boolean( editURL ) }
+			toggleChecked={ Boolean( editURL ) && isPagePublished }
 			toggleOnChange={ toggleMediaKit }
 			{ ...props }
 		/>

--- a/src/wizards/advertising/components/add-ons/index.js
+++ b/src/wizards/advertising/components/add-ons/index.js
@@ -1,3 +1,5 @@
+/* globals newspack_ads_wizard */
+
 /**
  * Ad Add-ons component
  */
@@ -6,14 +8,80 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
-import { PluginToggle } from '../../../../components/src';
+import { PluginToggle, ActionCard } from '../../../../components/src';
+import { useState } from 'react';
 
-export default function AddOns() {
+const MediaKitToggle = () => {
+	const [ isInFlight, setInFlight ] = useState( false );
+	const [ editURL, setEditURL ] = useState(
+		newspack_ads_wizard.media_kit_page_edit_url
+	);
+	const [ pageStatus, setPageStatus ] = useState(
+		newspack_ads_wizard.media_kit_page_status
+	);
+
+	const toggleMediaKit = () => {
+		setInFlight( true );
+		apiFetch( {
+			path: '/newspack/v1/wizard/billboard/media-kit',
+			method: pageStatus === 'publish' ? 'DELETE' : 'POST',
+		} )
+			.then( ( { edit_url, page_status } ) => {
+				setEditURL( edit_url );
+				setPageStatus( page_status );
+			} )
+			.finally( () => setInFlight( false ) );
+	};
+
+	const props = editURL
+		? {
+				href: editURL,
+				actionText: __( 'Edit Media Kit page', 'newspack-plugin' ),
+		  }
+		: {};
+
+	let description = __(
+		'Media Kit page is not published. Click the link to edit and publish it.',
+		'newspack-plugin'
+	);
+	let toggleEnabled = false;
+	switch ( pageStatus ) {
+		case 'publish':
+			description = __(
+				'Media Kit page is published. Click the link to edit it, or toggle this card to unpublish.',
+				'newspack-plugin'
+			);
+			toggleEnabled = true;
+			break;
+		case '':
+			description = __(
+				'Media Kit page has not been created. Toggle this card to create it.',
+				'newspack-plugin'
+			);
+			toggleEnabled = true;
+			break;
+	}
+
 	return (
+		<ActionCard
+			disabled={ isInFlight || ! toggleEnabled }
+			title={ __( 'Media Kit', 'newspack-plugin' ) }
+			description={ description }
+			toggle
+			toggleChecked={ Boolean( editURL ) }
+			toggleOnChange={ toggleMediaKit }
+			{ ...props }
+		/>
+	);
+};
+
+export default () => (
+	<>
 		<PluginToggle
 			plugins={ {
 				'super-cool-ad-inserter': {
@@ -26,5 +94,6 @@ export default function AddOns() {
 				},
 			} }
 		/>
-	);
-}
+		<MediaKitToggle />
+	</>
+);

--- a/src/wizards/advertising/components/add-ons/index.js
+++ b/src/wizards/advertising/components/add-ons/index.js
@@ -9,6 +9,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -24,6 +25,20 @@ const MediaKitToggle = () => {
 	const [ pageStatus, setPageStatus ] = useState(
 		newspack_ads_wizard.media_kit_page_status
 	);
+
+	if (
+		! newspack_ads_wizard.media_kit_page_status &&
+		! newspack_ads_wizard.media_kit_page_edit_url
+	) {
+		return (
+			<Notice isDismissible={ false } status="error">
+				{ __(
+					'Something went wrong, the Media Kit feature is unavailable.',
+					'newspack-plugin'
+				) }
+			</Notice>
+		);
+	}
 
 	const isPagePublished = pageStatus === 'publish';
 
@@ -62,7 +77,7 @@ const MediaKitToggle = () => {
 			);
 			toggleEnabled = true;
 			break;
-		case '':
+		case 'non-existent':
 			description = __(
 				'Media Kit page has not been created. Toggle this card to create it.',
 				'newspack-plugin'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Removes references to the `publisher-media-kit` plugin, which will now be included in `newspack-ads` plugin.
2. Change the Media Kit page handling in the Ads Wizard -> Add Ons tab

<img width="1004" alt="image" src="https://github.com/user-attachments/assets/dfbd654b-0850-4bb0-ab1c-c3968fd68e52">

The three states of the UI:

<img width="941" alt="image" src="https://github.com/user-attachments/assets/a3de4b00-d156-4dbc-bf59-78459058f3d5">

### How to test the changes in this Pull Request:

1. Switch `newspack-ads` to `feat/expose-media-kit` branch (https://github.com/Automattic/newspack-ads/pull/908)
1. Visit the Advertising Wizard -> Add Ons tab
2. Observe the UI acts as described in the comment above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->