### PR TITLE
fix(ras-acc): prevent invalid auth flow errors

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -385,7 +385,7 @@ final class Magic_Link {
 	}
 
 	/**
-	 * Check for magic link tokens generated within the last 60 seconds.
+	 * Check for active magic link tokens.
 	 *
 	 * @param \WP_User $user User to check the active magic link token for.
 	 *
@@ -399,7 +399,7 @@ final class Magic_Link {
 		$now    = time();
 		$tokens = \get_user_meta( $user->ID, self::TOKENS_META, true );
 
-		$expire = $now - MINUTE_IN_SECONDS;
+		$expire = $now - self::get_token_expiration_period();
 		if ( ! empty( $tokens ) ) {
 			foreach ( $tokens as $index => $token_data ) {
 				/** Clear expired tokens. */

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1959,7 +1959,7 @@ final class Reader_Activation {
 
 		$user_id = false;
 
-		if ( $existing_user ) {
+		if ( $existing_user && self::is_reader_without_password( $existing_user ) ) {
 			// Don't send OTP email for newsletter signup.
 			if ( ! isset( $metadata['registration_method'] ) || false === strpos( $metadata['registration_method'], 'newsletters-subscription' ) ) {
 				Logger::log( "User with $email already exists. Sending magic link." );

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -171,11 +171,11 @@ function renderWidget( form, errorHandler = null ) {
 		} )( jQuery );
 
 		button.addEventListener( 'click', e => {
+			e.preventDefault();
 			// Skip reCAPTCHA verification if the button has a data-skip-recaptcha attribute.
 			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
 				callback();
 			} else {
-				e.preventDefault();
 				grecaptcha.execute( widgetId );
 
 				// For some reason, WooCommerce checkout forms don't properly pin the widget in a fixed location, so we need to scroll to the top of the page to ensure it's visible.

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -50,14 +50,66 @@ window.newspackRAS.push( function ( readerActivation ) {
 			};
 
 			/**
+			 * Sets response message content.
+			 *
+			 * @param {string|HTMLElement} message Message content.
+			 * @param {boolean}            isError Whether the message is an error.
+			 *
+			 * @return {void}
+			 */
+			form.setMessageContent = ( message = '', isError = false ) => {
+				if ( message ) {
+					if ( typeof message === 'string' ) {
+						messageContentElement.innerHTML = message;
+					} else {
+						messageContentElement.appendChild( message );
+					}
+					if ( isError ) {
+						messageContentElement.classList.remove( 'newspack-ui__helper-text' );
+						messageContentElement.classList.add( 'newspack-ui__inline-error' );
+					} else {
+						messageContentElement.classList.remove( 'newspack-ui__inline-error' );
+						messageContentElement.classList.add( 'newspack-ui__helper-text' );
+					}
+					messageContentElement.style.display = 'block';
+
+					// If the message includes a registration toggle, hide the message when clicked.
+					messageContentElement
+						.querySelectorAll( 'a[data-set-action="register"], a[data-set-action="signin"]' )
+						.forEach( registerLink => {
+							registerLink.parentNode.setAttribute( 'data-action', 'signin' );
+
+							registerLink.addEventListener(
+								'click',
+								function () {
+									messageContentElement.innerHTML = '';
+								},
+								false
+							);
+						} );
+				} else {
+					messageContentElement.style.display = 'none';
+					messageContentElement.innerHTML = '';
+					messageContentElement.classList.remove(
+						'newspack-ui__inline-error',
+						'newspack-ui__helper-text'
+					);
+				}
+			};
+
+			/**
 			 * Handle auth form action selection.
 			 */
 			let formAction;
 			container.setFormAction = ( action, shouldFocus = false ) => {
-				const newspack_grecaptcha = window.newspack_grecaptcha || {};
 				if ( ! FORM_ALLOWED_ACTIONS.includes( action ) ) {
 					action = 'signin';
 				}
+				// Sign in step should clear any modal errors or messages.
+				if ( 'signin' === action ) {
+					form.setMessageContent();
+				}
+				const newspack_grecaptcha = window.newspack_grecaptcha || {};
 				if ( 'v2_invisible' === newspack_grecaptcha?.version ) {
 					if ( 'register' === action ) {
 						submitButtons.forEach( button => button.removeAttribute( 'data-skip-recaptcha' ) );
@@ -160,8 +212,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 			if ( sendCodeButton || resendCodeButton ) {
 				[ sendCodeButton, resendCodeButton ].forEach( button => {
 					button.addEventListener( 'click', function ( ev ) {
-						form.setMessageContent();
 						ev.preventDefault();
+						form.setMessageContent();
 						form.startLoginFlow();
 						const body = new FormData();
 						body.set( 'reader-activation-auth-form', 1 );
@@ -295,54 +347,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 							}
 						}
 					}
-				}
-			};
-
-			/**
-			 * Sets response message content.
-			 *
-			 * @param {string|HTMLElement} message Message content.
-			 * @param {boolean}            isError Whether the message is an error.
-			 *
-			 * @return {void}
-			 */
-			form.setMessageContent = ( message = '', isError = false ) => {
-				if ( message ) {
-					if ( typeof message === 'string' ) {
-						messageContentElement.innerHTML = message;
-					} else {
-						messageContentElement.appendChild( message );
-					}
-					if ( isError ) {
-						messageContentElement.classList.remove( 'newspack-ui__helper-text' );
-						messageContentElement.classList.add( 'newspack-ui__inline-error' );
-					} else {
-						messageContentElement.classList.remove( 'newspack-ui__inline-error' );
-						messageContentElement.classList.add( 'newspack-ui__helper-text' );
-					}
-					messageContentElement.style.display = 'block';
-
-					// If the message includes a registration toggle, hide the message when clicked.
-					messageContentElement
-						.querySelectorAll( 'a[data-set-action="register"], a[data-set-action="signin"]' )
-						.forEach( registerLink => {
-							registerLink.parentNode.setAttribute( 'data-action', 'signin' );
-
-							registerLink.addEventListener(
-								'click',
-								function () {
-									messageContentElement.innerHTML = '';
-								},
-								false
-							);
-						} );
-				} else {
-					messageContentElement.style.display = 'none';
-					messageContentElement.innerHTML = '';
-					messageContentElement.classList.remove(
-						'newspack-ui__inline-error',
-						'newspack-ui__helper-text'
-					);
 				}
 			};
 

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -105,8 +105,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 				if ( ! FORM_ALLOWED_ACTIONS.includes( action ) ) {
 					action = 'signin';
 				}
-				// Sign in step should clear any modal errors or messages.
-				if ( 'signin' === action ) {
+				// Signin and success steps should clear any modal errors or messages.
+				if ( 'signin' === action || 'success' === action ) {
 					form.setMessageContent();
 				}
 				const newspack_grecaptcha = window.newspack_grecaptcha || {};


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208214895993711/f

This PR addresses two auth modal error cases:

1. clears any auth modal message or error when transitioning to the sign in or success steps since these are the default first and final steps of the auth flow.

2. fixes an issue where recaptcha V2 event listeners would cause OTP submission logic to fire twice, resulting in OTP erroring, and then succeeding in quick succession


https://github.com/user-attachments/assets/268fc5d4-9e0d-4019-bfce-8117fa1ab127



### How to test the changes in this Pull Request:

1. As admin, ensure recaptcha v2 is enabled via Newspack > Connections menu
2. As a logged out reader, open the auth modal via the Sign in button in the site header
3. Attempt to create an account that already exists via the modal (via the Create an account button)
4. Confirm an error appears here (can be an account already exists error, or in some cases a recaptcha error)
5. Once you've confirmed the error, select the `Sign in to an existing account` button
6. Confirm the error message is cleared
7. Now attempt to login via OTP by copy/pasting the OTP code you receive by email into the auth modal
8. Confirm you are signed in as expected and the success modal appears with no errors
9. Repeat the above steps, but this time using an account that has a password setup. The only difference should be you do not receive an OTP code and can login with a password on step 7
10. Smoke test the auth modals other buttons and inputs

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->