### PR TITLE
fix(ras-acc): remove check to prevent credit card field reset

### DIFF
--- a/src/other-scripts/wc-cover-fees/index.js
+++ b/src/other-scripts/wc-cover-fees/index.js
@@ -23,9 +23,7 @@
 		} );
 		// Trigger checkout update on payment method change so it updates the fee.
 		$( document ).on( 'payment_method_selected', function () {
-			if ( checked ) {
-				$body.trigger( 'update_checkout', { update_shipping_method: false } );
-			}
+			$body.trigger( 'update_checkout', { update_shipping_method: false } );
 		} );
 	} );
 } )( jQuery );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This check was originally added as part of https://github.com/Automattic/newspack-plugin/pull/3330; my best guess is that additional changes have made this check unnecessary, but I could just be missing a certain case!

Note: There's a similar issue with apply a coupon after filling in the credit card information first, so this could be related in general to the use of `update_checkout` somehow. I'm still trying to puzzle that one out, but it's a much less likely order to have filled the form out in.

See: 1207817176293825-as-1208255803261156

### How to test the changes in this Pull Request:

1. Set up Stripe Gateway and at least one other payment processor (like WooPayments) under WooCommerce > Settings > Payments. Order them so Stripe is not the default (it should be at the bottom of the list)
2. Enable "Allow donors to cover transaction fees" under Newspack > Reader Revenue > Stripe Settings, but don't have it preselected.
3. On the `epic/ras-acc` branch as a new, not registered reader, make a One Time donation.
4. On the second screen, switch to Stripe to pay.
5. Fill in your credit card information, then check the box to cover the fees.
6. When the modal updates, the Transaction Details table will be there, but the credit card information will have been cleared. 
7. Apply this PR. 
8. In a new incognito window, repeat steps 3-6, and confirm that the credit card information remains in place.
9. Retest some of the steps from the original issue this fixed ([from the corresponding Blocks PR](https://github.com/Automattic/newspack-blocks/pull/1823/)) to confirm nothing has regressed:
   a. As a new reader with no saved billing details/payment information, trigger modal checkout via any donation block (recurring donation to guarantee the transaction details table appears)
   b. Proceed through the checkout flow until you get to the payment information step. Scroll down to see the Transactions details table.
   c. Confirm that it's not greyed out (blocked). 
   d. Smoke test the checkout modal in various other contexts (checkout buttons with tax/shipping/coupons/nyp/etc. setup, one-time donations, etc.)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->