### PR TITLE
feat(ras): add post checkout ras settings

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -747,6 +747,11 @@ class Donations {
 				[],
 				$cart_item_data
 			);
+
+			// Set checkout registration flag if user is not logged in.
+			if ( ! is_user_logged_in() && class_exists( '\Newspack_Blocks\Modal_Checkout' ) ) {
+				\Newspack_Blocks\Modal_Checkout::set_checkout_registration_flag();
+			}
 		}
 
 		$query_args = [];

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -342,6 +342,8 @@ final class Reader_Activation {
 			'contact_email_address'                    => Emails::get_reply_to_email(),
 			'woocommerce_registration_required'        => false,
 			'woocommerce_checkout_privacy_policy_text' => self::get_checkout_privacy_policy_text(),
+			'woocommerce_post_checkout_success_text'   => self::get_post_checkout_success_text(),
+			'woocommerce_post_checkout_registration_success_text' => self::get_post_checkout_registration_success_text(),
 		];
 
 		/**
@@ -2398,6 +2400,44 @@ final class Reader_Activation {
 			__(
 				"Your personal data will be used to process your order and create an account if one doesn't exist. This information will also support your experience throughout this website, and be used for other purposes described in our privacy policy.",
 				'newspack-plugin'
+			)
+		);
+	}
+
+	/**
+	 * Modal checkout success text.
+	 *
+	 * @return string Post checkout success text.
+	 */
+	public static function get_post_checkout_success_text() {
+		return \get_option(
+			self::OPTIONS_PREFIX . 'woocommerce_post_checkout_success_text',
+			sprintf(
+				// Translators: %s is the name of the site.
+				__(
+					'Thank you for supporting %s. Your transaction was successful.',
+					'newspack-plugin'
+				),
+				html_entity_decode( get_bloginfo( 'name' ) )
+			)
+		);
+	}
+
+	/**
+	 * Modal checkout registration success text.
+	 *
+	 * @return string Post checkout registration success text.
+	 */
+	public static function get_post_checkout_registration_success_text() {
+		return \get_option(
+			self::OPTIONS_PREFIX . 'woocommerce_post_checkout_registration_success_text',
+			sprintf(
+				// Translators: %s is the name of the site.
+				__(
+					'Thank you for supporting %s. Your account was created and your transaction was completed successfully.',
+					'newspack-plugin'
+				),
+				html_entity_decode( get_bloginfo( 'name' ) )
 			)
 		);
 	}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2415,7 +2415,7 @@ final class Reader_Activation {
 			sprintf(
 				// Translators: %s is the name of the site.
 				__(
-					'Thank you for supporting %s. Your transaction was successful.',
+					'Thank you for supporting %s. Your transaction was completed successfully.',
 					'newspack-plugin'
 				),
 				html_entity_decode( get_bloginfo( 'name' ) )
@@ -2434,7 +2434,7 @@ final class Reader_Activation {
 			sprintf(
 				// Translators: %s is the name of the site.
 				__(
-					'Thank you for supporting %s. Your account was created and your transaction was completed successfully.',
+					'Thank you for supporting %s. Your account has been created, and your transaction was completed successfully.',
 					'newspack-plugin'
 				),
 				html_entity_decode( get_bloginfo( 'name' ) )

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -457,7 +457,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 							<TextareaControl
 								label={ __( 'Post-checkout registration success message', 'newspack-plugin' ) }
 								help={ __(
-									'The success message to display to readers that have created a new account during checkout.',
+									'The success message to display to new readers that have an account automatically created after completing checkout.',
 									'newspack-plugin'
 								) }
 								{ ...getSharedProps( 'woocommerce_post_checkout_registration_success_text', 'text' ) }

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -3,7 +3,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, TextareaControl, ToggleControl } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -14,6 +14,7 @@ import {
 	ActionCard,
 	Button,
 	Card,
+	Grid,
 	Notice,
 	PluginInstaller,
 	SectionHeader,
@@ -431,42 +432,46 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 
 					<SectionHeader title={ __( 'Checkout Configuration', 'newspack-plugin' ) } />
 
-					<ActionCard
-						title={ __(
-							'Prompt logged out readers to sign in or register a new account before checkout',
+					<ToggleControl
+						label={ __(
+							'Require sign in or create account before checkout',
 							'newspack-plugin'
 						) }
-						description={ __(
-							'Require logged out readers to sign in or register a new account before proceeding to checkout.',
-							'newspack-plugin'
-						) }
-						toggleChecked={ config.woocommerce_registration_required }
-						toggleOnChange={ value => updateConfig( 'woocommerce_registration_required', value ) }
-					/>
-					<TextControl
-						label={ __( 'Checkout privacy policy text', 'newspack-plugin' ) }
 						help={ __(
-							'The privacy policy text to display at time of checkout for existing users. This will not show up unless a privacy page is set.',
+							'Prompt users who are not logged in to sign in or register a new account before proceeding to checkout.',
 							'newspack-plugin'
 						) }
-						{ ...getSharedProps( 'woocommerce_checkout_privacy_policy_text', 'text' ) }
+						checked={ config.woocommerce_registration_required }
+						onChange={ value => updateConfig( 'woocommerce_registration_required', value ) }
 					/>
-					<TextControl
-						label={ __( 'Post-checkout success message', 'newspack-plugin' ) }
-						help={ __(
-							'The success message to display to readers after completing checkout.',
-							'newspack-plugin'
-						) }
-						{ ...getSharedProps( 'woocommerce_post_checkout_success_text', 'text' ) }
-					/>
-					<TextControl
-						label={ __( 'Post-checkout registration success message', 'newspack-plugin' ) }
-						help={ __(
-							'The success message to display to readers that have created a new account during checkout.',
-							'newspack-plugin'
-						) }
-						{ ...getSharedProps( 'woocommerce_post_checkout_registration_success_text', 'text' ) }
-					/>
+					<Grid>
+						<TextareaControl
+							label={ __( 'Post-checkout success message', 'newspack-plugin' ) }
+							help={ __(
+								'The success message to display to readers after completing checkout.',
+								'newspack-plugin'
+							) }
+							{ ...getSharedProps( 'woocommerce_post_checkout_success_text', 'text' ) }
+						/>
+						<TextareaControl
+							label={ __( 'Post-checkout registration success message', 'newspack-plugin' ) }
+							help={ __(
+								'The success message to display to readers that have created a new account during checkout.',
+								'newspack-plugin'
+							) }
+							{ ...getSharedProps( 'woocommerce_post_checkout_registration_success_text', 'text' ) }
+						/>
+					</Grid>
+					<Grid>
+						<TextareaControl
+							label={ __( 'Checkout privacy policy text', 'newspack-plugin' ) }
+							help={ __(
+								'The privacy policy text to display at time of checkout for existing users. This will not show up unless a privacy page is set.',
+								'newspack-plugin'
+							) }
+							{ ...getSharedProps( 'woocommerce_checkout_privacy_policy_text', 'text' ) }
+						/>
+					</Grid>
 					<div className="newspack-buttons-card">
 						<Button
 							isPrimary

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -453,14 +453,16 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 							) }
 							{ ...getSharedProps( 'woocommerce_post_checkout_success_text', 'text' ) }
 						/>
-						<TextareaControl
-							label={ __( 'Post-checkout registration success message', 'newspack-plugin' ) }
-							help={ __(
-								'The success message to display to readers that have created a new account during checkout.',
-								'newspack-plugin'
-							) }
-							{ ...getSharedProps( 'woocommerce_post_checkout_registration_success_text', 'text' ) }
-						/>
+						{ config.woocommerce_registration_required && (
+							<TextareaControl
+								label={ __( 'Post-checkout registration success message', 'newspack-plugin' ) }
+								help={ __(
+									'The success message to display to readers that have created a new account during checkout.',
+									'newspack-plugin'
+								) }
+								{ ...getSharedProps( 'woocommerce_post_checkout_registration_success_text', 'text' ) }
+							/>
+						) }
 					</Grid>
 					<Grid>
 						<TextareaControl

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -438,7 +438,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 							'newspack-plugin'
 						) }
 						help={ __(
-							'Prompt users who are not logged in to sign in or register a new account before proceeding to checkout.',
+							'Prompt users who are not logged in to sign in or register a new account before proceeding to checkout. When disabled, an account will automatically be created with the email address used at checkout.',
 							'newspack-plugin'
 						) }
 						checked={ config.woocommerce_registration_required }

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -453,7 +453,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 							) }
 							{ ...getSharedProps( 'woocommerce_post_checkout_success_text', 'text' ) }
 						/>
