### PR TITLE
fix(my-account): show Orders & Payment Methods for migrated subscribers

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -130,8 +130,8 @@ class WooCommerce_My_Account {
 					$default_disabled_items[] = 'edit-address';
 				}
 
-				// Hide Orders and Payment Methods if the reader has no orders.
-				if ( ! $customer->get_is_paying_customer() && empty( wcs_get_users_subscriptions( $customer_id ) ) ) {
+				// Hide Orders and Payment Methods if the reader has no orders and no subscriptions.
+				if ( ! $customer->get_is_paying_customer() && ( function_exists( 'wcs_get_users_subscriptions' ) && empty( \wcs_get_users_subscriptions( $customer_id ) ) ) ) {
 					$default_disabled_items[] = 'orders';
 					$default_disabled_items[] = 'payment-methods';
 				}

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -131,7 +131,7 @@ class WooCommerce_My_Account {
 				}
 
 				// Hide Orders and Payment Methods if the reader has no orders.
-				if ( ! $customer->get_is_paying_customer() ) {
+				if ( ! $customer->get_is_paying_customer() && empty( wcs_get_users_subscriptions( $customer_id ) ) ) {
 					$default_disabled_items[] = 'orders';
 					$default_disabled_items[] = 'payment-methods';
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some subscribers (especially migrated ones) may not have any orders on the site. These subscribers should have access to the "Orders" and "Payment Methods" menu items in My Account, so they can manage subscriptions and update payment methods even without having any made any orders on the site.

### How to test the changes in this Pull Request:

1. Register a new reader account.
2. In WP admin > WooCommerce > Subscriptions, manually create a new subscription and assign it to the new reader account
3. Log in/verify as the reader. On `release`, observe that the menu in My Account lacks the "Orders" and "Payment Methods" items:

<img width="396" alt="Screenshot 2024-10-25 at 3 08 34 PM" src="https://github.com/user-attachments/assets/f883144b-57fb-4a55-8ac9-8e9ab63943bc">

4. Check out this branch and refresh. Confirm that the menu now does have the "Orders" and "Payment Methods" items, and that they're navigable:

<img width="391" alt="Screenshot 2024-10-25 at 3 08 13 PM" src="https://github.com/user-attachments/assets/eee83d13-e917-4dd2-9c31-040a1e5ca655">

5. Delete the subscription created in step 2 (make sure to permanently delete, don't just trash it). Refresh My Account and confirm that "My Subscription", "Orders", and "Payment Methods" items are not shown now that the user has no orders and no subscriptions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208555154605044