### PR TITLE
fix(phpcs): specify path in custom ruleset ref

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,7 @@
 	<rule ref="WordPress-VIP-Go" />
 
 	<!-- Newspack Plugin rules -->
-	<rule ref="phpcsSniffs" />
+	<rule ref="./phpcsSniffs" />
 
 	<rule ref="WordPress">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Same as https://github.com/Automattic/newspack-newsletters/pull/1637 but for this repo.

#3337 implemented some custom PHPCS sniffs, but for some reason the `<rule ref="phpcsSniffs" />` causes my IDE to fail to find them unless I specify a relative path from the repo's root directory.

### How to test the changes in this Pull Request:

If you use VS Code + a PHPCS/PHPCBF extension, you may observe on `trunk` that attempting to lint or fix errors throws an error about not being able to find the referenced sniff. This should fix it.

<img width="460" alt="Screenshot 2024-08-30 at 2 45 56 PM" src="https://github.com/user-attachments/assets/4de2f181-5658-4472-b512-1c57e2f5723f">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
