### PR TITLE
feat(pwa): enable SW file caching

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -145,7 +145,6 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-donations.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-category-pager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-salesforce.php';
-		include_once NEWSPACK_ABSPATH . 'includes/class-pwa.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-starter-content.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-amp-enhancements.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-newspack-image-credits.php';
@@ -160,6 +159,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-pwa.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-guest-contributor-role.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-search-authors-limit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';

--- a/includes/plugins/class-pwa.php
+++ b/includes/plugins/class-pwa.php
@@ -29,6 +29,14 @@ class PWA {
 
 		add_action( 'wp_front_service_worker', [ __CLASS__, 'bypass_service_worker' ], 100 );
 		add_action( 'wp_admin_service_worker', [ __CLASS__, 'bypass_service_worker' ], 100 );
+
+		// Replace the SW caching header ('no-cache' by default), so it can be cached (for a day).
+		add_action(
+			'wp_front_service_worker',
+			function () {
+				header( 'Cache-Control: max-age=86400, must-revalidate' );
+			} 
+		);
 	}
 
 	/**
@@ -107,7 +115,7 @@ class PWA {
 
 	/**
 	 * Temporary workaround to disable the offline post request handling script.
-	 * 
+	 *
 	 * @param WP_Service_Worker_Scripts $scripts The service worker scripts.
 	 *
 	 * @see - https://github.com/GoogleChromeLabs/pwa-wp/issues/1106


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Replaces the `Cache-Control` header used for PWA'a service worker file, so that it can be cached. 

Also moves the PWA plugin integration file to a more applicable place. 

### How to test the changes in this Pull Request:

1. On `trunk`
2. `$ curl -I <site-url>/wp.serviceworker`, observe the `cache-control: no-cache` header
3. Switch to this branch, repeat, observe the `Cache-Control: max-age=86400, must-revalidate` header sent

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208690313194038