### PR TITLE
fix(oauth): tweak precision of success google auth log

### DIFF
--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -248,6 +248,20 @@ class Google_Login {
 		}
 		$metadata['registration_method'] = 'google';
 		if ( $email ) {
+			do_action(
+				'newspack_log',
+				'newspack_google_login',
+				'Google Login Success',
+				[
+					'type'       => 'debug',
+					'data'       => [
+						'uid' => OAuth::get_unique_id(),
+					],
+					'user_email' => $email,
+					'file'       => 'newspack_google_login',
+				]
+			);
+
 			$existing_user = \get_user_by( 'email', $email );
 			$message       = __( 'Thank you for registering!', 'newspack-plugin' );
 			$data          = [
@@ -268,20 +282,6 @@ class Google_Login {
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
-
-			do_action(
-				'newspack_log',
-				'newspack_google_login',
-				'Google Login Success',
-				[
-					'type'       => 'debug',
-					'data'       => [
-						'uid' => OAuth::get_unique_id(),
-					],
-					'user_email' => $email,
-					'file'       => 'newspack_google_login',
-				]
-			);
 
 			return \rest_ensure_response(
 				[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Due to potential RAS errors while authenticating, we might not accurately log the successful Google login. This PR moves the log up, before RAS authentication.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->