### PR TITLE
chore(ia-refactor-get-name): changed abstract to function, added this->name

### DIFF
--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -31,6 +31,13 @@ class Advertising_Display_Ads extends Wizard {
 	const OPTION_NAME_GAM_NETWORK_CODE = '_newspack_ads_gam_network_code';
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Advertising';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -61,15 +68,6 @@ class Advertising_Display_Ads extends Wizard {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return esc_html__( 'Advertising', 'newspack-plugin' );
 	}
 
 	/**

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -20,6 +20,13 @@ class Advertising_Sponsors extends Wizard {
 	use Admin_Header;
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Advertising / Sponsors';
+
+	/**
 	 * Newspack Sponsors CPT name.
 	 * 
 	 * @var string
@@ -88,15 +95,6 @@ class Advertising_Sponsors extends Wizard {
 				]
 			);
 		}
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return esc_html__( 'Advertising / Sponsors', 'newspack-plugin' );
 	}
 
 	/**

--- a/includes/wizards/class-advertising-wizard.php
+++ b/includes/wizards/class-advertising-wizard.php
@@ -31,6 +31,13 @@ class Advertising_Wizard extends Wizard {
 	const OPTION_NAME_GAM_NETWORK_CODE = '_newspack_ads_gam_network_code';
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Advertising';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -61,15 +68,6 @@ class Advertising_Wizard extends Wizard {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'Advertising', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-analytics-wizard.php
+++ b/includes/wizards/class-analytics-wizard.php
@@ -22,6 +22,13 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Analytics_Wizard extends Wizard {
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Analytics';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -41,15 +48,6 @@ class Analytics_Wizard extends Wizard {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'Analytics', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -17,6 +17,13 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Components_Demo extends Wizard {
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Components demo';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -43,15 +50,6 @@ class Components_Demo extends Wizard {
 	 * @var bool.
 	 */
 	protected $hidden = true;
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return esc_html__( 'Components demo', 'newspack' );
-	}
 
 	/**
 	 * Enqueue Subscriptions Wizard scripts and styles.

--- a/includes/wizards/class-connections-wizard.php
+++ b/includes/wizards/class-connections-wizard.php
@@ -19,6 +19,13 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Connections_Wizard extends Wizard {
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Connections';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -31,15 +38,6 @@ class Connections_Wizard extends Wizard {
 	 * @var string
 	 */
 	protected $capability = 'manage_options';
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'Connections', 'newspack' );
-	}
 
 	/**
 	 * Enqueue Connections Wizard scripts and styles.

--- a/includes/wizards/class-engagement-wizard.php
+++ b/includes/wizards/class-engagement-wizard.php
@@ -24,6 +24,13 @@ class Engagement_Wizard extends Wizard {
 	const SKIP_CAMPAIGN_SETUP_OPTION = '_newspack_ras_skip_campaign_setup';
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Engagement';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -52,15 +59,6 @@ class Engagement_Wizard extends Wizard {
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
 		add_filter( 'jetpack_relatedposts_filter_date_range', [ $this, 'restrict_age_of_related_posts' ] );
 		add_filter( 'newspack_newsletters_settings_url', [ $this, 'newsletters_settings_url' ] );
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'Engagement', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-health-check-wizard.php
+++ b/includes/wizards/class-health-check-wizard.php
@@ -20,6 +20,13 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Health_Check_Wizard extends Wizard {
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Health Check';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -39,15 +46,6 @@ class Health_Check_Wizard extends Wizard {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'Health Check', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-popups-wizard.php
+++ b/includes/wizards/class-popups-wizard.php
@@ -20,6 +20,13 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Popups_Wizard extends Wizard {
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Campaigns';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -40,15 +47,6 @@ class Popups_Wizard extends Wizard {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
 		add_filter( 'newspack_popups_registered_criteria', [ $this, 'maybe_unregister_memberships_criteria' ] );
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'Campaigns', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -18,6 +18,13 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
  */
 class Reader_Revenue_Wizard extends Wizard {
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Reader Revenue';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -30,15 +37,6 @@ class Reader_Revenue_Wizard extends Wizard {
 	 * @var string
 	 */
 	protected $capability = 'manage_options';
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'Reader Revenue', 'newspack' );
-	}
 
 	/**
 	 * Constructor.

--- a/includes/wizards/class-settings.php
+++ b/includes/wizards/class-settings.php
@@ -20,6 +20,13 @@ class Settings extends Wizard {
 	const MODULE_ENABLED_PREFIX = 'module_enabled_';
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Settings';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -156,15 +163,6 @@ class Settings extends Wizard {
 				'args'                => $required_args,
 			]
 		);
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'Settings', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -30,6 +30,13 @@ class Setup_Wizard extends Wizard {
 	];
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Setup';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -62,15 +69,6 @@ class Setup_Wizard extends Wizard {
 		}
 		add_filter( 'show_admin_bar', [ $this, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 		$this->hidden = get_option( NEWSPACK_SETUP_COMPLETE, false );
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return esc_html__( 'Setup', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-site-design-wizard.php
+++ b/includes/wizards/class-site-design-wizard.php
@@ -19,6 +19,13 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Site_Design_Wizard extends Wizard {
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Site Design';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -31,15 +38,6 @@ class Site_Design_Wizard extends Wizard {
 	 * @var string
 	 */
 	protected $capability = 'manage_options';
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'Site Design', 'newspack' );
-	}
 
 	/**
 	 * Enqueue Subscriptions Wizard scripts and styles.

--- a/includes/wizards/class-syndication-wizard.php
+++ b/includes/wizards/class-syndication-wizard.php
@@ -19,6 +19,13 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class Syndication_Wizard extends Wizard {
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Syndication';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -38,15 +45,6 @@ class Syndication_Wizard extends Wizard {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'Syndication', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -19,6 +19,13 @@ define( 'NEWSPACK_WIZARD_COMPLETED_OPTION_PREFIX', 'newspack_wizard_completed_' 
 abstract class Wizard {
 
 	/**
+	 * The name of this wizard. Override this.
+	 *
+	 * @var string
+	 */
+	protected $name = '';
+
+	/**
 	 * The slug of this wizard. Override this.
 	 *
 	 * @var string
@@ -273,7 +280,9 @@ abstract class Wizard {
 	 *
 	 * @return string The wizard name.
 	 */
