### PR TITLE
feat(sync): add ESP sync notice to RAS wizard

### DIFF
--- a/includes/reader-activation/sync/class-sync.php
+++ b/includes/reader-activation/sync/class-sync.php
@@ -62,7 +62,7 @@ class Sync {
 		) {
 			$errors->add(
 				'esp_sync_not_allowed',
-				__( 'Sync is disabled for non-production sites. Set NEWSPACK_ALLOW_READER_SYNC to allow sync.', 'newspack-plugin' )
+				__( 'Sync is disabled for staging sites. To bypass this check, set the NEWSPACK_ALLOW_READER_SYNC constant in your wp-config.php.', 'newspack-plugin' )
 			);
 		}
 

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -246,6 +246,7 @@ class Engagement_Wizard extends Wizard {
 				'config'               => Reader_Activation::get_settings(),
 				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
 				'memberships'          => self::get_memberships_settings(),
+				'can_esp_sync'         => Reader_Activation\Sync::can_sync( true ),
 			]
 		);
 	}
@@ -278,6 +279,7 @@ class Engagement_Wizard extends Wizard {
 				'config'               => Reader_Activation::get_settings(),
 				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
 				'memberships'          => self::get_memberships_settings(),
+				'can_esp_sync'         => Reader_Activation\Sync::can_sync( true ),
 			]
 		);
 	}

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -246,7 +246,7 @@ class Engagement_Wizard extends Wizard {
 				'config'               => Reader_Activation::get_settings(),
 				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
 				'memberships'          => self::get_memberships_settings(),
-				'can_esp_sync'         => Reader_Activation\Sync::can_sync( true ),
+				'can_esp_sync'         => Reader_Activation\ESP_Sync::can_esp_sync( true ),
 			]
 		);
 	}
@@ -279,7 +279,7 @@ class Engagement_Wizard extends Wizard {
 				'config'               => Reader_Activation::get_settings(),
 				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
 				'memberships'          => self::get_memberships_settings(),
-				'can_esp_sync'         => Reader_Activation\Sync::can_sync( true ),
+				'can_esp_sync'         => Reader_Activation\ESP_Sync::can_esp_sync( true ),
 			]
 		);
 	}

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -357,7 +357,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 							<>
 								{ 0 < Object.keys(espSyncErrors).length && (
 									<Notice
-										noticeText={ Object.values(espSyncErrors).join( ', ' ) }
+										noticeText={ Object.values(espSyncErrors).join( ' ' ) }
 										isError
 									/>
 								) }

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -39,6 +39,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 	const [ prerequisites, setPrerequisites ] = useState( null );
 	const [ missingPlugins, setMissingPlugins ] = useState( [] );
 	const [ showAdvanced, setShowAdvanced ] = useState( false );
+	const [ espSyncErrors, setEspSyncErrors ] = useState( [] );
 	const updateConfig = ( key, val ) => {
 		setConfig( { ...config, [ key ]: val } );
 	};
@@ -48,10 +49,11 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 		apiFetch( {
 			path: '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
 		} )
-			.then( ( { config: fetchedConfig, prerequisites_status, memberships } ) => {
+			.then( ( { config: fetchedConfig, prerequisites_status, memberships, can_esp_sync } ) => {
 				setPrerequisites( prerequisites_status );
 				setConfig( fetchedConfig );
 				setMembershipsConfig( memberships );
+				setEspSyncErrors( can_esp_sync.errors );
 			} )
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
@@ -65,10 +67,11 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 			quiet: true,
 			data,
 		} )
-			.then( ( { config: fetchedConfig, prerequisites_status, memberships } ) => {
+			.then( ( { config: fetchedConfig, prerequisites_status, memberships, can_esp_sync } ) => {
 				setPrerequisites( prerequisites_status );
 				setConfig( fetchedConfig );
 				setMembershipsConfig( memberships );
+				setEspSyncErrors( can_esp_sync.errors );
 			} )
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
@@ -352,6 +355,12 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 					>
 						{ config.sync_esp && (
 							<>
+								{ 0 < Object.keys(espSyncErrors).length && (
+									<Notice
+										noticeText={ Object.values(espSyncErrors).join( ', ' ) }
+										isError
+									/>
+								) }
 								{ isMailchimp && (
 									<Mailchimp
 										value={ {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a notice to the RAS advanced settings wizard for whether the ESP sync can be used.

<img width="954" alt="image" src="https://github.com/user-attachments/assets/324315ba-9bae-49b2-9cdb-00f21a54153f">

### How to test the changes in this Pull Request:

1. Make sure you have RAS configured and ESP Sync enabled
2. If you have the `NEWSPACK_ALLOW_READER_SYNC` constant set, remove it
3. Visit the Engagement -> Reader Activation -> Advanced Settings -> Sync contacts to ESP wizard
4. Confirm you get the notice as illustrated above
5. Add the constant back
6. Refresh the wizard and confirm the notice is gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->