### PR TITLE
fix(auth): remove without password meta on admin profile updates

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -95,6 +95,7 @@ final class Reader_Activation {
 			\add_action( 'resetpass_form', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'password_reset', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'password_reset', [ __CLASS__, 'set_reader_has_password' ] );
+			\add_action( 'profile_update', [ __CLASS__, 'maybe_set_reader_has_password' ], 10, 3 );
 			\add_action( 'newspack_magic_link_authenticated', [ __CLASS__, 'set_reader_verified' ] );
 			\add_action( 'auth_cookie_expiration', [ __CLASS__, 'auth_cookie_expiration' ], 10, 3 );
 			\add_action( 'init', [ __CLASS__, 'setup_nav_menu' ] );
@@ -1062,6 +1063,28 @@ final class Reader_Activation {
 
 		delete_user_meta( $user->ID, self::WITHOUT_PASSWORD );
 		return true;
+	}
+
+	/**
+	 * Conditionally remove "without password" meta from user.
+	 *
+	 * If the a password is being set via user profile update,
+	 * And a previous password was not set, we remove the meta.
+	 *
+	 * @param int      $user_id       User ID.
+	 * @param \WP_User $old_user_data Old user data.
+	 * @param array    $user_data     User data.
+	 */
+	public static function maybe_set_reader_has_password( $user_id, $old_user_data, $user_data ) {
+		if ( ! self::is_user_reader( $old_user_data ) ) {
+			return;
+		}
+
+		$old_password = $old_user_data->user_pass;
+		$new_password = isset( $user_data['user_pass'] ) ? $user_data['user_pass'] : '';
+		if ( ! empty( $new_password ) && $old_password !== $new_password ) {
+			self::set_reader_has_password( $user_id );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208842146441484/f

This PR fixes an issue where adding a password for a user as admin did not clear the `WITHOUT_PASSWORD` meta which decided which auth form view to render:

![Screenshot 2024-11-25 at 16 52 03](https://github.com/user-attachments/assets/50c19f39-4d35-4c77-ae8d-a87c33e895a6)

### How to test the changes in this Pull Request:

1. As a reader, create a new account then log out
2. As admin, set a new password for this user via WP Admin Users menu
3. As a reader, attempt to log in. On this branch, the auth form will render the password input. On `epic/ras-acc` it will render OTP

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->