-	abstract public function get_name();
+	public function get_name() {
+		return esc_html__( $this->name, 'newspack-plugin' );
+	}
 
 	/**
 	 * Load wizard sections.

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -15,6 +15,13 @@ defined( 'ABSPATH' ) || exit;
 class Newspack_Dashboard extends Wizard {
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Newspack';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -294,15 +301,6 @@ class Newspack_Dashboard extends Wizard {
 				],
 			],
 		];
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return esc_html__( 'Newspack', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/newspack/class-newspack-settings.php
+++ b/includes/wizards/newspack/class-newspack-settings.php
@@ -22,6 +22,13 @@ defined( 'ABSPATH' ) || exit;
 class Newspack_Settings extends Wizard {
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'Newspack';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -109,15 +116,6 @@ class Newspack_Settings extends Wizard {
 				'label' => __( 'Additional Brands', 'newspack-plugin' ),
 			],
 		];
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return esc_html__( 'Newspack', 'newspack' );
 	}
 
 	/**

--- a/includes/wizards/newspack/class-seo-wizard.php
+++ b/includes/wizards/newspack/class-seo-wizard.php
@@ -19,6 +19,13 @@ require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
 class SEO_Wizard extends Wizard {
 
 	/**
+	 * The name of this wizard.
+	 *
+	 * @var string
+	 */
+	protected $name = 'SEO';
+
+	/**
 	 * The slug of this wizard.
 	 *
 	 * @var string
@@ -39,15 +46,6 @@ class SEO_Wizard extends Wizard {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
 		add_filter( 'wpseo_image_image_weight_limit', [ $this, 'ignore_yoast_weight_limit' ] );
-	}
-
-	/**
-	 * Get the name for this wizard.
-	 *
-	 * @return string The wizard name.
-	 */
-	public function get_name() {
-		return \esc_html__( 'SEO', 'newspack' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changed the `Wizard` class to use a normal `function` instead of `abstract` for `get_name()`.  Added a `$name` property to be overridden by each class.  This also fixes text domain from `newspack` to `newspack-plugin` in many cases.  

Advantages:
* For each class, moved the wizard name to the top of the code instead of in a function farther down in the code.
* Simpler creation of new classes.
* Standardizes return value and text domain to newspack-plugin. 
* Function can still be overridden if need be.

### How to test the changes in this Pull Request:

1. Pull branch.
2. Click in web browser on wizard pages to verify name still displays.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
