### PR TITLE
fix(recaptcha): various optimizations

### DIFF
--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -188,7 +188,8 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
 				successCallback();
 			} else {
-				grecaptcha.execute( widgetId );
+				// For some reason, WooCommerce checkout forms don't properly pin the widget in a fixed location, so we need to scroll to the top of the page to ensure it's visible.
+				grecaptcha.execute( widgetId ).then( () => document.documentElement.scrollIntoView( { behavior: 'smooth' } ) );
 			}
 		} );
 	} );

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -247,14 +247,22 @@ function render( forms = [], onSuccess = null, onError = null ) {
 	formsToHandle.forEach( form => {
 		if ( ! form.hasAttribute( 'data-recaptcha-rendered' ) ) {
 			form.addEventListener( 'focusin', () => {
-				if ( isV3 ) {
-					addHiddenV3Field( form );
-				}
 				if ( isV2 ) {
 					renderV2Widget( form, onSuccess, onError );
 				}
+				if ( isV3 ) {
+					addHiddenV3Field( form );
+				}
 			} );
 			form.setAttribute( 'data-recaptcha-rendered', 'true' );
+		} else {
+			// Call render methods to trigger refresh.
+			if ( isV2 ) {
+				renderV2Widget( form, onSuccess, onError );
+			}
+			if ( isV3 ) {
+				addHiddenV3Field( form );
+			}
 		}
 	} );
 }

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -269,16 +269,20 @@ function render( forms = [], onSuccess = null, onError = null ) {
 		: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
 
 	formsToHandle.forEach( form => {
-		if ( form.hasAttribute( 'data-recaptcha-rendered' ) ) {
-			return;
-		}
-		if ( isV3 ) {
-			addHiddenField( form );
-		}
-		if ( isV2 ) {
-			renderWidget( form, onSuccess, onError );
-		}
-		form.setAttribute( 'data-recaptcha-rendered', 'true' );
+		form.addEventListener( 'submit', e => {
+			e.preventDefault();
+			e.stopImmediatePropagation();
+			if ( ! form.hasAttribute( 'data-recaptcha-rendered' ) ) {
+				if ( isV3 ) {
+					addHiddenField( form );
+				}
+				if ( isV2 ) {
+					renderWidget( form, onSuccess, onError );
+				}
+				form.setAttribute( 'data-recaptcha-rendered', 'true' );
+			}
+			e.submitter.click();
+		} );
 	} );
 }
 

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -172,35 +172,20 @@ function renderWidget( form, onSuccess = null, onError = null ) {
 	};
 
 	submitButtons.forEach( button => {
-		// Don't render widget if the button has a data-skip-recaptcha attribute.
-		if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
-			return;
-		}
-
-		// Don't render widget if the button has been retried 3 times.
-		if ( button.hasAttribute( 'data-recaptcha-retry-count' ) && parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) >= 3 ) {
-			return;
-		}
-
 		// Refresh widget if it already exists.
 		if ( button.hasAttribute( 'data-recaptcha-widget-id' ) ) {
 			refreshWidget( button );
 			return;
 		}
 
-		// Don't render widget if the button is currently rendering recaptcha.
-		if ( button.hasAttribute( 'data-recaptcha-processing' ) ) {
-			return;
-		}
-		button.setAttribute( 'data-recaptcha-processing', 'true' );
-
-		// Callback when reCAPTCHA passes validation.
+		// Callback when reCAPTCHA passes validation or skip flag is present.
 		const successCallback = () => {
 			onSuccess?.()
 			form.requestSubmit( button );
 			refreshWidget( button );
 		};
 
