### PR TITLE
WC Memberships fixing CLI

### DIFF
--- a/includes/cli/class-initializer.php
+++ b/includes/cli/class-initializer.php
@@ -25,6 +25,7 @@ class Initializer {
 		add_action( 'init', [ __CLASS__, 'register_comands' ] );
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-ras.php';
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-co-authors-plus.php';
+		include_once NEWSPACK_ABSPATH . 'includes/cli/class-woocommerce-memberships.php';
 	}
 
 	/**
@@ -64,5 +65,7 @@ class Initializer {
 
 		WP_CLI::add_command( 'newspack migrate-co-authors-guest-authors', [ 'Newspack\CLI\Co_Authors_Plus', 'migrate_guest_authors' ] );
 		WP_CLI::add_command( 'newspack backfill-non-editing-contributors', [ 'Newspack\CLI\Co_Authors_Plus', 'backfill_non_editing_contributor' ] );
+
+		WP_CLI::add_command( 'newspack fix-wc-memberships', [ 'Newspack\CLI\WooCommerce_Memberships', 'fix_memberships' ] );
 	}
 }

--- a/includes/cli/class-woocommerce-memberships.php
+++ b/includes/cli/class-woocommerce-memberships.php
@@ -143,6 +143,9 @@ class WooCommerce_Memberships {
 			$subscription_ids = array_filter( explode( ',', $result['subscription_ids'] ?? '' ) );
 			$membership_ids = array_filter( explode( ',', $result['membership_ids'] ?? '' ) );
 
+			$user_id = $result['customer_user_id'];
+			$user = get_userdata( $user_id );
+
 			if ( empty( $subscription_ids ) ) {
 				$log_line = 'No subscription IDs, skipping.';
 				WP_CLI::warning( $log_line );
@@ -151,14 +154,12 @@ class WooCommerce_Memberships {
 			}
 
 			if ( count( $membership_ids ) > 1 ) {
-				$log_line = 'More than one membership ID, skipping.';
+				$log_line = sprintf( 'More than one membership ID for user %s, skipping.', $user->user_email );
 				WP_CLI::warning( $log_line );
 				self::$command_results['skipped'][] = $log_line;
 				continue;
 			}
 
-			$user_id = $result['customer_user_id'];
-			$user = get_userdata( $user_id );
 			if ( self::$verbose ) {
 				WP_CLI::line( sprintf( 'User: %s', $user->user_email ) );
 				WP_CLI::line( sprintf( '    - memberships: %s/wp-admin/edit.php?s=%s&post_type=wc_user_membership', $site_url, $user->user_email ) );

--- a/includes/cli/class-woocommerce-memberships.php
+++ b/includes/cli/class-woocommerce-memberships.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * WooCommerce Memberships CLI commands.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\CLI;
+
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\TodoSniff;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Memberships CLI commands.
+ */
+class WooCommerce_Memberships {
+	private static $live = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	private static $verbose = true; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+
+	/**
+	 * Migrate WooCommerce Memberships guest authors to regular users.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--live]
+	 * : Run the command in live mode, updating the subscriptions.
+	 *
+	 * [--verbose]
+	 * : Produce more output.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Assoc arguments.
+	 * @return void
+	 */
+	public function fix_memberships( $args, $assoc_args ) {
+		WP_CLI::line( '' );
+
+		self::$live = isset( $assoc_args['live'] ) ? true : false;
+		self::$verbose = isset( $assoc_args['verbose'] ) ? true : false;
+
+		if ( self::$live ) {
+			WP_CLI::line( 'Live mode - data will be changed.' );
+		} else {
+			WP_CLI::line( 'Dry run. Use --live flag to run in live mode.' );
+		}
+		WP_CLI::line( '' );
+
+		if ( ! function_exists( 'wc_memberships_get_membership_plan' ) ) {
+			WP_CLI::line( '' );
+			WP_CLI::error( 'WooCommerce Memberships plugin is not active.' );
+		}
+		if ( ! function_exists( 'wcs_get_subscription' ) ) {
+			WP_CLI::line( '' );
+			WP_CLI::error( 'WooCommerce Subscriptions plugin is not active.' );
+		}
+
+		$plan_product_ids = implode(
+			',',
+			array_reduce(
+				get_posts( [ 'post_type' => 'wc_membership_plan' ] ),
+				function( $acc, $post ) {
+					$maybe_product_ids = get_post_meta( $post->ID, '_product_ids', true );
+					$plan_product_ids = is_array( $maybe_product_ids ) ? $maybe_product_ids : [];
+					return array_merge( $plan_product_ids, $acc );
+				},
+				[]
+			)
+		);
+
+		global $wpdb;
+		$sql_query = "
+		WITH ActiveSubscriptions AS (
+			SELECT pm.meta_value AS customer_user_id,
+				GROUP_CONCAT(subscriptions.ID) AS subscription_ids
+			FROM {$wpdb->prefix}posts subscriptions
+			LEFT JOIN {$wpdb->prefix}postmeta pm ON subscriptions.ID = pm.post_id AND pm.meta_key = '_customer_user'
+			LEFT JOIN {$wpdb->prefix}woocommerce_order_items oi ON oi.order_id = subscriptions.ID
+			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta oim ON oi.order_item_id = oim.order_item_id AND oim.meta_key = '_product_id'
+			WHERE subscriptions.post_type = 'shop_subscription'
+			AND subscriptions.post_status = 'wc-active'
+			AND oim.meta_value IN ({$plan_product_ids})
+			GROUP BY pm.meta_value
+		),
+		ActiveMemberships AS (
+			SELECT memberships.post_author AS customer_user_id,
+				COUNT(DISTINCT memberships.ID) AS active_memberships_count
+			FROM {$wpdb->prefix}posts memberships
+			LEFT JOIN {$wpdb->prefix}postmeta mp ON memberships.ID = mp.post_id AND mp.meta_key = '_product_id'
+			WHERE memberships.post_type = 'wc_user_membership'
+			AND memberships.post_status IN ('wcm-active', 'wcm-free_trial')
+			AND mp.meta_value IN ({$plan_product_ids})
+			GROUP BY memberships.post_author
+		),
+		InactiveMemberships AS (
+			SELECT memberships.post_author AS customer_user_id,
+				GROUP_CONCAT(memberships.ID) AS membership_ids,
+				GROUP_CONCAT(memberships.post_status) AS membership_statuses
+			FROM {$wpdb->prefix}posts memberships
+			LEFT JOIN {$wpdb->prefix}postmeta mp ON memberships.ID = mp.post_id AND mp.meta_key = '_product_id'
+			WHERE memberships.post_type = 'wc_user_membership'
+			AND memberships.post_status NOT IN ('wcm-active', 'wcm-free_trial')
+			AND mp.meta_value IN ({$plan_product_ids})
+			GROUP BY memberships.post_author
+		)
+		SELECT s.customer_user_id,
+			s.subscription_ids,
+			im.membership_ids,
+			im.membership_statuses
+		FROM ActiveSubscriptions s
+		LEFT JOIN ActiveMemberships m ON s.customer_user_id = m.customer_user_id
+		LEFT JOIN InactiveMemberships im ON s.customer_user_id = im.customer_user_id
+		WHERE COALESCE(m.active_memberships_count, 0) = 0;
+		";
+
+
+		$results = $wpdb->get_results( $sql_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		$site_url = get_option( 'siteurl' );
+
+		foreach ( $results as $result ) {
+			$subscription_ids = array_filter( explode( ',', $result['subscription_ids'] ?? '' ) );
+			$membership_ids = array_filter( explode( ',', $result['membership_ids'] ?? '' ) );
+
+			if ( empty( $subscription_ids ) ) {
+				WP_CLI::warning( 'No subscription IDs, skipping.' );
+				continue;
+			}
+
+			if ( count( $membership_ids ) > 1 ) {
+				WP_CLI::warning( 'More than one membership ID, skipping.' );
+				continue;
+			}
+
+			$user_id = $result['customer_user_id'];
+			$user = get_userdata( $user_id );
+			if ( self::$verbose ) {
+				WP_CLI::line( sprintf( 'User: %s', $user->user_email ) );
+				WP_CLI::line( sprintf( '    - memberships: %s/wp-admin/edit.php?s=%s&post_type=wc_user_membership', $site_url, $user->user_email ) );
+				WP_CLI::line( sprintf( '    - subscriptions: %s/wp-admin/edit.php?s=%s&post_type=shop_subscription', $site_url, $user->user_email ) );
+			}
+			$latest_active_subscription_id = max( $subscription_ids );
+
+			if ( empty( $membership_ids ) ) {
+				// Determine the membership plan from the subscrption product.
+				$latest_active_subscription = \wcs_get_subscription( $latest_active_subscription_id );
+				$subscription_product_ids = array_reduce(
+					$latest_active_subscription->get_items(),
+					function( $acc, $item ) {
+						return array_merge( [ $item->get_product_id() ], $acc );
+					},
+					[]
+				);
+				$subscription_product_ids_meta_value_sql = implode(
+					' OR ',
+					array_map(
+						function( $id ) {
+							return "pm.meta_value LIKE '%i:{$id};%'";
+						},
+						$subscription_product_ids
+					)
+				);
+				$sql_query = "
+					SELECT p.ID AS membership_plan_id, p.post_title AS membership_plan_name
+					FROM {$wpdb->prefix}posts p
+					LEFT JOIN {$wpdb->prefix}postmeta pm ON p.ID = pm.post_id
+					WHERE p.post_type = 'wc_membership_plan'
+					AND pm.meta_key = '_product_ids'
+					AND {$subscription_product_ids_meta_value_sql}
+				";
+				$result = $wpdb->get_results( $sql_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				$plan_id = isset( $result[0]['membership_plan_id'] ) ? $result[0]['membership_plan_id'] : false;
+				if ( $plan_id === false ) {
+					WP_CLI::warning( sprintf( 'Could not determine plan id for subscription %d items, skipping.', $latest_active_subscription_id ) );
+					continue;
+				}
+				$plan = \wc_memberships_get_membership_plan( $plan_id );
+				$plan_product_ids = $plan->get_product_ids();
+				$product_ids = array_intersect( $subscription_product_ids, $plan_product_ids );
+				if ( empty( $product_ids ) ) {
+					WP_CLI::warning( sprintf( 'Could not determine product id for subscription %d and plan %d, skipping.', $latest_active_subscription_id, $plan_id ) );
+					continue;
+				}
+				if ( self::$live ) {
+					try {
+						$membership = \wc_memberships_create_user_membership(
+							[
+								'user_id'    => $user_id,
+								'plan_id'    => $plan_id,
+								'product_id' => $product_ids[0],
+								'order_id'   => $latest_active_subscription_id,
+							]
+						);
+						WP_CLI::success( sprintf( 'Created a membership (#%d) for user %s.', $membership->get_id(), $user->user_email ) );
+					} catch ( \Throwable $th ) {
+						WP_CLI::warning( sprintf( 'Could not create a membership for user %s.', $user->user_email ) );
+					}
+				} else {
+					WP_CLI::line( sprintf( 'In live mode, would create a membership for user %s.', $user->user_email ) );
+				}
+			} else {
+				$membership = \wc_memberships_get_user_membership( $membership_ids[0] );
+				if ( self::$live ) {
+					$membership->unschedule_expiration_events();
+					$membership->set_subscription_id( $latest_active_subscription_id );
+					$membership->set_end_date();
+					$membership->update_status( 'active' );
+					WP_CLI::success( sprintf( 'Activated membership (#%d) and relinked to subscription (#%d) for user %s.', $membership->get_id(), $latest_active_subscription_id, $user->user_email ) );
+				} else {
+					WP_CLI::line( sprintf( 'In live mode, would activate membership (#%d) and relink to subscription (#%d) for user %s.', $membership->get_id(), $latest_active_subscription_id, $user->user_email ) );
+				}
+			}
+			WP_CLI::line( '' );
+		}
+	}
+}

--- a/includes/cli/class-woocommerce-memberships.php
+++ b/includes/cli/class-woocommerce-memberships.php
@@ -115,7 +115,7 @@ class WooCommerce_Memberships {
 		";
 
 
-		$results = $wpdb->get_results( $sql_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $sql_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		$site_url = get_option( 'siteurl' );
 
@@ -174,7 +174,7 @@ class WooCommerce_Memberships {
 					AND pm.meta_key = '_product_ids'
 					AND {$subscription_product_ids_meta_value_sql}
 				";
-				$result = $wpdb->get_results( $sql_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				$result = $wpdb->get_results( $sql_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 				$plan_id = isset( $result[0]['membership_plan_id'] ) ? $result[0]['membership_plan_id'] : false;
 				if ( $plan_id === false ) {
 					WP_CLI::warning( sprintf( 'Could not determine plan id for subscription %d items, skipping.', $latest_active_subscription_id ) );

--- a/includes/cli/class-woocommerce-memberships.php
+++ b/includes/cli/class-woocommerce-memberships.php
@@ -214,6 +214,8 @@ class WooCommerce_Memberships {
 					continue;
 				}
 
+				$product_id = $product_ids[0];
+
 				/**
 				 * Check if the subscription is linked to any membership. Sometimes the membership
 				 * is missing the _product_id meta, which results in a false-positive.
@@ -230,10 +232,10 @@ class WooCommerce_Memberships {
 				if ( count( $linked_membership_sql_query_result ) ) {
 					$found_membership_id = $linked_membership_sql_query_result[0]['membership_id'];
 
-					$log_line = sprintf( 'Latest subscription (#%d) is linked to a membership (#%d), possibly the membership is missing the product ID, fixing.', $latest_active_subscription_id, $found_membership_id );
+					$log_line = sprintf( 'Latest subscription (#%d) is linked to a membership (#%d), possibly the membership is missing the product ID, setting product ID to %d.', $latest_active_subscription_id, $found_membership_id, $product_id );
 					$membership = new \WC_Memberships_Integration_Subscriptions_User_Membership( $found_membership_id );
 					if ( self::$live ) {
-						$membership->set_product_id( $product_ids[0] );
+						$membership->set_product_id( $product_id );
 						WP_CLI::success( $log_line );
 					} else {
 						WP_CLI::line( $log_line );
@@ -252,7 +254,7 @@ class WooCommerce_Memberships {
 							[
 								'user_id'    => $user_id,
 								'plan_id'    => $plan_id,
-								'product_id' => $product_ids[0],
+								'product_id' => $product_id,
 								'order_id'   => $latest_active_subscription->get_parent_id(),
 							]
 						);

--- a/includes/cli/class-woocommerce-memberships.php
+++ b/includes/cli/class-woocommerce-memberships.php
@@ -145,6 +145,11 @@ class WooCommerce_Memberships {
 			if ( empty( $membership_ids ) ) {
 				// Determine the membership plan from the subscrption product.
 				$latest_active_subscription = \wcs_get_subscription( $latest_active_subscription_id );
+				$latest_active_subscription_total = (float) $latest_active_subscription->get_total();
+				if ( $latest_active_subscription_total === 0 ) {
+					WP_CLI::warning( sprintf( 'Latest subscription %d total is 0, skipping.', $latest_active_subscription_id ) );
+					continue;
+				}
 				$subscription_product_ids = array_reduce(
 					$latest_active_subscription->get_items(),
 					function( $acc, $item ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a CLI command to fix WC Subscriptions & WC Memberships discrepancies. 

### How to test the changes in this Pull Request:

1. Set up a Membership Plan granted on Subscription
2. As separate readers, establish three membership-subscription pairs by buying the required product
1. Now, create some chaos:
    1. Delete one of the memberships (`wp post delete --force <id>`), keeping the subscription active
    2. Unlink a membership from subscription by deleting the `_subscription_id` meta field from the membership post
    3. Expire a membership, keeping the subscription active
4. Run `wp newspack fix-wc-memberships --verbose`, observe the output informing about the intended changes, and that the memberships were not fixed yet
5. Run `wp newspack fix-wc-memberships --verbose --live`, observe that fixed the memberships:
    1. The first one was re-created 
    2. The second one relinked
    3. The third one reactivated

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->