### PR TITLE
fix(ras-acc): re-add recaptcha to the WooCommerce checkout

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -25,6 +25,10 @@ final class Recaptcha {
 		\add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'register_scripts' ] );
 
+		// Add reCAPTCHA to the Woo checkout form.
+		\add_action( 'woocommerce_review_order_before_submit', [ __CLASS__, 'add_recaptcha_v2_to_checkout' ] );
+		\add_action( 'woocommerce_checkout_after_customer_details', [ __CLASS__, 'add_recaptcha_v3_to_checkout' ] );
+
 		// Verify reCAPTCHA on checkout submission.
 		\add_action( 'woocommerce_checkout_process', [ __CLASS__, 'verify_recaptcha_on_checkout' ] );
 	}
@@ -420,6 +424,72 @@ final class Recaptcha {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Render a container for the reCAPTCHA v2 checkbox widget.
+	 */
+	public static function render_recaptcha_v2_container() {
+		if ( ! self::can_use_captcha( 'v2' ) ) {
+			return;
+		}
+		?>
+		<div id="<?php echo \esc_attr( 'newspack-recaptcha-' . uniqid() ); ?>" class="grecaptcha-container"></div>
+		<?php
+	}
+
+	/**
+	 * Add reCAPTCHA v2 to Woo checkout.
+	 */
+	public static function add_recaptcha_v2_to_checkout() {
+		self::render_recaptcha_v2_container();
+	}
+
+	/**
+	 * Add reCAPTCHA v3 to Woo checkout.
+	 */
+	public static function add_recaptcha_v3_to_checkout() {
+		if ( ! self::can_use_captcha( 'v3' ) ) {
+			return;
+		}
+		$site_key = self::get_site_key();
+		?>
+		<script src="<?php echo \esc_url( self::get_script_url() ); ?>"></script>
+		<script>
+			grecaptcha.ready( function() {
+				var field;
+				function refreshToken() {
+					grecaptcha.execute(
+						'<?php echo \esc_attr( $site_key ); ?>',
+						{ action: 'checkout' }
+					).then( function( token ) {
+						if ( field ) {
+							field.value = token;
+						}
+					} );
+				}
+				setInterval( refreshToken, 30000 );
+				( function( $ ) {
+					if ( ! $ ) { return; }
+					$( document ).on( 'updated_checkout', refreshToken );
+					$( document.body ).on( 'checkout_error', refreshToken );
+				} )( jQuery );
+				grecaptcha.execute(
+					'<?php echo \esc_attr( $site_key ); ?>',
+					{ action: 'checkout' }
+				).then( function( token ) {
+					field       = document.createElement('input');
+					field.type  = 'hidden';
+					field.name  = 'g-recaptcha-response';
+					field.value = token;
+					var form = document.querySelector('form.checkout');
+					if ( form ) {
+						form.appendChild( field );
+					}
+				} );
+			} );
+		</script>
+		<?php
 	}
 
 	/**

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -430,7 +430,7 @@ final class Recaptcha {
 	 * Render a container for the reCAPTCHA v2 checkbox widget.
 	 */
 	public static function render_recaptcha_v2_container() {
-		if ( ! self::can_use_captcha( 'v2' ) ) {
+		if ( ! self::can_use_captcha( 'v2' ) || ( method_exists( 'Newspack_Blocks\Modal_Checkout', 'is_modal_checkout' ) && \Newspack_Blocks\Modal_Checkout::is_modal_checkout() ) ) {
 			return;
 		}
 		?>
@@ -449,7 +449,7 @@ final class Recaptcha {
 	 * Add reCAPTCHA v3 to Woo checkout.
 	 */
 	public static function add_recaptcha_v3_to_checkout() {
-		if ( ! self::can_use_captcha( 'v3' ) ) {
+		if ( ! self::can_use_captcha( 'v3' ) || ( method_exists( 'Newspack_Blocks\Modal_Checkout', 'is_modal_checkout' ) && \Newspack_Blocks\Modal_Checkout::is_modal_checkout() ) ) {
 			return;
 		}
 		$site_key = self::get_site_key();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The code that adds the g-recaptcha field to the WooCommerce cart checkout was removed as part of [this PR](https://github.com/Automattic/newspack-plugin/pull/3283).

Unfortunately this causes the regular cart not to be able to process orders when reCAPTCHA v3 is enabled. V2 still seems to work, but it's possibly because reCAPTCHA doesn't work at all. I've reinstated both.

### How to test the changes in this Pull Request:

1. Set up your site to use reCAPTCHA v3. 
2. Run through a regular modal checkout of a subscription product.
3. Go to My Account > Subscriptions, and edit the monthly amount for your subscription.
4. On the final step of trying to checkout, note the reCAPTCHA error.
5. Apply this PR. 
6. Repeat steps 3 and 4 and confirm that the reCAPTCHA error doesn't return.
7. Try a modal checkout purchase and confirm there are no errors.
8. Try a regular /shop to /cart purchase and confirm there are no errors.
9. Switch to reCAPTCHA v2, and repeat all the tests. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->