### PR TITLE
fix(salesforce): handle woocommerce inactive

### DIFF
--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -372,7 +372,7 @@ class Salesforce {
 
 		// Check if the webhook is configured.
 		$webhook_id = self::get_webhook();
-		$webhook    = wc_get_webhook( $webhook_id );
+		$webhook    = \wc_get_webhook( $webhook_id );
 		if ( null == $webhook ) {
 			return \rest_ensure_response(
 				[
@@ -882,7 +882,7 @@ class Salesforce {
 	 */
 	private static function delete_webhook( $webhook_id ) {
 		delete_option( self::SALESFORCE_WEBHOOK_ID );
-		$webhook = wc_get_webhook( $webhook_id );
+		$webhook = \wc_get_webhook( $webhook_id );
 		if ( null !== $webhook ) {
 			$webhook->delete( true );
 		}
@@ -1317,7 +1317,7 @@ class Salesforce {
 	 * @param array $opportunities Array of Opportunity IDs from Salesforce.
 	 */
 	private static function save_opportunity_ids( $order_id, $opportunities ) {
-		$order = wc_get_order( $order_id );
+		$order = \wc_get_order( $order_id );
 		if ( ! $order ) {
 			return;
 		}

--- a/includes/class-salesforce.php
+++ b/includes/class-salesforce.php
@@ -55,6 +55,9 @@ class Salesforce {
 	 * doesn't exist, create it.
 	 */
 	public static function platform_check() {
+		if ( ! function_exists( 'wc_get_webhook' ) ) {
+			return;
+		}
 		$is_newspack = Donations::is_platform_wc();
 		$webhook_id  = self::get_webhook();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If WC is inactive, the `wc_*` functions will be interpreted as namespaced (`Newspack\wc_*`). This plugin avoids that. 

### How to test the changes in this Pull Request:

Smoke test!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->