### PR TITLE
feat: add wildcard matching for `activeTabPaths` in `<TabbedNavigation ... />`

### DIFF
--- a/src/components/src/tabbed-navigation/index.js
+++ b/src/components/src/tabbed-navigation/index.js
@@ -16,6 +16,23 @@ const TabbedNavigation = ( { items, className, disableUpcoming, children = null 
 	const displayedItems = items.filter( item => ! item.isHiddenInTabbedNavigation );
 	const { location } = useHistory();
 	const currentIndex = findIndex( displayedItems, [ 'path', location.pathname ] );
+
+	function isActive( item, match, pathname ) {
+		if ( item.path === pathname ) {
+			return true;
+		}
+		if ( Array.isArray( item?.activeTabPaths ) ) {
+			return item.activeTabPaths.some( path => {
+				if ( path.endsWith( '*' ) ) {
+					const basePath = path.slice( 0, -1 );
+					return pathname.startsWith( basePath );
+				}
+				return item.activeTabPaths.includes( pathname );
+			} );
+		}
+		return match;
+	}
+	
 	return (
 		<div className={ classnames( 'newspack-tabbed-navigation', className ) }>
 			<ul>
@@ -23,12 +40,7 @@ const TabbedNavigation = ( { items, className, disableUpcoming, children = null 
 					<li key={ index }>
 						<NavLink
 							to={ item.path }
-							isActive={ ( match, { pathname } ) => {
-								if ( item.activeTabPaths ) {
-									return item.activeTabPaths.includes( pathname );
-								}
-								return match;
-							} }
+							isActive={ ( match, { pathname } ) => isActive(item, match, pathname) }
 							exact
 							activeClassName={ 'selected' }
 							className={ classnames( {

--- a/src/wizards/engagement/index.js
+++ b/src/wizards/engagement/index.js
@@ -86,11 +86,7 @@ class EngagementWizard extends Component {
 				label: __( 'Reader Activation', 'newspack-plugin' ),
 				path: '/reader-activation',
 				exact: true,
-				activeTabPaths: [
-					'/reader-activation',
-					'/reader-activation/campaign',
-					'/reader-activation/complete',
-				],
+				activeTabPaths: ['/reader-activation/*'],
 			},
 			{
 				label: __( 'Newsletters', 'newspack-plugin' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Refactors `isActive` logic for `<NavLink />` inside `<TabbedNavigation ... />` component to allow wildcard matching.

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets i.e. `git checkout origin/feat/ia-tabbed-navigation`
2. Navigate to below routes and confirm Reader Activation is active (underlined in blue): 
   * _/wp-admin/admin.php?page=newspack-engagement-wizard#/reader-activation_
   * _/wp-admin/admin.php?page=newspack-engagement-wizard#/reader-activation/campaign_
   * _/wp-admin/admin.php?page=newspack-engagement-wizard#/reader-activation/complete_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
