### PR TITLE
fix(sync): method name for `membership_saved` handler

### DIFF
--- a/includes/data-events/connectors/class-esp-connector.php
+++ b/includes/data-events/connectors/class-esp-connector.php
@@ -131,7 +131,7 @@ class ESP_Connector extends Reader_Activation\ESP_Sync {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function membership_saved( $timestamp, $data, $client_id ) {
-		$filtered_enabled_fields = Newspack_Newsletters::filter_enabled_fields(
+		$filtered_enabled_fields = Sync\Metadata::filter_enabled_fields(
 			[
 				'membership_status',
 				'membership_plan',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#3362 got merged without considering the changes from #3353.

This PR fixes the method call for the `membership_saved` handler.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->