### PR TITLE
fix(ras-acc): clear RAS user tokens on logout

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -71,6 +71,7 @@ final class Magic_Link {
 
 		/** Replace Newspack Newsletters Verification Email */
 		\add_filter( 'newspack_newsletters_email_verification_email', [ __CLASS__, 'newsletters_email_verification_email' ], 10, 3 );
+		\add_action( 'wp_logout', [ __CLASS__, 'clear_user_tokens' ], 10, 1 );
 	}
 
 	/**
@@ -265,10 +266,11 @@ final class Magic_Link {
 	/**
 	 * Clear all user tokens.
 	 *
-	 * @param \WP_User $user User to clear tokens for.
+	 * @param \WP_User|int $user User or user ID to clear tokens for.
 	 */
 	public static function clear_user_tokens( $user ) {
-		\delete_user_meta( $user->ID, self::TOKENS_META );
+		$user_id = $user instanceof \WP_User ? $user->ID : $user;
+		\delete_user_meta( $user_id, self::TOKENS_META );
 
 		/**
 		 * Fires after all user tokens are cleared.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208379852549386/f

This PR resolves an issue where persisted user tokens can prevent readers from logging in until the tokens expire (30 minutes) after logging out.

### How to test the changes in this Pull Request:

1. As a reader without a password, log in via otp using the auth modal
2. Immediately sign out
3. Without reloading, attempt to sign in again
4. On `epic/ras-acc` you will get stuck at the first step of the auth modal. The continue button will cause the form to load for a second, then do nothing. On this branch, you should get another OTP email and be able to sign in again.
5. Smoke test some other paths for the auth flow to ensure nothing else has broken.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->