### PR TITLE
fix: handle zero cover fee percentage

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -270,7 +270,7 @@ class WooCommerce_Cover_Fees {
 	 */
 	public static function get_fee_percentage( $subtotal ) {
 		$flat_percentage = 0;
-		if ( $subtotal > 0 ) {
+		if ( is_numeric( $subtotal ) && (float) $subtotal > 0 ) {
 			$total = self::get_total_with_fee( $subtotal );
 			// Just one decimal place, please.
 			$flat_percentage = (float) number_format( ( ( $total - $subtotal ) * 100 ) / $subtotal, 1 );

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -269,9 +269,12 @@ class WooCommerce_Cover_Fees {
 	 * @return string
 	 */
 	public static function get_fee_percentage( $subtotal ) {
-		$total = self::get_total_with_fee( $subtotal );
-		// Just one decimal place, please.
-		$flat_percentage = (float) number_format( ( ( $total - $subtotal ) * 100 ) / $subtotal, 1 );
+		$flat_percentage = 0;
+		if ( $subtotal > 0 ) {
+			$total = self::get_total_with_fee( $subtotal );
+			// Just one decimal place, please.
+			$flat_percentage = (float) number_format( ( ( $total - $subtotal ) * 100 ) / $subtotal, 1 );
+		}
 		return $flat_percentage . '%';
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1200550061930446/1208449408463805/f

Addresses an issue where the logic for rendering cover fee percentage text causes a fatal when switching subscriptions via My Account.

![Screenshot 2024-10-01 at 13 19 54](https://github.com/user-attachments/assets/407104f1-79b5-4d42-9f00-c80dbc79f670)

### How to test the changes in this Pull Request:

1. Ensure name your price is enabled
2. As a reader make a recurring donation
3. Visit My account and select the subscription management tab
4. If not already in the subscription view, select the subscription that was just purchased
5. Click "Change price"
6. Choose any subscription, input a new price, and submit
7. On `release` you will get a fatal. On this branch you will not.

Bonus: Go through the normal checkout flow for a donation with cover fees to confirm nothing has broken.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->