### PR TITLE
perf(data-events): queue dispatches to execute on shutdown

### DIFF
--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -38,13 +38,20 @@ final class Data_Events {
 	private static $global_handlers = [];
 
 	/**
+	 * Dispatches queued for execution on shutdown.
+	 *
+	 * @var array[]
+	 */
+	private static $queued_dispatches = [];
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
 		\add_action( 'wp_ajax_' . self::ACTION, [ __CLASS__, 'maybe_handle' ] );
 		\add_action( 'wp_ajax_nopriv_' . self::ACTION, [ __CLASS__, 'maybe_handle' ] );
+		\add_action( 'shutdown', [ __CLASS__, 'execute_queued_dispatches' ] );
 	}
-
 
 	/**
 	 * Maybe handle an event.
@@ -57,16 +64,24 @@ final class Data_Events {
 			\wp_die();
 		}
 
-		$action_name = isset( $_POST['action_name'] ) ? \sanitize_text_field( \wp_unslash( $_POST['action_name'] ) ) : null;
-		if ( empty( $action_name ) || ! isset( self::$actions[ $action_name ] ) ) {
+		$dispatches = isset( $_POST['dispatches'] ) ? $_POST['dispatches'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		if ( empty( $dispatches ) || ! is_array( $dispatches ) ) {
 			\wp_die();
 		}
 
-		$timestamp = isset( $_POST['timestamp'] ) ? \sanitize_text_field( \wp_unslash( $_POST['timestamp'] ) ) : null;
-		$data      = isset( $_POST['data'] ) ? $_POST['data'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$client_id = isset( $_POST['client_id'] ) ? \sanitize_text_field( \wp_unslash( $_POST['client_id'] ) ) : null;
+		foreach ( $dispatches as $dispatch ) {
+			$action_name = isset( $dispatch['action_name'] ) ? \sanitize_text_field( $dispatch['action_name'] ) : null;
+			if ( empty( $action_name ) || ! isset( self::$actions[ $action_name ] ) ) {
+				continue;
+			}
 
-		self::handle( $action_name, $timestamp, $data, $client_id );
+			$timestamp = isset( $dispatch['timestamp'] ) ? \sanitize_text_field( $dispatch['timestamp'] ) : null;
+			$data      = isset( $dispatch['data'] ) ? $dispatch['data'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$client_id = isset( $dispatch['client_id'] ) ? \sanitize_text_field( $dispatch['client_id'] ) : null;
+
+			self::handle( $action_name, $timestamp, $data, $client_id );
+		}
 
 		\wp_die();
 	}
@@ -312,8 +327,21 @@ final class Data_Events {
 			return $body;
 		}
 
+		self::$queued_dispatches[] = $body;
+	}
+
+	/**
+	 * Execute queued dispatches.
+	 */
+	public static function execute_queued_dispatches() {
+		if ( empty( self::$queued_dispatches ) ) {
+			return;
+		}
+
+		$actions = array_column( self::$queued_dispatches, 'action_name' );
+
 		Logger::log(
-			sprintf( 'Dispatching action "%s".', $action_name ),
+			sprintf( 'Dispatching actions: "%s".', implode( ', ', $actions ) ),
 			self::LOGGER_HEADER
 		);
 
@@ -325,16 +353,24 @@ final class Data_Events {
 			\admin_url( 'admin-ajax.php' )
 		);
 
-		return \wp_remote_post(
+		$request = \wp_remote_post(
 			$url,
 			[
 				'timeout'   => 0.01,
 				'blocking'  => false,
-				'body'      => $body,
+				'body'      => [ 'dispatches' => self::$queued_dispatches ],
 				'cookies'   => $_COOKIE, // phpcs:ignore
 				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
 			]
 		);
+
+		/**
+		 * Fires after dispatching queued actions.
+		 *
+		 * @param WP_Error|WP_HTTP_Response $request           The request object.
+		 * @param array                     $queued_dispatches The queued dispatches.
+		 */
+		\do_action( 'newspack_data_events_dispatched', $request, self::$queued_dispatches );
 	}
 }
 Data_Events::init();

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -328,6 +328,11 @@ final class Data_Events {
 		}
 
 		self::$queued_dispatches[] = $body;
