### PR TITLE
fix: hide dummy guest author email address

### DIFF
--- a/includes/cli/class-co-authors-plus.php
+++ b/includes/cli/class-co-authors-plus.php
@@ -192,7 +192,7 @@ class Co_Authors_Plus {
 			if ( isset( $post_meta['cap-user_email'] ) && ! empty( $post_meta['cap-user_email'] ) ) {
 				$user_data['user_email'] = $post_meta['cap-user_email'];
 			} else {
-				$dummy_email = '_migrated-' . $guest_author->ID . '-' . $user_login . '@example.com';
+				$dummy_email = \Newspack\Guest_Contributor_Role::get_dummy_email_address( '_migrated-' . $guest_author->ID . '-' . $user_login );
 				$user_data['user_email'] = $dummy_email;
 				if ( self::$verbose ) {
 					WP_CLI::line( sprintf( 'Missing email for Guest Author, email address will be updated to %s.', $dummy_email ) );

--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -78,7 +78,7 @@ class Guest_Contributor_Role {
 		}
 
 		// Hide author email on the frontend, if it's a placeholder email.
-		\add_filter( 'theme_mod_show_author_email', [ __CLASS__, 'hide_author_email' ] );
+		\add_filter( 'theme_mod_show_author_email', [ __CLASS__, 'should_display_author_email' ] );
 	}
 
 	/**
@@ -474,7 +474,7 @@ class Guest_Contributor_Role {
 	 *
 	 * @param bool $value Whether to show the author email.
 	 */
-	public static function hide_author_email( $value ) {
+	public static function should_display_author_email( $value ) {
 		if ( is_author() || is_singular() ) { // Run on archive pages and single posts/pages.
 			$author_id = get_the_author_meta( 'ID' );
 			$user = get_userdata( $author_id );

--- a/tests/class-newspack-unit-tests-bootstrap.php
+++ b/tests/class-newspack-unit-tests-bootstrap.php
@@ -31,6 +31,7 @@ class Newspack_Unit_Tests_Bootstrap {
 
 		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions, WordPress.PHP.DevelopmentFunctions, WordPress.PHP.IniSet.display_errors_Blacklisted, WordPress.PHP.IniSet.display_errors_Disallowed
 		ini_set( 'display_errors', 'on' );
+		ini_set( 'error_log', 'php://stdout' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		error_reporting( E_ALL );
 		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions, WordPress.PHP.DevelopmentFunctions, WordPress.PHP.IniSet.display_errors_Blacklisted, WordPress.PHP.IniSet.display_errors_Disallowed
 

--- a/tests/unit-tests/guest-contributor-role.php
+++ b/tests/unit-tests/guest-contributor-role.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Tests the Guest_Contributor_Role.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Guest_Contributor_Role;
+
+/**
+ * Tests the Guest_Contributor_Role.
+ */
+class Newspack_Test_Guest_Contributor_Role extends WP_UnitTestCase {
+	public static function set_up_before_class() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		Guest_Contributor_Role::setup_custom_role_and_capability();
+	}
+
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		wp_reset_postdata();
+	}
+
+	/**
+	 * On a post with author.
+	 */
+	public function test_guest_contributor_role_dummy_email_hiding_default() {
+		$email_domain = Guest_Contributor_Role::get_dummy_email_domain();
+		$user_id = \wp_insert_user(
+			[
+				'user_login' => 'guest-contributor',
+				'user_pass'  => '123',
+				'user_email' => 'guest-contributor@' . $email_domain,
+				'role'       => Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME,
+			]
+		);
+		$post_id = \wp_insert_post(
+			[
+				'post_title'  => 'Title',
+				'post_status' => 'publish',
+				'post_author' => $user_id,
+			]
+		);
+		global $wp_query;
+		$wp_query = new WP_Query(
+			[
+				'p' => $post_id,
+			]
+		);
+		$post = get_post( $post_id );
+		setup_postdata( $post );
+
+		self::assertEquals(
+			Guest_Contributor_Role::should_display_author_email( true ),
+			false,
+			'Email should be hidden for a Guest Contributor with a dummy email.'
+		);
+
+		// Update the user's email address.
+		\wp_update_user(
+			[
+				'ID'         => $user_id,
+				'user_email' => 'guest-contributor@legit-domain.com',
+			]
+		);
+		self::assertEquals(
+			Guest_Contributor_Role::should_display_author_email( true ),
+			true,
+			'Email should be displayed for a Guest Contributor with a regular email.'
+		);
+	}
+
+	/**
+	 * On a post with no author.
+	 */
+	public function test_guest_contributor_role_dummy_email_hiding_no_author() {
+		global $wp_query;
+		$wp_query->is_singular = true;
+		$should_hide = Guest_Contributor_Role::should_display_author_email( true );
+		self::assertEquals( null, get_the_author_meta( 'ID' ) );
+		self::assertEquals(
+			true,
+			$should_hide,
+			'Function should run successfully even if post apparently has no author. This can happen with co-authors-plus Guest Authors.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3370 was reverted in 01c0c2426ea8023d38f2186bd48029933fe1ec82 because of unhandled `false` return value from `get_userdata`. This PR reinstates #3370 with the offending line amended. 

### How to test the changes in this Pull Request:

See #3370

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->