### PR TITLE
fix(ras): redirect to home after registering on my account page

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1874,6 +1874,11 @@ final class Reader_Activation {
 					function_exists( 'wc_get_account_endpoint_url' ) ? \wc_get_account_endpoint_url( 'edit-account' ) : home_url()
 				);
 
+				// If we are on the my account page, add a redirect to the site's home page.
+				if ( function_exists( 'is_account_page' ) && is_account_page() ) {
+					$payload['redirect_to'] = \home_url();
+				}
+
 				$payload['registered']    = 1;
 				$payload['authenticated'] = 1;
 				return self::send_auth_form_response( $payload, false );

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -347,6 +347,13 @@ window.newspackRAS.push( function ( readerActivation ) {
 								}
 							}
 						}
+
+						if ( data?.redirect_to ) {
+							const continueButton = container.querySelector( '.auth-callback' );
+							if ( continueButton ) {
+								continueButton.setAttribute( 'href', data.redirect_to );
+							}
+						}
 					}
 				}
 			};


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208631669643217/f

This PR makes the registration modal continue button redirect to the sites home page when registering via the my account page to avoid the awkwardness of going to an unverified my account page.

![Screenshot 2024-10-31 at 16 49 30](https://github.com/user-attachments/assets/d17fd1a4-30e9-4053-8bc9-e4fa21133e5d)

### How to test the changes in this Pull Request:

1. As a logged out reader, go to the my account page (append `/my-account` to the site url)
2. Register a new account
3. Click continue once registration is successful and confirm you directed to the home page
4. Log out
5. From any other page aside from my-account, register a new account via the global Sign in button
6. Confirm you are not redirected and instead the auth flow behaves as expected

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->