### PR TITLE
feat: remove Woo Membersip sync fields

### DIFF
--- a/includes/data-events/connectors/class-esp-connector.php
+++ b/includes/data-events/connectors/class-esp-connector.php
@@ -41,7 +41,6 @@ class ESP_Connector extends Reader_Activation\ESP_Sync {
 		Data_Events::register_handler( [ __CLASS__, 'newsletter_updated' ], 'newsletter_subscribed' );
 		Data_Events::register_handler( [ __CLASS__, 'newsletter_updated' ], 'newsletter_updated' );
 		Data_Events::register_handler( [ __CLASS__, 'network_new_reader' ], 'network_new_reader' );
-		Data_Events::register_handler( [ __CLASS__, 'membership_saved' ], 'membership_saved' );
 	}
 
 	/**
@@ -121,35 +120,6 @@ class ESP_Connector extends Reader_Activation\ESP_Sync {
 		}
 
 		self::sync( $contact, 'RAS Order completed' );
-	}
-
-	/**
-	 * Handle membership creation or update.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 * @param int   $client_id ID of the client that triggered the event.
-	 */
-	public static function membership_saved( $timestamp, $data, $client_id ) {
-		$filtered_enabled_fields = Sync\Metadata::filter_enabled_fields(
-			[
-				'membership_status',
-				'membership_plan',
-				'membership_start_date',
-				'membership_end_date',
-			]
-		);
-		if ( empty( $filtered_enabled_fields ) ) {
-			return;
-		}
-		$contact = [ 'email' => $data['email'] ];
-		foreach ( $filtered_enabled_fields as $key => $value ) {
-			if ( isset( $data[ $key ] ) ) {
-				$contact['metadata'][ $key ] = $data[ $key ];
-			}
-		}
-
-		self::sync( $contact, 'RAS Woo Membership created or updated.' );
 	}
 
 	/**

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -225,28 +225,23 @@ class Metadata {
 	 */
 	public static function get_payment_fields() {
 		return [
-			'membership_status'     => 'Membership Status',
-			'membership_plan'       => 'Membership Plan',
-			// In most cases these fields won't be needed, because their values will match
-			// linked subscription dates. But some setups use memberships w/out subscriptions.
-			'membership_start_date' => 'Current Membership Start Date',
-			'membership_end_date'   => 'Current Membership End Date',
+			'membership_status'   => 'Membership Status',
 			// URL of the page on which the payment has happened.
-			'payment_page'          => 'Payment Page',
-			'payment_page_utm'      => 'Payment UTM: ',
-			'sub_start_date'        => 'Current Subscription Start Date',
-			'sub_end_date'          => 'Current Subscription End Date',
+			'payment_page'        => 'Payment Page',
+			'payment_page_utm'    => 'Payment UTM: ',
+			'sub_start_date'      => 'Current Subscription Start Date',
+			'sub_end_date'        => 'Current Subscription End Date',
 			// At what interval does the recurring payment occur – e.g. day, week, month or year.
-			'billing_cycle'         => 'Billing Cycle',
+			'billing_cycle'       => 'Billing Cycle',
 			// The total value of the recurring payment.
-			'recurring_payment'     => 'Recurring Payment',
-			'last_payment_date'     => 'Last Payment Date',
-			'last_payment_amount'   => 'Last Payment Amount',
+			'recurring_payment'   => 'Recurring Payment',
+			'last_payment_date'   => 'Last Payment Date',
+			'last_payment_amount' => 'Last Payment Amount',
 			// Product name, as it appears in WooCommerce.
-			'product_name'          => 'Product Name',
-			'next_payment_date'     => 'Next Payment Date',
+			'product_name'        => 'Product Name',
+			'next_payment_date'   => 'Next Payment Date',
 			// Total value spent by this customer on the site.
-			'total_paid'            => 'Total Paid',
+			'total_paid'          => 'Total Paid',
 		];
 	}
 

--- a/tests/unit-tests/reader-activation-sync-woocommerce.php
+++ b/tests/unit-tests/reader-activation-sync-woocommerce.php
@@ -83,9 +83,6 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 					'total_paid'                => '$' . ( self::USER_DATA['meta_input']['wc_total_spent'] + $order_data['total'] ),
 					'account'                   => self::$user_id,
 					'registration_date'         => $today,
-					'membership_plan'           => '',
-					'membership_start_date'     => '',
-					'membership_end_date'       => '',
 				],
 			],
 			$contact_data


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We have decided to push the addition of these fields until we revisit all the fields and maybe change our current schema.

See pamTN9-9St-p2

### How to test the changes in this Pull Request:

1. Confirm that sync is still working
2. Confirm Woo Membership fields are not available
3. Confirm Woo Membership fields are not synced

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208262205728468