### PR TITLE
feat: display list remote name on newsletter wizard

### DIFF
--- a/src/wizards/engagement/views/newsletters/index.js
+++ b/src/wizards/engagement/views/newsletters/index.js
@@ -353,6 +353,9 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 							simple
 							hasWhiteHeader
 							title={ list.remote_name }
+							description={
+								list?.type_label ? list.type_label : null
+							}
 							disabled={ inFlight }
 							toggleOnChange={ handleChange( index, 'active' ) }
 							toggleChecked={ list.active }

--- a/src/wizards/engagement/views/newsletters/index.js
+++ b/src/wizards/engagement/views/newsletters/index.js
@@ -352,8 +352,7 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 							isSmall
 							simple
 							hasWhiteHeader
-							title={ list.name }
-							description={ list?.type_label ? list.type_label : null }
+							title={ list.remote_name }
 							disabled={ inFlight }
 							toggleOnChange={ handleChange( index, 'active' ) }
 							toggleChecked={ list.active }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Correctly displays the list "remote name" (the name set in the ESP) in the Newsletters wizard

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-newsletters/pull/1672

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->