### PR TITLE
fix: cancelled subscriptions sync

### DIFF
--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class Metadata {
 
-	const DATE_FORMAT   = 'Y-m-d';
+	const DATE_FORMAT   = 'Y-m-d H:i:s';
 	const PREFIX        = 'NP_';
 	const PREFIX_OPTION = '_newspack_metadata_prefix';
 

--- a/tests/unit-tests/reader-activation-sync-woocommerce.php
+++ b/tests/unit-tests/reader-activation-sync-woocommerce.php
@@ -6,6 +6,7 @@
  */
 
 use Newspack\Reader_Activation\Sync;
+use Newspack\Reader_Activation\Sync\Metadata;
 
 require_once __DIR__ . '/../mocks/wc-mocks.php';
 
@@ -95,7 +96,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 
 		$payment_page_url = 'https://example.com/donate';
 		$contact_data = Sync\WooCommerce::get_contact_from_order( $order, $payment_page_url );
-		$today = gmdate( 'Y-m-d' );
+		$today = gmdate( Metadata::DATE_FORMAT );
 		$this->assertEquals(
 			[
 				'email'    => self::USER_DATA['user_email'],
@@ -161,11 +162,12 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 			]
 		);
 
+		$previous_order      = self::$current_order;
 		self::$current_order = $order;
 
 		$contact_data = Sync\WooCommerce::get_contact_from_order( $order );
-		$this->assertEmpty( $contact_data['metadata']['last_payment_date'] );
-		$this->assertEmpty( $contact_data['metadata']['last_payment_amount'] );
+		$this->assertEquals( $contact_data['metadata']['last_payment_date'], $previous_order->get_date_paid()->date( Metadata::DATE_FORMAT ) );
+		$this->assertEquals( $contact_data['metadata']['last_payment_amount'], self::$current_order->get_total() );
 	}
 
 	/**
@@ -183,7 +185,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 
 		$contact_data = Sync\WooCommerce::get_contact_from_customer( self::$user_id );
 		$this->assertEquals( $order_data['total'], $contact_data['metadata']['last_payment_amount'] );
-		$this->assertEquals( gmdate( 'Y-m-d' ), $contact_data['metadata']['last_payment_date'] );
+		$this->assertEquals( gmdate( Metadata::DATE_FORMAT ), $contact_data['metadata']['last_payment_date'] );
 	}
 
 	/**
@@ -194,7 +196,7 @@ class Newspack_Test_RAS_Sync_WooCommerce extends WP_UnitTestCase {
 			'customer_id' => self::$user_id,
 			'status'      => 'completed',
 			'total'       => 70,
-			'date_paid'   => gmdate( 'Y-m-d', strtotime( '-1 week' ) ),
+			'date_paid'   => gmdate( Metadata::DATE_FORMAT, strtotime( '-1 week' ) ),
 		];
 		$order = \wc_create_order( $completed_order_data );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes how Cancelled subscriptions are synced to the ESP.

It does tow things.

First, when we fetch the most recent cancelled subscription, we only consider subscriptions that have a at least one successful payment. So subscriptions that were never active are disregarded.

Second, it does not check if the current order is active to add the "Last payment" info. Even for cancelled subscriptions, we want to add this info.

For reference, the check was added in [this PR](https://github.com/Automattic/newspack-plugin/pull/2886). At that time, `get_last_order` could return a failed order. We no longer have this issue and this PR makes sure we get subscriptions with at least one successful order.

### How to test the changes in this Pull Request:

1. Make a one time donation
2.  Confirm sync works fine with the one time donation info
3. Make a recurring donation using this test card: 4000000000000341
4. Confirm that the synced contact still have the one time donation info (on `trunk`, you will see data from the failing subscription)
5. Now make a susccesful subscription and confirm the data is synced
6. Cancel the subscription and confirm the "ex-donor" info includes the "last payment" data
7.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->