### PR TITLE
fix(site-kit): update logger cron to hourly interval

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit-logger.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit-logger.php
@@ -47,7 +47,7 @@ class GoogleSiteKit_Logger {
 		if ( defined( 'NEWSPACK_CRON_DISABLE' ) && is_array( NEWSPACK_CRON_DISABLE ) && in_array( self::CRON_HOOK, NEWSPACK_CRON_DISABLE, true ) ) {
 			self::cron_deactivate();
 		} elseif ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+			wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR updates the site kit logger cron job from daily to hourly.

See https://a8c.slack.com/archives/C06G94HSV5G/p1729283797459139?thread_ts=1729283190.506369&cid=C06G94HSV5G for more details.

### How to test the changes in this Pull Request:

1. Tunnel your local site so your URL is public and connect Google Site Kit
2. Access admin via the local url (not the public one) to trigger a Site Kit disconnect.
3. Using something like WP-Crontrol, verify a new hourly `newspack_googlesitekit_disconnection_logger` cron event is present.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->