### PR TITLE
fix(wcs): remove subscriptions expiration feature flag

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -49,14 +49,10 @@ class WooCommerce_Subscriptions {
 	 * True if:
 	 * - WooCommerce Subscriptions is active and,
 	 * - Reader Activation is enabled and,
-	 * - The NEWSPACK_SUBSCRIPTIONS_EXPIRATION feature flag is defined and true.
 	 *
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		if ( ! defined( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION' ) || ! NEWSPACK_SUBSCRIPTIONS_EXPIRATION ) {
-			return false;
-		}
 		$is_enabled = self::is_active() && Reader_Activation::is_enabled();
 		/**
 		 * Filters whether subscriptions expiration is enabled.

--- a/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-meta.php
+++ b/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-meta.php
@@ -15,15 +15,6 @@ use Newspack\WooCommerce_Subscriptions;
  */
 class Newspack_Test_Subscriptions_Meta extends WP_UnitTestCase {
 	/**
-	 * Setup for the tests.
-	 */
-	public static function set_up_before_class() {
-		if ( ! defined( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION' ) ) {
-			define( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION', true );
-		}
-	}
-
-	/**
 	 * Test Subscriptions_Meta::maybe_record_cancelled_subscription_meta.
 	 */
 	public function test_maybe_record_cancelled_subscription_meta() {

--- a/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -15,15 +15,6 @@ use Newspack\Reader_Activation;
  */
 class Newspack_Test_WooCommerce_Subscriptions extends WP_UnitTestCase {
 	/**
-	 * Setup for the tests.
-	 */
-	public static function set_up_before_class() {
-		if ( ! defined( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION' ) ) {
-			define( 'NEWSPACK_SUBSCRIPTIONS_EXPIRATION', true );
-		}
-	}
-
-	/**
 	 * Test WooCommerce_Subscriptions::is_active.
 	 */
 	public function test_is_active() {
@@ -36,6 +27,6 @@ class Newspack_Test_WooCommerce_Subscriptions extends WP_UnitTestCase {
 	 */
 	public function test_is_enabled() {
 		$is_enabled = WooCommerce_Subscriptions::is_enabled();
-		$this->assertTrue( $is_enabled, 'WooCommerce Subscriptions integration should be enabled when Feature Flag is present.' );
+		$this->assertTrue( $is_enabled, 'WooCommerce Subscriptions integration should be enabled when RAS is enabled.' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This removes the `NEWSPACK_SUBSCRIPTIONS_EXPIRATION` feature flag!

### How to test the changes in this Pull Request:

1. Ensure the `NEWSPACK_SUBSCRIPTIONS_EXPIRATION` constant is not defined on your test site
2. Confirm [subscription expiration features](https://help.newspack.com/revenue/reader-revenue/subscriptions-payment-retries-and-expiration/) continue to work as expected

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->