### PR TITLE
fix: fatal and notice on php 8.3

### DIFF
--- a/includes/class-newspack-image-credits.php
+++ b/includes/class-newspack-image-credits.php
@@ -421,7 +421,8 @@ class Newspack_Image_Credits {
 					return $setting['key'] === $key;
 				}
 			);
-			return reset( array_values( $setting ) );
+			$setting_values = array_values( $setting );
+			return reset( $setting_values );
 		}
 
 		return $default_settings;
@@ -560,7 +561,7 @@ class Newspack_Image_Credits {
 	 */
 	public static function register_meta() {
 		foreach ( [
-			static::MEDIA_CREDIT_META, 
+			static::MEDIA_CREDIT_META,
 			static::MEDIA_CREDIT_URL_META,
 			static::MEDIA_CREDIT_ORG_META,
 			static::MEDIA_CREDIT_CAN_DISTRIBUTE_META,

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -325,12 +325,14 @@ class Setup_Wizard extends Wizard {
 			}
 		}
 		$theme_mods['theme_colors'] = get_theme_mod( 'theme_colors', 'default' );
-		if ( 'default' === $theme_mods['theme_colors'] ) {
-			$theme_mods['primary_color_hex']   = newspack_get_primary_color();
-			$theme_mods['secondary_color_hex'] = newspack_get_secondary_color();
-		} else {
-			$theme_mods['primary_color_hex']   = get_theme_mod( 'primary_color_hex', newspack_get_primary_color() );
-			$theme_mods['secondary_color_hex'] = get_theme_mod( 'secondary_color_hex', newspack_get_secondary_color() );
+		if ( function_exists( '\newspack_get_primary_color' ) ) {
+			if ( 'default' === $theme_mods['theme_colors'] ) {
+				$theme_mods['primary_color_hex']   = \newspack_get_primary_color();
+				$theme_mods['secondary_color_hex'] = \newspack_get_secondary_color();
+			} else {
+				$theme_mods['primary_color_hex']   = get_theme_mod( 'primary_color_hex', \newspack_get_primary_color() );
+				$theme_mods['secondary_color_hex'] = get_theme_mod( 'secondary_color_hex', \newspack_get_secondary_color() );
+			}
 		}
 
 		// Set custom header color to primary, if not set.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://app.asana.com/0/1208604228632024/1208604801170722/f

While testing the main plugin with WP 6.7 I ran into a fatal and warning. While not specific to 6.7, I thought I'd get a quick fix up to handle them.

### How to test the changes in this Pull Request:

Code review should be enough, but if you wanna verify here are some testing steps:

1. As admin visit Newspack > Site Design
2. Switch back and forth between themes, ending on Newspack and confirm you get no fatal errors
3. Now go to the Newspack dashboard
4. Reset Newspack to go through setup again 
5. Go through the setup flow being sure to interact with everything in the site design step
6. Confirm no notices are logged that look like this:

```
PHP Notice:  Only variables should be passed by reference in /Users/raz/Sites/newspack/plugin/includes/class-newspack-image-credits.php on line 424
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->