### PR TITLE
fix (ras-acc): recaptcha badge side-scroll

### DIFF
--- a/src/other-scripts/recaptcha/style.scss
+++ b/src/other-scripts/recaptcha/style.scss
@@ -10,5 +10,6 @@
 
 // Hide reCAPTCHA badge
 .grecaptcha-badge {
+	inset: 0 !important; // Prevents an odd side-scroll issue in the registration modal & block.
 	visibility: hidden !important;
 }

--- a/src/reader-activation-auth/style.scss
+++ b/src/reader-activation-auth/style.scss
@@ -11,6 +11,11 @@
 	.response-container {
 		margin-bottom: 12px;
 	}
+
+	// Prevent an odd side-scroll issue with reCAPTCHA 2.]
+	.grecaptcha-badge {
+		inset: 0 !important;
+	}
 }
 
 .entry-content .newspack-reader,

--- a/src/reader-activation-auth/style.scss
+++ b/src/reader-activation-auth/style.scss
@@ -11,11 +11,6 @@
 	.response-container {
 		margin-bottom: 12px;
 	}
-
-	// Prevent an odd side-scroll issue with reCAPTCHA 2.
-	.grecaptcha-badge {
-		inset: 0 !important;
-	}
 }
 
 .entry-content .newspack-reader,

--- a/src/reader-activation-auth/style.scss
+++ b/src/reader-activation-auth/style.scss
@@ -12,7 +12,7 @@
 		margin-bottom: 12px;
 	}
 
-	// Prevent an odd side-scroll issue with reCAPTCHA 2.]
+	// Prevent an odd side-scroll issue with reCAPTCHA 2.
 	.grecaptcha-badge {
 		inset: 0 !important;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue I've run into on the RAS-ACC testing site, but that I can't recreate locally 😕 

When using reCAPTCHA 2, either after successfully passing the reCAPTCHA by picking bikes/crosswalks/traffic lights, or after getting an error, the registration modal has a side-scroll due to the recaptcha badge:

### How to test the changes in this Pull Request:

1. Set the site to use the invisible flavour of reCAPTCHA 2 under Newspack > Connections.
2. In an incognito window, try signing in; hopefully you're like me and your behaviour is spammy enough to trigger something.
3. After picking your bikes successfully and getting to the success screen, or getting an error on the initial screen, scroll the mouse to the right -- hopefully you get this:

![CleanShot 2024-09-06 at 10 24 34](https://github.com/user-attachments/assets/26916101-b065-463a-9b35-83296fca45c8)

4. Apply the PR and run `npm run build`.
5. If you do get the side scroll, confirm that the PR fixes it; otherwise, please confirm that it doesn't cause any weirdness. The issue is the `right` style, but locally I only get three lines of inline CSS for this badge vs. ~12 for the RAS-ACC test site.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->