### PR TITLE
fix(oauth): validate ID and prevent early deletion

### DIFF
--- a/includes/oauth/class-oauth-transients.php
+++ b/includes/oauth/class-oauth-transients.php
@@ -207,7 +207,7 @@ class OAuth_Transients {
 	public static function cleanup() {
 		global $wpdb;
 		$table_name = self::get_table_name();
-		$wpdb->query( "DELETE FROM $table_name WHERE created_at < now() - interval 30 MINUTE LIMIT 1000" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "DELETE FROM $table_name WHERE created_at < utc_timestamp() - interval 30 MINUTE LIMIT 1000" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 }
 

--- a/includes/oauth/class-oauth-transients.php
+++ b/includes/oauth/class-oauth-transients.php
@@ -114,6 +114,10 @@ class OAuth_Transients {
 		global $wpdb;
 		$table_name = self::get_table_name();
 
+		if ( empty( $id ) ) {
+			return false;
+		}
+
 		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
 				'SELECT %1$s FROM %2$s WHERE id = "%3$s" AND scope = "%4$s"', // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder

--- a/includes/oauth/class-oauth-transients.php
+++ b/includes/oauth/class-oauth-transients.php
@@ -106,10 +106,11 @@ class OAuth_Transients {
 	 * @param string $id The reader's unique ID.
 	 * @param string $scope The scope of the data to get.
 	 * @param string $field_to_get The column to get. Defaults to 'value'.
+	 * @param bool   $delete Whether to delete the row after getting the value.
 	 *
 	 * @return mixed The value of the data, or false if not found.
 	 */
-	public static function get( $id, $scope, $field_to_get = 'value' ) {
+	public static function get( $id, $scope, $field_to_get = 'value', $delete = true ) {
 		global $wpdb;
 		$table_name = self::get_table_name();
 
@@ -124,7 +125,7 @@ class OAuth_Transients {
 		);
 
 		// Burn after reading.
-		if ( ! empty( $value ) && ( ! defined( 'NEWSPACK_OAUTH_TRANSIENTS_DEBUG' ) || ! NEWSPACK_OAUTH_TRANSIENTS_DEBUG ) ) {
+		if ( $delete && ! empty( $value ) && ( ! defined( 'NEWSPACK_OAUTH_TRANSIENTS_DEBUG' ) || ! NEWSPACK_OAUTH_TRANSIENTS_DEBUG ) ) {
 			self::delete( $id, $scope );
 		}
 
@@ -165,9 +166,13 @@ class OAuth_Transients {
 	 * @return mixed The value if it was set, false otherwise.
 	 */
 	public static function set( $id, $scope, $value ) {
+		if ( empty( $id ) ) {
+			return false;
+		}
+
 		global $wpdb;
 
-		$existing = self::get( $id, $scope );
+		$existing = self::get( $id, $scope, 'value', false );
 		if ( $existing ) {
 			return $existing;
 		}

--- a/includes/oauth/class-oauth-transients.php
+++ b/includes/oauth/class-oauth-transients.php
@@ -38,7 +38,7 @@ class OAuth_Transients {
 		if ( defined( 'NEWSPACK_CRON_DISABLE' ) && is_array( NEWSPACK_CRON_DISABLE ) && in_array( self::CRON_HOOK, NEWSPACK_CRON_DISABLE, true ) ) {
 			self::cron_deactivate();
 		} elseif ( ! \wp_next_scheduled( self::CRON_HOOK ) ) {
-				\wp_schedule_event( time(), 'weekly', self::CRON_HOOK );
+				\wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
 		}
 	}
 

--- a/includes/oauth/class-oauth.php
+++ b/includes/oauth/class-oauth.php
@@ -48,6 +48,11 @@ class OAuth {
 	public static function generate_csrf_token( $namespace ) {
 		$csrf_token = wp_generate_password( 40, false );
 		$transient_scope = self::CSRF_TOKEN_TRANSIENT_SCOPE_PREFIX . $namespace;
+		$unique_id = self::get_unique_id();
+		if ( ! $unique_id ) {
+			Logger::log( sprintf( 'Unable to get unique ID for CSRF token with "%s" namespace.', $namespace ) );
+			return false;
+		}
 		return OAuth_Transients::set( self::get_unique_id(), $transient_scope, $csrf_token );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

p1727694639714059-slack-C055SRT7WN4

This PR tweaks the custom OAuth transients strategy to prevent the transient ID from being stored as an empty string and prevent the token's early deletion when verifying an existing token for reuse.

Update: dc1840f11b64e8b3b104f0276260446fb593a98b fixes the cleanup method, which is currently using `now()` as time reference. This will use the system's time instead of UTC, which is the stored value. The commit changes it to `utc_timestamp()`. 1e724967e19116347b0e7a0a59a6aae887de0978 tweaks the cron from weekly to hourly. If it's supposed to clear anything older than 30 minutes, it doesn't seem like "weekly" is the best interval.

20fe0094a7ad77eb743fbec27f16cd3b7d4fc6f9 tweaks the logging strategy to add support for `newspack_log`.

### How to test the changes in this Pull Request:

#### Empty ID token

1. While on the `release` branch, make sure you have RAS setup with Google OAuth via NM
2. Navigate to a page with the auth form (`/my-account`)
3. Delete the `newspack-cid` cookie (DevTools -> Application -> Cookies)
4. Without refreshing the page, to ensure the cookie is not generated, start the auth flow
5. Via SQL, select the created transient and confirm the ID is an empty string
6. Check out this branch, repeat steps 3-4 and confirm you are unable to continue the flow without the cookie

#### Early deletion 

1. While on the `release` branch, start the Google OAuth flow
2. Before continuing, close the auth popup
3. Confirm via SQL that the transient token is in the database
4. Start the flow again
5. Confirm via SQL that the transient token is now gone
6. Attempt to finish the flow and confirm you get the "Authentication failed" error
7. Check out this branch, repeat steps 1-6 and confirm via the transient token persists and you are able to authenticate
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->