### PR TITLE
feat(webhooks): filter request priority

### DIFF
--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -555,6 +555,8 @@ final class Webhooks {
 	 * This is only applicable if using Action Scheduler.
 	 *
 	 * @param int $request_id Request ID.
+	 *
+	 * @return int
 	 */
 	private static function get_request_priority( $request_id ) {
 		$action_name = \get_post_meta( $request_id, 'action_name', true );

--- a/includes/data-events/class-webhooks.php
+++ b/includes/data-events/class-webhooks.php
@@ -550,6 +550,25 @@ final class Webhooks {
 	}
 
 	/**
+	 * Get the request priority.
+	 *
+	 * This is only applicable if using Action Scheduler.
+	 *
+	 * @param int $request_id Request ID.
+	 */
+	private static function get_request_priority( $request_id ) {
+		$action_name = \get_post_meta( $request_id, 'action_name', true );
+		/**
+		 * Filters the request priority.
+		 *
+		 * @param int    $priority    Request priority.
+		 * @param string $action_name Action name.
+		 * @param int    $request_id  Request ID.
+		 */
+		return apply_filters( 'newspack_webhooks_request_priority', 10, $action_name, $request_id );
+	}
+
+	/**
 	 * Create webhook request.
 	 *
 	 * @param int    $endpoint_id Endpoint ID.
@@ -707,7 +726,14 @@ final class Webhooks {
 		\update_post_meta( $request_id, 'scheduled', $time );
 		if ( self::use_action_scheduler() ) {
 			Logger::log( "Scheduling request {$request_id} for {$date_gmt} via Action Scheduler.", self::LOGGER_HEADER );
-			\as_schedule_single_action( $time, 'newspack_webhooks_as_process_request', [ $request_id ], 'newspack-data-events' );
+			\as_schedule_single_action(
+				$time,
+				'newspack_webhooks_as_process_request',
+				[ $request_id ],
+				'newspack-data-events',
+				false,
+				self::get_request_priority( $request_id )
+			);
 		} else {
 			Logger::log( "Scheduling request {$request_id} for {$date_gmt} via scheduled post publishing.", self::LOGGER_HEADER );
 			\wp_update_post(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1208510338230630-as-1208865846387764/f

Adds a filter to allow a custom priority argument when running a webhook request via ActionScheduler.

### How to test the changes in this Pull Request:

1. Setup a webhook endpoint for `reader_registered` and `reader_logged_in` (use https://webhook.site/)
2. Paste this code anywhere in the plugin:

```php
add_filter(
  'newspack_webhooks_request_priority',
  function( $priority, $action_name ) {
    if ( 'reader_registered' === $action_name ) {
      $priority = 1;
    }
    return $priority;
  },
  10,
  2
);
```

3. In a fresh session, go through the RAS flow for registering a new reader so it triggers both events
4. Confirm an AS action is created with priority 1 and the other with priority 10:

```sql
SELECT * from wp_actionscheduler_actions WHERE hook = 'newspack_webhooks_as_process_request'  ORDER BY scheduled_date_gmt DESC LIMIT 10;
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->