### PR TITLE
fix(dashboard): check theme mod key

### DIFF
--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -285,7 +285,7 @@ class Newspack_Dashboard extends Wizard {
 		$local_data = [
 			'settings'     => [
 				'siteName'      => $site_name,
-				'headerBgColor' => $theme_mods['header_color_hex'],
+				'headerBgColor' => $theme_mods['header_color_hex'] ?? '',
 			],
 			'sections'     => $this->get_dashboard(),
 			'plugins'      => get_plugins(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1205919985867982-as-1208686181349205/f

Checks the key to prevent a backend warning and a javascript fatal.

### How to test the changes in this Pull Request:

1. While on the epic branch, delete the `theme_mods_newspack-theme` option from the db
2. Navigate to Newspack -> Dashboard and confirm the page renders blank with a js error
3. Checkout this branch, refresh the page and confirm the dashboard renders without errors

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->