### PR TITLE
feat: adds jsdoc block for better type inference on ColorPicker component

### DIFF
--- a/src/components/src/color-picker/index.js
+++ b/src/components/src/color-picker/index.js
@@ -31,7 +31,7 @@ const { InteractiveDiv } = utils;
  * @param {string}             [props.className] - Additional class name.
  * @return {JSX.Element} ColorPicker component.
  */
-const ColorPicker = ( { label, color = '#fff', onChange, className = undefined } ) => {
+const ColorPicker = ( { label, color = '#fff', onChange, className } ) => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const ref = useRef();
 	const colordColor = colord( color );

--- a/src/components/src/color-picker/index.js
+++ b/src/components/src/color-picker/index.js
@@ -21,6 +21,16 @@ import './style.scss';
 extend( [ a11yPlugin ] );
 const { InteractiveDiv } = utils;
 
+/**
+ * ColorPicker component.
+ *
+ * @param {Object}             props             - Component props.
+ * @param {JSX.Element|string} props.label       - Label for the color picker.
+ * @param {string}             [props.color]     - Default color.
+ * @param {Function}           props.onChange    - Function to call when the color changes.
+ * @param {string}             [props.className] - Additional class name.
+ * @return {JSX.Element} ColorPicker component.
+ */
 const ColorPicker = ( { label, color = '#fff', onChange, className = undefined } ) => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const ref = useRef();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Reverts earlier decision (within the scope of Information Architecture project) of default assignment of `className` prop to `undefined` in ColorPicker component and instead adds JS doc for better type inference for consuming components.

This is needed in order to be able to add a `className='my-class-name'` on ColorPicker components inside `.tsx` files

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?