### PR TITLE
fix: replace recaptcha alerts with generic errors

### DIFF
--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -96,6 +96,37 @@ function addHiddenField( form ) {
 }
 
 /**
+ * Append a generic error message above the given form.
+ *
+ * @param {HTMLElement} form    The form element.
+ * @param {string}      message The error message to display.
+ */
+function addErrorMessage( form, message ) {
+	const errorText = document.createElement( 'p' );
+	errorText.textContent = message;
+	const container = document.createElement( 'div' );
+	container.classList.add(
+		'newspack-ui__notice',
+		'newspack-ui__notice--error',
+		'newspack-recaptcha-error'
+	);
+	container.appendChild( errorText );
+	form.insertBefore( container, form.firstChild );
+}
+
+/**
+ * Remove generic error messages from form if present.
+ *
+ * @param {HTMLElement} form The form element.
+ */
+function removeErrorMessages( form ) {
+	const errors = form.querySelectorAll( '.newspack-recaptcha-error' );
+	for ( const error of errors ) {
+		error.parentElement.removeChild( error );
+	}
+}
+
+/**
  * Remove the hidden reCAPTCHA v3 token field from the given form.
  *
  * @param {HTMLElement} form The form element.
@@ -168,10 +199,19 @@ function renderWidget( form, onSuccess = null, onError = null ) {
 			refreshWidget( button );
 		};
 
+		const errorCallback = ( message ) => {
+			if ( onError ) {
+				onError( message );
+			} else {
+				addErrorMessage( form, message );
+			}
+		}
+
 		// Render reCAPTCHA widget. See https://developers.google.com/recaptcha/docs/invisible#js_api for API reference.
 		const widgetId = grecaptcha.render( button, {
 			...options,
-			callback: successCallback,
+			// callback: successCallback,
+			callback: () => errorCallback( 'Test recaptcha error message.' ),
 			'error-callback': () => {
 				const retryCount = parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) || 0;
 				if ( retryCount < 3 ) {
@@ -179,17 +219,12 @@ function renderWidget( form, onSuccess = null, onError = null ) {
 					refreshWidget( button );
 				} else {
 					clearInterval( refreshIntervalId );
+					button.disabled = true;
 				}
 				const message = retryCount < 3
 					? wp.i18n.__( 'There was an error connecting with reCAPTCHA. Please try submitting again.', 'newspack-plugin' )
 					: wp.i18n.__( 'There was an error connecting with reCAPTCHA. Please reload the page and try again.', 'newspack-plugin' );
-				if ( onError ) {
-					onError( message );
-				} else {
-					// Recaptcha's default error behavior is to alert with the above message.
-					// eslint-disable-next-line no-alert
-					alert( message );
-				}
+				errorCallback( message );
 			},
 			'expired-callback': () => {
 				refreshWidget( button );
@@ -202,6 +237,8 @@ function renderWidget( form, onSuccess = null, onError = null ) {
 		button.addEventListener( 'click', e => {
 			e.preventDefault();
 			e.stopImmediatePropagation();
+			// Empty error messages if present.
+			removeErrorMessages( form );
 			// Skip reCAPTCHA verification if the button has a data-skip-recaptcha attribute.
 			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
 				successCallback();

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -105,13 +105,15 @@ function addErrorMessage( form, message ) {
 	const errorText = document.createElement( 'p' );
 	errorText.textContent = message;
 	const container = document.createElement( 'div' );
-	container.classList.add(
-		'newspack-ui__notice',
-		'newspack-ui__notice--error',
-		'newspack-recaptcha-error'
-	);
+	container.classList.add( 'newspack-recaptcha-error' );
 	container.appendChild( errorText );
-	form.insertBefore( container, form.firstChild );
+	// Newsletters block errors render below the form.
+	if ( form.parentElement.classList.contains( 'newspack-newsletters-subscribe' ) ) {
+		form.append( container );
+	} else {
+		container.classList.add( 'newspack-ui__notice', 'newspack-ui__notice--error' );
+		form.insertBefore( container, form.firstChild );
+	}
 }
 
 /**

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -210,8 +210,7 @@ function renderWidget( form, onSuccess = null, onError = null ) {
 		// Render reCAPTCHA widget. See https://developers.google.com/recaptcha/docs/invisible#js_api for API reference.
 		const widgetId = grecaptcha.render( button, {
 			...options,
-			// callback: successCallback,
-			callback: () => errorCallback( 'Test recaptcha error message.' ),
+			callback: successCallback,
 			'error-callback': () => {
 				const retryCount = parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) || 0;
 				if ( retryCount < 3 ) {

--- a/src/other-scripts/recaptcha/style.scss
+++ b/src/other-scripts/recaptcha/style.scss
@@ -15,5 +15,7 @@
 }
 
 .newspack-recaptcha-error {
-	margin-top: 0 !important;
+	&.newspack-ui__notice--error {
+		margin-top: 0 !important;
+	}
 }

--- a/src/other-scripts/recaptcha/style.scss
+++ b/src/other-scripts/recaptcha/style.scss
@@ -13,3 +13,7 @@
 	inset: 0 !important; // Prevents an odd side-scroll issue in the registration modal & block.
 	visibility: hidden !important;
 }
+
+.newspack-recaptcha-error {
+	margin-top: 0 !important;
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208950357031079/f

This PR replaces the default recaptcha failure alert behavior with generic errors appended to the relevant forms.

Checkout modal (passes custom error handler when rendering recaptcha):
![Screenshot 2024-12-13 at 13 02 47](https://github.com/user-attachments/assets/697f929f-8a14-4375-b887-13ed3ce2d3fa)

Registration modal (uses 'default' recaptcha error):
  ![Screenshot 2024-12-13 at 13 05 41](https://github.com/user-attachments/assets/7a4aefc9-6162-4f70-8750-9364ea0ee348)

Newsletters subscribe block (uses 'default' recaptcha error):
![Screenshot 2024-12-13 at 13 06 29](https://github.com/user-attachments/assets/e49434ae-025a-4b98-9e37-4a2afef73a32)

Registration block (uses 'default' recaptcha error):
![Screenshot 2024-12-13 at 13 07 47](https://github.com/user-attachments/assets/da3fc983-cb0c-4689-b4ea-b8c1049b5364)

### How to test the changes in this Pull Request:

Checkout the following Newsletters PR before testing: https://github.com/Automattic/newspack-newsletters/pull/1724

- Setup recaptcha v2, RAS, and the various blocks necessary to test the above forms
- Change [the following line](https://github.com/Automattic/newspack-plugin/blob/4ec967525117f0775b9cef259f7905fda4dd7957/src/other-scripts/recaptcha/index.js#L194) to: `callback: () => errorCallback( 'There was an error with reCAPTCHA. Please try again.' ),`. This will trigger an error even when recaptcha is successful for testing purposes.
- Submit each of above forms as reader, and verify the recaptcha errors look fine.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->