### PR TITLE
Fix ( guest-authors-for-cli ): allow GAs for CLI context

### DIFF
--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -98,24 +98,16 @@ class Guest_Contributor_Role {
 	 * @return void
 	 */
 	public static function early_init() {
-
-		// Enable Guest Authors...
-		// -- if constant exists and is true.
 		if ( defined( 'NEWSPACK_ENABLE_CAP_GUEST_AUTHORS' ) && NEWSPACK_ENABLE_CAP_GUEST_AUTHORS ) {
 			return;
 		}
-		// -- if site already has Guest Authors. 
-		if ( self::site_has_cap_guest_authors() ) {
-			return;
-		}
-		// -- if CLI context.
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			return;
 		}
-
-		// Disable Guest Authors.
-		add_filter( 'coauthors_guest_authors_enabled', '__return_false' );
-		add_action( 'admin_menu', [ __CLASS__, 'guest_author_menu_replacement' ] );
+		if ( ! self::site_has_cap_guest_authors() ) {
+			add_filter( 'coauthors_guest_authors_enabled', '__return_false' );
+			add_action( 'admin_menu', [ __CLASS__, 'guest_author_menu_replacement' ] );
+		}
 	}
 
 	/**

--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -98,13 +98,24 @@ class Guest_Contributor_Role {
 	 * @return void
 	 */
 	public static function early_init() {
+
+		// Enable Guest Authors...
+		// -- if constant exists and is true.
 		if ( defined( 'NEWSPACK_ENABLE_CAP_GUEST_AUTHORS' ) && NEWSPACK_ENABLE_CAP_GUEST_AUTHORS ) {
 			return;
 		}
-		if ( ! self::site_has_cap_guest_authors() ) {
-			add_filter( 'coauthors_guest_authors_enabled', '__return_false' );
-			add_action( 'admin_menu', [ __CLASS__, 'guest_author_menu_replacement' ] );
+		// -- if site already has Guest Authors. 
+		if ( self::site_has_cap_guest_authors() ) {
+			return;
 		}
+		// -- if CLI context.
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return;
+		}
+
+		// Disable Guest Authors.
+		add_filter( 'coauthors_guest_authors_enabled', '__return_false' );
+		add_action( 'admin_menu', [ __CLASS__, 'guest_author_menu_replacement' ] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix / idea: Don't turn off Guest Authors for CLI.  Most of the built-in CoAuthorsPlus CLI commands don't properly check to see if GAs are enabled or not.  If GAs are not enabled, then many commands will throw a PHP FATAL:

`PHP Fatal error:  Uncaught Error: Call to a member function get_guest_author_by() on null in /wp-content/plugins/co-authors-plus/php/class-wp-cli.php:1085`

Of all the CLIs, there is only 1 that checks if GAs are enabled:

https://github.com/Automattic/Co-Authors-Plus/blob/7330dc12643bd5f8dc3d177815f8b81ff5a72820/php/class-wp-cli.php#L855

Overall, it seems that the filter `coauthors_guest_authors_enabled` is generally ignored in CLI context, but used in WP Admin.  Which seems inline with what the Newspack Plugin wants: to disable the existing GA admin page and replace with the new Newspack Contributor admin page.

As such, this PR will keep GAs enabled for CLI.

This will also help with Newspack Custom Content Migrator and Newspack Migration Tools where their CLIs have a requirement for GA in their constructor.  ( Issue: https://github.com/Automattic/newspack-migration-tools/issues/41 )


### How to test the changes in this Pull Request:

1. Make sure Newspack and CoAuthorsPlus plugins are enabled.
2. Before pulling this branch, run a CAP CLI command such as `wp co-authors-plus create-author`
3. Verify PHP threw a FATAL error in debug.log.
4. Now, pull this branch and run the same command.
5. Verify that no fatal was thrown.  You'll just see a warning that arguments are missing: `-- Not found; creating profile. Warning: -- Failed to create guest author: display_name is a required field`.  That is OK.  It means no fatal was thrown and the CLI command can be used properly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->