### PR TITLE
fix(wc-memberships): prevent RAS from hijacking WC for Teams links

### DIFF
--- a/includes/plugins/class-teams-for-memberships.php
+++ b/includes/plugins/class-teams-for-memberships.php
@@ -22,6 +22,7 @@ class Teams_For_Memberships {
 	public static function init() {
 		add_filter( 'newspack_ras_metadata_keys', [ __CLASS__, 'add_teams_metadata_keys' ] );
 		add_filter( 'newspack_esp_sync_contact', [ __CLASS__, 'handle_esp_sync_contact' ] );
+		add_filter( 'newspack_my_account_disabled_pages', [ __CLASS__, 'enable_members_area_for_team_members' ] );
 	}
 
 	/**
@@ -100,6 +101,26 @@ class Teams_For_Memberships {
 		}
 
 		return $contact;
+	}
+
+	/**
+	 * Enable Members Area for team members only. Team owners/managers get access to the "Teams" menu instead.
+	 *
+	 * @param array $disabled_wc_menu_items Disabled WooCommerce menu items.
+	 *
+	 * @return array Updated disabled WooCommerce menu items.
+	 */
+	public static function enable_members_area_for_team_members( $disabled_wc_menu_items ) {
+		if ( ! function_exists( 'wc_memberships_for_teams_get_teams' ) ) {
+			return $disabled_wc_menu_items;
+		}
+		if (
+			in_array( 'members-area', $disabled_wc_menu_items, true ) &&
+			! empty( \wc_memberships_for_teams_get_teams( \get_current_user_id(), [ 'role' => 'member' ] ) )
+		) {
+			$disabled_wc_menu_items = array_values( array_diff( $disabled_wc_menu_items, [ 'members-area' ] ) );
+		}
+		return $disabled_wc_menu_items;
 	}
 }
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1482,6 +1482,11 @@ final class Reader_Activation {
 	 * @return string Filtered template path.
 	 */
 	public static function replace_woocommerce_auth_form( $template, $template_name ) {
+		// Allow template rewriting for `woocommerce-memberships-for-teams` plugin. This includes
+		// a link to join a team.
+		if ( is_int( stripos( $template, 'woocommerce-memberships-for-teams' ) ) ) {
+			return $template;
+		}
 		if ( 'myaccount/form-login.php' === $template_name ) {
 			$template = dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-activation/login-form.php';
 		}

--- a/includes/reader-revenue/my-account/style.scss
+++ b/includes/reader-revenue/my-account/style.scss
@@ -125,7 +125,10 @@
 		}
 	}
 
-
+	// Fixes an issue with form display caused by Newspack Theme CSS.
+	.entry-content p {
+		word-wrap: normal;
+	}
 }
 
 /* stylelint-disable-next-line */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents this plugin from hijacking custom WC templates from `woocommerce-memberships-for-teams` plugin, allowing this plugin to add handling of "join team" links.

Note that failing tests on CI are due to network-dependent unit tests: [here's a proposition to remove these](https://github.com/Automattic/newspack-plugin/pull/3541).

### How to test the changes in this Pull Request:

1. On `trunk`,
2. Ensure RAS is activated
1. Activate `woocommerce-memberships-for-teams` plugin and create a team with unlimited seats. Log in as the team owner. 
3. In "My Account" -> "Team" -> "Add Member" tab and copy the registration link
4. Visit that link in a new session, observe the RAS registration UI is presented
5. Switch to this branch, reload the page, observe a UI allowing to join a team ("Hey there! You've been invited to join…")
6. Visit "My Account" page in that new session, observe that in this case, the RAS registration UI is presented

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208691990383384