### PR TITLE
fix: hide duplicate notices if all was dismissed

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-duplicate-orders.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-duplicate-orders.php
@@ -150,6 +150,17 @@ class WooCommerce_Duplicate_Orders {
 			return;
 		}
 		$dismissed_duplicates = get_option( self::DISMISSED_DUPLICATES_OPTION_NAME, [] );
+
+		$orders_to_display = array_filter(
+			$existing_order_duplicates,
+			function( $order_duplicates ) use ( $dismissed_duplicates ) {
+				return ! in_array( $order_duplicates['ids'], $dismissed_duplicates );
+			}
+		);
+
+		if ( empty( $orders_to_display ) ) {
+			return;
+		}
 		?>
 		<div class="notice notice-info is-dismissible">
 			<!-- Admin notice added by newspack-plugin -->
@@ -158,11 +169,7 @@ class WooCommerce_Duplicate_Orders {
 					<?php echo esc_html__( 'There are some potentially duplicate transactions to review. Some of these might be intentional. Click this message to display the list of possible duplicates.', 'newspack-plugin' ); ?>
 				</summary>
 				<ul>
-					<?php foreach ( $existing_order_duplicates as $order_duplicates ) : ?>
-						<?php
-						if ( in_array( $order_duplicates['ids'], $dismissed_duplicates ) ) {
-							continue;}
-						?>
+					<?php foreach ( $orders_to_display as $order_duplicates ) : ?>
 						<li style="display: flex; align-items: center;">
 							<p style="margin: 0;">
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Make two purchases of the same product, price with the same user withing 10 minutes
2. trigger the cron `wp cron event run newspack_wc_check_order_duplicates`
3. Confirm you see the duplicate orders Notice in the admin panel
4. Dismiss the order
5. Confirm the notice is completely gone


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->