+		// Callback when reCAPTCHA rendering fails or expires.
 		const errorCallback = () => {
 			const retryCount = parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) || 0;
 			if ( retryCount < 3 ) {
@@ -208,7 +193,6 @@ function renderWidget( form, onSuccess = null, onError = null ) {
 				grecaptcha.execute( button.getAttribute( 'data-recaptcha-widget-id' ) );
 				button.setAttribute( 'data-recaptcha-retry-count', retryCount + 1 );
 			} else {
-				clearInterval( refreshIntervalId );
 				button.removeAttribute( 'data-recaptcha-retry-count' );
 				const message = wp.i18n.__( 'There was an error connecting with reCAPTCHA. Please reload the page and try again.', 'newspack-plugin' );
 				if ( onError ) {
@@ -221,17 +205,6 @@ function renderWidget( form, onSuccess = null, onError = null ) {
 			}
 		}
 
-		// Render reCAPTCHA widget. See https://developers.google.com/recaptcha/docs/invisible#js_api for API reference.
-		const widgetId = grecaptcha.render( button, {
-			...options,
-			callback: successCallback,
-			'error-callback': errorCallback,
-			'expired-callback': errorCallback,
-		} );
-
-		button.setAttribute( 'data-recaptcha-widget-id', widgetId );
-		const refreshIntervalId = setInterval( () => refreshWidget( button ), 120000 ); // Refresh widget every 2 minutes.
-
 		button.addEventListener( 'click', e => {
 			e.preventDefault();
 			e.stopImmediatePropagation();
@@ -241,10 +214,20 @@ function renderWidget( form, onSuccess = null, onError = null ) {
 			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
 				successCallback();
 			} else {
+				let widgetId = button.getAttribute( 'data-recaptcha-widget-id' );
+				if ( ! widgetId ) {
+					// Render reCAPTCHA widget. See https://developers.google.com/recaptcha/docs/invisible#js_api for API reference.
+					widgetId = grecaptcha.render( button, {
+						...options,
+						callback: successCallback,
+						'error-callback': errorCallback,
+						'expired-callback': errorCallback,
+					} );
+					button.setAttribute( 'data-recaptcha-widget-id', widgetId );
+				}
 				grecaptcha.execute( widgetId );
 			}
 		} );
-		button.removeAttribute( 'data-recaptcha-processing' );
 	} );
 }
 
