### PR TITLE
fix(woocommerce-emails): use the default email if there are no donation products

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -240,7 +240,7 @@ class Donations {
 	/**
 	 * Get the child products of the main donation product.
 	 */
-	public static function get_donation_product_child_products_ids() {
+	private static function get_donation_product_child_products_ids() {
 		$child_products_ids = [
 			'once'  => false,
 			'month' => false,

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -240,7 +240,7 @@ class Donations {
 	/**
 	 * Get the child products of the main donation product.
 	 */
-	private static function get_donation_product_child_products_ids() {
+	public static function get_donation_product_child_products_ids() {
 		$child_products_ids = [
 			'once'  => false,
 			'month' => false,

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -267,14 +267,7 @@ class WooCommerce_Connection {
 	 */
 	public static function send_customizable_receipt_email( $enable, $order, $class ) {
 		// If there are no donation products in the order, do not override the default WC receipt email.
-		$has_donation_product = false;
-		$donation_product_ids = array_values( \Newspack\Donations::get_donation_product_child_products_ids() );
-		foreach ( $order->get_items() as $item_id => $item ) {
-			if ( in_array( $item->get_product()->get_id(), $donation_product_ids ) ) {
-				$has_donation_product = true;
-				break;
-			}
-		}
+		$has_donation_product = \Newspack\Donations::get_order_donation_product_id( $order_id ) !== false;
 		if ( ! $has_donation_product ) {
 			return $enable;
 		}

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -266,6 +266,19 @@ class WooCommerce_Connection {
 	 * @return bool
 	 */
 	public static function send_customizable_receipt_email( $enable, $order, $class ) {
+		// If there are no donation products in the order, do not override the default WC receipt email.
+		$has_donation_product = false;
+		$donation_product_ids = array_values( \Newspack\Donations::get_donation_product_child_products_ids() );
+		foreach ( $order->get_items() as $item_id => $item ) {
+			if ( in_array( $item->get_product()->get_id(), $donation_product_ids ) ) {
+				$has_donation_product = true;
+				break;
+			}
+		}
+		if ( ! $has_donation_product ) {
+			return $enable;
+		}
+
 		// If we don't have a valid order, or the customizable email isn't enabled, bail.
 		if ( ! is_a( $order, 'WC_Order' ) || ! Emails::can_send_email( Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'] ) ) {
 			return $enable;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the custom receipt emails, so that they are not sent for order which do not contain donation products.

### How to test the changes in this Pull Request:

1. Ensure you have donation products set up, and at least one non-donation product 
2. Ensure the custom receipt email is enabled in Reader Revenue wizard -> Emails
3. Donate and observe the custom email is sent
4. Buy a non-donation product and observe a default WC email is sent

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208741538452766