### PR TITLE
fix: use user email for esp sync purposes

### DIFF
--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -341,7 +341,7 @@ class WooCommerce {
 		$last_name  = $customer->get_billing_last_name();
 		$full_name  = trim( "$first_name $last_name" );
 		$contact    = [
-			'email'    => ! empty( $customer->get_billing_email() ) ? $customer->get_billing_email() : $customer->get_email(),
+			'email'    => $customer->get_email(),
 			'metadata' => $metadata,
 		];
 		if ( ! empty( $full_name ) ) {

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -68,7 +68,7 @@ class WC_Customer {
 	public function get_billing_last_name() {
 		return get_user_meta( $this->get_id(), 'last_name', true );
 	}
-	public function get_billing_email() {
+	public function get_email() {
 		return get_userdata( $this->get_id() )->user_email;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When a user purchases something on a site with RAS activated and its info gets synced to the ESP, we were prioritizing the billing email over the user registered email.

This means that if the user registers with one email, but then uses a different email to make a purchase, it would create a new user in the ESP - but not in WP.

This PR makes sure we always use the user email for sync purposes.

Was there any specific reasons why we wanted to use billing email there? Do we really want this change?

### How to test the changes in this Pull Request:

1. on `trunk`
2. Register with a user
3. Make a donation or purchase something, but change your email in the checkout form
4. Confirm ESP syncs info about this purchase using the modified email
5. On this branch, confirm that all ESP syncs are tied to the original user email
6.
7.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208677634068371