### PR TITLE
fix: close newsletter on complete

### DIFF
--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -250,7 +250,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 						callback = ( authMessage, authData ) =>
 							openNewslettersSignupModal( {
 								callback: container.authCallback( authMessage, authData ),
-								closeOnSuccess: true,
 							} );
 					} else {
 						callback = container.authCallback;

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -250,6 +250,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 						callback = ( authMessage, authData ) =>
 							openNewslettersSignupModal( {
 								callback: container.authCallback( authMessage, authData ),
+								closeOnSuccess: true,
 							} );
 					} else {
 						callback = container.authCallback;

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -159,7 +159,6 @@ export function openAuthModal( config = {} ) {
 			},
 			content: null,
 			trigger: null,
-			closeOnSuccess: true,
 		},
 		...config,
 	};
@@ -195,7 +194,6 @@ export function openNewslettersSignupModal( config = {} ) {
 			labels: {},
 			content: null,
 			closeOnSuccess: true,
-
 		},
 		...config,
 	};

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -194,6 +194,8 @@ export function openNewslettersSignupModal( config = {} ) {
 			skipSuccess: false,
 			labels: {},
 			content: null,
+			closeOnSuccess: true,
+
 		},
 		...config,
 	};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where the newsletter modal wasn't closing on submit when it was triggered by the Sign In button. 

I don't entirely get _why_ this fixes it, since `true` is the default for this config value, but I'm just rolling with it! 

See: 1207817176293825-as-1208232700780031

### How to test the changes in this Pull Request:

1. On epic/ras-acc with the Newsletter modal enabled, try running through a sign up, and signing up to at least one newsletter at the end. Note that it doesn't close when the form is finished submitting.
2. Apply this PR and run `npm run build`.
3. Repeat step one, signing up again using the Sign In button and signing up for at least one newsletter. Confirm that the modal closes as expected.
4. Smoke test how the newsletter form works with purchases, specifically testing a donate block, a checkout button block, and one or the other with the after-checkout behaviour set to redirect to a different page to confirm that the modal remains open until the page redirects.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->