### PR TITLE
feat: add constant to disable Google OAuth in RAS

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1705,9 +1705,11 @@ final class Reader_Activation {
 
 	/**
 	 * Render third party auth buttons for an authentication form.
+	 *
+	 * If Google is connected to the site, this can be overridden by setting the `NEWSPACK_DISABLE_GOOGLE_OAUTH` environment constant.
 	 */
 	public static function render_third_party_auth() {
-		if ( ! Google_OAuth::is_oauth_configured() ) {
+		if ( ! Google_OAuth::is_oauth_configured() || ( defined( 'NEWSPACK_DISABLE_GOOGLE_OAUTH' ) && NEWSPACK_DISABLE_GOOGLE_OAUTH ) ) {
 			return;
 		}
 		?>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

To enable Google as a Sign-In option in RAS, all you need to do is connect Google to the site under Newspack > Connections.

Once that's done, though, you can't disable Google as a sign in option without severing that connection; that connection can be used for other things, like ads. You need to use CSS to hide the button. 

This PR adds a environmental constant, `NEWSPACK_DISABLE_GOOGLE_OAUTH`, that can be used to disable Google OAuth once Google is connected to a site. Down the road, it will probably make sense to have a separate control to disable OAuth specifically in the UI.

See: 1207817176293825-as-1208782453256681.

### How to test the changes in this Pull Request:

1. Set up your site to have Google as a Sign In option (there are some steps to do this on a test site here: PamTN9-9RR-p2
2. Run through a sign in and confirm the Google Sign In option appears:

![CleanShot 2024-11-22 at 16 26 36](https://github.com/user-attachments/assets/2b1eb8a7-4217-456d-a9ef-c5f907143e64)

3. In wp-config.php, add `define( 'NEWSPACK_DISABLE_GOOGLE_OAUTH', true );`
4. Run through a sign in again and confirm Google no longer appears:

![CleanShot 2024-11-22 at 16 26 15](https://github.com/user-attachments/assets/18ac1d8f-ba66-40d5-9dbe-b4329a658a66)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->