### PR TITLE
feat(wc-memberships): support team data in import

### DIFF
--- a/includes/plugins/wc-memberships/class-import-export.php
+++ b/includes/plugins/wc-memberships/class-import-export.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * WooCommerce Memberships Import/Export.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Memberships;
+
+/**
+ * WooCommerce Memberships Import/Export class.
+ */
+class Import_Export {
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_filter( 'wc_memberships_csv_import_user_memberships_data', [ __CLASS__, 'process_imported_data' ], 10, 5 );
+		add_action( 'wc_memberships_csv_import_user_membership', [ __CLASS__, 'handle_membership_import' ], 10, 4 );
+	}
+
+	/**
+	 * Is the woocommerce-memberships-for-teams plugin active?
+	 */
+	public static function is_wc_teams_active(): bool {
+		return class_exists( 'SkyVerge\WooCommerce\Memberships\Teams\Team' );
+	}
+
+	/**
+	 * Filter CSV User Membership import data before processing an import.
+	 *
+	 * @param array     $import_data the imported data as associative array.
+	 * @param string    $action either 'create' or 'merge' (update) a User Membership.
+	 * @param array     $columns CSV columns raw data.
+	 * @param array     $row CSV row raw data.
+	 * @param \stdClass $job import job.
+	 */
+	public static function process_imported_data( $import_data, $action, $columns, $row, $job ) {
+		if ( ! self::is_wc_teams_active() ) {
+			return $import_data;
+		}
+		foreach ( $columns as $column_name ) {
+			if ( stripos( $column_name, 'team_' ) !== false && isset( $row[ $column_name ] ) ) {
+				$import_data[ $column_name ] = $row[ $column_name ];
+			}
+		}
+		return $import_data;
+	}
+
+	/**
+	 * Fires upon creating or updating a User Membership from import data.
+	 *
+	 * @param \WC_Memberships_User_Membership $user_membership User Membership object.
+	 * @param string                          $action either 'create' or 'merge' (update) a User Membership.
+	 * @param array                           $data import data.
+	 * @param \stdClass                       $job import job.
+	 */
+	public static function handle_membership_import( $user_membership, $action, $data, $job ) {
+		if ( ! self::is_wc_teams_active() ) {
+			return;
+		}
+		if ( isset(
+			$data['user_id'],
+			$data['team_id'],
+			$data['team_name'],
+			$data['team_role']
+		) ) {
+			$team = false;
+			try {
+				$team = new \SkyVerge\WooCommerce\Memberships\Teams\Team( $data['team_id'] );
+			} catch ( \Throwable $th ) { // phpcs:disable Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				// Fail silently.
+			}
+			$user_id = $data['user_id'];
+			if ( ! $team ) {
+				// Create the team.
+				try {
+					$team = \wc_memberships_for_teams_create_team(
+						[
+							'owner_id'   => $user_id,
+							'plan_id'    => $data['membership_plan_id'],
+							'product_id' => $data['product_id'],
+							'order_id'   => $data['order_id'],
+							'name'       => $data['team_name'],
+						]
+					);
+				} catch ( \Throwable $th ) { // phpcs:disable Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+					return;
+				}
+			}
+			$member_added = false;
+			try {
+				$team->add_member( $user_id, $data['team_role'] );
+				$member_added = true;
+			} catch ( \Throwable $th ) {
+				// Fail silently.
+			}
+		}
+	}
+}
+Import_Export::init();

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -74,6 +74,7 @@ class Memberships {
 
 		include __DIR__ . '/class-block-patterns.php';
 		include __DIR__ . '/class-metering.php';
+		include __DIR__ . '/class-import-export.php';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WCM export will add team data to the resulting CSV file, but it won't handle that data in the import. This PR adds support for it. 

### How to test the changes in this Pull Request:

1. Ensure `woocommerce-memberships-for-teams` plugin is active
1. Create three teams (A, B, C) and add different users to them
2. Export the data using the default exporter (`/wp-admin/admin.php?page=wc_memberships_import_export`)
3. Remove team A (not just trash, remove permanently – use WP CLI) and its user, remove team B but leave the user (remove member with "keep membership" option)
4. Import the data (`/wp-admin/admin.php?page=wc_memberships_import_export&section=csv_import_user_memberships`), ticking the "Create a new user if no matching user is found" checkbox
5. Observe the teams state have been restored – teams A and B recreated, user from team A recreated and reassigned

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207649033573727