### PR TITLE
fix: command to fix active subs w/ missing next_payment dates

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -194,7 +194,7 @@ Fetching active subscriptions with missing or missed next_payment dates...
 
 		$query_args    = [
 			'subscriptions_per_page' => $batch_size,
-			'subscription_status'    => WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES,
+			'subscription_status'    => [ 'active', 'pending' ],
 			'offset'                 => 0,
 		];
 		$processed     = 0;
@@ -223,6 +223,7 @@ Fetching active subscriptions with missing or missed next_payment dates...
 
 				$result   = [
 					'ID'                => $subscription->get_id(),
+					'status'            => $subscription->get_status(),
 					'start_date'        => $subscription_start,
 					'next_payment_date' => $next_payment_date,
 					'billing_period'    => $subscription->get_billing_period(),
@@ -269,6 +270,7 @@ Fetching active subscriptions with missing or missed next_payment dates...
 				$results,
 				[
 					'ID',
+					'status',
 					'start_date',
 					'next_payment_date',
 					'billing_period',

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -221,7 +221,7 @@ Fetching active subscriptions with missing or missed next_payment dates...
 					continue;
 				}
 
-				$result   = [
+				$result = [
 					'ID'                => $subscription->get_id(),
 					'status'            => $subscription->get_status(),
 					'start_date'        => $subscription_start,
@@ -230,10 +230,14 @@ Fetching active subscriptions with missing or missed next_payment dates...
 					'missed_periods'    => 0,
 					'missed_total'      => 0,
 				];
-				$min_date = strtotime( $subscription_start );
-				while ( $min_date <= $now ) {
-					$result['missed_periods']++;
-					$min_date = strtotime( '+1 ' . $result['billing_period'], $min_date );
+				if ( ! empty( $result['billing_period'] ) && ! empty( $result['billing_interval'] ) ) {
+					$period   = $result['billing_period'];
+					$interval = (int) $result['billing_interval'];
+					$min_date = strtotime( "+$interval $period", strtotime( $subscription_start ) ); // Start after first period so we don't count in-progress periods as missed.
+					while ( $min_date <= $now ) {
+						$result['missed_periods']++;
+						$min_date = strtotime( "+$interval $period", $min_date );
+					}
 				}
 
 				if ( $result['missed_periods'] ) {

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -163,6 +163,131 @@ class WooCommerce_Cli {
 	}
 
 	/**
+	 * Fixes or reports active subscriptions that have missed next payment dates.
+	 * By default, will only process subscriptions started in the past 90 days.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : If set, will report results but will not make any changes.
+	 *
+	 * [--batch-size=<batch-size>]
+	 * : The number of subscriptions to process in each batch. Default: 50.
+	 *
+	 * [--start-date=<date-string>]
+	 * : A date string in YYYY-MM-DD format to use as the start date for the script. Default: 90 days ago.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public function fix_missing_next_payment_dates( $args, $assoc_args ) {
+		$dry_run    = ! empty( $assoc_args['dry-run'] );
+		$now        = time();
+		$batch_size = ! empty( $assoc_args['batch-size'] ) ? intval( $assoc_args['batch-size'] ) : 50;
+		$start_date = ! empty( $assoc_args['start-date'] ) ? strtotime( $assoc_args['start-date'] ) : strtotime( '-90 days', $now );
+
+		\WP_CLI::log(
+			'
+Fetching active subscriptions with missing or missed next_payment dates...
+		'
+		);
+
+		$query_args    = [
+			'subscriptions_per_page' => $batch_size,
+			'subscription_status'    => WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES,
+			'offset'                 => 0,
+		];
+		$processed     = 0;
+		$subscriptions = \wcs_get_subscriptions( $query_args );
+		$total_revenue = 0;
+		$results       = [];
+
+		while ( ! empty( $subscriptions ) ) {
+			foreach ( $subscriptions as $subscription_id => $subscription ) {
+				array_shift( $subscriptions );
+				$subscription_start = $subscription->get_date( 'start_date' );
+
+				// If the subscription start date is before the $args start date, we're done.
+				if ( strtotime( $subscription_start ) < $start_date ) {
+					$subscriptions = [];
+					break;
+				}
+
+				$next_payment_date = $subscription->get_date( 'next_payment' );
+				$is_in_past        = ! strtotime( $next_payment_date ) || strtotime( $next_payment_date ) < $now;
+
+				// Subscription has a valid next payment date and it's in the future, so skip.
+				if ( $next_payment_date && ! $is_in_past ) {
+					continue;
+				}
+
+				$result   = [
+					'ID'                => $subscription->get_id(),
+					'start_date'        => $subscription_start,
+					'next_payment_date' => $next_payment_date,
+					'billing_period'    => $subscription->get_billing_period(),
+					'missed_periods'    => 0,
+					'missed_total'      => 0,
+				];
+				$min_date = strtotime( $subscription_start );
+				while ( $min_date <= $now ) {
+					$result['missed_periods']++;
+					$min_date = strtotime( '+1 ' . $result['billing_period'], $min_date );
+				}
+
+				if ( $result['missed_periods'] ) {
+					$result['missed_total'] += $subscription->get_total() * $result['missed_periods'];
+					$total_revenue += $result['missed_total'];
+				}
+
+				if ( ! $dry_run ) {
+					$subscription->update_dates(
+						[
+							'next_payment' => $subscription->calculate_date( 'next_payment' ),
+						]
+					);
+					$subscription->save();
+					$result['next_payment_date'] = $subscription->get_date( 'next_payment' );
+				}
+
+				$results[] = $result;
+				$processed++;
+
+				// Get the next batch.
+				if ( empty( $subscriptions ) ) {
+					$query_args['offset'] += $batch_size;
+					$subscriptions        = \wcs_get_subscriptions( $query_args );
+				}
+			}
+		}
+
+		if ( empty( $results ) ) {
+			\WP_CLI::log( 'No subscriptions with missing next_payment dates found in the given time period.' );
+		} else {
+			\WP_CLI\Utils\format_items(
+				'table',
+				$results,
+				[
+					'ID',
+					'start_date',
+					'next_payment_date',
+					'billing_period',
+					'missed_periods',
+					'missed_total',
+				]
+			);
+			\WP_CLI::success(
+				sprintf(
+					'Finished processing %d subscriptions. %s',
+					$processed,
+					$total_revenue ? 'Total missed revenue: ' . \wp_strip_all_tags( html_entity_decode( \wc_price( $total_revenue ) ) ) : ''
+				)
+			);
+		}
+		\WP_CLI::line( '' );
+	}
+
+	/**
 	 * Outputs a list of subscription in CLI
 	 *
 	 * @param WC_Subscription[] $subscriptions The subscriptions.

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -230,14 +230,18 @@ Fetching active subscriptions with missing or missed next_payment dates...
 					'missed_periods'    => 0,
 					'missed_total'      => 0,
 				];
-				if ( ! empty( $result['billing_period'] ) && ! empty( $result['billing_interval'] ) ) {
-					$period   = $result['billing_period'];
-					$interval = (int) $result['billing_interval'];
-					$min_date = strtotime( "+$interval $period", strtotime( $subscription_start ) ); // Start after first period so we don't count in-progress periods as missed.
-					while ( $min_date <= $now ) {
-						$result['missed_periods']++;
-						$min_date = strtotime( "+$interval $period", $min_date );
-					}
+
+				// Can't process a broken subscription (missing a billing period or interval).
+				if ( empty( $result['billing_period'] ) || empty( $result['billing_interval'] ) ) {
+					continue;
+				}
+
+				$period   = $result['billing_period'];
+				$interval = (int) $result['billing_interval'];
+				$min_date = strtotime( "+$interval $period", strtotime( $subscription_start ) ); // Start after first period so we don't count in-progress periods as missed.
+				while ( $min_date <= $now ) {
+					$result['missed_periods']++;
+					$min_date = strtotime( "+$interval $period", $min_date );
 				}
 
 				if ( $result['missed_periods'] ) {

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -227,6 +227,7 @@ Fetching active subscriptions with missing or missed next_payment dates...
 					'start_date'        => $subscription_start,
 					'next_payment_date' => $next_payment_date,
 					'billing_period'    => $subscription->get_billing_period(),
+					'billing_interval'  => $subscription->get_billing_interval(),
 					'missed_periods'    => 0,
 					'missed_total'      => 0,
 				];

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -186,6 +186,13 @@ class WooCommerce_Cli {
 		$batch_size = ! empty( $assoc_args['batch-size'] ) ? intval( $assoc_args['batch-size'] ) : 50;
 		$start_date = ! empty( $assoc_args['start-date'] ) ? strtotime( $assoc_args['start-date'] ) : strtotime( '-90 days', $now );
 
+		if ( ! $dry_run ) {
+			\WP_CLI::line( "\n=====================\n=     LIVE MODE     =\n=====================\n" );
+		} else {
+			\WP_CLI::line( "\n===================\n=     DRY RUN     =\n===================\n" );
+		}
+		sleep( 2 );
+
 		\WP_CLI::log(
 			'
 Fetching active subscriptions with missing or missed next_payment dates...
@@ -205,59 +212,20 @@ Fetching active subscriptions with missing or missed next_payment dates...
 		while ( ! empty( $subscriptions ) ) {
 			foreach ( $subscriptions as $subscription_id => $subscription ) {
 				array_shift( $subscriptions );
-				$subscription_start = $subscription->get_date( 'start_date' );
 
 				// If the subscription start date is before the $args start date, we're done.
-				if ( strtotime( $subscription_start ) < $start_date ) {
+				if ( strtotime( $subscription->get_date( 'start_date' ) ) < $start_date ) {
 					$subscriptions = [];
 					break;
 				}
 
-				$next_payment_date = $subscription->get_date( 'next_payment' );
-				$is_in_past        = ! strtotime( $next_payment_date ) || strtotime( $next_payment_date ) < $now;
-
-				// Subscription has a valid next payment date and it's in the future, so skip.
-				if ( $next_payment_date && ! $is_in_past ) {
+				$result = self::calculate_next_payment_date( $subscription, $dry_run );
+				if ( ! $result ) {
 					continue;
-				}
-
-				$result = [
-					'ID'                => $subscription->get_id(),
-					'status'            => $subscription->get_status(),
-					'start_date'        => $subscription_start,
-					'next_payment_date' => $next_payment_date,
-					'billing_period'    => $subscription->get_billing_period(),
-					'billing_interval'  => $subscription->get_billing_interval(),
-					'missed_periods'    => 0,
-					'missed_total'      => 0,
-				];
-
-				// Can't process a broken subscription (missing a billing period or interval).
-				if ( empty( $result['billing_period'] ) || empty( $result['billing_interval'] ) ) {
-					continue;
-				}
-
-				$period   = $result['billing_period'];
-				$interval = (int) $result['billing_interval'];
-				$min_date = strtotime( "+$interval $period", strtotime( $subscription_start ) ); // Start after first period so we don't count in-progress periods as missed.
-				while ( $min_date <= $now ) {
-					$result['missed_periods']++;
-					$min_date = strtotime( "+$interval $period", $min_date );
 				}
 
 				if ( $result['missed_periods'] ) {
-					$result['missed_total'] += $subscription->get_total() * $result['missed_periods'];
 					$total_revenue += $result['missed_total'];
-				}
-
-				if ( ! $dry_run ) {
-					$subscription->update_dates(
-						[
-							'next_payment' => $subscription->calculate_date( 'next_payment' ),
-						]
-					);
-					$subscription->save();
-					$result['next_payment_date'] = $subscription->get_date( 'next_payment' );
 				}
 
 				$results[] = $result;
@@ -282,6 +250,7 @@ Fetching active subscriptions with missing or missed next_payment dates...
 					'status',
 					'start_date',
 					'next_payment_date',
+					'end_date',
 					'billing_period',
 					'missed_periods',
 					'missed_total',
@@ -296,6 +265,81 @@ Fetching active subscriptions with missing or missed next_payment dates...
 			);
 		}
 		\WP_CLI::line( '' );
+	}
+
+	/**
+	 * Given a subscription, calculates the next payment date and missed payments.
+	 *
+	 * @param WC_Subscription $subscription The subscription.
+	 * @param bool            $dry_run If set, will not make any changes.
+	 *
+	 * @return array|false The result array or false if the subscription is broken.
+	 */
+	public static function calculate_next_payment_date( $subscription, $dry_run = false ) {
+		$now                = time();
+		$subscription_start = $subscription->get_date( 'start_date' );
+		$next_payment_date  = $subscription->get_date( 'next_payment' );
+		$is_in_past         = ! strtotime( $next_payment_date ) || strtotime( $next_payment_date ) < $now;
+
+		// Subscription has a valid next payment date and it's in the future, so skip.
+		if ( $next_payment_date && ! $is_in_past ) {
+			return false;
+		}
+
+		$result = [
+			'ID'                => $subscription->get_id(),
+			'status'            => $subscription->get_status(),
+			'start_date'        => $subscription_start,
+			'next_payment_date' => $next_payment_date,
+			'end_date'          => $subscription->get_date( 'end' ),
+			'billing_period'    => $subscription->get_billing_period(),
+			'billing_interval'  => $subscription->get_billing_interval(),
+			'missed_periods'    => 0,
+			'missed_total'      => 0,
+		];
+
+		// Can't process a broken subscription (missing a billing period or interval).
+		if ( empty( $result['billing_period'] ) || empty( $result['billing_interval'] ) ) {
+			return false;
+		}
+
+		$period   = $result['billing_period'];
+		$interval = (int) $result['billing_interval'];
+		$min_date = strtotime( "+$interval $period", strtotime( $subscription_start ) ); // Start after first period so we don't count in-progress periods as missed.
+		$end_date = $now;
+
+		// If there were successful orders for this subscription, start from the last one.
+		$last_order = $subscription->get_last_order( 'all', 'any', [ 'pending', 'processing', 'on-hold', 'cancelled', 'refunded', 'failed' ] );
+		if ( $last_order && $last_order->get_date_completed() ) {
+			$min_date = strtotime( "+$interval $period", $last_order->get_date_completed()->getOffsetTimestamp() );
+		}
+
+		// If there's an end date, end there.
+		if ( ! empty( $result['end_date'] ) ) {
+			$end = strtotime( $result['end_date'] );
+		}
+
+		while ( $min_date <= $end ) {
+			$result['missed_periods']++;
+			$min_date = strtotime( "+$interval $period", $min_date );
+		}
+
+		if ( $result['missed_periods'] ) {
+			$result['missed_total'] += $subscription->get_total() * $result['missed_periods'];
+		}
+
+		$calculated_next_payment     = $subscription->calculate_date( 'next_payment' );
+		$result['next_payment_date'] = $calculated_next_payment;
+		if ( ! $dry_run && ( ! $end_date || $end > strtotime( $calculated_next_payment ) ) ) {
+			$subscription->update_dates(
+				[
+					'next_payment' => $calculated_next_payment,
+				]
+			);
+			$subscription->save();
+		}
+
+		return $result;
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -214,7 +214,7 @@ Fetching active subscriptions with missing or missed next_payment dates...
 				array_shift( $subscriptions );
 
 				// If the subscription start date is before the $args start date, we're done.
-				if ( strtotime( $subscription->get_date( 'start_date' ) ) < $start_date ) {
+				if ( strtotime( $subscription->get_date( 'start' ) ) < $start_date ) {
 					$subscriptions = [];
 					break;
 				}
@@ -277,7 +277,7 @@ Fetching active subscriptions with missing or missed next_payment dates...
 	 */
 	public static function calculate_next_payment_date( $subscription, $dry_run = false ) {
 		$now                = time();
-		$subscription_start = $subscription->get_date( 'start_date' );
+		$subscription_start = $subscription->get_date( 'start' );
 		$next_payment_date  = $subscription->get_date( 'next_payment' );
 		$is_in_past         = ! strtotime( $next_payment_date ) || strtotime( $next_payment_date ) < $now;
 
@@ -316,10 +316,10 @@ Fetching active subscriptions with missing or missed next_payment dates...
 
 		// If there's an end date, end there.
 		if ( ! empty( $result['end_date'] ) ) {
-			$end = strtotime( $result['end_date'] );
+			$end_date = strtotime( $result['end_date'] );
 		}
 
-		while ( $min_date <= $end ) {
+		while ( $min_date <= $end_date ) {
 			$result['missed_periods']++;
 			$min_date = strtotime( "+$interval $period", $min_date );
 		}
@@ -328,15 +328,17 @@ Fetching active subscriptions with missing or missed next_payment dates...
 			$result['missed_total'] += $subscription->get_total() * $result['missed_periods'];
 		}
 
-		$calculated_next_payment     = $subscription->calculate_date( 'next_payment' );
-		$result['next_payment_date'] = $calculated_next_payment;
-		if ( ! $dry_run && ( ! $end_date || $end > strtotime( $calculated_next_payment ) ) ) {
-			$subscription->update_dates(
-				[
-					'next_payment' => $calculated_next_payment,
-				]
-			);
-			$subscription->save();
+		$calculated_next_payment = $subscription->calculate_date( 'next_payment' );
+		if ( ! $result['end_date'] || strtotime( $result['end_date'] ) > strtotime( $calculated_next_payment ) ) {
+			$result['next_payment_date'] = $calculated_next_payment;
+			if ( ! $dry_run ) {
+				$subscription->update_dates(
+					[
+						'next_payment' => $calculated_next_payment,
+					]
+				);
+				$subscription->save();
+			}
 		}
 
 		return $result;

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cli.php
@@ -219,7 +219,7 @@ Fetching active subscriptions with missing or missed next_payment dates...
 					break;
 				}
 
-				$result = self::calculate_next_payment_date( $subscription, $dry_run );
+				$result = self::validate_subscription_dates( $subscription, $dry_run );
 				if ( ! $result ) {
 					continue;
 				}
@@ -268,14 +268,16 @@ Fetching active subscriptions with missing or missed next_payment dates...
 	}
 
 	/**
-	 * Given a subscription, calculates the next payment date and missed payments.
+	 * Validate renewal date for the given subscription, accounting for end date.
+	 * If missing, calculates the next_payment date and reports missed payments
+	 * since the last successful order or subscription start.
 	 *
 	 * @param WC_Subscription $subscription The subscription.
 	 * @param bool            $dry_run If set, will not make any changes.
 	 *
 	 * @return array|false The result array or false if the subscription is broken.
 	 */
-	public static function calculate_next_payment_date( $subscription, $dry_run = false ) {
+	public static function validate_subscription_dates( $subscription, $dry_run = false ) {
 		$now                = time();
 		$subscription_start = $subscription->get_date( 'start' );
 		$next_payment_date  = $subscription->get_date( 'next_payment' );

--- a/tests/unit-tests/woocommerce-cli.php
+++ b/tests/unit-tests/woocommerce-cli.php
@@ -64,9 +64,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 			]
 		);
 		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
-
-		// Subscription wasn't processed.
-		$this->assertFalse( $result, Subscription wasn't processed. );
+		$this->assertFalse( $result, 'Healthy subscription wasn’t processed.' );
 	}
 
 	/**
@@ -86,8 +84,6 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 			]
 		);
 		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
-
-		// Subscription was processed.
 		$this->assertEquals(
 			$result,
 			[
@@ -100,11 +96,10 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				'billing_interval'  => $subscription->get_billing_interval(),
 				'missed_periods'    => 6,
 				'missed_total'      => 60,
-			]
+			],
+			'Subscription was processed.'
 		);
-
-		// Next payment date is now in the future.
-		$this->assertGreaterThan( time(), strtotime( $subscription->get_date( 'next_payment' ) ) );
+		$this->assertGreaterThan( time(), strtotime( $subscription->get_date( 'next_payment' ) ), 'Next payment date is now in the future.' );
 	}
 
 	/**
@@ -134,8 +129,6 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 			]
 		);
 		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
-
-		// Subscription was processed.
 		$this->assertEquals(
 			$result,
 			[
@@ -148,11 +141,10 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				'billing_interval'  => $subscription->get_billing_interval(),
 				'missed_periods'    => 3,
 				'missed_total'      => 30,
-			]
+			],
+			'Subscription was processed.'
 		);
-
-		// Next payment date is now in the future.
-		$this->assertGreaterThan( time(), strtotime( $subscription->get_date( 'next_payment' ) ) );
+		$this->assertGreaterThan( time(), strtotime( $subscription->get_date( 'next_payment' ) ), 'Next payment date is now in the future.' );
 	}
 
 	/**
@@ -173,8 +165,6 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 			]
 		);
 		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
-
-		// Subscription was processed.
 		$this->assertEquals(
 			$result,
 			[
@@ -187,10 +177,9 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				'billing_interval'  => $subscription->get_billing_interval(),
 				'missed_periods'    => 6,
 				'missed_total'      => 60,
-			]
+			],
+			'Subscription was processed.'
 		);
-
-		// Next payment date not set because the end date will occur first.
-		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
+		$this->assertEmpty( $subscription->get_date( 'next_payment' ), 'Next payment date not set because the end date will occur first.' );
 	}
 }

--- a/tests/unit-tests/woocommerce-cli.php
+++ b/tests/unit-tests/woocommerce-cli.php
@@ -66,7 +66,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
 
 		// Subscription wasn't processed.
-		$this->assertFalse( $result );
+		$this->assertFalse( $result, Subscription wasn't processed. );
 	}
 
 	/**

--- a/tests/unit-tests/woocommerce-cli.php
+++ b/tests/unit-tests/woocommerce-cli.php
@@ -63,7 +63,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				],
 			]
 		);
-		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
+		$result = WooCommerce_Cli::validate_subscription_dates( $subscription );
 		$this->assertFalse( $result, 'Healthy subscription wasn’t processed.' );
 	}
 
@@ -83,7 +83,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				],
 			]
 		);
-		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
+		$result = WooCommerce_Cli::validate_subscription_dates( $subscription );
 		$this->assertEquals(
 			$result,
 			[
@@ -128,7 +128,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				],
 			]
 		);
-		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
+		$result = WooCommerce_Cli::validate_subscription_dates( $subscription );
 		$this->assertEquals(
 			$result,
 			[
@@ -164,7 +164,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				],
 			]
 		);
-		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
+		$result = WooCommerce_Cli::validate_subscription_dates( $subscription );
 		$this->assertEquals(
 			$result,
 			[

--- a/tests/unit-tests/woocommerce-cli.php
+++ b/tests/unit-tests/woocommerce-cli.php
@@ -104,7 +104,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 		);
 
 		// Next payment date is now in the future.
-		$this->assertGreaterThan( time(), strtotime( $result['next_payment_date'] ) );
+		$this->assertGreaterThan( time(), strtotime( $subscription->get_date( 'next_payment' ) ) );
 	}
 
 	/**
@@ -152,7 +152,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 		);
 
 		// Next payment date is now in the future.
-		$this->assertGreaterThan( time(), strtotime( $result['next_payment_date'] ) );
+		$this->assertGreaterThan( time(), strtotime( $subscription->get_date( 'next_payment' ) ) );
 	}
 
 	/**
@@ -174,7 +174,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 		);
 		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
 
-		// Subscription was processed, but next payment date not set because the end date will occur first..
+		// Subscription was processed.
 		$this->assertEquals(
 			$result,
 			[
@@ -189,5 +189,8 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				'missed_total'      => 60,
 			]
 		);
+
+		// Next payment date not set because the end date will occur first.
+		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
 	}
 }

--- a/tests/unit-tests/woocommerce-cli.php
+++ b/tests/unit-tests/woocommerce-cli.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Tests CLI scripts for WooComerce.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Cli;
+
+/**
+ * Tests the Webhooks functionality.
+ */
+class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
+	/**
+	 * A user to assign test subscriptions/orders.
+	 *
+	 * @var int
+	 */
+	private static $user_id = null;
+
+	/**
+	 * Set up before class.
+	 */
+	public static function set_up_before_class() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		self::$user_id = wp_insert_user(
+			[
+				'user_login' => 'test_user',
+				'user_email' => 'test@example.com',
+				'user_pass'  => 'password',
+				'meta_input' => [
+					'first_name'     => 'John',
+					'last_name'      => 'Doe',
+					'wc_total_spent' => 100,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Test a healthy subscription that has a future next_payment date.
+	 */
+	public function test_healthy_subscription() {
+		$subscription = new WC_Subscription(
+			[
+				'id'               => 1,
+				'status'           => 'active',
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+				'total'            => 10, // Amount of recurring payment.
+				'dates'            => [
+					'start'        => gmdate( 'Y-m-d H:i:s', strtotime( '-6 month' ) ),
+					'next_payment' => gmdate( 'Y-m-d H:i:s', strtotime( '+10 day' ) ),
+				],
+				'orders'           => [
+					wc_create_order(
+						[
+							'customer_id'    => self::$user_id,
+							'status'         => 'completed',
+							'total'          => 10,
+							'date_completed' => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+						]
+					),
+				],
+			]
+		);
+		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
+
+		// Subscription wasn't processed.
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test a subscription that's missing a next payment date and has no successful orders.
+	 */
+	public function test_missing_next_payment_date() {
+		$subscription = new WC_Subscription(
+			[
+				'id'               => 2,
+				'status'           => 'active',
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+				'total'            => 10, // Amount of recurring payment.
+				'dates'            => [
+					'start' => gmdate( 'Y-m-d H:i:s', strtotime( '-6 month' ) ),
+				],
+			]
+		);
+		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
+
+		// Subscription was processed.
+		$this->assertEquals(
+			$result,
+			[
+				'ID'                => $subscription->get_id(),
+				'status'            => $subscription->get_status(),
+				'start_date'        => $subscription->get_date( 'start' ),
+				'next_payment_date' => $subscription->calculate_date( 'next_payment' ),
+				'end_date'          => $subscription->get_date( 'end' ),
+				'billing_period'    => $subscription->get_billing_period(),
+				'billing_interval'  => $subscription->get_billing_interval(),
+				'missed_periods'    => 6,
+				'missed_total'      => 60,
+			]
+		);
+
+		// Next payment date is now in the future.
+		$this->assertGreaterThan( time(), strtotime( $result['next_payment_date'] ) );
+	}
+
+	/**
+	 * Test a subscription that's missing a next payment date but has a successful order.
+	 */
+	public function test_missing_next_payment_date_with_order() {
+		$subscription = new WC_Subscription(
+			[
+				'id'               => 3,
+				'status'           => 'active',
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+				'total'            => 10, // Amount of recurring payment.
+				'dates'            => [
+					'start' => gmdate( 'Y-m-d H:i:s', strtotime( '-6 month' ) ),
+				],
+				'orders'           => [
+					wc_create_order(
+						[
+							'customer_id'    => self::$user_id,
+							'status'         => 'completed',
+							'total'          => 10,
+							'date_completed' => gmdate( 'Y-m-d H:i:s', strtotime( '-3 month' ) ),
+						]
+					),
+				],
+			]
+		);
+		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
+
+		// Subscription was processed.
+		$this->assertEquals(
+			$result,
+			[
+				'ID'                => $subscription->get_id(),
+				'status'            => $subscription->get_status(),
+				'start_date'        => $subscription->get_date( 'start' ),
+				'next_payment_date' => $subscription->calculate_date( 'next_payment' ),
+				'end_date'          => $subscription->get_date( 'end' ),
+				'billing_period'    => $subscription->get_billing_period(),
+				'billing_interval'  => $subscription->get_billing_interval(),
+				'missed_periods'    => 3,
+				'missed_total'      => 30,
+			]
+		);
+
+		// Next payment date is now in the future.
+		$this->assertGreaterThan( time(), strtotime( $result['next_payment_date'] ) );
+	}
+
+	/**
+	 * Test a subscription that's missing a next payment date but has an end date before the calculated next payment date.
+	 */
+	public function test_missing_next_payment_date_with_end_date() {
+		$subscription = new WC_Subscription(
+			[
+				'id'               => 4,
+				'status'           => 'active',
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+				'total'            => 10, // Amount of recurring payment.
+				'dates'            => [
+					'start' => gmdate( 'Y-m-d H:i:s', strtotime( '-6 month' ) ),
+					'end'   => gmdate( 'Y-m-d H:i:s', strtotime( '+3 day' ) ),
+				],
+			]
+		);
+		$result = WooCommerce_Cli::calculate_next_payment_date( $subscription );
+
+		// Subscription was processed, but next payment date not set because the end date will occur first..
+		$this->assertEquals(
+			$result,
+			[
+				'ID'                => $subscription->get_id(),
+				'status'            => $subscription->get_status(),
+				'start_date'        => $subscription->get_date( 'start' ),
+				'next_payment_date' => 0,
+				'end_date'          => $subscription->get_date( 'end' ),
+				'billing_period'    => $subscription->get_billing_period(),
+				'billing_interval'  => $subscription->get_billing_interval(),
+				'missed_periods'    => 6,
+				'missed_total'      => 60,
+			]
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a CLI command to report and and optionally fix active or pending subscriptions that have a `next_payment` date in the past, or are missing a `next_payment` date entirely. This could happen if Action Scheduler jobs failed to update or renew subscriptions as scheduled, or as a result of missing data on migrated subscriptions.

### How to test the changes in this Pull Request:

1. Create some subscriptions with missing `next_payment` dates. This must be done using `wp shell` (replace `888` with a subscription ID on your test site) as the UI has safeguards to prevent the deletion of next payment dates. Make sure to do this for at least a few subscriptions that meet the following criteria:

  - A subscription started within the past 90 days
  - A subscription started more than 90 days ago
  - A subscription with no end date
  - A subscription with an end date BEFORE when the next payment date should be
  - A subscription with an end date AFTER when the next payment date
  - A subscription with at least one completed order
  - A subscription with no successful orders (you may need to create this one manually in the admin dashboard)

```bash
> $sub = wcs_get_subscription( 888 )
= WC_Subscription {#15359
    +refunds: null,
    +order_type: "shop_subscription",
  }

> $sub->delete_date( 'next_payment' ) // OR, update the `next_payment` date to a date in the past with $sub->update_dates( [ 'next_payment' => '2024-09-01 21:13:36' ] )
= null

> $sub->save()
= 888
```

2. Run the new CLI command in dry run mode and confirm it reports the subscriptions and missed total revenue, but without actually updating the subscriptions' `next_payment` dates:

```bash
$ wp newspack-woocommerce fix_missing_next_payment_dates --dry-run

===================
=     DRY RUN     =
===================


Fetching active subscriptions with missing or missed next_payment dates...

+-----+--------+---------------------+---------------------+---------------------+----------------+----------------+--------------+
| ID  | status | start_date          | next_payment_date   | end_date            | billing_period | missed_periods | missed_total |
+-----+--------+---------------------+---------------------+---------------------+----------------+----------------+--------------+
| 969 | active | 2023-11-04 20:25:12 | 0                   | 2024-11-04 22:25:44 | month          | 12             | 2400         |
| 888 | active | 2024-06-01 21:13:36 | 2024-12-01 21:13:36 | 0                   | month          | 5              | 250          |
| 475 | active | 2024-08-05 20:36:11 | 2024-11-11 19:24:45 | 0                   | month          | 0              | 0            |
+-----+--------+---------------------+---------------------+---------------------+----------------+----------------+--------------+
Success: Finished processing 3 subscriptions. Total missed revenue: $2,650.00
```

3. In the reported results, ensure the following are true:

  - Only subscriptions started in the past 90 days are handled
  - Subscriptions with no end date get a newly calculated `next_payment` date (reported in the `next_payment_date` column)
  - Subscriptions with a far-future end date should get a newly calculated `next_payment` date before the end date
  - Subscriptions with an imminent end date don't get a new `next_payment` date (they should show `0` in the `next_payment_date` column)
  - Missed periods and total values accurately reflect the number of renewals that should have occurred since the most recent completed renewal order (if any) or the subscription start (if no orders), and based on the subscription product's billing interval and period (e.g. every month/year, every 6 months, etc.).

4. Re-run the command with a `--start-date` arg in `YYYY-MM-DD` format and confirm that the command only reports subscriptions started after the given date.
5. Re-run the command without `--dry-run` and confirm that the command provides the same report data as in step 2, but also updates the subscriptions with the reported `next_payment` dates.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206214865188773