### PR TITLE
fix(reader-registration-block): fix initial newsletter checkbox state

### DIFF
--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -190,7 +190,7 @@ function render_block( $attrs, $content ) {
 	$checked = [];
 	if ( ! empty( $attrs['listsCheckboxes'] ) ) {
 		foreach ( $lists as $list_id => $list_name ) {
-			if ( ! isset( $attrs['listsCheckboxes'][ $list_id ] ) || false !== $attrs['listsCheckboxes'][ $list_id ] ) {
+			if ( isset( $attrs['listsCheckboxes'][ $list_id ] ) && true === $attrs['listsCheckboxes'][ $list_id ] ) {
 				$checked[] = $list_id;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with initial state of the newsletter checkboxes in the Reader Registration block (#2682)

### How to test the changes in this Pull Request:

1. On `trunk`, insert the Reader Registration block on a page and select at least two lists to be displayed in the sidebar block settings
2. Check one of the lists in the block, to make it selected by default
3. Publish the page and visit the frontend – observe both checkboxes are pre-selected
4. Switch to this branch, reload, observe only the list selected in the editor is pre-selected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->