### PR TITLE
feat(ga4): detect gate interaction blocks

### DIFF
--- a/includes/data-events/class-memberships.php
+++ b/includes/data-events/class-memberships.php
@@ -128,11 +128,41 @@ final class Memberships {
 	}
 
 	/**
+	 * Recursively get the unique block names from the post content.
+	 *
+	 * @param array $blocks The blocks.
+	 *
+	 * @return array
+	 */
+	private static function get_block_names_recursive( $blocks ) {
+		$block_names = [];
+		foreach ( $blocks as $block ) {
+			if ( ! empty( $block['blockName'] ) ) {
+				$block_names[] = $block['blockName'];
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$block_names = array_merge( $block_names, self::get_block_names_recursive( $block['innerBlocks'] ) );
+			}
+		}
+		return array_unique( $block_names );
+	}
+
+	/**
 	 * Get common metadata to be sent with all gate interaction events.
+	 *
+	 * @return array {
+	 *   The gate metadata.
+	 *
+	 *   @type int    $gate_post_id The gate post ID.
+	 *   @type array  $gate_blocks  Names of unique blocks in the gate post.
+	 * }
 	 */
 	private static function get_gate_metadata() {
+		$post_id = NewspackMemberships::get_gate_post_id();
+		$blocks  = self::get_block_names_recursive( parse_blocks( get_post_field( 'post_content', $post_id ) ) );
 		return [
-			'gate_post_id' => NewspackMemberships::get_gate_post_id(),
+			'gate_post_id' => $post_id,
+			'gate_blocks'  => $blocks,
 		];
 	}
 

