### PR TITLE
feat(wcs): add expired subscription cli tool

### DIFF
--- a/includes/cli/class-initializer.php
+++ b/includes/cli/class-initializer.php
@@ -26,6 +26,7 @@ class Initializer {
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-ras.php';
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-ras-esp-sync.php';
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-co-authors-plus.php';
+		include_once NEWSPACK_ABSPATH . 'includes/cli/class-woocommerce-subscriptions.php';
 	}
 
 	/**
@@ -66,5 +67,6 @@ class Initializer {
 				'schedule_author_term_backfill',
 			]
 		);
+		WP_CLI::add_command( 'newspack migrate-expired-subscriptions', [ 'Newspack\CLI\WooCommerce_Subscriptions', 'migrate_expired_subscriptions' ] );
 	}
 }

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * WooCommerce Subscriptions Integration CLI commands.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\CLI;
+
+use WP_CLI;
+use Newspack\Woocommerce_Subscriptions as WooCommerce_Subscriptions_Integration;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Subscriptions Integration CLI commands.
+ */
+class WooCommerce_Subscriptions {
+	/**
+	 * Flag for live mode.
+	 *
+	 * @var bool
+	 */
+	private static $live = false;
+
+	/**
+	 * Flag for verbose output.
+	 *
+	 * @var bool
+	 */
+	private static $verbose = false;
+
+	/**
+	 * Migrate on-hold WooCommerce subscriptions with failed renewal orders to expired status.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--live]
+	 * : Run the command in live mode, updating the subscriptions.
+	 *
+	 * [--verbose]
+	 * : Produce more output.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Assoc arguments.
+	 * @return void
+	 */
+	public function migrate_expired_subscriptions( $args, $assoc_args ) {
+		WP_CLI::line( '' );
+		if ( ! WooCommerce_Subscriptions_Integration::is_enabled() ) {
+			WP_CLI::error( 'WooCommerce Subscriptions Integration is not enabled.' );
+			WP_CLI::line( '' );
+			return;
+		}
+		self::$live    = isset( $assoc_args['live'] ) ? true : false;
+		self::$verbose = isset( $assoc_args['verbose'] ) ? true : false;
+		if ( self::$live ) {
+			WP_CLI::line( 'Live mode - subscription statuses will be updated.' );
+		} else {
+			WP_CLI::line( 'Dry run. Use --live flag to run in live mode.' );
+		}
+		$updated       = 0;
+		$page          = 1;
+		$per_page      = 25;
+		$subscriptions = wcs_get_subscriptions(
+			[
+				'paged'                  => $page,
+				'subscriptions_per_page' => $per_page,
+				'subscrition_status'     => 'on-hold',
+			]
+		);
+		if ( empty( $subscriptions ) ) {
+			WP_CLI::success( 'No on-hold subscriptions to process.' );
+			WP_CLI::line( '' );
+			return;
+		}
+		WP_CLI::line( 'Processing subscriptions...' );
+		WP_CLI::line( '' );
+		while ( ! empty( $subscriptions ) ) {
+			foreach ( $subscriptions as $subscription ) {
+				$id = $subscription->get_id();
+				if ( self::$verbose ) {
+					WP_CLI::line( 'Processing subscription ' . $id . '...' );
+				}
+				$renewal_orders = $subscription->get_related_orders( 'all', 'renewal' );
+				if ( empty( $renewal_orders ) ) {
+					if ( self::$verbose ) {
+						WP_CLI::line( 'Subscription ' . $id . ' has no renewal orders. Moving to next subscription...' );
+						WP_CLI::line( '' );
+					}
+					continue;
+				}
+				foreach ( $renewal_orders as $renewal_order ) {
+					if ( 'failed' === $renewal_order->get_status() ) {
+						if ( self::$verbose ) {
+							WP_CLI::line( 'Updating status for subscription ' . $id );
+						}
+						// Update the subscription status to expired.
+						if ( self::$live ) {
+							$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
+						}
+						++$updated;
+						break;
+					}
+				}
+				if ( self::$verbose ) {
+					WP_CLI::line( 'Finished processing subscription ' . $id );
+					WP_CLI::line( '' );
+				}
+			}
+			$subscriptions = wcs_get_subscriptions(
+				[
+					'paged'                  => ++$page,
+					'subscriptions_per_page' => $per_page,
+					'subscription_status'    => 'on-hold',
+				]
+			);
+		}
+		WP_CLI::success( 'Finished processing subscriptions. ' . $updated . ' subscriptions updated.' );
+		WP_CLI::line( '' );
+	}
+}

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -38,7 +38,7 @@ class WooCommerce_Subscriptions {
 	private static $ids = false;
 
 	/**
-	 * Migrate on-hold WooCommerce subscriptions with failed renewal orders to expired status.
+	 * Migrate status of on-hold WooCommerce subscriptions that have failed all payment retries to expired.
 	 *
 	 * ## OPTIONS
 	 *
@@ -51,8 +51,9 @@ class WooCommerce_Subscriptions {
 	 * [--ids]
 	 * : Comma-separated list of subscription IDs. If provided, only ubscriptions with these IDs will be processed.
 	 *
-	 * @param array $args Positional arguments.
+	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Assoc arguments.
+	 *
 	 * @return void
 	 */
 	public function migrate_expired_subscriptions( $args, $assoc_args ) {
@@ -65,27 +66,16 @@ class WooCommerce_Subscriptions {
 		self::$ids     = isset( $assoc_args['ids'] ) ? explode( ',', $assoc_args['ids'] ) : false;
 		self::$live    = isset( $assoc_args['live'] ) ? true : false;
 		self::$verbose = isset( $assoc_args['verbose'] ) ? true : false;
-		if ( self::$live ) {
-			WP_CLI::line( 'Live mode - subscription statuses will be updated.' );
-		} else {
-			WP_CLI::line( 'Dry run. Use --live flag to run in live mode.' );
-		}
 		$updated       = 0;
 		$page          = 1;
 		$per_page      = 25;
-		$subscriptions = wcs_get_subscriptions(
-			[
-				'paged'                  => $page,
-				'subscriptions_per_page' => $per_page,
-				'subscrition_status'     => 'on-hold',
-			]
-		);
+		$subscriptions = self::get_subscriptions( $page );
 		if ( empty( $subscriptions ) ) {
 			WP_CLI::success( 'No on-hold subscriptions to process.' );
 			WP_CLI::line( '' );
 			return;
 		}
-		WP_CLI::line( 'Processing subscriptions...' );
+		WP_CLI::line( 'Processing subscriptions in ' . ( self::$live ? 'live' : 'dry run' ) . ' mode...' );
 		WP_CLI::line( '' );
 		while ( ! empty( $subscriptions ) ) {
 			foreach ( $subscriptions as $subscription ) {
@@ -93,26 +83,56 @@ class WooCommerce_Subscriptions {
 				if ( self::$verbose ) {
 					WP_CLI::line( 'Processing subscription ' . $id . '...' );
 				}
-				$renewal_orders = $subscription->get_related_orders( 'all', 'renewal' );
-				if ( empty( $renewal_orders ) ) {
+				// A pending retry indicates the subscription is awaiting payment retry.
+				if ( $subscription->get_date( 'payment_retry' ) > 0 ) {
 					if ( self::$verbose ) {
-						WP_CLI::line( 'Subscription ' . $id . ' has no renewal orders. Moving to next subscription...' );
+						WP_CLI::line( 'Subscription is awaiting payment retry. Moving to next subscription...' );
 						WP_CLI::line( '' );
 					}
 					continue;
 				}
-				foreach ( $renewal_orders as $renewal_order ) {
-					if ( 'failed' === $renewal_order->get_status() ) {
-						if ( self::$verbose ) {
-							WP_CLI::line( 'Updating status for subscription ' . $id );
-						}
-						// Update the subscription status to expired.
-						if ( self::$live ) {
-							$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
-						}
-						++$updated;
-						break;
+				$renewal_order = $subscription->get_last_order(
+					'all',
+					[ 'renewal' ],
+					[
+						'completed',
+						'processing',
+						'refunded',
+					]
+				);
+				// No failed or pending renewal orders indicates the subscription was likely manually placed on hold.
+				if ( empty( $renewal_order ) ) {
+					if ( self::$verbose ) {
+						WP_CLI::line( 'Subscription has no pending renewal orders. Moving to next subscription...' );
+						WP_CLI::line( '' );
 					}
+					continue;
+				}
+				$last_retry = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $renewal_order, 'id' ) );
+				// No retries indicates the subscription was likely manually placed on hold.
+				if ( empty( $last_retry ) ) {
+					if ( self::$verbose ) {
+						WP_CLI::line( 'No retries scheduled. Moving to next subscription...' );
+						WP_CLI::line( '' );
+					}
+					continue;
+				}
+				// A non failed status indicates the retry was either manually cancelled
+				// or was successful at one point but likely placed on hold for some other reason.
+				if ( 'failed' !== $last_retry->get_status() ) {
+					if ( self::$verbose ) {
+						WP_CLI::line( 'Last retry does not have a failed status. Moving to next subscription...' );
+						WP_CLI::line( '' );
+					}
+					continue;
+				} else {
+					if ( self::$verbose ) {
+						WP_CLI::line( 'Updating subscription status to expired...' );
+					}
+					if ( self::$live ) {
+						$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
+					}
+					++$updated;
 				}
 				if ( self::$verbose ) {
 					WP_CLI::line( 'Finished processing subscription ' . $id );
@@ -122,6 +142,9 @@ class WooCommerce_Subscriptions {
 			$subscriptions = self::get_subscriptions( ++$page );
 		}
 		WP_CLI::success( 'Finished processing subscriptions. ' . $updated . ' subscriptions updated.' );
+		if ( ! self::$live ) {
+			WP_CLI::warning( 'Dry run. Use --live flag to process live subscriptions.' );
+		}
 		WP_CLI::line( '' );
 	}
 
@@ -134,21 +157,25 @@ class WooCommerce_Subscriptions {
 	 */
 	private static function get_subscriptions( $page = 1 ) {
 		$subscriptions = [];
-		if ( false === self::$ids ) {
-			$subscriptions = wcs_get_subscriptions(
-				[
-					'paged'                  => $page,
-					'subscriptions_per_page' => $per_page,
-					'subscrition_status'     => 'on-hold',
-				]
-			);
-		} else {
-			foreach ( self::$ids as $id ) {
+		if ( false !== self::$ids ) {
+			while ( ! empty( self::$ids ) ) {
+				$id = array_shift( self::$ids );
+				if ( ! is_numeric( $id ) ) {
+					continue;
+				}
 				$subscription = wcs_get_subscription( $id );
 				if ( $subscription ) {
 					$subscriptions[] = $subscription;
 				}
 			}
+		} else {
+			$subscriptions = wcs_get_subscriptions(
+				[
+					'paged'                  => $page,
+					'subscriptions_per_page' => 25,
+					'subscription_status'    => 'on-hold',
+				]
+			);
 		}
 		return $subscriptions;
 	}

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -130,6 +130,7 @@ class WooCommerce_Subscriptions {
 						WP_CLI::line( 'Updating subscription status to expired...' );
 					}
 					if ( self::$live ) {
+						$subscription->set_end_date( $last_retry->get_date() );
 						$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
 					}
 					++$updated;

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -132,6 +132,7 @@ class WooCommerce_Subscriptions {
 					if ( self::$live ) {
 						$subscription->set_end_date( $last_retry->get_date() );
 						$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
+						$subscription->save();
 					}
 					++$updated;
 				}

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -130,8 +130,8 @@ class WooCommerce_Subscriptions {
 						WP_CLI::line( 'Updating subscription status to expired...' );
 					}
 					if ( self::$live ) {
-						$subscription->set_end_date( $last_retry->get_date() );
 						$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
+						$subscription->set_end_date( $last_retry->get_date() );
 						$subscription->save();
 					}
 					++$updated;

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -31,6 +31,13 @@ class WooCommerce_Subscriptions {
 	private static $verbose = false;
 
 	/**
+	 * Subscription ids to process.
+	 *
+	 * @var bool|array
+	 */
+	private static $ids = false;
+
+	/**
 	 * Migrate on-hold WooCommerce subscriptions with failed renewal orders to expired status.
 	 *
 	 * ## OPTIONS
@@ -40,6 +47,9 @@ class WooCommerce_Subscriptions {
 	 *
 	 * [--verbose]
 	 * : Produce more output.
+	 *
+	 * [--ids]
+	 * : Comma-separated list of subscription IDs. If provided, only ubscriptions with these IDs will be processed.
 	 *
 	 * @param array $args Positional arguments.
 	 * @param array $assoc_args Assoc arguments.
@@ -52,6 +62,7 @@ class WooCommerce_Subscriptions {
 			WP_CLI::line( '' );
 			return;
 		}
+		self::$ids     = isset( $assoc_args['ids'] ) ? explode( ',', $assoc_args['ids'] ) : false;
 		self::$live    = isset( $assoc_args['live'] ) ? true : false;
 		self::$verbose = isset( $assoc_args['verbose'] ) ? true : false;
 		if ( self::$live ) {
@@ -108,15 +119,37 @@ class WooCommerce_Subscriptions {
 					WP_CLI::line( '' );
 				}
 			}
-			$subscriptions = wcs_get_subscriptions(
-				[
-					'paged'                  => ++$page,
-					'subscriptions_per_page' => $per_page,
-					'subscription_status'    => 'on-hold',
-				]
-			);
+			$subscriptions = self::get_subscriptions( ++$page );
 		}
 		WP_CLI::success( 'Finished processing subscriptions. ' . $updated . ' subscriptions updated.' );
 		WP_CLI::line( '' );
+	}
+
+	/**
+	 * Get subscriptions to process.
+	 *
+	 * @param int $page Page number.
+	 *
+	 * @return array
+	 */
+	private static function get_subscriptions( $page = 1 ) {
+		$subscriptions = [];
+		if ( false === self::$ids ) {
+			$subscriptions = wcs_get_subscriptions(
+				[
+					'paged'                  => $page,
+					'subscriptions_per_page' => $per_page,
+					'subscrition_status'     => 'on-hold',
+				]
+			);
+		} else {
+			foreach ( self::$ids as $id ) {
+				$subscription = wcs_get_subscription( $id );
+				if ( $subscription ) {
+					$subscriptions[] = $subscription;
+				}
+			}
+		}
+		return $subscriptions;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208702687864922/1208702687865965/f

This PR adds a cli command to migrate the status of all on-hold subscriptions that have failed all retries to expired:

```
NAME

  wp newspack migrate-expired-subscriptions

DESCRIPTION

  Migrate status of on-hold WooCommerce subscriptions that have failed all payment retries to expired.

SYNOPSIS

  wp newspack migrate-expired-subscriptions [--live] [--verbose] [--ids]

OPTIONS

  [--live]
    Run the command in live mode, updating the subscriptions.

  [--verbose]
    Produce more output.

  [--ids]
    Comma-separated list of subscription IDs. If provided, only subscriptions with these IDs will be processed.
```

### How to test the changes in this Pull Request:

1. Make sure you DO NOT have the `NEWSPACK_SUBSCRIPTIONS_EXPIRATION` constant defined
2. If you don't already have any active subscriptions, as a reader purchase a handful of subscriptions
3. Follow the steps here to trigger scheduled retry for a handful of subscriptions: https://woocommerce.com/document/subscriptions/develop/failed-payment-retry/#section-7
4. Ensure you have at least one subscription of each:
  - An on-hold subscription with all payment retries completed
  - An on-hold subscription that is awaiting another payment retry
  - An on-hold subscription that has no retries scheduled (manually move this to on-hold)
  - A non-on-hold subscription (active, expired, etc.)
5. Via terminal, run the `wp newspack migrate-expired-subscriptions --verbose` command. Confirm an error appears letting you know subscription integration is not enabled.
6. Define the `NEWSPACK_SUBSCRIPTIONS_EXPIRATION` constant: `define( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION', true );`
7. Via terminal, run the command again. Confirm the output shows you are in dry run mode, 1 subscription has been updated, and the other subscriptions are skipped with the expected reasons. Also confirm the non-on-hold subscription is not included.
8. Now include some ids to confirm the command will work on only the provided ids: `wp newspack migrate-expired-subscriptions --verbose --ids=1,2,3,4,5`
9. Finally, run the command with the live flag: `wp newspack migrate-expired-subscriptions --live`. Confirm the status of the on-hold subscription has updated to expired.
10. Smoke test the command with some more subscriptions!

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->