### PR TITLE
feat: add prop to conditionally trigger initial fetch

### DIFF
--- a/src/components/src/wizard/index.js
+++ b/src/components/src/wizard/index.js
@@ -34,14 +34,15 @@ const { HashRouter, Redirect, Route, Switch } = Router;
 
 /**
  * @typedef  {Object}     WizardProps
- * @property {string}     headerText            The header text.
- * @property {string}     [subHeaderText]       The sub-header text, optional.
- * @property {string}     [apiSlug]             The API slug, optional.
- * @property {string}     [className]           CSS classes, optional.
- * @property {any[]}      sections              Array of sections.
- * @property {boolean}    [hasSimpleFooter]     Indicates if a simple footer is used, optional.
- * @property {() => void} [renderAboveSections] Function to render content above sections, optional.
- * @property {string[]}   [requiredPlugins]     Array of required plugin strings, optional.
+ * @property {string}     headerText                The header text.
+ * @property {string}     [subHeaderText]           The sub-header text, optional.
+ * @property {string}     [apiSlug]                 The API slug, optional.
+ * @property {string}     [className]               CSS classes, optional.
+ * @property {any[]}      sections                  Array of sections.
+ * @property {boolean}    [hasSimpleFooter]         Indicates if a simple footer is used, optional.
+ * @property {() => void} [renderAboveSections]     Function to render content above sections, optional.
+ * @property {string[]}   [requiredPlugins]         Array of required plugin strings, optional.
+ * @property {boolean}    [isInitialFetchTriggered] Indicates if the initial fetch should be triggered, optional.
  */
 
 /**
@@ -61,6 +62,7 @@ const Wizard = ( {
 	className,
 	renderAboveSections,
 	requiredPlugins = [],
+	isInitialFetchTriggered = true,
 } ) => {
 	const isLoading = useSelect( select =>
 		select( WIZARD_STORE_NAMESPACE ).isLoading()
@@ -72,7 +74,7 @@ const Wizard = ( {
 	// Trigger initial data fetch. Some sections might not use the wizard data,
 	// but for consistency, fetching is triggered regardless of the section.
 	useSelect( select =>
-		select( WIZARD_STORE_NAMESPACE ).getWizardAPIData( apiSlug )
+		isInitialFetchTriggered && select( WIZARD_STORE_NAMESPACE ).getWizardAPIData( apiSlug )
 	);
 
 	let displayedSections = sections.filter( section => ! section.isHidden );

--- a/src/components/src/wizard/store/index.js
+++ b/src/components/src/wizard/store/index.js
@@ -16,7 +16,7 @@ import { createAction } from './utils.js';
 export const WIZARD_STORE_NAMESPACE = 'newspack/wizards';
 
 const DEFAULT_STATE = {
-	isLoading: true,
+	isLoading: false,
 	isQuietLoading: false,
 	apiData: {},
 	error: null,

--- a/src/wizards/newspack/views/settings/index.tsx
+++ b/src/wizards/newspack/views/settings/index.tsx
@@ -31,6 +31,7 @@ function Settings() {
 				className="newspack-admin__tabs"
 				headerText={ __( 'Newspack / Settings', 'newspack' ) }
 				sections={ sections }
+				isInitialFetchTriggered={ false }
 			/>
 		</Fragment>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a prop to the `<Wizard />` component to prevent the state resolver `*getWizardAPIData` from firing. This avoids prematurely setting loading state variables (`isLoading` and `isQuietLoading`) to `false`.

_Why is this needed?_

Setting `isQuietLoading` to `false` this way overrides any loading status triggered by child components via Redux, which may cause issues with the expected loading state.

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets `git checkout origin/feat/ia-wizard-initial-fetch && npm run build`
2. Navigate to _/wp-admin/admin.php?page=newspack-settings#/_
3. Confirm the page loads with loading screen:
![Screenshot 2024-10-08 at 22 13 51](https://github.com/user-attachments/assets/1b4376ec-412e-480a-b6b3-8a4ca64dc42c)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?