### PR TITLE
fix: required billing fields in My Account

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -434,12 +434,18 @@ class WooCommerce_My_Account {
 	 * @return bool True if the current checkout page is coming from a My Account referrer, false otherwise.
 	 */
 	public static function is_from_my_account() {
-		// If we got posted a `is_my_account` param, return true.
+		// If we're in My Account.
+		if ( \is_account_page() ) {
+			return true;
+		}
+
+		// If we have an `is_my_account` param in POST or GET.
 		$is_my_account_param = rest_sanitize_boolean( $_REQUEST['my_account_checkout'] ?? false ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( $is_my_account_param ) {
 			return true;
 		}
 
+		// If the referrer URL had a `my_account_checkout` param.
 		$referrer = \wp_get_referer();
 		if ( $referrer ) {
 			$referrer_query = \wp_parse_url( $referrer, PHP_URL_QUERY );
@@ -460,7 +466,7 @@ class WooCommerce_My_Account {
 	 * @return string
 	 */
 	public static function get_checkout_url( $url ) {
-		if ( \is_account_page() || self::is_from_my_account() ) {
+		if ( self::is_from_my_account() ) {
 			return \add_query_arg(
 				[
 					'my_account_checkout' => 1,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression that broke the address-editing solution in #2835, and adds a new `is_my_account` hidden billing field to checkouts originating from My Account so that we can determine post-checkout if the checkout originated from My Account (because we can only get the referrer URL from the immediately preceding page, not two pages earlier).

Also fixes a bug where clicking "Renew Now" or "Pay Now" from My Account redirects to the My Account main page instead of allowing you to complete the renewal.

See https://github.com/Automattic/newspack-blocks/pull/1869 too, which uses a fix from this PR.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/1869.
2. In **Newspack > Reader Revenue > Donations**, enable some but not all billing address fields.
3. As a reader, purchase a subscription via a modal checkout flow (Donate or Checkout Button blocks). Confirm that the post-checkout thank you page shown here uses the modal checkout template.
4. Log into My Account and visit **Addresses**. Edit your billing address and confirm that the fields here are only required if they're also required in **Newspack > Reader Revenue > Donations** (make sure to submit with empty optional fields to confirm the field validation, too).
5. Also in My Account, visit **My Subscription**  then **Renew Now**. Confirm that you're redirected to a Checkout form and NOT the My Account main page.
6. In the checkout page that loads, confirm that billing address fields are only required if they're also required in **Newspack > Reader Revenue > Donations**. (In the future, we should make the checkout flow from My Account a modal checkout flow to avoid this UI discrepancy.)
7. After completing the renewal, confirm that the "thank you" confirmation page does NOT use the modal checkout template. It should have the full site header and footer, and contain a link back to the main "My Account" page, like so:

<img width="838" alt="Screenshot 2024-09-03 at 6 38 46 PM" src="https://github.com/user-attachments/assets/aa47df44-ba3e-4b23-bd97-5ef8adf4cb07">

8. Smoke test a transaction via modal checkout using an express checkout method such as Apple Pay (see https://github.com/Automattic/newspack-blocks/pull/1573 for testing instructions) and confirm that the post-checkout thank you page shown here uses the modal checkout template.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208207058134668