### PR TITLE
refactor(ia): dashboard site status etc.

### DIFF
--- a/src/wizards/newspack/components/site-statuses/index.tsx
+++ b/src/wizards/newspack/components/site-statuses/index.tsx
@@ -21,20 +21,22 @@ const {
 const actions: Statuses = {
 	readerActivation: {
 		...siteStatuses.readerActivation,
-		then( { config: { enabled = false } }: { config: { enabled: boolean } } ) {
-			return enabled;
+		then( { config } ) {
+			return Boolean( config?.enabled );
 		},
 	},
 	googleAnalytics: {
 		...siteStatuses.googleAnalytics,
-		then( { propertyID = '' }: { propertyID: string } ) {
+		then( { propertyID = '' } ) {
 			return propertyID !== '';
 		},
 	},
 	googleAdManager: {
 		...siteStatuses.googleAdManager,
 		then( { services: { google_ad_manager } } ) {
-			return google_ad_manager.available && google_ad_manager.enabled === '1';
+			return (
+				google_ad_manager.available && google_ad_manager.enabled === '1'
+			);
 		},
 	},
 } as const;

--- a/src/wizards/newspack/components/site-statuses/site-status.tsx
+++ b/src/wizards/newspack/components/site-statuses/site-status.tsx
@@ -35,8 +35,11 @@ const SiteStatus = ( {
 }: Status ) => {
 	const parsedStatusLabels = { ...defaultStatuses, ...statuses };
 
-	const [ requestStatus, setRequestStatus ] = useState< StatusLabels >( 'idle' );
-	const [ failedDependencies, setFailedDependencies ] = useState< string[] >( [] );
+	const [ requestStatus, setRequestStatus ] =
+		useState< StatusLabels >( 'idle' );
+	const [ failedDependencies, setFailedDependencies ] = useState< string[] >(
+		[]
+	);
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 
 	const dependencies = structuredClone( dependenciesProp ) as Dependencies;
@@ -56,7 +59,10 @@ const SiteStatus = ( {
 			// Dependency check
 			if ( dependencies && Object.keys( dependencies ).length > 0 ) {
 				const failedDeps: string[] = [];
-				for ( const [ dependencyName, dependencyInfo ] of Object.entries( dependencies ) ) {
+				for ( const [
+					dependencyName,
+					dependencyInfo,
+				] of Object.entries( dependencies ) ) {
 					// Don't process active
 					if ( dependencyInfo.isActive ) {
 						continue;
@@ -86,7 +92,8 @@ const SiteStatus = ( {
 					setRequestStatus( apiRequest ? 'success' : 'error' );
 					resolve( apiRequest );
 				} )
-				.catch( () => {
+				.catch( e => {
+					console.log( e );
 					then( false );
 					setRequestStatus( 'error' );
 					reject();
@@ -107,9 +114,15 @@ const SiteStatus = ( {
 			) }
 			{ /* Error UI, link user to config */ }
 			{ requestStatus === 'error' && (
-				<Tooltip text={ __( 'Click to navigate to configuration', 'newspack-plugin' ) }>
+				<Tooltip
+					text={ __(
+						'Click to navigate to configuration',
+						'newspack-plugin'
+					) }
+				>
 					<a href={ configLink } className={ classes }>
-						{ label }: <span>{ parsedStatusLabels[ requestStatus ] }</span>
+						{ label }:{ ' ' }
+						<span>{ parsedStatusLabels[ requestStatus ] }</span>
 						<span className="hidden">{ __( 'Configure?' ) }</span>
 					</a>
 				</Tooltip>
@@ -120,10 +133,15 @@ const SiteStatus = ( {
 					text={ sprintf(
 						// translators: %s is a comma separated list of needed dependencies.
 						__( '%s must be installed & activated!' ),
-						failedDependencies.map( dep => dependencies[ dep ].label ).join( ', ' )
+						failedDependencies
+							.map( dep => dependencies[ dep ].label )
+							.join( ', ' )
 					) }
 				>
-					<button onClick={ () => setIsModalVisible( true ) } className={ classes }>
+					<button
+						onClick={ () => setIsModalVisible( true ) }
+						className={ classes }
+					>
 						{ label }:{ ' ' }
 						<span>
 							{ _n(
@@ -145,9 +163,12 @@ const SiteStatus = ( {
 				</Tooltip>
 			) }
 			{ /* Display standard UI for the rest */ }
-			{ [ 'error-preflight', 'success', 'idle', 'pending' ].includes( requestStatus ) && (
+			{ [ 'error-preflight', 'success', 'idle', 'pending' ].includes(
+				requestStatus
+			) && (
 				<div className={ classes }>
-					{ label }: <span>{ parsedStatusLabels[ requestStatus ] }</span>
+					{ label }:{ ' ' }
+					<span>{ parsedStatusLabels[ requestStatus ] }</span>
 				</div>
 			) }
 		</>

--- a/src/wizards/newspack/components/site-statuses/site-status.tsx
+++ b/src/wizards/newspack/components/site-statuses/site-status.tsx
@@ -22,6 +22,7 @@ const defaultStatuses = {
 	error: __( 'Disconnected', 'newspack-plugin' ),
 	'error-dependencies': undefined,
 	'error-preflight': undefined,
+	/* translators: %s is the HTTP status code */
 	'error-request': __( 'Request failed - %s', 'newspack-plugin' ),
 };
 
@@ -34,7 +35,10 @@ const SiteStatus = ( {
 	configLink,
 	then,
 }: Status ) => {
-	const parsedStatusLabels = { ...defaultStatuses, ...statuses };
+	const parsedStatusLabels: Record< StatusLabels, string > = {
+		...defaultStatuses,
+		...statuses,
+	};
 
 	const [ requestCode, setRequestCode ] = useState( 200 );
 
@@ -184,10 +188,12 @@ const SiteStatus = ( {
 				<div className={ classes }>
 					{ label }:{ ' ' }
 					<span>
-						{ sprintf(
-							parsedStatusLabels[ requestStatus ],
-							requestCode
-						) }
+						{ requestStatus === 'error-request'
+							? sprintf(
+									parsedStatusLabels[ requestStatus ],
+									requestCode
+							  )
+							: parsedStatusLabels[ requestStatus ] }
 					</span>
 				</div>
 			) }

--- a/src/wizards/newspack/components/site-statuses/site-status.tsx
+++ b/src/wizards/newspack/components/site-statuses/site-status.tsx
@@ -35,11 +35,8 @@ const SiteStatus = ( {
 }: Status ) => {
 	const parsedStatusLabels = { ...defaultStatuses, ...statuses };
 
-	const [ requestStatus, setRequestStatus ] =
-		useState< StatusLabels >( 'idle' );
-	const [ failedDependencies, setFailedDependencies ] = useState< string[] >(
-		[]
-	);
+	const [ requestStatus, setRequestStatus ] = useState< StatusLabels >( 'idle' );
+	const [ failedDependencies, setFailedDependencies ] = useState< string[] >( [] );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 
 	const dependencies = structuredClone( dependenciesProp ) as Dependencies;
@@ -59,10 +56,7 @@ const SiteStatus = ( {
 			// Dependency check
 			if ( dependencies && Object.keys( dependencies ).length > 0 ) {
 				const failedDeps: string[] = [];
-				for ( const [
-					dependencyName,
-					dependencyInfo,
-				] of Object.entries( dependencies ) ) {
+				for ( const [ dependencyName, dependencyInfo ] of Object.entries( dependencies ) ) {
 					// Don't process active
 					if ( dependencyInfo.isActive ) {
 						continue;
@@ -92,8 +86,7 @@ const SiteStatus = ( {
 					setRequestStatus( apiRequest ? 'success' : 'error' );
 					resolve( apiRequest );
 				} )
-				.catch( e => {
-					console.log( e );
+				.catch( () => {
 					then( false );
 					setRequestStatus( 'error' );
 					reject();
@@ -114,15 +107,9 @@ const SiteStatus = ( {
 			) }
 			{ /* Error UI, link user to config */ }
 			{ requestStatus === 'error' && (
-				<Tooltip
-					text={ __(
-						'Click to navigate to configuration',
-						'newspack-plugin'
-					) }
-				>
+				<Tooltip text={ __( 'Click to navigate to configuration', 'newspack-plugin' ) }>
 					<a href={ configLink } className={ classes }>
-						{ label }:{ ' ' }
-						<span>{ parsedStatusLabels[ requestStatus ] }</span>
+						{ label }: <span>{ parsedStatusLabels[ requestStatus ] }</span>
 						<span className="hidden">{ __( 'Configure?' ) }</span>
 					</a>
 				</Tooltip>
@@ -133,15 +120,10 @@ const SiteStatus = ( {
 					text={ sprintf(
 						// translators: %s is a comma separated list of needed dependencies.
 						__( '%s must be installed & activated!' ),
-						failedDependencies
-							.map( dep => dependencies[ dep ].label )
-							.join( ', ' )
+						failedDependencies.map( dep => dependencies[ dep ].label ).join( ', ' )
 					) }
 				>
-					<button
-						onClick={ () => setIsModalVisible( true ) }
-						className={ classes }
-					>
+					<button onClick={ () => setIsModalVisible( true ) } className={ classes }>
 						{ label }:{ ' ' }
 						<span>
 							{ _n(
@@ -163,12 +145,9 @@ const SiteStatus = ( {
 				</Tooltip>
 			) }
 			{ /* Display standard UI for the rest */ }
-			{ [ 'error-preflight', 'success', 'idle', 'pending' ].includes(
-				requestStatus
-			) && (
+			{ [ 'error-preflight', 'success', 'idle', 'pending' ].includes( requestStatus ) && (
 				<div className={ classes }>
-					{ label }:{ ' ' }
-					<span>{ parsedStatusLabels[ requestStatus ] }</span>
+					{ label }: <span>{ parsedStatusLabels[ requestStatus ] }</span>
 				</div>
 			) }
 		</>

--- a/src/wizards/newspack/components/site-statuses/site-status.tsx
+++ b/src/wizards/newspack/components/site-statuses/site-status.tsx
@@ -189,8 +189,8 @@ const SiteStatus = ( {
 					<span>
 						{ requestStatus === 'error-request'
 							? sprintf(
-									/* translators: %d is the HTTP status code */
 									__(
+										/* translators: %d is the HTTP status code */
 										'Request failed - %d',
 										'newspack-plugin'
 									),

--- a/src/wizards/newspack/components/site-statuses/site-status.tsx
+++ b/src/wizards/newspack/components/site-statuses/site-status.tsx
@@ -22,8 +22,8 @@ const defaultStatuses = {
 	error: __( 'Disconnected', 'newspack-plugin' ),
 	'error-dependencies': undefined,
 	'error-preflight': undefined,
-	/* translators: %s is the HTTP status code */
-	'error-request': __( 'Request failed - %s', 'newspack-plugin' ),
+	/* translators: %d is the HTTP status code */
+	'error-request': __( 'Request failed - %d', 'newspack-plugin' ),
 };
 
 const SiteStatus = ( {

--- a/src/wizards/newspack/components/site-statuses/site-status.tsx
+++ b/src/wizards/newspack/components/site-statuses/site-status.tsx
@@ -22,12 +22,13 @@ const defaultStatuses = {
 	error: __( 'Disconnected', 'newspack-plugin' ),
 	'error-dependencies': undefined,
 	'error-preflight': undefined,
+	'error-request': __( 'Request failed - %s', 'newspack-plugin' ),
 };
 
 const SiteStatus = ( {
 	label = '',
 	isPreflightValid = true,
-	dependencies: dependenciesProp = null,
+	dependencies: dependenciesProp,
 	statuses,
 	endpoint,
 	configLink,
@@ -35,11 +36,18 @@ const SiteStatus = ( {
 }: Status ) => {
 	const parsedStatusLabels = { ...defaultStatuses, ...statuses };
 
-	const [ requestStatus, setRequestStatus ] = useState< StatusLabels >( 'idle' );
-	const [ failedDependencies, setFailedDependencies ] = useState< string[] >( [] );
+	const [ requestCode, setRequestCode ] = useState( 200 );
+
+	const [ requestStatus, setRequestStatus ] =
+		useState< StatusLabels >( 'idle' );
+	const [ failedDependencies, setFailedDependencies ] = useState< string[] >(
+		[]
+	);
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 
-	const dependencies = structuredClone( dependenciesProp ) as Dependencies;
+	const dependencies = structuredClone< Dependencies | undefined >(
+		dependenciesProp
+	);
 
 	useEffect( () => {
 		makeRequest();
@@ -56,7 +64,10 @@ const SiteStatus = ( {
 			// Dependency check
 			if ( dependencies && Object.keys( dependencies ).length > 0 ) {
 				const failedDeps: string[] = [];
-				for ( const [ dependencyName, dependencyInfo ] of Object.entries( dependencies ) ) {
+				for ( const [
+					dependencyName,
+					dependencyInfo,
+				] of Object.entries( dependencies ) ) {
 					// Don't process active
 					if ( dependencyInfo.isActive ) {
 						continue;
@@ -80,15 +91,22 @@ const SiteStatus = ( {
 			setRequestStatus( 'pending' );
 			apiFetch( {
 				path: endpoint,
+				parse: false,
 			} )
-				.then( data => {
+				.then( async res => {
+					const response = res as Response;
+					setRequestCode( response.status );
+					const data = await response.json();
 					const apiRequest = then( data );
 					setRequestStatus( apiRequest ? 'success' : 'error' );
-					resolve( apiRequest );
+					resolve( data );
 				} )
-				.catch( () => {
-					then( false );
-					setRequestStatus( 'error' );
+				.catch( err => {
+					const status = err?.status ?? 500;
+					setRequestStatus(
+						status > 399 ? 'error-request' : 'error'
+					);
+					setRequestCode( status );
 					reject();
 				} );
 		} );
@@ -107,23 +125,34 @@ const SiteStatus = ( {
 			) }
 			{ /* Error UI, link user to config */ }
 			{ requestStatus === 'error' && (
-				<Tooltip text={ __( 'Click to navigate to configuration', 'newspack-plugin' ) }>
+				<Tooltip
+					text={ __(
+						'Click to navigate to configuration',
+						'newspack-plugin'
+					) }
+				>
 					<a href={ configLink } className={ classes }>
-						{ label }: <span>{ parsedStatusLabels[ requestStatus ] }</span>
+						{ label }:{ ' ' }
+						<span>{ parsedStatusLabels[ requestStatus ] }</span>
 						<span className="hidden">{ __( 'Configure?' ) }</span>
 					</a>
 				</Tooltip>
 			) }
 			{ /* Error Dependencies, dependencies install modal */ }
-			{ requestStatus === 'error-dependencies' && (
+			{ requestStatus === 'error-dependencies' && dependencies && (
 				<Tooltip
 					text={ sprintf(
 						// translators: %s is a comma separated list of needed dependencies.
 						__( '%s must be installed & activated!' ),
-						failedDependencies.map( dep => dependencies[ dep ].label ).join( ', ' )
+						failedDependencies
+							.map( dep => dependencies[ dep ].label )
+							.join( ', ' )
 					) }
 				>
-					<button onClick={ () => setIsModalVisible( true ) } className={ classes }>
+					<button
+						onClick={ () => setIsModalVisible( true ) }
+						className={ classes }
+					>
 						{ label }:{ ' ' }
 						<span>
 							{ _n(
@@ -145,9 +174,21 @@ const SiteStatus = ( {
 				</Tooltip>
 			) }
 			{ /* Display standard UI for the rest */ }
-			{ [ 'error-preflight', 'success', 'idle', 'pending' ].includes( requestStatus ) && (
+			{ [
+				'error-preflight',
+				'success',
+				'idle',
+				'pending',
+				'error-request',
+			].includes( requestStatus ) && (
 				<div className={ classes }>
-					{ label }: <span>{ parsedStatusLabels[ requestStatus ] }</span>
+					{ label }:{ ' ' }
+					<span>
+						{ sprintf(
+							parsedStatusLabels[ requestStatus ],
+							requestCode
+						) }
+					</span>
 				</div>
 			) }
 		</>

--- a/src/wizards/newspack/components/site-statuses/site-status.tsx
+++ b/src/wizards/newspack/components/site-statuses/site-status.tsx
@@ -189,8 +189,8 @@ const SiteStatus = ( {
 					<span>
 						{ requestStatus === 'error-request'
 							? sprintf(
+									/* translators: %d is the HTTP status code */
 									__(
-										/* translators: %d is the HTTP status code */
 										'Request failed - %d',
 										'newspack-plugin'
 									),

--- a/src/wizards/newspack/components/site-statuses/site-status.tsx
+++ b/src/wizards/newspack/components/site-statuses/site-status.tsx
@@ -53,14 +53,14 @@ const SiteStatus = ( {
 		makeRequest();
 	}, [] );
 
-	const makeRequest = ( pluginInfo = {} ) => {
+	function makeRequest( pluginInfo = {} ) {
 		// When/if a dependency is activated update reference.
 		if ( dependencies && Object.keys( pluginInfo ).length > 0 ) {
 			for ( const [ pluginName ] of Object.entries( pluginInfo ) ) {
 				dependencies[ pluginName ].isActive = true;
 			}
 		}
-		return new Promise( ( resolve, reject ) => {
+		return new Promise< void | boolean >( resolve => {
 			// Dependency check
 			if ( dependencies && Object.keys( dependencies ).length > 0 ) {
 				const failedDeps: string[] = [];
@@ -99,7 +99,7 @@ const SiteStatus = ( {
 					const data = await response.json();
 					const apiRequest = then( data );
 					setRequestStatus( apiRequest ? 'success' : 'error' );
-					resolve( data );
+					resolve( apiRequest );
 				} )
 				.catch( err => {
 					const status = err?.status ?? 500;
@@ -107,10 +107,10 @@ const SiteStatus = ( {
 						status > 399 ? 'error-request' : 'error'
 					);
 					setRequestCode( status );
-					reject();
+					resolve();
 				} );
 		} );
-	};
+	}
 
 	const classes = `newspack-site-status newspack-site-status__${ requestStatus }`;
 

--- a/src/wizards/newspack/components/site-statuses/site-status.tsx
+++ b/src/wizards/newspack/components/site-statuses/site-status.tsx
@@ -22,8 +22,7 @@ const defaultStatuses = {
 	error: __( 'Disconnected', 'newspack-plugin' ),
 	'error-dependencies': undefined,
 	'error-preflight': undefined,
-	/* translators: %d is the HTTP status code */
-	'error-request': __( 'Request failed - %d', 'newspack-plugin' ),
+	'error-request': undefined,
 };
 
 const SiteStatus = ( {
@@ -190,7 +189,11 @@ const SiteStatus = ( {
 					<span>
 						{ requestStatus === 'error-request'
 							? sprintf(
-									parsedStatusLabels[ requestStatus ],
+									/* translators: %d is the HTTP status code */
+									__(
+										'Request failed - %d',
+										'newspack-plugin'
+									),
 									requestCode
 							  )
 							: parsedStatusLabels[ requestStatus ] }

--- a/src/wizards/newspack/types/site-statuses.d.ts
+++ b/src/wizards/newspack/types/site-statuses.d.ts
@@ -5,6 +5,7 @@ type StatusLabels =
 	| 'error'
 	| 'error-dependencies'
 	| 'error-preflight'
+	| 'error-request' // 404, 500
 	| 'pending'
 	| 'pending-install'
 	| 'idle';
@@ -15,7 +16,7 @@ type Status = {
 	isPreflightValid?: boolean;
 	configLink: string;
 	endpoint: string;
-	dependencies?: Dependencies | null;
+	dependencies?: Dependencies;
 	then: ( args: any ) => boolean;
 };
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. The code merged in from https://github.com/Automattic/newspack-plugin/pull/3566 fixed a data problem however the underlying bug still exists. If an error is returned, `config` property doesn't exist.
![Screenshot 2024-11-25 at 08 39 20](https://github.com/user-attachments/assets/eaf07684-9860-444b-954d-612ec3497ef5)
Caused by:
https://github.com/Automattic/newspack-plugin/blob/92384d80270d05d03bb3b42e859a54ce6dca4c47/src/wizards/newspack/components/site-statuses/index.tsx#L22-L27
This PR introduces code that will convert response objects not containing `config` property (e.g. error) to `false`.
2. Refactors how response codes, specifically within error range (>399), are handled + displayed in FE.
3. Refactored some inline type assignments.

### How to test the changes in this Pull Request:

1. Checkout `feat/ia-dashboard` then open `includes/wizards/audience/class-audience-wizard.php`.
4. Test error responses by adding
```php
return new WP_REST_Response(
	[],
	500
);
```
before `rest_ensure_response` in
https://github.com/Automattic/newspack-plugin/blob/c3bd7c6bcd82bb99be69fee174266da130e26e45/includes/wizards/audience/class-audience-wizard.php#L217-L226
5. Navigate to _/wp-admin/admin.php?page=newspack-dashboard#/_
6. Under "Site Status" Reader Activation resolves correctly and correct response code is returned.

![Screenshot 2024-11-22 at 22 18 02](https://github.com/user-attachments/assets/fe1d5a0a-7b02-419a-85c9-47e2c14cc08c)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->