### PR TITLE
fix(ia): remove `wp_enqueue_style` for newsletter.css

### DIFF
--- a/includes/wizards/class-newsletters-wizard.php
+++ b/includes/wizards/class-newsletters-wizard.php
@@ -324,15 +324,6 @@ class Newsletters_Wizard extends Wizard {
 			true
 		);
 
-		\wp_register_style(
-			'newspack-newsletters-wizard',
-			Newspack::plugin_url() . '/dist/newsletters.css',
-			$this->get_style_dependencies(),
-			NEWSPACK_PLUGIN_VERSION
-		);
-		\wp_style_add_data( 'newspack-newsletters-wizard', 'rtl', 'replace' );
-		\wp_enqueue_style( 'newspack-newsletters-wizard' );
-
 		$data = [];
 		if ( method_exists( 'Newspack\Newsletters\Subscription_Lists', 'get_add_new_url' ) ) {
 			$data['new_subscription_lists_url'] = \Newspack\Newsletters\Subscription_Lists::get_add_new_url();


### PR DESCRIPTION
newsletter css is housed in commons

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes enqueuing of newsletter css, the css can be found in commons bundle.

![Screenshot 2024-11-07 at 10 30 40](https://github.com/user-attachments/assets/bb2737f9-0f6f-460f-9e7f-449ed5fdaed3)

### How to test the changes in this Pull Request:

1. Checkout this branch i.e. `git checkout origin/fix/ia-newsletters-css`
2. Navigate to _/wp-admin/edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters#/_
3. Confirm network/console error is gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?