### PR TITLE
fix: avoid duplicate info notices in email editors

### DIFF
--- a/src/other-scripts/emails/index.js
+++ b/src/other-scripts/emails/index.js
@@ -49,6 +49,7 @@ const ReaderRevenueEmailSidebar = compose( [
 	useEffect( () => {
 		if ( config?.editor_notice ) {
 			createNotice( 'info', config.editor_notice, {
+				id: 'newspack_email_info',
 				isDismissible: false,
 			} );
 		}
@@ -61,6 +62,7 @@ const ReaderRevenueEmailSidebar = compose( [
 				config.from_email || newspack_emails.from_email
 			),
 			{
+				id: 'newspack_email_sender',
 				isDismissible: false,
 			}
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents duplicate undismissible info notices from appearing in custom email editors.

### How to test the changes in this Pull Request:

1. On `trunk`, edit a custom Newspack email such as the Reader Revenue custom receipt email.
2. Observe that two info notices are rendered twice at the top of the editor area.
3. Check out this branch, refresh, confirm each notice is rendered only once.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->