### PR TITLE
feat(subscriptions): add setting to reattempt payment after final retry

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -164,6 +164,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-search-authors-limit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce-subscriptions.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-teams-for-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-newspack-elections.php';
 

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -164,7 +164,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-search-authors-limit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce.php';
-		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce-subscriptions.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-teams-for-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-newspack-elections.php';
 

--- a/includes/plugins/class-woocommerce-subscriptions.php
+++ b/includes/plugins/class-woocommerce-subscriptions.php
@@ -17,7 +17,8 @@ class WooCommerce_Subscriptions {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_post_retry_payment_attempt_setting' ], 11, 1 );
+		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_post_retry_setting' ], 11, 1 );
+		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_post_retry' ], 99, 1 );
 	}
 
 	/**
@@ -36,7 +37,7 @@ class WooCommerce_Subscriptions {
 	 *
 	 * @return array
 	 */
-	public static function add_post_retry_payment_attempt_setting( $settings ) {
+	public static function add_post_retry_setting( $settings ) {
 		if ( self::is_active() ) {
 			return array_merge(
 				$settings,
@@ -50,9 +51,9 @@ class WooCommerce_Subscriptions {
 					[
 						'name'              => __( 'Post-retry Payment Attempt', 'newspack-plugin' ),
 						'desc'              => __( 'The number of days after final retry to reattempt payment when automatic retries are enabled', 'newspack-plugin' ),
-						'id'                => 'newspack_subscriptions_post_retry_payment_attempt',
+						'id'                => 'newspack_subscriptions_post_retry_days',
 						'css'               => 'max-width:80px;',
-						'value'             => self::get_post_retry_payment_attempt(),
+						'value'             => self::get_post_retry_days(),
 						'type'              => 'number',
 						'custom_attributes' => array(
 							'min'  => 0,
@@ -74,8 +75,32 @@ class WooCommerce_Subscriptions {
 	 *
 	 * @return int
 	 */
-	public static function get_post_retry_payment_attempt() {
-		return absint( get_option( 'newspack_subscriptions_post_retry_payment_attempt', 0 ) );
+	public static function get_post_retry_days() {
+		return absint( get_option( 'newspack_subscriptions_post_retry_days', 0 ) );
+	}
+
+	/**
+	 * Conditionally adds post-retry rule to retry rules.
+	 *
+	 * @param array $retry_rules Subscriptions retry rules.
+	 */
+	public static function maybe_apply_post_retry( $retry_rules ) {
+		if ( self::is_active() ) {
+			$post_retry_days = self::get_post_retry_days();
+			if ( $post_retry_days > 0 ) {
+				$final_retry_rule                                    = end( $retry_rules );
+				$post_retry_rule                                     = $final_retry_rule;
+				$final_order_status                                  = $final_retry_rule['status_to_apply_to_order'];
+				$final_subscription_status                           = $final_retry_rule['status_to_apply_to_subscription'];
+				$final_retry_rule['status_to_apply_to_order']        = 'pending';
+				$final_retry_rule['status_to_apply_to_subscription'] = 'on-hold';
+				$post_retry_rule['status_to_apply_to_order']         = $final_order_status;
+				$post_retry_rule['status_to_apply_to_subscription']  = $final_subscription_status;
+				$post_retry_rule['retry_after_interval']             = DAY_IN_SECONDS * $post_retry_days;
+				return array_merge( $retry_rules, [ $post_retry_rule ] );
+			}
+		}
+		return $retry_rules;
 	}
 }
 WooCommerce_Subscriptions::init();

--- a/includes/plugins/class-woocommerce-subscriptions.php
+++ b/includes/plugins/class-woocommerce-subscriptions.php
@@ -17,8 +17,8 @@ class WooCommerce_Subscriptions {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_post_retry_setting' ], 11, 1 );
-		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_post_retry_rule' ], 99, 1 );
+		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_on_hold_duration_setting' ], 11, 1 );
+		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_on_hold_duration_rule' ], 99, 1 );
 	}
 
 	/**
@@ -31,13 +31,13 @@ class WooCommerce_Subscriptions {
 	}
 
 	/**
-	 * Add post-retry payment attempt setting.
+	 * Add on-hold duration setting.
 	 *
 	 * @param array $settings Subscription settings.
 	 *
 	 * @return array
 	 */
-	public static function add_post_retry_setting( $settings ) {
+	public static function add_on_hold_duration_setting( $settings ) {
 		if ( self::is_active() ) {
 			return array_merge(
 				$settings,
@@ -49,11 +49,11 @@ class WooCommerce_Subscriptions {
 						'id'   => 'newspack_subscriptions_options',
 					],
 					[
-						'name'              => __( 'Post-retry Payment Attempt', 'newspack-plugin' ),
-						'desc'              => __( 'The number of days after final retry to reattempt payment when automatic retries are enabled', 'newspack-plugin' ),
-						'id'                => 'newspack_subscriptions_post_retry_days',
+						'name'              => __( 'On-hold Duration', 'newspack-plugin' ),
+						'desc'              => __( 'The number of days after all automatic payment retries have failed before attempting a final payment attempt and ending retries.', 'newspack-plugin' ),
+						'id'                => 'newspack_subscriptions_on_hold_duration',
 						'css'               => 'max-width:80px;',
-						'value'             => self::get_post_retry_days(),
+						'value'             => self::get_on_hold_duration(),
 						'type'              => 'number',
 						'custom_attributes' => array(
 							'min'  => 0,
@@ -71,22 +71,22 @@ class WooCommerce_Subscriptions {
 	}
 
 	/**
-	 * Get post-retry payment attempt. Defaults to 0.
+	 * Get on-hold duration. Defaults to 0.
 	 *
 	 * @return int
 	 */
-	public static function get_post_retry_days() {
-		return absint( get_option( 'newspack_subscriptions_post_retry_days', 0 ) );
+	public static function get_on_hold_duration() {
+		return absint( get_option( 'newspack_subscriptions_on_hold_duration', 0 ) );
 	}
 
 	/**
-	 * Conditionally adds post-retry rule to retry rules.
+	 * Conditionally adds on-hold duration rule to retry rules.
 	 *
 	 * @param array $retry_rules Subscriptions retry rules.
 	 */
-	public static function maybe_apply_post_retry_rule( $retry_rules ) {
+	public static function maybe_apply_on_hold_duration_rule( $retry_rules ) {
 		if ( self::is_active() ) {
-			$post_retry_days = self::get_post_retry_days();
+			$post_retry_days = self::get_on_hold_duration();
 			if ( $post_retry_days > 0 ) {
 				$final_retry_rule          = array_pop( $retry_rules );
 				$final_order_status        = $final_retry_rule['status_to_apply_to_order'];

--- a/includes/plugins/class-woocommerce-subscriptions.php
+++ b/includes/plugins/class-woocommerce-subscriptions.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * WooCommerce Subscriptions integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class WooCommerce_Subscriptions {
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_post_retry_payment_attempt_setting' ], 11, 1 );
+	}
+
+	/**
+	 * Check if WooCommerce Subscriptions is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_active() {
+		return class_exists( 'WC_Subscriptions' );
+	}
+
+	/**
+	 * Add post-retry payment attempt setting.
+	 *
+	 * @param array $settings Subscription settings.
+	 *
+	 * @return array
+	 */
+	public static function add_post_retry_payment_attempt_setting( $settings ) {
+		if ( self::is_active() ) {
+			return array_merge(
+				$settings,
+				[
+					[
+						'name' => __( 'Newspack Subscriptions Settings', 'newspack-plugin' ),
+						'type' => 'title',
+						'desc' => __( 'Subscriptions settings added by Newspack.', 'newspack-plugin' ),
+						'id'   => 'newspack_subscriptions_options',
+					],
+					[
+						'name'              => __( 'Post-retry Payment Attempt', 'newspack-plugin' ),
+						'desc'              => __( 'The number of days after final retry to reattempt payment when automatic retries are enabled', 'newspack-plugin' ),
+						'id'                => 'newspack_subscriptions_post_retry_payment_attempt',
+						'css'               => 'max-width:80px;',
+						'value'             => self::get_post_retry_payment_attempt(),
+						'type'              => 'number',
+						'custom_attributes' => array(
+							'min'  => 0,
+							'step' => 1,
+						),
+					],
+					[
+						'type' => 'sectionend',
+						'id'   => 'newspack_subscriptions_options',
+					],
+				]
+			);
+		}
+		return $settings;
+	}
+
+	/**
+	 * Get post-retry payment attempt. Defaults to 0.
+	 *
+	 * @return int
+	 */
+	public static function get_post_retry_payment_attempt() {
+		return absint( get_option( 'newspack_subscriptions_post_retry_payment_attempt', 0 ) );
+	}
+}
+WooCommerce_Subscriptions::init();

--- a/includes/plugins/class-woocommerce-subscriptions.php
+++ b/includes/plugins/class-woocommerce-subscriptions.php
@@ -18,7 +18,7 @@ class WooCommerce_Subscriptions {
 	 */
 	public static function init() {
 		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_post_retry_setting' ], 11, 1 );
-		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_post_retry' ], 99, 1 );
+		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_post_retry_rule' ], 99, 1 );
 	}
 
 	/**
@@ -84,20 +84,33 @@ class WooCommerce_Subscriptions {
 	 *
 	 * @param array $retry_rules Subscriptions retry rules.
 	 */
-	public static function maybe_apply_post_retry( $retry_rules ) {
+	public static function maybe_apply_post_retry_rule( $retry_rules ) {
 		if ( self::is_active() ) {
 			$post_retry_days = self::get_post_retry_days();
 			if ( $post_retry_days > 0 ) {
-				$final_retry_rule                                    = end( $retry_rules );
-				$post_retry_rule                                     = $final_retry_rule;
-				$final_order_status                                  = $final_retry_rule['status_to_apply_to_order'];
-				$final_subscription_status                           = $final_retry_rule['status_to_apply_to_subscription'];
-				$final_retry_rule['status_to_apply_to_order']        = 'pending';
-				$final_retry_rule['status_to_apply_to_subscription'] = 'on-hold';
-				$post_retry_rule['status_to_apply_to_order']         = $final_order_status;
-				$post_retry_rule['status_to_apply_to_subscription']  = $final_subscription_status;
-				$post_retry_rule['retry_after_interval']             = DAY_IN_SECONDS * $post_retry_days;
-				return array_merge( $retry_rules, [ $post_retry_rule ] );
+				$final_retry_rule          = array_pop( $retry_rules );
+				$final_order_status        = $final_retry_rule['status_to_apply_to_order'];
+				$final_subscription_status = $final_retry_rule['status_to_apply_to_subscription'];
+				$retry_rules               = array_merge(
+					$retry_rules,
+					[
+						array_merge(
+							$final_retry_rule,
+							[
+								'status_to_apply_to_order' => 'pending',
+								'status_to_apply_to_subscription' => 'on-hold',
+							]
+						),
+						array_merge(
+							$final_retry_rule,
+							[
+								'status_to_apply_to_order' => $final_order_status,
+								'status_to_apply_to_subscription' => $final_subscription_status,
+								'retry_after_interval'     => DAY_IN_SECONDS * $post_retry_days,
+							]
+						),
+					]
+				);
 			}
 		}
 		return $retry_rules;

--- a/includes/plugins/class-woocommerce-subscriptions.php
+++ b/includes/plugins/class-woocommerce-subscriptions.php
@@ -50,7 +50,6 @@ class WooCommerce_Subscriptions {
 					],
 					[
 						'name'              => __( 'On-hold Duration', 'newspack-plugin' ),
-						'desc'              => __( 'The number of days after all automatic payment retries have failed before attempting a final payment attempt and ending retries.', 'newspack-plugin' ),
 						'id'                => 'newspack_subscriptions_on_hold_duration',
 						'css'               => 'max-width:80px;',
 						'value'             => self::get_on_hold_duration(),
@@ -58,6 +57,14 @@ class WooCommerce_Subscriptions {
 						'custom_attributes' => array(
 							'min'  => 0,
 							'step' => 1,
+						),
+						'desc'              => sprintf(
+							// Translators: %s is a line break.
+							__(
+								'Set the number of days a subscription remains in the On-Hold status after all automatic payment retries have failed.%sDuring this period, subscribers can update their payment details to restore the subscription at their current price. Once this time expires, the subscription will automatically transition to expired.',
+								'newspack-plugin'
+							),
+							'<br>'
 						),
 					],
 					[
@@ -85,33 +92,20 @@ class WooCommerce_Subscriptions {
 	 * @param array $retry_rules Subscriptions retry rules.
 	 */
 	public static function maybe_apply_on_hold_duration_rule( $retry_rules ) {
-		if ( self::is_active() ) {
-			$post_retry_days = self::get_on_hold_duration();
-			if ( $post_retry_days > 0 ) {
-				$final_retry_rule          = array_pop( $retry_rules );
-				$final_order_status        = $final_retry_rule['status_to_apply_to_order'];
-				$final_subscription_status = $final_retry_rule['status_to_apply_to_subscription'];
-				$retry_rules               = array_merge(
-					$retry_rules,
-					[
-						array_merge(
-							$final_retry_rule,
-							[
-								'status_to_apply_to_order' => 'pending',
-								'status_to_apply_to_subscription' => 'on-hold',
-							]
-						),
-						array_merge(
-							$final_retry_rule,
-							[
-								'status_to_apply_to_order' => $final_order_status,
-								'status_to_apply_to_subscription' => $final_subscription_status,
-								'retry_after_interval'     => DAY_IN_SECONDS * $post_retry_days,
-							]
-						),
-					]
-				);
+		if ( self::is_active() && count( $retry_rules ) > 0 ) {
+			$on_hold_duration = self::get_on_hold_duration();
+			if ( 0 < $on_hold_duration ) {
+				$retry_rules[] = [
+					'retry_after_interval'            => $on_hold_duration * DAY_IN_SECONDS,
+					'status_to_apply_to_order'        => 'pending',
+					'status_to_apply_to_subscription' => 'on-hold',
+				];
 			}
+			$retry_rules[] = [
+				'retry_after_interval'            => 0,
+				'status_to_apply_to_order'        => 'failed',
+				'status_to_apply_to_subscription' => 'expired',
+			];
 		}
 		return $retry_rules;
 	}

--- a/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WooCommerce Subscriptions integration class.
+ * WooCommerce Subscriptions On-Hold Duration class.
  *
  * @package Newspack
  */
@@ -12,22 +12,13 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Main class.
  */
-class WooCommerce_Subscriptions {
+class On_Hold_Duration {
 	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
 		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_on_hold_duration_setting' ], 11, 1 );
 		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_on_hold_duration_rule' ], 99, 1 );
-	}
-
-	/**
-	 * Check if WooCommerce Subscriptions is active.
-	 *
-	 * @return bool
-	 */
-	public static function is_active() {
-		return class_exists( 'WC_Subscriptions' );
 	}
 
 	/**
@@ -38,7 +29,7 @@ class WooCommerce_Subscriptions {
 	 * @return array
 	 */
 	public static function add_on_hold_duration_setting( $settings ) {
-		if ( self::is_active() ) {
+		if ( WooCommerce_Subscriptions::is_active() ) {
 			return array_merge(
 				$settings,
 				[
@@ -92,7 +83,7 @@ class WooCommerce_Subscriptions {
 	 * @param array $retry_rules Subscriptions retry rules.
 	 */
 	public static function maybe_apply_on_hold_duration_rule( $retry_rules ) {
-		if ( self::is_active() && count( $retry_rules ) > 0 ) {
+		if ( WooCommerce_Subscriptions::is_active() && count( $retry_rules ) > 0 ) {
 			$on_hold_duration = self::get_on_hold_duration();
 			if ( 0 < $on_hold_duration ) {
 				$retry_rules[] = [
@@ -110,4 +101,3 @@ class WooCommerce_Subscriptions {
 		return $retry_rules;
 	}
 }
-WooCommerce_Subscriptions::init();

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -14,11 +14,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class WooCommerce_Subscriptions {
 	/**
-	 * Feature flag for the Newspack Subscriptions Expiration feature.
-	 */
-	const NEWSPACK_SUBSCRIPTIONS_EXPIRATION_FEATURE_FLAG = 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION';
-
-	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
@@ -46,7 +41,7 @@ class WooCommerce_Subscriptions {
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		return Reader_Activation::is_enabled() && defined( self::NEWSPACK_SUBSCRIPTIONS_EXPIRATION_FEATURE_FLAG ) && self::NEWSPACK_SUBSCRIPTIONS_EXPIRATION_FEATURE_FLAG;
+		return Reader_Activation::is_enabled() && defined( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION' ) && NEWSPACK_SUBSCRIPTIONS_EXPIRATION;
 	}
 }
 WooCommerce_Subscriptions::init();

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -46,7 +46,7 @@ class WooCommerce_Subscriptions {
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		return Reader_Activation::is_enabled() && defined( self::NEWSPACK_SUBSCRIPTIONS_EXPIRATION_FEATURE_FLAG );
+		return Reader_Activation::is_enabled() && defined( self::NEWSPACK_SUBSCRIPTIONS_EXPIRATION_FEATURE_FLAG ) && self::NEWSPACK_SUBSCRIPTIONS_EXPIRATION_FEATURE_FLAG;
 	}
 }
 WooCommerce_Subscriptions::init();

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * WooCommerce Subscriptions Integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class WooCommerce_Subscriptions {
+	/**
+	 * Feature flag for the Newspack Subscriptions Expiration feature.
+	 */
+	const NEWSPACK_SUBSCRIPTIONS_EXPIRATION_FEATURE_FLAG = 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION';
+
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		if ( self::is_enabled() ) {
+			include_once __DIR__ . '/class-on-hold-duration.php';
+
+			On_Hold_Duration::init();
+		}
+	}
+
+	/**
+	 * Check if WooCommerce Subscriptions is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_active() {
+		return class_exists( 'WC_Subscriptions' );
+	}
+
+	/**
+	 * Check if WooCommerce Subscriptions Integration is enabled.
+	 *
+	 * Enalbed if Reader activation is enabled and the feature flag is defined.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		return Reader_Activation::is_enabled() && defined( self::NEWSPACK_SUBSCRIPTIONS_EXPIRATION_FEATURE_FLAG );
+	}
+}
+WooCommerce_Subscriptions::init();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208702687864922/1208702687865959/f

This PR adds a new 'On-hold duration' setting for subscriptions. This setting adds a new retry rule set to the specified number of days in WooCommerce > Settings > Subscriptions > On-hold Duration:

![Screenshot 2024-11-25 at 15 53 34](https://github.com/user-attachments/assets/023dd7aa-6ba7-442b-9099-20045a28de06)

### How to test the changes in this Pull Request:

1. As admin, go to WooCommerce > Settings > Subscriptions and scroll down. Confirm there is a new section added for Newspack subscriptions settings. Also confirm the On-hold Duration setting is present.
2. Select a non-zero value and save. Confirm the setting persists on reload
3. As a reader, purchase any subscription product
4. As admin, go to the edit subscriptions page for this subscription (WooCommerce > Subscriptions)
5. Follow these steps to manually trigger 5 payment retries: https://woocommerce.com/document/subscriptions/develop/failed-payment-retry/#section-7
6. Run one more time, verify a sixth job is scheduled set to run the number of days set in the On-hold Duration setting:
![Screenshot 2024-11-20 at 17 06 12](https://github.com/user-attachments/assets/beb0c023-a2fd-4fe0-a553-ffa98bacdbf8)
7. Visit the edit subscription page for the subscription. Confirm the subscription is still on-hold. Also confirm the renewal order is still in a pending status:
![Screenshot 2024-11-20 at 17 10 12](https://github.com/user-attachments/assets/5c72934d-38f7-499f-8b0a-131145c81adb)
8. Run the scheduled action one more time. Confirm no new scheduled action is added (this should be the final retry rule)
9. Go back to the edit subscription page and verify the subscription is now expired and the renewal order status is set to failed:
![Screenshot 2024-11-20 at 17 12 03](https://github.com/user-attachments/assets/abdf871a-4034-4329-9f34-f9f69d61954f)
10. Set the On-hold duration setting to 0 and repeat the above steps. This time the fifth scheduled action should trigger the subscription to expire and the renewal order to fail.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->