### PR TITLE
feat(ras-acc): make sure modal checkout still works without RAS

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -130,6 +130,7 @@ final class Reader_Activation {
 				'otp_auth_action'       => Magic_Link::OTP_AUTH_ACTION,
 				'otp_rate_interval'     => Magic_Link::RATE_INTERVAL,
 				'account_url'           => function_exists( 'wc_get_account_endpoint_url' ) ? \wc_get_account_endpoint_url( 'dashboard' ) : '',
+				'ras_is_enabled'        => self::is_enabled(),
 			];
 
 			if ( Recaptcha::can_use_captcha() ) {

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -130,7 +130,7 @@ final class Reader_Activation {
 				'otp_auth_action'       => Magic_Link::OTP_AUTH_ACTION,
 				'otp_rate_interval'     => Magic_Link::RATE_INTERVAL,
 				'account_url'           => function_exists( 'wc_get_account_endpoint_url' ) ? \wc_get_account_endpoint_url( 'dashboard' ) : '',
-				'ras_is_enabled'        => self::is_enabled(),
+				'is_ras_enabled'        => self::is_enabled(),
 			];
 
 			if ( Recaptcha::can_use_captcha() ) {

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -433,7 +433,7 @@ const readerActivation = {
 	getCheckoutData,
 	isPendingCheckout,
 	resetCheckoutData,
-	...( newspack_ras_config.ras_is_enabled && { openAuthModal } )
+	...( newspack_ras_config.is_ras_enabled && { openAuthModal } )
 };
 
 /**

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -170,7 +170,6 @@ export function openAuthModal( config = {} ) {
 		}
 		return;
 	}
-
 	if ( readerActivation._openAuthModal ) {
 		readerActivation._openAuthModal( config );
 	} else {

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -170,6 +170,7 @@ export function openAuthModal( config = {} ) {
 		}
 		return;
 	}
+
 	if ( readerActivation._openAuthModal ) {
 		readerActivation._openAuthModal( config );
 	} else {
@@ -419,7 +420,6 @@ const readerActivation = {
 	setAuthenticated,
 	refreshAuthentication,
 	getReader,
-	openAuthModal,
 	openNewslettersSignupModal,
 	hasAuthLink,
 	getOTPHash,
@@ -433,6 +433,7 @@ const readerActivation = {
 	getCheckoutData,
 	isPendingCheckout,
 	resetCheckoutData,
+	...( newspack_ras_config.ras_is_enabled && { openAuthModal } )
 };
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Is a redo of https://github.com/Automattic/newspack-blocks/pull/1866 based on feedback -- I'm not 100% sure about my approach here, so any feedback on that is welcome!

This PR makes it possible to use the modal checkout when RAS isn't enabled, to match the current behaviour on trunk.

The main difference between the RAS-based checkout is that the initial checkout screen will require you to fill our the email address with the other billing details, since it won't be pre-populated from the Sign In/Sign Up screen.

See: 1207817176293825-as-1208164200882316

### How to test the changes in this Pull Request:


1. Start on a test site without RAS enabled, or disable it by running `wp option delete newspack_reader_activation_enabled`.
2. Set up three blocks: a regular Checkout Button block, one with a variable product, and a Donate block.
3. On epic/ras-acc in an incognito window, try to run the checkout in any of the blocks; only the initial variation picker will open.
4. Apply this PR and run `npm run build`.
5. In the incognito window, run through each checkout and confirm it works.
6. Enable RAS (run `wp option update newspack_reader_activation_enabled 1` or use the wizard), or re-test this PR on a second test site with RAS enabled.
7. Smoke test the checkout flows as a new reader and as a logged in reader and confirm that you get the Sign In prompts at the appropriate points, and that the checkout works as usual.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->