-						{ config.woocommerce_registration_required && (
+						{ ! config.woocommerce_registration_required && (
 							<TextareaControl
 								label={ __( 'Post-checkout registration success message', 'newspack-plugin' ) }
 								help={ __(

--- a/src/wizards/engagement/views/reader-activation/index.js
+++ b/src/wizards/engagement/views/reader-activation/index.js
@@ -451,7 +451,22 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 						) }
 						{ ...getSharedProps( 'woocommerce_checkout_privacy_policy_text', 'text' ) }
 					/>
-
+					<TextControl
+						label={ __( 'Post-checkout success message', 'newspack-plugin' ) }
+						help={ __(
+							'The success message to display to readers after completing checkout.',
+							'newspack-plugin'
+						) }
+						{ ...getSharedProps( 'woocommerce_post_checkout_success_text', 'text' ) }
+					/>
+					<TextControl
+						label={ __( 'Post-checkout registration success message', 'newspack-plugin' ) }
+						help={ __(
+							'The success message to display to readers that have created a new account during checkout.',
+							'newspack-plugin'
+						) }
+						{ ...getSharedProps( 'woocommerce_post_checkout_registration_success_text', 'text' ) }
+					/>
 					<div className="newspack-buttons-card">
 						<Button
 							isPrimary
@@ -482,6 +497,8 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 									metadata_prefix: config.metadata_prefix,
 									woocommerce_registration_required: config.woocommerce_registration_required,
 									woocommerce_checkout_privacy_policy_text: config.woocommerce_checkout_privacy_policy_text,
+									woocommerce_post_checkout_success_text: config.woocommerce_post_checkout_success_text,
+									woocommerce_post_checkout_registration_success_text: config.woocommerce_post_checkout_registration_success_text,
 								} );
 							} }
 							disabled={ inFlight }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds post checkout success message settings to the Checkout Configuration section of the engagement wizard

Forced checkout registration enabled:
![Screenshot 2024-11-08 at 12 12 52](https://github.com/user-attachments/assets/48e5364d-d0b7-4e93-80bc-aeb09b592272)

And disabled:
![Screenshot 2024-11-08 at 12 12 57](https://github.com/user-attachments/assets/96de3563-eff1-48d3-80f4-f234471fce0f)

### How to test the changes in this Pull Request:

1. As admin, go to Newspack > Engagement > Show Advanced Settings
2. Scroll to the Checkout Configuration section
3. Verify the new fields are present (pictured above)
4. Edit and save the two fields
5. Verify your change persist through a refresh

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->