### PR TITLE
fix(ras-acc): make helper text size more specific

### DIFF
--- a/src/newspack-ui/scss/elements/forms/_index.scss
+++ b/src/newspack-ui/scss/elements/forms/_index.scss
@@ -27,8 +27,8 @@
 	}
 
 	// Form inline text - helper and error.
-	&__helper-text,
-	&__inline-error {
+	& &__helper-text,
+	& &__inline-error {
 		color: var(--newspack-ui-color-neutral-60);
 		display: block;
 		font-size: var(--newspack-ui-font-size-xs);
@@ -48,12 +48,12 @@
 		}
 	}
 
-	&__inline-error {
+	& &__inline-error {
 		color: var(--newspack-ui-color-error-50);
 	}
 
 	// Error class to apply to specific fields.
-	&__field-error,
+	& &__field-error,
 	[data-form-status="400"] {
 		// Attribute added to sign-up modal form on failure.
 		--newspack-ui-color-input-border: var(--newspack-ui-color-error-50);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes the font size used for the NYP text and coupon error message in RAS-ACC -- the styles were inheriting incorrectly. 

See 1207817176293825-as-1208868035568741

### How to test the changes in this Pull Request:

1. Enable coupons under WooCommerce > Settings, and create one under WooCommerce > Marketing > Coupons.
2. Create a NYP product.
3. Add a checkout button block to a page, and assign it the NYP product.
4. Run through a checkout; on the second screen, note the size of the NYP instructions. To test the coupon text, enter some random text and hit 'Apply'. The text for both is 16px when it should be 14px:

![CleanShot 2024-11-28 at 14 03 40@2x](https://github.com/user-attachments/assets/66e34c4e-a9fd-4adb-a62f-c34b78e14fe6)

5. Apply this PR and run `npm run build`.
6. Confirm that the font size for both is now 14px:

![CleanShot 2024-11-28 at 14 05 19](https://github.com/user-attachments/assets/c6058434-4128-42c6-989d-265493174cad)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->