### PR TITLE
Refactor (IA) for body css for react vs partial react pages

### DIFF
--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -203,4 +203,17 @@ class Advertising_Sponsors extends Wizard {
 	
 		return $submenu_file;
 	}
+
+	/**
+	 * Add body class for wizard pages.
+	 * 
+	 * @param string $classes The current body classes.
+	 */
+	public function add_body_class( $classes ) {
+		if ( ! $this->is_wizard_page() ) {
+			return $classes;
+		}
+		$classes .= parent::add_body_class( $classes ) . ' newspack-wizard-partial-react';
+		return $classes;
+	}
 }

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -203,17 +203,4 @@ class Advertising_Sponsors extends Wizard {
 	
 		return $submenu_file;
 	}
-
-	/**
-	 * Add body class for wizard pages.
-	 * 
-	 * @param string $classes The current body classes.
-	 */
-	public function add_body_class( $classes ) {
-		if ( ! $this->is_wizard_page() ) {
-			return $classes;
-		}
-		$classes .= parent::add_body_class( $classes ) . ' newspack-wizard-partial-react';
-		return $classes;
-	}
 }

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -41,6 +41,7 @@ class Newspack_Dashboard extends Wizard {
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_page' ], 1 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
+		add_filter( 'admin_body_class', [ $this, 'add_body_class' ] );
 	}
 
 	/**

--- a/includes/wizards/traits/trait-wizards-admin-header.php
+++ b/includes/wizards/traits/trait-wizards-admin-header.php
@@ -34,6 +34,7 @@ trait Admin_Header {
 		$this->title = $args['title'] ?? __( 'Newspack Settings', 'newspack-plugin' );
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_header_enqueue' ] );
 		add_action( 'all_admin_notices', [ $this, 'admin_header_render' ] );
+		add_filter( 'admin_body_class', [ $this, 'admin_header_body_class' ] );
 	}
 
 	/**
@@ -105,5 +106,14 @@ trait Admin_Header {
 			?>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Add body class for admin header.
+	 * 
+	 * @param string $classes The current body classes.
+	 */
+	public function admin_header_body_class( $classes ) {
+		return $classes . ' newspack-admin-header';
 	}
 }

--- a/src/components/src/with-wizard/style.scss
+++ b/src/components/src/with-wizard/style.scss
@@ -5,8 +5,8 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "../../../shared/scss/colors";
 
-// Reset Padding of the Admin Page for full react pages (ignoring partial react pages).
-body.newspack-wizard-page:not(.newspack-wizard-partial-react) {
+// Reset Padding of the Admin Page for full react pages (ignoring admin-header-only pages).
+body.newspack-wizard-page:not(.newspack-admin-header) {
 
 	background: white;
 

--- a/src/components/src/with-wizard/style.scss
+++ b/src/components/src/with-wizard/style.scss
@@ -5,13 +5,9 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "../../../shared/scss/colors";
 
-// Reset Padding of the Admin Page
+// Reset Padding of the Admin Page for full react pages (ignoring partial react pages).
+body.newspack-wizard-page:not(.newspack-wizard-partial-react) {
 
-.toplevel_page_newspack-dashboard:not(.menu-top),
-.toplevel_page_newspack:not(.menu-top),
-body[class*="toplevel_page_newspack-"]:not(.menu-top),
-body[class*="newspack_page_newspack-"],
-body[class*="toplevel_page_advertising-"] {
 	background: white;
 
 	#wpcontent {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This code cleans up the body `scss/css` to one selector that will cover all wizards.  Because the new `epic/ia` wizards all call `add_body_class`, this means all wizards will have `newspack-wizard-page` class on the body.  Also, since all old wizards (which I assume won't be used in `epic/ia`), but still, since they extend from the same `wizards` abstract class they too will get the `newspack-wizard-page` class on the body.

So the `css` selector simply becomes `body.newspack-wizard-page` in order to apply a white background and other padding resets.

In cases where only a "partial react" wizard is needed (like when overriding Newspack Ads, Newspack Network, or anywhere where we only need the `Admin_Header`), there is a `:not(.newspack-wizard-partial-react)` psuedo-class (*renamed* to `:not(.newspack-admin-header`) that can use by ~overriding `add_body_class` on a per-wizard basis~ (*changed* to automatically on the `Admin_Header` trait).

Please see `src/components/src/with-wizard/style.scss` in this PR.

There were tweaks that needed to be applied to get all the wizards standardized.

* `includes/wizards/newspack/class-newspack-dashboard.php` - was missing the the `newspack-wizard-page` body css
* ~`includes/wizards/advertising/class-advertising-sponsors.php` - needed to have the "not" classes `newspack-wizard-page newspack-wizard-partial-react` added.~ (*changed* to automatically on the `Admin_Header` trait).

Let me know if this doesn't make sense or the css class names need to change.  Overall this will make it easier when adding more Wizards from existing plugins like Newspack Network (my current task).  Thanks!

### How to test the changes in this Pull Request:

1. Pull this branch.
2. `npm run build` or `npm run watch` 
3.  Use web browser to click through all Wizards.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
