### PR TITLE
fix(ia): regression, updated ras endpoint

### DIFF
--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -298,8 +298,8 @@ class Newspack_Dashboard extends Wizard {
 						'success' => __( 'Enabled', 'newspack-plugin' ),
 						'error'   => __( 'Disabled', 'newspack-plugin' ),
 					],
-					'endpoint'     => '/newspack/v1/wizard/newspack-engagement-wizard/reader-activation',
-					'configLink'   => admin_url( 'admin.php?page=newspack-engagement-wizard#/reader-activation' ),
+					'endpoint'     => '/newspack/v1/wizard/newspack-audience/reader-activation',
+					'configLink'   => admin_url( 'admin.php?page=newspack-audience#/' ),
 					'dependencies' => [
 						'woocommerce' => [
 							'label'    => __( 'Woocommerce', 'newspack-plugin' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes endpoint for Reader Activation "Site Status" caused by regression introduced in https://github.com/Automattic/newspack-plugin/pull/3500 

### How to test the changes in this Pull Request:

1. Checkout this branch - `git checkout origin/fix/ia-dashboard-ras-endpoint`
2. Navigate to _/wp-admin/admin.php?page=newspack-dashboard#/_ and confirm Reader Activation "Site Status" works correctly.

| Before | After |
| --------- | ---------- |
| ![Screenshot 2024-11-20 at 13 15 18](https://github.com/user-attachments/assets/f30379be-080d-4a2b-a0f4-bf5c3ac41741) &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | ![Screenshot 2024-11-22 at 08 16 17](https://github.com/user-attachments/assets/390a77f8-bfc9-4750-aea9-ed79f275aefc) ![Screenshot 2024-11-22 at 08 20 27](https://github.com/user-attachments/assets/c1b00de9-17ac-4983-ad9a-356fe5b5dd02) |

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?