### PR TITLE
fix(auth): simplify pending checkout

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -35,14 +35,7 @@ final class Magic_Link {
 	const OTP_AUTH_ACTION  = 'np_otp_auth';
 	const OTP_HASH_COOKIE  = 'np_otp_hash';
 	const ACCEPTED_PARAMS  = [
-		'newspack_modal_checkout',
-		'type',
-		'layout',
-		'frequency',
-		'amount',
-		'other',
-		'product_id',
-		'variation_id',
+		'checkout',
 	];
 
 	/**

--- a/includes/data-events/class-woo-user-registration.php
+++ b/includes/data-events/class-woo-user-registration.php
@@ -47,7 +47,7 @@ final class Woo_User_Registration {
 	public static function checkout_process() {
 
 		/**
-		 * On Newspack\Donations::process_donation_form(), we add these values to the cart.
+		 * On Newspack\Donations::process_donation_request(), we add these values to the cart.
 		 *
 		 * Later, we add them to the order (Newspack\Donations::checkout_create_order_line_item()) and use it to send the metadata to Newspack on donation events.
 		 *

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -770,7 +770,7 @@ class Memberships {
 			window.newspackRAS = window.newspackRAS || [];
 			window.newspackRAS.push( function( ras ) {
 				ras.on( 'reader', function( ev ) {
-					if ( ev.detail.authenticated && ! window?.newspackReaderActivation?.isPendingCheckout() ) {
+					if ( ev.detail.authenticated && ! window?.newspackReaderActivation?.getPendingCheckout() ) {
 						if ( ras.overlays.get().length ) {
 							ras.on( 'overlay', function( ev ) {
 								if ( ! ev.detail.overlays.length ) {

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -4,7 +4,7 @@
  * Internal dependencies.
  */
 import { domReady, formatTime } from '../utils';
-import { getCheckoutRedirectUrl } from '../reader-activation/checkout';
+import { getPendingCheckout } from '../reader-activation/checkout';
 import { openNewslettersSignupModal } from '../reader-activation-newsletters/newsletters-modal';
 
 import './google-oauth';
@@ -219,11 +219,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 						body.set( 'reader-activation-auth-form', 1 );
 						body.set( 'npe', emailInput.value );
 						body.set( 'action', 'link' );
-						if ( readerActivation.isPendingCheckout() ) {
-							const redirectUrl = getCheckoutRedirectUrl();
-							if ( redirectUrl ) {
-								body.set( 'redirect_url', redirectUrl );
-							}
+						const pendingCheckout = getPendingCheckout();
+						if ( pendingCheckout ) {
+							const url = new URL( window.location.href );
+							url.searchParams.set( 'checkout', 1 );
+							body.set( 'redirect_url', url.toString() );
 						}
 						fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 							method: 'POST',
@@ -372,11 +372,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 					return form.endLoginFlow( newspack_reader_activation_labels.invalid_email, 400 );
 				}
-				if ( readerActivation.isPendingCheckout() ) {
-					const redirectUrl = getCheckoutRedirectUrl();
-					if ( redirectUrl ) {
-						body.set( 'redirect_url', redirectUrl );
-					}
+				const pendingCheckout = getPendingCheckout();
+				if ( pendingCheckout ) {
+					const url = new URL( window.location.href );
+					url.searchParams.set( 'checkout', 1 );
+					body.set( 'redirect_url', url.toString() );
 				}
 				if ( 'otp' === action ) {
 					readerActivation

--- a/src/reader-activation/checkout.js
+++ b/src/reader-activation/checkout.js
@@ -9,85 +9,20 @@ import Store from './store.js';
 export const store = Store();
 
 /**
- * Get the current checkout.
+ * Set the pending checkout URL.
  *
- * @return {Object} Checkout data.
+ * @param {string|false} url
  */
-export function getCheckout() {
-	return store.get( 'checkout' ) || {};
-}
-
-/**
- * Set the current checkout data.
- *
- * @param {Object} data Checkout data. Optional.
- *                      If empty or not provided, the checkout data will be cleared.
- */
-export function setCheckoutData( data = {} ) {
-	store.set( 'checkout', data, false );
+export function setPendingCheckout( url = false ) {
+	store.set( 'pending_checkout', url, false );
 	emit( EVENTS.reader, getReader() );
 }
 
 /**
- * Get the reader checkout data.
+ * Get the pending checkout URL.
  *
- * @param {string} key Checkout data key. Optional.
- *
- * @return {any} Reader checkout data.
+ * @return {string|false} Pending checkout URL.
  */
-export function getCheckoutData( key ) {
-	const checkout = getCheckout();
-	if ( ! key ) {
-		return checkout;
-	}
-	return checkout?.[ key ];
-}
-
-/**
- * Whether checkout is pending.
- *
- * @return {boolean} Whether checkout is pending.
- */
-export function isPendingCheckout() {
-	const checkout = getCheckout();
-	if ( Object.keys( checkout ).length ) {
-		return true;
-	}
-	return false;
-}
-
-/**
- * Reset the reader checkout data.
- */
-export function resetCheckoutData() {
-	setCheckoutData();
-}
-
-/**
- * Get a checkout redirect URL.
- *
- * @return {string} A checkout redirect URL if checkout data is present.
- *                  Otherwise, an empty string
- */
-export function getCheckoutRedirectUrl() {
-	const checkoutType = getCheckoutData( 'type' );
-	if ( ! checkoutType ) {
-		return '';
-	}
-	const redirectUrl = new URL( window.location.href );
-	redirectUrl.searchParams.set( 'newspack_modal_checkout', 1 );
-	redirectUrl.searchParams.set( 'type', checkoutType );
-	// Add checkout button params.
-	if ( checkoutType === 'checkout_button' ) {
-		redirectUrl.searchParams.set( 'product_id', getCheckoutData( 'product_id' ) ?? '' );
-		redirectUrl.searchParams.set( 'variation_id', getCheckoutData( 'variation_id' ) ?? '' );
-	}
-	// Add donate params.
-	if ( checkoutType === 'donate' ) {
-		redirectUrl.searchParams.set( 'layout', getCheckoutData( 'layout' ) ?? '' );
-		redirectUrl.searchParams.set( 'frequency', getCheckoutData( 'frequency' ?? '' ) );
-		redirectUrl.searchParams.set( 'amount', getCheckoutData( 'amount' ) ?? '' );
-		redirectUrl.searchParams.set( 'other', getCheckoutData( 'other' ) ?? '' );
-	}
-	return redirectUrl.href;
+export function getPendingCheckout() {
+	return store.get( 'pending_checkout' ) || false;
 }

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -3,7 +3,7 @@
 window.newspack_ras_config = window.newspack_ras_config || {};
 
 import Store from './store.js';
-import { isPendingCheckout, setCheckoutData, getCheckoutData, resetCheckoutData } from './checkout.js';
+import { getPendingCheckout, setPendingCheckout } from './checkout.js';
 import { EVENTS, on, off, emit } from './events.js';
 import { getCookie, setCookie, generateID } from './utils.js';
 import overlays from './overlays.js';
@@ -429,10 +429,8 @@ const readerActivation = {
 	authenticateOTP,
 	setAuthStrategy,
 	getAuthStrategy,
-	setCheckoutData,
-	getCheckoutData,
-	isPendingCheckout,
-	resetCheckoutData,
+	setPendingCheckout,
+	getPendingCheckout,
 	...( newspack_ras_config.is_ras_enabled && { openAuthModal } )
 };
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

https://github.com/Automattic/newspack-blocks/pull/1896 changes how the cart generation is handled for anonymous sessions. The cart is expected to be added to the session before authentication, allowing for this logic to be simplified.

The only stored value should now be the redirect URL so the checkout state can be recovered on `?checkout=1`.

### How to test the changes in this Pull Request:

Read more at https://github.com/Automattic/newspack-blocks/pull/1896

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->