### PR TITLE
feat(reader-data): add a CLI command to align reader membership data

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -9,6 +9,8 @@ namespace Newspack;
 
 use Newspack\Memberships;
 
+require_once NEWSPACK_ABSPATH . 'includes/reader-activation/cli/class-sync-reader-data-cli.php';
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -131,7 +133,7 @@ final class Reader_Data {
 	 *
 	 * @param string $key Key.
 	 */
-	private static function get_meta_key_name( $key ) {
+	public static function get_meta_key_name( $key ) {
 		return 'newspack_reader_data_item_' . $key;
 	}
 

--- a/includes/reader-activation/cli/class-sync-reader-data-cli.php
+++ b/includes/reader-activation/cli/class-sync-reader-data-cli.php
@@ -36,15 +36,12 @@ final class Sync_Reader_Data_CLI {
 	}
 
 	/**
-	 * Verify a reader account, allowing them to skip the account ownership verification flow.
+	 * Fix discrepancies between stored reader data and memberships.
 	 *
 	 * ## OPTIONS
 	 *
 	 * [--live]
 	 * : Live mode, performing the fix.
-	 *
-	 * [--verbose]
-	 * : Produce more output.
 	 *
 	 * @param array $args Positional args.
 	 * @param array $assoc_args Associative args.
@@ -52,7 +49,6 @@ final class Sync_Reader_Data_CLI {
 	public static function fix_reader_data_and_membership_discrepancy( $args, $assoc_args ) {
 		\WP_CLI::line( '' );
 		$live = isset( $assoc_args['live'] ) ? true : false;
-		$verbose = isset( $assoc_args['verbose'] ) ? true : false;
 
 		if ( $live ) {
 			\WP_CLI::line( 'Live mode - data will be changed.' );

--- a/includes/reader-activation/cli/class-sync-reader-data-cli.php
+++ b/includes/reader-activation/cli/class-sync-reader-data-cli.php
@@ -1,0 +1,113 @@
+<?php // phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users, WordPress.DB.DirectDatabaseQuery
+/**
+ * Reader Activation Data CLI sync script.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Newspack\Memberships;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Sync Reader Data CLI Class.
+ */
+final class Sync_Reader_Data_CLI {
+	/**
+	 * Initialized this class and adds hooks to register CLI commands
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_commands' ] );
+	}
+
+	/**
+	 * Register CLI command.
+	 */
+	public static function register_commands() {
+		if ( ! defined( 'WP_CLI' ) ) {
+			return;
+		}
+
+		\WP_CLI::add_command( 'newspack reader-data sync-memberships', [ __CLASS__, 'fix_reader_data_and_membership_discrepancy' ] );
+	}
+
+	/**
+	 * Verify a reader account, allowing them to skip the account ownership verification flow.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--live]
+	 * : Live mode, performing the fix.
+	 *
+	 * [--verbose]
+	 * : Produce more output.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public static function fix_reader_data_and_membership_discrepancy( $args, $assoc_args ) {
+		\WP_CLI::line( '' );
+		$live = isset( $assoc_args['live'] ) ? true : false;
+		$verbose = isset( $assoc_args['verbose'] ) ? true : false;
+
+		if ( $live ) {
+			\WP_CLI::line( 'Live mode - data will be changed.' );
+		} else {
+			\WP_CLI::line( 'Dry run. Use --live flag to run in live mode.' );
+		}
+		\WP_CLI::line( '' );
+
+		global $wpdb;
+		// This will return all members who have discrepancies in the active memberships
+		// and the reader data stored. The SQL will return a lot of false-positives, because
+		// The membership plan IDs in the reader data are not sorted.
+		$sql = "
+            SELECT u.ID AS user_id,
+                GROUP_CONCAT(DISTINCT p.post_parent ORDER BY p.post_parent) AS actual_membership_plan_ids,
+                -- Clean the stored memberships by removing '[]\"' characters
+                REPLACE(REPLACE(REPLACE(um.meta_value, '[', ''), ']', ''), '\"', '') AS stored_membership_plan_ids
+            FROM {$wpdb->posts} p
+            LEFT JOIN {$wpdb->users} u
+                ON p.post_author = u.ID
+            LEFT JOIN {$wpdb->prefix}usermeta um
+                ON u.ID = um.user_id
+                AND um.meta_key = %s
+            WHERE p.post_type = 'wc_user_membership'
+            AND p.post_status = 'wcm-active'
+            GROUP BY u.ID
+            HAVING actual_membership_plan_ids != stored_membership_plan_ids
+            OR stored_membership_plan_ids IS NULL
+        ";
+
+		$reader_data_user_meta_key = Reader_Data::get_meta_key_name( 'active_memberships' );
+		$potentially_misaliged_members = $wpdb->get_results( $wpdb->prepare( $sql, $reader_data_user_meta_key ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		foreach ( $potentially_misaliged_members as $reader_data ) {
+			// Rule out false-positives.
+			$actual_membership_plan_ids = explode( ',', $reader_data->actual_membership_plan_ids ?? '' );
+			$stored_membership_plan_ids = explode( ',', $reader_data->stored_membership_plan_ids ?? '' );
+			sort( $actual_membership_plan_ids );
+			sort( $stored_membership_plan_ids );
+
+			if ( $actual_membership_plan_ids === $stored_membership_plan_ids ) {
+				// False positive.
+				continue;
+			}
+
+			if ( $live ) {
+				$update_result = update_user_meta( $reader_data->user_id, $reader_data_user_meta_key, implode( ',', $actual_membership_plan_ids ) );
+				if ( $update_result !== false ) {
+					\WP_CLI::success( sprintf( 'Updated user #%d reader data.', $reader_data->user_id ) );
+				}
+			} else {
+				\WP_CLI::log( sprintf( 'Would update user #%d reader data.', $reader_data->user_id ) );
+			}
+		}
+
+		\WP_CLI::line( '' );
+	}
+}
+Sync_Reader_Data_CLI::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a CLI command to realign the reader data and memberships data. The memberships data is updated only on membership status change, and user login. This means that any reader who had a membership before that code was deployed, and had not logged in since, won't have the memberships data available in their user meta.  

### How to test the changes in this Pull Request:

1. Create a user membership, and then verify that the `newspack_reader_data_item_active_memberships` user meta has been populated with the membership plan ID
2. Run `wp newspack reader-data sync-memberships --live` and observe that there is no output about any memberships being processed (or at least not about the user used in the previous step)
3. Delete the `newspack_reader_data_item_active_memberships` user meta from the user
4. Run the CLI command again, observe it reports success in realigning the data, and that the `newspack_reader_data_item_active_memberships` has been restored

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208761499995144