### PR TITLE
fix(sync): place esp sync admin features behind a constant

### DIFF
--- a/includes/reader-activation/sync/class-esp-sync-admin.php
+++ b/includes/reader-activation/sync/class-esp-sync-admin.php
@@ -27,6 +27,9 @@ class ESP_Sync_Admin extends ESP_Sync {
 	 * Initializes hooks.
 	 */
 	public static function init_hooks() {
+		if ( ! defined( 'NEWSPACK_ESP_SYNC_ADMIN' ) || ! NEWSPACK_ESP_SYNC_ADMIN ) {
+			return;
+		}
 		add_action( 'admin_init', [ __CLASS__, 'process_admin_action' ] );
 		add_filter( 'user_row_actions', [ __CLASS__, 'user_row_actions' ], 100, 2 );
 		add_filter( 'bulk_actions-users', [ __CLASS__, 'bulk_actions' ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We'll wait until the manual sync covers all fields, rather than just WooCommerce-related meta, to make this feature publicly available.

### How to test the changes in this Pull Request:

1. Make sure you have RAS enabled and ESP Sync is active and without restrictions (no error notices on the ESP Sync wizard)
2.  Checkout this branch, navigate to the Users table and confirm the manual sync options are not available (no batch action nor sync link in the user row action)
3. Add `define( 'NEWSPACK_ESP_SYNC_ADMIN', true );` to your `wp-config.php`, refresh the Users page and confirm the options are now available

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->