### PR TITLE
fix: only apply merging to plain objects

### DIFF
--- a/src/wizards/hooks/use-wizard-api-fetch.ts
+++ b/src/wizards/hooks/use-wizard-api-fetch.ts
@@ -186,25 +186,26 @@ export function useWizardApiFetch( slug: string ) {
 					updateSettings( method, response );
 				}
 
-				if ( updateCacheKey && updateCacheKey instanceof Object ) {
+				if ( updateCacheKey && updateCacheKey.constructor === Object ) {
 					// Derive the key and method from the updateCacheKey object.
 					const [ updateCacheKeyKey, updateCacheKeyMethod ]: [
 						keyof WizardData,
 						ApiMethods,
 					] = Object.entries( updateCacheKey )[ 0 ];
 
-					// If the cached value is an object, merge the new response with existing cache.
-					const newCache =
-						wizardData[ updateCacheKeyKey ][
-							updateCacheKeyMethod
-						] instanceof Object
-							? {
-									...wizardData[ updateCacheKeyKey ][
-										updateCacheKeyMethod
-									],
-									...response,
-							  }
-							: response;
+					const cachedValue =
+						wizardData[ updateCacheKeyKey ][ updateCacheKeyMethod ];
+
+					let newCache;
+
+					if ( cachedValue && cachedValue.constructor === Object ) {
+						newCache = {
+							...cachedValue,
+							...response,
+						};
+					} else {
+						newCache = response;
+					}
 
 					updateSettings(
 						Object.entries( updateCacheKey )[ 0 ],
@@ -212,6 +213,7 @@ export function useWizardApiFetch( slug: string ) {
 						null
 					);
 				}
+
 				for ( const replaceMethod of updateCacheMethods ) {
 					updateSettings( replaceMethod, response );
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When merging caches using `updateCacheKey` the logic assumes all values are plain `objects`. This is causing Array cache types being converted to objects.

Example:
```ts
['one', 'two']
// is becoming
{"0":"one", "1": "two"}
```

This PR aims to fix this.

### How to test the changes in this Pull Request:

1. Checkout and build assets `git checkout origin/fix/wizardapifetch-cache-merging && npm run build`.
2. Navigate to _/wp-admin/admin.php?page=newspack-settings_
3. Scroll down to "Webhook Endpoints" and add, edit and delete Endpoints and confirm changes reflect between tab changes and page refreshes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->