### PR TITLE
chore(cli): fix setup command synopsis

### DIFF
--- a/includes/cli/class-setup.php
+++ b/includes/cli/class-setup.php
@@ -26,7 +26,7 @@ class Setup {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--site=<WordPress site url>]
+	 * [--site=<WordPress-site-url>]
 	 * : If passed, will use post content from the given URL to populate starter content.
 	 *
 	 * @param array $args Positional arguments.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the synopsis of the WP CLI `newspack setup` command. The `<arg>` part can't have spaces.  

### How to test the changes in this Pull Request:

1. Run `wp newspack setup` on `trunk`, observe a warning logged
2. Run again on this branch, observe no warning

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->