### PR TITLE
fix(esp-sync): sync Connected Account field

### DIFF
--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -215,6 +215,12 @@ class Google_Login {
 			}
 		}
 		$metadata['registration_method'] = 'google';
+		if ( ! isset( $metadata['current_page_url'] ) ) {
+			$referrer = $request->get_header( 'referer' );
+			if ( \wp_http_validate_url( $referrer ) ) {
+				$metadata['current_page_url'] = $referrer;
+			}
+		}
 		if ( $email ) {
 			$existing_user = \get_user_by( 'email', $email );
 			$message       = __( 'Thank you for registering!', 'newspack-plugin' );

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -226,6 +226,9 @@ class Google_Login {
 			];
 
 			if ( $existing_user ) {
+				// Update user meta with connected account info.
+				\update_user_meta( $existing_user->ID, Reader_Activation::CONNECTED_ACCOUNT, 'google' );
+
 				// Log the user in.
 				$result  = Reader_Activation::set_current_reader( $existing_user->ID );
 				$message = __( 'Thank you for signing in!', 'newspack-plugin' );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -31,6 +31,7 @@ final class Reader_Activation {
 	const EMAIL_VERIFIED                    = 'np_reader_email_verified';
 	const WITHOUT_PASSWORD                  = 'np_reader_without_password';
 	const REGISTRATION_METHOD               = 'np_reader_registration_method';
+	const CONNECTED_ACCOUNT                 = 'np_reader_connected_account';
 	const READER_SAVED_GENERIC_DISPLAY_NAME = 'np_reader_saved_generic_display_name';
 
 	/**

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -7,7 +7,6 @@
 
 namespace Newspack\Reader_Activation\Sync;
 
-use Error;
 use Newspack\Reader_Activation;
 use Newspack\Logger;
 

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -357,13 +357,15 @@ class Metadata {
 	 */
 	private static function add_utm_data( $metadata ) {
 		// Capture UTM params and signup/payment page URLs as meta for registration or payment.
-		if ( self::has_key( 'current_page_url', $metadata ) || self::has_key( 'payment_page', $metadata ) ) {
+		if ( self::has_key( 'current_page_url', $metadata ) || self::has_key( 'registration_page', $metadata ) || self::has_key( 'payment_page', $metadata ) ) {
 			$is_payment = self::has_key( 'payment_page', $metadata );
 			$raw_url    = false;
 			if ( $is_payment ) {
 				$raw_url = self::get_key_value( 'payment_page', $metadata );
-			} else {
+			} elseif ( self::has_key( 'current_page_url', $metadata ) ) {
 				$raw_url = self::get_key_value( 'current_page_url', $metadata );
+			} else {
+				$raw_url = self::get_key_value( 'registration_page', $metadata );
 			}
 
 			$parsed_url = \wp_parse_url( $raw_url );

--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -232,7 +232,7 @@ class WooCommerce {
 		$last_name  = $customer->get_billing_last_name();
 		$full_name  = trim( "$first_name $last_name" );
 		$contact    = [
-			'email'    => $customer->get_billing_email(),
+			'email'    => ! empty( $customer->get_billing_email() ) ? $customer->get_billing_email() : $customer->get_email(),
 			'metadata' => $metadata,
 		];
 		if ( ! empty( $full_name ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Restores the syncing of the `NP_Connected Account` field, which was dropped at some point in the past.

### How to test the changes in this Pull Request:

1. In WP admin > Engagement > Reader Activation > Advanced Settings, enable the **Connected Account** field for syncing.
2. As a reader, complete a purchase via Woo checkout (modal or not) using a real live Gmail address.
3. Log out, then log in via Google SSO using the Gmail address.
4. In the connected ESP, confirm that contact's metadata has the following:
  - `NP_Registration Method` is `woocommerce`
  - `NP_Connected Account` is `google`
5. In a new session, register a new account via Google SSO using a different Gmail address.
6. Complete another purchase via Woo checkout.
7. In the connected ESP, confirm that contact's metadata has the following:
  - `NP_Registration Method` is `google`
  - `NP_Connected Account` is `google`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208262205728462