### PR TITLE
fix(woocommerce-memberships): membership status check with post status instead of type

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -937,7 +937,7 @@ class Memberships {
 		if ( ! property_exists( $post, 'post_type' ) ) {
 			return $post_status;
 		}
-		if ( 'wc_user_membership' !== $post->post_type || ! in_array( $post->post_type, [ 'wcm-cancelled', 'wcm-expired', 'wcm-paused' ], true ) || ! self::is_active() || ! function_exists( 'wc_memberships_get_user_membership' ) ) {
+		if ( 'wc_user_membership' !== $post->post_type || ! in_array( $post->post_status, [ 'wcm-cancelled', 'wcm-expired', 'wcm-paused' ], true ) || ! self::is_active() || ! function_exists( 'wc_memberships_get_user_membership' ) ) {
 			return $post_status;
 		}
 		$integrations = wc_memberships()->get_integrations_instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While following up on an open issue, I noticed that the fix in #3338 contains an error: instead of checking the `post_status` against the membership status, it checks the `post_type`, which will always cause the check to fail and thus not execute the fix. This should fix the fix.

### How to test the changes in this Pull Request:

Follow testing instructions for #3268 and #3338 and confirm that both work as described.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207858308890295