### PR TITLE
fix: hide My Account links if not relevant

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -126,13 +126,21 @@ class WooCommerce_My_Account {
 				if ( empty( array_filter( $billing_address ) ) && empty( array_filter( $billing_address ) ) ) {
 					$default_disabled_items[] = 'edit-address';
 				}
+
+				// Hide Orders and Payment Methods if the reader has no orders.
+				if ( ! $customer->get_is_paying_customer() ) {
+					$default_disabled_items[] = 'orders';
+					$default_disabled_items[] = 'payment-methods';
+				}
 			}
 			if ( function_exists( 'wc_get_customer_available_downloads' ) ) {
-				$customer_id           = \get_current_user_id();
 				$wc_customer_downloads = \wc_get_customer_available_downloads( $customer_id );
 				if ( empty( $wc_customer_downloads ) ) {
 					$default_disabled_items[] = 'downloads';
 				}
+			}
+			if ( function_exists( 'wcs_user_has_subscription' ) && ! \wcs_user_has_subscription( $customer_id ) ) {
+				$default_disabled_items[] = 'subscriptions';
 			}
 
 			$disabled_wc_menu_items = \apply_filters( 'newspack_my_account_disabled_pages', $default_disabled_items );

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -149,6 +149,12 @@ class WooCommerce_My_Account {
 					unset( $items[ $key ] );
 				}
 			}
+
+			// Move "Account Details" and "S"ubscriptions" to the top of the menu.
+			if ( isset( $items['subscriptions'] ) ) {
+				$items = [ 'subscriptions' => $items['subscriptions'] ] + $items;
+			}
+			$items = [ 'edit-account' => $items['edit-account'] ] + $items;
 		}
 
 		return $items;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I'm not sure when this changed, but at some point in the past we used to hide "Subscriptions", "Orders", and "Payment Methods" links in the My Account dashboard if the customer didn't have any subscriptions or orders to manage. This PR restores that feature to remove those links that are irrelevant to non-paying customers.

### How to test the changes in this Pull Request:

1. Sign up as a new reader without making any purchases and log into/verify with My Account.
2. Confirm that "Subscriptions", "Orders", and "Payment Methods" links are not shown ("Newsletters" is still shown if the Newsletters plugin is available, to allow the user to sign up for newsletters if desired):

<img width="1221" alt="Screenshot 2024-09-05 at 10 12 04 AM" src="https://github.com/user-attachments/assets/2324f056-4c4e-428e-961b-018b26506f11">

3. Complete a donation or purchase and revisit My Account. Confirm that "Subscriptions", "Orders", and "Payment Methods" links are now shown, and that "Account Details" and "Subscriptions" links are the first two items in the menu.

<img width="1228" alt="Screenshot 2024-09-05 at 10 19 32 AM" src="https://github.com/user-attachments/assets/3ed81b81-8061-4f20-89b6-599bb0c2ecf7">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->