### PR TITLE
refactor: wizards menu order handling

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -127,7 +127,7 @@ final class Newspack {
 
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
-		
+
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/traits/trait-wizards-admin-header.php';
 
 		// Newspack Wizards and Sections.
@@ -140,8 +140,8 @@ final class Newspack {
 
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
-		
-		// Advertising Wizard. 
+
+		// Advertising Wizard.
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/advertising/class-advertising-display-ads.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/advertising/class-advertising-sponsors.php';
 

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -44,22 +44,25 @@ class Wizards {
 			'settings'                => new Settings(),
 			// v2 Information Architecture.
 			'newspack-dashboard'      => new Newspack_Dashboard(),
-			'newspack-settings'       => new Newspack_Settings( 
+			'newspack-settings'       => new Newspack_Settings(
 				[
 					'sections' => [
 						'custom-events' => 'Newspack\Wizards\Newspack\Custom_Events_Section',
 						'social-pixels' => 'Newspack\Wizards\Newspack\Pixels_Section',
 						'recirculation' => 'Newspack\Wizards\Newspack\Recirculation_Section',
 					],
-				] 
+				]
 			),
 			'advertising-display-ads' => new Advertising_Display_Ads(),
 			'advertising-sponsors'    => new Advertising_Sponsors(),
+			'network'                 => new Network_Wizard(),
+			'newsletters'             => new Newsletters_Wizard(),
 		];
 
-		// Not needed in $wizards[] since it's just for Admin Headers, not full react pages.
-		new Network_Wizard();
-		new Newsletters_Wizard();
+		// Allow custom menu order.
+		add_filter( 'custom_menu_order', '__return_true' );
+		// Fix menu order for wizards with parent menu items.
+		add_filter( 'menu_order', [ __CLASS__, 'menu_order' ], 11 );
 	}
 
 	/**
@@ -133,6 +136,39 @@ class Wizards {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Update menu order for wizards with parent menu items.
+	 *
+	 * @param array $menu_order The current menu order.
+	 *
+	 * @return array The updated menu order.
+	 */
+	public static function menu_order( $menu_order ) {
+		$index = array_search( 'newspack-dashboard', $menu_order, true );
+		if ( false === $index ) {
+			return $menu_order;
+		}
+		$ordered_wizards = [];
+		foreach ( self::$wizards as $slug => $wizard ) {
+			if ( ! empty( $wizard->parent_menu ) && ! empty( $wizard->menu_order ) ) {
+				$ordered_wizards[ $wizard->menu_order ] = $wizard->parent_menu;
+			}
+		}
+		if ( empty( $ordered_wizards ) ) {
+			return $menu_order;
+		}
+		ksort( $ordered_wizards );
+		foreach ( array_reverse( $ordered_wizards ) as $menu_item ) {
+			$key = array_search( $menu_item, $menu_order, true );
+			if ( false === $key ) {
+				continue;
+			}
+			array_splice( $menu_order, $key, 1 );
+			array_splice( $menu_order, $index + 1, 0, $menu_item );
+		}
+		return $menu_order;
 	}
 }
 Wizards::init();

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -56,6 +56,20 @@ class Advertising_Display_Ads extends Wizard {
 	);
 
 	/**
+	 * The parent menu item name.
+	 *
+	 * @var string
+	 */
+	public $parent_menu = 'advertising-display-ads';
+
+	/**
+	 * Order relative to the Newspack Dashboard menu item.
+	 *
+	 * @var int
+	 */
+	public $menu_order = 4;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -546,8 +560,7 @@ class Advertising_Display_Ads extends Wizard {
 			$this->capability,
 			$this->slug,
 			array( $this, 'render_wizard' ),
-			$icon,
-			3.5
+			$icon
 		);
 		add_submenu_page(
 			$this->slug,

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -21,21 +21,21 @@ class Advertising_Sponsors extends Wizard {
 
 	/**
 	 * Newspack Sponsors CPT name.
-	 * 
+	 *
 	 * @var string
 	 */
 	const CPT_NAME = 'newspack_spnsrs_cpt';
 
 	/**
 	 * Sponsors CPT list path.
-	 * 
+	 *
 	 * @var string
 	 */
 	const URL = 'edit.php?post_type=newspack_spnsrs_cpt';
 
-	/** 
+	/**
 	 * Advertising Page path.
-	 * 
+	 *
 	 * @var string
 	 */
 	const PARENT_URL = 'admin.php?page=advertising-display-ads';
@@ -46,13 +46,6 @@ class Advertising_Sponsors extends Wizard {
 	 * @var string
 	 */
 	protected $capability = 'manage_options';
-
-	/**
-	 * High menu priority since we need core registrations to exist before we can modify them.
-	 *
-	 * @var int
-	 */
-	protected $menu_priority = 99;
 
 	/**
 	 * Advertising_Sponsors Constructor.
@@ -83,8 +76,8 @@ class Advertising_Sponsors extends Wizard {
 							'textContent' => esc_html__( 'Settings', 'newspack-plugin' ),
 							'href'        => admin_url( static::URL . '&page=newspack-sponsors-settings-admin' ),
 						],
-					], 
-					'title' => $this->get_name(), 
+					],
+					'title' => $this->get_name(),
 				]
 			);
 		}
@@ -174,7 +167,7 @@ class Advertising_Sponsors extends Wizard {
 	 * Parent file filter. Used to determine active menu items.
 	 *
 	 * @param string $parent_file Parent file to be overridden.
-	 * @return string 
+	 * @return string
 	 */
 	public function parent_file( $parent_file ) {
 		global $pagenow, $typenow;
@@ -182,11 +175,11 @@ class Advertising_Sponsors extends Wizard {
 		if ( in_array( $pagenow, [ 'post.php', 'post-new.php' ] ) && $typenow === static::CPT_NAME ) {
 			return 'advertising-display-ads';
 		}
-		
+
 		if ( isset( $_GET['page'] ) && $_GET['page'] === 'newspack-sponsors-settings-admin' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return static::PARENT_URL;
 		}
-	
+
 		return $parent_file;
 	}
 
@@ -200,7 +193,7 @@ class Advertising_Sponsors extends Wizard {
 		if ( isset( $_GET['page'] ) && $_GET['page'] === 'newspack-sponsors-settings-admin' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return static::URL;
 		}
-	
+
 		return $submenu_file;
 	}
 }

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -31,13 +31,6 @@ class Components_Demo extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Priority setting for ordering admin submenu items.
-	 *
-	 * @var int.
-	 */
-	protected $menu_priority = 100;
-
-	/**
 	 * Whether the wizard should be displayed in the Newspack submenu.
 	 *
 	 * @var bool.

--- a/includes/wizards/class-network-wizard.php
+++ b/includes/wizards/class-network-wizard.php
@@ -31,6 +31,20 @@ class Network_Wizard extends Wizard {
 	private $screen_type = '';
 
 	/**
+	 * The parent menu item name.
+	 *
+	 * @var string
+	 */
+	public $parent_menu = 'newspack-network';
+
+	/**
+	 * Order relative to the Newspack Dashboard menu item.
+	 *
+	 * @var int
+	 */
+	public $menu_order = 5;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -38,7 +52,7 @@ class Network_Wizard extends Wizard {
 		if ( ! is_plugin_active( 'newspack-network/newspack-network.php' ) ) {
 			return;
 		}
-		
+
 		// Admin screens based on Newspack Network plugin's admin pages and post types.
 		$this->admin_screens = [
 			'page'      => [
@@ -55,8 +69,8 @@ class Network_Wizard extends Wizard {
 			],
 		];
 
-		// Move entire Network Menu. Use a high priority to load after Network Plugin itself loads.
-		add_action( 'admin_menu', [ $this, 'move_menu' ], 99 );
+		// Update menu information.
+		add_action( 'admin_menu', [ $this, 'modify_menu' ], 11 );
 
 		// Use current_screen for better detection of which admin screen we might be on.
 		add_action( 'current_screen', [ $this, 'current_screen' ] );
@@ -77,7 +91,7 @@ class Network_Wizard extends Wizard {
 		}
 
 		// Check for admin post type screen: Listings page and classic editor (add new + edit), but not block editor.
-		if ( ! empty( $current_screen->post_type ) 
+		if ( ! empty( $current_screen->post_type )
 			&& ! empty( $this->admin_screens['post_type'][ $current_screen->post_type ] )
 			&& false === $current_screen->is_block_editor ) {
 			$this->slug = $current_screen->post_type;
@@ -120,10 +134,9 @@ class Network_Wizard extends Wizard {
 	 *
 	 * @return void
 	 */
-	public function move_menu() {
-
+	public function modify_menu() {
 		global $menu;
-		
+
 		// Find the Newspack Network menu item in the admin menu.
 		$network_key = null;
 		foreach ( $menu as $k => $v ) {
@@ -133,29 +146,16 @@ class Network_Wizard extends Wizard {
 				break;
 			}
 		}
-		
+
 		// Verify a key was found.
 		if ( empty( $network_key ) ) {
 			return;
 		}
-		
+
 		// Adjust the network menu attributes.
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$menu[ $network_key ][0] = __( 'Network', 'newspack-plugin' );
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$menu[ $network_key ][6] = 'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="none" stroke="none" d="M12 3.3c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8s-4-8.8-8.8-8.8zm6.5 5.5h-2.6C15.4 7.3 14.8 6 14 5c2 .6 3.6 2 4.5 3.8zm.7 3.2c0 .6-.1 1.2-.2 1.8h-2.9c.1-.6.1-1.2.1-1.8s-.1-1.2-.1-1.8H19c.2.6.2 1.2.2 1.8zM12 18.7c-1-.7-1.8-1.9-2.3-3.5h4.6c-.5 1.6-1.3 2.9-2.3 3.5zm-2.6-4.9c-.1-.6-.1-1.1-.1-1.8 0-.6.1-1.2.1-1.8h5.2c.1.6.1 1.1.1 1.8s-.1 1.2-.1 1.8H9.4zM4.8 12c0-.6.1-1.2.2-1.8h2.9c-.1.6-.1 1.2-.1 1.8 0 .6.1 1.2.1 1.8H5c-.2-.6-.2-1.2-.2-1.8zM12 5.3c1 .7 1.8 1.9 2.3 3.5H9.7c.5-1.6 1.3-2.9 2.3-3.5zM10 5c-.8 1-1.4 2.3-1.8 3.8H5.5C6.4 7 8 5.6 10 5zM5.5 15.3h2.6c.4 1.5 1 2.8 1.8 3.7-1.8-.6-3.5-2-4.4-3.7zM14 19c.8-1 1.4-2.2 1.8-3.7h2.6C17.6 17 16 18.4 14 19z"></path></svg>' );
-
-		// Try to move the network item to a higher position near "Newspack".
-		$new_position = '3.9';
-
-		// if position/key collision, keep increasing increment.
-		while ( array_key_exists( $new_position, $menu ) ) {
-			$new_position .= '9';
-		}
-
-		// Move network menu in the array.
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$menu[ $new_position ] = $menu[ $network_key ];
-		unset( $menu[ $network_key ] );
 	}
 }

--- a/includes/wizards/class-newsletters-wizard.php
+++ b/includes/wizards/class-newsletters-wizard.php
@@ -30,11 +30,18 @@ class Newsletters_Wizard extends Wizard {
 	private $admin_screens = [];
 
 	/**
-	 * Must be run after Newsletters Plugin.
+	 * The parent menu item name.
 	 *
-	 * @var int.
+	 * @var string
 	 */
-	protected $menu_priority = 11;
+	public $parent_menu = 'edit.php?post_type=newspack_nl_cpt';
+
+	/**
+	 * Order relative to the Newspack Dashboard menu item.
+	 *
+	 * @var int
+	 */
+	public $menu_order = 2;
 
 	/**
 	 * Constructor.
@@ -94,10 +101,6 @@ class Newsletters_Wizard extends Wizard {
 	 * Adjusts the Newsletters menu. Called from parent constructor 'admin_menu'.
 	 */
 	public function add_page() {
-
-		// Move the entire Newsletters CPT menu.
-		$this->move_cpt_menu();
-
 		// Remove "Add New" menu item.
 		remove_submenu_page( 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, 'post-new.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
 
@@ -268,46 +271,6 @@ class Newsletters_Wizard extends Wizard {
 	 */
 	public function is_wizard_page() {
 		return isset( $this->admin_screens[ $this->get_screen_slug() ] );
-	}
-
-	/**
-	 * Move CPT Menu using a decimal value. (CPT objects only allow integer positions).
-	 *
-	 * @return void
-	 */
-	private function move_cpt_menu() {
-
-		// @todo: Is there a better way to set a CPT Menu position to a decimal value????
-
-		global $menu;
-
-		// Look for the Newsletters parent menu in the admin menu.
-		$current_position = null;
-		foreach ( $menu as $position => $item ) {
-			// Test each item until found.
-			if ( $item[2] === 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ) {
-				$current_position = $position;
-				break;
-			}
-		}
-
-		// Verify a key was found.
-		if ( empty( $current_position ) ) {
-			return;
-		}
-
-		// Move the item to a higher position near "Newspack".
-		$new_position = '3.3';
-
-		// if position/key collision, keep increasing increment... 3.3 => 3.33 => 3.333 ...
-		while ( array_key_exists( $new_position, $menu ) ) {
-			$new_position .= '3';
-		}
-
-		// Move menu in the array.
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$menu[ $new_position ] = $menu[ $current_position ];
-		unset( $menu[ $current_position ] );
 	}
 
 	/**

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -40,13 +40,6 @@ abstract class Wizard {
 	protected $hidden = false;
 
 	/**
-	 * Priority setting for ordering admin submenu items.
-	 *
-	 * @var int.
-	 */
-	protected $menu_priority = 2;
-
-	/**
 	 * Array to store instances of section objects.
 	 *
 	 * @var Wizards\Section[]
@@ -54,16 +47,30 @@ abstract class Wizard {
 	protected $sections = [];
 
 	/**
+	 * The parent menu item name.
+	 *
+	 * @var string
+	 */
+	public $parent_menu = '';
+
+	/**
+	 * Order relative to the Newspack Dashboard menu item.
+	 *
+	 * @var int
+	 */
+	public $menu_order = 0;
+
+	/**
 	 * Initialize.
 	 *
 	 * @param array $args Array of optional arguments. i.e. `sections`.
-	 * @return void 
-	 * 
+	 * @return void
+	 *
 	 * @example
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-		add_action( 'admin_menu', [ $this, 'add_page' ], $this->menu_priority );
+		add_action( 'admin_menu', [ $this, 'add_page' ], 2 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {
 			$this->load_wizard_sections( $args['sections'] );
@@ -98,7 +105,7 @@ abstract class Wizard {
 	/**
 	 * Is Wizard admin page being viewed.
 	 *
-	 * @return bool 
+	 * @return bool
 	 */
 	public function is_wizard_page() {
 		return filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) === $this->slug;
@@ -277,7 +284,7 @@ abstract class Wizard {
 
 	/**
 	 * Load wizard sections.
-	 * 
+	 *
 	 * @param string[] $sections Array of Section class names.
 	 */
 	public function load_wizard_sections( $sections ) {
@@ -291,7 +298,7 @@ abstract class Wizard {
 
 	/**
 	 * Add body class for wizard pages.
-	 * 
+	 *
 	 * @param string $classes The current body classes.
 	 */
 	public function add_body_class( $classes ) {

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -29,13 +29,6 @@ class Newspack_Dashboard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Priority setting for ordering admin submenu items. Dashboard must come first.
-	 *
-	 * @var int.
-	 */
-	protected $menu_priority = 1;
-
-	/**
 	 * Initialize.
 	 */
 	public function __construct() {

--- a/includes/wizards/newspack/class-newspack-settings.php
+++ b/includes/wizards/newspack/class-newspack-settings.php
@@ -36,16 +36,9 @@ class Newspack_Settings extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Priority setting for ordering admin submenu items. Settings must come second.
-	 *
-	 * @var int.
-	 */
-	protected $menu_priority = 2;
-
-	/**
 	 * Get Settings local data
 	 *
-	 * @return [] 
+	 * @return []
 	 */
 	public function get_local_data() {
 		$google_site_kit_url = google_site_kit_available() ? admin_url( 'admin.php?page=googlesitekit-settings#/connected-services/analytics-4' ) : admin_url( 'admin.php?page=googlesitekit-splash' );
@@ -148,7 +141,7 @@ class Newspack_Settings extends Wizard {
 		 * JavaScript
 		 */
 		wp_localize_script(
-			'newspack-wizards', 
+			'newspack-wizards',
 			'newspackSettings',
 			$this->get_local_data()
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I started investigating the different ways we're managing menu order for wizard, prompted by @ronchambers [comment](https://github.com/Automattic/newspack-plugin/pull/3490#issue-2603331787) regarding the Newsletters' wizard menu order:

> I was having a hard time setting the Newsletters CPT parent menu item to a decimal value. It seems that CPTs only support an integer value for menu_positon. So I created a function that will loop through global $menu and then move the CPT to position 3.3 or "3.33" if something is already at 3.3. See the current code in function move_cpt_menu(). You may want to look at function registered_post_type_newsletters( $post_type ) to see how I'm changing the menu_icon but when I try to change the menu_position to 3.3 in that function it doesn't work.

Turns out we have multiple strategies in place:
- [hook priority](https://github.com/Automattic/newspack-plugin/blob/26a610637adb00022e7c59bf3108987391dc5b06/includes/wizards/class-wizard.php#L66)
- [`add_menu_page()` argument](https://github.com/Automattic/newspack-plugin/blob/26a610637adb00022e7c59bf3108987391dc5b06/includes/wizards/advertising/class-advertising-display-ads.php#L550)
- [custom reordering logic](https://github.com/Automattic/newspack-plugin/blob/26a610637adb00022e7c59bf3108987391dc5b06/includes/wizards/class-network-wizard.php#L148-L159)

This is hard to maintain and unpredictable. In this refactor PR I propose a consolidated strategy applied in the `class-wizards.php`:

https://github.com/Automattic/newspack-plugin/blob/406bc54174789f7f83cddc1cefede77b4caee5dd/includes/class-wizards.php#L141-L172

Each wizard with a parent menu item can use the public vars `parent_menu` and `menu_order` to determine how it should render relative to the `newspack-dashboard` wizard:

https://github.com/Automattic/newspack-plugin/blob/406bc54174789f7f83cddc1cefede77b4caee5dd/includes/wizards/class-network-wizard.php#L33-L45

Result:

<img width="161" alt="image" src="https://github.com/user-attachments/assets/72b2eb80-3ad4-4457-b584-2c151e64f826">

This PR also deprecates the `menu_priority` variable from the abstract class. It's a bit misleading, as it only applies the hook priority to the `admin_menu` hook. This is not a guaranteed way of setting the menu order because it gets overridden by the `add_menu_page` argument.


### How to test the changes in this Pull Request:

1. Checkout this PR, make sure you have Ads, Network, and Newsletters plugin active
2. Confirm the menu order reflects the image above
3. Click each menu and confirm it behaves as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->