### PR TITLE
fix(mc): handle standard merge fields when fixing duplicates

### DIFF
--- a/includes/cli/class-mailchimp.php
+++ b/includes/cli/class-mailchimp.php
@@ -62,7 +62,7 @@ class Mailchimp {
 
 		$result = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" );
 		if ( is_wp_error( $result ) || empty( $result['merge_fields'] || ! is_array( $result['merge_fields'] ) ) ) {
-			\WP_CLI::error( __( 'Could not connect to Mailchimp API. Is the site connected to Mailchimp?', 'newspack-subscription-migrations' ) );
+			\WP_CLI::error( __( 'Could not connect to Mailchimp API. Is the site connected to Mailchimp?', 'newspack-plugin' ) );
 		}
 		$fields = $result['merge_fields'];
 
@@ -123,7 +123,7 @@ class Mailchimp {
 		$prefix           = $assoc_args['prefix'] ?? '';
 
 		if ( empty( $fields_to_delete ) ) {
-			\WP_CLI::error( __( 'Please specify at least one field to delete.', 'newspack-subscription-migrations' ) );
+			\WP_CLI::error( __( 'Please specify at least one field to delete.', 'newspack-plugin' ) );
 		}
 
 		$all_fields       = Metadata::get_all_fields();
@@ -149,7 +149,7 @@ class Mailchimp {
 
 		$result = Mailchimp_API::get( "lists/$audience_id/merge-fields?count=1000" );
 		if ( is_wp_error( $result ) || empty( $result['merge_fields'] || ! is_array( $result['merge_fields'] ) ) ) {
-			\WP_CLI::error( __( 'Could not connect to Mailchimp API. Is the site connected to Mailchimp?', 'newspack-subscription-migrations' ) );
+			\WP_CLI::error( __( 'Could not connect to Mailchimp API. Is the site connected to Mailchimp?', 'newspack-plugin' ) );
 		}
 		$fields = $result['merge_fields'];
 
@@ -450,8 +450,7 @@ class Mailchimp {
 	 * @return array
 	 */
 	private static function get_fields_to_check_for_duplicates() {
-		$all_fields = Metadata::get_all_fields();
-		$fields     = array_map(
+		$fields = array_map(
 			function( $key ) {
 				return Metadata::get_key( $key );
 			},
@@ -462,6 +461,13 @@ class Mailchimp {
 		$fields = array_merge(
 			$fields,
 			[
+				// Standard Mailchimp merge fields.
+				'First Name',
+				'Last Name',
+				'Phone',
+				'Address',
+
+				// Other Newspack-specific fields.
 				'origin_newspack',
 				'newsletters_subscription_method',
 				'current_page_url',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows our script to consolidate and fix duplicate merge fields to also handle standard Mailchimp merge fields (First/Last Name, Phone, Address) in addition to Newspack-specific fields.

### How to test the changes in this Pull Request:

1. In your connected Mailchimp audience, create duplicate merge fields for `First Name`, `Last Name`, `Phone`, and `Address`. These fields usually exist for every Mailchimp audience and can also be a part of our contact metadata payload, which means they could be duplicated by our sync methods.
2. Fill out these fields for some existing contacts in your audience.
3. Run `wp newspack mailchimp merge-fields fix-duplicates --dry-run` and confirm that the duplicate fields are reported.
4. Run `wp newspack mailchimp merge-fields fix-duplicates` and confirm that the duplicate fields are deleted in Mailchimp, and that the info you filled out in step 2 get consolidated into the original instances of those fields.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->