### PR TITLE
feat: `useWizardApiFetch` add manual cache handling logic

### DIFF
--- a/src/wizards/hooks/use-wizard-api-fetch.ts
+++ b/src/wizards/hooks/use-wizard-api-fetch.ts
@@ -15,6 +15,17 @@ import { WIZARD_STORE_NAMESPACE } from '../../components/src/wizard/store';
 import { WizardApiError } from '../errors';
 
 /**
+ * Remove query arguments from a path. Similar to `removeQueryArgs` in `@wordpress/url`, but this function
+ * removes all query arguments from a string and returns it.
+ *
+ * @param str String to remove query arguments from.
+ * @return The string without query arguments.
+ */
+function removeQueryArgs( str: string ) {
+	return str.split( '?' ).at( 0 ) ?? str;
+}
+
+/**
  * Holds in-progress promises for each fetch request.
  */
 let promiseCache: Record< string, any > = {};
@@ -107,19 +118,37 @@ export function useWizardApiFetch( slug: string ) {
 	/**
 	 * Updates the wizard data at the specified path.
 	 *
-	 * @param path The path to update in the wizard data.
+	 * @param cacheKeyPath The cacheKeyPath to update in the wizard data.
 	 * @return     Function to update the wizard data.
 	 */
-	function updateWizardData( path: string | null ) {
-		return ( prop: string | string[], value: any, p = path ) =>
+	function updateWizardData( cacheKeyPath: string | null ) {
+		/**
+		 * Updates the wizard data prop at the specified path.
+		 *
+		 * @param prop                 The property to update in the wizard path data. i.e. 'GET'
+		 * @param value                The value to set for the property.
+		 * @param cacheKeyPathOverride The path to update in the wizard data.
+		 */
+		return (
+			prop: string | string[],
+			value: any,
+			cacheKeyPathOverride = cacheKeyPath
+		) => {
+			// Remove query parameters from the cacheKeyPath
+
+			const normalizedPath = cacheKeyPathOverride
+				? removeQueryArgs( cacheKeyPathOverride )
+				: cacheKeyPathOverride;
+
 			updateWizardSettings( {
 				slug,
 				path: [
-					p,
+					normalizedPath,
 					...( Array.isArray( prop ) ? prop : [ prop ] ),
 				].filter( str => typeof str === 'string' ),
 				value,
 			} );
+		};
 	}
 
 	/**
@@ -138,6 +167,7 @@ export function useWizardApiFetch( slug: string ) {
 			const { on } = onCallbacks< T >( callbacks ?? {} );
 			const updateSettings = updateWizardData( opts.path );
 			const { path, method = 'GET' } = opts;
+			const cacheKeyPath = removeQueryArgs( path ?? '' );
 			const {
 				isCached = method === 'GET',
 				updateCacheKey = null,
@@ -147,7 +177,7 @@ export function useWizardApiFetch( slug: string ) {
 
 			const {
 				error: cachedError,
-				[ path ]: { [ method ]: cachedMethod = null } = {},
+				[ cacheKeyPath ]: { [ method ]: cachedMethod = null } = {},
 			}: WizardData = wizardData;
 
 			function thenCallback( response: T ) {
@@ -197,19 +227,19 @@ export function useWizardApiFetch( slug: string ) {
 
 			function finallyCallback() {
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				const { [ path ]: _removed, ...newData } = promiseCache;
+				const { [ cacheKeyPath ]: _removed, ...newData } = promiseCache;
 				promiseCache = newData;
 				requests.current = requests.current.filter(
-					request => request !== path
+					request => request !== cacheKeyPath
 				);
 				setIsFetching( requests.current.length > 0 );
 				on( 'onFinally' );
 			}
 
 			// If the promise is already in progress, return it before making a new request.
-			if ( promiseCache[ path ] ) {
+			if ( promiseCache[ cacheKeyPath ] ) {
 				setIsFetching( true );
-				return promiseCache[ path ]
+				return promiseCache[ cacheKeyPath ]
 					.then( thenCallback )
 					.catch( catchCallback )
 					.finally( finallyCallback );
@@ -224,9 +254,9 @@ export function useWizardApiFetch( slug: string ) {
 
 			setIsFetching( true );
 			on( 'onStart' );
-			requests.current.push( path );
+			requests.current.push( cacheKeyPath );
 
-			promiseCache[ path ] = wizardApiFetch( {
+			promiseCache[ cacheKeyPath ] = wizardApiFetch( {
 				isQuietFetch: true,
 				isLocalError: true,
 				...options,
@@ -245,6 +275,20 @@ export function useWizardApiFetch( slug: string ) {
 		isFetching,
 		errorMessage: error ? error.message : null,
 		error,
+		cache( cacheKey: string ) {
+			return {
+				get( method: ApiMethods = 'GET' ) {
+					return wizardData[ cacheKey ][ method ];
+				},
+				set( value: any, method: ApiMethods = 'GET' ) {
+					updateWizardSettings( {
+						slug,
+						path: [ cacheKey, method ],
+						value,
+					} );
+				},
+			};
+		},
 		setError(
 			value: string | WizardErrorType | null | { message: string }
 		) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`useWizardApiFetch` caches in 3 ways:
* Automatically for `GET` requests for specific `path`s.
* `updateCacheKey`: Useful when different requests share the same response/cache schema.
* `updateCacheMethods`: Useful when requests share the same `path` and response/cache schema.

**The problem:**
There are certain scenarios where return structures do not align with the cached object. These situations require either more configuration inside `useWizardApiFetch` or providing an API for directly interfacing with it, this PR introduces the latter. 

Additionally, changes where made to fix how paths are stored as cache keys by removing query arguments.

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets `git checkout origin/feat/manual-cache-logic && npm run build`
2. Open _/src/wizards/newspack/views/settings/display-settings/index.tsx_
3. Update:
```ts
const { wizardApiFetch, isFetching, errorMessage } = useWizardApiFetch(
	'newspack-settings/theme-mods'
);
```
to
```ts
const { wizardApiFetch, isFetching, errorMessage, cache } =
	useWizardApiFetch( 'newspack-settings/theme-mods' );
const themeModsCache = cache(
	'/newspack/v1/wizard/newspack-setup-wizard/theme'
);
```
4. Add below element to return statement.
```ts
<button
	onClick={ () => {
		const showAuthorBio = ! data.show_author_bio;
		setData( {
			...data,
			show_author_bio: showAuthorBio,
		} );
		themeModsCache.set( {
			theme_mods: {
				...data,
				show_author_bio: showAuthorBio,
			},
		} );
	} }
>
	{ __( 'Toggle Author Bio', 'newspack-plugin' ) }
</button>
```
5. Run `npm run watch|build` and navigate to _/wp-admin/admin.php?page=newspack-settings#/display-settings_
6. Depending on where you added the `<button>`, you should see below.
![Screenshot 2024-10-18 at 08 53 00](https://github.com/user-attachments/assets/23df7b31-db0d-44e3-a259-c798163d2010)
7. Upon clicking "Toggle Author Bio" button you will see the Author Bio control toggle on/off.
8. Navigate to different tab i.e. "Additional Brands" and then back to "Display Settings" tab and confirm the control is as you left it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
