### PR TITLE
fix(ras-acc): handle recaptcha submit errors

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -125,7 +125,7 @@ final class Recaptcha {
 			\wp_enqueue_script(
 				self::SCRIPT_HANDLE,
 				Newspack::plugin_url() . '/dist/other-scripts/recaptcha.js',
-				[ self::SCRIPT_HANDLE_API ],
+				[ self::SCRIPT_HANDLE_API, 'wp-i18n' ],
 				NEWSPACK_PLUGIN_VERSION,
 				true
 			);

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -61,7 +61,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				if ( 'v2_invisible' === newspack_grecaptcha?.version ) {
 					if ( 'register' === action ) {
 						submitButtons.forEach( button => button.removeAttribute( 'data-skip-recaptcha' ) );
-						newspack_grecaptcha.render( [ form ] );
+						newspack_grecaptcha.render( [ form ], ( error ) => form.setMessageContent( error, true ) );
 					} else {
 						submitButtons.forEach( button => button.setAttribute( 'data-skip-recaptcha', '' ) );
 					}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150051/f

This PR addresses a problem where Firefox could end up with a strange recaptcha connection error and prevent v2 form submissions. This PR addresses this by adding an error callback and forcing a recaptcha refresh when an error is detected.

![Screenshot 2024-08-28 at 13 34 57](https://github.com/user-attachments/assets/179c4fa1-7b07-4c74-84d7-f85b24547223)


### How to test the changes in this Pull Request:

Be sure to also checkout the following PRs before testing:
- https://github.com/Automattic/newspack-blocks/pull/1859

1. As logged out user, try to trigger the connection error (see below note)
2. Confirm a recaptcha error appears within the auth or checkout modal and not as an alert
3. Confirm resubmitting the form is successful

Note: This one is a bit tricky to reproduce. I found the best way to get the connection error to appear is to:

1. Use Firefox
4. Enable v2 recaptcha
5. Set recaptcha slider all the way down via Admin console: https://www.google.com/recaptcha/admin
6. Repeatedly go through the auth registration + checkout flow via a donation block, logout, go through the regular auth registration flow via signin button and repeat a handful of times

But truthfully not sure exactly what causes the issue...

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->