### PR TITLE
fix(esp-wc-metadata): last payment date & amount handling

### DIFF
--- a/includes/data-events/connectors/class-connector.php
+++ b/includes/data-events/connectors/class-connector.php
@@ -97,7 +97,7 @@ abstract class Connector {
 		}
 
 		$order_id = $data['platform_data']['order_id'];
-		$contact  = WooCommerce_Connection::get_contact_from_order( $order_id, $data['referer'], true );
+		$contact = WooCommerce_Connection::get_contact_from_order( $order_id, $data['referer'] );
 
 		if ( ! $contact ) {
 			return;

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -377,12 +377,11 @@ class WooCommerce_Connection {
 	 * Get data for a customer to sync to the connected ESP.
 	 *
 	 * @param int|\WC_Customer $customer Customer object or customer ID.
-	 * @param \WC_Order|false  $order Order object to sync with. If not given, the last successful order will be used.
 	 * @param bool|string      $payment_page_url Payment page URL. If not provided, checkout URL will be used.
 	 *
 	 * @return array|false Contact data or false.
 	 */
-	public static function get_contact_from_customer( $customer, $order = false, $payment_page_url = false ) {
+	public static function get_contact_from_customer( $customer, $payment_page_url = false ) {
 		if ( ! is_a( $customer, 'WC_Customer' ) ) {
 			$customer = new \WC_Customer( $customer );
 		}
@@ -393,17 +392,14 @@ class WooCommerce_Connection {
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_date' ) ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ]        = \wc_format_localized_price( $customer->get_total_spent() );
 
-		// If no order is passed as the argument, use the last successful order.
-		if ( $order === false ) {
-			$order = self::get_last_successful_order( $customer );
-		}
+		$order = self::get_last_successful_order( $customer );
 
 		// Get the order metadata.
 		$order_metadata = [];
 		if ( $order ) {
 			$order_metadata = self::get_contact_order_metadata( $order, $payment_page_url );
 		} else {
-			// If the customer has no successful orders or if no order is provided???, clear out subscription-related fields.
+			// If the customer has no successful orders, clear out subscription-related fields.
 			$payment_fields = array_keys( Newspack_Newsletters::get_payment_metadata_fields() );
 			foreach ( $payment_fields as $meta_key ) {
 				$metadata[ Newspack_Newsletters::get_metadata_key( $meta_key ) ] = '';
@@ -442,7 +438,7 @@ class WooCommerce_Connection {
 			return;
 		}
 
-		return self::get_contact_from_customer( $order->get_customer_id(), $order, $payment_page_url );
+		return self::get_contact_from_customer( $order->get_customer_id(), $payment_page_url );
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -14,9 +14,10 @@ defined( 'ABSPATH' ) || exit;
  */
 class WooCommerce_Connection {
 	/**
-	 * Statuses considered active subscriptions.
+	 * Statuses considered active.
 	 */
 	const ACTIVE_SUBSCRIPTION_STATUSES = [ 'active', 'pending', 'pending-cancel' ];
+	const ACTIVE_ORDER_STATUSES = [ 'processing', 'completed' ];
 
 	/**
 	 * Initialize.
@@ -233,11 +234,10 @@ class WooCommerce_Connection {
 	 *
 	 * @param \WC_Order|int $order WooCommerce order or order ID.
 	 * @param bool|string   $payment_page_url Payment page URL. If not provided, checkout URL will be used.
-	 * @param bool          $is_new Whether the order is new and should count as the last payment amount.
 	 *
 	 * @return array Contact order metadata.
 	 */
-	public static function get_contact_order_metadata( $order, $payment_page_url = false, $is_new = false ) {
+	private static function get_contact_order_metadata( $order, $payment_page_url = false ) {
 		if ( ! is_a( $order, 'WC_Order' ) ) {
 			$order = \wc_get_order( $order );
 		}
@@ -246,8 +246,13 @@ class WooCommerce_Connection {
 			return [];
 		}
 
+		$is_subscription = false;
+		if ( function_exists( 'wcs_is_subscription' ) ) {
+			$is_subscription = \wcs_is_subscription( $order );
+		}
 		// Only update last payment data if new payment has been received.
-		$payment_received = $is_new && $order->has_status( [ 'processing', 'completed' ] );
+		$active_statuses = $is_subscription ? self::ACTIVE_SUBSCRIPTION_STATUSES : self::ACTIVE_ORDER_STATUSES;
+		$payment_received = $order->has_status( $active_statuses );
 
 		$metadata = [];
 
@@ -268,8 +273,11 @@ class WooCommerce_Connection {
 			}
 		}
 
-		$order_subscriptions = \wcs_is_subscription( $order ) ? [ $order ] : \wcs_get_subscriptions_for_order( $order->get_id(), [ 'order_type' => 'any' ] );
-		$is_donation_order   = Donations::is_donation_order( $order );
+		$order_subscriptions = [];
+		if ( function_exists( 'wcs_is_subscription' ) ) {
+			$order_subscriptions = \wcs_is_subscription( $order ) ? [ $order ] : \wcs_get_subscriptions_for_order( $order->get_id(), [ 'order_type' => 'any' ] );
+		}
+		$is_donation_order = Donations::is_donation_order( $order );
 
 		// One-time transaction.
 		if ( empty( $order_subscriptions ) ) {
@@ -368,36 +376,34 @@ class WooCommerce_Connection {
 	/**
 	 * Get data for a customer to sync to the connected ESP.
 	 *
-	 * @param \WC_Customer    $customer Customer object.
-	 * @param \WC_Order|false $order Order object to sync with. If not given, the last successful order will be used.
-	 * @param bool|string     $payment_page_url Payment page URL. If not provided, checkout URL will be used.
-	 * @param bool            $is_new Whether the order is new and should count as the last payment amount.
+	 * @param int|\WC_Customer $customer Customer object or customer ID.
+	 * @param \WC_Order|false  $order Order object to sync with. If not given, the last successful order will be used.
+	 * @param bool|string      $payment_page_url Payment page URL. If not provided, checkout URL will be used.
 	 *
 	 * @return array|false Contact data or false.
 	 */
-	public static function get_contact_from_customer( $customer, $order = false, $payment_page_url = false, $is_new = false ) {
+	public static function get_contact_from_customer( $customer, $order = false, $payment_page_url = false ) {
 		if ( ! is_a( $customer, 'WC_Customer' ) ) {
-			return false;
+			$customer = new \WC_Customer( $customer );
 		}
 
-		$metadata       = [];
-		$order_metadata = [];
-		$last_order     = self::get_last_successful_order( $customer );
+		$metadata = [];
 
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'account' ) ]           = $customer->get_id();
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'registration_date' ) ] = $customer->get_date_created()->date( Newspack_Newsletters::METADATA_DATE_FORMAT );
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'total_paid' ) ]        = \wc_format_localized_price( $customer->get_total_spent() );
 
-		// If a more recent order exists, use it to sync.
-		if ( ! $order || ( $last_order && $order->get_id() !== $last_order->get_id() ) ) {
-			$order = $last_order;
+		// If no order is passed as the argument, use the last successful order.
+		if ( $order === false ) {
+			$order = self::get_last_successful_order( $customer );
 		}
 
 		// Get the order metadata.
+		$order_metadata = [];
 		if ( $order ) {
-			$order_metadata = self::get_contact_order_metadata( $order, $payment_page_url, $is_new );
+			$order_metadata = self::get_contact_order_metadata( $order, $payment_page_url );
 		} else {
-			// If the customer has no successful orders, clear out subscription-related fields.
+			// If the customer has no successful orders or if no order is provided???, clear out subscription-related fields.
 			$payment_fields = array_keys( Newspack_Newsletters::get_payment_metadata_fields() );
 			foreach ( $payment_fields as $meta_key ) {
 				$metadata[ Newspack_Newsletters::get_metadata_key( $meta_key ) ] = '';
@@ -424,11 +430,10 @@ class WooCommerce_Connection {
 	 *
 	 * @param \WC_Order|int $order WooCommerce order or order ID.
 	 * @param bool|string   $payment_page_url Payment page URL. If not provided, checkout URL will be used.
-	 * @param bool          $is_new Whether the order is new and should count as the last payment amount.
 	 *
 	 * @return array|false Contact data or false.
 	 */
-	public static function get_contact_from_order( $order, $payment_page_url = false, $is_new = false ) {
+	public static function get_contact_from_order( $order, $payment_page_url = false ) {
 		if ( ! is_a( $order, 'WC_Order' ) ) {
 			$order = \wc_get_order( $order );
 		}
@@ -437,10 +442,7 @@ class WooCommerce_Connection {
 			return;
 		}
 
-		$user_id  = $order->get_customer_id();
-		$customer = new \WC_Customer( $user_id );
-
-		return self::get_contact_from_customer( $customer, $order, $payment_page_url, $is_new );
+		return self::get_contact_from_customer( $order->get_customer_id(), $order, $payment_page_url );
 	}
 
 	/**

--- a/tests/class-newspack-unit-tests-bootstrap.php
+++ b/tests/class-newspack-unit-tests-bootstrap.php
@@ -69,6 +69,8 @@ class Newspack_Unit_Tests_Bootstrap {
 		// Load the WP testing environment.
 		require_once $_tests_dir . '/includes/bootstrap.php';
 
+		ini_set( 'error_log', 'php://stdout' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+
 		define( 'IS_TEST_ENV', 1 );
 	}
 

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -1,4 +1,4 @@
-<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FileComment.Missing, Generic.Files.OneObjectStructurePerFile.MultipleFound
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FileComment.Missing, Generic.Files.OneObjectStructurePerFile.MultipleFound, Universal.Files.SeparateFunctionsFromOO.Mixed
 
 class WC_Install {
 	public static function create_pages() {
@@ -34,4 +34,132 @@ class WC_Payment_Gateways {
 	public function payment_gateways() {
 		return self::$gateways;
 	}
+}
+
+class WC_DateTime extends DateTime {
+	public function date( $format ) {
+		return gmdate( $format, $this->getTimestamp() );
+	}
+}
+
+class WC_Customer {
+	public $data = [];
+	public function __construct( $user_id ) {
+		$this->data = [
+			'user_id'      => $user_id,
+			'date_created' => gmdate( 'Y-m-d H:i:s' ),
+		];
+	}
+	public function get_id() {
+		return $this->data['user_id'];
+	}
+	public function get_date_created() {
+		return new WC_DateTime( $this->data['date_created'] );
+	}
+	public function get_total_spent() {
+		return get_user_meta( $this->get_id(), 'wc_total_spent', true );
+	}
+	public function get_billing_first_name() {
+		return get_user_meta( $this->get_id(), 'first_name', true );
+	}
+	public function get_billing_last_name() {
+		return get_user_meta( $this->get_id(), 'last_name', true );
+	}
+	public function get_billing_email() {
+		return get_userdata( $this->get_id() )->user_email;
+	}
+}
+
+$orders_database = [];
+
+class WC_Order {
+	public $data = [ 'items' => [] ];
+	public function __construct( $data ) {
+		global $orders_database;
+		$data['id'] = count( $orders_database ) + 1;
+		if ( ! isset( $data['date_paid'] ) ) {
+			$data['date_paid'] = gmdate( 'Y-m-d H:i:s' );
+		}
+		$this->data = array_merge( $data, $this->data );
+		if ( $data['status'] === 'completed' ) {
+			// Update customer's total spent.
+			$customer = new WC_Customer( $this->get_customer_id() );
+			$total_spent = $customer->get_total_spent() + $this->get_total();
+			update_user_meta( $customer->get_id(), 'wc_total_spent', $total_spent );
+			// Add the order to the mock DB.
+		}
+		$orders_database[] = $this;
+	}
+	public function get_id() {
+		return $this->data['id'];
+	}
+	public function get_customer_id() {
+		return $this->data['customer_id'];
+	}
+	public function get_meta( $field_name ) {
+		return null;
+	}
+	public function has_status( $statuses ) {
+		return in_array( $this->data['status'], $statuses );
+	}
+	public function get_items() {
+		return $this->data['items'];
+	}
+	public function get_date_paid() {
+		return new WC_DateTime( $this->data['date_paid'] );
+	}
+	public function get_total() {
+		return $this->data['total'];
+	}
+	public function get_status() {
+		return $this->data['status'];
+	}
+}
+
+function wc_create_order( $data ) {
+	return new WC_Order( $data );
+}
+function wc_format_localized_price( $price ) {
+	return '$' . $price;
+}
+function wc_get_checkout_url() {
+	return 'https://example.com/checkout';
+}
+function wcs_is_subscription( $order ) {
+	return false;
+}
+function wcs_get_subscriptions_for_order( $order ) {
+	return [];
+}
+function wcs_get_users_subscriptions( $order ) {
+	return [];
+}
+function wc_get_orders( $args ) {
+	global $orders_database;
+	$orders = $orders_database;
+	if ( isset( $args['customer_id'] ) ) {
+		// Filter by customer.
+		$orders = array_filter(
+			$orders_database,
+			function( $order ) use ( $args ) {
+				return $order->get_customer_id() === $args['customer_id'];
+			}
+		);
+	}
+	if ( isset( $args['status'] ) ) {
+		// Filter by status.
+		$orders = array_filter(
+			$orders_database,
+			function( $order ) use ( $args ) {
+				return 'wc-' . $order->get_status() === $args['status'][0];
+			}
+		);
+	}
+	usort(
+		$orders,
+		function( $a, $b ) {
+			return $b->get_date_paid()->getTimestamp() <=> $a->get_date_paid()->getTimestamp();
+		}
+	);
+	return $orders;
 }

--- a/tests/unit-tests/woocommerce-connection.php
+++ b/tests/unit-tests/woocommerce-connection.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Tests WooCommerce connection.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Connection;
+
+require_once __DIR__ . '/../mocks/wc-mocks.php';
+
+/**
+ * Tests WooCommerce connection.
+ */
+class Newspack_Test_WooCommerce_Connection extends WP_UnitTestCase {
+	const USER_DATA = [
+		'user_login' => 'test_user',
+		'user_email' => 'test@example.com',
+		'user_pass'  => 'password',
+		'meta_input' => [
+			'first_name'     => 'John',
+			'last_name'      => 'Doe',
+			'wc_total_spent' => 100,
+		],
+	];
+
+	private static $user_id = null; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+
+	public static function set_up_before_class() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		self::$user_id = wp_insert_user( self::USER_DATA );
+	}
+
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		// Clear the mock orders DB.
+		global $orders_database;
+		$orders_database = [];
+		// Reset the user.
+		wp_delete_user( self::$user_id );
+		self::$user_id = wp_insert_user( self::USER_DATA );
+	}
+
+	/**
+	 * Test payment metadata extraction - basic shape of the data.
+	 */
+	public function test_woocommerce_connection_payment_metadata_basic() {
+		$customer = new WC_Customer( self::$user_id );
+		$order_data = [
+			'customer_id' => self::$user_id,
+			'status'      => 'completed',
+			'total'       => 50,
+		];
+		$order = \wc_create_order( $order_data );
+		$payment_page_url = 'https://example.com/donate';
+		$contact_data = WooCommerce_Connection::get_contact_from_order( $order, $payment_page_url );
+		$today = gmdate( 'Y-m-d' );
+		$this->assertEquals(
+			[
+				'email'    => self::USER_DATA['user_email'],
+				'name'     => self::USER_DATA['meta_input']['first_name'] . ' ' . self::USER_DATA['meta_input']['last_name'],
+				'metadata' => [
+					'NP_Payment Page'                    => $payment_page_url,
+					'NP_Membership Status'               => 'customer',
+					'NP_Product Name'                    => '',
+					'NP_Last Payment Amount'             => '$' . $order_data['total'],
+					'NP_Last Payment Date'               => $today,
+					'NP_Payment UTM: source'             => '',
+					'NP_Payment UTM: medium'             => '',
+					'NP_Payment UTM: campaign'           => '',
+					'NP_Payment UTM: term'               => '',
+					'NP_Payment UTM: content'            => '',
+					'NP_Current Subscription Start Date' => '',
+					'NP_Current Subscription End Date'   => '',
+					'NP_Billing Cycle'                   => '',
+					'NP_Recurring Payment'               => '',
+					'NP_Next Payment Date'               => '',
+					'NP_Total Paid'                      => '$' . ( self::USER_DATA['meta_input']['wc_total_spent'] + $order_data['total'] ),
+					'NP_Account'                         => self::$user_id,
+					'NP_Registration Date'               => $today,
+				],
+			],
+			$contact_data
+		);
+	}
+
+
+	/**
+	 * Test payment metadata extraction using a failed order.
+	 */
+	public function test_woocommerce_connection_payment_metadata_with_failed_order() {
+		$order = \wc_create_order(
+			[
+				'customer_id' => self::$user_id,
+				'status'      => 'failed',
+				'total'       => 60,
+			]
+		);
+		$contact_data = WooCommerce_Connection::get_contact_from_order( $order );
+		$this->assertEmpty( $contact_data['metadata']['NP_Last Payment Date'] );
+		$this->assertEmpty( $contact_data['metadata']['NP_Last Payment Amount'] );
+	}
+
+	/**
+	 * Test payment metadata extraction - using customer as source.
+	 */
+	public function test_woocommerce_connection_payment_metadata_from_customer() {
+		$order_data = [
+			'customer_id' => self::$user_id,
+			'status'      => 'completed',
+			'total'       => 70,
+		];
+		$order = \wc_create_order( $order_data );
+		$contact_data = WooCommerce_Connection::get_contact_from_customer( self::$user_id );
+		$this->assertEquals( '$' . $order_data['total'], $contact_data['metadata']['NP_Last Payment Amount'] );
+		$this->assertEquals( gmdate( 'Y-m-d' ), $contact_data['metadata']['NP_Last Payment Date'] );
+	}
+
+	/**
+	 * Test payment metadata extraction - using customer who's last order was failed as source.
+	 */
+	public function test_woocommerce_connection_payment_metadata_from_customer_with_last_order_failed() {
+		$completed_order_data = [
+			'customer_id' => self::$user_id,
+			'status'      => 'completed',
+			'total'       => 70,
+			'date_paid'   => gmdate( 'Y-m-d', strtotime( '-1 week' ) ),
+		];
+		$order = \wc_create_order( $completed_order_data );
+		// A more recent, but failed, order.
+		$failed_order_data = [
+			'customer_id' => self::$user_id,
+			'status'      => 'failed',
+			'total'       => 89,
+		];
+		$order = \wc_create_order( $failed_order_data );
+		$contact_data = WooCommerce_Connection::get_contact_from_customer( self::$user_id );
+		$this->assertEquals( '$' . $completed_order_data['total'], $contact_data['metadata']['NP_Last Payment Amount'] );
+		$this->assertEquals( $completed_order_data['date_paid'], $contact_data['metadata']['NP_Last Payment Date'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the handling of of "last payment" ESP metadata (`NP_Last Payment Date`, `NP_Last Payment Amount`). 

### How to test the changes in this Pull Request:

1. On `trunk`, make a recurring donation as a new reader
2. Call the `\Newspack\WooCommerce_Connection::get_contact_from_customer(new WC_Customer(<user-id>))` in `wp shell` – observe the `NP_Last Payment Date` and `NP_Last Payment Amount` fields are empty 
3. Switch to this branch, call the code again, observe the expected fields are there

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207471874427924