### PR TITLE
feat: add Newspack Elections block patterns

### DIFF
--- a/includes/class-newspack-elections.php
+++ b/includes/class-newspack-elections.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Govpack
+ * Newspack Elections Block Patterns.
  *
- * @package Govpack
+ * @package Newspack
  */
 
 namespace Newspack;
 
 /**
- *
+ * Newspack_Elections class.
  */
-class Elections_Block_Patterns {
+class Newspack_Elections {
 	/**
 	 * Initialize hooks.
 	 */
@@ -71,4 +71,4 @@ class Elections_Block_Patterns {
 		}
 	}
 }
-Elections_Block_Patterns::init();
+Newspack_Elections::init();

--- a/includes/class-newspack-elections.php
+++ b/includes/class-newspack-elections.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Govpack
+ *
+ * @package Govpack
+ */
+
+namespace Newspack;
+
+/**
+ *
+ */
+class Elections_Block_Patterns {
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'admin_init', [ __CLASS__, 'register_block_patterns' ] );
+	}
+
+	/**
+	 * Get block patterns.
+	 *
+	 * Each pattern content should be a PHP file in the block-patterns directory
+	 * named after the pattern slug.
+	 *
+	 * @return array
+	 */
+	public static function get_block_patterns() {
+		return [
+			'home-pre-results-ap'    => __( 'Homepage Pre-Results Module — AP', 'newspack-plugin' ),
+			'home-results-ap'        => __( 'Homepage Results Module — AP', 'newspack-plugin' ),
+			'live-results-post-ap'   => __( 'Live Election Results Post — AP', 'newspack-plugin' ),
+			'home-pre-results-ddhq'  => __( 'Homepage Pre-Results Module — DDHQ', 'newspack-plugin' ),
+			'home-results-ddhq'      => __( 'Homepage Results Module — DDHQ', 'newspack-plugin' ),
+			'live-results-post-ddhq' => __( 'Live Election Results Post — DDHQ', 'newspack-plugin' ),
+		];
+	}
+
+	/**
+	 * Register block patterns.
+	 */
+	public static function register_block_patterns() {
+		// Bail if Newspack Elections is not active.
+		if ( ! class_exists( '\Govpack\Core\Govpack' ) ) {
+			return false;
+		}
+
+		\register_block_pattern_category( 'newspack-plugin', [ 'label' => __( 'Newspack Elections', 'newspack-plugin' ) ] );
+		$patterns = self::get_block_patterns();
+		foreach ( $patterns as $slug => $title ) {
+			$path = __DIR__ . '/templates/block-patterns/elections/' . $slug . '.php';
+			if ( ! file_exists( $path ) ) {
+				continue;
+			}
+			ob_start();
+			require $path;
+			$content = ob_get_clean();
+			if ( empty( $content ) ) {
+				continue;
+			}
+			\register_block_pattern(
+				'newspack-elections/' . $slug,
+				[
+					'categories'  => [ 'newspack-plugin' ],
+					'title'       => $title,
+					'description' => _x( 'Help format and provide context to AP and DDHQ elections embeds.', 'Block pattern description', 'newspack-plugin' ),
+					'content'     => $content,
+				]
+			);
+		}
+	}
+}
+Elections_Block_Patterns::init();

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -117,6 +117,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/tracking/class-twitter-pixel.php';
 		include_once NEWSPACK_ABSPATH . 'includes/revisions-control/class-revisions-control.php';
 		include_once NEWSPACK_ABSPATH . 'includes/authors/class-authors-custom-fields.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-newspack-elections.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-provider.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-generated.php';

--- a/includes/templates/block-patterns/elections/home-pre-results-ap.php
+++ b/includes/templates/block-patterns/elections/home-pre-results-ap.php
@@ -2,7 +2,7 @@
 /**
  * Homepage Pre-Results Module — AP.
  *
- * @package Govpack
+ * @package Newspack
  */
 
 ?>

