### PR TITLE
ESP sync - all plan names & bugfix

### DIFF
--- a/includes/data-events/connectors/class-esp-connector.php
+++ b/includes/data-events/connectors/class-esp-connector.php
@@ -134,7 +134,7 @@ class ESP_Connector extends Reader_Activation\ESP_Sync {
 		$filtered_enabled_fields = Sync\Metadata::filter_enabled_fields(
 			[
 				'membership_status',
-				'membership_plan',
+				'membership_plans',
 				'membership_start_date',
 				'membership_end_date',
 			]

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -351,7 +351,7 @@ Data_Events::register_listener(
 		if ( ! $membership_plan ) {
 			return;
 		}
-		$latest_membership = \wc_memberships_get_user_membership( $args['user_membership_id'] );
+		$current_membership = \wc_memberships_get_user_membership( $args['user_membership_id'] );
 		$memberships = \wc_memberships_get_user_memberships( $args['user_id'] );
 		$user       = \get_user_by( 'id', $args['user_id'] );
 		$user_email = $user ? $user->user_email : '';
@@ -363,9 +363,9 @@ Data_Events::register_listener(
 			'user_id'               => $args['user_id'],
 			'email'                 => $user_email,
 			'membership_plans'      => implode( ', ', $membership_plans_names ),
-			'membership_status'     => $latest_membership->get_status(),
-			'membership_start_date' => $latest_membership->get_start_date(),
-			'membership_end_date'   => $latest_membership->get_end_date(),
+			'membership_status'     => $current_membership->get_status(),
+			'membership_start_date' => $current_membership->get_start_date(),
+			'membership_end_date'   => $current_membership->get_end_date(),
 		];
 	}
 );

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -351,16 +351,21 @@ Data_Events::register_listener(
 		if ( ! $membership_plan ) {
 			return;
 		}
-		$membership = \wc_memberships_get_user_membership( $args['user_membership_id'] );
+		$latest_membership = \wc_memberships_get_user_membership( $args['user_membership_id'] );
+		$memberships = \wc_memberships_get_user_memberships( $args['user_id'] );
 		$user       = \get_user_by( 'id', $args['user_id'] );
 		$user_email = $user ? $user->user_email : '';
+		$membership_plans_names = [];
+		foreach ( $memberships as $membership ) {
+			$membership_plans_names[] = $membership->get_plan()->get_name();
+		}
 		return [
 			'user_id'               => $args['user_id'],
 			'email'                 => $user_email,
-			'membership_plan'       => $membership_plan->get_name(),
-			'membership_status'     => $membership->get_status(),
-			'membership_start_date' => $membership->get_start_date(),
-			'membership_end_date'   => $membership->get_end_date(),
+			'membership_plans'      => implode( ', ', $membership_plans_names ),
+			'membership_status'     => $latest_membership->get_status(),
+			'membership_start_date' => $latest_membership->get_start_date(),
+			'membership_end_date'   => $latest_membership->get_end_date(),
 		];
 	}
 );

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -206,16 +206,23 @@ class Metadata {
 	 */
 	public static function get_basic_fields() {
 		return [
-			'account'              => 'Account',
-			'registration_date'    => 'Registration Date',
-			'connected_account'    => 'Connected Account',
-			'signup_page'          => 'Signup Page',
-			'signup_page_utm'      => 'Signup UTM: ',
-			'newsletter_selection' => 'Newsletter Selection',
-			'referer'              => 'Referrer Path',
-			'registration_page'    => 'Registration Page',
-			'current_page_url'     => 'Registration Page',
-			'registration_method'  => 'Registration Method',
+			'account'               => 'Account',
+			'registration_date'     => 'Registration Date',
+			'connected_account'     => 'Connected Account',
+			'signup_page'           => 'Signup Page',
+			'signup_page_utm'       => 'Signup UTM: ',
+			'newsletter_selection'  => 'Newsletter Selection',
+			'referer'               => 'Referrer Path',
+			'registration_page'     => 'Registration Page',
+			'current_page_url'      => 'Registration Page',
+			'registration_method'   => 'Registration Method',
+			// Membership fields.
+			'membership_status'     => 'Membership Status',
+			'membership_plans'      => 'Membership Plans',
+			// In most cases the fields below won't be needed, because their values will match
+			// linked subscription dates. But some setups use memberships w/out subscriptions.
+			'membership_start_date' => 'Current Membership Start Date',
+			'membership_end_date'   => 'Current Membership End Date',
 		];
 	}
 
@@ -226,28 +233,22 @@ class Metadata {
 	 */
 	public static function get_payment_fields() {
 		return [
-			'membership_status'     => 'Membership Status',
-			'membership_plans'      => 'Membership Plans',
-			// In most cases these fields won't be needed, because their values will match
-			// linked subscription dates. But some setups use memberships w/out subscriptions.
-			'membership_start_date' => 'Current Membership Start Date',
-			'membership_end_date'   => 'Current Membership End Date',
 			// URL of the page on which the payment has happened.
-			'payment_page'          => 'Payment Page',
-			'payment_page_utm'      => 'Payment UTM: ',
-			'sub_start_date'        => 'Current Subscription Start Date',
-			'sub_end_date'          => 'Current Subscription End Date',
+			'payment_page'        => 'Payment Page',
+			'payment_page_utm'    => 'Payment UTM: ',
+			'sub_start_date'      => 'Current Subscription Start Date',
+			'sub_end_date'        => 'Current Subscription End Date',
 			// At what interval does the recurring payment occur – e.g. day, week, month or year.
-			'billing_cycle'         => 'Billing Cycle',
+			'billing_cycle'       => 'Billing Cycle',
 			// The total value of the recurring payment.
-			'recurring_payment'     => 'Recurring Payment',
-			'last_payment_date'     => 'Last Payment Date',
-			'last_payment_amount'   => 'Last Payment Amount',
+			'recurring_payment'   => 'Recurring Payment',
+			'last_payment_date'   => 'Last Payment Date',
+			'last_payment_amount' => 'Last Payment Amount',
 			// Product name, as it appears in WooCommerce.
-			'product_name'          => 'Product Name',
-			'next_payment_date'     => 'Next Payment Date',
+			'product_name'        => 'Product Name',
+			'next_payment_date'   => 'Next Payment Date',
 			// Total value spent by this customer on the site.
-			'total_paid'            => 'Total Paid',
+			'total_paid'          => 'Total Paid',
 		];
 	}
 

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -227,7 +227,7 @@ class Metadata {
 	public static function get_payment_fields() {
 		return [
 			'membership_status'     => 'Membership Status',
-			'membership_plan'       => 'Membership Plan',
+			'membership_plans'      => 'Membership Plans',
 			// In most cases these fields won't be needed, because their values will match
 			// linked subscription dates. But some setups use memberships w/out subscriptions.
 			'membership_start_date' => 'Current Membership Start Date',

--- a/tests/unit-tests/reader-activation-sync-woocommerce.php
+++ b/tests/unit-tests/reader-activation-sync-woocommerce.php
@@ -83,7 +83,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 					'total_paid'                => '$' . ( self::USER_DATA['meta_input']['wc_total_spent'] + $order_data['total'] ),
 					'account'                   => self::$user_id,
 					'registration_date'         => $today,
-					'membership_plan'           => '',
+					'membership_plans'          => '',
 					'membership_start_date'     => '',
 					'membership_end_date'       => '',
 				],

--- a/tests/unit-tests/reader-activation-sync-woocommerce.php
+++ b/tests/unit-tests/reader-activation-sync-woocommerce.php
@@ -83,9 +83,6 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 					'total_paid'                => '$' . ( self::USER_DATA['meta_input']['wc_total_spent'] + $order_data['total'] ),
 					'account'                   => self::$user_id,
 					'registration_date'         => $today,
-					'membership_plans'          => '',
-					'membership_start_date'     => '',
-					'membership_end_date'       => '',
 				],
 			],
 			$contact_data


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Changes the ESP field names `Membership Plan`  (added in #3353) to `Membership Plans`, to handle multiple plan names
3. Fixes a bug reported here: https://github.com/Automattic/newspack-plugin/pull/3353#issuecomment-2332225051

Note that 1. is not a breaking change since #3353 is not released. This PR will have to be merged to `alpha` ("alpha-hotfix"). 

### How to test the changes in this Pull Request:

1. In the Engagement wizard, "Email Service Provider (ESP) Advanced Settings" section, ensure "Sync contacts to ESP" is toggled on
4. Create a new membership, with a new contact – observe it's synced to the ESP, with `Membership Plans` field present
5. Add a plan to the membership, observe both plans' names are synced in the field

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->