### PR TITLE
fix: show "My Membership" links in My Account menu for team members

### DIFF
--- a/includes/plugins/class-teams-for-memberships.php
+++ b/includes/plugins/class-teams-for-memberships.php
@@ -22,6 +22,7 @@ class Teams_For_Memberships {
 	public static function init() {
 		add_filter( 'newspack_ras_metadata_keys', [ __CLASS__, 'add_teams_metadata_keys' ] );
 		add_filter( 'newspack_esp_sync_contact', [ __CLASS__, 'handle_esp_sync_contact' ] );
+		add_filter( 'newspack_my_account_disabled_pages', [ __CLASS__, 'enable_members_area_for_team_members' ] );
 	}
 
 	/**
@@ -100,6 +101,26 @@ class Teams_For_Memberships {
 		}
 
 		return $contact;
+	}
+
+	/**
+	 * Enable Members Area for team members only. Team owners/managers get access to the "Teams" menu instead.
+	 *
+	 * @param array $disabled_wc_menu_items Disabled WooCommerce menu items.
+	 *
+	 * @return array Updated disabled WooCommerce menu items.
+	 */
+	public static function enable_members_area_for_team_members( $disabled_wc_menu_items ) {
+		if ( ! function_exists( 'wc_memberships_for_teams_get_teams' ) ) {
+			return $disabled_wc_menu_items;
+		}
+		if (
+			in_array( 'members-area', $disabled_wc_menu_items, true ) &&
+			! empty( \wc_memberships_for_teams_get_teams( \get_current_user_id(), [ 'role' => 'member' ] ) )
+		) {
+			$disabled_wc_menu_items = array_values( array_diff( $disabled_wc_menu_items, [ 'members-area' ] ) );
+		}
+		return $disabled_wc_menu_items;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows the "My Membership" menu item and its submenu items to be shown to team members only. Team members who join a team by invitation have no other way to view or manage their team membership.

### How to test the changes in this Pull Request:

1. On this branch, create a team and assign an owner or manager
2. Confirm that a regular reader (not a member or owner/manager of any team) and the team owner/manager do not see the "Memberships" or "My Membership" menu item in My Account.
3. As the team owner/manager, invite another reader by email or link to join the team.
4. In a new session, join the team via the invitation from step 3.
5. Confirm that as the team member, you do see the "My Membership" menu item and its submenu items in My Account.

<img width="1249" alt="Screenshot 2024-11-12 at 10 41 31 AM" src="https://github.com/user-attachments/assets/cc7d721b-6c84-4590-922c-e3bec51a39a2">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->