### PR TITLE
fix(newspack-ui): prevent override for form label display

### DIFF
--- a/src/newspack-ui/scss/elements/forms/_labels.scss
+++ b/src/newspack-ui/scss/elements/forms/_labels.scss
@@ -11,7 +11,7 @@
 		// For labels containing radio, checkbox inputs:
 		&:has(input[type="checkbox"]),
 		&:has(input[type="radio"]) {
-			display: grid;
+			display: grid !important;
 			gap: 0 var(--newspack-ui-spacer-base);
 			grid-template-columns: var(--newspack-ui-spacer-4) 1fr;
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Goes with the following Blocks PR: https://github.com/Automattic/newspack-blocks/pull/1951

This PR fixes an issue where it was possible for other stylesheets to override the value of `newspack-ui` form label display. We fix this by adding the `!important` flag to the `display` declaration.

Before:
![Screenshot 2024-11-13 at 10 52 21](https://github.com/user-attachments/assets/da9f3906-1cf2-4c49-932d-e21aeb8b1988)

After:
![Screenshot 2024-11-13 at 10 52 02](https://github.com/user-attachments/assets/2de4c9f6-e0f8-4d64-9d92-117e9066e5e8)

**NOTE**: The fix for the broken margins lives in the blocks PR: https://github.com/Automattic/newspack-blocks/pull/1951

### How to test the changes in this Pull Request:

1. As admin add Mailchimp for WooCommerce to your test site and get it connected
2. Ensure the Mailchimp for WooCommerce newsletters checkbox is added at checkout via Mailchimp > Store > Checkout page settings
![Screenshot 2024-11-13 at 10 42 29](https://github.com/user-attachments/assets/40e9fa00-8779-4466-8823-3022f7850cf6)
3. As a reader open modal checkout via any checkout button or donate block
4. On the billing fields screen scroll to the bottom and ensure the subscription checkbox text and input are aligned as pictured in 'After' above.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->