### PR TITLE
fix(onboarding): add expected localized variable for GAM setup

### DIFF
--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -653,6 +653,13 @@ class Setup_Wizard extends Wizard {
 			$this->get_style_dependencies(),
 			NEWSPACK_PLUGIN_VERSION
 		);
+		\wp_localize_script(
+			'newspack-setup-wizard',
+			'newspack_ads_wizard',
+			array(
+				'can_connect_google' => OAuth::is_proxy_configured( 'google' ),
+			)
+		);
 		wp_style_add_data( 'newspack-setup-wizard', 'rtl', 'replace' );
 		wp_enqueue_style( 'newspack-setup-wizard' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#3417 as a hotfix.

p1726147575112819-slack-C015W6BES8J

#2986 introduced a bug to the onboarding wizard using the `newspack_ads_wizard` localized variable without adding it to the setup wizard script.

This PR replicates the localized variable from the ads wizard to the setup wizard.

### How to test the changes in this Pull Request:

1. While on trunk, visit `/wp-admin/admin.php?page=newspack-setup-wizard#/services`
2. Toggle Google Ad Manager on and confirm you get the `newspack_ads_wizard is undefined` error
3. Check out this branch, refresh, and confirm the error is gone and the wizard behaves as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->