### PR TITLE
fix(ras-acc): undo bad merge updates

### DIFF
--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -367,6 +367,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 					return form.endLoginFlow( newspack_reader_activation_labels.invalid_email, 400 );
 				}
+				if ( readerActivation.isPendingCheckout() ) {
+					const redirectUrl = getCheckoutRedirectUrl();
+					if ( redirectUrl ) {
+						body.set( 'redirect_url', redirectUrl );
+					}
+				}
 				if ( 'otp' === action ) {
 					readerActivation
 						.authenticateOTP( body.get( 'otp_code' ) )


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR undoes a small change that occured during a bad merge on my part.

Specifically, a few lines that were added in https://github.com/Automattic/newspack-plugin/pull/3343 were removed in the merge.

### How to test the changes in this Pull Request:

Visually verify the code. You can also see https://github.com/Automattic/newspack-plugin/pull/3343 for testing instructions if you'd like to test more thoroughly.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->