### PR TITLE
fix: dont load textdomain too early

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -40,6 +40,7 @@ final class Newspack {
 	public function __construct() {
 		$this->define_constants();
 		$this->includes();
+		add_action( 'init', [ __CLASS__, 'load_textdomain' ] );
 		add_action( 'admin_init', [ $this, 'admin_redirects' ] );
 		add_action( 'current_screen', [ $this, 'restrict_user_access' ] );
 		add_action( 'current_screen', [ $this, 'wizard_redirect' ] );
@@ -50,6 +51,13 @@ final class Newspack {
 		add_action( 'all_admin_notices', [ $this, 'remove_notifications' ], -9999 );
 		register_activation_hook( NEWSPACK_PLUGIN_FILE, [ $this, 'activation_hook' ] );
 		register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ $this, 'deactivation_hook' ] );
+	}
+
+	/**
+	 * Set text domain.
+	 */
+	public static function load_textdomain() {
+		load_plugin_textdomain( 'newspack-plugin', false, NEWSPACK_PLUGIN_BASEDIR . '/languages' );
 	}
 
 	/**

--- a/newspack.php
+++ b/newspack.php
@@ -16,12 +16,14 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'NEWSPACK_PLUGIN_VERSION', '5.9.1' );
 
-// Load language files.
-load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-
 // Define NEWSPACK_PLUGIN_FILE.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {
 	define( 'NEWSPACK_PLUGIN_FILE', __FILE__ );
+}
+
+// Define NEWSPACK_PLUGIN_BASEDIR.
+if ( ! defined( 'NEWSPACK_PLUGIN_BASEDIR' ) ) {
+	define( 'NEWSPACK_PLUGIN_BASEDIR', plugin_dir_path( __FILE__ ) );
 }
 
 require_once 'vendor/autoload.php';

--- a/newspack.php
+++ b/newspack.php
@@ -23,7 +23,7 @@ if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {
 
 // Define NEWSPACK_PLUGIN_BASEDIR.
 if ( ! defined( 'NEWSPACK_PLUGIN_BASEDIR' ) ) {
-	define( 'NEWSPACK_PLUGIN_BASEDIR', plugin_dir_path( __FILE__ ) );
+	define( 'NEWSPACK_PLUGIN_BASEDIR', dirname( plugin_basename( NEWSPACK_PLUGIN_FILE ) ) );
 }
 
 require_once 'vendor/autoload.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes early call to load_plugin_textdomain

### How to test the changes in this Pull Request:

1. Smoke test
2. Test if translations are loaded

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->