### PR TITLE
Couple bug fixes for ESP sync CLI command

### DIFF
--- a/includes/cli/class-ras-esp-sync.php
+++ b/includes/cli/class-ras-esp-sync.php
@@ -224,9 +224,9 @@ class RAS_ESP_Sync extends Reader_Activation\ESP_Sync {
 					if ( \is_wp_error( $result ) ) {
 						static::log(
 							sprintf(
-								// Translators: $1$s is the contact's email address. %2$s is the error message.
-								__( 'Error syncing contact info for %1$s. %2$s' ),
-								$customer->get_email(),
+								// Translators: $1$s is the contact's user ID. %2$s is the error message.
+								__( 'Error syncing contact info for user ID %1$d. %2$s' ),
+								$user_id,
 								$result->get_error_message()
 							)
 						);
@@ -354,16 +354,16 @@ class RAS_ESP_Sync extends Reader_Activation\ESP_Sync {
 	 * [--active-only]
 	 * : If passed, only sync users who have active subscriptions, otherwise resync all users.
 	 *
-	 * [--migrated-subscriptions=<stripe|piano-csv|strive-csv>]
+	 * [--migrated-subscriptions=<stripe|piano-csv|stripe-csv>]
 	 * : If passed, will only query for subscriptions that were migrated via the Newspack Subscription Migrations plugin using the Stripe/Piano CSV importers, or the legacy Stripe migrator. The Newspack Subscription Migrations plugin must be active to use this flag.
 	 *
-	 * [--subscription-ids=<id1,id2...>]
+	 * [--subscription-ids=<id1,id2,etc>]
 	 * : Comma-delimited list of subscription IDs. If passed, will only process those specific subscriptions.
 	 *
-	 * [--user-ids=<id1,id2...>]
+	 * [--user-ids=<id1,id2,etc>]
 	 * : Comma-delimited list of user IDs. If passed, will only process subscriptions associated with those specific users.
 	 *
-	 * [--order-ids=<id1,id2...>]
+	 * [--order-ids=<id1,id2,etc>]
 	 * : Comma-delimited list of order IDs. If passed, will only process subscriptions associated with those specific orders.
 	 *
 	 * [--batch-size=<number>]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix PR.**

This PR fixes a couple bugs in the ESP sync CLI command.

1. The parser did not like the ellipses in the docs like `[--subscription-ids=<id1,id2...>]`, so those parameters weren't getting recognized.
2. When an error was thrown during sync, the command threw a fatal error because the `$customer` object didn't exist.

### How to test the changes in this Pull Request:

1. Before applying this PR try e.g. `wp newspack esp sync --user-ids=1`. Observe the following output:

```
Warning: The `wp newspack esp sync` command has an invalid synopsis part: [--subscription-ids=<id1,id2...>]
Warning: The `wp newspack esp sync` command has an invalid synopsis part: [--user-ids=<id1,id2...>]
Warning: The `wp newspack esp sync` command has an invalid synopsis part: [--order-ids=<id1,id2...>]
Error: Parameter errors:
 unknown --user-ids parameter
```

2. Add the following to the top of `ESP_Sync::sync_contact` so an error is always thrown:

```
	return new \WP_Error(
		'newspack_esp_sync_contact',
		sprintf(
		// Translators: %d is the user ID.
			__( 'Customer with ID %d does not exist.', 'newspack-plugin' ),
			1
		)
	);
```
3. Run `wp newspack esp sync`. Observe output like the following:

```
[11-Dec-2024 00:10:05 UTC] PHP Fatal error:  Uncaught Error: Call to a member function get_email() on null in /Users/claudiulodro/Local Sites/newspackdev/app/public/wp-content/plugins/newspack-plugin/includes/cli/class-ras-esp-sync.php:229
...
```

3. Apply this patch. Verify that the `--user-ids` flag works and that when an error is thrown you now get something like `Error syncing contact info for user ID 3. Customer with ID 1 does not exist` instead of a fatal error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->