### PR TITLE
fix(esp-sync): normalize contact data on direct upsert calls

### DIFF
--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -35,6 +35,14 @@ class Metadata {
 	public static $keys = [];
 
 	/**
+	 * Initialize hooks.
+	 */
+	public static function init_hooks() {
+		// Normalize contact data on upsert calls directly from Newsletters plugin (e.g. Subscription Form block).
+		add_filter( 'newspack_newsletters_contact_data', [ __CLASS__, 'normalize_contact_data' ] );
+	}
+
+	/**
 	 * Get the metadata keys map for Reader Activation.
 	 *
 	 * @return array List of fields.
@@ -394,3 +402,4 @@ class Metadata {
 		return apply_filters( 'newspack_esp_sync_normalize_contact', $contact );
 	}
 }
+Metadata::init_hooks();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3362 removed `normalize_contact_data` as a filter on the `newspack_newsletters_contact_data` hook. However, this results in `upsert` calls that happen outside of this plugin's `Sync` classes to sync un-normalized metadata.

This PR restores the filter, but this will result in the data from `upsert` calls from the `Sync` classes being normalized twice. I'm open to feedback on how this can be improved, but for now this fixes the issue.

### How to test the changes in this Pull Request:

1. On `trunk` in both this plugin and Newsletters, sign up for newsletter lists as a new reader via the Newsletter Subscription Form block.
2. Observe in the Logger output and in the connected ESP contact that the metadata synced upon registration contains raw, un-normalized metadata keys (e.g. `connected_account` instead of `NP_Account` or `current_page_url` instead of `NP_Registration Page`).
3. Check out this branch, repeat with a different email address and confirm that the synced metadata contains only normalized, prefixed keys.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->