### PR TITLE
Feat: IA Setup Wizard

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -64,6 +64,7 @@ final class Newspack {
 		define( 'NEWSPACK_ACTIVATION_TRANSIENT', '_newspack_activation_redirect' );
 		define( 'NEWSPACK_NRH_CONFIG', 'newspack_nrh_config' );
 		define( 'NEWSPACK_CLIENT_ID_COOKIE_NAME', 'newspack-cid' );
+		define( 'NEWSPACK_SETUP_COMPLETE', 'newspack_setup_complete' );
 	}
 
 	/**
@@ -247,7 +248,7 @@ final class Newspack {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
-		$redirect_url   = admin_url( 'admin.php?page=newspack' );
+		$redirect_url   = admin_url( 'admin.php?page=newspack-dashboard' );
 		$newspack_reset = filter_input( INPUT_GET, 'newspack_reset', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( 'starter-content' === $newspack_reset ) {
 			Starter_Content::remove_starter_content();
@@ -349,7 +350,7 @@ final class Newspack {
 		$post_type_mapping = [
 			Emails::POST_TYPE => [
 				'base' => 'edit',
-				'url'  => esc_url( admin_url( 'admin.php?page=newspack' ) ),
+				'url'  => esc_url( admin_url( 'admin.php?page=newspack-dashboard' ) ),
 			],
 		];
 
@@ -392,6 +393,13 @@ final class Newspack {
 	 */
 	public static function is_debug_mode() {
 		return defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG;
+	}
+
+	/**
+	 * Is the Setup completed?
+	 */
+	public static function is_setup_complete() {
+		return get_option( NEWSPACK_SETUP_COMPLETE );
 	}
 
 	/**

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -29,7 +29,6 @@ class Wizards {
 	 */
 	public static function init() {
 		self::$wizards = [
-			'setup'                   => new Setup_Wizard(),
 			'site-design'             => new Site_Design_Wizard(),
 			'reader-revenue'          => new Reader_Revenue_Wizard(),
 			'syndication'             => new Syndication_Wizard(),
@@ -42,6 +41,7 @@ class Wizards {
 			'settings'                => new Settings(),
 			// v2 Information Architecture.
 			'newspack-dashboard'      => new Newspack_Dashboard(),
+			'setup'                   => new Setup_Wizard(),
 			'newspack-settings'       => new Newspack_Settings(
 				[
 					'sections' => [

--- a/includes/wizards/advertising/class-advertising-display-ads.php
+++ b/includes/wizards/advertising/class-advertising-display-ads.php
@@ -84,6 +84,9 @@ class Advertising_Display_Ads extends Wizard {
 	 * Constructor.
 	 */
 	public function __construct() {
+		if ( ! Newspack::is_setup_complete() ) { 
+			return;
+		}
 		parent::__construct();
 		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
 	}

--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -66,6 +66,9 @@ class Advertising_Sponsors extends Wizard {
 	 * Advertising_Sponsors Constructor.
 	 */
 	public function __construct() {
+		if ( ! Newspack::is_setup_complete() ) { 
+			return;
+		}
 		if ( ! is_plugin_active( 'newspack-sponsors/newspack-sponsors.php' ) ) {
 			return;
 		}

--- a/includes/wizards/audience/class-audience-campaigns.php
+++ b/includes/wizards/audience/class-audience-campaigns.php
@@ -32,6 +32,11 @@ class Audience_Campaigns extends Wizard {
 	 * Constructor.
 	 */
 	public function __construct() {
+
+		if ( ! Newspack::is_setup_complete() ) { 
+			return;
+		}
+
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
 		add_filter( 'newspack_popups_registered_criteria', [ $this, 'maybe_unregister_memberships_criteria' ] );

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -53,6 +53,11 @@ class Audience_Wizard extends Wizard {
 	 * Audience Configuration Constructor.
 	 */
 	public function __construct() {
+
+		if ( ! Newspack::is_setup_complete() ) { 
+			return;
+		}
+
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
 

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -9,9 +9,6 @@ namespace Newspack;
 
 use WP_Error, WP_REST_Server;
 defined( 'ABSPATH' ) || exit;
-require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
-
-define( 'NEWSPACK_SETUP_COMPLETE', 'newspack_setup_complete' );
 
 /**
  * Setup Newspack.
@@ -35,6 +32,20 @@ class Setup_Wizard extends Wizard {
 	 * @var string
 	 */
 	protected $slug = 'newspack-setup-wizard';
+
+	/**
+	 * The parent menu item name.
+	 *
+	 * @var string
+	 */
+	public $parent_menu = 'newspack-dashboard';
+
+	/**
+	 * Make sure Setup is first submenu item (after the dashboard wizard creates the "Newspack" menu).
+	 *
+	 * @var int.
+	 */
+	protected $admin_menu_priority = 2;
 
 	/**
 	 * The capability required to access this wizard.
@@ -682,9 +693,9 @@ class Setup_Wizard extends Wizard {
 		if ( ! current_user_can( $this->capability ) ) {
 			return;
 		}
-		foreach ( $submenu['newspack'] as $key => $value ) {
+		foreach ( $submenu['newspack-dashboard'] as $key => $value ) {
 			if ( 'newspack-setup-wizard' !== $value[2] ) {
-				unset( $submenu['newspack'][ $key ] );
+				unset( $submenu['newspack-dashboard'][ $key ] );
 			}
 		}
 	}

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -139,7 +139,7 @@ abstract class Wizard {
 		$support_email = ( defined( 'NEWSPACK_SUPPORT_EMAIL' ) && NEWSPACK_SUPPORT_EMAIL ) ? NEWSPACK_SUPPORT_EMAIL : false;
 
 		$urls = [
-			'dashboard'      => Wizards::get_url( 'dashboard' ),
+			'dashboard'      => Wizards::get_url( 'newspack-dashboard' ),
 			'public_path'    => Newspack::plugin_url() . '/dist/',
 			'bloginfo'       => [
 				'name' => get_bloginfo( 'name' ),
@@ -159,7 +159,7 @@ abstract class Wizard {
 					array(
 						'newspack_reset' => 'starter-content',
 					),
-					Wizards::get_url( 'dashboard' )
+					Wizards::get_url( 'newspack-dashboard' )
 				)
 			);
 		}
@@ -172,7 +172,7 @@ abstract class Wizard {
 					array(
 						'newspack_reset' => 'reset',
 					),
-					Wizards::get_url( 'dashboard' )
+					Wizards::get_url( 'newspack-dashboard' )
 				)
 			);
 		}


### PR DESCRIPTION
Draft:  initial dev and local testing.  

Notes:

- Moved `define( 'NEWSPACK_SETUP_COMPLETE', 'newspack_setup_complete' );` to a more global position (outside the setup class) so it can be more clearly used by other classes.
- Since the slug was changed from `admin.php?page=newspack` to `admin.php?page=newspack-dashboard` some clean up was needed in other places.  (Otherwise we'll need to rollback the slug to just `newspack`).
- Moved the setup wizard's instantiation to after dashboard so that the main Newspack menu is created prior to the "Setup" submenu item being added.  Also set `$admin_menu_priority = 2;` for extra safety.
- I assumed the Advertising and Audience menus shouldn't appear until after Setup is complete....but please verify.



---



### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->