### PR TITLE
fix(ia): wizards admin-header fix dynamic property creation deprecation warning

### DIFF
--- a/includes/wizards/traits/trait-wizards-admin-header.php
+++ b/includes/wizards/traits/trait-wizards-admin-header.php
@@ -25,6 +25,13 @@ trait Admin_Header {
 	protected $tabs = [];
 
 	/**
+	 * Holds the admin title.
+	 *
+	 * @var string
+	 */
+	protected $title = '';
+
+	/**
 	 * Initialize the admin header script with localized data.
 	 *
 	 * @param array $args Title and tabs array.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds property to `Newspack\Wizards\Traits\Admin_header` to fix php warning "PHP Deprecated:  Creation of dynamic property X"

### How to test the changes in this Pull Request:

1. Checkout this branch `git checkout fix/dynamic-property-title`
2. Navigate to _/wp-admin/edit.php?post_type=newspack_spnsrs_cpt_ 
3. Open or tail `wp-content/debug.log`
4. Confirm no entries exist for "PHP Deprecated:  Creation of dynamic property Newspack\Advertising_Sponsors::$title"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
