### PR TITLE
fix: change the current product criteria for sync

### DIFF
--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -102,7 +102,7 @@ class WooCommerce {
 			array_keys( \wcs_get_users_subscriptions( $user_id ) ),
 			function( $acc, $subscription_id ) {
 				$subscription = \wcs_get_subscription( $subscription_id );
-				if ( $subscription->has_status( [ 'on-hold', 'cancelled', 'expired' ] ) ) {
+				if ( $subscription->has_status( WooCommerce_Connection::FORMER_SUBSCRIBER_STATUSES ) ) {
 					$acc[] = $subscription_id;
 				}
 				return $acc;

--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -92,7 +92,7 @@ class WooCommerce {
 	private static function get_most_recent_cancelled_or_expired_subscription( $user_id ) {
 		$subcriptions = array_reduce(
 			array_keys( \wcs_get_users_subscriptions( $user_id ) ),
-			function( $acc, $subscription_id ) use ( $product_ids ) {
+			function( $acc, $subscription_id ) {
 				$subscription = \wcs_get_subscription( $subscription_id );
 				if ( $subscription->has_status( [ 'on-hold', 'cancelled', 'expired' ] ) ) {
 					$acc[] = $subscription_id;
@@ -116,7 +116,10 @@ class WooCommerce {
 	 */
 	private static function get_one_time_donation_order_for_user( $user_id ) {
 		$donation_product = Donations::get_donation_product( 'once' );
-		$user_has_donated = wc_customer_bought_product( null, $user_id, $donation_product->get_id() );
+		if ( ! $donation_product ) {
+			return;
+		}
+		$user_has_donated = \wc_customer_bought_product( null, $user_id, $donation_product );
 		if ( ! $user_has_donated ) {
 			return;
 		}

--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -79,7 +79,15 @@ class WooCommerce {
 			return $one_time_donation_order;
 		}
 
-		return false;
+		/**
+		 * Filter the order containing what we consider to be the "Current Product" for a given user when nothing is found.
+		 *
+		 * This is used for tests to mock the return value.
+		 *
+		 * @param false $current_product_order The returned value.
+		 * @return int $user_id The user ID.
+		 */
+		return apply_filters( 'newspack_reader_activation_get_current_product_order_for_sync', false, $user_id );
 	}
 
 	/**

--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -41,6 +41,107 @@ class WooCommerce {
 	}
 
 	/**
+	 * Get the order containing what we consider to be the "Current Product" for a given user.
+	 *
+	 * All the payment fields that are synced relate to this product.
+	 *
+	 * The criteria for the "Current Product" are:
+	 * 1. The most recent subscription (either regular subscriptions or recurring donations).
+	 * 2. If no active subscriptions, the most recently cancelled or expired subscription.
+	 * 3. If no subscriptions at all, the most recent one-time donation.
+	 *
+	 * @param \WC_Customer $customer Customer object.
+	 *
+	 * @return \WC_Order|false Order object or false.
+	 */
+	private static function get_current_product_order_for_sync( $customer ) {
+		if ( ! is_a( $customer, 'WC_Customer' ) ) {
+			return false;
+		}
+
+		$user_id = $customer->get_id();
+
+		// 1. The most recent subscription (either regular subscriptions or recurring donations).
+		$active_subscriptions = WooCommerce_Connection::get_active_subscriptions_for_user( $user_id );
+		if ( ! empty( $active_subscriptions ) ) {
+			return \wcs_get_subscription( reset( $active_subscriptions ) );
+		}
+
+		// 2. If no active subscriptions, the most recently cancelled or expired subscription.
+		$most_recent_cancelled_or_expired_subscription = self::get_most_recent_cancelled_or_expired_subscription( $user_id );
+		if ( $most_recent_cancelled_or_expired_subscription ) {
+			return \wcs_get_subscription( $most_recent_cancelled_or_expired_subscription );
+		}
+
+		// 3. If no subscriptions at all, the most recent one-time donation.
+		$one_time_donation_order = self::get_one_time_donation_order_for_user( $user_id );
+		if ( $one_time_donation_order ) {
+			return $one_time_donation_order;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the most recent cancelled or expired subscription for a user.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return ?WCS_Subscription A Subscription object or null.
+	 */
+	private static function get_most_recent_cancelled_or_expired_subscription( $user_id ) {
+		$subcriptions = array_reduce(
+			array_keys( \wcs_get_users_subscriptions( $user_id ) ),
+			function( $acc, $subscription_id ) use ( $product_ids ) {
+				$subscription = \wcs_get_subscription( $subscription_id );
+				if ( $subscription->has_status( [ 'on-hold', 'cancelled', 'expired' ] ) ) {
+					$acc[] = $subscription_id;
+				}
+				return $acc;
+			},
+			[]
+		);
+
+		if ( ! empty( $subcriptions ) ) {
+			return reset( $subcriptions );
+		}
+	}
+
+	/**
+	 * Get the most recent one-time donation order for a user.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return ?WC_Order An Order object or null.
+	 */
+	private static function get_one_time_donation_order_for_user( $user_id ) {
+		$donation_product = Donations::get_donation_product( 'once' );
+		$user_has_donated = wc_customer_bought_product( null, $user_id, $donation_product->get_id() );
+		if ( ! $user_has_donated ) {
+			return;
+		}
+
+		// If user has donated, we'll loop through their orders to find the most recent donation.
+		// If this method was called, that's because they don't have any active subscriptions, so there shouldn't be too many.
+		$args = [
+			'customer_id' => $user_id,
+			'status'      => [ 'wc-completed' ],
+			'limit'       => -1,
+			'order'       => 'DESC',
+			'orderby'     => 'date',
+			'return'      => 'objects',
+		];
+
+		// Return the most recent completed order.
+		$orders = \wc_get_orders( $args );
+		foreach ( $orders as $order ) {
+			if ( Donations::is_donation_order( $order ) ) {
+				return $order;
+			}
+		}
+	}
+
+	/**
 	 * Get data about a customer's order to sync to the connected ESP.
 	 *
 	 * @param \WC_Order|int $order WooCommerce order or order ID.
@@ -212,7 +313,7 @@ class WooCommerce {
 		$metadata['registration_date'] = $customer->get_date_created()->date( Metadata::DATE_FORMAT );
 		$metadata['total_paid']        = \wc_format_localized_price( $customer->get_total_spent() );
 
-		$order = WooCommerce_Connection::get_last_successful_order( $customer );
+		$order = self::get_current_product_order_for_sync( $customer );
 
 		// Get the order metadata.
 		$order_metadata = [];

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -161,51 +161,6 @@ class WooCommerce_Connection {
 	}
 
 	/**
-	 * Get the most recent active subscription, or the last successful order for a given customer.
-	 *
-	 * @param \WC_Customer $customer Customer object.
-	 *
-	 * @return \WC_Order|false Order object or false.
-	 */
-	public static function get_last_successful_order( $customer ) {
-		if ( ! is_a( $customer, 'WC_Customer' ) ) {
-			return false;
-		}
-
-		$user_id = $customer->get_id();
-
-		// Prioritize any currently active subscriptions.
-		$active_subscriptions = self::get_active_subscriptions_for_user( $user_id );
-		if ( ! empty( $active_subscriptions ) ) {
-			return \wcs_get_subscription( reset( $active_subscriptions ) );
-		}
-
-		// If no active subscriptions, get the most recent completed order.
-		// See https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query for query args.
-		$args = [
-			'customer_id' => $user_id,
-			'status'      => [ 'wc-completed' ],
-			'limit'       => 1,
-			'order'       => 'DESC',
-			'orderby'     => 'date',
-			'return'      => 'objects',
-		];
-
-		// Return the most recent completed order.
-		$orders = \wc_get_orders( $args );
-		if ( ! empty( $orders ) ) {
-			return reset( $orders );
-		}
-
-		// If no completed orders or active subscriptions, they might still have an inactive subscription.
-		if ( ! empty( $user_subscriptions ) ) {
-			return reset( $user_subscriptions );
-		}
-
-		return false;
-	}
-
-	/**
 	 * Filter post request made by the Stripe Gateway for Stripe payments.
 	 *
 	 * @param array     $post_data An array of metadata.

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -19,6 +19,12 @@ class WooCommerce_Connection {
 	const ACTIVE_SUBSCRIPTION_STATUSES = [ 'active', 'pending', 'pending-cancel' ];
 	const ACTIVE_ORDER_STATUSES = [ 'processing', 'completed' ];
 
+
+	/**
+	 * These are the status a subscription can have for us to consider it from a former subscriber.
+	 */
+	const FORMER_SUBSCRIBER_STATUSES = [ 'on-hold', 'cancelled', 'expired' ];
+
 	/**
 	 * Initialize.
 	 *

--- a/tests/mocks/newsletters-mocks.php
+++ b/tests/mocks/newsletters-mocks.php
@@ -1,0 +1,5 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FileComment.Missing, Generic.Files.OneObjectStructurePerFile.MultipleFound, Universal.Files.SeparateFunctionsFromOO.Mixed
+
+if ( ! class_exists( 'Newspack_Newsletters_Contacts' ) ) {
+	class Newspack_Newsletters_Contacts {}
+}

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -167,3 +167,7 @@ function wc_get_orders( $args ) {
 	);
 	return $orders;
 }
+
+function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
+	return false;
+}

--- a/tests/unit-tests/reader-activation-sync-woocommerce.php
+++ b/tests/unit-tests/reader-activation-sync-woocommerce.php
@@ -57,6 +57,14 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 			],
 		];
 		$order = \wc_create_order( $order_data );
+
+		add_filter(
+			'newspack_reader_activation_get_current_product_order_for_sync',
+			function() use ( $order ) {
+				return $order;
+			}
+		);
+
 		$payment_page_url = 'https://example.com/donate';
 		$contact_data = Sync\WooCommerce::get_contact_from_order( $order, $payment_page_url );
 		$today = gmdate( 'Y-m-d' );
@@ -109,6 +117,15 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 			],
 		];
 		$order = \wc_create_order( $order_data );
+
+
+		add_filter(
+			'newspack_reader_activation_get_current_product_order_for_sync',
+			function() use ( $order ) {
+				return $order;
+			}
+		);
+
 		$contact_data = Sync\WooCommerce::get_contact_from_order( $order );
 		$this->assertEquals( 'test_source', $contact_data['metadata']['payment_page_utm_source'] );
 		$this->assertEquals( 'test_campaign', $contact_data['metadata']['payment_page_utm_campaign'] );
@@ -125,6 +142,15 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 				'total'       => 60,
 			]
 		);
+
+
+		add_filter(
+			'newspack_reader_activation_get_current_product_order_for_sync',
+			function() use ( $order ) {
+				return $order;
+			}
+		);
+
 		$contact_data = Sync\WooCommerce::get_contact_from_order( $order );
 		$this->assertEmpty( $contact_data['metadata']['last_payment_date'] );
 		$this->assertEmpty( $contact_data['metadata']['last_payment_amount'] );
@@ -140,6 +166,14 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 			'total'       => 70,
 		];
 		$order = \wc_create_order( $order_data );
+
+		add_filter(
+			'newspack_reader_activation_get_current_product_order_for_sync',
+			function() use ( $order ) {
+				return $order;
+			}
+		);
+
 		$contact_data = Sync\WooCommerce::get_contact_from_customer( self::$user_id );
 		$this->assertEquals( '$' . $order_data['total'], $contact_data['metadata']['last_payment_amount'] );
 		$this->assertEquals( gmdate( 'Y-m-d' ), $contact_data['metadata']['last_payment_date'] );
@@ -156,6 +190,14 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 			'date_paid'   => gmdate( 'Y-m-d', strtotime( '-1 week' ) ),
 		];
 		$order = \wc_create_order( $completed_order_data );
+
+		add_filter(
+			'newspack_reader_activation_get_current_product_order_for_sync',
+			function() use ( $order ) {
+				return $order;
+			}
+		);
+
 		// A more recent, but failed, order.
 		$failed_order_data = [
 			'customer_id' => self::$user_id,

--- a/tests/unit-tests/reader-activation-sync-woocommerce.php
+++ b/tests/unit-tests/reader-activation-sync-woocommerce.php
@@ -13,6 +13,14 @@ require_once __DIR__ . '/../mocks/wc-mocks.php';
  * Tests Reader Activation Sync WooCommerce.
  */
 class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
+
+	/**
+	 * The current order that will be returned in the filter
+	 *
+	 * @var ?WC_Order
+	 */
+	public static $current_order = false;
+
 	const USER_DATA = [
 		'user_login' => 'test_user',
 		'user_email' => 'test@example.com',
@@ -37,6 +45,32 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 		// Reset the user.
 		wp_delete_user( self::$user_id );
 		self::$user_id = wp_insert_user( self::USER_DATA );
+
+		add_filter(
+			'newspack_reader_activation_get_current_product_order_for_sync',
+			[ __CLASS__, 'get_current_order' ]
+		);
+	}
+
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		remove_filter(
+			'newspack_reader_activation_get_current_product_order_for_sync',
+			[ __CLASS__, 'get_current_order' ]
+		);
+	}
+
+	/**
+	 * Get the current order for the test.
+	 *
+	 * @return ?WC_Order
+	 */
+	public static function get_current_order() {
+		return self::$current_order;
 	}
 
 	/**
@@ -57,13 +91,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 			],
 		];
 		$order = \wc_create_order( $order_data );
-
-		add_filter(
-			'newspack_reader_activation_get_current_product_order_for_sync',
-			function() use ( $order ) {
-				return $order;
-			}
-		);
+		self::$current_order = $order;
 
 		$payment_page_url = 'https://example.com/donate';
 		$contact_data = Sync\WooCommerce::get_contact_from_order( $order, $payment_page_url );
@@ -117,14 +145,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 			],
 		];
 		$order = \wc_create_order( $order_data );
-
-
-		add_filter(
-			'newspack_reader_activation_get_current_product_order_for_sync',
-			function() use ( $order ) {
-				return $order;
-			}
-		);
+		self::$current_order = $order;
 
 		$contact_data = Sync\WooCommerce::get_contact_from_order( $order );
 		$this->assertEquals( 'test_source', $contact_data['metadata']['payment_page_utm_source'] );
@@ -143,13 +164,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 			]
 		);
 
-
-		add_filter(
-			'newspack_reader_activation_get_current_product_order_for_sync',
-			function() use ( $order ) {
-				return $order;
-			}
-		);
+		self::$current_order = $order;
 
 		$contact_data = Sync\WooCommerce::get_contact_from_order( $order );
 		$this->assertEmpty( $contact_data['metadata']['last_payment_date'] );
@@ -167,12 +182,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 		];
 		$order = \wc_create_order( $order_data );
 
-		add_filter(
-			'newspack_reader_activation_get_current_product_order_for_sync',
-			function() use ( $order ) {
-				return $order;
-			}
-		);
+		self::$current_order = $order;
 
 		$contact_data = Sync\WooCommerce::get_contact_from_customer( self::$user_id );
 		$this->assertEquals( '$' . $order_data['total'], $contact_data['metadata']['last_payment_amount'] );
@@ -191,12 +201,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 		];
 		$order = \wc_create_order( $completed_order_data );
 
-		add_filter(
-			'newspack_reader_activation_get_current_product_order_for_sync',
-			function() use ( $order ) {
-				return $order;
-			}
-		);
+		self::$current_order = $order;
 
 		// A more recent, but failed, order.
 		$failed_order_data = [

--- a/tests/unit-tests/reader-activation-sync.php
+++ b/tests/unit-tests/reader-activation-sync.php
@@ -9,6 +9,8 @@ use Newspack\Reader_Activation;
 use Newspack\Reader_Activation\Sync;
 use Newspack\Reader_Activation\ESP_Sync;
 
+require_once __DIR__ . '/../mocks/newsletters-mocks.php';
+
 /**
  * Test the Esp_Metadata_Sync class.
  */
@@ -74,6 +76,8 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		Reader_Activation::update_setting( 'mailchimp_audience_id', '123' );
 		$errors = ESP_Sync::can_esp_sync( true );
 		$this->assertNotContains( 'ras_esp_master_list_id_not_found', $errors->get_error_codes(), 'Master list ID is set' );
+
+		$this->assertTrue( ESP_Sync::can_esp_sync(), 'Reader data should be syncable after conditions are met' );
 	}
 
 	/**

--- a/tests/unit-tests/reader-activation-sync.php
+++ b/tests/unit-tests/reader-activation-sync.php
@@ -74,8 +74,6 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		Reader_Activation::update_setting( 'mailchimp_audience_id', '123' );
 		$errors = ESP_Sync::can_esp_sync( true );
 		$this->assertNotContains( 'ras_esp_master_list_id_not_found', $errors->get_error_codes(), 'Master list ID is set' );
-
-		$this->assertTrue( ESP_Sync::can_esp_sync(), 'Reader data should be syncable after conditions are met' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the criteria to get what is considered the "Current product" for sync purposes

### How to test the changes in this Pull Request:

1. Just for testing, make the `get_current_product_order_for_sync` method public
2. Create a user with different sets of purchases, and make sure the method always return the expected result, according to tis description
3. Make sure to test subscriptions, expired subscriptions, one time donations, recurring donations and a user with only a regular purchase (not subscription and not donation)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208262205728470