### PR TITLE
fix(wizard-admin-menu-priority): reinstate admin menu action hook priority

### DIFF
--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -70,6 +70,15 @@ class Advertising_Display_Ads extends Wizard {
 	public $menu_order = 4;
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * Important: keep this at 2 otherwise parent menu won't expand/highlight for class-advertising-sponsors.php
+	 * 
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 2;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -48,6 +48,13 @@ class Advertising_Sponsors extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 99;
+
+	/**
 	 * Advertising_Sponsors Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -31,6 +31,13 @@ class Components_Demo extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 100;
+
+	/**
 	 * Whether the wizard should be displayed in the Newspack submenu.
 	 *
 	 * @var bool.

--- a/includes/wizards/class-listings-wizard.php
+++ b/includes/wizards/class-listings-wizard.php
@@ -56,6 +56,13 @@ class Listings_Wizard extends Wizard {
 	public $menu_order = 3;
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 99;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -61,6 +61,13 @@ abstract class Wizard {
 	public $menu_order = 0;
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 2;
+
+	/**
 	 * Initialize.
 	 *
 	 * @param array $args Array of optional arguments. i.e. `sections`.
@@ -70,7 +77,7 @@ abstract class Wizard {
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-		add_action( 'admin_menu', [ $this, 'add_page' ] );
+		add_action( 'admin_menu', [ $this, 'add_page' ], $this->admin_menu_hook_priority );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {
 			$this->load_wizard_sections( $args['sections'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We lost the ability to set the `admin_menu` action hook priority in the parent Wizard class.  This PR reinstates that ability.

Somewhere in the midst of the [previous two merges](https://github.com/Automattic/newspack-plugin/commits/epic/ia/includes/wizards/class-wizard.php) the variable `$menu_priority` was removed, but the variable is still needed for the priority for the `admin_menu` hook.

I found this issue because the parent menu for "Advertising > Sponsors" wasn't being expended properly locally but on the staging site the menu was fine.

**Local (prior to this PR fix):**

![image](https://github.com/user-attachments/assets/54cbd879-467f-40f3-a0a1-355111363968)

**Staging site is currently working:**

![image](https://github.com/user-attachments/assets/262ce789-883b-4fb4-9dfa-808f803e48ec)


### Variable renamed:

To be a bit most specific about what the variable does, I renamed it from `menu_priority` to `admin_menu_hook_priority`.  It's a bit wordy, but I wanted to differentiate it from the variables that are used by the `custom_menu_order`.

I also looked through the previous commits and added the variable back to the classes that had it prior.  Basically any class that was using it with a priority above 10.  For the classes that had the priority at 1 (newspack-dashboard) or 2 (newspack-settings), I didn't add it back since 2 is already the default.

For `includes/wizards/advertising/class-advertising-display-ads.php` I did keep the 2 in the code with a note: `* Important: keep this at 2 otherwise parent menu won't expand/highlight for class-advertising-sponsors.php`

### How to test the changes in this Pull Request:

1. Pull branch on top of `epic/ia`.
2. Use WP-Admin in browser to verify menu functions correctly for IA related items.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->