### PR TITLE
fix(webhooks): deprecate global endpoint

### DIFF
--- a/includes/data-events/class-api.php
+++ b/includes/data-events/class-api.php
@@ -102,7 +102,7 @@ final class Api {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return new \WP_Error(
 				'newspack_rest_forbidden',
-				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				esc_html__( 'You cannot use this resource.', 'newspack-plugin' ),
 				[
 					'status' => 403,
 				]
@@ -165,7 +165,7 @@ final class Api {
 				[
 					'success' => false,
 					'code'    => false,
-					'message' => esc_html__( 'Invalid URL.', 'newspack' ),
+					'message' => esc_html__( 'Invalid URL.', 'newspack-plugin' ),
 				]
 			);
 		}

--- a/includes/data-events/class-api.php
+++ b/includes/data-events/class-api.php
@@ -129,9 +129,6 @@ final class Api {
 					'sanitize_callback' => 'sanitize_text_field',
 				],
 			],
-			'global'       => [
-				'type' => 'boolean',
-			],
 			'disabled'     => [
 				'type' => 'boolean',
 			],
@@ -249,16 +246,16 @@ final class Api {
 		if ( empty( $args['url'] ) || \esc_url_raw( $args['url'], [ 'https' ] ) !== $args['url'] ) {
 			return new \WP_Error(
 				'newspack_webhooks_invalid_url',
-				esc_html__( 'Invalid URL.', 'newspack' ),
+				esc_html__( 'Invalid URL.', 'newspack-plugin' ),
 				[
 					'status' => 400,
 				]
 			);
 		}
-		if ( ! $args['global'] && empty( $args['actions'] ) ) {
+		if ( empty( $args['actions'] ) ) {
 			return new \WP_Error(
 				'newspack_webhooks_invalid_actions',
-				esc_html__( 'You must select actions to trigger this endpoint. Set it to global if this endpoint is meant for all actions.', 'newspack' ),
+				esc_html__( 'You must select actions to trigger this endpoint.', 'newspack-plugin' ),
 				[
 					'status' => 400,
 				]
@@ -267,15 +264,13 @@ final class Api {
 		if ( empty( $args['id'] ) ) {
 			$endpoint = Webhooks::create_endpoint(
 				$args['url'],
-				$args['actions'] ?? [],
-				$args['global']
+				$args['actions'] ?? []
 			);
 		} else {
 			$endpoint = Webhooks::update_endpoint(
 				$args['id'],
 				$args['url'],
 				$args['actions'] ?? [],
-				$args['global'],
 				$args['disabled']
 			);
 		}

--- a/src/components/src/modal/index.js
+++ b/src/components/src/modal/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies.
  */
-import { Component } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import { Modal as BaseComponent } from '@wordpress/components';
 
 /**
@@ -18,21 +18,15 @@ import './style.scss';
  */
 import classnames from 'classnames';
 
-class Modal extends Component {
-	/**
-	 * Render.
-	 */
-	render() {
-		const { className, isWide, isNarrow, ...otherProps } = this.props;
-		const classes = classnames(
-			'newspack-modal',
-			isWide && 'newspack-modal--wide',
-			isNarrow && 'newspack-modal--narrow',
-			className
-		);
+function Modal( { className, isWide, isNarrow, ...otherProps }, ref ) {
+	const classes = classnames(
+		'newspack-modal',
+		isWide && 'newspack-modal--wide',
+		isNarrow && 'newspack-modal--narrow',
+		className
+	);
 
-		return <BaseComponent className={ classes } { ...otherProps } />;
-	}
+	return <BaseComponent className={ classes } { ...otherProps } ref={ ref } />;
+
 }
-
-export default Modal;
+export default forwardRef( Modal );

--- a/src/wizards/connections/views/main/webhooks.js
+++ b/src/wizards/connections/views/main/webhooks.js
@@ -266,7 +266,7 @@ const Webhooks = () => {
 				/>
 				<Button
 					variant="primary"
-					onClick={ () => setEditing( { global: true } ) }
+					onClick={ () => setEditing( {} ) }
 					disabled={ inFlight }
 				>
 					{ __( 'Add New Endpoint', 'newspack-plugin' ) }
@@ -298,17 +298,10 @@ const Webhooks = () => {
 								return (
 									<>
 										{ __( 'Actions:', 'newspack-plugin' ) }{ ' ' }
-										{ endpoint.global ? (
-											<span className="newspack-webhooks__endpoint__action">
-												{ __( 'global', 'newspack-plugin' ) }
-											</span>
-										) : (
-											endpoint.actions.map( action => (
-												<span key={ action } className="newspack-webhooks__endpoint__action">
-													{ action }
-												</span>
-											) )
-										) }
+										{ endpoint.actions.map( action => (
+											<span key={ action } className="newspack-webhooks__endpoint__action">
+												{ action }
+											</span> ) ) }
 									</>
 								);
 							} }
@@ -521,21 +514,11 @@ const Webhooks = () => {
 					/>
 					<Grid columns={ 1 } gutter={ 16 }>
 						<h3>{ __( 'Actions', 'newspack-plugin' ) }</h3>
-						<CheckboxControl
-							checked={ editing.global }
-							onChange={ value => setEditing( { ...editing, global: value } ) }
-							label={ __( 'Global', 'newspack-plugin' ) }
-							help={ __(
-								'Leave this checked if you want this endpoint to receive data from all actions.',
-								'newspack-plugin'
-							) }
-							disabled={ inFlight }
-						/>
 						{ actions.length > 0 && (
 							<>
 								<p>
 									{ __(
-										'If this endpoint is not global, select which actions should trigger this endpoint:',
+										'Select which actions should trigger this endpoint:',
 										'newspack-plugin'
 									) }
 								</p>
@@ -543,10 +526,9 @@ const Webhooks = () => {
 									{ actions.map( ( action, i ) => (
 										<CheckboxControl
 											key={ i }
-											disabled={ editing.global || inFlight }
+											disabled={ inFlight }
 											label={ action }
 											checked={ ( editing.actions && editing.actions.includes( action ) ) || false }
-											indeterminate={ editing.global }
 											onChange={ () => {
 												const currentActions = editing.actions || [];
 												if ( currentActions.includes( action ) ) {

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -200,7 +200,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 		);
 		$request_id = Data_Events\Webhooks::get_endpoint_requests( $this->action_endpoint )[0]['id'];
 		wp_publish_post( $request_id );
-		$this->assertEquals( 'https://example.com/webhook', $http_url );
+		$this->assertEquals( 'https://example.com/webhook/test_action', $http_url );
 		$this->assertEquals( 'POST', $http_args['method'] );
 		$this->assertEquals( 'application/json', $http_args['headers']['Content-Type'] );
 		$this->assertEquals( get_post_meta( $request_id, 'body', true ), $http_args['body'] );
@@ -331,10 +331,10 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 	public function test_system_endpoint() {
 		Data_Events\Webhooks::register_system_endpoint( 'test', 'https://example.com/test' );
 		$endpoints = Data_Events\Webhooks::get_endpoints();
-		$this->assertSame( 4, count( $endpoints ) );
-		$this->assertSame( 'test', $endpoints[3]['id'] );
-		$this->assertTrue( $endpoints[3]['system'] );
-		$this->assertFalse( $endpoints[2]['system'] );
+		$this->assertSame( 3, count( $endpoints ) );
+		$this->assertSame( 'test', $endpoints[2]['id'] );
+		$this->assertTrue( $endpoints[2]['system'] );
+		$this->assertFalse( $endpoints[1]['system'] );
 
 		$ep = Data_Events\Webhooks::get_endpoint( 'test' );
 		$this->assertSame( 'test', $ep['id'] );
@@ -345,17 +345,13 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 	 * Tests that getting endpoint requests fetch requests for system endpoints.
 	 */
 	public function test_get_endpoint_requests() {
-		Data_Events\Webhooks::register_system_endpoint( 'test-2', 'https://example.com/test', [], true );
-		Data_Events\Webhooks::register_system_endpoint( 'test-3', 'https://example2.com/test', [ 'test_action' ] );
+		Data_Events\Webhooks::register_system_endpoint( 'test-2', 'https://example2.com/test', [ 'test_action' ] );
 		$this->dispatch_event();
 
 		$requests = Data_Events\Webhooks::get_endpoint_requests( $this->action_endpoint );
 		$this->assertSame( 1, count( $requests ) );
 
 		$requests = Data_Events\Webhooks::get_endpoint_requests( 'test-2' );
-		$this->assertSame( 1, count( $requests ) );
-
-		$requests = Data_Events\Webhooks::get_endpoint_requests( 'test-3' );
 		$this->assertSame( 1, count( $requests ) );
 	}
 

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -68,6 +68,22 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Teardown.
+	 */
+	public function tear_down() {
+		// Remove all endpoints.
+		$terms = get_terms(
+			[
+				'taxonomy'   => Data_Events\Webhooks::ENDPOINT_TAXONOMY,
+				'hide_empty' => false,
+			]
+		);
+		foreach ( $terms as $term ) {
+			wp_delete_term( $term->term_id, Data_Events\Webhooks::ENDPOINT_TAXONOMY );
+		}
+	}
+
+	/**
 	 * Dispatch a sample data event.
 	 *
 	 * @param string $action_name Action name.

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -147,8 +147,8 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 	 */
 	public function test_disable_endpoint() {
 		Data_Events\Webhooks::disable_endpoint( $this->action_endpoint );
-		$endpoints = Data_Events\Webhooks::get_endpoints();
-		$this->assertEquals( true, $endpoints[0]['disabled'] );
+		$endpoint = Data_Events\Webhooks::get_endpoint( $this->action_endpoint );
+		$this->assertEquals( true, $endpoints['disabled'] );
 	}
 
 	/**
@@ -277,8 +277,8 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 			$retries++;
 		}
 
-		$endpoints = Data_Events\Webhooks::get_endpoints();
-		$this->assertTrue( $endpoints[0]['disabled'] );
+		$endpoint = Data_Events\Webhooks::get_endpoint( $this->action_endpoint );
+		$this->assertTrue( $endpoints['disabled'] );
 	}
 
 	/**

--- a/tests/unit-tests/webhooks.php
+++ b/tests/unit-tests/webhooks.php
@@ -148,7 +148,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 	public function test_disable_endpoint() {
 		Data_Events\Webhooks::disable_endpoint( $this->action_endpoint );
 		$endpoint = Data_Events\Webhooks::get_endpoint( $this->action_endpoint );
-		$this->assertEquals( true, $endpoints['disabled'] );
+		$this->assertEquals( true, $endpoint['disabled'] );
 	}
 
 	/**
@@ -278,7 +278,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 		}
 
 		$endpoint = Data_Events\Webhooks::get_endpoint( $this->action_endpoint );
-		$this->assertTrue( $endpoints['disabled'] );
+		$this->assertTrue( $endpoint['disabled'] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1208602681752393/f

Global webhook endpoints can be very disruptive to the site as our data events base grows. There's no clear use for such a feature, so we should deprecate it for now.

### How to test the changes in this Pull Request:

1. Make sure you have `define( 'NEWSPACK_EXPERIMENTAL_WEBHOOKS', true );` in your `wp-config.php`
2. Checkout this branch and visit "Newspack -> Connections"
3. Create a new endpoint and confirm the global checkbox is no longer an option
4. Attempt to save without selecting any actions and confirm you get an error message
5. Set the endpoint URL (use https://webook.site), select the `reader_logged_in` action and save
6. In a new session, authenticate as a reader
7. In the dashboard, click the endpoint's card "View Requests" and confirm the request is created
8. Wait until it's processed and confirm the endpoint receives the data

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208602681752393