### PR TITLE
fix(ras): do not require Woo plugins if using NRH

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -656,6 +656,22 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Get an array of required plugins for satisfying Reader Revenue prerequisites.
+	 * WooCommerce and Woo Subscriptions are required for Newspack, but not for NRH.
+	 */
+	public static function get_reader_revenue_required_plugins() {
+		$required_plugins = [
+			'newspack-blocks' => class_exists( '\Newspack_Blocks' ),
+		];
+
+		if ( Donations::is_platform_wc() ) {
+			$required_plugins['woocommerce'] = class_exists( 'WooCommerce' );
+			$required_plugins['woocommerce-subscriptions'] = class_exists( 'WCS_Query' );
+		}
+		return $required_plugins;
+	}
+
+	/**
 	 * Are the Legal Pages settings configured?
 	 * Allows for blank values.
 	 */
@@ -762,11 +778,7 @@ final class Reader_Activation {
 			],
 			'reader_revenue'   => [
 				'active'       => self::is_reader_revenue_ready(),
-				'plugins'      => [
-					'newspack-blocks'           => class_exists( '\Newspack_Blocks' ),
-					'woocommerce'               => function_exists( 'WC' ),
-					'woocommerce-subscriptions' => class_exists( 'WC_Subscriptions_Product' ),
-				],
+				'plugins'      => self::get_reader_revenue_required_plugins(),
 				'label'        => __( 'Reader Revenue', 'newspack-plugin' ),
 				'description'  => __( 'Setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack-plugin' ),
 				'instructions' => __( 'Set platform to "Newspack" or "News Revenue Hub" and configure your default donation settings. If using News Revenue Hub, set an Organization ID and a Donor Landing Page in News Revenue Hub Settings.', 'newspack-plugin' ),

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -140,7 +140,7 @@ abstract class Wizard {
 			'is_debug_mode'       => Newspack::is_debug_mode(),
 			'has_completed_setup' => get_option( NEWSPACK_SETUP_COMPLETE ),
 			'site_title'          => get_option( 'blogname' ),
-			'is_atomic'           => defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID,
+			'is_managed'          => method_exists( 'Newspack_Manager', 'is_connected_to_manager' ) && \Newspack_Manager::is_connected_to_manager(),
 		];
 
 		wp_localize_script( 'newspack_data', 'newspack_urls', $urls );

--- a/src/components/src/plugin-installer/index.js
+++ b/src/components/src/plugin-installer/index.js
@@ -155,7 +155,7 @@ class PluginInstaller extends Component {
 	render() {
 		const { autoInstall, isSmall, withoutFooterButton } = this.props;
 		const { pluginInfo } = this.state;
-		const { is_atomic: isAtomic } = window;
+		const { is_atomic: isAtomic } = window.newspack_aux_data || {};
 		const slugs = Object.keys( pluginInfo );
 
 		// Store all plugin status info for installer button text value based on current status.

--- a/src/components/src/plugin-installer/index.js
+++ b/src/components/src/plugin-installer/index.js
@@ -155,7 +155,7 @@ class PluginInstaller extends Component {
 	render() {
 		const { autoInstall, isSmall, withoutFooterButton } = this.props;
 		const { pluginInfo } = this.state;
-		const { is_atomic: isAtomic } = window.newspack_aux_data || {};
+		const { is_managed: isManaged } = window.newspack_aux_data || {};
 		const slugs = Object.keys( pluginInfo );
 
 		// Store all plugin status info for installer button text value based on current status.
@@ -201,7 +201,7 @@ class PluginInstaller extends Component {
 						} else if ( ! installable ) {
 							actionText = (
 								<span className="newspack-plugin-installer__status">
-									{ isAtomic
+									{ isManaged
 										? __( 'Contact Newspack support to install', 'newspack-plugin' )
 										: __( 'Plugin must be installed manually', 'newspack-plugin' ) }
 									<span className="newspack-checkbox-icon" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Reader Activation features support both Newspack (WooCommerce) and NRH reader revenue platforms, but currently the UI requires WooCommerce plugins to be active even if using NRH. This fixes prerequisites by only requiring Woo plugins if the reader revenue platform is set to "Newspack".

Also fixes a feature that was implemented in #2482 but incorrectly. The message shown for plugins that can't be installed programmatically from a public URL should differ for hosted Newspack sites compared to externally-hosted sites.

### How to test the changes in this Pull Request:

1. Deactivate WooCommerce and WooCommerce Subscriptions plugins.
2. Set your reader revenue platform to NRH and set an Organization ID string and a Donor Landing Page.
3. Visit Engagement > Reader Activation. On `trunk`, observe that you see a notification that the Woo plugins are required instead of the Reader Activation settings UI:

<img width="1368" alt="Screenshot 2024-12-10 at 4 26 50 PM" src="https://github.com/user-attachments/assets/809e3b03-f0b5-40a5-9e21-e1045955432a">

4. Check out this branch and refresh. Now confirm that you can see the Reader Activation UI:

<img width="1370" alt="Screenshot 2024-12-10 at 4 28 23 PM" src="https://github.com/user-attachments/assets/3750dd55-788f-49e3-a6a0-e80d5e6aa357">

5. Set your reader revenue platform to Newspack, then revisit Engagement > Reader Activation (without reactivating the plugins) and confirm that you see the required plugins notification again.
6. Delete the WooCommerce Subscriptions plugin from your site and refresh. Confirm that the message shown in the plugin notification says `Plugin must be installed manually` if your site is not a managed Newspack site:

<img width="1069" alt="Screenshot 2024-12-10 at 4 57 03 PM" src="https://github.com/user-attachments/assets/afebff2e-8224-4a0c-bc22-82caec88e42c">

7. Connect your site to a manager instance and refresh. Confirm that the message now says `Contact Newspack support to install`:

<img width="1062" alt="Screenshot 2024-12-10 at 4 51 40 PM" src="https://github.com/user-attachments/assets/d88492f0-ba26-44c2-900f-b124a938d7b9">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208923545061650