### PR TITLE
fix: wizards - update type check conditional for `custom_logo`

### DIFF
--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -520,7 +520,7 @@ class Setup_Wizard extends Wizard {
 				continue;
 			}
 
-			if ( ! empty( $value ) && in_array( $key, $this->media_theme_mods ) ) {
+			if ( ! empty( $value['id'] ) && in_array( $key, $this->media_theme_mods ) ) {
 				$value = $value['id'];
 			}
 			set_theme_mod( $key, $value );

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -520,7 +520,7 @@ class Setup_Wizard extends Wizard {
 				continue;
 			}
 
-			if ( '' !== $value && in_array( $key, $this->media_theme_mods ) ) {
+			if ( ! empty( $value ) && in_array( $key, $this->media_theme_mods ) ) {
 				$value = $value['id'];
 			}
 			set_theme_mod( $key, $value );

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -520,7 +520,7 @@ class Setup_Wizard extends Wizard {
 				continue;
 			}
 
-			if ( null !== $value && in_array( $key, $this->media_theme_mods ) ) {
+			if ( '' !== $value && in_array( $key, $this->media_theme_mods ) ) {
 				$value = $value['id'];
 			}
 			set_theme_mod( $key, $value );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changes introduced in #3433 produced a bug relating to how `custom_logo` and `newspack_footer_logo` theme mods are saved. 

`PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string`

This PR fixes this issue by correctly testing incoming values by the correct type.

### How to test the changes in this Pull Request:

1. Checkout this branch i.e. `git checkout origin/fix/wizard-custom-logo-save`
2. Navigate to _/wp-admin/admin.php?page=newspack-site-design-wizard#/settings_
3. Scroll to Header and Footer sections. Test the following:
   * You're able to add/update Logos and changes persist between page refreshes.
   * You're able to remove Logos (saving without error) and changes persist between page refreshes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->