### PR TITLE
fix(ras-acc): don't close modal when redirecting

### DIFF
--- a/src/reader-activation-newsletters/newsletters-modal.js
+++ b/src/reader-activation-newsletters/newsletters-modal.js
@@ -65,7 +65,7 @@ export function openNewslettersSignupModal( config = {} ) {
 	container.config = config;
 
 	container.newslettersSignupCallback = ( message, data ) => {
-		if ( ! config?.skipClose ) {
+		if ( config?.closeOnSuccess ) {
 			close();
 		}
 		if ( config?.callback ) {

--- a/src/reader-activation-newsletters/newsletters-modal.js
+++ b/src/reader-activation-newsletters/newsletters-modal.js
@@ -65,7 +65,9 @@ export function openNewslettersSignupModal( config = {} ) {
 	container.config = config;
 
 	container.newslettersSignupCallback = ( message, data ) => {
-		close();
+		if ( ! config?.skipClose ) {
+			close();
+		}
 		if ( config?.callback ) {
 			config.callback( message, data );
 		}

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -159,7 +159,7 @@ export function openAuthModal( config = {} ) {
 			},
 			content: null,
 			trigger: null,
-			skipClose: false,
+			closeOnSuccess: true,
 		},
 		...config,
 	};

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -159,6 +159,7 @@ export function openAuthModal( config = {} ) {
 			},
 			content: null,
 			trigger: null,
+			skipClose: false,
 		},
 		...config,
 	};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR, along with https://github.com/Automattic/newspack-blocks/pull/1855, stops the modal checkout from fully closing when the last step is redirecting to a different URL, so the process feels smoother.

The testing steps are all in https://github.com/Automattic/newspack-blocks/pull/1855.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->