@@ -266,20 +249,15 @@ function render( forms = [], onSuccess = null, onError = null ) {
 		: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
 
 	formsToHandle.forEach( form => {
-		form.addEventListener( 'submit', e => {
-			if ( ! form.hasAttribute( 'data-recaptcha-rendered' ) ) {
-				e.preventDefault();
-				e.stopImmediatePropagation();
-				if ( isV3 ) {
-					addHiddenField( form );
-				}
-				if ( isV2 ) {
-					renderWidget( form, onSuccess, onError );
-				}
-				form.setAttribute( 'data-recaptcha-rendered', 'true' );
+		if ( ! form.hasAttribute( 'data-recaptcha-rendered' ) ) {
+			if ( isV3 ) {
+				addHiddenField( form );
 			}
-			e.submitter.click();
-		} );
+			if ( isV2 ) {
+				renderWidget( form, onSuccess, onError );
+			}
+			form.setAttribute( 'data-recaptcha-rendered', 'true' );
+		}
 	} );
 }
 

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -201,11 +201,23 @@ function renderWidget( form, onSuccess = null, onError = null ) {
 			refreshWidget( button );
 		};
 
-		const errorCallback = ( message ) => {
-			if ( onError ) {
-				onError( message );
+		const errorCallback = () => {
+			const retryCount = parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) || 0;
+			if ( retryCount < 3 ) {
+				refreshWidget( button );
+				grecaptcha.execute( button.getAttribute( 'data-recaptcha-widget-id' ) );
+				button.setAttribute( 'data-recaptcha-retry-count', retryCount + 1 );
 			} else {
-				addErrorMessage( form, message );
+				clearInterval( refreshIntervalId );
+				button.removeAttribute( 'data-recaptcha-retry-count' );
+				const message = wp.i18n.__( 'There was an error connecting with reCAPTCHA. Please reload the page and try again.', 'newspack-plugin' );
+				if ( onError ) {
+					onError( message );
+				} else {
+					// Recaptcha's default error behavior is to alert with the above message.
+					// eslint-disable-next-line no-alert
+					addErrorMessage( form, message );
+				}
 			}
 		}
 
@@ -213,23 +225,8 @@ function renderWidget( form, onSuccess = null, onError = null ) {
 		const widgetId = grecaptcha.render( button, {
 			...options,
 			callback: successCallback,
-			'error-callback': () => {
-				const retryCount = parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) || 0;
-				if ( retryCount < 3 ) {
-					button.setAttribute( 'data-recaptcha-retry-count', retryCount + 1 );
-					refreshWidget( button );
-				} else {
-					clearInterval( refreshIntervalId );
-					button.disabled = true;
-				}
-				const message = retryCount < 3
-					? wp.i18n.__( 'There was an error connecting with reCAPTCHA. Please try submitting again.', 'newspack-plugin' )
-					: wp.i18n.__( 'There was an error connecting with reCAPTCHA. Please reload the page and try again.', 'newspack-plugin' );
-				errorCallback( message );
-			},
-			'expired-callback': () => {
-				refreshWidget( button );
-			},
+			'error-callback': errorCallback,
+			'expired-callback': errorCallback,
 		} );
 
 		button.setAttribute( 'data-recaptcha-widget-id', widgetId );
@@ -270,9 +267,9 @@ function render( forms = [], onSuccess = null, onError = null ) {
 
 	formsToHandle.forEach( form => {
 		form.addEventListener( 'submit', e => {
-			e.preventDefault();
-			e.stopImmediatePropagation();
 			if ( ! form.hasAttribute( 'data-recaptcha-rendered' ) ) {
+				e.preventDefault();
+				e.stopImmediatePropagation();
 				if ( isV3 ) {
 					addHiddenField( form );
 				}

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -85,13 +85,10 @@ function addHiddenV3Field( form ) {
 		setInterval( () => refreshV3Token( field, action ), 30000 ); // Refresh token every 30 seconds.
 
 		// Refresh reCAPTCHAs on Woo checkout update and error.
-		( function ( $ ) {
-			if ( ! $ ) {
-				return;
-			}
-			$( document ).on( 'updated_checkout', () => refreshV3Token( field, action ) );
-			$( document.body ).on( 'checkout_error', () => refreshV3Token( field, action ) );
-		} )( jQuery );
+		if ( jQuery ) {
+			jQuery( document ).on( 'updated_checkout', () => refreshV3Token( field, action ) );
+			jQuery( document.body ).on( 'checkout_error', () => refreshV3Token( field, action ) );
+		}
 	}
 }
 
@@ -179,6 +176,13 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 			'expired-callback': errorCallback,
 		} );
 		button.setAttribute( 'data-recaptcha-widget-id', widgetId );
+
+		// Refresh reCAPTCHA widgets on Woo checkout update and error.
+		if ( jQuery ) {
+			jQuery( document ).on( 'updated_checkout', () => renderV2Widget( form, onSuccess, onError ) );
+			jQuery( document.body ).on( 'checkout_error', () => renderV2Widget( form, onSuccess, onError ) );
+		}
+
 		button.addEventListener( 'click', e => {
 			e.preventDefault();
 			e.stopImmediatePropagation();

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -188,8 +188,12 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
 				successCallback();
 			} else {
-				// For some reason, WooCommerce checkout forms don't properly pin the widget in a fixed location, so we need to scroll to the top of the page to ensure it's visible.
-				grecaptcha.execute( widgetId ).then( () => document.documentElement.scrollIntoView( { behavior: 'smooth' } ) );
+				grecaptcha.execute( widgetId ).then( () => {
+					// If we are in an iframe scroll to top.
+					if ( window?.location !== window?.parent?.location ) {
+						document.body.scrollIntoView( { behavior: 'smooth' } );
+					}
+				} );
 			}
 		} );
 	} );

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -25,7 +25,7 @@ function domReady( callback ) {
 }
 
 window.newspack_grecaptcha = window.newspack_grecaptcha || {
-	destroy,
+	destroy: destroyV3Field,
 	render,
 	version: newspack_recaptcha_data.version,
 };
@@ -38,14 +38,14 @@ const isInvisible = 'v2_invisible' === newspack_recaptcha_data.version;
 /**
  * Destroy hidden reCAPTCHA v3 token fields to avoid unnecessary reCAPTCHA checks.
  */
-function destroy( forms = [] ) {
+function destroyV3Field( forms = [] ) {
 	if ( isV3 ) {
 		const formsToHandle = forms.length
 			? forms
 			: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
 
 		formsToHandle.forEach( form => {
-			removeHiddenField( form );
+			removeHiddenV3Field( form );
 		} );
 	}
 }
@@ -58,7 +58,7 @@ function destroy( forms = [] ) {
  *
  * @return {Promise<void>|void} A promise that resolves when the token is refreshed.
  */
-function refresh( field, action = 'submit' ) {
+function refreshV3Token( field, action = 'submit' ) {
 	if ( field ) {
 		// Get a token to pass to the server. See https://developers.google.com/recaptcha/docs/v3 for API reference.
 		return grecaptcha.execute( siteKey, { action } ).then( token => {
@@ -72,7 +72,7 @@ function refresh( field, action = 'submit' ) {
  *
  * @param {HTMLElement} form The form element.
  */
-function addHiddenField( form ) {
+function addHiddenV3Field( form ) {
 	let field = form.querySelector( 'input[name="g-recaptcha-response"]' );
 	if ( ! field ) {
 		field = document.createElement( 'input' );
@@ -81,18 +81,114 @@ function addHiddenField( form ) {
 		form.appendChild( field );
 
 		const action = form.getAttribute( 'data-newspack-recaptcha' ) || 'submit';
-		refresh( field, action );
-		setInterval( () => refresh( field, action ), 30000 ); // Refresh token every 30 seconds.
+		refreshV3Token( field, action );
+		setInterval( () => refreshV3Token( field, action ), 30000 ); // Refresh token every 30 seconds.
 
 		// Refresh reCAPTCHAs on Woo checkout update and error.
 		( function ( $ ) {
 			if ( ! $ ) {
 				return;
 			}
-			$( document ).on( 'updated_checkout', () => refresh( field, action ) );
-			$( document.body ).on( 'checkout_error', () => refresh( field, action ) );
+			$( document ).on( 'updated_checkout', () => refreshV3Token( field, action ) );
+			$( document.body ).on( 'checkout_error', () => refreshV3Token( field, action ) );
 		} )( jQuery );
 	}
+}
+
+/**
+ * Remove the hidden reCAPTCHA v3 token field from the given form.
+ *
+ * @param {HTMLElement} form The form element.
+ */
+function removeHiddenV3Field( form ) {
+	const field = form.querySelector( 'input[name="g-recaptcha-response"]' );
+	if ( field ) {
+		field.parentElement.removeChild( field );
+	}
+}
+
+/**
+ * Refresh the reCAPTCHA v2 widget attached to the given element.
+ *
+ * @param {HTMLElement} el Element with the reCAPTCHA widget to refresh.
+ */
+function refreshV2Widget( el ) {
+	const widgetId = parseInt( el.getAttribute( 'data-recaptcha-widget-id' ) );
+	if ( ! isNaN( widgetId ) ) {
+		grecaptcha.reset( widgetId );
+	}
+}
+
+/**
+ * Render reCAPTCHA v2 widget on the given form.
+ *
+ * @param {HTMLElement}   form      The form element.
+ * @param {Function|null} onSuccess Callback to handle success. Optional.
+ * @param {Function|null} onError   Callback to handle errors. Optional.
+ */
+function renderV2Widget( form, onSuccess = null, onError = null ) {
+	// Common render options for reCAPTCHA v2 widget. See https://developers.google.com/recaptcha/docs/invisible#render_param for supported params.
+	const options = {
+		sitekey: siteKey,
+		size: isInvisible ? 'invisible' : 'normal',
+		isolated: true,
+	};
+
+	const submitButtons = [
+		...form.querySelectorAll( 'input[type="submit"], button[type="submit"]' )
+	];
+	submitButtons.forEach( button => {
+			// Don't render widget if the button has a data-skip-recaptcha attribute.
+			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
+				return;
+			}
+			// Refresh widget if it already exists.
+			if ( button.hasAttribute( 'data-recaptcha-widget-id' ) ) {
+				refreshV2Widget( button );
+				return;
+			}
+			// Callback when reCAPTCHA passes validation or skip flag is present.
+			const successCallback = () => {
+				onSuccess?.()
+				form.requestSubmit( button );
+				refreshV2Widget( button );
+			};
+			// Callback when reCAPTCHA rendering fails or expires.
+			const errorCallback = () => {
+				const retryCount = parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) || 0;
+				if ( retryCount < 3 ) {
+					refreshV2Widget( button );
+					grecaptcha.execute( button.getAttribute( 'data-recaptcha-widget-id' ) );
+					button.setAttribute( 'data-recaptcha-retry-count', retryCount + 1 );
+				} else {
+					const message = wp.i18n.__( 'There was an error connecting with reCAPTCHA. Please reload the page and try again.', 'newspack-plugin' );
+					if ( onError ) {
+						onError( message );
+					} else {
+						addErrorMessage( form, message );
+					}
+				}
+			}
+			const widgetId = grecaptcha.render( button, {
+				...options,
+				callback: successCallback,
+				'error-callback': errorCallback,
+				'expired-callback': errorCallback,
+			} );
+			button.setAttribute( 'data-recaptcha-widget-id', widgetId );
+			button.addEventListener( 'click', e => {
+				e.preventDefault();
+				e.stopImmediatePropagation();
+				// Empty error messages if present.
+				removeErrorMessages( form );
+				// Skip reCAPTCHA verification if the button has a data-skip-recaptcha attribute.
+				if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
+					successCallback();
+				} else {
+					grecaptcha.execute( widgetId );
+				}
+			} );
+		} );
 }
 
 /**
@@ -129,109 +225,6 @@ function removeErrorMessages( form ) {
 }
 
 /**
- * Remove the hidden reCAPTCHA v3 token field from the given form.
- *
- * @param {HTMLElement} form The form element.
- */
-function removeHiddenField( form ) {
-	const field = form.querySelector( 'input[name="g-recaptcha-response"]' );
-	if ( field ) {
-		field.parentElement.removeChild( field );
-	}
-}
-
-/**
- * Refresh the reCAPTCHA v2 widget attached to the given element.
- *
- * @param {HTMLElement} el Element with the reCAPTCHA widget to refresh.
- */
-function refreshWidget( el ) {
-	const widgetId = parseInt( el.getAttribute( 'data-recaptcha-widget-id' ) );
-	if ( ! isNaN( widgetId ) ) {
-		grecaptcha.reset( widgetId );
-	}
-}
-
-/**
- * Render reCAPTCHA v2 widget on the given form.
- *
- * @param {HTMLElement}   form      The form element.
- * @param {Function|null} onSuccess Callback to handle success. Optional.
- * @param {Function|null} onError   Callback to handle errors. Optional.
- */
-function renderWidget( form, onSuccess = null, onError = null ) {
-	const submitButtons = [
-		...form.querySelectorAll( 'input[type="submit"], button[type="submit"]' ),
-	];
-
-	// Common render options for reCAPTCHA v2 widget. See https://developers.google.com/recaptcha/docs/invisible#render_param for supported params.
-	const options = {
-		sitekey: siteKey,
-		size: isInvisible ? 'invisible' : 'normal',
-		isolated: true,
-	};
-
-	submitButtons.forEach( button => {
-		// Refresh widget if it already exists.
-		if ( button.hasAttribute( 'data-recaptcha-widget-id' ) ) {
-			refreshWidget( button );
-			return;
-		}
-
-		// Callback when reCAPTCHA passes validation or skip flag is present.
-		const successCallback = () => {
-			onSuccess?.()
-			form.requestSubmit( button );
-			refreshWidget( button );
-		};
-
-		// Callback when reCAPTCHA rendering fails or expires.
-		const errorCallback = () => {
-			const retryCount = parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) || 0;
-			if ( retryCount < 3 ) {
-				refreshWidget( button );
-				grecaptcha.execute( button.getAttribute( 'data-recaptcha-widget-id' ) );
-				button.setAttribute( 'data-recaptcha-retry-count', retryCount + 1 );
-			} else {
-				button.removeAttribute( 'data-recaptcha-retry-count' );
-				const message = wp.i18n.__( 'There was an error connecting with reCAPTCHA. Please reload the page and try again.', 'newspack-plugin' );
-				if ( onError ) {
-					onError( message );
-				} else {
-					// Recaptcha's default error behavior is to alert with the above message.
-					// eslint-disable-next-line no-alert
-					addErrorMessage( form, message );
-				}
-			}
-		}
-
-		button.addEventListener( 'click', e => {
-			e.preventDefault();
-			e.stopImmediatePropagation();
-			// Empty error messages if present.
-			removeErrorMessages( form );
-			// Skip reCAPTCHA verification if the button has a data-skip-recaptcha attribute.
-			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
-				successCallback();
-			} else {
-				let widgetId = button.getAttribute( 'data-recaptcha-widget-id' );
-				if ( ! widgetId ) {
-					// Render reCAPTCHA widget. See https://developers.google.com/recaptcha/docs/invisible#js_api for API reference.
-					widgetId = grecaptcha.render( button, {
-						...options,
-						callback: successCallback,
-						'error-callback': errorCallback,
-						'expired-callback': errorCallback,
-					} );
-					button.setAttribute( 'data-recaptcha-widget-id', widgetId );
-				}
-				grecaptcha.execute( widgetId );
-			}
-		} );
-	} );
-}
-
-/**
  * Render reCAPTCHA elements.
  *
  * @param {Array}         forms     Array of form elements to render reCAPTCHA on.
@@ -250,12 +243,14 @@ function render( forms = [], onSuccess = null, onError = null ) {
 
 	formsToHandle.forEach( form => {
 		if ( ! form.hasAttribute( 'data-recaptcha-rendered' ) ) {
-			if ( isV3 ) {
-				addHiddenField( form );
-			}
-			if ( isV2 ) {
-				renderWidget( form, onSuccess, onError );
-			}
+			form.addEventListener( 'focusin', () => {
+				if ( isV3 ) {
+					addHiddenV3Field( form );
+				}
+				if ( isV2 ) {
+					renderV2Widget( form, onSuccess, onError );
+				}
+			} );
 			form.setAttribute( 'data-recaptcha-rendered', 'true' );
 		}
 	} );

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -138,57 +138,60 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 		...form.querySelectorAll( 'input[type="submit"], button[type="submit"]' )
 	];
 	submitButtons.forEach( button => {
-			// Don't render widget if the button has a data-skip-recaptcha attribute.
-			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
-				return;
-			}
-			// Refresh widget if it already exists.
-			if ( button.hasAttribute( 'data-recaptcha-widget-id' ) ) {
+		// Don't render widget if the button has a data-skip-recaptcha attribute.
+		if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
+			return;
+		}
+		// Refresh widget if it already exists.
+		if ( button.hasAttribute( 'data-recaptcha-widget-id' ) ) {
+			refreshV2Widget( button );
+			return;
+		}
+		// Callback when reCAPTCHA passes validation or skip flag is present.
+		const successCallback = () => {
+			onSuccess?.()
+			form.requestSubmit( button );
+			refreshV2Widget( button );
+		};
+		// Callback when reCAPTCHA rendering fails or expires.
+		const errorCallback = () => {
+			const retryCount = parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) || 0;
+			if ( retryCount < 3 ) {
 				refreshV2Widget( button );
-				return;
-			}
-			// Callback when reCAPTCHA passes validation or skip flag is present.
-			const successCallback = () => {
-				onSuccess?.()
-				form.requestSubmit( button );
-				refreshV2Widget( button );
-			};
-			// Callback when reCAPTCHA rendering fails or expires.
-			const errorCallback = () => {
-				const retryCount = parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) || 0;
-				if ( retryCount < 3 ) {
-					refreshV2Widget( button );
-					grecaptcha.execute( button.getAttribute( 'data-recaptcha-widget-id' ) );
-					button.setAttribute( 'data-recaptcha-retry-count', retryCount + 1 );
+				grecaptcha.execute( button.getAttribute( 'data-recaptcha-widget-id' ) );
+				button.setAttribute( 'data-recaptcha-retry-count', retryCount + 1 );
+			} else {
+				const message = wp.i18n.__( 'There was an error connecting with reCAPTCHA. Please reload the page and try again.', 'newspack-plugin' );
+				if ( onError ) {
+					onError( message );
 				} else {
-					const message = wp.i18n.__( 'There was an error connecting with reCAPTCHA. Please reload the page and try again.', 'newspack-plugin' );
-					if ( onError ) {
-						onError( message );
-					} else {
-						addErrorMessage( form, message );
-					}
+					addErrorMessage( form, message );
 				}
 			}
-			const widgetId = grecaptcha.render( button, {
-				...options,
-				callback: successCallback,
-				'error-callback': errorCallback,
-				'expired-callback': errorCallback,
-			} );
-			button.setAttribute( 'data-recaptcha-widget-id', widgetId );
-			button.addEventListener( 'click', e => {
-				e.preventDefault();
-				e.stopImmediatePropagation();
-				// Empty error messages if present.
-				removeErrorMessages( form );
-				// Skip reCAPTCHA verification if the button has a data-skip-recaptcha attribute.
-				if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
-					successCallback();
-				} else {
-					grecaptcha.execute( widgetId );
-				}
-			} );
+		}
+		const container = document.createElement( 'div' );
+		container.classList.add( 'grecaptcha-container' );
+		button.parentElement.append( container );
+		const widgetId = grecaptcha.render( container, {
+			...options,
+			callback: successCallback,
+			'error-callback': errorCallback,
+			'expired-callback': errorCallback,
 		} );
+		button.setAttribute( 'data-recaptcha-widget-id', widgetId );
+		button.addEventListener( 'click', e => {
+			e.preventDefault();
+			e.stopImmediatePropagation();
+			// Empty error messages if present.
+			removeErrorMessages( form );
+			// Skip reCAPTCHA verification if the button has a data-skip-recaptcha attribute.
+			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
+				successCallback();
+			} else {
+				grecaptcha.execute( widgetId );
+			}
+		} );
+	} );
 }
 
 /**

--- a/src/other-scripts/recaptcha/style.scss
+++ b/src/other-scripts/recaptcha/style.scss
@@ -13,3 +13,9 @@
 	inset: 0 !important; // Prevents an odd side-scroll issue in the registration modal & block.
 	visibility: hidden !important;
 }
+
+.newspack-recaptcha-error {
+	&.newspack-ui__notice--error {
+		margin-top: 0 !important;
+	}
+}

--- a/src/other-scripts/recaptcha/style.scss
+++ b/src/other-scripts/recaptcha/style.scss
@@ -9,8 +9,12 @@
 }
 
 // Hide reCAPTCHA badge
+.grecaptcha-container,
 .grecaptcha-badge {
 	inset: 0 !important; // Prevents an odd side-scroll issue in the registration modal & block.
+	width: 0 !important;
+	height: 0 !important;
+	display: none !important;
 	visibility: hidden !important;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208950357031079/f

This PR makes some optimizations to our recaptcha implementation:

1. Only render recaptcha once a form is focused
2. Auto retry on recaptcha error/expire
3. Specify recaptcha container so we don't break form layouts

![Screenshot 2024-12-16 at 14 26 17](https://github.com/user-attachments/assets/71ca63a6-d151-4018-9949-13ec02a07ccb)

### How to test the changes in this Pull Request:

1. Enable recaptcha v2
2. As reader open any page/post that contains a newsletters subscribe block but do not focus the form yet.
4. In browser dev tools, search for an element with a `data-recaptcha-widget-id` attribute. There should be none
5. Now click anywhere in the form
6. In dev tools again, search for an element with a `data-recaptcha-widget-id` attribute. The button in the focused form should have this.
7. Now smoke test all of the following, each time making sure the layout of the forms don't change as you focus:
    - [x] Checkout Button or Donate block
    - [x] Newsletters subscribe block
    - [x] Registration block
    - [x] RAS-ACC auth registration modal
8. Enable recaptcha v3
9. Repeat steps 2-6, this time searching for a hidden input with a name of `g-recaptcha-response`.
10. Now smoke test all of the following:
    - [x] Checkout Button or Donate block
    - [x] Newsletters subscribe block
    - [x] Registration block
    - [x] RAS-ACC auth registration modal
11. Disable recaptcha and smoke test the following
    - [x] Checkout Button or Donate block
    - [x] Newsletters subscribe block
    - [x] Registration block
    - [x] RAS-ACC auth registration modal

**Testing recaptcha errors:**
To test auto-retry on recaptcha error, you can force the error callback by replacing this line with `callback: errorCallback`: https://github.com/Automattic/newspack-plugin/blob/ba6f10f15127d5c016d7557da6684270749f385c/src/other-scripts/recaptcha/index.js#L177

1. Re-enable recaptcha v2
2. As reader, go through any relevant form
3. After recaptcha is triggered, instead of succeeding the error callback should be triggered, re-prompting the widget (in normal circumstances a render failure would not trigger the widget to appear)
4. This should happen 3 times before an error is rendered asking for a page reload.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->