### PR TITLE
fix(auth): check for otp hash cookie when processing auth request

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -417,6 +417,11 @@ final class Magic_Link {
 			return new \WP_Error( 'newspack_magic_link_invalid_user', __( 'Invalid user.', 'newspack-plugin' ) );
 		}
 
+		// If an OTP hash cookie is not set, ignore any active tokens.
+		if ( ! isset( $_COOKIE[ self::OTP_HASH_COOKIE ] ) ) {
+			return false;
+		}
+
 		$now    = time();
 		$tokens = \get_user_meta( $user->ID, self::TOKENS_META, true );
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208730419008823

This PR fixes an issue where its possible for readers to have otp token meta stored, but no otp hash cookie present which leads to the auth form getting stuck at the signin step.

### How to test the changes in this Pull Request:

1. As a reader, in an incognito window, open the auth modal via the sign in button
2. Enter the reader email to trigger sending an OTP code (but dont enter it)
3. Close the incognito window
4. Open a new incognito and try to login with the same email again. On `epic` the form will be stuck. On this branch it will not.

Note: On step 4, the auth modal will give you a warning to wait a minute before requesting another code if opened within a minute of the first window. This is expected. Its very unlikely readers will run into this particular issue within the otp timer minute window, but if we'd like to account for this as well, let me know!

![Screenshot 2024-11-19 at 10 13 26](https://github.com/user-attachments/assets/64481393-dd16-46f7-a4a2-8aab1ba8e953)


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->