+
+		// If we're in shutdown, execute the dispatches immediately.
+		if ( did_action( 'shutdown' ) ) {
+			self::execute_queued_dispatches();
+		}
 	}
 
 	/**
@@ -371,6 +376,9 @@ final class Data_Events {
 		 * @param array                     $queued_dispatches The queued dispatches.
 		 */
 		\do_action( 'newspack_data_events_dispatched', $request, self::$queued_dispatches );
+
+		// Clear the queue in case of a retry.
+		self::$queued_dispatches = [];
 	}
 }
 Data_Events::init();

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -77,6 +77,32 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that executing queued dispatches triggers the dispatched action hook.
+	 */
+	public function test_execute_queued_dispatches() {
+		$action_name = 'test_action';
+		$data        = [ 'test' => 'data' ];
+
+		$hook_request = null;
+		$hook_queued_dispatches = null;
+
+		$hook = function( $request, $queued_dispatches ) use ( &$hook_request, &$hook_queued_dispatches ) {
+			$hook_request = $request;
+			$hook_queued_dispatches = $queued_dispatches;
+		};
+		add_action( 'newspack_data_events_dispatched', $hook, 10, 2 );
+
+		Data_Events::register_action( $action_name );
+		Data_Events::dispatch( $action_name, $data );
+		Data_Events::execute_queued_dispatches();
+
+		$this->assertIsArray( $hook_request );
+		$this->assertIsArray( $hook_queued_dispatches );
+		$this->assertEquals( $action_name, $hook_queued_dispatches[0]['action_name'] );
+		$this->assertEquals( $data, $hook_queued_dispatches[0]['data'] );
+	}
+
+	/**
 	 * Test triggering the handler.
 	 */
 	public function test_handler() {

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -74,10 +74,6 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 
 		// Assert the hook was called once.
 		$this->assertEquals( 1, $call_count );
-
-		// Assert it returns a WP_Http response.
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'http_response', $result );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

p1733922470397489-slack-C055SRT7WN4

Depending on the setup, a site can execute 5 dispatches when a reader registers:

 - `membership_status_active`
 - `membership_saved`
 - `reader_logged_in`
 - `reader_registered`
 - `network_user_updated`

The list grows if the registration happens during a subscription purchase.

Other actions on the site can also dispatch multiple events.

Each dispatch runs a `wp_remote_post()`. Even though it's a non-blocking execution with a timeout of 0.01, calling this function for every dispatch is unnecessary and costs performance.

This PR proposes queueing the dispatches to be executed in a single `wp_remote_post()` called on the `shutdown` hook. This hook runs right before PHP shuts down execution, including on fatal errors.

### How to test the changes in this Pull Request:

1. Make sure you have RAS configured and `NEWSPACK_LOG_LEVEL` set to at least `2` on `wp-config.php`
2. Add a webhook endpoint (https://webhook.site/ is your friend) assigned to the actions listed above
3. On a fresh session, register a new reader
4. Confirm you get the following log: (actions may vary according to your setup, but you should get at least `reader_registered` and `reader_logged_in` in the same run

```
Dispatching actions: "membership_status_active, membership_saved, reader_logged_in, reader_registered, network_user_updated".
```

5. Confirm you get the logs for handler execution as well:

```
[Newspack\Data_Events::handle]: Executing global action handlers for "membership_status_active".
[Newspack\Data_Events::handle]: Executing action handlers for "membership_status_active".
[Newspack\Data_Events::handle]: Executing global action handlers for "membership_saved".
[Newspack\Data_Events::handle]: Executing action handlers for "membership_saved".
[Newspack\Data_Events::handle]: Executing global action handlers for "reader_logged_in".
[Newspack\Data_Events::handle]: Executing action handlers for "reader_logged_in".
[Newspack\Data_Events::handle]: Executing global action handlers for "reader_registered".
[Newspack\Data_Events::handle]: Executing action handlers for "reader_registered".
[Newspack\Data_Events::handle]: Executing global action handlers for "network_user_updated".
[Newspack\Data_Events::handle]: Executing action handlers for "network_user_updated".
```

6. Wait until the webhook requests are processed and confirm every request reached your endpoint with the expected data

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->