### PR TITLE
fix: make some newspack UI styles more specific

### DIFF
--- a/src/newspack-ui/scss/_modals.scss
+++ b/src/newspack-ui/scss/_modals.scss
@@ -70,6 +70,7 @@
 			z-index: 10;
 
 			h2 {
+				color: inherit;
 				font-family: var(--newspack-ui-font-family);
 				font-size: var(--newspack-ui-font-size-s);
 				line-height: var(--newspack-ui-line-height-s);

--- a/src/newspack-ui/scss/elements/_tables.scss
+++ b/src/newspack-ui/scss/elements/_tables.scss
@@ -1,6 +1,7 @@
 .newspack-ui {
 	table {
 		border: 0;
+		font-family: var(--newspack-ui-font-family);
 		font-size: var(--newspack-ui-font-size-xs); // Prevent relative font size
 		line-height: var(--newspack-ui-line-height-xs);
 		margin: calc(var(--newspack-ui-spacer-base) / -2) 0; // Offset cell padding.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is just a quick two line PR that fixes two issues that came up so far from beta site reviews.

See 1207817176293825-as-1208344705374755 and 1207817176293825-as-1208344705374765

### How to test the changes in this Pull Request:

1. Copy the following CSS to the Customizer.

```
h2 {
  color:#338BFD;
}

table {
  font-family: 'Chalkboard',sans-serif;
}
```


2. On epic/ras-acc, start a checkout on a product that will show the transaction details table (like a donation with Stripe Gateway and opt to cover fees, or a subscription product.
3. Note the modal header is picking up your Custom CSS color, and the transaction details are picking up your font.

![CleanShot 2024-09-20 at 10 42 27](https://github.com/user-attachments/assets/6d89dd12-91f0-40bd-b57a-4832b2311bde)

4. Apply this PR & run `npm run build`.
5. Repeat steps 2 and 3 and confirm the styles look right:

![CleanShot 2024-09-20 at 10 41 16](https://github.com/user-attachments/assets/5785d947-da29-446d-9167-2bde9e60b8f1)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->