### PR TITLE
fix(reader-registration-block): fix styles of newsletter lists

### DIFF
--- a/src/blocks/reader-registration/style.scss
+++ b/src/blocks/reader-registration/style.scss
@@ -29,11 +29,6 @@
 			}
 			.newspack-reader__lists {
 				flex: 1 1 31.7073%;
-				padding: 1.2rem;
-				display: flex;
-				flex-direction: column;
-				justify-content: center;
-				align-items: flex-start;
 				h3 {
 					display: block;
 					margin: 0.4rem 0.4rem 0.8rem;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a styling issue. 

### How to test the changes in this Pull Request:

1. On `trunk`, ensure you have about five lists configured in the Enagement -> Newsletters settings, add descriptions to each to inflate the character count
2. Add a Reader Registration block somewhere, enable "Enable newsletter subscription" in the "Newsletter Subscription" sidebar panel, toggle all available lists, publish
3. Visit the front-end, observe the lists are cut off in the UI, not allowing to scroll up fully
4. Switch to this branch, observe issue is gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208645333789040