### PR TITLE
Hotfix/woo subs vs memberships expiration

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -57,6 +57,7 @@ class Memberships {
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
 		add_action( 'wp', [ __CLASS__, 'remove_unnecessary_content_restriction' ], 11 );
+		add_action( 'woocommerce_subscription_status_updated', [ __CLASS__, 'handle_subscription_status_change' ], 10, 3 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -987,6 +988,36 @@ class Memberships {
 		return array_slice( $settings, 0, $position_of_show_excerpts_setting, true ) +
 			[ $setting['id'] => $setting ] +
 			array_slice( $settings, $position_of_show_excerpts_setting, null, true );
+	}
+
+	/**
+	 * Unschedule membership expiration events when a subscription reactivates a membership.
+	 * Otherwise, an expired memberhip that's reactivated because of a new subscription
+	 * purchase will become expired a while later, due to a scheduled expiration.
+	 *
+	 * @param \WC_Subscription $subscription Subscription being changed.
+	 * @param string           $new_subscription_status Subscription status changing to.
+	 * @param string           $old_subscription_status Subscription status changing from.
+	 */
+	public static function handle_subscription_status_change( \WC_Subscription $subscription, $new_subscription_status, $old_subscription_status ) {
+		if ( $new_subscription_status !== 'active' || ! function_exists( 'wc_memberships' ) ) {
+			return;
+		}
+		$integrations = \wc_memberships()->get_integrations_instance();
+		if ( ! $integrations ) {
+			return;
+		}
+		$integration = $integrations->get_subscriptions_instance();
+		// Get Memberships tied to the Subscription.
+		$user_memberships = $integration->get_memberships_from_subscription( $subscription->get_id() );
+		if ( ! $user_memberships ) {
+			return;
+		}
+
+		// For each, unschedule expiration events.
+		foreach ( $user_memberships as $user_membership ) {
+			$user_membership->unschedule_expiration_events();
+		}
 	}
 }
 Memberships::init();

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -57,7 +57,6 @@ class Memberships {
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
 		add_action( 'wp', [ __CLASS__, 'remove_unnecessary_content_restriction' ], 11 );
-		add_action( 'woocommerce_subscription_status_updated', [ __CLASS__, 'handle_subscription_status_change' ], 10, 3 );
 		add_filter( 'wc_memberships_expire_user_membership', [ __CLASS__, 'handle_wc_memberships_expire_user_membership' ], 10, 2 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
@@ -991,35 +990,6 @@ class Memberships {
 			array_slice( $settings, $position_of_show_excerpts_setting, null, true );
 	}
 
-	/**
-	 * Unschedule membership expiration events when a subscription reactivates a membership.
-	 * Otherwise, an expired memberhip that's reactivated because of a new subscription
-	 * purchase will become expired a while later, due to a scheduled expiration.
-	 *
-	 * @param \WC_Subscription $subscription Subscription being changed.
-	 * @param string           $new_subscription_status Subscription status changing to.
-	 * @param string           $old_subscription_status Subscription status changing from.
-	 */
-	public static function handle_subscription_status_change( \WC_Subscription $subscription, $new_subscription_status, $old_subscription_status ) {
-		if ( $new_subscription_status !== 'active' || ! function_exists( 'wc_memberships' ) ) {
-			return;
-		}
-		$integrations = \wc_memberships()->get_integrations_instance();
-		if ( ! $integrations ) {
-			return;
-		}
-		$integration = $integrations->get_subscriptions_instance();
-		// Get Memberships tied to the Subscription.
-		$user_memberships = $integration->get_memberships_from_subscription( $subscription->get_id() );
-		if ( ! $user_memberships ) {
-			return;
-		}
-
-		// For each, unschedule expiration events.
-		foreach ( $user_memberships as $user_membership ) {
-			$user_membership->unschedule_expiration_events();
-		}
-	}
 	/**
 	 * Prevent User Membership expiring, if run in the CRON job. This is another way of
 	 * preventing expiration, in addition to handle_subscription_status_change.

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -991,26 +991,18 @@ class Memberships {
 	}
 
 	/**
-	 * Prevent User Membership expiring, if run in the CRON job. This is another way of
-	 * preventing expiration, in addition to handle_subscription_status_change.
-	 *
-	 * It appears that there's a race condition between the results of the unschedule_expiration_events
-	 * method call in handle_subscription_status_change, and the scheduled expiration events.
-	 * This filter ensures that even if the unschedule_expiration_events doesn't fire early enough,
-	 * this filter will catch the issue.
+	 * Prevent User Membership expiring, if the linked subscription is active.
 	 *
 	 * @param bool                            $expire true will expire this membership, false will retain it - default: true, expire it.
 	 * @param \WC_Memberships_User_Membership $user_membership the User Membership object being expired.
 	 */
 	public static function handle_wc_memberships_expire_user_membership( $expire, $user_membership ) {
-		// Check if the user membership has an active subscription.
 		$integration = wc_memberships()->get_integrations_instance()->get_subscriptions_instance();
 		if ( ! $integration ) {
 			return $expire;
 		}
 		$subscription = $integration->get_subscription_from_membership( $user_membership->get_id() );
 		if ( $subscription ) {
-			// Get subscription status.
 			$subscription_status = $integration->get_subscription_status( $subscription );
 			if ( 'active' === $subscription_status ) {
 				return false;

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -18,7 +18,6 @@ defined( 'ABSPATH' ) || exit;
 class Memberships {
 
 	const GATE_CPT = 'np_memberships_gate';
-	const CRON_HOOK = 'np_memberships_fix_expired_memberships';
 	const SKIP_RESTRICTION_IN_RSS_OPTION_NAME = 'newspack_skip_content_restriction_in_rss_feeds';
 
 	/**
@@ -57,7 +56,6 @@ class Memberships {
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
-		add_filter( 'get_post_status', [ __CLASS__, 'check_membership_status' ], 10, 2 );
 		add_action( 'wp', [ __CLASS__, 'remove_unnecessary_content_restriction' ], 11 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
@@ -71,10 +69,6 @@ class Memberships {
 		add_filter( 'newspack_gate_content', 'wp_filter_content_tags' );
 		add_filter( 'newspack_gate_content', 'wp_replace_insecure_home_url' );
 		add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
-
-		// Scheduled fix for prematurely expired memberships.
-		add_action( 'init', [ __CLASS__, 'cron_init' ] );
-		add_action( self::CRON_HOOK, [ __CLASS__, 'fix_expired_memberships_for_active_subscriptions' ] );
 
 		include __DIR__ . '/class-block-patterns.php';
 		include __DIR__ . '/class-metering.php';
@@ -921,133 +915,6 @@ class Memberships {
 		}
 
 		return $has_access;
-	}
-
-	/**
-	 * Check if a user has an active subscription with the required products when checking membership status.
-	 * If they have an active subscription, but the membership is cancelled,
-	 * reset inactive memberships to active link to the active subscription.
-	 *
-	 * @param string  $post_status Post status.
-	 * @param WP_Post $post Post object.
-	 *
-	 * @return string
-	 */
-	public static function check_membership_status( $post_status, $post ) {
-		if ( ! property_exists( $post, 'post_type' ) ) {
-			return $post_status;
-		}
-		if ( 'wc_user_membership' !== $post->post_type || ! in_array( $post->post_status, [ 'wcm-cancelled', 'wcm-expired', 'wcm-paused' ], true ) || ! self::is_active() || ! function_exists( 'wc_memberships_get_user_membership' ) ) {
-			return $post_status;
-		}
-		$integrations = wc_memberships()->get_integrations_instance();
-		$integration  = $integrations ? $integrations->get_subscriptions_instance() : null;
-		$membership   = wc_memberships_get_user_membership( $post->ID );
-		$plan_id      = $membership->get_plan_id();
-		if ( $integration && $integration->has_membership_plan_subscription( $plan_id ) ) {
-			$subscription_plan    = new \WC_Memberships_Integration_Subscriptions_Membership_Plan( $plan_id );
-			$required_products    = $subscription_plan->get_subscription_product_ids();
-			$active_subscriptions = WooCommerce_Connection::get_active_subscriptions_for_user( $membership->get_user_id(), $required_products );
-			$has_subscription     = ! empty( $active_subscriptions );
-			if ( $has_subscription ) {
-				$post_status = 'wcm-active';
-				$membership  = new \WC_Memberships_Integration_Subscriptions_User_Membership( $post->ID );
-				$membership->unschedule_expiration_events();
-				$membership->set_subscription_id( $active_subscriptions[0] );
-				$membership->set_end_date(); // Clear the end date.
-				$membership->update_status( 'active' );
-			}
-		}
-
-		return $post_status;
-	}
-
-	/**
-	 * Deactivate the cron job.
-	 */
-	public static function cron_deactivate() {
-		\wp_clear_scheduled_hook( self::CRON_HOOK );
-	}
-
-	/**
-	 * Schedule an hourly cron job to check for and fix expired memberships linked to active subscriptions.
-	 */
-	public static function cron_init() {
-		\register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );
-
-		if ( defined( 'NEWSPACK_ENABLE_MEMBERSHIPS_FIX_CRON' ) && NEWSPACK_ENABLE_MEMBERSHIPS_FIX_CRON ) {
-			if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-				\wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
-			}
-		} else {
-			self::cron_deactivate();
-		}
-	}
-
-	/**
-	 * Ensure that memberships tied to active subscriptions haven't expired prematurely.
-	 * Will loop through all active subscriptions on the site and check all memberships associated with it.
-	 */
-	public static function fix_expired_memberships_for_active_subscriptions() {
-		if ( ! function_exists( 'wc_memberships' ) ) {
-			return;
-		}
-
-
-		$max_per_batch           = 100;
-		$processed_batches       = 0;
-		$reactivated_memberships = 0;
-		$active_subscriptions    = WooCommerce_Connection::get_batch_of_active_subscriptions( $max_per_batch, $processed_batches );
-		if ( empty( $active_subscriptions ) ) {
-			return;
-		}
-
-		Logger::log( __( 'Checking for expired memberships linked to active subscriptions...', 'newspack-plugin' ) );
-
-		$active_membership_statuses = \wc_memberships()->get_user_memberships_instance()->get_active_access_membership_statuses();
-		while ( ! empty( $active_subscriptions ) ) {
-			$subscription = array_shift( $active_subscriptions );
-			try {
-				$memberships = \wc_memberships_get_memberships_from_subscription( $subscription );
-				if ( $memberships ) {
-					foreach ( $memberships as $membership ) {
-						// If the membership is not active and has an end date in the past, reactivate it.
-						if ( $membership && ! $membership->has_status( $active_membership_statuses ) && $membership->has_end_date() && $membership->get_end_date( 'timestamp' ) < time() ) {
-							$membership->unschedule_expiration_events();
-							$membership->set_end_date(); // Clear the end date.
-							$membership->update_status( 'active' ); // Reactivate the membership.
-							$reactivated_memberships++;
-						}
-					}
-				}
-			} catch ( Exception $e ) {
-				// Log the error.
-				Logger::log(
-					sprintf(
-						// Translators: %1$d is the membership ID, %2$s is the subscription ID.
-						__( 'Failed to reactivate membership %1$d linked to active subscription %2$s.', 'newspack-plugin' ),
-						$membership->get_id(),
-						$subscription->get_id()
-					)
-				);
-			}
-
-			// Get the next batch of active subscriptions.
-			if ( empty( $active_subscriptions ) ) {
-				$processed_batches++;
-				$active_subscriptions = WooCommerce_Connection::get_batch_of_active_subscriptions( $max_per_batch, $processed_batches * $max_per_batch );
-			}
-		}
-
-		if ( 0 < $reactivated_memberships ) {
-			Logger::log(
-				sprintf(
-					// Translators: %d is the number of reactivated memberships.
-					__( 'Reactivated %d memberships linked to active subscriptions.', 'newspack-plugin' ),
-					$reactivated_memberships
-				)
-			);
-		}
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -125,30 +125,6 @@ class WooCommerce_Connection {
 	}
 
 	/**
-	 * Get a batch of active Woo Subscriptions.
-	 *
-	 * @param int $batch_size Max number of subscriptions to get.
-	 * @param int $offset     Number to skip.
-	 *
-	 * @return array|false Array of subscription objects, or false if no more to fetch.
-	 */
-	public static function get_batch_of_active_subscriptions( $batch_size = 100, $offset = 0 ) {
-		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
-			return false;
-		}
-
-		$subscriptions = \wcs_get_subscriptions(
-			[
-				'status'                 => self::ACTIVE_SUBSCRIPTION_STATUSES,
-				'subscriptions_per_page' => $batch_size,
-				'offset'                 => $offset,
-			]
-		);
-
-		return ! empty( $subscriptions ) ? array_values( $subscriptions ) : false;
-	}
-
-	/**
 	 * Does the given user have any subscriptions with an active status?
 	 * Can optionally pass an array of product IDs. If given, only subscriptions
 	 * that have at least one of the given product IDs will be returned.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Alternative solution to the problem originally tackled in #3050, then amended in #3060, #3268, #3338, and #3380. The issue was that a re-activated membership would transition to expired status shortly after reactivation (which happens by buying a new subscription). 

The original solution was acting retroactively on the expired memberships (in a CRON hook, and when reading post status), causing OOM issues on sites with a lot of memberships (10k+). 

The solution proposed takes a proactive approach, unscheduling a membership expiration when a related subscription is reactivated.

### How to test the changes in this Pull Request:

1. Checkout the first commit (bbf0992379d57a58de6fe2467eedf409ba98f370), which reverts the previous solution – this way the problem is not addressed in any way
2. Set up a Membership Plan that's tied to a product purchase and set "Subscription length"
3. As a reader, purchase the product 
4. In WP Admin, confirm that the membership was granted
5. Cancel the subscription and observe the membership was cancelled, too
6. Again as a reader, purchase the subscription again
7. Observe that the membership was reactivated, and then set to "Expired" again (this might happen in a quick succession, but you can trace the story in the membership notes)
8. Checkout this branch (the second commit) and repeat the test. Observe that the membership is not expired after the new subscription reactivates it 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208230183010467
  - https://app.asana.com/0/0/1207858308890295