### PR TITLE
fix(ras-acc): add config flag to skip newsletters signup modal

### DIFF
--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -295,9 +295,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 
 					let callback;
 					if (
-						container.authCallback &&
+						! container.config?.skipNewslettersSignup &&
 						data?.registered &&
-						! readerActivation.isPendingCheckout()
+						container.authCallback
 					) {
 						callback = ( authMessage, authData ) =>
 							openNewslettersSignupModal( {

--- a/src/reader-activation/checkout.js
+++ b/src/reader-activation/checkout.js
@@ -49,7 +49,11 @@ export function getCheckoutData( key ) {
  * @return {boolean} Whether checkout is pending.
  */
 export function isPendingCheckout() {
-	return getCheckoutData( 'is_pending_checkout' );
+	const checkout = getCheckout();
+	if ( Object.keys( checkout ).length ) {
+		return true;
+	}
+	return false;
 }
 
 /**

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -149,6 +149,7 @@ export function openAuthModal( config = {} ) {
 			callback: null,
 			initialState: null,
 			skipSuccess: false,
+			skipNewslettersSignup: false,
 			labels: {
 				signin: {
 					title: null,


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/inbox/1206274567818680/1208232700780031/1208232700780049/f

This PR addresses an issue where if checkout data is present in local storage, the auth flow will always skip the newsletters signup step. We fix this by adding an explicit skipNewslettersSignup flag to the auth modal config object and using this to decide whether to bypass the newsletters modal instead.

### How to test the changes in this Pull Request:

1. As admin, ensure the `Present newsletter signup after checkout and registration` setting is enabled and newsletter lists are selected via Newspack > Engagement > Show Advanced Settings
2. As a logged out reader, visit any page with a donate or checkout button
3. Trigger the auth + checkout flow by clicking the button
4. Do not submit the form. Instead close it via the close button at the top right of the modal
5. Click the Sign in button in the site header to trigger just the auth flow
6. Select the `Create an account` button in the auth modal and register a new account
7. Confirm the newsletter signup modal appears as the final step of the auth flow

Bonus:
- Smoke test the auth + checkout flow with newsletters signup modal
- Smoke test accessing restricted content after purchasing the necessary subscription/donation product on the content restricted post/page (the page should reload AFTER auth/checkout is complete)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->