### PR TITLE
fix: duplicate orders save on cron

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-duplicate-orders.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-duplicate-orders.php
@@ -118,7 +118,7 @@ class WooCommerce_Duplicate_Orders {
 	 * @param bool   $save Whether to save the result as the option.
 	 * @param bool   $upsert Whether to upsert the option (merge with existing).
 	 */
-	public static function check_for_order_duplicates( $cutoff_time = DAY_IN_SECONDS, $save = false, $upsert = true ): array {
+	public static function check_for_order_duplicates( $cutoff_time = DAY_IN_SECONDS, $save = true, $upsert = true ): array {
 		$order_duplicates = self::get_order_duplicates( $cutoff_time );
 		if ( empty( $order_duplicates ) ) {
 			return [];
@@ -237,7 +237,7 @@ class WooCommerce_Duplicate_Orders {
 		$cutoff_time = strtotime( $cutoff_time_str ) - time();
 		$save_as_option = isset( $assoc_args['save'] ) ? $assoc_args['save'] : false;
 
-		$duplicates = self::check_for_order_duplicates( $cutoff_time, $save_as_option, false );
+		$duplicates = self::check_for_order_duplicates( $cutoff_time, $save_as_option );
 
 		if ( empty( $duplicates ) ) {
 			\WP_CLI::success( 'No duplicate orders found.' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There were a fee oversights in my review in https://github.com/Automattic/newspack-plugin/pull/3555

First. The cron job will not save the duplicates, so the notices will never appear. This fixes it.

Also, the CLI command name says it is an upsert, but it was passing a parameter that would override the whole option. Fixed it as well

### How to test the changes in this Pull Request:

Perform the tests on https://github.com/Automattic/newspack-plugin/pull/3555

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->