### PR TITLE
fix: cast values for transaction fee options

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -162,7 +162,7 @@ class WooCommerce_Cover_Fees {
 					type="checkbox"
 					style="margin-right: 8px;"
 					value="1"
-					<?php if ( get_option( 'newspack_donations_allow_covering_fees_default', false ) ) : ?>
+					<?php if ( boolval( get_option( 'newspack_donations_allow_covering_fees_default', false ) ) ) : ?>
 						checked
 					<?php endif; ?>
 				/>

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -505,7 +505,7 @@ class Reader_Revenue_Wizard extends Wizard {
 				'woopayments' => $wc_configuration_manager->woopayments_data(),
 			],
 			'additional_settings'      => [
-				'allow_covering_fees'         => boolval( get_option( 'newspack_donations_allow_covering_fees', true ) ),
+				'allow_covering_fees'         => boolval( get_option( 'newspack_donations_allow_covering_fees', false ) ),
 				'allow_covering_fees_default' => boolval( get_option( 'newspack_donations_allow_covering_fees_default', false ) ),
 				'allow_covering_fees_label'   => get_option( 'newspack_donations_allow_covering_fees_label', '' ),
 				'fee_multiplier'              => get_option( 'newspack_blocks_donate_fee_multiplier', '2.9' ),

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -382,14 +382,14 @@ class Reader_Revenue_Wizard extends Wizard {
 	 */
 	public function update_additional_settings( $settings ) {
 		if ( isset( $settings['allow_covering_fees'] ) ) {
-			update_option( 'newspack_donations_allow_covering_fees', $settings['allow_covering_fees'] );
+			update_option( 'newspack_donations_allow_covering_fees', intval( $settings['allow_covering_fees'] ) );
 		}
 		if ( isset( $settings['allow_covering_fees_default'] ) ) {
 			update_option( 'newspack_donations_allow_covering_fees_default', $settings['allow_covering_fees_default'] );
 		}
 
 		if ( isset( $settings['allow_covering_fees_label'] ) ) {
-			update_option( 'newspack_donations_allow_covering_fees_label', $settings['allow_covering_fees_label'] );
+			update_option( 'newspack_donations_allow_covering_fees_label', intval( $settings['allow_covering_fees_label'] ) );
 		}
 		if ( isset( $settings['fee_multiplier'] ) ) {
 			update_option( 'newspack_blocks_donate_fee_multiplier', $settings['fee_multiplier'] );
@@ -505,8 +505,8 @@ class Reader_Revenue_Wizard extends Wizard {
 				'woopayments' => $wc_configuration_manager->woopayments_data(),
 			],
 			'additional_settings'      => [
-				'allow_covering_fees'         => get_option( 'newspack_donations_allow_covering_fees', true ),
-				'allow_covering_fees_default' => get_option( 'newspack_donations_allow_covering_fees_default', false ),
+				'allow_covering_fees'         => boolval( get_option( 'newspack_donations_allow_covering_fees', true ) ),
+				'allow_covering_fees_default' => boolval( get_option( 'newspack_donations_allow_covering_fees_default', false ) ),
 				'allow_covering_fees_label'   => get_option( 'newspack_donations_allow_covering_fees_label', '' ),
 				'fee_multiplier'              => get_option( 'newspack_blocks_donate_fee_multiplier', '2.9' ),
 				'fee_static'                  => get_option( 'newspack_blocks_donate_fee_static', '0.3' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug where a non-existent `newspack_donations_allow_covering_fees` option can't be updated to `false`.

### How to test the changes in this Pull Request:

1. On `release`, ensure the `newspack_donations_allow_covering_fees` doesn't exist (`wp option delete newspack_donations_allow_covering_fees` via CLI)
2. Visit **Newspack > Reader Revenue > Donations** and attempt to disable the "Collect transaction fees" option. Observe it can't be disabled and keeps getting reset to ON.
3. Check out this branch and retry step 2. Confirm it can be toggled off and on again.
4. Smoke test transaction fee settings in both admin and front-end checkouts, and confirm that updating the values persists in both contexts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208829612195264