### PR TITLE
fix(wcs): update subscriptions expiration cli behavior

### DIFF
--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -128,17 +128,17 @@ class WooCommerce_Subscriptions {
 					}
 					continue;
 				} else {
+					if ( $subscription->is_manual() || ! $subscription->payment_method_supports( 'subscription_date_changes' ) ) {
+						if ( self::$verbose ) {
+							WP_CLI::line( 'Subscription does not support retries. Moving to next subscription...' );
+							WP_CLI::line( '' );
+						}
+						continue;
+					}
 					$retry_date       = $last_retry->get_date();
 					$on_hold_duration = On_Hold_Duration::get_on_hold_duration();
 					// If the retry date is within the on-hold duration, schedule a final retry.
 					if ( wcs_date_to_time( $retry_date ) + ( $on_hold_duration * DAY_IN_SECONDS ) > time() ) {
-						if ( $subscription->is_manual() || ! $subscription->payment_method_supports( 'subscription_date_changes' ) ) {
-							if ( self::$verbose ) {
-								WP_CLI::line( 'Subscription does not support retries. Moving to next subscription...' );
-								WP_CLI::line( '' );
-							}
-							continue;
-						}
 						if ( self::$verbose ) {
 							WP_CLI::line( 'Retry date is within the on-hold duration. Scheduling final retry...' );
 						}

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -170,6 +170,7 @@ class WooCommerce_Subscriptions {
 						if ( self::$live ) {
 							$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
 							$subscription->set_end_date( $retry_date );
+							$subscription->update_meta_data( '_newspack_cli_status_updated', true );
 							$subscription->save();
 						}
 						++$updated;

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -153,6 +153,12 @@ class WooCommerce_Subscriptions {
 									WP_CLI::line( '' );
 								}
 								continue;
+							} else {
+								$subscription->add_order_note(
+									__( 'Final payment retry scheduled by Newspack CLI command.', 'newspack-plugin' )
+								);
+								$subscription->update_meta_data( '_newspack_cli_retry_scheduled', true );
+								$subscription->save();
 							}
 						}
 						++$scheduled;

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -9,6 +9,7 @@ namespace Newspack\CLI;
 
 use WP_CLI;
 use Newspack\Woocommerce_Subscriptions as WooCommerce_Subscriptions_Integration;
+use Newspack\On_Hold_Duration;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -66,6 +67,7 @@ class WooCommerce_Subscriptions {
 		self::$ids     = isset( $assoc_args['ids'] ) ? explode( ',', $assoc_args['ids'] ) : false;
 		self::$live    = isset( $assoc_args['live'] ) ? true : false;
 		self::$verbose = isset( $assoc_args['verbose'] ) ? true : false;
+		$scheduled     = 0;
 		$updated       = 0;
 		$page          = 1;
 		$per_page      = 25;
@@ -126,15 +128,32 @@ class WooCommerce_Subscriptions {
 					}
 					continue;
 				} else {
-					if ( self::$verbose ) {
-						WP_CLI::line( 'Updating subscription status to expired...' );
+					$retry_date       = $last_retry->get_date();
+					$on_hold_duration = On_Hold_Duration::get_on_hold_duration();
+					// If the retry date is within the on-hold duration, schedule a final retry.
+					if ( wcs_date_to_time( $retry_date ) + ( $on_hold_duration * DAY_IN_SECONDS ) > time() ) {
+						if ( self::$verbose ) {
+							WP_CLI::line( 'Retry date is within the on-hold duration. Scheduling final retry...' );
+						}
+						if ( self::$live ) {
+							// Retry rules can only be applied when payment attempt flag is set.
+							add_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
+							\WCS_Retry_Manager::maybe_apply_retry_rule( $subscription, $renewal_order );
+							remove_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
+						}
+						++$scheduled;
+					} else {
+						// Otherwise, if the retry date is past the on-hold duration, update the subscription status to expired.
+						if ( self::$verbose ) {
+							WP_CLI::line( 'Updating subscription status to expired...' );
+						}
+						if ( self::$live ) {
+							$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
+							$subscription->set_end_date( $retry_date );
+							$subscription->save();
+						}
+						++$updated;
 					}
-					if ( self::$live ) {
-						$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
-						$subscription->set_end_date( $last_retry->get_date() );
-						$subscription->save();
-					}
-					++$updated;
 				}
 				if ( self::$verbose ) {
 					WP_CLI::line( 'Finished processing subscription ' . $id );
@@ -143,7 +162,7 @@ class WooCommerce_Subscriptions {
 			}
 			$subscriptions = self::get_subscriptions( ++$page );
 		}
-		WP_CLI::success( 'Finished processing subscriptions. ' . $updated . ' subscriptions updated.' );
+		WP_CLI::success( 'Finished processing subscriptions. ' . $updated . ' subscriptions updated. ' . $scheduled . ' retries scheduled.' );
 		if ( ! self::$live ) {
 			WP_CLI::warning( 'Dry run. Use --live flag to process live subscriptions.' );
 		}

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -132,6 +132,13 @@ class WooCommerce_Subscriptions {
 					$on_hold_duration = On_Hold_Duration::get_on_hold_duration();
 					// If the retry date is within the on-hold duration, schedule a final retry.
 					if ( wcs_date_to_time( $retry_date ) + ( $on_hold_duration * DAY_IN_SECONDS ) > time() ) {
+						if ( $subscription->is_manual() || ! $subscription->payment_method_supports( 'subscription_date_changes' ) ) {
+							if ( self::$verbose ) {
+								WP_CLI::line( 'Subscription does not support retries. Moving to next subscription...' );
+								WP_CLI::line( '' );
+							}
+							continue;
+						}
 						if ( self::$verbose ) {
 							WP_CLI::line( 'Retry date is within the on-hold duration. Scheduling final retry...' );
 						}
@@ -140,6 +147,13 @@ class WooCommerce_Subscriptions {
 							add_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
 							\WCS_Retry_Manager::maybe_apply_retry_rule( $subscription, $renewal_order );
 							remove_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
+							if ( 0 === $subscription->get_date( 'payment_retry' ) ) {
+								if ( self::$verbose ) {
+									WP_CLI::error( 'Failed to schedule payment retry. Moving to next subscription...' );
+									WP_CLI::line( '' );
+								}
+								continue;
+							}
 						}
 						++$scheduled;
 					} else {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This updates the `wp newspack migrate-expired-subscription` command behavior to schedule a final retry when the last retry took place within the sites on-hold duration.

### How to test the changes in this Pull Request:

1. Make sure you DO NOT have the NEWSPACK_SUBSCRIPTIONS_EXPIRATION constant defined
2. If you don't already have any active subscriptions, as a reader purchase a handful of subscriptions
3. Follow the steps here to trigger scheduled retry for a handful of subscriptions: https://woocommerce.com/document/subscriptions/develop/failed-payment-retry/#section-7
4. Ensure you have at least two subscriptions that are on-hold and have gone through all possible retries
5. Define the NEWSPACK_SUBSCRIPTIONS_EXPIRATION constant: define( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION', true );
6. Now we want to set the last retry date for one of the subscriptions to sometime in the past that is greater than the sites on-hold duration (which defaults to 30 days). If you didn't have an old subscription to test on, you can manually do this via wp shell with the following:
```
$s=wcs_get_subscription(SUBSCRIPTION_ID);
$o=$s->get_last_order('all');
$retry=\WCS_Retry_Manager::store()->get_last_retry_for_order(wcs_get_objects_property($o, 'id'));
$retry->get_date_gmt(); // To get the date in gmt
$retry->update_date_gmt('2024-10-12 09:44:14'); // Replace date based on output from last step minus however many months to exceed on-hold duration
```
7. Via terminal, run the `wp newspack migrate-expired-subscriptions --verbose --ids=1,2` command. `ids` should be the two subscriptions from above.
8. Confirm the output shows 1 subscription has been updated, and the other subscription has a retry scheduled.
9. Now run the command again with the `--live` flag.
10. Confirm the subscriptions have been updated accordingly, one set to expired and a new `woocommerce_scheduled_subscription_payment_retry` scheduled action added for the other.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->