### PR TITLE
feat: also trigger subscription change events on switch

### DIFF
--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -179,7 +179,7 @@ When a WooCommerce Subscription is cancelled.
 
 ### `donation_subscription_changed`
 
-When a WooCommerce Subscription status changes.
+When a WooCommerce Subscription status changes, or when there's a subscription switch (change in the product within the subscription. Usually a change in the recurrence or the amount of the subscription).
 
 | Name              | Type     |
 | ----------------- | -------- |
@@ -195,7 +195,7 @@ When a WooCommerce Subscription status changes.
 
 ### `product_subscription_changed`
 
-When a non-donation subscription status changes.
+When a non-donation subscription status changes, or when there's a subscription switch (change in the product within the subscription. Usually an upgrade or downgrade, or a change in the recurrence or the amount of the subscription).
 
 | Name              | Type     |
 | ----------------- | -------- |

--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -253,6 +253,46 @@ Data_Events::register_listener(
 );
 
 /**
+ * For when a donation subscription is switched (recurrence/amount change).
+ */
+Data_Events::register_listener(
+	'woocommerce_subscriptions_switch_completed',
+	'donation_subscription_changed',
+	function( $order ) {
+
+		if ( ! function_exists( 'wcs_get_objects_property' ) ) {
+			return;
+		}
+
+		$switch_order_data = wcs_get_objects_property( $order, 'subscription_switch_data' );
+
+		if ( empty( $switch_order_data ) || ! is_array( $switch_order_data ) ) {
+			return;
+		}
+
+		$subscription_id = array_key_first( $switch_order_data );
+
+		$subscription = wcs_get_subscription( $subscription_id );
+
+		if ( ! $subscription instanceof \WC_Subscription ) {
+			return;
+		}
+
+		$data = \Newspack\Data_Events\Utils::get_recurring_donation_data( $subscription );
+		if ( ! is_array( $data ) ) {
+			return;
+		}
+		return array_merge(
+			$data,
+			[
+				'status_before' => $subscription->get_status(),
+				'status_after'  => $subscription->get_status(),
+			]
+		);
+	}
+);
+
+/**
  * When a non-donation subscription status changes.
  * The subscription will be removed from the user's list of active subscriptions.
  */
@@ -284,6 +324,59 @@ Data_Events::register_listener(
 			'recurrence'      => $subscription->get_billing_period(),
 			'status_before'   => $status_from,
 			'status_after'    => $status_to,
+		];
+	}
+);
+
+/**
+ * For when a non-donation subscription is switched (recurrence/amount change).
+ */
+Data_Events::register_listener(
+	'woocommerce_subscriptions_switch_completed',
+	'product_subscription_changed',
+	function( $order ) {
+
+		if ( ! function_exists( 'wcs_get_objects_property' ) ) {
+			return;
+		}
+
+		$switch_order_data = wcs_get_objects_property( $order, 'subscription_switch_data' );
+
+		if ( empty( $switch_order_data ) || ! is_array( $switch_order_data ) ) {
+			return;
+		}
+
+		$subscription_id = array_key_first( $switch_order_data );
+
+		$subscription = wcs_get_subscription( $subscription_id );
+
+		if ( ! $subscription instanceof \WC_Subscription ) {
+			return;
+		}
+
+		$product_ids = array_values(
+			array_filter(
+				\Newspack\WooCommerce_Connection::get_products_for_order( $subscription->get_id() ),
+				function( $product_id ) {
+					return ! Donations::is_donation_product( $product_id );
+				}
+			)
+		);
+
+		if ( empty( $product_ids ) ) {
+			return;
+		}
+
+		return [
+			'user_id'         => $subscription->get_customer_id(),
+			'email'           => $subscription->get_billing_email(),
+			'subscription_id' => $subscription->get_id(),
+			'product_ids'     => $product_ids,
+			'amount'          => (float) $subscription->get_total(),
+			'currency'        => $subscription->get_currency(),
+			'recurrence'      => $subscription->get_billing_period(),
+			'status_before'   => $subscription->get_status(),
+			'status_after'    => $subscription->get_status(),
 		];
 	}
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Also trigger the data events for subscription changes when there's a subscription switch.

### How to test the changes in this Pull Request:

Questions:

1. Do the docs look ok?
2. Do you think we should add an additional param to the event identifying the type of change (status or switch)? - Note that we don't have access to the previous state of the subscription to add to the event exactly what changed
3. How do I configure a non donation subscription that can be downgraded/upgraded to another product?
4. Should we keep this only to donations for now?

Testing donations:

1. As a reader, make a recurring donation
2. Go to My Account > My Subscription
3. Click on "Change price"
5. choose a product and a value and submit
6. Visit card and proceed to checkout
7. Complete checkout
8. Check that the donation_changed event is fired with the correct info (you can set a webhook using https://webhook.site/ for that if you want)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208541920545689