### PR TITLE
Fix/wizard admin menu priority 3

### DIFF
--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -153,8 +153,8 @@ class Wizards {
 		}
 		$ordered_wizards = [];
 		foreach ( self::$wizards as $slug => $wizard ) {
-			if ( ! empty( $wizard->parent_menu ) && ! empty( $wizard->menu_order ) ) {
-				$ordered_wizards[ $wizard->menu_order ] = $wizard->parent_menu;
+			if ( ! empty( $wizard->parent_menu ) && ! empty( $wizard->parent_menu_order ) ) {
+				$ordered_wizards[ $wizard->parent_menu_order ] = $wizard->parent_menu;
 			}
 		}
 		if ( empty( $ordered_wizards ) ) {

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -29,42 +29,41 @@ class Wizards {
 	 */
 	public static function init() {
 		self::$wizards = [
+			'setup'                   => new Setup_Wizard(),
+			'site-design'             => new Site_Design_Wizard(),
+			'reader-revenue'          => new Reader_Revenue_Wizard(),
+			'advertising'             => new Advertising_Wizard(),
+			'syndication'             => new Syndication_Wizard(),
+			'analytics'               => new Analytics_Wizard(),
+			'components-demo'         => new Components_Demo(),
+			'seo'                     => new SEO_Wizard(),
+			'health-check'            => new Health_Check_Wizard(),
+			'engagement'              => new Engagement_Wizard(),
+			'popups'                  => new Popups_Wizard(),
+			'connections'             => new Connections_Wizard(),
+			'settings'                => new Settings(),
 			// v2 Information Architecture.
-			// 'newspack-dashboard'      => new Newspack_Dashboard(),
-			// 'newspack-settings'       => new Newspack_Settings(
-			// 	[
-			// 		'sections' => [
-			// 			'custom-events' => 'Newspack\Wizards\Newspack\Custom_Events_Section',
-			// 			'social-pixels' => 'Newspack\Wizards\Newspack\Pixels_Section',
-			// 			'recirculation' => 'Newspack\Wizards\Newspack\Recirculation_Section',
-			// 		],
-			// 	]
-			// ),
+			'newspack-dashboard'      => new Newspack_Dashboard(),
+			'newspack-settings'       => new Newspack_Settings(
+				[
+					'sections' => [
+						'custom-events' => 'Newspack\Wizards\Newspack\Custom_Events_Section',
+						'social-pixels' => 'Newspack\Wizards\Newspack\Pixels_Section',
+						'recirculation' => 'Newspack\Wizards\Newspack\Recirculation_Section',
+					],
+				]
+			),
 			'advertising-display-ads' => new Advertising_Display_Ads(),
 			'advertising-sponsors'    => new Advertising_Sponsors(),
-			// 'listings'                => new Listings_Wizard(),
-			// 'network'                 => new Network_Wizard(),
-			// 'newsletters'             => new Newsletters_Wizard(),
-			// Old pages.  Load after V2...remove when no longer needed.
-			// 'setup'                   => new Setup_Wizard(),
-			// 'site-design'             => new Site_Design_Wizard(),
-			// 'reader-revenue'          => new Reader_Revenue_Wizard(),
-			// 'advertising'             => new Advertising_Wizard(),
-			// 'syndication'             => new Syndication_Wizard(),
-			// 'analytics'               => new Analytics_Wizard(),
-			// 'components-demo'         => new Components_Demo(),
-			// 'seo'                     => new SEO_Wizard(),
-			// 'health-check'            => new Health_Check_Wizard(),
-			// 'engagement'              => new Engagement_Wizard(),
-			// 'popups'                  => new Popups_Wizard(),
-			// 'connections'             => new Connections_Wizard(),
-			// 'settings'                => new Settings(),
+			'listings'                => new Listings_Wizard(),
+			'network'                 => new Network_Wizard(),
+			'newsletters'             => new Newsletters_Wizard(),
 		];
 
 		// Allow custom menu order.
-		// add_filter( 'custom_menu_order', '__return_true' );
-		// // Fix menu order for wizards with parent menu items.
-		// add_filter( 'menu_order', [ __CLASS__, 'menu_order' ], 11 );
+		add_filter( 'custom_menu_order', '__return_true' );
+		// Fix menu order for wizards with parent menu items.
+		add_filter( 'menu_order', [ __CLASS__, 'menu_order' ], 11 );
 	}
 
 	/**

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -29,41 +29,42 @@ class Wizards {
 	 */
 	public static function init() {
 		self::$wizards = [
-			'setup'                   => new Setup_Wizard(),
-			'site-design'             => new Site_Design_Wizard(),
-			'reader-revenue'          => new Reader_Revenue_Wizard(),
-			'advertising'             => new Advertising_Wizard(),
-			'syndication'             => new Syndication_Wizard(),
-			'analytics'               => new Analytics_Wizard(),
-			'components-demo'         => new Components_Demo(),
-			'seo'                     => new SEO_Wizard(),
-			'health-check'            => new Health_Check_Wizard(),
-			'engagement'              => new Engagement_Wizard(),
-			'popups'                  => new Popups_Wizard(),
-			'connections'             => new Connections_Wizard(),
-			'settings'                => new Settings(),
 			// v2 Information Architecture.
-			'newspack-dashboard'      => new Newspack_Dashboard(),
-			'newspack-settings'       => new Newspack_Settings(
-				[
-					'sections' => [
-						'custom-events' => 'Newspack\Wizards\Newspack\Custom_Events_Section',
-						'social-pixels' => 'Newspack\Wizards\Newspack\Pixels_Section',
-						'recirculation' => 'Newspack\Wizards\Newspack\Recirculation_Section',
-					],
-				]
-			),
+			// 'newspack-dashboard'      => new Newspack_Dashboard(),
+			// 'newspack-settings'       => new Newspack_Settings(
+			// 	[
+			// 		'sections' => [
+			// 			'custom-events' => 'Newspack\Wizards\Newspack\Custom_Events_Section',
+			// 			'social-pixels' => 'Newspack\Wizards\Newspack\Pixels_Section',
+			// 			'recirculation' => 'Newspack\Wizards\Newspack\Recirculation_Section',
+			// 		],
+			// 	]
+			// ),
 			'advertising-display-ads' => new Advertising_Display_Ads(),
 			'advertising-sponsors'    => new Advertising_Sponsors(),
-			'listings'                => new Listings_Wizard(),
-			'network'                 => new Network_Wizard(),
-			'newsletters'             => new Newsletters_Wizard(),
+			// 'listings'                => new Listings_Wizard(),
+			// 'network'                 => new Network_Wizard(),
+			// 'newsletters'             => new Newsletters_Wizard(),
+			// Old pages.  Load after V2...remove when no longer needed.
+			// 'setup'                   => new Setup_Wizard(),
+			// 'site-design'             => new Site_Design_Wizard(),
+			// 'reader-revenue'          => new Reader_Revenue_Wizard(),
+			// 'advertising'             => new Advertising_Wizard(),
+			// 'syndication'             => new Syndication_Wizard(),
+			// 'analytics'               => new Analytics_Wizard(),
+			// 'components-demo'         => new Components_Demo(),
+			// 'seo'                     => new SEO_Wizard(),
+			// 'health-check'            => new Health_Check_Wizard(),
+			// 'engagement'              => new Engagement_Wizard(),
+			// 'popups'                  => new Popups_Wizard(),
+			// 'connections'             => new Connections_Wizard(),
+			// 'settings'                => new Settings(),
 		];
 
 		// Allow custom menu order.
-		add_filter( 'custom_menu_order', '__return_true' );
-		// Fix menu order for wizards with parent menu items.
-		add_filter( 'menu_order', [ __CLASS__, 'menu_order' ], 11 );
+		// add_filter( 'custom_menu_order', '__return_true' );
+		// // Fix menu order for wizards with parent menu items.
+		// add_filter( 'menu_order', [ __CLASS__, 'menu_order' ], 11 );
 	}
 
 	/**

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -70,23 +70,18 @@ class Advertising_Display_Ads extends Wizard {
 	public $parent_menu_order = 4;
 
 	/**
-	 * Priority for this wizard's submenu item within the Advertising parent menu.
+	 * Use a high priorty so that the Advertising parent menu will be created
+	 * prior to submenu items being added.
 	 * 
 	 * @var int.
 	 */
-	protected $submenu_priority = 2;
+	protected $add_page_priority = 1;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-
-		// Create parent menu for the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab) before any submenu items are added.
-		add_action( 'admin_menu', array( $this, 'add_parent_menu' ), 1 );
-		
-		// Add this wizard's page with $submenu_priority = 2 so it will be added directly after the parent menu is created.
 		parent::__construct();
-
 		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
 	}
 
@@ -562,9 +557,10 @@ class Advertising_Display_Ads extends Wizard {
 	}
 
 	/**
-	 * Add a parent menu for all the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab).
+	 * Add a parent menu for all the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab),
+	 * and a first menu item too.
 	 */
-	public function add_parent_menu() {
+	public function add_page() {
 		// SVG generated via https://boxy-svg.com/ with path width/height 20px.
 		$icon = 'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="none" stroke="none" d="M 2 12 C 2 4.313 10.333 -0.491 17 3.352 C 20.094 5.136 22 8.433 22 12 C 22 19.686 13.667 24.49 7 20.647 C 3.906 18.863 2 15.567 2 12 Z M 12 3.727 C 5.622 3.727 1.635 10.621 4.824 16.136 C 6.304 18.696 9.04 20.273 12 20.273 C 18.378 20.273 22.365 13.378 19.176 7.863 C 17.696 5.304 14.96 3.727 12 3.727 Z M 10.471 9.292 C 10.112 9.543 10 9.808 10 10.003 C 10 10.198 10.112 10.463 10.471 10.714 C 10.827 10.962 11.366 11.144 12 11.144 C 12.943 11.144 13.834 11.41 14.512 11.883 C 15.186 12.356 15.714 13.089 15.714 13.997 C 15.714 14.904 15.187 15.637 14.512 16.11 C 14.043 16.436 13.475 16.664 12.857 16.774 L 12.857 17.135 C 12.857 17.793 12.143 18.205 11.571 17.876 C 11.306 17.723 11.143 17.44 11.143 17.135 L 11.143 16.774 C 10.55 16.675 9.985 16.448 9.488 16.11 C 8.814 15.637 8.286 14.904 8.286 13.997 C 8.286 13.338 9 12.926 9.571 13.255 C 9.837 13.408 10 13.691 10 13.997 C 10 14.192 10.112 14.456 10.471 14.707 C 10.827 14.956 11.366 15.138 12 15.138 C 12.634 15.138 13.173 14.956 13.529 14.707 C 13.888 14.456 14 14.192 14 13.997 C 14 13.801 13.888 13.537 13.529 13.286 C 13.173 13.037 12.634 12.855 12 12.855 C 11.057 12.855 10.166 12.59 9.488 12.116 C 8.814 11.644 8.286 10.91 8.286 10.003 C 8.286 9.095 8.813 8.362 9.488 7.889 C 9.985 7.552 10.55 7.324 11.143 7.225 L 11.143 6.865 C 11.143 6.206 11.857 5.794 12.429 6.123 C 12.694 6.276 12.857 6.559 12.857 6.865 L 12.857 7.225 C 13.474 7.335 14.045 7.563 14.512 7.889 C 15.186 8.362 15.714 9.095 15.714 10.003 C 15.714 10.661 15 11.073 14.429 10.744 C 14.163 10.591 14 10.308 14 10.003 C 14 9.808 13.888 9.543 13.529 9.292 C 13.173 9.043 12.634 8.862 12 8.862 C 11.366 8.862 10.827 9.043 10.471 9.292 Z"></path></svg>' );
 		add_menu_page(
@@ -575,12 +571,6 @@ class Advertising_Display_Ads extends Wizard {
 			array( $this, 'render_wizard' ),
 			$icon
 		);
-	}
-
-	/**
-	 * Add submenu page for this wizard.
-	 */
-	public function add_page() {
 		add_submenu_page(
 			$this->slug,
 			__( 'Advertising / Display Ads', 'newspack-plugin' ),

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -75,7 +75,7 @@ class Advertising_Display_Ads extends Wizard {
 	 * 
 	 * @var int.
 	 */
-	protected $add_page_priority = 1;
+	protected $admin_menu_priority = 1;
 
 	/**
 	 * Constructor.

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -74,6 +74,9 @@ class Advertising_Display_Ads extends Wizard {
 	 * and this wizard page itself too, using a priority < 10 so the Advertising parent menu exists
 	 * prior to other wizard and Sponsors Plugins submenu items being added.
 	 * 
+	 * The value here is only for competing Advertising menu items. It is not related to any 
+	 * 'newspack-dashboard' menu items.
+	 * 
 	 * @var int.
 	 */
 	protected $admin_menu_hook_priority = 9;
@@ -578,8 +581,7 @@ class Advertising_Display_Ads extends Wizard {
 			__( 'Display Ads', 'newspack-plugin' ),
 			$this->capability,
 			$this->slug,
-			array( $this, 'render_wizard' ),
-			0 // Make sure this is first item in submenu.
+			array( $this, 'render_wizard' )
 		);
 	}
 }

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -70,17 +70,19 @@ class Advertising_Display_Ads extends Wizard {
 	public $menu_order = 4;
 
 	/**
+	 * Create parent menu for the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab),
+	 * and this wizard page itself too, using a priority < 10 so the Advertising parent menu exists
+	 * prior to other wizard and Sponsors Plugins submenu items being added.
+	 * 
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 9;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		
-		// Create a parent admin menu for the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab).
-		// note: priority must be < 10 so parent menu exists prior to submenu items being added.
-		add_action( 'admin_menu', [ $this, 'add_parent_menu' ], 9 );
-
-		// Setup this wizard's page.
 		parent::__construct();
-
 		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
 	}
 
@@ -556,9 +558,10 @@ class Advertising_Display_Ads extends Wizard {
 	}
 
 	/**
-	 * Add a parent menu for the Advertising wizards.
+	 * Add a parent menu for all the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab),
+	 * and a page for this wizard too.
 	 */
-	public function add_parent_menu() {
+	public function add_page() {
 		// SVG generated via https://boxy-svg.com/ with path width/height 20px.
 		$icon = 'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="none" stroke="none" d="M 2 12 C 2 4.313 10.333 -0.491 17 3.352 C 20.094 5.136 22 8.433 22 12 C 22 19.686 13.667 24.49 7 20.647 C 3.906 18.863 2 15.567 2 12 Z M 12 3.727 C 5.622 3.727 1.635 10.621 4.824 16.136 C 6.304 18.696 9.04 20.273 12 20.273 C 18.378 20.273 22.365 13.378 19.176 7.863 C 17.696 5.304 14.96 3.727 12 3.727 Z M 10.471 9.292 C 10.112 9.543 10 9.808 10 10.003 C 10 10.198 10.112 10.463 10.471 10.714 C 10.827 10.962 11.366 11.144 12 11.144 C 12.943 11.144 13.834 11.41 14.512 11.883 C 15.186 12.356 15.714 13.089 15.714 13.997 C 15.714 14.904 15.187 15.637 14.512 16.11 C 14.043 16.436 13.475 16.664 12.857 16.774 L 12.857 17.135 C 12.857 17.793 12.143 18.205 11.571 17.876 C 11.306 17.723 11.143 17.44 11.143 17.135 L 11.143 16.774 C 10.55 16.675 9.985 16.448 9.488 16.11 C 8.814 15.637 8.286 14.904 8.286 13.997 C 8.286 13.338 9 12.926 9.571 13.255 C 9.837 13.408 10 13.691 10 13.997 C 10 14.192 10.112 14.456 10.471 14.707 C 10.827 14.956 11.366 15.138 12 15.138 C 12.634 15.138 13.173 14.956 13.529 14.707 C 13.888 14.456 14 14.192 14 13.997 C 14 13.801 13.888 13.537 13.529 13.286 C 13.173 13.037 12.634 12.855 12 12.855 C 11.057 12.855 10.166 12.59 9.488 12.116 C 8.814 11.644 8.286 10.91 8.286 10.003 C 8.286 9.095 8.813 8.362 9.488 7.889 C 9.985 7.552 10.55 7.324 11.143 7.225 L 11.143 6.865 C 11.143 6.206 11.857 5.794 12.429 6.123 C 12.694 6.276 12.857 6.559 12.857 6.865 L 12.857 7.225 C 13.474 7.335 14.045 7.563 14.512 7.889 C 15.186 8.362 15.714 9.095 15.714 10.003 C 15.714 10.661 15 11.073 14.429 10.744 C 14.163 10.591 14 10.308 14 10.003 C 14 9.808 13.888 9.543 13.529 9.292 C 13.173 9.043 12.634 8.862 12 8.862 C 11.366 8.862 10.827 9.043 10.471 9.292 Z"></path></svg>' );
 		add_menu_page(
@@ -569,20 +572,6 @@ class Advertising_Display_Ads extends Wizard {
 			array( $this, 'render_wizard' ),
 			$icon
 		);
-
-		// When creating a blank menu (ie: no submenu items added yet), we need to add the slug to the $submenu array otherwise
-		// WordPress will create a duplicate submenu for the parent menu upon the first run of add_submenu_page
-		// link: https://github.com/WordPress/WordPress/blob/3ba197a255df605d846d2124f45d6364ec9aed12/wp-admin/includes/plugin.php#L1495
-		// Another way around this is to move the add_menu_page tino the add_page function and set a admin_menu priority of 9 or less.
-		// But that would mean copying all the funtions from parent::_construct into this class.
-		global $submenu;
-		$submenu[ $this->slug ] = array();
-	}
-
-	/**
-	 * Add an admin page for this wizard to live on.
-	 */
-	public function add_page() {
 		add_submenu_page(
 			$this->slug,
 			__( 'Advertising / Display Ads', 'newspack-plugin' ),

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -556,6 +556,21 @@ class Advertising_Display_Ads extends Wizard {
 	}
 
 	/**
+	 * Add an admin page for this wizard to live on.
+	 */
+	public function add_page() {
+		add_submenu_page(
+			$this->slug,
+			__( 'Advertising / Display Ads', 'newspack-plugin' ),
+			__( 'Display Ads', 'newspack-plugin' ),
+			$this->capability,
+			$this->slug,
+			array( $this, 'render_wizard' ),
+			0 // Make sure this is first item in submenu.
+		);
+	}
+
+	/**
 	 * Add a parent menu for the Advertising wizards.
 	 */
 	public function add_parent_menu() {
@@ -577,20 +592,5 @@ class Advertising_Display_Ads extends Wizard {
 		// But that would mean copying all the funtions from parent::_construct into this class.
 		global $submenu;
 		$submenu[ $this->slug ] = array();
-	}
-
-	/**
-	 * Add an admin page for this wizard to live on.
-	 */
-	public function add_page() {
-		add_submenu_page(
-			$this->slug,
-			__( 'Advertising / Display Ads', 'newspack-plugin' ),
-			__( 'Display Ads', 'newspack-plugin' ),
-			$this->capability,
-			$this->slug,
-			array( $this, 'render_wizard' ),
-			0 // Make sure this is first item in submenu.
-		);
 	}
 }

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -70,6 +70,15 @@ class Advertising_Display_Ads extends Wizard {
 	public $menu_order = 4;
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * Important: keep this at 2 otherwise parent menu won't expand/highlight for class-advertising-sponsors.php
+	 * 
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 2;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -556,21 +556,6 @@ class Advertising_Display_Ads extends Wizard {
 	}
 
 	/**
-	 * Add an admin page for this wizard to live on.
-	 */
-	public function add_page() {
-		add_submenu_page(
-			$this->slug,
-			__( 'Advertising / Display Ads', 'newspack-plugin' ),
-			__( 'Display Ads', 'newspack-plugin' ),
-			$this->capability,
-			$this->slug,
-			array( $this, 'render_wizard' ),
-			0 // Make sure this is first item in submenu.
-		);
-	}
-
-	/**
 	 * Add a parent menu for the Advertising wizards.
 	 */
 	public function add_parent_menu() {
@@ -592,5 +577,20 @@ class Advertising_Display_Ads extends Wizard {
 		// But that would mean copying all the funtions from parent::_construct into this class.
 		global $submenu;
 		$submenu[ $this->slug ] = array();
+	}
+
+	/**
+	 * Add an admin page for this wizard to live on.
+	 */
+	public function add_page() {
+		add_submenu_page(
+			$this->slug,
+			__( 'Advertising / Display Ads', 'newspack-plugin' ),
+			__( 'Display Ads', 'newspack-plugin' ),
+			$this->capability,
+			$this->slug,
+			array( $this, 'render_wizard' ),
+			0 // Make sure this is first item in submenu.
+		);
 	}
 }

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -63,7 +63,7 @@ class Advertising_Display_Ads extends Wizard {
 	public $parent_menu = 'advertising-display-ads';
 
 	/**
-	 * Order of the Advertisers parent menu relative to the Newspack Dashboard parent menu.
+	 * Order relative to the Newspack Dashboard menu item.
 	 *
 	 * @var int
 	 */

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -63,29 +63,30 @@ class Advertising_Display_Ads extends Wizard {
 	public $parent_menu = 'advertising-display-ads';
 
 	/**
-	 * Order relative to the Newspack Dashboard menu item.
+	 * Order of the Advertisers parent menu relative to the Newspack Dashboard parent menu.
 	 *
 	 * @var int
 	 */
-	public $menu_order = 4;
+	public $parent_menu_order = 4;
 
 	/**
-	 * Create parent menu for the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab),
-	 * and this wizard page itself too, using a priority < 10 so the Advertising parent menu exists
-	 * prior to other wizard and Sponsors Plugins submenu items being added.
-	 * 
-	 * The value here is only for competing Advertising menu items. It is not related to any 
-	 * 'newspack-dashboard' menu items.
+	 * Priority for this wizard's submenu item within the Advertising parent menu.
 	 * 
 	 * @var int.
 	 */
-	protected $admin_menu_hook_priority = 9;
+	protected $submenu_priority = 2;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
+
+		// Create parent menu for the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab) before any submenu items are added.
+		add_action( 'admin_menu', array( $this, 'add_parent_menu' ), 1 );
+		
+		// Add this wizard's page with $submenu_priority = 2 so it will be added directly after the parent menu is created.
 		parent::__construct();
+
 		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
 	}
 
@@ -561,10 +562,9 @@ class Advertising_Display_Ads extends Wizard {
 	}
 
 	/**
-	 * Add a parent menu for all the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab),
-	 * and a page for this wizard too.
+	 * Add a parent menu for all the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab).
 	 */
-	public function add_page() {
+	public function add_parent_menu() {
 		// SVG generated via https://boxy-svg.com/ with path width/height 20px.
 		$icon = 'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="none" stroke="none" d="M 2 12 C 2 4.313 10.333 -0.491 17 3.352 C 20.094 5.136 22 8.433 22 12 C 22 19.686 13.667 24.49 7 20.647 C 3.906 18.863 2 15.567 2 12 Z M 12 3.727 C 5.622 3.727 1.635 10.621 4.824 16.136 C 6.304 18.696 9.04 20.273 12 20.273 C 18.378 20.273 22.365 13.378 19.176 7.863 C 17.696 5.304 14.96 3.727 12 3.727 Z M 10.471 9.292 C 10.112 9.543 10 9.808 10 10.003 C 10 10.198 10.112 10.463 10.471 10.714 C 10.827 10.962 11.366 11.144 12 11.144 C 12.943 11.144 13.834 11.41 14.512 11.883 C 15.186 12.356 15.714 13.089 15.714 13.997 C 15.714 14.904 15.187 15.637 14.512 16.11 C 14.043 16.436 13.475 16.664 12.857 16.774 L 12.857 17.135 C 12.857 17.793 12.143 18.205 11.571 17.876 C 11.306 17.723 11.143 17.44 11.143 17.135 L 11.143 16.774 C 10.55 16.675 9.985 16.448 9.488 16.11 C 8.814 15.637 8.286 14.904 8.286 13.997 C 8.286 13.338 9 12.926 9.571 13.255 C 9.837 13.408 10 13.691 10 13.997 C 10 14.192 10.112 14.456 10.471 14.707 C 10.827 14.956 11.366 15.138 12 15.138 C 12.634 15.138 13.173 14.956 13.529 14.707 C 13.888 14.456 14 14.192 14 13.997 C 14 13.801 13.888 13.537 13.529 13.286 C 13.173 13.037 12.634 12.855 12 12.855 C 11.057 12.855 10.166 12.59 9.488 12.116 C 8.814 11.644 8.286 10.91 8.286 10.003 C 8.286 9.095 8.813 8.362 9.488 7.889 C 9.985 7.552 10.55 7.324 11.143 7.225 L 11.143 6.865 C 11.143 6.206 11.857 5.794 12.429 6.123 C 12.694 6.276 12.857 6.559 12.857 6.865 L 12.857 7.225 C 13.474 7.335 14.045 7.563 14.512 7.889 C 15.186 8.362 15.714 9.095 15.714 10.003 C 15.714 10.661 15 11.073 14.429 10.744 C 14.163 10.591 14 10.308 14 10.003 C 14 9.808 13.888 9.543 13.529 9.292 C 13.173 9.043 12.634 8.862 12 8.862 C 11.366 8.862 10.827 9.043 10.471 9.292 Z"></path></svg>' );
 		add_menu_page(
@@ -575,6 +575,12 @@ class Advertising_Display_Ads extends Wizard {
 			array( $this, 'render_wizard' ),
 			$icon
 		);
+	}
+
+	/**
+	 * Add submenu page for this wizard.
+	 */
+	public function add_page() {
 		add_submenu_page(
 			$this->slug,
 			__( 'Advertising / Display Ads', 'newspack-plugin' ),

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -70,19 +70,17 @@ class Advertising_Display_Ads extends Wizard {
 	public $menu_order = 4;
 
 	/**
-	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
-	 *
-	 * Important: keep this at 2 otherwise parent menu won't expand/highlight for class-advertising-sponsors.php
-	 * 
-	 * @var int.
-	 */
-	protected $admin_menu_hook_priority = 2;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
+		
+		// Create a parent admin menu for the Advertising wizards (Ads, Sponsors Plugin CPT + Settings tab).
+		// note: priority must be < 10 so parent menu exists prior to submenu items being added.
+		add_action( 'admin_menu', [ $this, 'add_parent_menu' ], 9 );
+
+		// Setup this wizard's page.
 		parent::__construct();
+
 		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
 	}
 
@@ -558,9 +556,9 @@ class Advertising_Display_Ads extends Wizard {
 	}
 
 	/**
-	 * Add an admin page for the wizard to live on.
+	 * Add a parent menu for the Advertising wizards.
 	 */
-	public function add_page() {
+	public function add_parent_menu() {
 		// SVG generated via https://boxy-svg.com/ with path width/height 20px.
 		$icon = 'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill="none" stroke="none" d="M 2 12 C 2 4.313 10.333 -0.491 17 3.352 C 20.094 5.136 22 8.433 22 12 C 22 19.686 13.667 24.49 7 20.647 C 3.906 18.863 2 15.567 2 12 Z M 12 3.727 C 5.622 3.727 1.635 10.621 4.824 16.136 C 6.304 18.696 9.04 20.273 12 20.273 C 18.378 20.273 22.365 13.378 19.176 7.863 C 17.696 5.304 14.96 3.727 12 3.727 Z M 10.471 9.292 C 10.112 9.543 10 9.808 10 10.003 C 10 10.198 10.112 10.463 10.471 10.714 C 10.827 10.962 11.366 11.144 12 11.144 C 12.943 11.144 13.834 11.41 14.512 11.883 C 15.186 12.356 15.714 13.089 15.714 13.997 C 15.714 14.904 15.187 15.637 14.512 16.11 C 14.043 16.436 13.475 16.664 12.857 16.774 L 12.857 17.135 C 12.857 17.793 12.143 18.205 11.571 17.876 C 11.306 17.723 11.143 17.44 11.143 17.135 L 11.143 16.774 C 10.55 16.675 9.985 16.448 9.488 16.11 C 8.814 15.637 8.286 14.904 8.286 13.997 C 8.286 13.338 9 12.926 9.571 13.255 C 9.837 13.408 10 13.691 10 13.997 C 10 14.192 10.112 14.456 10.471 14.707 C 10.827 14.956 11.366 15.138 12 15.138 C 12.634 15.138 13.173 14.956 13.529 14.707 C 13.888 14.456 14 14.192 14 13.997 C 14 13.801 13.888 13.537 13.529 13.286 C 13.173 13.037 12.634 12.855 12 12.855 C 11.057 12.855 10.166 12.59 9.488 12.116 C 8.814 11.644 8.286 10.91 8.286 10.003 C 8.286 9.095 8.813 8.362 9.488 7.889 C 9.985 7.552 10.55 7.324 11.143 7.225 L 11.143 6.865 C 11.143 6.206 11.857 5.794 12.429 6.123 C 12.694 6.276 12.857 6.559 12.857 6.865 L 12.857 7.225 C 13.474 7.335 14.045 7.563 14.512 7.889 C 15.186 8.362 15.714 9.095 15.714 10.003 C 15.714 10.661 15 11.073 14.429 10.744 C 14.163 10.591 14 10.308 14 10.003 C 14 9.808 13.888 9.543 13.529 9.292 C 13.173 9.043 12.634 8.862 12 8.862 C 11.366 8.862 10.827 9.043 10.471 9.292 Z"></path></svg>' );
 		add_menu_page(
@@ -571,13 +569,28 @@ class Advertising_Display_Ads extends Wizard {
 			array( $this, 'render_wizard' ),
 			$icon
 		);
+
+		// When creating a blank menu (ie: no submenu items added yet), we need to add the slug to the $submenu array otherwise
+		// WordPress will create a duplicate submenu for the parent menu upon the first run of add_submenu_page
+		// link: https://github.com/WordPress/WordPress/blob/3ba197a255df605d846d2124f45d6364ec9aed12/wp-admin/includes/plugin.php#L1495
+		// Another way around this is to move the add_menu_page tino the add_page function and set a admin_menu priority of 9 or less.
+		// But that would mean copying all the funtions from parent::_construct into this class.
+		global $submenu;
+		$submenu[ $this->slug ] = array();
+	}
+
+	/**
+	 * Add an admin page for this wizard to live on.
+	 */
+	public function add_page() {
 		add_submenu_page(
 			$this->slug,
 			__( 'Advertising / Display Ads', 'newspack-plugin' ),
 			__( 'Display Ads', 'newspack-plugin' ),
 			$this->capability,
 			$this->slug,
-			array( $this, 'render_wizard' )
+			array( $this, 'render_wizard' ),
+			0 // Make sure this is first item in submenu.
 		);
 	}
 }

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -48,20 +48,21 @@ class Advertising_Sponsors extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Advertising_Sponsors Constructor.
+	 * Priority for this wizard's submenu adjustments after the Sponsors Plugin is done adding it's menu items.
 	 * 
-	 * Note: Do not call parent::__construct because we don't need a wizard page created since we're
-	 * using/modifying the pages (CPT + Settings) from the Newspack Sponsors plugin.
+	 * @var int.
+	 */
+	protected $submenu_priority = 11;
+
+	/**
+	 * Advertising_Sponsors Constructor.
 	 */
 	public function __construct() {
 		if ( ! is_plugin_active( 'newspack-sponsors/newspack-sponsors.php' ) ) {
 			return;
 		}
+		parent::__construct();
 
-		// Adjust the Sponsors menu after the Sponsor Plugin has added it's items (priority > 10).
-		add_action( 'admin_menu', [ $this, 'move_sponsors_cpt_menu' ], 11 );
-
-		// Adjust the Sponsors CPT prior to registration.
 		add_action( 'register_post_type_args', [ $this, 'update_sponsors_cpt_args' ], 10, 2 );
 
 		// Below filters are used to determine active menu items.
@@ -69,10 +70,6 @@ class Advertising_Sponsors extends Wizard {
 		add_filter( 'submenu_file', [ $this, 'submenu_file' ] );
 
 		if ( $this->is_wizard_page() ) {
-
-			// Add via parent function.
-			add_filter( 'admin_body_class', [ $this, 'add_body_class' ] );
-
 			// Initialize Wizards Admin Header.
 			$this->admin_header_init(
 				[
@@ -115,9 +112,27 @@ class Advertising_Sponsors extends Wizard {
 	}
 
 	/**
+	 * Enqueue scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		if ( ! $this->is_wizard_page() ) {
+			return;
+		}
+		Newspack::load_common_assets();
+		wp_register_style(
+			'advertising-display-ads',
+			Newspack::plugin_url() . '/dist/billboard.css',
+			$this->get_style_dependencies(),
+			NEWSPACK_PLUGIN_VERSION
+		);
+		wp_style_add_data( 'advertising-display-ads', 'rtl', 'replace' );
+		wp_enqueue_style( 'advertising-display-ads' );
+	}
+
+	/**
 	 * Move Sponsors CPT menu item under the ($) Advertising menu.
 	 */
-	public function move_sponsors_cpt_menu() {
+	public function add_page() {
 		global $submenu;
 		$parent_slug = 'advertising-display-ads';
 		if ( isset( $submenu[ $parent_slug ] ) ) {

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -53,7 +53,7 @@ class Advertising_Sponsors extends Wizard {
 	 * 
 	 * @var int.
 	 */
-	protected $add_page_priority = 11;
+	protected $admin_menu_priority = 11;
 
 	/**
 	 * Advertising_Sponsors Constructor.

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -117,7 +117,6 @@ class Advertising_Sponsors extends Wizard {
 	 */
 	public function move_sponsors_cpt_menu() {
 		global $submenu;
-		
 		$parent_slug = 'advertising-display-ads';
 		if ( isset( $submenu[ $parent_slug ] ) ) {
 			$submenu[ $parent_slug ][] = array( // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -48,11 +48,12 @@ class Advertising_Sponsors extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Priority for this wizard's submenu adjustments after the Sponsors Plugin is done adding it's menu items.
+	 * Use a late priority for this wizard's menu adjustments so they happen
+	 * after the Sponsors Plugin is done adding it's menu items.
 	 * 
 	 * @var int.
 	 */
-	protected $submenu_priority = 11;
+	protected $add_page_priority = 11;
 
 	/**
 	 * Advertising_Sponsors Constructor.

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -52,7 +52,6 @@ class Advertising_Sponsors extends Wizard {
 	 * 
 	 * Note: Do not call parent::__construct because we don't need a wizard page created since we're
 	 * using/modifying the pages (CPT + Settings) from the Newspack Sponsors plugin.
-	 * 
 	 */
 	public function __construct() {
 		if ( ! is_plugin_active( 'newspack-sponsors/newspack-sponsors.php' ) ) {

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -48,6 +48,13 @@ class Advertising_Sponsors extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 99;
+
+	/**
 	 * Advertising_Sponsors Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -112,6 +112,9 @@ class Advertising_Sponsors extends Wizard {
 		return isset( $_GET['post_type'] ) && $_GET['post_type'] === static::CPT_NAME; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
+	/**
+	 * Move Sponsors CPT menu item under the ($) Advertising menu.
+	 */
 	public function move_sponsors_cpt_menu() {
 		global $submenu;
 		
@@ -183,7 +186,4 @@ class Advertising_Sponsors extends Wizard {
 
 		return $submenu_file;
 	}
-
-
-
 }

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -59,7 +59,10 @@ class Advertising_Sponsors extends Wizard {
 			return;
 		}
 
-		add_action( 'admin_menu', [ $this, 'move_sponsors_cpt_menu' ] );
+		// Adjust the Sponsors menu after the Sponsor Plugin has added it's items (priority > 10).
+		add_action( 'admin_menu', [ $this, 'move_sponsors_cpt_menu' ], 11 );
+
+		// Adjust the Sponsors CPT prior to registration.
 		add_action( 'register_post_type_args', [ $this, 'update_sponsors_cpt_args' ], 10, 2 );
 
 		// Below filters are used to determine active menu items.

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -48,20 +48,16 @@ class Advertising_Sponsors extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
-	 *
-	 * @var int.
-	 */
-	protected $admin_menu_hook_priority = 99;
-
-	/**
 	 * Advertising_Sponsors Constructor.
+	 * 
+	 * Note: Do not call parent::__construct because we don't need a wizard page created since we're
+	 * using/modifying the pages (CPT + Settings) from the Newspack Sponsors plugin.
+	 * 
 	 */
 	public function __construct() {
 		if ( ! is_plugin_active( 'newspack-sponsors/newspack-sponsors.php' ) ) {
 			return;
 		}
-		parent::__construct();
 
 		add_action( 'admin_menu', [ $this, 'move_sponsors_cpt_menu' ] );
 		add_action( 'register_post_type_args', [ $this, 'update_sponsors_cpt_args' ], 10, 2 );
@@ -71,6 +67,10 @@ class Advertising_Sponsors extends Wizard {
 		add_filter( 'submenu_file', [ $this, 'submenu_file' ] );
 
 		if ( $this->is_wizard_page() ) {
+
+			// Add via parent function.
+			add_filter( 'admin_body_class', [ $this, 'add_body_class' ] );
+
 			// Initialize Wizards Admin Header.
 			$this->admin_header_init(
 				[
@@ -112,29 +112,9 @@ class Advertising_Sponsors extends Wizard {
 		return isset( $_GET['post_type'] ) && $_GET['post_type'] === static::CPT_NAME; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
-	/**
-	 * Enqueue scripts and styles.
-	 */
-	public function enqueue_scripts_and_styles() {
-		if ( ! $this->is_wizard_page() ) {
-			return;
-		}
-		Newspack::load_common_assets();
-		wp_register_style(
-			'advertising-display-ads',
-			Newspack::plugin_url() . '/dist/billboard.css',
-			$this->get_style_dependencies(),
-			NEWSPACK_PLUGIN_VERSION
-		);
-		wp_style_add_data( 'advertising-display-ads', 'rtl', 'replace' );
-		wp_enqueue_style( 'advertising-display-ads' );
-	}
-
-	/**
-	 * Move Sponsors CPT menu item under the ($) Advertising menu.
-	 */
 	public function move_sponsors_cpt_menu() {
 		global $submenu;
+		
 		$parent_slug = 'advertising-display-ads';
 		if ( isset( $submenu[ $parent_slug ] ) ) {
 			$submenu[ $parent_slug ][] = array( // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -203,4 +183,7 @@ class Advertising_Sponsors extends Wizard {
 
 		return $submenu_file;
 	}
+
+
+
 }

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -31,6 +31,13 @@ class Components_Demo extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 100;
+
+	/**
 	 * Whether the wizard should be displayed in the Newspack submenu.
 	 *
 	 * @var bool.

--- a/includes/wizards/class-components-demo.php
+++ b/includes/wizards/class-components-demo.php
@@ -31,13 +31,6 @@ class Components_Demo extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
-	 *
-	 * @var int.
-	 */
-	protected $admin_menu_hook_priority = 100;
-
-	/**
 	 * Whether the wizard should be displayed in the Newspack submenu.
 	 *
 	 * @var bool.

--- a/includes/wizards/class-listings-wizard.php
+++ b/includes/wizards/class-listings-wizard.php
@@ -56,6 +56,13 @@ class Listings_Wizard extends Wizard {
 	public $menu_order = 3;
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 99;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-listings-wizard.php
+++ b/includes/wizards/class-listings-wizard.php
@@ -53,7 +53,7 @@ class Listings_Wizard extends Wizard {
 	 *
 	 * @var int
 	 */
-	public $menu_order = 3;
+	public $parent_menu_order = 3;
 
 	/**
 	 * Constructor.

--- a/includes/wizards/class-listings-wizard.php
+++ b/includes/wizards/class-listings-wizard.php
@@ -56,12 +56,6 @@ class Listings_Wizard extends Wizard {
 	public $menu_order = 3;
 
 	/**
-	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
-	 *
-	 * @var int.
-	 */
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/includes/wizards/class-listings-wizard.php
+++ b/includes/wizards/class-listings-wizard.php
@@ -60,7 +60,6 @@ class Listings_Wizard extends Wizard {
 	 *
 	 * @var int.
 	 */
-	protected $admin_menu_hook_priority = 99;
 
 	/**
 	 * Constructor.

--- a/includes/wizards/class-network-wizard.php
+++ b/includes/wizards/class-network-wizard.php
@@ -42,7 +42,7 @@ class Network_Wizard extends Wizard {
 	 *
 	 * @var int
 	 */
-	public $menu_order = 5;
+	public $parent_menu_order = 5;
 
 	/**
 	 * Constructor.

--- a/includes/wizards/class-newsletters-wizard.php
+++ b/includes/wizards/class-newsletters-wizard.php
@@ -55,7 +55,7 @@ class Newsletters_Wizard extends Wizard {
 	 *
 	 * @var int
 	 */
-	public $menu_order = 2;
+	public $parent_menu_order = 2;
 
 	/**
 	 * Constructor.

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -61,6 +61,15 @@ abstract class Wizard {
 	public $menu_order = 0;
 
 	/**
+	 * Admin Menu Hook Priority when calling parent 'admin_menu'/'add_page' hook
+	 * Default is WordPress's default hook priority: 10
+	 * Override this on a per-wizard basis.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 10;
+
+	/**
 	 * Initialize.
 	 *
 	 * @param array $args Array of optional arguments. i.e. `sections`.
@@ -70,7 +79,7 @@ abstract class Wizard {
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-		add_action( 'admin_menu', [ $this, 'add_page' ] );
+		add_action( 'admin_menu', [ $this, 'add_page' ], $this->admin_menu_hook_priority );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {
 			$this->load_wizard_sections( $args['sections'] );

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -61,6 +61,13 @@ abstract class Wizard {
 	public $menu_order = 0;
 
 	/**
+	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_hook_priority = 2;
+
+	/**
 	 * Initialize.
 	 *
 	 * @param array $args Array of optional arguments. i.e. `sections`.
@@ -70,7 +77,7 @@ abstract class Wizard {
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-		add_action( 'admin_menu', [ $this, 'add_page' ] );
+		add_action( 'admin_menu', [ $this, 'add_page' ], $this->admin_menu_hook_priority );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {
 			$this->load_wizard_sections( $args['sections'] );

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -61,13 +61,6 @@ abstract class Wizard {
 	public $menu_order = 0;
 
 	/**
-	 * Admin Menu Hook Priority when calling 'admin_menu' action hook.
-	 *
-	 * @var int.
-	 */
-	protected $admin_menu_hook_priority = 2;
-
-	/**
 	 * Initialize.
 	 *
 	 * @param array $args Array of optional arguments. i.e. `sections`.
@@ -77,7 +70,7 @@ abstract class Wizard {
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-		add_action( 'admin_menu', [ $this, 'add_page' ], $this->admin_menu_hook_priority );
+		add_action( 'admin_menu', [ $this, 'add_page' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {
 			$this->load_wizard_sections( $args['sections'] );
@@ -90,7 +83,7 @@ abstract class Wizard {
 	 */
 	public function add_page() {
 		add_submenu_page(
-			$this->hidden ? 'hidden' : 'newspack',
+			$this->hidden ? 'hidden' : 'newspack', // @TODO: change to 'newspack-dashboard'.
 			$this->get_name(),
 			$this->get_name(),
 			$this->capability,

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -61,14 +61,14 @@ abstract class Wizard {
 	public $parent_menu_order = 0;
 
 	/**
-	 * Priority for when 'add_page' callback fires. Default is WordPress's default hook priority of 10
-	 * Override this on a per-wizard basis if there is a need to adjust the order that 'add_page' fires.
+	 * Priority for when 'admin_menu'/'add_page' callback fires. Default is WordPress's default hook priority of 10
+	 * Override this on a per-wizard basis if there is a need to adjust the order that 'admin_menu'/'add_page' fires.
 	 * Example: set priority < 10 so add_page is called before other pages. Or > 10 so it's called after other
 	 * pages or plugins are loaded.
 	 *
 	 * @var int.
 	 */
-	protected $add_page_priority = 10;
+	protected $admin_menu_priority = 10;
 
 	/**
 	 * Initialize.
@@ -80,7 +80,7 @@ abstract class Wizard {
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-		add_action( 'admin_menu', [ $this, 'add_page' ], $this->add_page_priority );
+		add_action( 'admin_menu', [ $this, 'add_page' ], $this->admin_menu_priority );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {
 			$this->load_wizard_sections( $args['sections'] );

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -54,20 +54,20 @@ abstract class Wizard {
 	public $parent_menu = '';
 
 	/**
-	 * Order relative to the Newspack Dashboard menu item.
+	 * Parent menu order relative to the Newspack Dashboard menu item.
 	 *
 	 * @var int
 	 */
-	public $menu_order = 0;
+	public $parent_menu_order = 0;
 
 	/**
-	 * Admin Menu Hook Priority when calling parent 'admin_menu'/'add_page' hook
+	 * Admin Menu Hook Priority when parent 'admin_menu'/'add_page' hook fires.
 	 * Default is WordPress's default hook priority: 10
-	 * Override this on a per-wizard basis.
+	 * Override this on a per-wizard basis to adjust submenus item within a parent menu.
 	 *
 	 * @var int.
 	 */
-	protected $admin_menu_hook_priority = 10;
+	protected $submenu_priority = 10;
 
 	/**
 	 * Initialize.
@@ -79,7 +79,8 @@ abstract class Wizard {
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-		add_action( 'admin_menu', [ $this, 'add_page' ], $this->admin_menu_hook_priority );
+
+		add_action( 'admin_menu', [ $this, 'add_page' ], $this->submenu_priority );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {
 			$this->load_wizard_sections( $args['sections'] );
@@ -92,7 +93,7 @@ abstract class Wizard {
 	 */
 	public function add_page() {
 		add_submenu_page(
-			$this->hidden ? 'hidden' : 'newspack',
+			$this->hidden ? 'hidden' : $this->parent_menu,
 			$this->get_name(),
 			$this->get_name(),
 			$this->capability,

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -61,13 +61,14 @@ abstract class Wizard {
 	public $parent_menu_order = 0;
 
 	/**
-	 * Admin Menu Hook Priority when parent 'admin_menu'/'add_page' hook fires.
-	 * Default is WordPress's default hook priority: 10
-	 * Override this on a per-wizard basis to adjust submenus item within a parent menu.
+	 * Priority for when 'add_page' callback fires. Default is WordPress's default hook priority of 10
+	 * Override this on a per-wizard basis if there is a need to adjust the order that 'add_page' fires.
+	 * Example: set priority < 10 so add_page is called before other pages. Or > 10 so it's called after other
+	 * pages or plugins are loaded.
 	 *
 	 * @var int.
 	 */
-	protected $submenu_priority = 10;
+	protected $add_page_priority = 10;
 
 	/**
 	 * Initialize.
@@ -79,7 +80,7 @@ abstract class Wizard {
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-		add_action( 'admin_menu', [ $this, 'add_page' ], $this->submenu_priority );
+		add_action( 'admin_menu', [ $this, 'add_page' ], $this->add_page_priority );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {
 			$this->load_wizard_sections( $args['sections'] );

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -83,7 +83,7 @@ abstract class Wizard {
 	 */
 	public function add_page() {
 		add_submenu_page(
-			$this->hidden ? 'hidden' : 'newspack', // @TODO: change to 'newspack-dashboard'.
+			$this->hidden ? 'hidden' : 'newspack',
 			$this->get_name(),
 			$this->get_name(),
 			$this->capability,

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -79,7 +79,6 @@ abstract class Wizard {
 	 * $my_wizard = new My_Wizard( [ 'sections' => [ 'my-wizard-section' => 'Newspack\Wizards\My_Wizard\My_Wizard_Section' ] ] );
 	 */
 	public function __construct( $args = [] ) {
-
 		add_action( 'admin_menu', [ $this, 'add_page' ], $this->submenu_priority );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		if ( isset( $args['sections'] ) ) {

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -34,7 +34,7 @@ class Newspack_Dashboard extends Wizard {
 	 * 
 	 * @var int.
 	 */
-	protected $add_page_priority = 1;
+	protected $admin_menu_priority = 1;
 
 	/**
 	 * Get Dashboard data

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -29,6 +29,15 @@ class Newspack_Dashboard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
+	 * Initialize.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', [ $this, 'add_page' ], 1 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
+		add_filter( 'admin_body_class', [ $this, 'add_body_class' ] );
+	}
+
+	/**
 	 * Get Dashboard data
 	 *
 	 * @return []

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -29,15 +29,25 @@ class Newspack_Dashboard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Admin Menu Hook Priority when calling parent 'admin_menu'/'add_page' hook
-	 * Make sure this wizard's menu is added first.
+	 * Priority for this wizard's submenu item within the Newspack parent menu.
 	 * 
-	 * The value here is only for competing Wizards in the 'newspack-dashboard'
-	 * parent menu.
-	 *
 	 * @var int.
 	 */
-	protected $admin_menu_hook_priority = 1;
+	protected $submenu_priority = 2;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+
+		// Create parent menu for the Newspack wizards before any submenu items are added.
+		add_action( 'admin_menu', array( $this, 'add_parent_menu' ), 1 );
+		
+		// Add this wizard's page with $submenu_priority = 2 so it will be added directly after the parent menu is created.
+		parent::__construct();
+
+		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
+	}
 
 	/**
 	 * Get Dashboard data
@@ -373,9 +383,9 @@ class Newspack_Dashboard extends Wizard {
 	}
 
 	/**
-	 * Add an admin page for the wizard to live on.
+	 * Add a parent menu for Newspack.
 	 */
-	public function add_page() {
+	public function add_parent_menu() {
 		$icon = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjE4cHgiIGhlaWdodD0iNjE4cHgiIHZpZXdCb3g9IjAgMCA2MTggNjE4IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPHBhdGggZD0iTTMwOSwwIEM0NzkuNjU2NDk1LDAgNjE4LDEzOC4zNDQyOTMgNjE4LDMwOS4wMDE3NTkgQzYxOCw0NzkuNjU5MjI2IDQ3OS42NTY0OTUsNjE4IDMwOSw2MTggQzEzOC4zNDM1MDUsNjE4IDAsNDc5LjY1OTIyNiAwLDMwOS4wMDE3NTkgQzAsMTM4LjM0NDI5MyAxMzguMzQzNTA1LDAgMzA5LDAgWiBNMTc0LDE3MSBMMTc0LDI2Mi42NzEzNTYgTDE3NS4zMDUsMjY0IEwxNzQsMjY0IEwxNzQsNDQ2IEwyNDEsNDQ2IEwyNDEsMzMwLjkxMyBMMzUzLjk5Mjk2Miw0NDYgTDQ0NCw0NDYgTDE3NCwxNzEgWiBNNDQ0LDI5OSBMMzg5LDI5OSBMNDEwLjQ3NzYxLDMyMSBMNDQ0LDMyMSBMNDQ0LDI5OSBaIE00NDQsMjM1IEwzMjcsMjM1IEwzNDguMjQ1OTE5LDI1NyBMNDQ0LDI1NyBMNDQ0LDIzNSBaIE00NDQsMTcxIEwyNjQsMTcxIEwyODUuMjkwNTEyLDE5MyBMNDQ0LDE5MyBMNDQ0LDE3MSBaIiBpZD0iQ29tYmluZWQtU2hhcGUiIGZpbGw9IiMyQTdERTEiPjwvcGF0aD4KICAgIDwvZz4KPC9zdmc+';
 		add_menu_page(
 			$this->get_name(),
@@ -386,6 +396,12 @@ class Newspack_Dashboard extends Wizard {
 			$icon,
 			3
 		);
+	}
+
+	/**
+	 * Add the first submenu item.
+	 */
+	public function add_page() {
 		$first_subnav_title = get_option( NEWSPACK_SETUP_COMPLETE ) ? __( 'Dashboard', 'newspack' ) : __( 'Setup', 'newspack' );
 		add_submenu_page(
 			$this->slug,

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -31,6 +31,9 @@ class Newspack_Dashboard extends Wizard {
 	/**
 	 * Admin Menu Hook Priority when calling parent 'admin_menu'/'add_page' hook
 	 * Make sure this wizard's menu is added first.
+	 * 
+	 * The value here is only for competing Wizards in the 'newspack-dashboard'
+	 * parent menu.
 	 *
 	 * @var int.
 	 */

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -29,25 +29,12 @@ class Newspack_Dashboard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Priority for this wizard's submenu item within the Newspack parent menu.
+	 * Use a high priorty so that the Newspack parent menu will be created
+	 * prior to submenu items being added.
 	 * 
 	 * @var int.
 	 */
-	protected $submenu_priority = 2;
-
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-
-		// Create parent menu for the Newspack wizards before any submenu items are added.
-		add_action( 'admin_menu', array( $this, 'add_parent_menu' ), 1 );
-		
-		// Add this wizard's page with $submenu_priority = 2 so it will be added directly after the parent menu is created.
-		parent::__construct();
-
-		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
-	}
+	protected $add_page_priority = 1;
 
 	/**
 	 * Get Dashboard data
@@ -383,9 +370,9 @@ class Newspack_Dashboard extends Wizard {
 	}
 
 	/**
-	 * Add a parent menu for Newspack.
+	 * Add a parent menu for Newspack and the first submenu item.
 	 */
-	public function add_parent_menu() {
+	public function add_page() {
 		$icon = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjE4cHgiIGhlaWdodD0iNjE4cHgiIHZpZXdCb3g9IjAgMCA2MTggNjE4IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPHBhdGggZD0iTTMwOSwwIEM0NzkuNjU2NDk1LDAgNjE4LDEzOC4zNDQyOTMgNjE4LDMwOS4wMDE3NTkgQzYxOCw0NzkuNjU5MjI2IDQ3OS42NTY0OTUsNjE4IDMwOSw2MTggQzEzOC4zNDM1MDUsNjE4IDAsNDc5LjY1OTIyNiAwLDMwOS4wMDE3NTkgQzAsMTM4LjM0NDI5MyAxMzguMzQzNTA1LDAgMzA5LDAgWiBNMTc0LDE3MSBMMTc0LDI2Mi42NzEzNTYgTDE3NS4zMDUsMjY0IEwxNzQsMjY0IEwxNzQsNDQ2IEwyNDEsNDQ2IEwyNDEsMzMwLjkxMyBMMzUzLjk5Mjk2Miw0NDYgTDQ0NCw0NDYgTDE3NCwxNzEgWiBNNDQ0LDI5OSBMMzg5LDI5OSBMNDEwLjQ3NzYxLDMyMSBMNDQ0LDMyMSBMNDQ0LDI5OSBaIE00NDQsMjM1IEwzMjcsMjM1IEwzNDguMjQ1OTE5LDI1NyBMNDQ0LDI1NyBMNDQ0LDIzNSBaIE00NDQsMTcxIEwyNjQsMTcxIEwyODUuMjkwNTEyLDE5MyBMNDQ0LDE5MyBMNDQ0LDE3MSBaIiBpZD0iQ29tYmluZWQtU2hhcGUiIGZpbGw9IiMyQTdERTEiPjwvcGF0aD4KICAgIDwvZz4KPC9zdmc+';
 		add_menu_page(
 			$this->get_name(),
@@ -396,12 +383,6 @@ class Newspack_Dashboard extends Wizard {
 			$icon,
 			3
 		);
-	}
-
-	/**
-	 * Add the first submenu item.
-	 */
-	public function add_page() {
 		$first_subnav_title = get_option( NEWSPACK_SETUP_COMPLETE ) ? __( 'Dashboard', 'newspack' ) : __( 'Setup', 'newspack' );
 		add_submenu_page(
 			$this->slug,

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -29,15 +29,6 @@ class Newspack_Dashboard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Initialize.
-	 */
-	public function __construct() {
-		add_action( 'admin_menu', [ $this, 'add_page' ], 1 );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
-		add_filter( 'admin_body_class', [ $this, 'add_body_class' ] );
-	}
-
-	/**
 	 * Get Dashboard data
 	 *
 	 * @return []

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -29,13 +29,12 @@ class Newspack_Dashboard extends Wizard {
 	protected $capability = 'manage_options';
 
 	/**
-	 * Initialize.
+	 * Admin Menu Hook Priority when calling parent 'admin_menu'/'add_page' hook
+	 * Make sure this wizard's menu is added first.
+	 *
+	 * @var int.
 	 */
-	public function __construct() {
-		add_action( 'admin_menu', [ $this, 'add_page' ], 1 );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
-		add_filter( 'admin_body_class', [ $this, 'add_body_class' ] );
-	}
+	protected $admin_menu_hook_priority = 1;
 
 	/**
 	 * Get Dashboard data


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The [original wizards code](https://github.com/Automattic/newspack-plugin/blob/489ce0fb7390f9fabc5956844ac7b437c2c701ac/includes/wizards/class-wizard.php#L52) in `trunk` gave us the ability to adjust the priority of a wizard's `add_page` callback.  Somewhere in the timeline of the `epic/ia` development, this ability was hard-code then removed around the time we were fixing the parent menu custom ordering.  In the end, after [attempt 1](https://github.com/Automattic/newspack-plugin/pull/3534) and [attempt 2](https://github.com/Automattic/newspack-plugin/pull/3535), and lots of discussion, testing and a huddle with @miguelpeixe - we've settled on this PR in order to reinstate the removed code.

Changes:
- The parent menu order variable was renamed to be more descriptive of what it does: `$parent_menu_order`.
- The reinstated variable for add page priority was give a descriptive name: `$add_page_priority`.
- The old/hard-coded `newspack` parent menu was changed to `$this->parent_menu` so wizards can control which parent menu they are added to.
- Some minimal changes were made to the advertising wizards and the dashboard.

### How to test the changes in this Pull Request:

1. Pull this branch on top of `epic/ia`.
2. Run `npm run build` if you haven't already for `epic/ia`.
3. Verify the wp-admin menus are displaying as expected.

![parent-order](https://github.com/user-attachments/assets/1dfd8bb7-63d2-48a0-ac30-f4e2cf9bcfb4)

![advertising](https://github.com/user-attachments/assets/c6378caa-4879-4fd8-a40f-5db57c8bba65)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->