### PR TITLE
feat(ia-admin-header-selected): Allow ability to force selected tab

### DIFF
--- a/src/wizards/admin-header/index.tsx
+++ b/src/wizards/admin-header/index.tsx
@@ -29,7 +29,7 @@ export function WizardsAdminHeader( {
 			<div className="newspack-tabbed-navigation">
 				<ul>
 					{ tabs.map( ( tab, i ) => {
-						const selected = ( tab.forceSelected ) ? true : window.location.href === tab.href;
+						const selected = tab.forceSelected ? true : window.location.href === tab.href;
 						return (
 							<li key={ `${ tab.textContent }:${ i }` }>
 								<a

--- a/src/wizards/admin-header/index.tsx
+++ b/src/wizards/admin-header/index.tsx
@@ -10,6 +10,7 @@ export function WizardsAdminHeader( {
 	tabs: Array< {
 		textContent: string;
 		href: string;
+		forceSelected: boolean;
 	} >;
 } ) {
 	return (
@@ -28,12 +29,13 @@ export function WizardsAdminHeader( {
 			<div className="newspack-tabbed-navigation">
 				<ul>
 					{ tabs.map( ( tab, i ) => {
+						const selected = ( tab.forceSelected ) ? true : window.location.href === tab.href;
 						return (
 							<li key={ `${ tab.textContent }:${ i }` }>
 								<a
 									href={ tab.href }
 									className={
-										window.location.href === tab.href
+										selected
 											? 'selected'
 											: ''
 									}

--- a/src/wizards/types/window.d.ts
+++ b/src/wizards/types/window.d.ts
@@ -4,6 +4,7 @@ declare global {
 			tabs: Array< {
 				textContent: string;
 				href: string;
+				forceSelected: boolean;
 			} >;
 			title: string;
 		};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows ability to force a tab to be selected for Admin Header.  Some URLs are hard to match, like when editing a taxonomy term.  URL:

`/wp-admin/term.php?taxonomy=newspack_nl_advertiser&tag_ID=32&post_type=newspack_nl_cpt&wp_http_referer=%2Fwp-admin%2Fedit-tags.php%3Ftaxonomy%3Dnewspack_nl_advertiser%26post_type%3Dnewspack_nl_cpt`

Due to the dynamic nature of this URL, we need a way to highlight the correct Admin Header tab programmatically.

A visual display is here:

![image](https://github.com/user-attachments/assets/9c6ecfe6-68f2-40b4-b4cf-300c957eb4b1)

To do this, the PHP code would be:

```
$this->admin_header_init(
	[
		'tabs'  => [
			[
				'textContent' => esc_html__( 'Ads', 'newspack-plugin' ),
				'href'        => admin_url( 'edit.php?post_type=newspack_nl_ads_cpt' ),
			],
			[
				'textContent'   => esc_html__( 'Advertisers', 'newspack-plugin' ),
				'href'          => admin_url( 'edit-tags.php?taxonomy=newspack_nl_advertiser&post_type=newspack_nl_cpt' ),
				'forceSelected' => ( 'newspack_nl_advertiser' === $screen_slug ),
			],
		],
		'title' => $this->get_name(), 
	]
);
```

The element `forceSelected` is optional.  It can be set directly to `true` or it can be used with `str_contains` or `preg_match` or your own PHP function that might inspect the current wp-admin URL and make a determination if `true` needs to be set or not.

### How to test the changes in this Pull Request:

1. Pull branch.
2. Activate pluign.
3. `npm run build`
4. Add `'forceSelected' => true,` to an IA Wizard that uses the `Admin_Header` trait and tabs.
5. View in web browser that tab will be selected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->