### PR TITLE
Feat/mailchimp related tweaks

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -84,14 +84,6 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=jetpack',
 			],
-			'mailchimp-for-woocommerce'   => [
-				'Name'        => 'Mailchimp for WooCommerce',
-				'Description' => \esc_html__( 'Connects WooCommerce to Mailchimp to sync your store data, send targeted campaigns to your customers, and sell more stuff.', 'newspack' ),
-				'Author'      => \esc_html__( 'Mailchimp', 'newspack' ),
-				'AuthorURI'   => \esc_url( 'https://mailchimp.com' ),
-				'PluginURI'   => \esc_url( 'https://mailchimp.com/connect-your-store/' ),
-				'Download'    => 'wporg',
-			],
 			'newspack-ads'                => [
 				'Name'        => \esc_html__( 'Newspack Ads', 'newspack' ),
 				'Description' => \esc_html__( 'Ads integration.', 'newspack' ),

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -84,6 +84,14 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=jetpack',
 			],
+			'mailchimp-for-woocommerce'   => [
+				'Name'        => 'Mailchimp for WooCommerce',
+				'Description' => \esc_html__( 'Connects WooCommerce to Mailchimp to sync your store data, send targeted campaigns to your customers, and sell more stuff.', 'newspack' ),
+				'Author'      => \esc_html__( 'Mailchimp', 'newspack' ),
+				'AuthorURI'   => \esc_url( 'https://mailchimp.com' ),
+				'PluginURI'   => \esc_url( 'https://mailchimp.com/connect-your-store/' ),
+				'Download'    => 'wporg',
+			],
 			'newspack-ads'                => [
 				'Name'        => \esc_html__( 'Newspack Ads', 'newspack' ),
 				'Description' => \esc_html__( 'Ads integration.', 'newspack' ),

--- a/src/wizards/engagement/components/active-campaign.js
+++ b/src/wizards/engagement/components/active-campaign.js
@@ -38,6 +38,15 @@ export default function ActiveCampaign( { value, onChange } ) {
 				title={ __( 'ActiveCampaign settings', 'newspack-plugin' ) }
 				description={ __( 'Settings for the ActiveCampaign integration.', 'newspack-plugin' ) }
 			/>
+			{ value.masterList === '' && (
+				<Notice
+					noticeText={ __(
+						'No Master List selected. You will not be able to send reader activity data to ActiveCampaign.',
+						'newspack-plugin'
+					) }
+					isError
+				/>
+			)}
 			<SelectControl
 				label={ __( 'Master List', 'newspack-plugin' ) }
 				help={ __(

--- a/src/wizards/engagement/components/mailchimp.js
+++ b/src/wizards/engagement/components/mailchimp.js
@@ -38,6 +38,15 @@ export default function Mailchimp( { value, onChange } ) {
 				title={ __( 'Mailchimp settings', 'newspack-plugin' ) }
 				description={ __( 'Settings for the Mailchimp integration.', 'newspack-plugin' ) }
 			/>
+			{ value.audienceId === '' && (
+				<Notice
+					noticeText={ __(
+						'No Mailchimp audience selected. You will not be able to send reader activity data to Mailchimp.',
+						'newspack-plugin'
+					) }
+					isError
+				/>
+			)}
 			<SelectControl
 				label={ __( 'Audience ID', 'newspack-plugin' ) }
 				help={ __( 'Choose an audience to receive reader activity data.', 'newspack-plugin' ) }
@@ -51,17 +60,17 @@ export default function Mailchimp( { value, onChange } ) {
 			/>
 			{ value.audienceId && (
 				<SelectControl
-					label={ __( 'Default reader status', 'newspack' ) }
+					label={ __( 'Default reader status', 'newspack-plugin' ) }
 					help={ __(
 						'Choose which MailChimp status readers should have by default if they are not subscribed to any newsletters',
-						'newspack'
+						'newspack-plugin'
 					) }
 					disabled={ inFlight }
 					value={ value.readerDefaultStatus }
 					onChange={ handleChange( 'readerDefaultStatus' ) }
 					options={ [
-						{ value: 'transactional', label: __( 'Transactional/Non-Subscribed', 'newspack' ) },
-						{ value: 'subscribed', label: __( 'Subscribed', 'newspack' ) },
+						{ value: 'transactional', label: __( 'Transactional/Non-Subscribed', 'newspack-plugin' ) },
+						{ value: 'subscribed', label: __( 'Subscribed', 'newspack-plugin' ) },
 					] }
 				/>
 			) }

--- a/src/wizards/engagement/views/newsletters/index.js
+++ b/src/wizards/engagement/views/newsletters/index.js
@@ -25,7 +25,6 @@ import {
 	ActionCard,
 	Grid,
 	PluginInstaller,
-	SectionHeader,
 	SelectControl,
 	TextControl,
 	Waiting,
@@ -413,13 +412,6 @@ const Newsletters = () => {
 				setInitialProvider={ setInitialProvider }
 			/>
 			<SubscriptionLists lockedLists={ lockedLists } initialProvider={ initialProvider } />
-			{ 'mailchimp' === newslettersConfig?.newspack_newsletters_service_provider && (
-				<>
-					<hr />
-					<SectionHeader title={ __( 'WooCommerce integration', 'newspack-plugin' ) } />
-					<PluginInstaller plugins={ [ 'mailchimp-for-woocommerce' ] } withoutFooterButton />
-				</>
-			) }
 		</>
 	);
 };

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -391,6 +391,11 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 						<Button
 							isPrimary
 							onClick={ () => {
+								if (isMailchimp && config.sync_esp && config.mailchimp_audience_id === '') {
+									// eslint-disable-next-line no-alert
+									alert( __( 'Please select a Mailchimp Audience ID.', 'newspack-plugin' ) );
+									return
+								}
 								saveConfig( {
 									newsletters_label: config.newsletters_label, // TODO: Deprecate this in favor of user input via the prompt copy wizard.
 									mailchimp_audience_id: config.mailchimp_audience_id,

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -391,10 +391,17 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 						<Button
 							isPrimary
 							onClick={ () => {
-								if (isMailchimp && config.sync_esp && config.mailchimp_audience_id === '') {
-									// eslint-disable-next-line no-alert
-									alert( __( 'Please select a Mailchimp Audience ID.', 'newspack-plugin' ) );
-									return
+								if ( config.sync_esp ) {
+									if (isMailchimp && config.mailchimp_audience_id === '') {
+										// eslint-disable-next-line no-alert
+										alert( __( 'Please select a Mailchimp Audience ID.', 'newspack-plugin' ) );
+										return
+									}
+									if (isActiveCampaign && config.active_campaign_master_list === '') {
+										// eslint-disable-next-line no-alert
+										alert( __( 'Please select an ActiveCampaign Master List.', 'newspack-plugin' ) );
+										return
+									}
 								}
 								saveConfig( {
 									newsletters_label: config.newsletters_label, // TODO: Deprecate this in favor of user input via the prompt copy wizard.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Two tweaks related to Mailchimp handling:

1. Removes the `mailchimp-for-woocommerce` plugin installation prompt from the Engagement Wizard
3. Adds an error notice if the ESP sync list (for Mailchimp and ActiveCampaign) is set to "None":

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/ebec1b4f-4588-41e9-92ee-597d437d4cab">

### How to test the changes in this Pull Request:

1. Set Mailchimp as the ESP
5. Go to Engagement wizard -> Reader Activation tab -> Advanced Settings, and toggle on the "Sync contacts to ESP" option
6. Observe that if the Audience ID is set to "None", an error notice with the appropriate message appears
7. Try to save the settings – observe a browser alert displayed, and that the settings won't be saved if the ESP Sync is enabled and the Audience ID is set to "None"
8. Go to Newsletters tab in the same wizard, observe there's no "WooCommerce integration" section at the bottom

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208173056022058
  - https://app.asana.com/0/0/1208161447317923