### PR TITLE
feat: mark perfmatters as a required plugin

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -28,6 +28,7 @@ class Plugin_Manager {
 		'google-site-kit',
 		'newspack-blocks',
 		'wp-parsely',
+		'perfmatters',
 	];
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Mark perfmatters as required

### How to test the changes in this Pull Request:

1. Confirm you don't see the deactivate option for Perfmatters

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->