### PR TITLE
fix: media credit placeholder not saving

### DIFF
--- a/includes/class-newspack-image-credits.php
+++ b/includes/class-newspack-image-credits.php
@@ -403,7 +403,7 @@ class Newspack_Image_Credits {
 				'key'         => 'newspack_image_credits_placeholder',
 				'label'       => __( 'Placeholder Image', 'newspack-image-credits' ),
 				'type'        => 'image',
-				'value'       => null,
+				'value'       => '',
 			],
 			[
 				'description' => __( 'Automatically populate image credits from EXIF or IPTC metadata when uploading new images.', 'newspack-image-credits' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes issue when saving Media Credit placeholder image. Selected image is stored in theme mods when clicking save.

### How to test the changes in this Pull Request:

1. Checkout this branch i.e. `git checkout fix/media-credit-placeholder`
2. Navigate to _/wp-admin/admin.php?page=newspack-site-design-wizard#/settings_
3. Scroll down to "Media Credit" section.
![Screenshot 2024-09-18 at 21 01 53](https://github.com/user-attachments/assets/4713d11c-3268-4deb-bfcd-08eb85107dee)
4. Select an image from Media Library.
5. Click "Save".
6. Refresh browser and confirm image has been stored in `theme_mods_*` (replace "*" with theme name) option.
![Screenshot 2024-09-18 at 21 05 30](https://github.com/user-attachments/assets/0f13cd4a-afc8-4dfa-bc6f-e742bdee7b09)
7. Additional confirmation can be done by invoking the `wp theme mod list` WP CLI command.
![Screenshot 2024-09-18 at 21 08 08](https://github.com/user-attachments/assets/f44c7019-a5d8-40a6-aa89-35db4c335bf5)
8. Remove image and save. Refresh browser and ensure no placeholder image is present.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?