--- a/includes/templates/block-patterns/elections/home-pre-results-ap.php
+++ b/includes/templates/block-patterns/elections/home-pre-results-ap.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Homepage Pre-Results Module — AP.
+ *
+ * @package Govpack
+ */
+?>
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1} -->
+<h1 class="wp-block-heading has-text-align-center"><a href="#"><?php _e( 'Demonyms Head to the Polls!', 'newspack-plugin' ); ?></a></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","style":{"color":{"background":"#fff562"}}} -->
+<p class="has-text-align-center has-background" style="background-color:#fff562"><?php _e( 'Update the above headline throughout election night. Set it to link to your primary election results story. Delete these yellow paragraphs before publishing.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:columns {"className":"is-style-borders"} -->
+<div class="wp-block-columns is-style-borders"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showDate":false,"showImage":false,"showAuthor":false,"mediaPosition":"right","typeScale":2} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'More space for election day  / voting stories.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"postsToShow":1} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Use this column for election-day stories and to let readers know when polls close.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:html -->
+<?php _e( 'AP RESULTS EMBED GOES HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html -->
+
+<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showDate":false,"showImage":false,"showAuthor":false} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Use this to point to your election-results pages. It\'s ok if they\'re not receiving data yet. It will be helpful for SEO if you link early in the day.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:paragraph {"align":"center","style":{"color":{"background":"#fff562"}}} -->
+<p class="has-text-align-center has-background" style="background-color:#fff562"><?php _e( 'Update the copy on the below newsletter signup to tell people they\'ll find out when results start coming in, and when races are declared, if they sign up.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"light-gray","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="wp-block-heading has-text-align-center"><?php _e( 'Sign up to receive updates.', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"100%"} -->
+<div class="wp-block-column" style="flex-basis:100%"><!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php _e( 'We\'ll be monitoring Pittsburgh\'s key races until the results are in. Sign up for our mailing list to get the latest updates sent directly to your inbox.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:newspack-newsletters/subscribe {"className":"is-style-modern"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/includes/templates/block-patterns/elections/home-pre-results-ap.php
+++ b/includes/templates/block-patterns/elections/home-pre-results-ap.php
@@ -4,6 +4,7 @@
  *
  * @package Govpack
  */
+
 ?>
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1} -->

--- a/includes/templates/block-patterns/elections/home-pre-results-ddhq.php
+++ b/includes/templates/block-patterns/elections/home-pre-results-ddhq.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Homepage Pre-Results Module — DDHQ.
+ *
+ * @package Govpack
+ */
+?>
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1} -->
+<h1 class="wp-block-heading has-text-align-center"><a href="#"><?php _e( 'Demonyms Head to the Polls!', 'newspack-plugin' ); ?></a></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","style":{"color":{"background":"#fff562"}}} -->
+<p class="has-text-align-center has-background" style="background-color:#fff562"><?php _e( 'Update the above headline throughout election night. Set it to link to your primary election results story. Delete these yellow paragraphs before publishing.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:columns {"className":"is-style-borders"} -->
+<div class="wp-block-columns is-style-borders"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showDate":false,"showImage":false,"showAuthor":false,"mediaPosition":"right","typeScale":2} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'More space for election day  / voting stories.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"postsToShow":1} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Use this column for election-day stories and to let readers know when polls close.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:html -->
+<?php _e( 'DDHQ RESULTS EMBED GOES HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html -->
+
+<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showDate":false,"showImage":false,"showAuthor":false} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Use this to point to your election-results pages. It\'s ok if they\'re not receiving data yet. It will be helpful for SEO if you link early in the day.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:html -->
+<?php _e( 'DDHQ JS SNIPPET GOES HERE! (Should be provided to you by DDHQ)', 'newspack-plugin' ); ?>
+<!-- /wp:html -->
+
+<!-- wp:paragraph {"align":"center","style":{"color":{"background":"#fff562"}}} -->
+<p class="has-text-align-center has-background" style="background-color:#fff562"><?php _e( 'Update the copy on the below newsletter signup to tell people they\'ll find out when results start coming in, and when races are declared, if they sign up.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"light-gray","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="wp-block-heading has-text-align-center"><?php _e( 'Sign up to receive updates.', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"100%"} -->
+<div class="wp-block-column" style="flex-basis:100%"><!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php _e( 'We\'ll be monitoring Pittsburgh\'s key races until the results are in. Sign up for our mailing list to get the latest updates sent directly to your inbox.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:newspack-newsletters/subscribe {"className":"is-style-modern"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/includes/templates/block-patterns/elections/home-pre-results-ddhq.php
+++ b/includes/templates/block-patterns/elections/home-pre-results-ddhq.php
@@ -2,7 +2,7 @@
 /**
  * Homepage Pre-Results Module — DDHQ.
  *
- * @package Govpack
+ * @package Newspack
  */
 
 ?>

--- a/includes/templates/block-patterns/elections/home-pre-results-ddhq.php
+++ b/includes/templates/block-patterns/elections/home-pre-results-ddhq.php
@@ -4,6 +4,7 @@
  *
  * @package Govpack
  */
+
 ?>
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1} -->

--- a/includes/templates/block-patterns/elections/home-results-ap.php
+++ b/includes/templates/block-patterns/elections/home-results-ap.php
@@ -2,7 +2,7 @@
 /**
  * Homepage Results Module — AP.
  *
- * @package Govpack
+ * @package Newspack
  */
 
 ?>

--- a/includes/templates/block-patterns/elections/home-results-ap.php
+++ b/includes/templates/block-patterns/elections/home-results-ap.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Homepage Results Module — AP.
+ *
+ * @package Govpack
+ */
+?>
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1} -->
+<h1 class="wp-block-heading has-text-align-center"><a href="#"><?php _e( 'Election Coverage Live Updated Heading', 'newspack-plugin' ); ?></a></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","style":{"color":{"background":"#fff562"}}} -->
+<p class="has-text-align-center has-background" style="background-color:#fff562"><?php _e( 'Update the above headline throughout election night. Set it to link to your primary election results story. Delete these yellow paragraphs before publishing.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:columns {"className":"is-style-borders"} -->
+<div class="wp-block-columns is-style-borders"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showDate":false,"showImage":false,"showAuthor":false,"mediaPosition":"right","typeScale":2} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Modify the above Posts block to contain election related stories (can use categories or tags for this).', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:heading -->
+<h2 class="wp-block-heading"><?php _e( 'Decision 2024', 'newspack-plugin' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'AP EMBED CODE GOES HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Results are coming in for the 2024 elections! <a href="#">See all the results that matter to Illinoisians!</a>', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Use this column for embedded live results of the most salient race for your audience.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:html -->
+<?php _e( 'AP EMBED CODE GOES HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Use this column for embedded live results of a secondary key race for your audience.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:paragraph {"align":"center","style":{"color":{"background":"#fff562"}}} -->
+<p class="has-text-align-center has-background" style="background-color:#fff562"><?php _e( 'Update the copy on the below newsletter signup to highlight politics / election coverage, and tell people they\'ll find out when races are declared if they sign up.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"light-gray","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="wp-block-heading has-text-align-center"><?php _e( 'Sign up to receive updates.', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"100%"} -->
+<div class="wp-block-column" style="flex-basis:100%"><!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php _e( 'We\'ll be monitoring Pittsburgh\'s key races until the results are in. Sign up for our mailing list to get the latest updates sent directly to your inbox.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:newspack-newsletters/subscribe {"className":"is-style-modern"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/includes/templates/block-patterns/elections/home-results-ap.php
+++ b/includes/templates/block-patterns/elections/home-results-ap.php
@@ -4,6 +4,7 @@
  *
  * @package Govpack
  */
+
 ?>
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1} -->

--- a/includes/templates/block-patterns/elections/home-results-ddhq.php
+++ b/includes/templates/block-patterns/elections/home-results-ddhq.php
@@ -2,7 +2,7 @@
 /**
  * Homepage Results Module — DDHQ.
  *
- * @package Govpack
+ * @package Newspack
  */
 
 ?>

--- a/includes/templates/block-patterns/elections/home-results-ddhq.php
+++ b/includes/templates/block-patterns/elections/home-results-ddhq.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Homepage Results Module — DDHQ.
+ *
+ * @package Govpack
+ */
+?>
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1} -->
+<h1 class="wp-block-heading has-text-align-center"><a href="#"><?php _e( 'Election Coverage Live Updated Heading', 'newspack-plugin' ); ?></a></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","style":{"color":{"background":"#fff562"}}} -->
+<p class="has-text-align-center has-background" style="background-color:#fff562"><?php _e( 'Update the above headline throughout election night. Set it to link to your primary election results story. Delete these yellow paragraphs before publishing.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:columns {"className":"is-style-borders"} -->
+<div class="wp-block-columns is-style-borders"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:newspack-blocks/homepage-articles {"className":"is-style-borders","showExcerpt":false,"showDate":false,"showImage":false,"showAuthor":false,"mediaPosition":"right","typeScale":2} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Modify the above Posts block to contain election related stories (can use categories or tags for this).', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:heading -->
+<h2 class="wp-block-heading"><?php _e( 'Decision 2024', 'newspack-plugin' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'DDHQ EMBED CODE GOES HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Results are coming in for the 2024 elections! <a href="#">See all the results that matter to Illinoisians!', 'newspsack-elections' ); ?></a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Use this column for embedded live results of the most salient race for your audience.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:html -->
+<?php _e( 'DDHQ EMBED CODE GOES HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Use this column for embedded live results of a secondary key race for your audience.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:paragraph {"align":"center","style":{"color":{"background":"#fff562"}}} -->
+<p class="has-text-align-center has-background" style="background-color:#fff562"><?php _e( 'Update the copy on the below newsletter signup to highlight politics / election coverage, and tell people they\'ll find out when races are declared if they sign up.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:html -->
+<?php _e( 'DDHQ JS SNIPPET GOES HERE! (Should be provided to you by DDHQ)', 'newspack-plugin' ); ?>
+<!-- /wp:html -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"light-gray","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="wp-block-heading has-text-align-center"><?php _e( 'Sign up to receive updates.', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"100%"} -->
+<div class="wp-block-column" style="flex-basis:100%"><!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><?php _e( 'We\'ll be monitoring Pittsburgh\'s key races until the results are in. Sign up for our mailing list to get the latest updates sent directly to your inbox.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:newspack-newsletters/subscribe {"className":"is-style-modern"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/includes/templates/block-patterns/elections/home-results-ddhq.php
+++ b/includes/templates/block-patterns/elections/home-results-ddhq.php
@@ -4,6 +4,7 @@
  *
  * @package Govpack
  */
+
 ?>
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1} -->

--- a/includes/templates/block-patterns/elections/live-results-post-ap.php
+++ b/includes/templates/block-patterns/elections/live-results-post-ap.php
@@ -4,6 +4,7 @@
  *
  * @package Govpack
  */
+
 ?>
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:paragraph {"className":"np-template-helper","style":{"color":{"background":"#fff562"}}} -->

--- a/includes/templates/block-patterns/elections/live-results-post-ap.php
+++ b/includes/templates/block-patterns/elections/live-results-post-ap.php
@@ -2,7 +2,7 @@
 /**
  * Live Election Results Post — AP.
  *
- * @package Govpack
+ * @package Newspack
  */
 
 ?>

--- a/includes/templates/block-patterns/elections/live-results-post-ap.php
+++ b/includes/templates/block-patterns/elections/live-results-post-ap.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Live Election Results Post — AP.
+ *
+ * @package Govpack
+ */
+?>
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph {"className":"np-template-helper","style":{"color":{"background":"#fff562"}}} -->
+<p class="np-template-helper has-background" style="background-color:#fff562"><?php _e( 'Welcome to Newspack\'s Election Results template. This article pattern is designed to work with AP results embeds. If you\'re not sure how to access those, contact AP. We\'ve included guidance throughout the template to help you build an election results page that highlights your unique value to your audience and drives engagement. <strong>Make sure to delete these guide paragraphs with yellow backgrounds before publishing</strong>.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Replace this text with a tight intro explaining that this page contains live election results that will be updated automatically throughout the race.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading -->
+<h2 class="wp-block-heading"><?php _e( 'Key local races', 'newspack-plugin' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM AP HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'For the above embed block, we recommend embedding results that are specific to your audience and community — this might be a tight local race, a key ballot measure, or a collection of races of specific demographic interest. Include as many or as few as appropriate. Focus on the races where your proximity to your readers gives you a comparative advantage!', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"backgroundColor":"light-gray","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:paragraph -->
+<p><?php _e( 'Subscribe to our newsletter and we\'ll tell you the minute results start coming in and when a winner is declared.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:newspack-newsletters/subscribe {"className":"is-style-modern"} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Don\'t forget to modify the copy for the above newsletter subscription block to fit your editorial strategy and planning.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading"><?php _e( 'More regional races', 'newspack-plugin' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'For the following results blocks, we recommend repeating a simple visualization for secondary races that may be relevant for your audience, such as local house races in your area.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 1', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM AP HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 2', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM AP HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 3', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM AP HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:separator {"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="wp-block-heading has-text-align-center"><?php _e( 'Support our coverage of key local issues', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:newspack-blocks/donate {"className":"is-style-modern"} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'If your site offers a paid membership/subscription model, swap these Donation Blocks out for registration/subscription blocks.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator {"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+<!-- /wp:separator --></div>
+<!-- /wp:group -->
+
+<!-- wp:newspack-blocks/homepage-articles {"showDate":false,"showAuthor":false,"postLayout":"grid","typeScale":2,"sectionHeader":"FULL ELECTION COVERAGE"} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Only keep the above Homepage Posts Block if your site does not use Jetpack\'s Related Posts. If you use Related Posts, delete the above block. If you don\'t have a sidebar on this page with links to other coverage, consider moving this block higher up.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator {"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 4', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM AP HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 5', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM AP HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 6', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM AP HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/includes/templates/block-patterns/elections/live-results-post-ddhq.php
+++ b/includes/templates/block-patterns/elections/live-results-post-ddhq.php
@@ -2,7 +2,7 @@
 /**
  * Live Election Results Post — DDHQ.
  *
- * @package Govpack
+ * @package Newspack
  */
 
 ?>

--- a/includes/templates/block-patterns/elections/live-results-post-ddhq.php
+++ b/includes/templates/block-patterns/elections/live-results-post-ddhq.php
@@ -4,6 +4,7 @@
  *
  * @package Govpack
  */
+
 ?>
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:paragraph {"className":"np-template-helper","style":{"color":{"background":"#fff562"}}} -->

--- a/includes/templates/block-patterns/elections/live-results-post-ddhq.php
+++ b/includes/templates/block-patterns/elections/live-results-post-ddhq.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Live Election Results Post — DDHQ.
+ *
+ * @package Govpack
+ */
+?>
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph {"className":"np-template-helper","style":{"color":{"background":"#fff562"}}} -->
+<p class="np-template-helper has-background" style="background-color:#fff562"><?php _e( 'Welcome to Newspack\'s Election Results template. This article pattern is designed to work with DDHQ results embeds. If you\'re not sure how to access those, contact DDHQ. We\'ve included guidance throughout the template to help you build an election results page that highlights your unique value to your audience and drives engagement. <strong>Make sure to delete these guide paragraphs with yellow backgrounds before publishing.</strong>', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Replace this text with a tight intro explaining that this page contains live election results that will be updated automatically throughout the race.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading -->
+<h2 class="wp-block-heading"><?php _e( 'Key local races', 'newspack-plugin' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM DDHQ HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'For the above embed block, we recommend embedding results that are specific to your audience and community — this might be a tight local race, a key ballot measure, or a collection of races of specific demographic interest. Include as many or as few as appropriate. Focus on the races where your proximity to your readers gives you a comparative advantage!', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"backgroundColor":"light-gray","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:paragraph -->
+<p><?php _e( 'Subscribe to our newsletter and we\'ll tell you the minute results start coming in and when a winner is declared.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:newspack-newsletters/subscribe {"className":"is-style-modern"} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Don\'t forget to modify the copy for the above newsletter subscription block to fit your editorial strategy and planning.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading"><?php _e( 'More regional races', 'newspack-plugin' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'For the following results blocks, we recommend repeating a simple visualization for secondary races that may be relevant for your audience, such as local house races in your area.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 1', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM DDHQ HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 2', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM DDHQ HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 3', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM DDHQ HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:separator {"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="wp-block-heading has-text-align-center">Support our coverage of key local issues</h3>
+<!-- /wp:heading -->
+
+<!-- wp:newspack-blocks/donate {"className":"is-style-modern"} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'If your site offers a paid membership/subscription model, swap these Donation Blocks out for registration/subscription blocks.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator {"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+<!-- /wp:separator --></div>
+<!-- /wp:group -->
+
+<!-- wp:newspack-blocks/homepage-articles {"showDate":false,"showAuthor":false,"postLayout":"grid","typeScale":2,"sectionHeader":"FULL ELECTION COVERAGE"} /-->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#fff562"}}} -->
+<p class="has-background" style="background-color:#fff562"><?php _e( 'Only keep the above Homepage Posts Block if your site does not use Jetpack\'s Related Posts. If you use Related Posts, delete the above block. If you don\'t have a sidebar on this page with links to other coverage, consider moving this block higher up.', 'newspack-plugin' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator {"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 4', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM DDHQ HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 5', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM DDHQ HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php _e( 'Race 6', 'newspack-plugin' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE EMBED CODE FROM DDHQ HERE!', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->
+
+<!-- wp:html -->
+<?php _e( 'PASTE DDHQ JS SNIPPET HERE! (Should be provided to you by DDHQ)', 'newspack-plugin' ); ?>
+<!-- /wp:html --></div>
+<!-- /wp:group -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the Newspack Elections patterns to the Newspack Plugin.

### How to test the changes in this Pull Request:

1. Apply this PR and install the [Newspack Elections](https://github.com/Automattic/newspack-elections) plugin.
2. Create a page.
3. Navigate to the Block Insert menu (`+` button in top left header) > Patterns, and confirm that there's a section for Newspack Elections, with six patterns.
4. Insert each of the six patterns one at a time, and confirm:
   * That the contents of the pattern matches the examples under WP Admin > Posts > Patterns on https://ras-acc.newspackstaging.com.
   * That all blocks render correctly -- specifically homepage post blocks, subscription blocks, and donate blocks.
5. Deactivate the Newspack Elections plugin.
6. Navigate to the Block Insert menu (`+` button in top left header) > Patterns and confirm that the Elections section is now gone.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->