### PR TITLE
fix(oauth): start php session if no session available

### DIFF
--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -123,7 +123,7 @@ class Google_Login {
 
 		if ( ! wp_verify_nonce( sanitize_text_field( $_GET[ self::AUTH_CALLBACK ] ), self::AUTH_CALLBACK ) ) {
 			/* translators: %s is a unique user id */
-			sprintf( __( 'Nonce verification failed for id: %s', 'newspack-plugin' ), OAuth::get_unique_id() );
+			self::handle_error( sprintf( __( 'Nonce verification failed for id: %s', 'newspack-plugin' ), OAuth::get_unique_id() ) );
 			wp_die( esc_html__( 'Invalid nonce.', 'newspack-plugin' ) );
 			return;
 		}

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -122,7 +122,8 @@ class Google_Login {
 		}
 
 		if ( ! wp_verify_nonce( sanitize_text_field( $_GET[ self::AUTH_CALLBACK ] ), self::AUTH_CALLBACK ) ) {
-			self::handle_error( __( 'Nonce verification failed.', 'newspack-plugin' ) );
+			/* translators: %s is a unique user id */
+			sprintf( __( 'Nonce verification failed for id: %s', 'newspack-plugin' ), OAuth::get_unique_id() );
 			wp_die( esc_html__( 'Invalid nonce.', 'newspack-plugin' ) );
 			return;
 		}

--- a/includes/oauth/class-oauth.php
+++ b/includes/oauth/class-oauth.php
@@ -37,7 +37,9 @@ class OAuth {
 			$id = session_id(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.session_session_id
 		}
 		if ( ! $id ) {
-			session_start(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.session_session_start
+			if ( session_status() !== PHP_SESSION_ACTIVE ) { // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.session_session_status
+				session_start(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.session_session_start
+			}
 			$id = session_id(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.session_session_id
 		}
 		return $id;

--- a/includes/oauth/class-oauth.php
+++ b/includes/oauth/class-oauth.php
@@ -36,6 +36,10 @@ class OAuth {
 		if ( ! $id ) {
 			$id = session_id(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.session_session_id
 		}
+		if ( ! $id ) {
+			session_start(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.session_session_start
+			$id = session_id(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.session_session_id
+		}
 		return $id;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In WordPress, the PHP session might not be always started. This change ensures that it always will be.

### How to test the changes in this Pull Request:

I was not able to reproduce the conditions under which a session would not be started. A smoke test should be enough.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->