### PR TITLE
hotfix: reinstate #3370 with fix

### DIFF
--- a/includes/cli/class-co-authors-plus.php
+++ b/includes/cli/class-co-authors-plus.php
@@ -192,7 +192,7 @@ class Co_Authors_Plus {
 			if ( isset( $post_meta['cap-user_email'] ) && ! empty( $post_meta['cap-user_email'] ) ) {
 				$user_data['user_email'] = $post_meta['cap-user_email'];
 			} else {
-				$dummy_email = '_migrated-' . $guest_author->ID . '-' . $user_login . '@example.com';
+				$dummy_email = \Newspack\Guest_Contributor_Role::get_dummy_email_address( '_migrated-' . $guest_author->ID . '-' . $user_login );
 				$user_data['user_email'] = $dummy_email;
 				if ( self::$verbose ) {
 					WP_CLI::line( sprintf( 'Missing email for Guest Author, email address will be updated to %s.', $dummy_email ) );

--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -478,7 +478,7 @@ class Guest_Contributor_Role {
 		if ( is_author() || is_singular() ) { // Run on archive pages and single posts/pages.
 			$author_id = get_the_author_meta( 'ID' );
 			$user = get_userdata( $author_id );
-			if ( self::is_guest_author( $user ) && self::is_dummy_email_address( $user->user_email ) ) {
+			if ( false !== $user && self::is_guest_author( $user ) && self::is_dummy_email_address( $user->user_email ) ) {
 				return false;
 			}
 		}

--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -76,6 +76,9 @@ class Guest_Contributor_Role {
 			add_action( 'edit_user_profile', [ __CLASS__, 'edit_user_profile' ] );
 			add_action( 'wp_update_user', [ __CLASS__, 'edit_user_profile_update' ] );
 		}
+
+		// Hide author email on the frontend, if it's a placeholder email.
+		\add_filter( 'theme_mod_show_author_email', [ __CLASS__, 'hide_author_email' ] );
 	}
 
 	/**
@@ -177,16 +180,45 @@ class Guest_Contributor_Role {
 		\update_option( self::SETTINGS_VERSION_OPTION_NAME, $current_settings_version );
 	}
 
-		/**
-		 * Filters user validation to allow empty emails for guest authors
-		 *
-		 * When creating a new user, also automatically generate a username from the display name.
-		 *
-		 * @param WP_Error $errors WP_Error object (passed by reference).
-		 * @param bool     $update Whether this is a user update.
-		 * @param stdClass $user   User object (passed by reference).
-		 * @return WP_Error
-		 */
+	/**
+	 * Get dummy email domain.
+	 */
+	public static function get_dummy_email_domain() {
+		return \apply_filters( 'newspack_guest_author_email_domain', 'example.com' );
+	}
+
+	/**
+	 * Is a dummy email address?
+	 *
+	 * @param string $email_address Email address to check.
+	 */
+	public static function is_dummy_email_address( $email_address ) {
+		return strpos( $email_address, '@' . self::get_dummy_email_domain() ) !== false;
+	}
+
+	/**
+	 * Create a placeholder/dummy email address.
+	 *
+	 * @param WP_User|string $user_or_name The user, or just the name.
+	 */
+	public static function get_dummy_email_address( $user_or_name ) {
+		$email_domain = self::get_dummy_email_domain();
+		if ( is_string( $user_or_name ) ) {
+			return $user_or_name . '@' . $email_domain;
+		}
+		return $user->user_login . '@' . $email_domain;
+	}
+
+	/**
+	 * Filters user validation to allow empty emails for guest authors
+	 *
+	 * When creating a new user, also automatically generate a username from the display name.
+	 *
+	 * @param WP_Error $errors WP_Error object (passed by reference).
+	 * @param bool     $update Whether this is a user update.
+	 * @param stdClass $user   User object (passed by reference).
+	 * @return WP_Error
+	 */
 	public static function user_profile_update_errors( $errors, $update, $user ) {
 
 		if ( ! isset( $user->role ) || self::CONTRIBUTOR_NO_EDIT_ROLE_NAME !== $user->role ) {
@@ -216,7 +248,7 @@ class Guest_Contributor_Role {
 
 		if ( empty( $user->user_email ) ) {
 			// Create a placeholder email address to avoid any issues with empty emails.
-			$user->user_email = $user->user_login . '@example.com';
+			$user->user_email = self::get_dummy_email_address( $user );
 		}
 
 		return $errors;
@@ -433,6 +465,22 @@ class Guest_Contributor_Role {
 	public static function cme_capabilities_add_user_multi_roles( $value ) {
 		if ( self::is_adding_user_with_no_edit_role() ) {
 			return false;
+		}
+		return $value;
+	}
+
+	/**
+	 * Hide the author email on the frontend if it's a placeholder email.
+	 *
+	 * @param bool $value Whether to show the author email.
+	 */
+	public static function hide_author_email( $value ) {
+		if ( is_author() || is_singular() ) { // Run on archive pages and single posts/pages.
+			$author_id = get_the_author_meta( 'ID' );
+			$user = get_userdata( $author_id );
+			if ( self::is_guest_author( $user ) && self::is_dummy_email_address( $user->user_email ) ) {
+				return false;
+			}
 		}
 		return $value;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3370 introduced a fatal when visiting CAP guest author archive pages. #3374 reverted that changeset. This PR reverts the revert and adds a fix for the fatal.

### How to test the changes in this Pull Request:

1. Check out [v5.3.1](https://github.com/Automattic/newspack-plugin/releases/tag/v5.3.1).
2. Ensure `NEWSPACK_DISABLE_CAP_GUEST_AUTHORS` isn't defined or is set to `false` in wp-config.php.
3. Create a new CAP Guest Author and visit their archive page, or visit the archive page of an existing guest author. Observe a fatal error:

```
PHP Fatal error:  Uncaught TypeError: Newspack\Guest_Contributor_Role::is_guest_author(): Argument #1 ($user) must be of type WP_User, bool given, called in /newspack-repos/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php on line 482 and defined in /newspack-repos/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:103
```

4. Check out this branch, refresh, and confirm the fatal is avoided.
5. Also confirm that testing instructions for #3370 still work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->