### PR TITLE
fix: let "Cover fees" checkbox work with any payment method

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -13,7 +13,8 @@ defined( 'ABSPATH' ) || exit;
  * WooCommerce Order UTM class.
  */
 class WooCommerce_Cover_Fees {
-	const CUSTOM_FIELD_NAME = 'newspack-wc-pay-fees';
+	const CUSTOM_FIELD_NAME  = 'newspack-wc-pay-fees';
+	const SUPPORTED_GATEWAYS = [ 'stripe', 'woocommerce_payments' ];
 
 	/**
 	 * Initialize hooks.
@@ -134,7 +135,7 @@ class WooCommerce_Cover_Fees {
 		if ( ! self::should_allow_covering_fees() ) {
 			return false;
 		}
-		if ( ! isset( $data['payment_method'] ) || 'stripe' !== $data['payment_method'] ) {
+		if ( ! isset( $data['payment_method'] ) || ! in_array( $data['payment_method'], self::SUPPORTED_GATEWAYS, true ) ) {
 			return false;
 		}
 		if ( ! isset( $data[ self::CUSTOM_FIELD_NAME ] ) || '1' !== $data[ self::CUSTOM_FIELD_NAME ] ) {
@@ -149,7 +150,7 @@ class WooCommerce_Cover_Fees {
 	 * @param string $payment_gateway The slug for the payment gateway rendering these payment fields.
 	 */
 	public static function render_stripe_input( $payment_gateway ) {
-		if ( ! self::should_allow_covering_fees() || 'stripe' !== $payment_gateway ) {
+		if ( ! self::should_allow_covering_fees() || ! in_array( $payment_gateway, self::SUPPORTED_GATEWAYS, true ) ) {
 			return;
 		}
 		?>

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -23,7 +23,7 @@ class WooCommerce_Cover_Fees {
 		\add_action( 'woocommerce_checkout_update_order_review', [ __CLASS__, 'persist_fee_selection' ] );
 		\add_action( 'woocommerce_cart_calculate_fees', [ __CLASS__, 'add_transaction_fee' ] );
 		\add_action( 'woocommerce_checkout_order_processed', [ __CLASS__, 'add_order_note' ], 1, 3 );
-		\add_action( 'wc_stripe_payment_fields_stripe', [ __CLASS__, 'render_stripe_input' ] );
+		\add_action( 'newspack_blocks_after_payment_fields', [ __CLASS__, 'render_stripe_input' ] );
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'print_checkout_helper_script' ] );
 	}
 
@@ -134,7 +134,7 @@ class WooCommerce_Cover_Fees {
 		if ( ! self::should_allow_covering_fees() ) {
 			return false;
 		}
-		if ( ! isset( $data['payment_method'] ) || 'stripe' !== $data['payment_method'] ) {
+		if ( ! isset( $data['payment_method'] ) ) {
 			return false;
 		}
 		if ( ! isset( $data[ self::CUSTOM_FIELD_NAME ] ) || '1' !== $data[ self::CUSTOM_FIELD_NAME ] ) {
@@ -145,8 +145,10 @@ class WooCommerce_Cover_Fees {
 
 	/**
 	 * Render the "cover fees" input for Stripe.
+	 *
+	 * @param string $payment_gateway The slug for the payment gateway rendering these payment fields.
 	 */
-	public static function render_stripe_input() {
+	public static function render_stripe_input( $payment_gateway ) {
 		if ( ! self::should_allow_covering_fees() ) {
 			return;
 		}
@@ -154,7 +156,7 @@ class WooCommerce_Cover_Fees {
 		<fieldset>
 			<p class="form-row newspack-cover-fees" style="display: flex;">
 				<input
-					id="<?php echo esc_attr( self::CUSTOM_FIELD_NAME ); ?>"
+					id="<?php echo esc_attr( self::CUSTOM_FIELD_NAME . '_' . $payment_gateway ); ?>"
 					name="<?php echo esc_attr( self::CUSTOM_FIELD_NAME ); ?>"
 					type="checkbox"
 					style="margin-right: 8px;"
@@ -163,7 +165,7 @@ class WooCommerce_Cover_Fees {
 						checked
 					<?php endif; ?>
 				/>
-				<label for=<?php echo esc_attr( self::CUSTOM_FIELD_NAME ); ?> style="display:inline;">
+				<label for=<?php echo esc_attr( self::CUSTOM_FIELD_NAME . '_' . $payment_gateway ); ?> style="display:inline;">
 					<?php
 					$custom_message = get_option( 'newspack_donations_allow_covering_fees_label', '' );
 					if ( ! empty( $custom_message ) ) {
@@ -210,13 +212,6 @@ class WooCommerce_Cover_Fees {
 			[ 'jquery' ],
 			NEWSPACK_PLUGIN_VERSION,
 			[ 'in_footer' => true ]
-		);
-		wp_localize_script(
-			$handler,
-			'newspack_wc_cover_fees',
-			[
-				'custom_field_name' => self::CUSTOM_FIELD_NAME,
-			]
 		);
 	}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -134,7 +134,7 @@ class WooCommerce_Cover_Fees {
 		if ( ! self::should_allow_covering_fees() ) {
 			return false;
 		}
-		if ( ! isset( $data['payment_method'] ) ) {
+		if ( ! isset( $data['payment_method'] ) || 'stripe' !== $data['payment_method'] ) {
 			return false;
 		}
 		if ( ! isset( $data[ self::CUSTOM_FIELD_NAME ] ) || '1' !== $data[ self::CUSTOM_FIELD_NAME ] ) {
@@ -149,7 +149,7 @@ class WooCommerce_Cover_Fees {
 	 * @param string $payment_gateway The slug for the payment gateway rendering these payment fields.
 	 */
 	public static function render_stripe_input( $payment_gateway ) {
-		if ( ! self::should_allow_covering_fees() ) {
+		if ( ! self::should_allow_covering_fees() || 'stripe' !== $payment_gateway ) {
 			return;
 		}
 		?>

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -118,7 +118,7 @@ class WooCommerce_Cover_Fees {
 			// but at this point handling coupons + covering fees is an edge case.
 			return false;
 		}
-		if ( true !== boolval( get_option( 'newspack_donations_allow_covering_fees' ) ) ) {
+		if ( true !== boolval( get_option( 'newspack_donations_allow_covering_fees', true ) ) ) {
 			return false;
 		}
 		return true;

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class WooCommerce_Cover_Fees {
 	const CUSTOM_FIELD_NAME  = 'newspack-wc-pay-fees';
-	const SUPPORTED_GATEWAYS = [ 'stripe', 'woocommerce_payments' ];
+	const SUPPORTED_GATEWAYS = [ 'stripe' ];
 
 	/**
 	 * Initialize hooks.

--- a/src/other-scripts/wc-cover-fees/index.js
+++ b/src/other-scripts/wc-cover-fees/index.js
@@ -1,23 +1,39 @@
-/* globals jQuery, newspack_wc_cover_fees */
+/* globals jQuery */
 ( function ( $ ) {
 	if ( ! $ ) {
 		return;
 	}
 	const $body = $( document.body );
+	const getInputs = function () {
+		return Array.from( document.querySelectorAll( '.newspack-cover-fees input' ) );
+	};
 	$body.on( 'init_checkout', function () {
 		const form = document.querySelector( 'form.checkout' );
 		if ( ! form ) {
 			return;
 		}
-		let checked = document.getElementById( newspack_wc_cover_fees.custom_field_name )?.checked;
+		let checked = document.querySelector( '.newspack-cover-fees input' )?.checked;
 		form.addEventListener( 'change', function () {
-			// Get element on every change because the DOM is replaced by AJAX.
-			const input = document.getElementById( newspack_wc_cover_fees.custom_field_name );
-			if ( ! input ) {
+			// Get elements on every change because the DOM is replaced by AJAX.
+			const inputs = getInputs();
+			if ( ! inputs.length ) {
 				return;
 			}
-			if ( checked !== input.checked ) {
-				checked = input.checked;
+
+			// Check if any checkbox has changed.
+			const update = inputs.find( function ( input ) {
+				if ( input.checked !== checked ) {
+					return true;
+				}
+				return false;
+			} );
+
+			// Update checked state of all checkboxes.
+			if ( update ) {
+				checked = update.checked;
+				inputs.forEach( function ( input ) {
+					input.checked = checked;
+				} );
 				$body.trigger( 'update_checkout', { update_shipping_method: false } );
 			}
 		} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-blocks/pull/1915, uses a custom hook to render the "cover transaction fees" checkbox for every payment method rendered in the Woo checkout flow. This allows the "cover transaction fees" option to be shown after any payment fields instead of relying on a custom hook in the Stripe payment gateway plugin that's tied to the "legacy" Stripe checkout experience.

### How to test the changes in this Pull Request:

1. Start on `release` for this repo and Newspack Blocks.
2. In Newspack > Reader Revenue > Stripe Settings, ensure that "Allow donors to cover transaction fees" is checked.
3. In WooCommerce > Settings > Payments, enable the Stripe payment gateway, ~the WooPayments gateway,~ and at least one other payment method (such as "Check payments").
4. In WooCommerce > Settings > Payments > Stripe > Manage > Settings > Advanced Settings, make sure the "Enable the legacy checkout experience" option is **unchecked**:

<img width="1059" alt="Screenshot 2024-10-21 at 3 16 07 PM" src="https://github.com/user-attachments/assets/84993ac3-0fd3-45ec-9d52-5657a600903f">

5. As a reader, start a donation checkout via the Donate block and proceed to the second screen (payment methods).
6. Select "credit/debit card" for the Stripe payment gateway and observe that the transaction fees checkbox doesn't appear here.
7. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/1915 and refresh the modal checkout, or start a new donation and proceed to the payment screen again. Confirm that the transaction fees checkbox DOES appear for the Stripe ~and WooPayments~ payment methods, but not any other payment methods. 
8. Confirm that the fee is displayed in a price breakdown when the checkbox is selected, and that the price breakdown is hidden when the checkbox is unselected. ~Also confirm that the fee status persists when switching between Stripe and WooPayments, and that the checkbox states for each payment method always match between the two.~
9. Complete a donation with the checkbox both checked and unchecked, and confirm that the order total includes the fee only if the checkbox is checked.
10. Also complete a donation by checking the box, then switching to a payment method other than Stripe ~or WooPayments~. Confirm that the fee is hidden when switching to an unsupported payment method, and that the order total upon completion with that payment method does not include the fee.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->