### PR TITLE
fix: prevent PHP notice while checking my-account page

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -449,7 +449,7 @@ class WooCommerce_My_Account {
 	 */
 	public static function is_from_my_account() {
 		// If we're in My Account.
-		if ( function_exists( 'is_account_page' ) && \is_account_page() ) {
+		if ( did_action( 'wp' ) && function_exists( 'is_account_page' ) && \is_account_page() ) {
 			return true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-blocks/pull/1869 added a `is_from_my_account` check in `is_modal_checkout` method. This method is ran in multiple places, also before WP is ready to run `is_page` (called by `is_account_page` in `is_from_my_account`). This change ensures that `is_account_page` is only run when the `'wp'` action was run. I know, it's a lot of running.

### How to test the changes in this Pull Request:

1. On `trunk`, load any page, observe `PHP Notice:  Function is_page was called <strong>incorrectly</strong>. Conditional query tags do not work before the query is run. Before then, they always return false.` logged
2. Switch to this branch, observe no PHP notice logged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->