### PR TITLE
feat(starter-content): e2e improvements; removal CLI command

### DIFF
--- a/includes/class-starter-content.php
+++ b/includes/class-starter-content.php
@@ -226,6 +226,6 @@ class Starter_Content {
 	 * @return bool E2E testing environment?
 	 */
 	public static function is_e2e() {
-		return defined( 'WP_NEWSPACK_IS_E2E' ) && WP_NEWSPACK_IS_E2E;
+		return defined( 'NEWSPACK_IS_E2E' ) && NEWSPACK_IS_E2E;
 	}
 }

--- a/includes/cli/class-initializer.php
+++ b/includes/cli/class-initializer.php
@@ -39,6 +39,7 @@ class Initializer {
 		}
 
 		WP_CLI::add_command( 'newspack setup', 'Newspack\CLI\Setup' );
+		WP_CLI::add_command( 'newspack remove-starter-content', [ 'Newspack\Starter_Content','remove_starter_content' ] );
 
 		// Utility commands for managing RAS data via WP CLI.
 		WP_CLI::add_command(

--- a/includes/cli/class-setup.php
+++ b/includes/cli/class-setup.php
@@ -121,8 +121,9 @@ class Setup {
 			return WP_CLI::error( $response->data['message'] );
 		}
 
-		WP_CLI::line( 'Creating Posts' );
-		for ( $i = 0; $i < 40; $i++ ) {
+		$posts_count = \Newspack\Starter_Content::is_e2e() ? 10 : 40;
+		WP_CLI::line( sprintf( 'Creating %d posts', $posts_count ) );
+		for ( $i = 0; $i < $posts_count; $i++ ) {
 			$request  = new WP_REST_Request( 'POST', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-setup-wizard/starter-content/post/' . $i );
 			$response = rest_do_request( $request );
 			echo '.';

--- a/includes/starter_content/class-starter-content-generated.php
+++ b/includes/starter_content/class-starter-content-generated.php
@@ -57,7 +57,7 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 		}
 		$page_templates = [ '', 'single-feature.php' ];
 		$paragraphs     = explode( PHP_EOL, self::get_lipsum( 'paras', 5 ) );
-		$title          = self::generate_title();
+		$title          = self::generate_title( $post_index );
 		$post_data      = [
 			'post_title'   => $title,
 			'post_name'    => sanitize_title_with_dashes( $title, '', 'save' ),
@@ -247,11 +247,12 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 	/**
 	 * Generate a post title
 	 *
+	 * @param int $post_index The index of the created post.
 	 * @return string The title.
 	 */
-	public static function generate_title() {
+	public static function generate_title( $post_index = 0 ) {
 		if ( Starter_Content::is_e2e() ) {
-			return file_get_contents( NEWSPACK_ABSPATH . 'includes/raw_assets/markup/title.txt' );
+			return $post_index . ' ' . file_get_contents( NEWSPACK_ABSPATH . 'includes/raw_assets/markup/title.txt' );
 		}
 		$title = self::get_lipsum( 'words', wp_rand( 7, 14 ) );
 		$title = ucfirst( strtolower( str_replace( '.', '', $title ) ) ); // Remove periods, convert to sentence case.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Small improvements to how starter content is handled.

### How to test the changes in this Pull Request:

1. Generate starter content with `wp newspack setup`
2. Remove it with `wp newspack remove-starter-content` – observe it's removed
3. Add `NEWSPACK_IS_E2E` environment variable and generate starter content again 
4. Observe all posts have the same image and content, and the titles are prefixed with the post index

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->