--- a/includes/data-events/class-memberships.php
+++ b/includes/data-events/class-memberships.php
@@ -128,45 +128,6 @@ final class Memberships {
 	}
 
 	/**
-	 * Recursively get the unique block names from the post content.
-	 *
-	 * @param array $blocks The blocks.
-	 *
-	 * @return array
-	 */
-	private static function get_block_names_recursive( $blocks ) {
-		$block_names = [];
-		foreach ( $blocks as $block ) {
-			if ( ! empty( $block['blockName'] ) ) {
-				$block_names[] = $block['blockName'];
-			}
-			if ( ! empty( $block['innerBlocks'] ) ) {
-				$block_names = array_merge( $block_names, self::get_block_names_recursive( $block['innerBlocks'] ) );
-			}
-		}
-		return array_unique( $block_names );
-	}
-
-	/**
-	 * Get common metadata to be sent with all gate interaction events.
-	 *
-	 * @return array {
-	 *   The gate metadata.
-	 *
-	 *   @type int    $gate_post_id The gate post ID.
-	 *   @type array  $gate_blocks  Names of unique blocks in the gate post.
-	 * }
-	 */
-	private static function get_gate_metadata() {
-		$post_id = NewspackMemberships::get_gate_post_id();
-		$blocks  = self::get_block_names_recursive( parse_blocks( get_post_field( 'post_content', $post_id ) ) );
-		return [
-			'gate_post_id' => $post_id,
-			'gate_blocks'  => $blocks,
-		];
-	}
-
-	/**
 	 * A listener for the registration block form submission
 	 *
 	 * Will trigger the event with "form_submission" as action in all cases.
@@ -184,7 +145,7 @@ final class Memberships {
 			return;
 		}
 		$data = array_merge(
-			self::get_gate_metadata(),
+			NewspackMemberships::get_gate_metadata(),
 			[
 				'action'      => self::FORM_SUBMISSION,
 				'action_type' => 'registration',
@@ -217,7 +178,7 @@ final class Memberships {
 			$action = self::FORM_SUBMISSION_FAILURE;
 		}
 		$data = array_merge(
-			self::get_gate_metadata(),
+			NewspackMemberships::get_gate_metadata(),
 			[
 				'action'      => $action,
 				'action_type' => 'registration',
@@ -243,7 +204,7 @@ final class Memberships {
 		}
 		$item = array_shift( $order->get_items() );
 		$data = array_merge(
-			self::get_gate_metadata(),
+			NewspackMemberships::get_gate_metadata(),
 			[
 				'action_type' => 'paid_membership',
 				'order_id'    => $order_id,

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -464,10 +464,10 @@ class GA4 {
 		$params['product_id']   = $data['product_id'] ?? '';
 		$params['amount']       = $data['amount'] ?? '';
 		$params['currency']     = $data['currency'] ?? '';
-		// Check for meaningful blocks.
-		$params['gate_has_donation_block']     = in_array( 'newspack-blocks/donate', $data['gate_blocks'] ) ? 'yes' : 'no';
-		$params['gate_has_registration_block'] = in_array( 'newspack/reader-registration', $data['gate_blocks'] ) ? 'yes' : 'no';
-		$params['gate_has_checkout_button']    = in_array( 'newspack-blocks/checkout-button', $data['gate_blocks'] ) ? 'yes' : 'no';
+		// Meaningful blocks.
+		$params['gate_has_donation_block']     = $data['gate_has_donation_block'];
+		$params['gate_has_registration_block'] = $data['gate_has_registration_block'];
+		$params['gate_has_checkout_button']    = $data['gate_has_checkout_button'];
 		return $params;
 	}
 

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -459,12 +459,15 @@ class GA4 {
 		$params['action']       = $data['action'] ?? '';
 		$params['action_type']  = $data['action_type'] ?? '';
 		$params['referrer']     = $data['referer'] ?? '';
-		// Retain both instances of referrer spelling to ensure publisher reports are not broken.
-		$params['referer']      = $data['referer'] ?? '';
+		$params['referer']      = $data['referer'] ?? ''; // Retain both instances of referrer spelling to ensure publisher reports are not broken.
 		$params['order_id']     = $data['order_id'] ?? '';
 		$params['product_id']   = $data['product_id'] ?? '';
 		$params['amount']       = $data['amount'] ?? '';
 		$params['currency']     = $data['currency'] ?? '';
+		// Check for meaningful blocks.
+		$params['gate_has_donation_block']     = in_array( 'newspack-blocks/donate', $data['gate_blocks'] ) ? 'yes' : 'no';
+		$params['gate_has_registration_block'] = in_array( 'newspack/reader-registration', $data['gate_blocks'] ) ? 'yes' : 'no';
+		$params['gate_has_checkout_button']    = in_array( 'newspack-blocks/checkout-button', $data['gate_blocks'] ) ? 'yes' : 'no';
 		return $params;
 	}
 

--- a/src/memberships-gate/gate.js
+++ b/src/memberships-gate/gate.js
@@ -1,3 +1,4 @@
+/* globals newspack_memberships_gate */
 /**
  * Internal dependencies
  */
@@ -45,6 +46,20 @@ function addFormInputs( gate ) {
 }
 
 /**
+ * Get the full event payload for GA4.
+ *
+ * @param {Array} payload The event payload.
+ *
+ * @return {Array} The full event payload
+ */
+function getEventPayload( payload ) {
+	return {
+		...newspack_memberships_gate.metadata,
+		...payload,
+	}
+}
+
+/**
  * Handle when the gate is seen.
  */
 function handleSeen( gate ) {
@@ -56,7 +71,7 @@ function handleSeen( gate ) {
 		action: 'seen',
 	};
 	if ( 'function' === typeof window.gtag && payload ) {
-		window.gtag( 'event', eventName, payload );
+		window.gtag( 'event', eventName, getEventPayload( payload ) );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1207968369116742/f

Adds support for the following new GA4 parameters on `gate_interaction` events:

- `gate_has_donation_block`: `yes|no`
- `gate_has_registration_block`: `yes|no`
- `gate_has_checkout_button`: `yes|no`

### How to test the changes in this Pull Request:

1. Confirm you have support for Newspack's custom events with the GA4 integration (Analytics wizard -> Newspack Custom Events)
2. Also make sure you have RAS configured with gated content
3. Edit your gate to include a Donate, Reader Registration and Checkout Button blocks
4. Go through the gate flow (whichever method that completes the flow for the gate)
5. Confirm the GA4 event is sent with all params set to `yes`
6. Remove the 2 blocks that don't fit the gate
7. Go through the gate flow again and confirm the 2 blocks are `no` and the remaining block is `yes`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->