### PR TITLE
fix(ia): deprecate webhooks global endpoint

### DIFF
--- a/src/wizards/newspack/views/settings/connections/webhooks/endpoint-actions-card.tsx
+++ b/src/wizards/newspack/views/settings/connections/webhooks/endpoint-actions-card.tsx
@@ -33,27 +33,22 @@ function EndpointActionsCard( {
 			description={ () => {
 				if ( endpoint.disabled && endpoint.disabled_error ) {
 					return `${ __(
-						'Endpoint disabled due to error:',
+						'Endpoint disabled due to error',
 						'newspack-plugin'
 					) }: ${ endpoint.disabled_error }`;
 				}
 				return (
 					<Fragment>
 						{ __( 'Actions:', 'newspack-plugin' ) }{ ' ' }
-						{ endpoint.global ? (
-							<span className="newspack-webhooks__endpoint-action">
-								{ __( 'global', 'newspack-plugin' ) }
+						{ endpoint.actions.map( action => (
+							<span
+								key={ action }
+								className="newspack-webhooks__endpoint-action"
+							>
+								{ action }
 							</span>
-						) : (
-							endpoint.actions.map( action => (
-								<span
-									key={ action }
-									className="newspack-webhooks__endpoint-action"
-								>
-									{ action }
-								</span>
-							) )
-						) }
+						) )
+					 }
 					</Fragment>
 				);
 			} }

--- a/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
+++ b/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
@@ -30,7 +30,6 @@ const defaultEndpoint: Endpoint = {
 	disabled_error: false,
 	id: 0,
 	system: '',
-	global: true,
 	actions: [],
 	bearer_token: '',
 };

--- a/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
+++ b/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, Fragment } from '@wordpress/element';
+import { useState, useEffect, useRef, Fragment } from '@wordpress/element';
 import {
 	CheckboxControl as WpCheckboxControl,
 	TextControl,
@@ -55,12 +55,48 @@ const Upsert = ( {
 		message?: string;
 	} >( {} );
 
+	const modalRef = useRef( null as HTMLElement | null );
+
 	const onSuccess = ( endpointId: string | number, response: Endpoint[] ) => {
 		setEndpoints( response );
 		setAction( null, endpointId );
 	};
 
+	function validateUrl( url: string ): string | false {
+		if ( ! url ) {
+			return __( 'URL is required.', 'newspack-plugin' );
+		}
+		const pattern = new RegExp(
+			/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/
+		);
+		if ( ! pattern.test( url ) ) {
+			return __( 'Invalid URL format.', 'newspack-plugin' );
+		}
+		return false;
+	}
+
+	function validateEndpoint( endpointToValidate: Endpoint ) {
+		const errors = [];
+		const urlError = validateUrl( endpointToValidate.url );
+		if ( urlError ) {
+			errors.push( urlError );
+		}
+		if ( ! endpointToValidate.actions || ! endpointToValidate.actions.length ) {
+			errors.push( __( 'At least one action is required.', 'newspack-plugin' ) );
+		}
+		if ( errors.length ) {
+			setError( errors.join( ' ' ) );
+		} else {
+			setError( null );
+		}
+		return errors;
+	}
+
 	function upsertEndpoint( endpointToUpsert: Endpoint ) {
+		const errors = validateEndpoint( endpointToUpsert );
+		if ( errors.length ) {
+			return;
+		}
 		wizardApiFetch< Endpoint[] >(
 			{
 				path: `/newspack/v1/webhooks/endpoints/${
@@ -78,9 +114,14 @@ const Upsert = ( {
 	}
 
 	function testEndpoint(
-		url: string | undefined,
+		url: string,
 		bearer_token: string | undefined
 	) {
+		const urlError = validateUrl( url );
+		if ( urlError ) {
+			setError( urlError );
+			return;
+		}
 		wizardApiFetch< { success: boolean; code: number; message: string } >(
 			{
 				path: '/newspack/v1/webhooks/endpoints/test',
@@ -111,9 +152,16 @@ const Upsert = ( {
 		);
 	}
 
+	useEffect( () => {
+		if ( errorMessage ) {
+			modalRef?.current?.querySelector('.components-modal__content')?.scrollTo( { top: 0, left: 0, behavior: 'smooth' } );
+		}
+	}, [ errorMessage ] );
+
 	return (
 		<Fragment>
 			<Modal
+				ref={ modalRef }
 				title={ __( 'Webhook Endpoint', 'newspack-plugin' ) }
 				onRequestClose={ () => {
 					setAction( null, endpoint.id );
@@ -204,23 +252,11 @@ const Upsert = ( {
 				/>
 				<Grid columns={ 1 } gutter={ 16 }>
 					<h3>{ __( 'Actions', 'newspack-plugin' ) }</h3>
-					<CheckboxControl
-						checked={ editing.global }
-						onChange={ ( value: boolean ) =>
-							setEditing( { ...editing, global: value } )
-						}
-						label={ __( 'Global', 'newspack-plugin' ) }
-						help={ __(
-							'Leave this checked if you want this endpoint to receive data from all actions.',
-							'newspack-plugin'
-						) }
-						disabled={ inFlight }
-					/>
 					{ actions.length > 0 && (
 						<Fragment>
 							<p>
 								{ __(
-									'If this endpoint is not global, select which actions should trigger this endpoint:',
+									'Select which actions should trigger this endpoint:',
 									'newspack-plugin'
 								) }
 							</p>
@@ -228,7 +264,7 @@ const Upsert = ( {
 								{ actions.map( ( actionKey, i ) => (
 									<CheckboxControl
 										key={ i }
-										disabled={ editing.global || inFlight }
+										disabled={ inFlight }
 										label={ actionKey }
 										checked={
 											( editing.actions &&
@@ -237,7 +273,6 @@ const Upsert = ( {
 												) ) ||
 											false
 										}
-										indeterminate={ editing.global }
 										onChange={ () => {
 											const currentActions =
 												editing.actions || [];

--- a/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
+++ b/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
@@ -63,8 +63,6 @@ const Upsert = ( {
 		setAction( null, endpointId );
 	};
 
-
-
 	function upsertEndpoint( endpointToUpsert: Endpoint ) {
 		const errors = validateEndpoint( endpointToUpsert );
 		if ( errors.length ) {

--- a/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
+++ b/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
@@ -24,6 +24,7 @@ import {
 	Modal,
 	Grid,
 } from '../../../../../../../components/src';
+import { validateEndpoint, validateUrl } from '../utils';
 
 /**
  * Checkbox control props override.
@@ -62,41 +63,15 @@ const Upsert = ( {
 		setAction( null, endpointId );
 	};
 
-	function validateUrl( url: string ): string | false {
-		if ( ! url ) {
-			return __( 'URL is required.', 'newspack-plugin' );
-		}
-		const pattern = new RegExp(
-			/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/
-		);
-		if ( ! pattern.test( url ) ) {
-			return __( 'Invalid URL format.', 'newspack-plugin' );
-		}
-		return false;
-	}
 
-	function validateEndpoint( endpointToValidate: Endpoint ) {
-		const errors = [];
-		const urlError = validateUrl( endpointToValidate.url );
-		if ( urlError ) {
-			errors.push( urlError );
-		}
-		if ( ! endpointToValidate.actions || ! endpointToValidate.actions.length ) {
-			errors.push( __( 'At least one action is required.', 'newspack-plugin' ) );
-		}
-		if ( errors.length ) {
-			setError( errors.join( ' ' ) );
-		} else {
-			setError( null );
-		}
-		return errors;
-	}
 
 	function upsertEndpoint( endpointToUpsert: Endpoint ) {
 		const errors = validateEndpoint( endpointToUpsert );
 		if ( errors.length ) {
+			setError( errors.join( ' ' ) );
 			return;
 		}
+		setError( null );
 		wizardApiFetch< Endpoint[] >(
 			{
 				path: `/newspack/v1/webhooks/endpoints/${

--- a/src/wizards/newspack/views/settings/connections/webhooks/utils.tsx
+++ b/src/wizards/newspack/views/settings/connections/webhooks/utils.tsx
@@ -93,13 +93,15 @@ export function validateUrl( url: string ): string | false {
 	if ( ! url ) {
 		return __( 'URL is required.', 'newspack-plugin' );
 	}
-	const pattern = new RegExp(
-		/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/
-	);
-	if ( ! pattern.test( url ) ) {
+	try {
+		const urlObject = new URL( url );
+		if ( urlObject.protocol !== 'https:' ) {
+			return __( 'HTTPS protocol is required for the endpoint URL.', 'newspack-plugin' );
+		}
+		return false;
+	} catch ( error ) {
 		return __( 'Invalid URL format.', 'newspack-plugin' );
 	}
-	return false;
 }
 
 /**

--- a/src/wizards/newspack/views/settings/connections/webhooks/utils.tsx
+++ b/src/wizards/newspack/views/settings/connections/webhooks/utils.tsx
@@ -5,6 +5,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { settings, check, close, reusableBlock } from '@wordpress/icons';
 
@@ -80,4 +81,41 @@ export function getRequestStatusIcon(
  */
 export function hasEndpointErrors( endpoint: Endpoint ): boolean {
 	return endpoint.requests.some( request => request.errors.length );
+}
+
+/**
+ * Validate endpoint URL.
+ *
+ * @param url The URL to validate.
+ * @return    Error message if URL is invalid, false otherwise.
+ */
+export function validateUrl( url: string ): string | false {
+	if ( ! url ) {
+		return __( 'URL is required.', 'newspack-plugin' );
+	}
+	const pattern = new RegExp(
+		/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/
+	);
+	if ( ! pattern.test( url ) ) {
+		return __( 'Invalid URL format.', 'newspack-plugin' );
+	}
+	return false;
+}
+
+/**
+ * Validate an endpoint.
+ *
+ * @param endpointToValidate The endpoint to validate.
+ * @return                   An array of error messages.
+ */
+export function validateEndpoint( endpointToValidate: Endpoint ): string[] {
+	const errors = [];
+	const urlError = validateUrl( endpointToValidate.url );
+	if ( urlError ) {
+		errors.push( urlError );
+	}
+	if ( ! endpointToValidate.actions || ! endpointToValidate.actions.length ) {
+		errors.push( __( 'At least one action is required.', 'newspack-plugin' ) );
+	}
+	return errors;
 }

--- a/src/wizards/newspack/views/settings/connections/webhooks/utils.tsx
+++ b/src/wizards/newspack/views/settings/connections/webhooks/utils.tsx
@@ -105,16 +105,16 @@ export function validateUrl( url: string ): string | false {
 /**
  * Validate an endpoint.
  *
- * @param endpointToValidate The endpoint to validate.
- * @return                   An array of error messages.
+ * @param endpoint The endpoint to validate.
+ * @return         An array of error messages.
  */
-export function validateEndpoint( endpointToValidate: Endpoint ): string[] {
+export function validateEndpoint( endpoint: Endpoint ): string[] {
 	const errors = [];
-	const urlError = validateUrl( endpointToValidate.url );
+	const urlError = validateUrl( endpoint.url );
 	if ( urlError ) {
 		errors.push( urlError );
 	}
-	if ( ! endpointToValidate.actions || ! endpointToValidate.actions.length ) {
+	if ( ! endpoint.actions || ! endpoint.actions.length ) {
 		errors.push( __( 'At least one action is required.', 'newspack-plugin' ) );
 	}
 	return errors;

--- a/src/wizards/newspack/views/settings/types.d.ts
+++ b/src/wizards/newspack/views/settings/types.d.ts
@@ -41,7 +41,6 @@ type Endpoint = {
 	disabled_error: boolean;
 	id: string | number;
 	system: string;
-	global: boolean;
 	actions: string[];
 	bearer_token?: string;
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1205919985867982-as-1208628153846581/f

Implements changes from #3492 to the IA project.

### How to test the changes in this Pull Request:

1. Navigate to "Newspack -> Settings" and at the Connections tab, scroll to the Webhooks section 
2. Click to create a new endpoint and confirm the "Global" option is no longer available
3. Attempt to save without a URL or selecting any actions
4. Confirm the modal scrolls to the top and you see an error message
5. Fill a random string (invalid URL) and attempt to save
6. Confirm you get an error due to invalid format
7. Put a valid URL and select some actions
8. Confirm you can save the endpoint
9. Refresh the page and confirm the endpoint persist

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->