### PR TITLE
fix: override button, text styles

### DIFF
--- a/src/newspack-ui/scss/elements/_typography.scss
+++ b/src/newspack-ui/scss/elements/_typography.scss
@@ -6,6 +6,8 @@
 	-webkit-font-smoothing: antialiased;
 
 	p {
+		font-size: inherit;
+		line-height: inherit;
 		margin: var(--newspack-ui-spacer-2) 0;
 	}
 
@@ -30,57 +32,57 @@
 		font-weight: normal;
 	}
 
-	&__font--2xs {
+	.newspack-ui__font--2xs {
 		font-size: var(--newspack-ui-font-size-2xs);
 		line-height: var(--newspack-ui-line-height-2xs);
 	}
 
-	&__font--xs {
+	.newspack-ui__font--xs {
 		font-size: var(--newspack-ui-font-size-xs);
 		line-height: var(--newspack-ui-line-height-xs);
 	}
 
-	&__font--s {
+	.newspack-ui__font--s {
 		font-size: var(--newspack-ui-font-size-s);
 		line-height: var(--newspack-ui-line-height-s);
 	}
 
-	&__font--m {
+	.newspack-ui__font--m {
 		font-size: var(--newspack-ui-font-size-m);
 		line-height: var(--newspack-ui-line-height-m);
 	}
 
-	&__font--l {
+	.newspack-ui__font--l {
 		font-size: var(--newspack-ui-font-size-l);
 		line-height: var(--newspack-ui-line-height-l);
 	}
 
-	&__font--xl {
+	.newspack-ui__font--xl {
 		font-size: var(--newspack-ui-font-size-xl);
 		line-height: var(--newspack-ui-line-height-xl);
 	}
 
-	&__font--2xl {
+	.newspack-ui__font--2xl {
 		font-size: var(--newspack-ui-font-size-2xl);
 		line-height: var(--newspack-ui-line-height-2xl);
 	}
 
-	&__font--3xl {
+	.newspack-ui__font--3xl {
 		font-size: var(--newspack-ui-font-size-3xl);
 		line-height: var(--newspack-ui-line-height-3xl);
 	}
 
-	&__font--4xl {
+	.newspack-ui__font--4xl {
 		font-size: var(--newspack-ui-font-size-4xl);
 		line-height: var(--newspack-ui-line-height-4xl);
 	}
 
-	&__font--5xl {
+	.newspack-ui__font--5xl {
 		font-size: var(--newspack-ui-font-size-5xl);
 		line-height: var(--newspack-ui-line-height-5xl);
 	}
 
-	&__font--6xl {
+	.newspack-ui__font--6xl {
 		font-size: var(--newspack-ui-font-size-6xl);
 		line-height: var(--newspack-ui-line-height-6xl);
 	}

--- a/src/newspack-ui/scss/elements/_typography.scss
+++ b/src/newspack-ui/scss/elements/_typography.scss
@@ -17,6 +17,8 @@
 	h6 {
 		font-family: var(--newspack-ui-font-family);
 		font-weight: var(--newspack-ui-font-weight-strong);
+		letter-spacing: unset;
+		text-transform: unset;
 	}
 
 	strong,

--- a/src/newspack-ui/scss/elements/_typography.scss
+++ b/src/newspack-ui/scss/elements/_typography.scss
@@ -32,57 +32,57 @@
 		font-weight: normal;
 	}
 
-	.newspack-ui__font--2xs {
+	& &__font--2xs {
 		font-size: var(--newspack-ui-font-size-2xs);
 		line-height: var(--newspack-ui-line-height-2xs);
 	}
 
-	.newspack-ui__font--xs {
+	& &__font--xs {
 		font-size: var(--newspack-ui-font-size-xs);
 		line-height: var(--newspack-ui-line-height-xs);
 	}
 
-	.newspack-ui__font--s {
+	& &__font--s {
 		font-size: var(--newspack-ui-font-size-s);
 		line-height: var(--newspack-ui-line-height-s);
 	}
 
-	.newspack-ui__font--m {
+	& &__font--m {
 		font-size: var(--newspack-ui-font-size-m);
 		line-height: var(--newspack-ui-line-height-m);
 	}
 
-	.newspack-ui__font--l {
+	& &__font--l {
 		font-size: var(--newspack-ui-font-size-l);
 		line-height: var(--newspack-ui-line-height-l);
 	}
 
-	.newspack-ui__font--xl {
+	& &__font--xl {
 		font-size: var(--newspack-ui-font-size-xl);
 		line-height: var(--newspack-ui-line-height-xl);
 	}
 
-	.newspack-ui__font--2xl {
+	& &__font--2xl {
 		font-size: var(--newspack-ui-font-size-2xl);
 		line-height: var(--newspack-ui-line-height-2xl);
 	}
 
-	.newspack-ui__font--3xl {
+	& &__font--3xl {
 		font-size: var(--newspack-ui-font-size-3xl);
 		line-height: var(--newspack-ui-line-height-3xl);
 	}
 
-	.newspack-ui__font--4xl {
+	& &__font--4xl {
 		font-size: var(--newspack-ui-font-size-4xl);
 		line-height: var(--newspack-ui-line-height-4xl);
 	}
 
-	.newspack-ui__font--5xl {
+	& &__font--5xl {
 		font-size: var(--newspack-ui-font-size-5xl);
 		line-height: var(--newspack-ui-line-height-5xl);
 	}
 
-	.newspack-ui__font--6xl {
+	& &__font--6xl {
 		font-size: var(--newspack-ui-font-size-6xl);
 		line-height: var(--newspack-ui-line-height-6xl);
 	}

--- a/src/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/src/newspack-ui/scss/elements/forms/_buttons.scss
@@ -9,6 +9,7 @@
 		display: inline-flex;
 		font-family: var(--newspack-ui-font-family);
 		font-size: var(--newspack-ui-font-size-s);
+		font-style: normal;
 		font-weight: 600;
 		gap: calc(var(--newspack-ui-spacer-base) / 2);
 		letter-spacing: initial; // Override for custom styles.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR, along with https://github.com/Automattic/newspack-blocks/pull/1922, fixes some minor styling issues I spotted when testing RAS-ACC with the custom CSS from ~20 of our publisher sites.

Please see the steps in https://github.com/Automattic/newspack-blocks/pull/1922 for testing.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->