### PR TITLE
fix(ras-acc): correct My Account custom font sizing clash

### DIFF
--- a/src/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/src/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -32,8 +32,14 @@
 		max-width: var(--newspack-ui-modal-width-s);
 	}
 
-	.newspack-reader-auth__inline-wrapper h2 {
-		font-size: var(--newspack-ui-font-size-m);
-		font-weight: 600;
+	.newspack-reader-auth__inline-wrapper {
+		h2 {
+			font-size: var(--newspack-ui-font-size-m);
+			font-weight: 600;
+		}
+
+		p {
+			font-size: var(--newspack-ui-font-size-s);
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a possible issue with very common custom CSS.

See 1207817176293825-as-1208873548407902

### How to test the changes in this Pull Request:

1. Add this CSS to the Customizer - it's a pretty common style of snippet that we use to increases/decrease content font sizes:

```
.entry-content p, 
.entry-content li {
    font-size: 1.1rem;
}
```

2. In an incognito window, go to My Account, and log in to an existing RAS account.
3. Note the appearance of the OPT message:

![CleanShot 2024-11-29 at 11 37 54](https://github.com/user-attachments/assets/2fb43d72-73ac-400f-986f-04f6220e4c98)

4. Apply this PR and run `npm run build`.
5. Confirm that the message is now sized correctly:

![CleanShot 2024-11-29 at 11 38 50](https://github.com/user-attachments/assets/b38fab6c-dfd3-45e9-9a51-c540ac1f6b06)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->