### PR TITLE
Fix(epic-ia): hidden menu on php8

### DIFF
--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -146,7 +146,7 @@ class Advertising_Sponsors extends Wizard {
 
 		// Register Settings page.
 		add_submenu_page(
-			null, // No parent menu item, means its not on the menu.
+			'', // No parent menu item, means its not on the menu.
 			__( 'Newspack Sponsors: Site-Wide Settings', 'newspack-sponsors' ),
 			__( 'Settings', 'newspack-sponsors' ),
 			'manage_options',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes issue in PHP 8.  Blank string is now preferred when hiding a menu item.  Null will write a deprecation notice to debug.log.  Attached.

![image](https://github.com/user-attachments/assets/132622c0-b33c-4711-b536-db51e0781349)


### How to test the changes in this Pull Request:

1. Pull branch.
2. Activate plugin.
3. Login to wp-admin so that the admin menu loads.
4. Check wp-content/debug.log.  (Assumes you have debug logging on.)
5. Debug log will no longer write deprecation notice now that null has been replaced with ''.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->