### PR TITLE
feat(metering): dispatch RAS activity on content restriction

### DIFF
--- a/src/memberships-gate/metering.js
+++ b/src/memberships-gate/metering.js
@@ -77,6 +77,7 @@ function meter( ras ) {
 	// Lock content if reached limit, remove gate content if not.
 	if ( settings.count <= data.content.length && ! data.content.includes( settings.post_id ) ) {
 		lockContent();
+		ras.dispatchActivity( 'metering_restricted', { post_id: settings.post_id, metering: data } );
 		locked = true;
 	} else {
 		const gates = document.querySelectorAll( '.newspack-memberships__gate' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1208347477266676/f

Because our content restriction strategy implements new layers on top of Woo Memberships for metered content restriction, we don't fully support 3rd parties to leverage our implementation for their content features.

2 public methods can already be used to detect content restriction on the Newspack side:

- `Newspack\Memberships::is_post_restricted( $post_id );`: whether the post is restricted on the backend.
- `Newspack\Memberships\Metering::is_metering();`: whether the restricted post (method above) should be allowed to render due to metering rules. This will always be reading from the global `$post` and should only be used in a `is_singular()` context.

The second method will also return `true` if the metering is supposed to happen in the front-end (anonymous metering). That's what we don't have an API for.

This PR proposes this API to be a listener on a RAS activity dispatch so that it can be used like this:

```js
window.newspackRAS = window.newspackRAS || [];
window.newspackRAS.push( ras => {
	ras.on( 'activity', function( ev ) {
		const { action, data } = ev.details;
		if ( 'metering_restricted' === action ) {
			// Do stuff here.
			console.log( data );
		}
	} );
} );
```

The data payload:

```js
{
  "post_id": "117",          // Restricted post ID
  "metering": {              // Current metering configuration for the reader
    "content": [             // List of allowed post IDs
      "122"
    ],
    "expiration": 1726887600 // Metering expiration
  }
}
```

### How to test the changes in this Pull Request:

1. Make sure you have RAS configured with Woo Memberships and content gating
2. Edit your content gate to allow metered access of 1 post for anonymous readers
3. In a fresh session, visit 2 articles so you hit the gate
4. Open DevTools, inspect `localStorage`, and confirm the `np_reader_1_activity` item includes a `metering_restricted` activity with the data payload as exemplified above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->