### PR TITLE
fix(sync): remove localized number format

### DIFF
--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -234,7 +234,7 @@ class WooCommerce {
 			}
 			$order_date_paid = $order->get_date_paid();
 			if ( $payment_received && ! empty( $order_date_paid ) ) {
-				$metadata['last_payment_amount'] = \wc_format_localized_price( $order->get_total() );
+				$metadata['last_payment_amount'] = $order->get_total();
 				$metadata['last_payment_date']   = $order_date_paid->date( Metadata::DATE_FORMAT );
 			}
 
@@ -270,7 +270,7 @@ class WooCommerce {
 			$metadata['recurring_payment'] = $current_subscription->get_total();
 
 			if ( $payment_received ) {
-				$metadata['last_payment_amount'] = \wc_format_localized_price( $current_subscription->get_total() );
+				$metadata['last_payment_amount'] = $current_subscription->get_total();
 				$metadata['last_payment_date']   = $current_subscription->get_date( 'last_order_date_paid' ) ? $current_subscription->get_date( 'last_order_date_paid' ) : gmdate( Metadata::DATE_FORMAT );
 			}
 
@@ -322,7 +322,7 @@ class WooCommerce {
 
 		$metadata['account']           = $customer->get_id();
 		$metadata['registration_date'] = $customer->get_date_created()->date( Metadata::DATE_FORMAT );
-		$metadata['total_paid']        = \wc_format_localized_price( $customer->get_total_spent() );
+		$metadata['total_paid']        = $customer->get_total_spent();
 
 		$order = self::get_current_product_order_for_sync( $customer );
 

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -123,9 +123,6 @@ class WC_Order {
 function wc_create_order( $data ) {
 	return new WC_Order( $data );
 }
-function wc_format_localized_price( $price ) {
-	return '$' . $price;
-}
 function wc_get_checkout_url() {
 	return 'https://example.com/checkout';
 }

--- a/tests/unit-tests/reader-activation-sync-woocommerce.php
+++ b/tests/unit-tests/reader-activation-sync-woocommerce.php
@@ -104,7 +104,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 					'payment_page'              => $payment_page_url,
 					'membership_status'         => 'customer',
 					'product_name'              => '',
-					'last_payment_amount'       => '$' . $order_data['total'],
+					'last_payment_amount'       => $order_data['total'],
 					'last_payment_date'         => $today,
 					'payment_page_utm_source'   => 'test_source',
 					'payment_page_utm_medium'   => '',
@@ -116,7 +116,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 					'billing_cycle'             => '',
 					'recurring_payment'         => '',
 					'next_payment_date'         => '',
-					'total_paid'                => '$' . ( self::USER_DATA['meta_input']['wc_total_spent'] + $order_data['total'] ),
+					'total_paid'                => self::USER_DATA['meta_input']['wc_total_spent'] + $order_data['total'],
 					'account'                   => self::$user_id,
 					'registration_date'         => $today,
 				],
@@ -182,7 +182,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 		self::$current_order = $order;
 
 		$contact_data = Sync\WooCommerce::get_contact_from_customer( self::$user_id );
-		$this->assertEquals( '$' . $order_data['total'], $contact_data['metadata']['last_payment_amount'] );
+		$this->assertEquals( $order_data['total'], $contact_data['metadata']['last_payment_amount'] );
 		$this->assertEquals( gmdate( 'Y-m-d' ), $contact_data['metadata']['last_payment_date'] );
 	}
 
@@ -208,7 +208,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 		];
 		$order = \wc_create_order( $failed_order_data );
 		$contact_data = Sync\WooCommerce::get_contact_from_customer( self::$user_id );
-		$this->assertEquals( '$' . $completed_order_data['total'], $contact_data['metadata']['last_payment_amount'] );
+		$this->assertEquals( $completed_order_data['total'], $contact_data['metadata']['last_payment_amount'] );
 		$this->assertEquals( $completed_order_data['date_paid'], $contact_data['metadata']['last_payment_date'] );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The values sent for syncing shouldn't preserve the localized format given it may ignore the decimal separator depending on how the 3rd party handles numbers.

This PR removes the `wc_format_localized_price()` call so numbers are treated raw.

### How to test the changes in this Pull Request:

1. While in the master branch, setup RAS using Mailchimp and WooCommerce with `,` (comma) as your decimal separator
2. Donate as a reader and confirm the Last Payment Amount and Total Paid fields are 100x higher than the expected (the decimal separator was ignored)
3. Check out this branch, repeat step 2 and confirm the values are correct

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->