### PR TITLE
fix(wcs): update subscription expiration feature

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -73,12 +73,12 @@ class On_Hold_Duration {
 	}
 
 	/**
-	 * Get on-hold duration. Defaults to 0.
+	 * Get on-hold duration. Defaults to 30.
 	 *
 	 * @return int
 	 */
 	public static function get_on_hold_duration() {
-		return absint( get_option( 'newspack_subscriptions_on_hold_duration', 0 ) );
+		return absint( get_option( 'newspack_subscriptions_on_hold_duration', 30 ) );
 	}
 
 	/**

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-meta.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-meta.php
@@ -18,6 +18,7 @@ class Subscriptions_Meta {
 	const CANCELLATION_REASON_ADMIN_PENDING_CANCEL = 'manually-pending-cancel';
 	const CANCELLATION_REASON_USER_CANCELLED       = 'user-cancelled';
 	const CANCELLATION_REASON_USER_PENDING_CANCEL  = 'user-pending-cancel';
+	const CANCELLATION_REASON_EXPIRED              = 'expired';
 
 	/**
 	 * Initialize hooks and filters.
@@ -38,8 +39,8 @@ class Subscriptions_Meta {
 	 * @param string          $from_status   The status the subscription is changing from.
 	 */
 	public static function maybe_record_cancelled_subscription_meta( $subscription, $to_status, $from_status ) {
-		// We only care about active, cancelled, and pending statuses.
-		if ( ! in_array( $to_status, [ 'active', 'cancelled', 'pending-cancel' ], true ) || in_array( $from_status, [ 'cancelled', 'expired' ], true ) ) {
+		// We only care about active, cancelled, expired, and pending statuses.
+		if ( ! in_array( $to_status, [ 'active', 'cancelled', 'expired', 'pending-cancel' ], true ) || in_array( $from_status, [ 'cancelled', 'expired' ], true ) ) {
 			return;
 		}
 
@@ -59,6 +60,10 @@ class Subscriptions_Meta {
 				$meta_value = is_admin() ? self::CANCELLATION_REASON_ADMIN_CANCELLED : self::CANCELLATION_REASON_USER_CANCELLED;
 				$subscription->update_meta_data( self::CANCELLATION_REASON_META_KEY, $meta_value );
 			}
+			$subscription->save();
+		}
+		if ( 'expired' === $to_status ) {
+			$subscription->update_meta_data( self::CANCELLATION_REASON_META_KEY, self::CANCELLATION_REASON_EXPIRED );
 			$subscription->save();
 		}
 		if ( 'pending-cancel' === $to_status ) {

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -54,7 +54,16 @@ class WooCommerce_Subscriptions {
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		return self::is_active() && Reader_Activation::is_enabled() && defined( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION' ) && NEWSPACK_SUBSCRIPTIONS_EXPIRATION;
+		if ( ! defined( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION' ) || ! NEWSPACK_SUBSCRIPTIONS_EXPIRATION ) {
+			return false;
+		}
+		$is_enabled = self::is_active() && Reader_Activation::is_enabled();
+		/**
+		 * Filters whether subscriptions expiration is enabled.
+		 *
+		 * @param bool $is_enabled
+		 */
+		return apply_filters( 'newspack_subscriptions_expiration_enabled', $is_enabled );
 	}
 }
 WooCommerce_Subscriptions::init();

--- a/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-meta.php
+++ b/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-meta.php
@@ -51,11 +51,17 @@ class Newspack_Test_Subscriptions_Meta extends WP_UnitTestCase {
 			$subscription->get_meta( Subscriptions_Meta::CANCELLATION_REASON_META_KEY ),
 			'Cancellation reason meta should be reset when subscription is updated to active from pending-cancel status.'
 		);
-		Subscriptions_Meta::maybe_record_cancelled_subscription_meta( $subscription, 'cancelled', 'pending-cancel', $subscription );
+		Subscriptions_Meta::maybe_record_cancelled_subscription_meta( $subscription, 'cancelled', 'pending-cancel' );
 		$this->assertEquals(
 			Subscriptions_Meta::CANCELLATION_REASON_USER_CANCELLED,
 			$subscription->get_meta( Subscriptions_Meta::CANCELLATION_REASON_META_KEY ),
 			'Cancellation reason meta should be set to user-cancelled when subscription is cancelled from pending-cancel status.'
+		);
+		Subscriptions_Meta::maybe_record_cancelled_subscription_meta( $subscription, 'expired', 'active' );
+		$this->assertEquals(
+			Subscriptions_Meta::CANCELLATION_REASON_EXPIRED,
+			$subscription->get_meta( Subscriptions_Meta::CANCELLATION_REASON_META_KEY ),
+			'Cancellation reason meta should be set to expired when subscription is expired from active status.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR updates the subscriptions expiration feature by:

1. Adding `expired` cancellation reason meta value 
2. Adding a filter to the `is_enabled` WCS integration method
3. Updating the default on-hold duration to 30 days

### How to test the changes in this Pull Request:

1. Ensure the FF and newspack debugging is enabled in wp-config (FF: `define( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION', true );`)
2. As a reader, either purchase a subscription or cancel subscriptions until you only have a single active subscription.
4. As admin, set the subscription status to expired an save.
5. Confirm the `newspack_subscriptions_cancellation_reason` Woo meta is present for the subscription on reload
![Screenshot 2024-12-09 at 12 50 10](https://github.com/user-attachments/assets/ac0373f2-7fdb-4a28-aa2d-459e93706249)
6. Check the logs for normalized esp data and confirm the expiration reason is present with a value of `expired`
![Screenshot 2024-12-09 at 12 46 41](https://github.com/user-attachments/assets/00f7ce15-fc5d-494a-8ec1-a1b174e95cf5)
7. Somewhere on the site, add a hook to the `newspack_subscriptions_expiration_enabled` to force disable the feature.
8. Repeat the above steps, but this time confirm no meta is added in both Woo and the ESP
9. Make sure the `newspack_subscriptions_on_hold_duration` option is not set on your site
10. Go to WooCommerce > Settings > Subscriptions and scroll to the bottom
11. Confirm the on-hold duration is set to 30 days


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->