### PR TITLE
fix(ia): core update nag margins

### DIFF
--- a/src/components/src/with-wizard/style.scss
+++ b/src/components/src/with-wizard/style.scss
@@ -5,6 +5,13 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "../../../shared/scss/colors";
 
+// Fix update nag margins for admin-header-only pages.
+body.newspack-wizard-page.newspack-admin-header {
+	.update-nag {
+		margin-bottom: 25px;
+	}
+}
+
 // Reset Padding of the Admin Page for full react pages (ignoring admin-header-only pages).
 body.newspack-wizard-page:not(.newspack-admin-header) {
 
@@ -12,6 +19,12 @@ body.newspack-wizard-page:not(.newspack-admin-header) {
 
 	#wpcontent {
 		padding-left: 0;
+
+		// Fix update nag margins.
+		.update-nag {
+			margin-bottom: 25px;
+			margin-left: 22px;
+		}
 	}
 
 	#wpbody-content {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1205919985867982-as-1208354721118905/f

Fixes the core update nag margins when navigating Newspack wizards for both full wizard pages and header-only:

| | Before | After |
| --- | --- | --- |
| Header-only | <img width="566" alt="image" src="https://github.com/user-attachments/assets/b4cd2fa8-afa3-4ec7-90a6-7b8ae02fb6fd"> | <img width="570" alt="image" src="https://github.com/user-attachments/assets/133b69d9-6608-407a-a5b3-b53dd2ee156f"> |
| Wizard page | <img width="622" alt="image" src="https://github.com/user-attachments/assets/d7038341-3315-46ad-9240-b243d2d2166f"> | <img width="637" alt="image" src="https://github.com/user-attachments/assets/2178eb5d-c576-45ee-8076-93b3298d957e"> |

### How to test the changes in this Pull Request:

1. Checkout this branch, navigate to the wizard pages and admin-header-only pages
2. Confirm the margins are correct, as in the images above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->