### PR TITLE
Fix/wizard admin menu priority 2

### DIFF
--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -29,19 +29,6 @@ class Wizards {
 	 */
 	public static function init() {
 		self::$wizards = [
-			'setup'                   => new Setup_Wizard(),
-			'site-design'             => new Site_Design_Wizard(),
-			'reader-revenue'          => new Reader_Revenue_Wizard(),
-			'advertising'             => new Advertising_Wizard(),
-			'syndication'             => new Syndication_Wizard(),
-			'analytics'               => new Analytics_Wizard(),
-			'components-demo'         => new Components_Demo(),
-			'seo'                     => new SEO_Wizard(),
-			'health-check'            => new Health_Check_Wizard(),
-			'engagement'              => new Engagement_Wizard(),
-			'popups'                  => new Popups_Wizard(),
-			'connections'             => new Connections_Wizard(),
-			'settings'                => new Settings(),
 			// v2 Information Architecture.
 			'newspack-dashboard'      => new Newspack_Dashboard(),
 			'newspack-settings'       => new Newspack_Settings(
@@ -58,6 +45,20 @@ class Wizards {
 			'listings'                => new Listings_Wizard(),
 			'network'                 => new Network_Wizard(),
 			'newsletters'             => new Newsletters_Wizard(),
+			// Old pages.  Load after V2...remove when no longer needed.
+			'setup'                   => new Setup_Wizard(),
+			'site-design'             => new Site_Design_Wizard(),
+			'reader-revenue'          => new Reader_Revenue_Wizard(),
+			'advertising'             => new Advertising_Wizard(),
+			'syndication'             => new Syndication_Wizard(),
+			'analytics'               => new Analytics_Wizard(),
+			'components-demo'         => new Components_Demo(),
+			'seo'                     => new SEO_Wizard(),
+			'health-check'            => new Health_Check_Wizard(),
+			'engagement'              => new Engagement_Wizard(),
+			'popups'                  => new Popups_Wizard(),
+			'connections'             => new Connections_Wizard(),
+			'settings'                => new Settings(),
 		];
 
 		// Allow custom menu order.

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -70,15 +70,6 @@ class Advertising_Display_Ads extends Wizard {
 	public $menu_order = 4;
 
 	/**
-	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
-	 *
-	 * Important: keep this at 2 otherwise parent menu won't expand/highlight for class-advertising-sponsors.php
-	 * 
-	 * @var int.
-	 */
-	protected $admin_menu_hook_priority = 2;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -577,7 +568,8 @@ class Advertising_Display_Ads extends Wizard {
 			__( 'Display Ads', 'newspack-plugin' ),
 			$this->capability,
 			$this->slug,
-			array( $this, 'render_wizard' )
+			array( $this, 'render_wizard' ),
+			0 // Make sure this is first item in submenu. CPTs seem to be added at position "1" .
 		);
 	}
 }

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -70,6 +70,15 @@ class Advertising_Display_Ads extends Wizard {
 	public $menu_order = 4;
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * Important: keep this at 2 otherwise parent menu won't expand/highlight for class-advertising-sponsors.php
+	 * 
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 2;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -569,7 +569,7 @@ class Advertising_Display_Ads extends Wizard {
 			$this->capability,
 			$this->slug,
 			array( $this, 'render_wizard' ),
-			0 // Make sure this is first item in submenu. CPTs seem to be added at position "1" .
+			0 // Make sure this is first item in submenu.
 		);
 	}
 }

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -7,7 +7,7 @@
 
 namespace Newspack;
 
-use Newspack_Sponsors\Settings;
+use Newspack_Sponsors\Settings as Newspack_Sponsors_Settings;
 use Newspack\Wizards\Traits\Admin_Header;
 
 defined( 'ABSPATH' ) || exit;
@@ -48,13 +48,6 @@ class Advertising_Sponsors extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
-	 *
-	 * @var int.
-	 */
-	protected $admin_menu_hook_priority = 99;
-
-	/**
 	 * Advertising_Sponsors Constructor.
 	 */
 	public function __construct() {
@@ -63,7 +56,9 @@ class Advertising_Sponsors extends Wizard {
 		}
 		parent::__construct();
 
-		add_action( 'admin_menu', [ $this, 'move_sponsors_cpt_menu' ] );
+		// Must be run after Sponsors Plugin's 'admin_menu' has run.
+		add_action( 'admin_menu', [ $this, 'move_sponsors_cpt_menu' ], 11 );
+		// Remove Sponsors CPT from the parent menu.
 		add_action( 'register_post_type_args', [ $this, 'update_sponsors_cpt_args' ], 10, 2 );
 
 		// Below filters are used to determine active menu items.
@@ -134,24 +129,18 @@ class Advertising_Sponsors extends Wizard {
 	 * Move Sponsors CPT menu item under the ($) Advertising menu.
 	 */
 	public function move_sponsors_cpt_menu() {
-		global $submenu;
-		$parent_slug = 'advertising-display-ads';
-		if ( isset( $submenu[ $parent_slug ] ) ) {
-			$submenu[ $parent_slug ][] = array( // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				__( 'Sponsors', 'newspack-plugin' ),
-				'manage_options',
-				static::URL,
-			);
-		}
 
-		// Register Settings page.
+		// Remove the Settings page added by Sponsors Plugin.
+		remove_submenu_page( 'edit.php?post_type=newspack_spnsrs_cpt', 'newspack-sponsors-settings-admin' );
+
+		// Re-add the Settings page as hidden.
 		add_submenu_page(
 			'', // No parent menu item, means its not on the menu.
-			__( 'Newspack Sponsors: Site-Wide Settings', 'newspack-sponsors' ),
-			__( 'Settings', 'newspack-sponsors' ),
+			__( 'Newspack Sponsors: Site-Wide Settings', 'newspack-plugin' ),
+			__( 'Settings', 'newspack-plugin' ),
 			'manage_options',
 			'newspack-sponsors-settings-admin',
-			[ Settings::class, 'create_admin_page' ]
+			[ Newspack_Sponsors_Settings::class, 'create_admin_page' ]
 		);
 	}
 
@@ -165,7 +154,7 @@ class Advertising_Sponsors extends Wizard {
 	public function update_sponsors_cpt_args( $args, $post_type ) {
 		if ( $post_type === static::CPT_NAME ) {
 			// Move the CPT under the Advertising menu. Necessary to hide default Sponsors CPT menu item.
-			$args['show_in_menu'] = static::PARENT_URL;
+			$args['show_in_menu'] = 'advertising-display-ads';
 		}
 		return $args;
 	}

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -68,11 +68,10 @@ class Advertising_Sponsors extends Wizard {
 		// Move Sponsors Settings page (after Sponsors Plugin loads - set priority > 10 ).
 		add_action( 'admin_menu', [ $this, 'move_sponsors_settings_menu' ], 11 );
 
+		// Determine active menu items.
+		add_filter( 'submenu_file', [ $this, 'submenu_file' ] );
+		
 		if ( $this->is_wizard_page() ) {
-
-			// Below filters are used to determine active menu items.
-			add_filter( 'parent_file', [ $this, 'parent_file' ] );
-			add_filter( 'submenu_file', [ $this, 'submenu_file' ] );
 
 			// Add CSS classes by calling parent add_body_class() .
 			add_filter( 'admin_body_class', [ $this, 'add_body_class' ] );
@@ -129,14 +128,16 @@ class Advertising_Sponsors extends Wizard {
 		// Re-add the Settings page as hidden if we're on the CPT screen.
 		if ( $this->is_wizard_page() ) {
 
-			add_submenu_page(
+			$title = __( 'Newspack Sponsors: Site-Wide Settings', 'newspack-plugin' );
+			$hook = add_submenu_page(
 				'', // No parent menu item, means its not on the menu.
-				__( 'Newspack Sponsors: Site-Wide Settings', 'newspack-plugin' ),
+				$title,
 				__( 'Settings', 'newspack-plugin' ),
 				$this->capability,
 				'newspack-sponsors-settings-admin',
 				[ Newspack_Sponsors_Settings::class, 'create_admin_page' ]
 			);
+			$this->fix_hidden_screen_title( $hook, $title );
 
 		}
 	}
@@ -157,33 +158,13 @@ class Advertising_Sponsors extends Wizard {
 	}
 
 	/**
-	 * Parent file filter. Used to determine active menu items.
-	 *
-	 * @param string $parent_file Parent file to be overridden.
-	 * @return string
-	 */
-	public function parent_file( $parent_file ) {
-		global $pagenow, $typenow;
-
-		if ( in_array( $pagenow, [ 'post.php', 'post-new.php' ] ) && $typenow === static::CPT_NAME ) {
-			return static::PARENT_SLUG;
-		}
-
-		if ( isset( $_GET['page'] ) && $_GET['page'] === 'newspack-sponsors-settings-admin' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return static::PARENT_URL;
-		}
-
-		return $parent_file;
-	}
-
-	/**
 	 * Submenu file filter. Used to determine active submenu items.
 	 *
 	 * @param string $submenu_file Submenu file to be overridden.
 	 * @return string
 	 */
 	public function submenu_file( $submenu_file ) {
-		if ( isset( $_GET['page'] ) && $_GET['page'] === 'newspack-sponsors-settings-admin' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['post_type'] ) && $_GET['post_type'] === static::CPT_NAME ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return static::CPT_URL;
 		}
 

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -153,6 +153,8 @@ class Advertising_Sponsors extends Wizard {
 		if ( $post_type === static::CPT_NAME ) {
 			// Move the CPT under the Advertising menu. Necessary to hide default Sponsors CPT menu item.
 			$args['show_in_menu'] = static::PARENT_SLUG;
+			// Change CPT submenu text from "All Sponsors" to "Sponsors".
+			$args['labels']['all_items'] = __( 'Sponsors', 'newspack-plugin' );
 		}
 		return $args;
 	}

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -129,7 +129,7 @@ class Advertising_Sponsors extends Wizard {
 		if ( $this->is_wizard_page() ) {
 
 			$title = __( 'Newspack Sponsors: Site-Wide Settings', 'newspack-plugin' );
-			$hook = add_submenu_page(
+			add_submenu_page(
 				'', // No parent menu item, means its not on the menu.
 				$title,
 				__( 'Settings', 'newspack-plugin' ),
@@ -137,7 +137,7 @@ class Advertising_Sponsors extends Wizard {
 				'newspack-sponsors-settings-admin',
 				[ Newspack_Sponsors_Settings::class, 'create_admin_page' ]
 			);
-			$this->fix_hidden_screen_title( $hook, $title );
+			$this->fix_hidden_screen_title( 'admin_page_newspack-sponsors-settings-admin', $title );
 
 		}
 	}

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -48,6 +48,13 @@ class Advertising_Sponsors extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 99;
+
+	/**
 	 * Advertising_Sponsors Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -31,7 +31,14 @@ class Advertising_Sponsors extends Wizard {
 	 *
 	 * @var string
 	 */
-	const URL = 'edit.php?post_type=newspack_spnsrs_cpt';
+	const CPT_URL = 'edit.php?post_type=newspack_spnsrs_cpt';
+
+	/**
+	 * Advertising Page slug.
+	 *
+	 * @var string
+	 */
+	const PARENT_SLUG = 'advertising-display-ads';
 
 	/**
 	 * Advertising Page path.
@@ -54,29 +61,33 @@ class Advertising_Sponsors extends Wizard {
 		if ( ! is_plugin_active( 'newspack-sponsors/newspack-sponsors.php' ) ) {
 			return;
 		}
-		parent::__construct();
 
-		// Must be run after Sponsors Plugin's 'admin_menu' has run.
-		add_action( 'admin_menu', [ $this, 'move_sponsors_cpt_menu' ], 11 );
-		// Remove Sponsors CPT from the parent menu.
+		// Move Sponsors CPT under Advertising menu.
 		add_action( 'register_post_type_args', [ $this, 'update_sponsors_cpt_args' ], 10, 2 );
 
-		// Below filters are used to determine active menu items.
-		add_filter( 'parent_file', [ $this, 'parent_file' ] );
-		add_filter( 'submenu_file', [ $this, 'submenu_file' ] );
+		// Move Sponsors Settings page (after Sponsors Plugin loads - set priority > 10 ).
+		add_action( 'admin_menu', [ $this, 'move_sponsors_settings_menu' ], 11 );
 
 		if ( $this->is_wizard_page() ) {
+
+			// Below filters are used to determine active menu items.
+			add_filter( 'parent_file', [ $this, 'parent_file' ] );
+			add_filter( 'submenu_file', [ $this, 'submenu_file' ] );
+
+			// Add CSS classes by calling parent add_body_class() .
+			add_filter( 'admin_body_class', [ $this, 'add_body_class' ] );
+
 			// Initialize Wizards Admin Header.
 			$this->admin_header_init(
 				[
 					'tabs'  => [
 						[
 							'textContent' => esc_html__( 'All Sponsors', 'newspack-plugin' ),
-							'href'        => admin_url( static::URL ),
+							'href'        => admin_url( static::CPT_URL ),
 						],
 						[
 							'textContent' => esc_html__( 'Settings', 'newspack-plugin' ),
-							'href'        => admin_url( static::URL . '&page=newspack-sponsors-settings-admin' ),
+							'href'        => admin_url( static::CPT_URL . '&page=newspack-sponsors-settings-admin' ),
 						],
 					],
 					'title' => $this->get_name(),
@@ -108,40 +119,26 @@ class Advertising_Sponsors extends Wizard {
 	}
 
 	/**
-	 * Enqueue scripts and styles.
+	 * Move the Sponsors Settings menu location.
 	 */
-	public function enqueue_scripts_and_styles() {
-		if ( ! $this->is_wizard_page() ) {
-			return;
+	public function move_sponsors_settings_menu() {
+
+		// Remove the Settings page that was added by Sponsors Plugin.
+		remove_submenu_page( static::CPT_URL, 'newspack-sponsors-settings-admin' );
+
+		// Re-add the Settings page as hidden if we're on the CPT screen.
+		if ( $this->is_wizard_page() ) {
+
+			add_submenu_page(
+				'', // No parent menu item, means its not on the menu.
+				__( 'Newspack Sponsors: Site-Wide Settings', 'newspack-plugin' ),
+				__( 'Settings', 'newspack-plugin' ),
+				$this->capability,
+				'newspack-sponsors-settings-admin',
+				[ Newspack_Sponsors_Settings::class, 'create_admin_page' ]
+			);
+
 		}
-		Newspack::load_common_assets();
-		wp_register_style(
-			'advertising-display-ads',
-			Newspack::plugin_url() . '/dist/billboard.css',
-			$this->get_style_dependencies(),
-			NEWSPACK_PLUGIN_VERSION
-		);
-		wp_style_add_data( 'advertising-display-ads', 'rtl', 'replace' );
-		wp_enqueue_style( 'advertising-display-ads' );
-	}
-
-	/**
-	 * Move Sponsors CPT menu item under the ($) Advertising menu.
-	 */
-	public function move_sponsors_cpt_menu() {
-
-		// Remove the Settings page added by Sponsors Plugin.
-		remove_submenu_page( 'edit.php?post_type=newspack_spnsrs_cpt', 'newspack-sponsors-settings-admin' );
-
-		// Re-add the Settings page as hidden.
-		add_submenu_page(
-			'', // No parent menu item, means its not on the menu.
-			__( 'Newspack Sponsors: Site-Wide Settings', 'newspack-plugin' ),
-			__( 'Settings', 'newspack-plugin' ),
-			'manage_options',
-			'newspack-sponsors-settings-admin',
-			[ Newspack_Sponsors_Settings::class, 'create_admin_page' ]
-		);
 	}
 
 	/**
@@ -154,7 +151,7 @@ class Advertising_Sponsors extends Wizard {
 	public function update_sponsors_cpt_args( $args, $post_type ) {
 		if ( $post_type === static::CPT_NAME ) {
 			// Move the CPT under the Advertising menu. Necessary to hide default Sponsors CPT menu item.
-			$args['show_in_menu'] = 'advertising-display-ads';
+			$args['show_in_menu'] = static::PARENT_SLUG;
 		}
 		return $args;
 	}
@@ -169,7 +166,7 @@ class Advertising_Sponsors extends Wizard {
 		global $pagenow, $typenow;
 
 		if ( in_array( $pagenow, [ 'post.php', 'post-new.php' ] ) && $typenow === static::CPT_NAME ) {
-			return 'advertising-display-ads';
+			return static::PARENT_SLUG;
 		}
 
 		if ( isset( $_GET['page'] ) && $_GET['page'] === 'newspack-sponsors-settings-admin' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -187,7 +184,7 @@ class Advertising_Sponsors extends Wizard {
 	 */
 	public function submenu_file( $submenu_file ) {
 		if ( isset( $_GET['page'] ) && $_GET['page'] === 'newspack-sponsors-settings-admin' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return static::URL;
+			return static::CPT_URL;
 		}
 
 		return $submenu_file;

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -31,6 +31,13 @@ class Components_Demo extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 100;
+
+	/**
 	 * Whether the wizard should be displayed in the Newspack submenu.
 	 *
 	 * @var bool.

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -31,13 +31,6 @@ class Components_Demo extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
-	 *
-	 * @var int.
-	 */
-	protected $admin_menu_hook_priority = 100;
-
-	/**
 	 * Whether the wizard should be displayed in the Newspack submenu.
 	 *
 	 * @var bool.

--- a/includes/wizards/class-listings-wizard.php
+++ b/includes/wizards/class-listings-wizard.php
@@ -56,6 +56,13 @@ class Listings_Wizard extends Wizard {
 	public $menu_order = 3;
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 99;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -61,6 +61,13 @@ abstract class Wizard {
 	public $menu_order = 0;
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 2;
+
+	/**
 	 * Initialize.
 	 *
 	 * @param array $args Array of optional arguments. i.e. `sections`.
@@ -70,7 +77,7 @@ abstract class Wizard {
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-		add_action( 'admin_menu', [ $this, 'add_page' ] );
+		add_action( 'admin_menu', [ $this, 'add_page' ], $this->admin_menu_hook_priority );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {
 			$this->load_wizard_sections( $args['sections'] );

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -308,4 +308,26 @@ abstract class Wizard {
 		$classes .= ' newspack-wizard-page';
 		return $classes;
 	}
+
+	/**
+	 * Fix Hidden Screen's HTML <title>
+	 * 
+	 * In cases where the $submenu hidden item array ( $submenu[''] = array of hidden submenu items ) is defined after the parent_slug's
+	 * item array ( $submenu['post type url or menu-slug'] = array of submenu items ), the HTML <title> will not be set and a debug.log
+	 * deprecated notice will be written: PHP Deprecated:  strip_tags(): Passing null ... is deprecated in wp-admin/admin-header.php on line 36
+	 * 
+	 * If the hidden array is defined before the parent slug array, then the HTML <title> is shown and no debug.log notice. To avoid this
+	 * issue completely, so we don't need to worry about where things are in the $submenu array, we'll proactivally set the title here just in case.
+	 * 
+	 * @param string $hook  Submenu hook.
+	 * @param string $title HTML <title>.
+	 * 
+	 * @return void
+	 */
+	public function fix_hidden_screen_title( $hook, $title ) {
+		add_action(
+			"load-{$hook}",
+			fn() => $GLOBALS['title'] = $title // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, Squiz.PHP.DisallowMultipleAssignments.Found
+		);
+	}
 }

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -61,13 +61,6 @@ abstract class Wizard {
 	public $menu_order = 0;
 
 	/**
-	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
-	 *
-	 * @var int.
-	 */
-	protected $admin_menu_hook_priority = 2;
-
-	/**
 	 * Initialize.
 	 *
 	 * @param array $args Array of optional arguments. i.e. `sections`.
@@ -77,7 +70,7 @@ abstract class Wizard {
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-		add_action( 'admin_menu', [ $this, 'add_page' ], $this->admin_menu_hook_priority );
+		add_action( 'admin_menu', [ $this, 'add_page' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {
 			$this->load_wizard_sections( $args['sections'] );

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -83,7 +83,7 @@ abstract class Wizard {
 	 */
 	public function add_page() {
 		add_submenu_page(
-			$this->hidden ? 'hidden' : 'newspack',
+			$this->hidden ? 'hidden' : 'newspack', // @TODO: change to 'newspack-dashboard'.
 			$this->get_name(),
 			$this->get_name(),
 			$this->capability,

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -29,15 +29,6 @@ class Newspack_Dashboard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Initialize.
-	 */
-	public function __construct() {
-		add_action( 'admin_menu', [ $this, 'add_page' ], 1 );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
-		add_filter( 'admin_body_class', [ $this, 'add_body_class' ] );
-	}
-
-	/**
 	 * Get Dashboard data
 	 *
 	 * @return []


### PR DESCRIPTION
Work in progress:

I found a way around the need for `$admin_menu_hook_priority` for Ads/Sponsors.  One of the issue was the loading priority of the plugins.  Depending on when Newspack Plugin is loaded vs when Newpack Sponsors plugin is loaded will change the orders of `admin_menu` hooks.  The old hook priority was allowing us to create the new menu in `advertising-display-ads` (priority 2) then sponsors plugin would add the settings page (priority 10), then `advertising-sponsors` could fire (priority 99).

Hidden pages must go at the end of the $submenu array.  If `$submenu['']` is created by a early `admin_menu(<10)` in Yoast or Jetpack, this means the hidden array will be above our Wizard pages.  This means that parent_file and submenu_file won't be found. (Test with/without Jetpack/Yoast).

```
    [advertising-display-ads] => Array
        (
            [0] => Array
                (
                    [0] => Display Ads
                    [1] => manage_options
                    [2] => advertising-display-ads
                    [3] => Advertising / Display Ads
                )

            [1] => Array
                (
                    [0] => Sponsors
                    [1] => manage_options
                    [2] => edit.php?post_type=newspack_spnsrs_cpt
                )

        )

    [admin.php?page=advertising-display-ads] => Array
        (
            [0] => Array
                (
                    [0] => All Sponsors
                    [1] => edit_posts
                    [2] => edit.php?post_type=newspack_spnsrs_cpt
                    [3] => Sponsors
                )

        )

    [] => Array
        (
            [0] => Array
                (
                    [0] => Settings
                    [1] => manage_options
                    [2] => newspack-sponsors-settings-admin
                    [3] => Newspack Sponsors: Site-Wide Settings
                )

        )

    [edit.php?post_type=newspack_spnsrs_cpt] => Array
        (
            [0] => Array
                (
                    [0] => Settings
                    [1] => manage_options
                    [2] => newspack-sponsors-settings-admin
                    [3] => Newspack Sponsors: Site-Wide Settings
                )

        )
```


I need update includes/wizards/class-listings-wizard.php

I think we can just remove it for includes/wizards/class-components-demo.php

Notes:

old menu slug is "newspack" => new menu slug is "newspack-dashboard"
we don't need `$admin_menu_hook_priority` as long as the instantiation of each wizard in `class-wizards.php` is in correct order.  problems could still exist for child plugins that could be initialized before or after the newspack plugin.  in these cases we could probably just handle as one-offs in each of the child plugin `class-*-wizard.php` file.

Testing:

- Review comments/concerns again: https://github.com/Automattic/newspack-plugin/pull/3534
- With/without jetpack/yoast (hidden menus).
- plugin load over Newspack vs Sponsors (db: wp_options.option_name = 'active_plugins' )









### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->