### PR TITLE
Fix/payment utm meta fields

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -357,16 +357,16 @@ class WooCommerce_Connection {
 
 		// Clear out any payment-related fields that don't relate to the current order.
 		$payment_fields = array_keys( Newspack_Newsletters::get_payment_metadata_fields() );
+		$utm_meta_field = Newspack_Newsletters::get_metadata_key( 'payment_page_utm' );
+		foreach ( WooCommerce_Order_UTM::$params as $param ) {
+			if ( ! isset( $metadata[ $utm_meta_field . $param ] ) ) {
+				$metadata[ $utm_meta_field . $param ] = '';
+			}
+		}
 		foreach ( $payment_fields as $meta_key ) {
 			$meta_field = Newspack_Newsletters::get_metadata_key( $meta_key );
-			if ( ! isset( $metadata[ $meta_field ] ) ) {
-				if ( 'payment_page_utm' === $meta_key ) {
-					foreach ( WooCommerce_Order_UTM::$params as $param ) {
-						$metadata[ $meta_field . $param ] = '';
-					}
-				} else {
-					$metadata[ $meta_field ] = '';
-				}
+			if ( ! isset( $metadata[ $meta_field ] ) && 'payment_page_utm' !== $meta_key ) {
+				$metadata[ $meta_field ] = '';
 			}
 		}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -267,6 +267,17 @@ class WooCommerce_Connection {
 		$metadata[ Newspack_Newsletters::get_metadata_key( 'payment_page' ) ] = $payment_page_url;
 
 		$utm = $order->get_meta( 'utm' );
+		if ( empty( $utm ) ) {
+			$utm = [];
+			// Try the explicit `utm_<name>` meta.
+			foreach ( WooCommerce_Order_UTM::$params as $param ) {
+				$param_name = 'utm_' . $param;
+				$utm_value = $order->get_meta( $param_name );
+				if ( ! empty( $utm_value ) ) {
+					$utm[ $param ] = $utm_value;
+				}
+			}
+		}
 		if ( ! empty( $utm ) ) {
 			foreach ( $utm as $key => $value ) {
 				$metadata[ Newspack_Newsletters::get_metadata_key( 'payment_page_utm' ) . $key ] = $value;

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -74,6 +74,7 @@ $orders_database = [];
 
 class WC_Order {
 	public $data = [ 'items' => [] ];
+	public $meta = [];
 	public function __construct( $data ) {
 		global $orders_database;
 		$data['id'] = count( $orders_database ) + 1;
@@ -88,6 +89,9 @@ class WC_Order {
 			update_user_meta( $customer->get_id(), 'wc_total_spent', $total_spent );
 			// Add the order to the mock DB.
 		}
+		if ( isset( $data['meta'] ) ) {
+			$this->meta = $data['meta'];
+		}
 		$orders_database[] = $this;
 	}
 	public function get_id() {
@@ -97,7 +101,7 @@ class WC_Order {
 		return $this->data['customer_id'];
 	}
 	public function get_meta( $field_name ) {
-		return null;
+		return isset( $this->meta[ $field_name ] ) ? $this->meta[ $field_name ] : null;
 	}
 	public function has_status( $statuses ) {
 		return in_array( $this->data['status'], $statuses );

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -101,7 +101,7 @@ class WC_Order {
 		return $this->data['customer_id'];
 	}
 	public function get_meta( $field_name ) {
-		return isset( $this->meta[ $field_name ] ) ? $this->meta[ $field_name ] : null;
+		return isset( $this->meta[ $field_name ] ) ? $this->meta[ $field_name ] : '';
 	}
 	public function has_status( $statuses ) {
 		return in_array( $this->data['status'], $statuses );

--- a/tests/unit-tests/newsletters.php
+++ b/tests/unit-tests/newsletters.php
@@ -91,7 +91,9 @@ class Newspack_Test_Newspack_Newsletters extends WP_UnitTestCase {
 			],
 		];
 		$normalized_contact = Newspack_Newsletters::normalize_contact_data( $contact );
-		self::assertEquals( $normalized_contact['email'], $contact['email'] );
-		self::assertEquals( $normalized_contact['metadata']['NP_Payment UTM: campaign'], $utm_params['campaign'] );
+		self::assertEquals( $contact['email'], $normalized_contact['email'] );
+		self::assertEquals( $utm_params['campaign'], $normalized_contact['metadata']['NP_Payment UTM: campaign'] );
+		self::assertEquals( $utm_params['content'], $normalized_contact['metadata']['NP_Payment UTM: content'] );
+		self::assertEquals( '', $normalized_contact['metadata']['NP_Payment UTM: term'] );
 	}
 }

--- a/tests/unit-tests/newsletters.php
+++ b/tests/unit-tests/newsletters.php
@@ -57,4 +57,41 @@ class Newspack_Test_Newspack_Newsletters extends WP_UnitTestCase {
 			'Expected to get the same lists back when no master list is set.'
 		);
 	}
+
+	/**
+	 * Contact handling.
+	 */
+	public static function test_newsletters_contact_handling() {
+		$utm_params = [
+			'campaign' => 'test_campaign',
+			'content'  => 'test_content',
+		];
+		$contact = [
+			'email'    => 'test@email.com',
+			'name'     => 'John Doe',
+			'metadata' => [
+				'NP_Payment Page'                    => '/donate/?utm_campaign=' . $utm_params['campaign'] . '&utm_content=' . $utm_params['content'],
+				'NP_Payment UTM: campaign'           => $utm_params['campaign'],
+				'NP_Membership Status'               => 'Donor',
+				'NP_Product Name'                    => 'Donate: One-Time',
+				'NP_Last Payment Amount'             => '20.00',
+				'NP_Last Payment Date'               => '2024-08-27',
+				'NP_Payment UTM: source'             => '',
+				'NP_Payment UTM: medium'             => '',
+				'NP_Payment UTM: term'               => '',
+				'NP_Payment UTM: content'            => $utm_params['content'],
+				'NP_Current Subscription Start Date' => '',
+				'NP_Current Subscription End Date'   => '',
+				'NP_Billing Cycle'                   => '',
+				'NP_Recurring Payment'               => '',
+				'NP_Next Payment Date'               => '',
+				'NP_Total Paid'                      => '109.00',
+				'NP_Account'                         => '492',
+				'NP_Registration Date'               => '2024-08-26',
+			],
+		];
+		$normalized_contact = Newspack_Newsletters::normalize_contact_data( $contact );
+		self::assertEquals( $normalized_contact['email'], $contact['email'] );
+		self::assertEquals( $normalized_contact['metadata']['NP_Payment UTM: campaign'], $utm_params['campaign'] );
+	}
 }

--- a/tests/unit-tests/woocommerce-connection.php
+++ b/tests/unit-tests/woocommerce-connection.php
@@ -48,6 +48,14 @@ class Newspack_Test_WooCommerce_Connection extends WP_UnitTestCase {
 			'customer_id' => self::$user_id,
 			'status'      => 'completed',
 			'total'       => 50,
+			'meta'        => [
+				'utm' => [
+					'source'   => 'test_source',
+					'campaign' => 'test_campaign',
+					'term'     => 'test_term',
+					'content'  => 'test_content',
+				],
+			],
 		];
 		$order = \wc_create_order( $order_data );
 		$payment_page_url = 'https://example.com/donate';
@@ -63,11 +71,11 @@ class Newspack_Test_WooCommerce_Connection extends WP_UnitTestCase {
 					'NP_Product Name'                    => '',
 					'NP_Last Payment Amount'             => '$' . $order_data['total'],
 					'NP_Last Payment Date'               => $today,
-					'NP_Payment UTM: source'             => '',
+					'NP_Payment UTM: source'             => 'test_source',
 					'NP_Payment UTM: medium'             => '',
-					'NP_Payment UTM: campaign'           => '',
-					'NP_Payment UTM: term'               => '',
-					'NP_Payment UTM: content'            => '',
+					'NP_Payment UTM: campaign'           => 'test_campaign',
+					'NP_Payment UTM: term'               => 'test_term',
+					'NP_Payment UTM: content'            => 'test_content',
 					'NP_Current Subscription Start Date' => '',
 					'NP_Current Subscription End Date'   => '',
 					'NP_Billing Cycle'                   => '',

--- a/tests/unit-tests/woocommerce-connection.php
+++ b/tests/unit-tests/woocommerce-connection.php
@@ -43,7 +43,6 @@ class Newspack_Test_WooCommerce_Connection extends WP_UnitTestCase {
 	 * Test payment metadata extraction - basic shape of the data.
 	 */
 	public function test_woocommerce_connection_payment_metadata_basic() {
-		$customer = new WC_Customer( self::$user_id );
 		$order_data = [
 			'customer_id' => self::$user_id,
 			'status'      => 'completed',
@@ -90,6 +89,27 @@ class Newspack_Test_WooCommerce_Connection extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Test payment metadata extraction - with different location of UTM meta.
+	 * Newspack will set the 'utm' order meta, but when importing data, a one-to-one relation
+	 * might be needed. In such a case, a field in the imported data would correspond to
+	 * a string meta field, instead of the UTM params being stored as serialized values.
+	 */
+	public function test_woocommerce_connection_payment_metadata_utm() {
+		$order_data = [
+			'customer_id' => self::$user_id,
+			'status'      => 'completed',
+			'total'       => 50,
+			'meta'        => [
+				'utm_source'   => 'test_source',
+				'utm_campaign' => 'test_campaign',
+			],
+		];
+		$order = \wc_create_order( $order_data );
+		$contact_data = WooCommerce_Connection::get_contact_from_order( $order );
+		$this->assertEquals( 'test_source', $contact_data['metadata']['NP_Payment UTM: source'] );
+		$this->assertEquals( 'test_campaign', $contact_data['metadata']['NP_Payment UTM: campaign'] );
+	}
 
 	/**
 	 * Test payment metadata extraction using a failed order.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Newspack will set the `utm` order meta, but when importing data, a one-to-one relation might be needed. In such a case, a field in the imported data would correspond to a string meta field, instead of the UTM params being stored as serialized values.

In other words, when an order has `utm_campaign` meta field set, but no value at `utm` meta field, the former value should be used for `NP_Payment UTM: campaign` ESP meta field.

### How to test the changes in this Pull Request:

Change should be verifiable by reading the tests, but here are the reproduction steps if need be:

1. Make a donation on a page with **no** UTM params in the URL 
1. Update the order meta, setting a `utm_campaign` meta field to some value
2. On `trunk`, observe that `\Newspack\WooCommerce_Connection::get_contact_from_order(<order-id>)` won't return `metadata.NP_Payment UTM: campaign` field
3. On this branch, observe the field is present, with the expected value

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207898544020915