### PR TITLE
fix(ras-sync): deprecate redundant Signup_Page meta field

### DIFF
--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -209,7 +209,6 @@ class Metadata {
 			'account'              => 'Account',
 			'registration_date'    => 'Registration Date',
 			'connected_account'    => 'Connected Account',
-			'signup_page'          => 'Signup Page',
 			'signup_page_utm'      => 'Signup UTM: ',
 			'newsletter_selection' => 'Newsletter Selection',
 			'referer'              => 'Referrer Path',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Deprecates the `NP_Signup Page` contact meta field, which is currently not synced anywhere and seems redundant with the `NP_Registration Page` field.

### How to test the changes in this Pull Request:

1. Visit **Engagement > Reader Activation > Advanced settings > Email Service Provider (ESP) Advanced Settings** and confirm there's no `Signup Page` option here.

<img width="1044" alt="Screenshot 2024-09-20 at 10 28 50 AM" src="https://github.com/user-attachments/assets/2d9f664d-fe37-4efa-9c05-2eb3195a8209">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->