### PR TITLE
feat(site-kit): add logging when site kit disconnects

### DIFF
--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -83,6 +83,9 @@ class Logger {
 	 * @param string $code    The log code (i.e. newspack_google_login).
 	 * @param string $message The message to log.
 	 * @param array  $data    The data to log.
+	 *      Optional. Additional parameters.
+	 *      @type string $user_email The current users email address.
+	 *      @type file   $file       The name of the file to write the local log to.
 	 * @param string $type    The type of log. Defaults to 'error'.
 	 */
 	public static function newspack_log( $code, $message, $data, $type = 'error' ) {

--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -80,15 +80,16 @@ class Logger {
 	/**
 	 * A logger for newspack manager logging.
 	 *
-	 * @param string $code    The log code (i.e. newspack_google_login).
-	 * @param string $message The message to log.
-	 * @param array  $data    The data to log.
+	 * @param string $code      The log code (i.e. newspack_google_login).
+	 * @param string $message   The message to log.
+	 * @param array  $data      The data to log.
 	 *      Optional. Additional parameters.
 	 *      @type string $user_email The current users email address.
 	 *      @type file   $file       The name of the file to write the local log to.
-	 * @param string $type    The type of log. Defaults to 'error'.
+	 * @param string $type      The type of log. Defaults to 'error'.
+	 * @param string $log_level The Log level.
 	 */
-	public static function newspack_log( $code, $message, $data, $type = 'error' ) {
+	public static function newspack_log( $code, $message, $data, $type = 'error', $log_level = 2 ) {
 		$email = '';
 		if ( isset( $data['user_email'] ) ) {
 			$email = $data['user_email'];
@@ -108,6 +109,7 @@ class Logger {
 				'data'       => $data,
 				'user_email' => $email,
 				'file'       => $file,
+				'log_level'  => $log_level,
 			]
 		);
 	}

--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -76,4 +76,36 @@ class Logger {
 	public static function error( $payload, $header = 'NEWSPACK' ) {
 		return self::log( $payload, $header, 'error' );
 	}
+
+	/**
+	 * A logger for newspack manager logging.
+	 *
+	 * @param string $code    The log code (i.e. newspack_google_login).
+	 * @param string $message The message to log.
+	 * @param array  $data    The data to log.
+	 * @param string $type    The type of log. Defaults to 'error'.
+	 */
+	public static function newspack_log( $code, $message, $data, $type = 'error' ) {
+		$email = '';
+		if ( isset( $data['user_email'] ) ) {
+			$email = $data['user_email'];
+			unset( $data['user_email'] );
+		}
+		$file = $code;
+		if ( isset( $data['file'] ) ) {
+			$file = $data['file'];
+			unset( $data['file'] );
+		}
+		do_action(
+			'newspack_log',
+			$code,
+			$message,
+			[
+				'type'       => $type,
+				'data'       => $data,
+				'user_email' => $email,
+				'file'       => $file,
+			]
+		);
+	}
 }

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -155,6 +155,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-jetpack.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-gravityforms.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit-logger.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-mailchimp-for-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';

--- a/includes/plugins/google-site-kit/class-googlesitekit-logger.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit-logger.php
@@ -107,7 +107,7 @@ class GoogleSiteKit_Logger {
 	 */
 	public static function handle_cron_event() {
 		if ( ! get_option( self::get_sitekit_ga4_has_connected_admin_option_name(), false ) ) {
-			self::log( self::LOG_CODE_DISCONNECTED, 'No active Google Site Kit connections found', false );
+			self::log( self::LOG_CODE_DISCONNECTED, 'No active Google Site Kit connections found', false, 3 );
 		}
 	}
 
@@ -124,8 +124,9 @@ class GoogleSiteKit_Logger {
 	 * @param string $code      The code for the log.
 	 * @param string $message   The message to log. Optional.
 	 * @param bool   $backtrace Whether to include a backtrace.
+	 * @param int    $log_level The log level.
 	 */
-	public static function log( $code, $message, $backtrace = true ) {
+	private static function log( $code, $message, $backtrace = true, $log_level = 2 ) {
 		$data = [
 			'file'       => $code,
 			'user_email' => wp_get_current_user()->user_email,
@@ -134,7 +135,7 @@ class GoogleSiteKit_Logger {
 			$e                 = new \Exception();
 			$data['backtrace'] = $e->getTraceAsString();
 		}
-		Logger::newspack_log( $code, $message, $data );
+		Logger::newspack_log( $code, $message, $data, 'error', $log_level );
 	}
 }
 GoogleSiteKit_Logger::init();

--- a/includes/plugins/google-site-kit/class-googlesitekit-logger.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit-logger.php
@@ -30,10 +30,12 @@ class GoogleSiteKit_Logger {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_action( 'init', [ __CLASS__, 'cron_init' ] );
-		add_action( 'delete_option_' . self::get_sitekit_ga4_has_connected_admin_option_name(), [ __CLASS__, 'log_disconnected_admins' ] );
-		add_filter( 'update_user_metadata', [ __CLASS__, 'maybe_log_disconnected_reason' ], 10, 5 );
-		add_action( self::CRON_HOOK, [ __CLASS__, 'maybe_log_disconnected_admins' ] );
+		if ( GoogleSiteKit::is_active() ) {
+			add_action( 'admin_init', [ __CLASS__, 'cron_init' ] );
+			add_action( 'delete_option_' . self::get_sitekit_ga4_has_connected_admin_option_name(), [ __CLASS__, 'log_disconnected_admins' ] );
+			add_filter( 'update_user_metadata', [ __CLASS__, 'maybe_log_disconnected_reason' ], 10, 5 );
+			add_action( self::CRON_HOOK, [ __CLASS__, 'maybe_log_disconnected_admins' ] );
+		}
 	}
 
 	/**

--- a/includes/plugins/google-site-kit/class-googlesitekit-logger.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit-logger.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Google Site Kit Logger class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Google\Site_Kit\Core\Authentication\Has_Connected_Admins;
+use Google\Site_Kit\Core\Authentication\Disconnected_Reason;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class GoogleSiteKit_Logger {
+	/**
+	 * The hook name for site kit disconnection logger cron job.
+	 */
+	const CRON_HOOK = 'newspack_googlesitekit_disconnection_logger';
+
+	/**
+	 * The log code for disconnections.
+	 */
+	const LOG_CODE_DISCONNECTED = 'newspack_googlesitekit_disconnected';
+
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'cron_init' ] );
+		add_action( 'delete_option_' . self::get_sitekit_ga4_has_connected_admin_option_name(), [ __CLASS__, 'log_disconnected_admins' ] );
+		add_filter( 'update_user_metadata', [ __CLASS__, 'maybe_log_disconnected_reason' ], 10, 5 );
+		add_action( self::CRON_HOOK, [ __CLASS__, 'maybe_log_disconnected_admins' ] );
+	}
+
+	/**
+	 * Schedule cron job to check for site kit connection. If the connection is lost we log it.
+	 */
+	public static function cron_init() {
+		register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );
+
+		if ( defined( 'NEWSPACK_CRON_DISABLE' ) && is_array( NEWSPACK_CRON_DISABLE ) && in_array( self::CRON_HOOK, NEWSPACK_CRON_DISABLE, true ) ) {
+			self::cron_deactivate();
+		} elseif ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Deactivate the cron job.
+	 */
+	public static function cron_deactivate() {
+		wp_clear_scheduled_hook( self::CRON_HOOK );
+	}
+
+
+	/**
+	 * Get the name of the option under which Site Kit's GA4 has connected admin flag is stored.
+	 */
+	private static function get_sitekit_ga4_has_connected_admin_option_name() {
+		if ( class_exists( 'Google\Site_Kit\Core\Authentication\Has_Connected_Admins' ) ) {
+			return Has_Connected_Admins::OPTION;
+		}
+		return 'googlesitekit_has_connected_admins';
+	}
+
+	/**
+	 * Get the name of the option under which Site Kit's disconnected reason is stored.
+	 */
+	private static function get_sitekit_ga4_disconnected_reason_option_name() {
+		if ( class_exists( 'Google\Site_Kit\Core\Authentication\Disconnected_Reason' ) ) {
+			return Disconnected_Reason::OPTION;
+		}
+		return 'googlesitekit_disconnected_reason';
+	}
+
+	/**
+	 * Logs disconnect reason when user meta update is triggered.
+	 *
+	 * @param bool   $check      Whether to update metadata.
+	 * @param int    $object_id  Object ID.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 * @param mixed  $prev_value Previous meta value.
+	 */
+	public static function maybe_log_disconnected_reason( $check, $object_id, $meta_key, $meta_value, $prev_value ) {
+		if (
+			// The meta key will have the database prefixed so we need to use str_contains.
+			str_contains( $meta_key, self::get_sitekit_ga4_disconnected_reason_option_name() ) &&
+			$meta_value !== $prev_value
+		) {
+			self::log(
+				self::LOG_CODE_DISCONNECTED,
+				'Google Site Kit has been disconnected with reason ' . $meta_value
+			);
+		}
+		return $check;
+	}
+
+	/**
+	 * Logs when cron event runs and all admins are disconnected.
+	 */
+	public static function maybe_log_disconnected_admins() {
+		if ( ! get_option( self::get_sitekit_ga4_has_connected_admin_option_name(), false ) ) {
+			self::log( self::LOG_CODE_DISCONNECTED, 'Google Site Kit has been disconnected', false );
+		}
+	}
+
+	/**
+	 * Log when all admins are disconnected.
+	 */
+	public static function log_disconnected_admins() {
+		self::log( self::LOG_CODE_DISCONNECTED, 'Google Site Kit has been disconnected for all admins' );
+	}
+
+	/**
+	 * Main site kit logger.
+	 *
+	 * @param string $code      The code for the log.
+	 * @param string $message   The message to log. Optional.
+	 * @param bool   $backtrace Whether to include a backtrace.
+	 */
+	public static function log( $code, $message, $backtrace = true ) {
+		$data = [
+			'file'       => $code,
+			'user_email' => wp_get_current_user()->user_email,
+		];
+		if ( $backtrace ) {
+			$e                 = new \Exception();
+			$data['backtrace'] = $e->getTraceAsString();
+		}
+		Logger::newspack_log( $code, $message, $data );
+	}
+}
+GoogleSiteKit_Logger::init();

--- a/includes/plugins/google-site-kit/class-googlesitekit-logger.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit-logger.php
@@ -34,7 +34,7 @@ class GoogleSiteKit_Logger {
 			add_action( 'admin_init', [ __CLASS__, 'cron_init' ] );
 			add_action( 'delete_option_' . self::get_sitekit_ga4_has_connected_admin_option_name(), [ __CLASS__, 'log_disconnected_admins' ] );
 			add_filter( 'update_user_metadata', [ __CLASS__, 'maybe_log_disconnected_reason' ], 10, 5 );
-			add_action( self::CRON_HOOK, [ __CLASS__, 'maybe_log_disconnected_admins' ] );
+			add_action( self::CRON_HOOK, [ __CLASS__, 'handle_cron_event' ] );
 		}
 	}
 
@@ -105,9 +105,9 @@ class GoogleSiteKit_Logger {
 	/**
 	 * Logs when cron event runs and all admins are disconnected.
 	 */
-	public static function maybe_log_disconnected_admins() {
+	public static function handle_cron_event() {
 		if ( ! get_option( self::get_sitekit_ga4_has_connected_admin_option_name(), false ) ) {
-			self::log( self::LOG_CODE_DISCONNECTED, 'Google Site Kit has been disconnected', false );
+			self::log( self::LOG_CODE_DISCONNECTED, 'No active Google Site Kit connections found', false );
 		}
 	}
 

--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -27,7 +27,7 @@ class GoogleSiteKit {
 		add_action( 'wp_footer', [ __CLASS__, 'insert_ga4_analytics' ] );
 		add_filter( 'option_googlesitekit_analytics_settings', [ __CLASS__, 'filter_ga_settings' ] );
 		add_filter( 'googlesitekit_gtag_opt', [ __CLASS__, 'add_ga_custom_parameters' ] );
-		add_action( 'delete_option_' . Has_Connected_Admins::OPTION, [ __CLASS__, 'maybe_log_disconnect' ] );
+		add_action( 'delete_option_' . self::get_sitekit_ga4_has_connected_admin_option_name(), [ __CLASS__, 'log_disconnect' ] );
 	}
 
 	/**
@@ -96,6 +96,16 @@ class GoogleSiteKit {
 			return Settings::OPTION;
 		}
 		return false;
+	}
+
+	/**
+	 * Get the name of the option under which Site Kit's GA4 has connected admin flag is stored.
+	 */
+	private static function get_sitekit_ga4_has_connected_admin_option_name() {
+		if ( class_exists( 'Google\Site_Kit\Core\Authentication\Has_Connected_Admins' ) ) {
+			return Has_Connected_Admins::OPTION;
+		}
+		return 'googlesitekit_has_connected_admins';
 	}
 
 	/**
@@ -178,14 +188,15 @@ class GoogleSiteKit {
 	 *
 	 * @param string $option Option being deleted.
 	 */
-	public static function maybe_log_disconnect( $option ) {
+	public static function log_disconnect( $option ) {
+		$code    = 'newspack_googlesitekit_disconnect';
 		$message = 'Google Site Kit has been disconnected.';
 		// TODO: Determine what data needs to be logged.
 		$data = [
 			'user_email' => wp_get_current_user()->user_email,
-			'file'       => 'class-googlesitekit.php',
+			'file'       => $code,
 		];
-		Logger::newspack_log( 'newspack_googlesitekit_disconnect', $message, $data );
+		Logger::newspack_log( $code, $message, $data );
 	}
 }
 GoogleSiteKit::init();

--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -9,6 +9,7 @@ namespace Newspack;
 
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Modules\Analytics_4\Settings;
+use Google\Site_Kit\Core\Authentication\Disconnected_Reason;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -26,6 +27,7 @@ class GoogleSiteKit {
 		add_action( 'wp_footer', [ __CLASS__, 'insert_ga4_analytics' ] );
 		add_filter( 'option_googlesitekit_analytics_settings', [ __CLASS__, 'filter_ga_settings' ] );
 		add_filter( 'googlesitekit_gtag_opt', [ __CLASS__, 'add_ga_custom_parameters' ] );
+		add_action( 'updated_user_meta', [ __CLASS__, 'maybe_log_disconnect' ], 10, 5 );
 	}
 
 	/**
@@ -169,6 +171,22 @@ class GoogleSiteKit {
 		}
 		$custom_params = \Newspack\Data_Events\Connectors\GA4::get_custom_parameters();
 		return array_merge( $custom_params, $gtag_opt );
+	}
+
+	/**
+	 * Log when a user disconnects from Google Site Kit.
+	 *
+	 * @param int    $meta_id    Meta ID.
+	 * @param int    $object_id  Object ID.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 */
+	public static function maybe_log_disconnect( $meta_id, $object_id, $meta_key, $meta_value ) {
+		if ( str_contains( $meta_key, Disconnected_Reason::OPTION ) ) {
+			// TODO: Determine what needs to be logged/alerted.
+			Logger::log( 'User has been disconnected from Google Site Kit.' );
+			Logger::log( 'Disconnect reason: ' . $meta_value );
+		}
 	}
 }
 GoogleSiteKit::init();

--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -9,7 +9,7 @@ namespace Newspack;
 
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Modules\Analytics_4\Settings;
-use Google\Site_Kit\Core\Authentication\Disconnected_Reason;
+use Google\Site_Kit\Core\Authentication\Has_Connected_Admins;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -27,7 +27,7 @@ class GoogleSiteKit {
 		add_action( 'wp_footer', [ __CLASS__, 'insert_ga4_analytics' ] );
 		add_filter( 'option_googlesitekit_analytics_settings', [ __CLASS__, 'filter_ga_settings' ] );
 		add_filter( 'googlesitekit_gtag_opt', [ __CLASS__, 'add_ga_custom_parameters' ] );
-		add_action( 'updated_user_meta', [ __CLASS__, 'maybe_log_disconnect' ], 10, 5 );
+		add_action( 'delete_option_' . Has_Connected_Admins::OPTION, [ __CLASS__, 'maybe_log_disconnect' ] );
 	}
 
 	/**
@@ -176,17 +176,11 @@ class GoogleSiteKit {
 	/**
 	 * Log when a user disconnects from Google Site Kit.
 	 *
-	 * @param int    $meta_id    Meta ID.
-	 * @param int    $object_id  Object ID.
-	 * @param string $meta_key   Meta key.
-	 * @param mixed  $meta_value Meta value.
+	 * @param string $option Option being deleted.
 	 */
-	public static function maybe_log_disconnect( $meta_id, $object_id, $meta_key, $meta_value ) {
-		if ( str_contains( $meta_key, Disconnected_Reason::OPTION ) ) {
-			// TODO: Determine what needs to be logged/alerted.
-			Logger::log( 'User has been disconnected from Google Site Kit.' );
-			Logger::log( 'Disconnect reason: ' . $meta_value );
-		}
+	public static function maybe_log_disconnect( $option ) {
+		// TODO: Determine what needs to be logged/alerted.
+		Logger::log( 'Google Site Kit has been disconnected.' );
 	}
 }
 GoogleSiteKit::init();

--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -179,8 +179,13 @@ class GoogleSiteKit {
 	 * @param string $option Option being deleted.
 	 */
 	public static function maybe_log_disconnect( $option ) {
-		// TODO: Determine what needs to be logged/alerted.
-		Logger::log( 'Google Site Kit has been disconnected.' );
+		$message = 'Google Site Kit has been disconnected.';
+		// TODO: Determine what data needs to be logged.
+		$data = [
+			'user_email' => wp_get_current_user()->user_email,
+			'file'       => 'class-googlesitekit.php',
+		];
+		Logger::newspack_log( 'newspack_googlesitekit_disconnect', $message, $data );
 	}
 }
 GoogleSiteKit::init();

--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -71,6 +71,15 @@ class GoogleSiteKit {
 	}
 
 	/**
+	 * Get whether Site Kit is active.
+	 *
+	 * @return bool Whether Site Kit is active.
+	 */
+	public static function is_active() {
+		return class_exists( 'Google\Site_Kit\Core\Modules\Module' );
+	}
+
+	/**
 	 * Get whether the current user is connected.
 	 *
 	 * @return bool Whether the user is connected to Google through Site Kit.
@@ -111,11 +120,10 @@ class GoogleSiteKit {
 	 * Fetch data for the GA account data and set up GA4.
 	 */
 	public static function setup_sitekit_ga4() {
-		if ( ! class_exists( 'Google\Site_Kit\Core\Modules\Module' ) ) {
+		if ( ! self::is_active() ) {
 			return;
 		}
 		require_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekitanalytics.php';
-		require_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit-logger.php';
 
 		if ( ! self::is_user_connected() ) {
 			return;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206274567818686/1207849727795693

This PR adds newspack manager logging whenever we detect a site kit disconnection via:

1. the `delete_option_{option}` hook for the `has_connected_admin` option.
2. the `update_user_metadata` hook for when the `disconnected_reason` user meta is updated.
3. a cron job that checks to see if there are any admin connection daily

For the first two cases, a backtrace is included in the log. For the final one, we simply log a message.

![Screenshot 2024-10-15 at 14 59 47](https://github.com/user-attachments/assets/1cdbe193-c37c-4822-8b84-b9e8c6a4af5c)

### How to test the changes in this Pull Request:

1. Tunnel your local site so your URL is public and connect Google Site Kit
2. Access admin via the local url (not the public one) to trigger a Site Kit disconnect.
3. Using something like WP-Crontrol, verify a new daily `newspack_googlesitekit_disconnection_logger` cron event is present.
4. Trigger the event and check for a log file in `/tmp/` like `/tmp/2024-XX-XX-newspack_googlesitekit_disconnect`
5. Verify the following logs are present:
  - `No active Google Site Kit connections found`
  - `Google Site Kit has been disconnected for all admins`
  - `Google Site Kit has been disconnected with reason REASON`

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->