### PR TITLE
fix(emails): account for false order value in email hook

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -267,14 +267,14 @@ class WooCommerce_Connection {
 	 * @return bool
 	 */
 	public static function send_customizable_receipt_email( $enable, $order, $class ) {
-		// If there are no donation products in the order, do not override the default WC receipt email.
-		$has_donation_product = \Newspack\Donations::get_order_donation_product_id( $order->get_id() ) !== false;
-		if ( ! $has_donation_product ) {
+		// If we don't have a valid order, or the customizable email isn't enabled, bail.
+		if ( empty( $order ) || ! is_a( $order, 'WC_Order' ) || ! Emails::can_send_email( Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'] ) ) {
 			return $enable;
 		}
 
-		// If we don't have a valid order, or the customizable email isn't enabled, bail.
-		if ( ! is_a( $order, 'WC_Order' ) || ! Emails::can_send_email( Reader_Revenue_Emails::EMAIL_TYPES['RECEIPT'] ) ) {
+		// If there are no donation products in the order, do not override the default WC receipt email.
+		$has_donation_product = \Newspack\Donations::get_order_donation_product_id( $order->get_id() ) !== false;
+		if ( ! $has_donation_product ) {
 			return $enable;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Looks like `$order` can be false in some cases:

```
An error of type E_ERROR was caused in line 271 of the file /srv/htdocs/wp-content/plugins/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php. Error message: Uncaught Error: Call to a member function get_id() on null in /srv/htdocs/wp-content/plugins/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:271
```

This PR fixes this by checking the value of `$order` BEFORE calling `get_id`

### How to test the changes in this Pull Request:

1. Go through the checkout flow for a donation product and for a non-donation product and monitor logs.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->