### PR TITLE
fix(ras-acc): replace email param with secret for magic links

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -1197,7 +1197,7 @@ final class Magic_Link {
 		$verification_url   = \add_query_arg(
 			[
 				'action'   => self::AUTH_ACTION,
-				'email'    => self::generate_secret( $user ),
+				'secret'   => self::generate_secret( $user ),
 				'token'    => $token_data['token'],
 				'redirect' => urlencode( $url ),
 			],

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -351,6 +351,14 @@ final class Magic_Link {
 
 		$expire = $now - self::get_token_expiration_period();
 		if ( ! empty( $tokens ) ) {
+
+			/**
+			 * Filters the magic link rate interval.
+			 *
+			 * @param int $rate_interval Magic link rate interval.
+			 */
+			$rate_interval = apply_filters( 'newspack_magic_link_rate_interval', self::RATE_INTERVAL );
+
 			/** Limit maximum tokens to 5. */
 			$tokens = array_slice( $tokens, -4, 4 );
 			foreach ( $tokens as $index => $token_data ) {
@@ -359,7 +367,7 @@ final class Magic_Link {
 					unset( $tokens[ $index ] );
 				}
 				/** Rate limit token generation. */
-				if ( $token_data['time'] + self::RATE_INTERVAL > $now ) {
+				if ( $token_data['time'] + $rate_interval > $now ) {
 					return new \WP_Error( 'rate_limit_exceeded', __( 'Please wait a minute before requesting another authorization code.', 'newspack-plugin' ) );
 				}
 			}

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -768,13 +768,16 @@ final class Magic_Link {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$secret = filter_input( INPUT_GET, 'secret', FILTER_SANITIZE_STRING );
 			if ( $secret ) {
-				$users = \get_users(
+				$user_query = new \WP_User_Query(
 					[
-						'meta_key'   => self::USER_SECRET_META,
-						'meta_value' => $secret, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+						'meta_key'    => self::USER_SECRET_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+						'meta_value'  => $secret, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+						'number'      => 1,
+						'count_total' => false,
 					]
 				);
-				if ( empty( $users ) || count( $users ) > 1 ) {
+				$users      = $user_query->get_results();
+				if ( empty( $users ) ) {
 					$errored = true;
 				} else {
 					$user = $users[0];

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -104,6 +104,14 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test simple secret generation.
+	 */
+	public function test_generate_secret() {
+		$secret = Magic_Link::generate_secret( get_user_by( 'id', self::$user_id ) );
+		$this->assertEquals( $secret, wp_hash( 'reader@test.com' ) );
+	}
+
+	/**
 	 * Test rate limiting of token generation.
 	 */
 	public function test_rate_limit() {

--- a/tests/unit-tests/magic-link.php
+++ b/tests/unit-tests/magic-link.php
@@ -130,6 +130,33 @@ class Newspack_Test_Magic_Link extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test whether up to five tokens can be generated and validated.
+	 */
+	public function test_multiple_tokens() {
+		/**
+		 * Filter the rate interval to 0 seconds.
+		 *
+		 * @param int $rate_interval The rate interval in seconds.
+		 */
+		function modify_magic_link_rate_interval( $rate_interval ) {
+			return 0;
+		}
+		add_filter( 'newspack_magic_link_rate_interval', 'modify_magic_link_rate_interval', 10 );
+		$tokens = [];
+		for ( $i = 0; $i <= 5; $i++ ) {
+			$tokens[] = Magic_Link::generate_token( get_user_by( 'id', self::$user_id ) );
+		}
+		remove_filter( 'newspack_magic_link_rate_interval', 'modify_magic_link_rate_interval', 10 );
+		foreach ( $tokens as $index => $token ) {
+			if ( $index < 1 ) {
+				$this->assertTrue( is_wp_error( Magic_Link::validate_token( self::$user_id, $token['client'], $token['token'] ) ) );
+			} else {
+				$this->assertTokenIsValid( Magic_Link::validate_token( self::$user_id, $token['client'], $token['token'] ) );
+			}
+		}
+	}
+
+	/**
 	 * Test single-use quality of a token.
 	 */
 	public function test_single_use_token() {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208379852549384/f

This PR removes the email param from magic links and instead uses a random secret which is stored as user meta when the magic link is generated.

![Screenshot 2024-10-14 at 16 25 38](https://github.com/user-attachments/assets/05b541e5-d341-4b4d-aeca-89b652f52e58)

Note: With these changes the login link will no longer be good after logging in via the auth flow. I'm not sure if this is expected, but I imagine these links should not work permanently. Let me know if this is not the case and the secret should be stored long term.

### How to test the changes in this Pull Request:

- As a logged out reader, attempt to login via the auth modal
- In the OTP email, verify the magic link no longer contains an email address as a param
- Click the magic link and verify you are logged in
- Log out
- Click the magic link in the same email once again and verify you are not able to be authenticated this time

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->