### PR TITLE
fix: remove Newspack Elections requirement from patterns

### DIFF
--- a/includes/plugins/class-newspack-elections.php
+++ b/includes/plugins/class-newspack-elections.php
@@ -41,11 +41,6 @@ class Newspack_Elections {
 	 * Register block patterns.
 	 */
 	public static function register_block_patterns() {
-		// Bail if Newspack Elections is not active.
-		if ( ! class_exists( '\Govpack\Core\Govpack' ) ) {
-			return false;
-		}
-
 		\register_block_pattern_category( 'newspack-plugin', [ 'label' => __( 'Newspack Elections', 'newspack-plugin' ) ] );
 		$patterns = self::get_block_patterns();
 		foreach ( $patterns as $slug => $title ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the check for the Newspack Elections plugin before loading the Elections patterns.

### How to test the changes in this Pull Request:

1. Start on a test site without Newspack Elections installed.
2. Apply this PR.
3. Create a new page.
4. Navigate to the Block Inserter (the `+` button in top left corner of the editor) and open the Patterns tab.
5. Confirm you can see the Newspack Elections section in the patterns, and that it contains six block patterns.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->