### PR TITLE
fix(memberships): prioritize paywall restrictions over regwall restrictions

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -869,13 +869,7 @@ class Memberships {
 					case 'wc_memberships_view_delayed_taxonomy_term':
 					case 'wc_memberships_view_delayed_post_content':
 					case 'wc_memberships_view_restricted_post_content':
-						if ( self::can_manage_woocommerce( $all_caps ) ) {
-							$all_caps[ $cap ] = true;
-							break;
-						}
-
-						// Allow user who can edit posts (by default: editors, authors, contributors).
-						if ( isset( $all_caps['edit_posts'] ) && true === $all_caps['edit_posts'] ) {
+						if ( self::user_has_content_access_from_role( $all_caps ) ) {
 							$all_caps[ $cap ] = true;
 							break;
 						}
@@ -895,6 +889,17 @@ class Memberships {
 						$rules            = wc_memberships()->get_rules_instance()->get_post_content_restriction_rules( $post_id );
 						$all_caps[ $cap ] = self::user_has_content_access_from_rules( $user_id, $rules, $post_id );
 
+						/**
+						 * Filter the user's access to content.
+						 *
+						 * @param bool  $has_access Whether the user has access to the content.
+						 * @param string $cap The capability being checked.
+						 * @param int $user_id The user ID.
+						 * @param int $post_id The post ID.
+						 * @param \WC_Memberships_Membership_Plan_Rule[] $rules The rules that apply to the content.
+						 */
+						$all_caps[ $cap ] = apply_filters( 'newspack_memberships_user_has_content_access', $all_caps[ $cap ], $cap, $user_id, $post_id, $rules );
+
 						break;
 
 					case 'wc_memberships_view_delayed_product':
@@ -909,6 +914,25 @@ class Memberships {
 		}
 
 		return $all_caps;
+	}
+
+	/**
+	 * Checks if a user has content access from user role.
+	 * Overrides behavior from WooCommerce Memberships plugin.
+	 *
+	 * @param array $all_caps All the user's capabilities.
+	 */
+	public static function user_has_content_access_from_role( $all_caps ) {
+		// Allow users who can manage WooCommerce.
+		if ( self::can_manage_woocommerce( $all_caps ) ) {
+			return true;
+		}
+
+		// Allow users who can edit posts (by default: editors, authors, contributors).
+		if ( isset( $all_caps['edit_posts'] ) && true === $all_caps['edit_posts'] ) {
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -933,33 +957,44 @@ class Memberships {
 			return true;
 		}
 
-		$integrations      = wc_memberships()->get_integrations_instance();
+		$wc_memberships    = wc_memberships();
+		$integrations      = $wc_memberships->get_integrations_instance();
 		$integration       = $integrations ? $integrations->get_subscriptions_instance() : null;
 		$require_all_plans = self::get_require_all_plans_setting();
 		$has_access        = false;
 		$has_subscription  = false;
+		$has_paywall       = false;
 
 		foreach ( $rules as $rule ) {
 			$membership_plan_id = $rule->get_membership_plan_id();
-			if ( $integration && $integration->has_membership_plan_subscription( $membership_plan_id ) ) {
+			$membership_plan    = $rule->get_membership_plan();
+			$is_regwall         = $membership_plan->is_access_method( 'signup' );
+			$is_paywall         = $membership_plan->is_access_method( 'purchase' );
+			if ( $is_paywall && $integration && $integration->has_membership_plan_subscription( $membership_plan_id ) ) {
+				$has_paywall        = true;
 				$subscription_plan  = new \WC_Memberships_Integration_Subscriptions_Membership_Plan( $membership_plan_id );
 				$required_products  = $subscription_plan->get_subscription_product_ids();
-				$has_subscription   = ! empty( WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $required_products ) );
+				$has_subscription   = $has_subscription || ! empty( WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $required_products ) );
 			}
 
-			// If no object ID is provided, then we are looking at rules that apply to whole post types or taxonomies.
+			// If no object ID is provided, then we are checking the user's access to entire post types or taxonomies.
 			// In this case, rules that apply to specific objects should be skipped.
 			if ( empty( $object_id ) && $rule->has_objects() ) {
 				continue;
 			}
 
-			if ( $has_subscription || wc_memberships_is_user_active_or_delayed_member( $user_id, $rule->get_membership_plan_id() ) ) {
-				$has_access = true;
-				if ( ! $require_all_plans ) {
+			// Check if the user should have free access to the content.
+			// If both a regwall and a paywall apply to the content, the paywall takes precedence.
+			// If the user has a manually-assigned membership plan, they should have access to the content even without owning a subscription.
+			$has_free_access = $is_regwall && $has_paywall ? $has_subscription : wc_memberships_is_user_active_or_delayed_member( $user_id, $rule->get_membership_plan_id() );
+			$has_access      = $has_subscription || $has_free_access;
+
+			// Check if the user has either paid or free access to the content, and if they need membership in all plans or just one.
+			if ( $has_access ) {
+				if ( ! $require_all_plans && ! $is_regwall ) {
 					break;
 				}
 			} elseif ( $require_all_plans ) {
-				$has_access = false;
 				break;
 			}
 		}

--- a/src/memberships-gate/editor.js
+++ b/src/memberships-gate/editor.js
@@ -61,7 +61,10 @@ function GateEdit() {
 					// translators: %s is the list of plans.
 					__( "You're currently editing a gate for content restricted by: %s", 'newspack-plugin' ),
 					Object.values( newspack_memberships_gate.gate_plans ).join( ', ' )
-				)
+				),
+				{
+					id: 'newspack-memberships-gate-plan'
+				}
 			);
 		}
 	}, [] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR acknowledges that there's a hierarchy of membership plans in Newspack sites, where restrictions from premium/paid membership plans should take precedence over those from free plans. This follows the concept of the reader funnel, where a publication guides anonymous readers to become registered readers, and then paying readers.

By default, the way the Woo Memberships plugin handles access to restricted content, if a reader encounters content that may be restricted by more than one membership plan, they will be granted access as soon as they gain membership to any applicable membership plan, whether free or paid. This means in a site using an unmodified Woo Memberships setup, it's not possible to create a funnel-like hierarchy of membership plans with both free and paid membership plans. #2623 attempted to address this by adding an admin-facing option to require membership in all applicable plans in order to access restricted content. However, this solution still only solves the hierarchy issue if there's just a single paid plan on top of the free plan.

For sites with more complex membership strategies, they may offer multiple different types of paid membership, each of which could restrict different types of content. These sites can't currently offer a free membership plan on top of those paid plans—if the free plan restricts the same content as other paid plans, any registered reader will be able to access all premium content without having a paid membership. If the site enables the "require membership in all plans" option, then any content that might be restricted by more than one plan won't be accessible by paid readers unless they buy membership in _all_ premium plans.

This PR addresses this shortcoming by checking if content is being restricted by both a free membership plan (we're calling this a "regwall" or registration wall) and at least one paid membership plan (we're calling this a "paywall"). If so, then membership in the free/regwall plan is not enough to gain access to the content—they must have membership in at least one applicable paid membership plan, or all paid plans if the "require membership in all plans" option is enabled. This should allow for more complex content gating strategies that combine regwalls with metered paywalls applied to multiple different paid membership plans.

Lastly, because we've seen a lot of different content gating and revenue strategies across various Newspack sites, this adds a new `newspack_memberships_user_has_content_access` filter that could come in handy in the future, which will let us or third-party developers hook into the filter and decide whether to grant access to specific posts on a per-user basis. Open to suggestions on how to make this even more useful.

### How to test the changes in this Pull Request:

#### Configuration

We need to set up a complex content gating strategy. This will require several steps:

1. In **Products**, create at least two virtual/downloadable subscription-type products. Let's call these "Featured Access" and "Arts Patron", for the categories each paid subscription product will provide access to.
2. In **WooCommerce > Memberships > Membership Plans**, publish **three** different membership plans:
  - Regwall: Restricts access to **all** posts, grants access upon account registration
  - "Featured" paywall: Restricts access to posts with the "Featured" category, grants access upon active subscription to the "Featured Access" product
  - "Arts" paywall: Restricts access to posts with the "Arts" category, grants access upon active subscription to the "Arts Patron" product

3. In **Newspack > Engagement > Reader Activation > Advanced Settings**, leave the "require membership in all plans" option OFF for now. Configure and publish the following content gates:

  - **Primary gate:** Should be unmetered and targeted to anonymous (unregistered) readers who land on articles that are restricted only by the regwall (i.e. not Featured or Arts posts). Let's create a generic message for these readers:

<img width="1113" alt="Screenshot 2024-11-22 at 11 02 14 AM" src="https://github.com/user-attachments/assets/62274553-104c-4ef9-9b3c-2170286260a8">

  - **Featured gate:** This metered gate targets both unregistered readers and registered readers who have NOT subscribed to the paid "Featured Access" product. This gate should be metered to 0 articles for anonymous readers, 3 for registered readers, and needs some Non-member and Member conditional blocks to target readers of each class:

<img width="1732" alt="Screenshot 2024-11-22 at 11 10 51 AM" src="https://github.com/user-attachments/assets/28f67f08-b812-4349-8423-76d59ebaf2db">

  - **Arts gate:** This gate targets both unregistered readers and registered readers who have NOT subscribed to the paid "Arts Patron" product. This gate should also be metered, and the content can be more or less the same as the Featured gate but with messaging and a Checkout Button block for the Arts Patron product instead.

#### Testing content restriction and access as a reader

1. Visit the site in a new incognito session and visit an article with the Featured category, an article with the Arts category, and and article with neither category. Confirm that you see the correct "regwall" content gate message for each article.
2. Register for a free account without purchasing any products. Confirm that you can access all non-Featured and non-Arts articles now that you meet membership requirements for those articles.
3. This is where things break down. On `release`, visit a bunch of Arts and Featured articles. Observe that as a registered but not paying reader, you can now access an unlimited number of Featured and Arts articles for free. This is because with the "require membership in all plans" option OFF, as a registered reader you're granted access to these articles because you meet access requirements for at least one membership plan (the free regwall). Not great for revenue strategy.
4. Check out this branch, and repeat steps 1-3 with a new reader account (you could use the same reader account too, but it gets complicated to count how many articles you've read of each type per session). This time, confirm that:
  - Before registering, you see the correct regwall content gate message for Arts, Featured, and non-Arts/Featured articles
  - After registering for a free account, you can still access an unlimited number of non-Arts and non-Featured articles while signed in
  - After registering, you can access three Arts AND three Featured articles for free (or however many are allowed by metering settings for each gate)
  - After viewing the number of articles allowed by metering settings, you see the correct paywall gate for both Arts and Featured articles

5. In the same session, purchase a "Featured Access" subscription. Confirm that you can now access all Featured articles for free, INCLUDING articles with both Featured and Arts categories, but that you still see the Arts paywall on articles tagged only with Arts.
6. In the same session, purchase an "Arts Patron" subscription and confirm that you can now access all Arts articles, too.
7. Lastly, test that the "require membership in all plans" option still works. In a new session, register for an account and purchase just a "Featured Access" subscription, then visit an article with both Featured and Arts categories. Confirm that you see the Arts Patron paywall because you now need both subscriptions to gain access.
8. Purchase the Arts Patron subscription and confirm that you can now access articles with both Featured and Arts categories.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->