### PR TITLE
feat(auth-modal): onSuccess, onDismiss, and onError callbacks

### DIFF
--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -301,7 +301,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 					) {
 						callback = ( authMessage, authData ) =>
 							openNewslettersSignupModal( {
-								callback: container.authCallback( authMessage, authData ),
+								onSuccess: container.authCallback( authMessage, authData ),
 								closeOnSuccess: true,
 							} );
 					} else {

--- a/src/reader-activation-auth/auth-modal.js
+++ b/src/reader-activation-auth/auth-modal.js
@@ -22,24 +22,24 @@ export function openAuthModal( config = {} ) {
 	const modalTrigger = config.trigger;
 
 	if ( reader?.authenticated ) {
-		if ( config.callback ) {
-			config.callback();
+		if ( config.onSuccess && typeof config.onSuccess === 'function' ) {
+			config.onSuccess();
 		}
 		return;
 	}
 
 	const container = getModalContainer();
 	if ( ! container ) {
-		if ( config.callback ) {
-			config.callback();
+		if ( config.onSuccess && typeof config.onSuccess === 'function' ) {
+			config.onSuccess();
 		}
 		return;
 	}
 
 	const modal = container.closest( '.newspack-reader-auth-modal' );
 	if ( ! modal ) {
-		if ( config.callback ) {
-			config.callback();
+		if ( config.onSuccess && typeof config.onSuccess === 'function' ) {
+			config.onSuccess();
 		}
 		return;
 	}
@@ -47,9 +47,9 @@ export function openAuthModal( config = {} ) {
 	/**
 	 * Close the auth modal.
 	 *
-	 * @param {boolean} silent Whether to close the modal without triggering the callback.
+	 * @param {boolean} dismiss Whether it's a dismiss action.
 	 */
-	const close = ( silent = false ) => {
+	const close = ( dismiss = true ) => {
 		container.config = {};
 		modal.setAttribute( 'data-state', 'closed' );
 		document.body.classList.remove( 'newspack-signin' );
@@ -66,8 +66,8 @@ export function openAuthModal( config = {} ) {
 			modalTrigger.focus();
 		}
 
-		if ( ! silent && config.onClose && typeof config.onClose === 'function' ) {
-			config.onClose();
+		if ( dismiss && config.onDismiss && typeof config.onDismiss === 'function' ) {
+			config.onDismiss();
 		}
 	};
 
@@ -96,9 +96,9 @@ export function openAuthModal( config = {} ) {
 	container.config = config;
 
 	container.authCallback = ( message, data ) => {
-		close( true );
-		if ( config.callback ) {
-			config.callback( message, data );
+		close( false );
+		if ( config.onSuccess && typeof config.onSuccess === 'function' ) {
+			config.onSuccess( message, data );
 		}
 	};
 

--- a/src/reader-activation-auth/auth-modal.js
+++ b/src/reader-activation-auth/auth-modal.js
@@ -44,7 +44,12 @@ export function openAuthModal( config = {} ) {
 		return;
 	}
 
-	const close = () => {
+	/**
+	 * Close the auth modal.
+	 *
+	 * @param {boolean} silent Whether to close the modal without triggering the callback.
+	 */
+	const close = ( silent = false ) => {
 		container.config = {};
 		modal.setAttribute( 'data-state', 'closed' );
 		document.body.classList.remove( 'newspack-signin' );
@@ -59,6 +64,10 @@ export function openAuthModal( config = {} ) {
 
 		if ( modalTrigger ) {
 			modalTrigger.focus();
+		}
+
+		if ( ! silent && config.onClose && typeof config.onClose === 'function' ) {
+			config.onClose();
 		}
 	};
 
@@ -87,7 +96,7 @@ export function openAuthModal( config = {} ) {
 	container.config = config;
 
 	container.authCallback = ( message, data ) => {
-		close();
+		close( true );
 		if ( config.callback ) {
 			config.callback( message, data );
 		}

--- a/src/reader-activation-auth/index.js
+++ b/src/reader-activation-auth/index.js
@@ -46,7 +46,7 @@ window.newspackRAS.push( readerActivation => {
 		function handleAccountLinkClick( ev ) {
 			ev.preventDefault();
 			const modalTrigger = ev.target;
-			let callback, redirect;
+			let onSuccess, redirect;
 			if ( ev.target.getAttribute( 'data-redirect' ) ) {
 				redirect = ev.target.getAttribute( 'data-redirect' );
 			} else {
@@ -63,13 +63,14 @@ window.newspackRAS.push( readerActivation => {
 				}
 			}
 			if ( redirect && redirect !== '#' ) {
-				callback = () => {
+				onSuccess = () => {
 					window.location.href = redirect;
 				};
 			}
 
 			openAuthModal( {
-				callback,
+				onSuccess,
+				onError: onSuccess,
 				trigger: modalTrigger,
 			} );
 		}

--- a/src/reader-activation-auth/index.js
+++ b/src/reader-activation-auth/index.js
@@ -46,7 +46,7 @@ window.newspackRAS.push( readerActivation => {
 		function handleAccountLinkClick( ev ) {
 			ev.preventDefault();
 			const modalTrigger = ev.target;
-			let onSuccess, redirect;
+			let callback, redirect;
 			if ( ev.target.getAttribute( 'data-redirect' ) ) {
 				redirect = ev.target.getAttribute( 'data-redirect' );
 			} else {
@@ -63,14 +63,14 @@ window.newspackRAS.push( readerActivation => {
 				}
 			}
 			if ( redirect && redirect !== '#' ) {
-				onSuccess = () => {
+				callback = () => {
 					window.location.href = redirect;
 				};
 			}
 
 			openAuthModal( {
-				onSuccess,
-				onError: onSuccess,
+				onSuccess: callback,
+				onError: callback,
 				trigger: modalTrigger,
 			} );
 		}

--- a/src/reader-activation-newsletters/newsletters-modal.js
+++ b/src/reader-activation-newsletters/newsletters-modal.js
@@ -21,21 +21,26 @@ export function getModalContainer() {
 export function openNewslettersSignupModal( config = {} ) {
 	const container = getModalContainer();
 	if ( ! container ) {
-		if ( config?.callback ) {
-			config.callback();
+		if ( config?.onSuccess && typeof config.onSuccess === 'function' ) {
+			config.onSuccess();
 		}
 		return;
 	}
 
 	const modal = container.closest( '.newspack-newsletters-signup-modal' );
 	if ( ! modal ) {
-		if ( config?.callback ) {
-			config.callback();
+		if ( config?.onSuccess && typeof config.onSuccess === 'function' ) {
+			config.onSuccess();
 		}
 		return;
 	}
 
-	const close = () => {
+	/**
+	 * Close the modal.
+	 *
+	 * @param {boolean} dismiss Whether it's a dismiss action.
+	 */
+	const close = ( dismiss = true ) => {
 		container.config = {};
 		modal.setAttribute( 'data-state', 'closed' );
 		if ( modal?.overlayId && window?.newspackReaderActivation?.overlays ) {
@@ -44,6 +49,9 @@ export function openNewslettersSignupModal( config = {} ) {
 		const openerContent = container.querySelector( '.opener-content' );
 		if ( openerContent ) {
 			openerContent.remove();
+		}
+		if ( dismiss && config.onDismiss && typeof config.onDismiss === 'function' ) {
+			config.onDismiss();
 		}
 	};
 
@@ -66,10 +74,10 @@ export function openNewslettersSignupModal( config = {} ) {
 
 	container.newslettersSignupCallback = ( message, data ) => {
 		if ( config?.closeOnSuccess ) {
-			close();
+			close( false );
 		}
-		if ( config?.callback ) {
-			config.callback( message, data );
+		if ( config?.onSuccess && typeof config.onSuccess === 'function' ) {
+			config.onSuccess( message, data );
 		}
 	};
 

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -147,6 +147,7 @@ export function openAuthModal( config = {} ) {
 	config = {
 		...{
 			callback: null,
+			onClose: null,
 			initialState: null,
 			skipSuccess: false,
 			skipNewslettersSignup: false,

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -146,8 +146,9 @@ export function openAuthModal( config = {} ) {
 	// Set default config.
 	config = {
 		...{
-			callback: null,
-			onClose: null,
+			onSuccess: null,
+			onDismiss: null,
+			onError: null,
 			initialState: null,
 			skipSuccess: false,
 			skipNewslettersSignup: false,
@@ -166,8 +167,8 @@ export function openAuthModal( config = {} ) {
 	};
 
 	if ( newspack_ras_config.is_logged_in ) {
-		if ( config.callback ) {
-			config.callback();
+		if ( config.onSuccess && typeof config.onSuccess === 'function' ) {
+			config.onSuccess();
 		}
 		return;
 	}
@@ -175,8 +176,8 @@ export function openAuthModal( config = {} ) {
 		readerActivation._openAuthModal( config );
 	} else {
 		console.warn( 'Authentication modal not available' ); // eslint-disable-line no-console
-		if ( config.callback ) {
-			config.callback();
+		if ( config.onError && typeof config.onError === 'function' ) {
+			config.onError();
 		}
 	}
 }
@@ -190,7 +191,9 @@ export function openNewslettersSignupModal( config = {} ) {
 	// Set default config.
 	config = {
 		...{
-			callback: null,
+			onSuccess: null,
+			onDissmiss: null,
+			onError: null,
 			initialState: null,
 			skipSuccess: false,
 			labels: {},
@@ -204,8 +207,8 @@ export function openNewslettersSignupModal( config = {} ) {
 		readerActivation._openNewslettersSignupModal( config );
 	} else {
 		console.warn( 'Newsletters signup modal not available' ); // eslint-disable-line no-console
-		if ( config?.callback ) {
-			config.callback();
+		if ( config?.onError && typeof config.onError === 'function' ) {
+			config.onError();
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for a callback when the auth modal closes without authenticating.

### How to test the changes in this Pull Request:

Context and instructions at https://github.com/Automattic/newspack-blocks/pull/1908

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->