### PR TITLE
feat(ras): login reader after successful password reset

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -84,6 +84,7 @@ final class Reader_Activation {
 		\add_action( 'wp_footer', [ __CLASS__, 'render_auth_modal' ] );
 		\add_action( 'wp_footer', [ __CLASS__, 'render_newsletters_signup_modal' ] );
 		\add_action( 'wp_ajax_newspack_reader_activation_newsletters_signup', [ __CLASS__, 'newsletters_signup' ] );
+		\add_action( 'woocommerce_customer_reset_password', [ __CLASS__, 'login_after_password_reset' ] );
 
 		if ( self::is_enabled() ) {
 			\add_action( 'clear_auth_cookie', [ __CLASS__, 'clear_auth_intention_cookie' ] );
@@ -1923,13 +1924,7 @@ final class Reader_Activation {
 			return new \WP_Error( 'newspack_authenticate_invalid_user', __( 'Invalid user.', 'newspack-plugin' ) );
 		}
 
-		$user_id = \absint( $user->ID );
-
-		\wp_clear_auth_cookie();
-		\wp_set_current_user( $user->ID );
-		\wp_set_auth_cookie( $user->ID, true );
-		\do_action( 'wp_login', $user->user_login, $user );
-		Logger::log( 'Logged in user ' . $user->ID );
+		self::log_in_reader( $user );
 
 		return $user;
 	}
@@ -2358,6 +2353,32 @@ final class Reader_Activation {
 		}
 
 		return $email_address;
+	}
+
+
+	/**
+	 * Log in a reader.
+	 *
+	 * @param WP_User $user WP_User object.
+	 */
+	private static function log_in_reader( $user ) {
+		\wp_clear_auth_cookie();
+		\wp_set_current_user( $user->ID );
+		\wp_set_auth_cookie( $user->ID, true );
+		\do_action( 'wp_login', $user->user_login, $user );
+		Logger::log( 'Logged in user ' . $user->ID );
+	}
+
+	/**
+	 * Login a reader after they have successfully reset their password.
+	 *
+	 * @param WP_User $user WP_User object.
+	 */
+	public static function login_after_password_reset( $user ) {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+		self::log_in_reader( $user );
 	}
 }
 Reader_Activation::init();

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1924,7 +1924,11 @@ final class Reader_Activation {
 			return new \WP_Error( 'newspack_authenticate_invalid_user', __( 'Invalid user.', 'newspack-plugin' ) );
 		}
 
-		self::log_in_reader( $user );
+		\wp_clear_auth_cookie();
+		\wp_set_current_user( $user->ID );
+		\wp_set_auth_cookie( $user->ID, true );
+		\do_action( 'wp_login', $user->user_login, $user );
+		Logger::log( 'Logged in user ' . $user->ID );
 
 		return $user;
 	}
@@ -2355,20 +2359,6 @@ final class Reader_Activation {
 		return $email_address;
 	}
 
-
-	/**
-	 * Log in a reader.
-	 *
-	 * @param WP_User $user WP_User object.
-	 */
-	private static function log_in_reader( $user ) {
-		\wp_clear_auth_cookie();
-		\wp_set_current_user( $user->ID );
-		\wp_set_auth_cookie( $user->ID, true );
-		\do_action( 'wp_login', $user->user_login, $user );
-		Logger::log( 'Logged in user ' . $user->ID );
-	}
-
 	/**
 	 * Login a reader after they have successfully reset their password.
 	 *
@@ -2378,7 +2368,7 @@ final class Reader_Activation {
 		if ( ! self::is_enabled() ) {
 			return;
 		}
-		self::log_in_reader( $user );
+		set_current_reader( $user );
 	}
 }
 Reader_Activation::init();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208631669643213/f

This PR logs in a reader after they have successfully reset their password when RAS is enabled:

![Screenshot 2024-10-30 at 11 22 27](https://github.com/user-attachments/assets/5ec0817d-f744-4ec9-915e-970c3a4e930b)

### How to test the changes in this Pull Request:

1. As admin, ensure RAS is enabled
2. As a reader, go to my account and go through the reset password flow
3. Ensure you are automatically logged in after resetting the password at the password reset form pictured above
4. Log out
5. Trigger the auth flow via the sign in button
6. Enter the same reader email as from step 1, but don't input your password. Instead click the Forgot Password button
7. Go through the reset flow and again ensure you are automatically logged in after resetting the password at the password reset form pictured above

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->