### PR TITLE
feat(woocommerce): remove internal metadata from REST API response

### DIFF
--- a/includes/plugins/class-woocommerce.php
+++ b/includes/plugins/class-woocommerce.php
@@ -18,7 +18,8 @@ class WooCommerce {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_action( 'wp_loaded', [ __CLASS__,'disable_wc_author_archive_override' ] );
+		add_action( 'wp_loaded', [ __CLASS__, 'disable_wc_author_archive_override' ] );
+		add_filter( 'woocommerce_rest_prepare_shop_order_object', [ __CLASS__, 'modify_shop_order_wc_rest_api_payload' ] );
 	}
 
 	/**
@@ -26,6 +27,30 @@ class WooCommerce {
 	 */
 	public static function disable_wc_author_archive_override() {
 		remove_action( 'template_redirect', 'wc_disable_author_archives_for_customers', 10 );
+	}
+
+	/**
+	 * Remove Newspack internal-use meta data from /order REST API response.
+	 * These might cause confusion and should not be used by third parties.
+	 *
+	 * @param \WP_REST_Response $response The response object.
+	 * @return WP_REST_Response
+	 */
+	public static function modify_shop_order_wc_rest_api_payload( $response ) {
+		$data = $response->get_data();
+		if ( ! isset( $data['meta_data'] ) ) {
+			return $response;
+		}
+		foreach ( $data['meta_data'] as $key => $value ) {
+			if ( ! isset( $value->get_data()['value'] ) || ! is_string( $value->get_data()['value'] ) ) {
+				continue;
+			}
+			if ( stripos( $value->get_data()['key'], '_newspack' ) === 0 ) {
+				unset( $data['meta_data'][ $key ] );
+			}
+		}
+		$response->set_data( $data );
+		return $response;
 	}
 }
 WooCommerce::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Newspack attaches some internal metadata to orders (`_newspack_modal_checkout_url`, `_newspack_referer` at this time). This has caused confusion in one third-party integration, since the `_newspack_modal_checkout_url` was assumed to be the origin URL of a transaction. To avoid such confusions, this PR removes the internal (`_newspack*`) metadata from order REST API response. 

### How to test the changes in this Pull Request:

1. On `trunk`, make a donation, note the order ID
2. Open a WP Admin page and run `wp.apiFetch({path: 'wc/v3/orders/<order ID here>'})`
3. In the Network tab, observe the response has `meta_data._newspack_modal_checkout_url`, `meta_data._newspack_referer` fields present
4. Switch to this branch, make the request again – observe the metadata is not present anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208860660003464