### PR TITLE
fix(ras): update checkout setting text and add privacy policy text field

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -320,29 +320,28 @@ final class Reader_Activation {
 	 * @return mixed[] Settings default values keyed by their name.
 	 */
 	private static function get_settings_config() {
-		$woocommerce_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
-		$label                             = self::get_reader_activation_labels( 'newsletters_cta' );
-		$settings_config                   = [
-			'enabled'                           => false,
-			'enabled_account_link'              => true,
-			'account_link_menu_locations'       => [ 'tertiary-menu' ],
-			'newsletters_label'                 => $label,
-			'use_custom_lists'                  => false,
-			'newsletter_lists'                  => [],
-			'terms_text'                        => '',
-			'terms_url'                         => '',
-			'sync_esp'                          => true,
-			'metadata_prefix'                   => Sync\Metadata::get_prefix(),
-			'metadata_fields'                   => Sync\Metadata::get_fields(),
-			'sync_esp_delete'                   => true,
-			'active_campaign_master_list'       => '',
-			'mailchimp_audience_id'             => '',
-			'mailchimp_reader_default_status'   => 'transactional',
-			'emails'                            => Emails::get_emails( array_values( Reader_Activation_Emails::EMAIL_TYPES ), false ),
-			'sender_name'                       => Emails::get_from_name(),
-			'sender_email_address'              => Emails::get_from_email(),
-			'contact_email_address'             => Emails::get_reply_to_email(),
-			'woocommerce_registration_required' => false,
+		$settings_config = [
+			'enabled'                                  => false,
+			'enabled_account_link'                     => true,
+			'account_link_menu_locations'              => [ 'tertiary-menu' ],
+			'newsletters_label'                        => self::get_reader_activation_labels( 'newsletters_cta' ),
+			'use_custom_lists'                         => false,
+			'newsletter_lists'                         => [],
+			'terms_text'                               => '',
+			'terms_url'                                => '',
+			'sync_esp'                                 => true,
+			'metadata_prefix'                          => Sync\Metadata::get_prefix(),
+			'metadata_fields'                          => Sync\Metadata::get_fields(),
+			'sync_esp_delete'                          => true,
+			'active_campaign_master_list'              => '',
+			'mailchimp_audience_id'                    => '',
+			'mailchimp_reader_default_status'          => 'transactional',
+			'emails'                                   => Emails::get_emails( array_values( Reader_Activation_Emails::EMAIL_TYPES ), false ),
+			'sender_name'                              => Emails::get_from_name(),
+			'sender_email_address'                     => Emails::get_from_email(),
+			'contact_email_address'                    => Emails::get_reply_to_email(),
+			'woocommerce_registration_required'        => false,
+			'woocommerce_checkout_privacy_policy_text' => self::get_checkout_privacy_policy_text(),
 		];
 
 		/**
@@ -2380,6 +2379,22 @@ final class Reader_Activation {
 	 */
 	public static function is_woocommerce_registration_required() {
 		return (bool) \get_option( self::OPTIONS_PREFIX . 'woocommerce_registration_required', false );
+	}
+
+	/**
+	 * Modal checkout registration privacy policy text.
+	 *
+	 * @return string Privacy policy text.
+	 */
+	public static function get_checkout_privacy_policy_text() {
+		return \get_option(
+			self::OPTIONS_PREFIX . 'woocommerce_checkout_privacy_policy_text',
+			// New default WooCommerce privacy policy text to indicate we are creating an account for new user registrations.
+			__(
+				"Your personal data will be used to process your order and create an account if one doesn't exist. This information will also support your experience throughout this website, and be used for other purposes described in our privacy policy.",
+				'newspack-plugin'
+			)
+		);
 	}
 }
 Reader_Activation::init();

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -443,6 +443,14 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 						toggleChecked={ config.woocommerce_registration_required }
 						toggleOnChange={ value => updateConfig( 'woocommerce_registration_required', value ) }
 					/>
+					<TextControl
+						label={ __( 'Checkout privacy policy text', 'newspack-plugin' ) }
+						help={ __(
+							'The privacy policy text to display at time of checkout for existing users. This will not show up unless a privacy page is set.',
+							'newspack-plugin'
+						) }
+						{ ...getSharedProps( 'woocommerce_checkout_privacy_policy_text', 'text' ) }
+					/>
 
 					<div className="newspack-buttons-card">
 						<Button
@@ -473,6 +481,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 									metadata_fields: config.metadata_fields,
 									metadata_prefix: config.metadata_prefix,
 									woocommerce_registration_required: config.woocommerce_registration_required,
+									woocommerce_checkout_privacy_policy_text: config.woocommerce_checkout_privacy_policy_text,
 								} );
 							} }
 							disabled={ inFlight }

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -429,7 +429,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 
 					<hr />
 
-					<SectionHeader title={ __( 'Modal Checkout Login and Registration', 'newspack-plugin' ) } />
+					<SectionHeader title={ __( 'Checkout Configuration', 'newspack-plugin' ) } />
 
 					<ActionCard
 						title={ __(
@@ -437,7 +437,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 							'newspack-plugin'
 						) }
 						description={ __(
-							'Present logged out readers with the option to sign in or register a new account before proceeding to checkout.',
+							'Require logged out readers to sign in or register a new account before proceeding to checkout.',
 							'newspack-plugin'
 						) }
 						toggleChecked={ config.woocommerce_registration_required }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Goes with this blocks PR: https://github.com/Automattic/newspack-blocks/pull/1936

Updates the checkout settings heading and forced registration description text. Also adds a new checkout field to update the checkout privacy policy text for modal checkout:

![Screenshot 2024-10-31 at 16 04 07](https://github.com/user-attachments/assets/30fd58a7-c4f0-40cb-84e8-b2a14b33ef2c)

### How to test the changes in this Pull Request:

Be sure to also checkout the changes in this blocks PR before testing: https://github.com/Automattic/newspack-blocks/pull/1936

1. As admin go to Newspack > Engagement > Show Advanced Settings
2. Confirm the bottom section is now 'Checkout Configuration'
3. Confirm the updated description text for the `Prompt logged out readers to sign in or register a new account before checkout` setting as pictured above
4. Confirm there is a new field for checkout privacy policy text
5. As a reader, go through the checkout flow and verify the privacy policy text in the checkout modal matches the text in this field
6. As admin, update the privacy policy text
7. Go through checkout again and confirm the text has been updated in the modal as well.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->