### PR TITLE
fix: get secondary, variation colors updating in RAS-ACC emails

### DIFF
--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -514,8 +514,12 @@ class Emails {
 				$theme_colors = newspack_get_theme_colors();
 				\Newspack_Newsletters::update_color_palette(
 					[
-						'primary'      => $theme_colors['primary_color'],
-						'primary-text' => $theme_colors['primary_text_color'],
+						'primary'             => $theme_colors['primary_color'],
+						'primary-text'        => $theme_colors['primary_text_color'],
+						'primary-variation'   => $theme_colors['primary_color_variation'],
+						'secondary'           => $theme_colors['secondary_color'],
+						'secondary-text'      => $theme_colors['secondary_text_color'],
+						'secondary-variation' => $theme_colors['secondary_color_variation'],
 					]
 				);
 			}
@@ -674,12 +678,17 @@ class Emails {
 			return;
 		}
 
-		if ( $previous_value['primary_color_hex'] !== $updated_value['primary_color_hex'] ) {
+		if ( ( $previous_value['primary_color_hex'] !== $updated_value['primary_color_hex'] ) || ( $previous_value['secondary_color_hex'] !== $updated_value['secondary_color_hex'] ) ) {
 			// Update the newsletters color palette.
 			$updated = \Newspack_Newsletters::update_color_palette(
 				[
-					'primary'      => $updated_value['primary_color_hex'],
-					'primary-text' => newspack_get_color_contrast( $updated_value['primary_color_hex'] ),
+					'primary'             => $updated_value['primary_color_hex'],
+					'primary-text'        => newspack_get_color_contrast( $updated_value['primary_color_hex'] ),
+					'primary-variation'   => newspack_adjust_brightness( $updated_value['primary_color_hex'], -40 ),
+					'secondary'           => $updated_value['secondary_color_hex'],
+					'secondary-text'      => newspack_get_color_contrast( $updated_value['secondary_color_hex'] ),
+					'secondary-variation' => newspack_adjust_brightness( $updated_value['secondary_color_hex'], -40 ),
+
 				]
 			);
 
@@ -703,10 +712,18 @@ class Emails {
 					[
 						$previous_value['primary_color_hex'],
 						newspack_get_color_contrast( $previous_value['primary_color_hex'] ),
+						newspack_adjust_brightness( $previous_value['primary_color_hex'], -40 ),
+						$previous_value['secondary_color_hex'],
+						newspack_get_color_contrast( $previous_value['secondary_color_hex'] ),
+						newspack_adjust_brightness( $previous_value['secondary_color_hex'], -40 ),
 					],
 					[
 						$updated_value['primary_color_hex'],
 						newspack_get_color_contrast( $updated_value['primary_color_hex'] ),
+						newspack_adjust_brightness( $updated_value['primary_color_hex'], -40 ),
+						$updated_value['secondary_color_hex'],
+						newspack_get_color_contrast( $updated_value['secondary_color_hex'] ),
+						newspack_adjust_brightness( $updated_value['secondary_color_hex'], -40 ),
 					],
 					$email_html
 				);

--- a/includes/emails/class-emails.php
+++ b/includes/emails/class-emails.php
@@ -516,10 +516,10 @@ class Emails {
 					[
 						'primary'             => $theme_colors['primary_color'],
 						'primary-text'        => $theme_colors['primary_text_color'],
-						'primary-variation'   => $theme_colors['primary_color_variation'],
+						'primary-variation'   => $theme_colors['primary_variation'],
 						'secondary'           => $theme_colors['secondary_color'],
 						'secondary-text'      => $theme_colors['secondary_text_color'],
-						'secondary-variation' => $theme_colors['secondary_color_variation'],
+						'secondary-variation' => $theme_colors['secondary_variation'],
 					]
 				);
 			}

--- a/includes/util.php
+++ b/includes/util.php
@@ -581,10 +581,10 @@ function newspack_get_theme_colors() {
 	return [
 		'primary_color'             => $primary_color,
 		'primary_text_color'        => newspack_get_color_contrast( $primary_color ),
-		'primary_color_variation'   => newspack_adjust_brightness( $primary_color, -40 ),
+		'primary_variation'   => newspack_adjust_brightness( $primary_color, -40 ),
 		'secondary_color'           => $secondary_color,
 		'secondary_text_color'      => newspack_get_color_contrast( $secondary_color ),
-		'secondary_color_variation' => newspack_adjust_brightness( $secondary_color, -40 ),
+		'secondary_variation' => newspack_adjust_brightness( $secondary_color, -40 ),
 	];
 }
 

--- a/includes/util.php
+++ b/includes/util.php
@@ -553,14 +553,14 @@ function newspack_adjust_brightness( $hex, $steps ) {
 		$hex = str_repeat( substr( $hex, 0, 1 ), 2 ) . str_repeat( substr( $hex, 1, 1 ), 2 ) . str_repeat( substr( $hex, 2, 1 ), 2 );
 	}
 
-	// Split into three parts: R, G and B
+	// Split into three parts: R, G and B.
 	$color_parts = str_split( $hex, 2 );
 	$new_shade   = '#';
 
 	foreach ( $color_parts as $color ) {
-		$color      = hexdec( $color ); // Convert to decimal
-		$color      = max( 0, min( 255, $color + $steps ) ); // Adjust color
-		$new_shade .= str_pad( dechex( $color ), 2, '0', STR_PAD_LEFT ); // Make two char hex code
+		$color      = hexdec( $color ); // Convert to decimal.
+		$color      = max( 0, min( 255, $color + $steps ) ); // Adjust color.
+		$new_shade .= str_pad( dechex( $color ), 2, '0', STR_PAD_LEFT ); // Make two char hex code.
 	}
 
 	return $new_shade;
@@ -579,12 +579,12 @@ function newspack_get_theme_colors() {
 	$secondary_color         = get_theme_mod( 'secondary_color_hex', $default_secondary_color );
 
 	return [
-		'primary_color'             => $primary_color,
-		'primary_text_color'        => newspack_get_color_contrast( $primary_color ),
-		'primary_variation'   => newspack_adjust_brightness( $primary_color, -40 ),
-		'secondary_color'           => $secondary_color,
-		'secondary_text_color'      => newspack_get_color_contrast( $secondary_color ),
-		'secondary_variation' => newspack_adjust_brightness( $secondary_color, -40 ),
+		'primary_color'        => $primary_color,
+		'primary_text_color'   => newspack_get_color_contrast( $primary_color ),
+		'primary_variation'    => newspack_adjust_brightness( $primary_color, -40 ),
+		'secondary_color'      => $secondary_color,
+		'secondary_text_color' => newspack_get_color_contrast( $secondary_color ),
+		'secondary_variation'  => newspack_adjust_brightness( $secondary_color, -40 ),
 	];
 }
 

--- a/includes/util.php
+++ b/includes/util.php
@@ -538,17 +538,53 @@ function newspack_get_color_contrast( $hex ) {
 }
 
 /**
+ * Adjust a hexidecimal colour value to lighten or darken it.
+ *
+ * @param  string $hex Hexidecimal value of the color to adjust.
+ * @param  string $steps Number of 'steps' to adjust the hexidecimal value's brightness.
+ * @return string Updated hexidecimal value.
+ */
+function newspack_adjust_brightness( $hex, $steps ) {
+
+	$steps = max( -255, min( 255, $steps ) );
+
+	$hex = str_replace( '#', '', $hex );
+	if ( 3 == strlen( $hex ) ) {
+		$hex = str_repeat( substr( $hex, 0, 1 ), 2 ) . str_repeat( substr( $hex, 1, 1 ), 2 ) . str_repeat( substr( $hex, 2, 1 ), 2 );
+	}
+
+	// Split into three parts: R, G and B
+	$color_parts = str_split( $hex, 2 );
+	$new_shade   = '#';
+
+	foreach ( $color_parts as $color ) {
+		$color      = hexdec( $color ); // Convert to decimal
+		$color      = max( 0, min( 255, $color + $steps ) ); // Adjust color
+		$new_shade .= str_pad( dechex( $color ), 2, '0', STR_PAD_LEFT ); // Make two char hex code
+	}
+
+	return $new_shade;
+}
+
+
+/**
  * Get theme primary and secondary colors or defaults if none present.
  *
  * @return array An array containing primary and secondary colors.
  */
 function newspack_get_theme_colors() {
 	$default_primary_color   = function_exists( 'newspack_get_primary_color' ) ? newspack_get_primary_color() : '#3366ff';
+	$default_secondary_color = function_exists( 'newspack_get_secondary_color' ) ? newspack_get_secondary_color() : '#666666';
 	$primary_color           = get_theme_mod( 'primary_color_hex', $default_primary_color );
+	$secondary_color         = get_theme_mod( 'secondary_color_hex', $default_secondary_color );
 
 	return [
-		'primary_color'      => $primary_color,
-		'primary_text_color' => newspack_get_color_contrast( $primary_color ),
+		'primary_color'             => $primary_color,
+		'primary_text_color'        => newspack_get_color_contrast( $primary_color ),
+		'primary_color_variation'   => newspack_adjust_brightness( $primary_color, -40 ),
+		'secondary_color'           => $secondary_color,
+		'secondary_text_color'      => newspack_get_color_contrast( $secondary_color ),
+		'secondary_color_variation' => newspack_adjust_brightness( $secondary_color, -40 ),
 	];
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR helps make sure the primary variation, secondary, and secondary variation colours are all updated in the emails when they're changed in the customizer, like the primary colour. 

See 1207817176293825-as-1208629737155847

### How to test the changes in this Pull Request:

1. Navigate to the Customizer and change the Primary and Secondary colours.

![CleanShot 2024-11-11 at 21 09 16](https://github.com/user-attachments/assets/bc93e154-3110-4c4f-9164-027705cd2bd2)

2. Navigate to Newspack > Engagement > Advanced Settings, and scroll to Transactional Emails.
3. Pick an email to test, and reset it.
4. Edit the email, and add four buttons, one each using the Primary, Primary Variation, Secondary and Secondary Variation colours.

![CleanShot 2024-11-11 at 21 10 02](https://github.com/user-attachments/assets/ef7486cc-e425-4874-8ede-ee1003394fb8)

5. Send yourself a test email, noting the colours of the buttons.
6. View the sent email; the Primary button should match, but the rest will be using colours that don't match the test email. They'll match your last set of custom colours, or a set from before that.

![CleanShot 2024-11-11 at 21 10 38](https://github.com/user-attachments/assets/ca9e3735-d7bc-4770-9da2-d9ca15d4fc97)

7. Apply this PR.
8. Navigate to the Customizer again to change the Primary and Secondary colours again.
9. Refresh the email editor, and resend a test email.
10. Confirm that the button colours in the editor and the buttons in the email now match.

![CleanShot 2024-11-11 at 21 14 29](https://github.com/user-attachments/assets/bd29d4f8-cd9d-4fab-a874-006e0486d120)
![CleanShot 2024-11-11 at 21 14 41](https://github.com/user-attachments/assets/41996656-dd8c-4ef8-aadd-ee93c701223a)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->