### PR TITLE
feat(corrections): add corrections and clarifications behind feature flag

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -125,6 +125,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/tracking/class-twitter-pixel.php';
 		include_once NEWSPACK_ABSPATH . 'includes/revisions-control/class-revisions-control.php';
 		include_once NEWSPACK_ABSPATH . 'includes/authors/class-authors-custom-fields.php';
+		include_once NEWSPACK_ABSPATH . 'includes/corrections/class-corrections.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-provider.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-generated.php';

--- a/includes/corrections/README.md
+++ b/includes/corrections/README.md
@@ -22,7 +22,7 @@ Corrections are stored as `newspack_correction` custom post type. A correction c
 | ----------------------------- | -------- | -------------- | --------------------------------------------------------------- |
 | `title`                       | `string` | `post_title`   | The correction title. Defaults to 'Correction for [post title]' |
 | `content`                     | `string` | `post_content` | The correction text.                                            |
-| `newspack_correction_date`    | `string` | `post_meta`    | Correction date. Note this is different from the post date.     |
+| `date`                        | `string` | `post_date`    | The date assigned to the correction.                            |
 | `newspack_correction-post-id` | `int`    | `post_meta`    | The ID of the post to which the correction is associated.       |
 
 In addition, some correction data is stored in the associated post as post meta:

--- a/includes/corrections/README.md
+++ b/includes/corrections/README.md
@@ -1,0 +1,34 @@
+# Corrections
+
+This feature allows authors to add article corrections to the top or bottom of a post.
+
+## How it works
+
+When you enable this feature, a new meta box will be added to the post editor screen. You can use this meta box to add a correction to the post. The correction will be displayed at the top or bottom of the post, depending on the settings.
+
+## Usage
+
+This feature can be enabled by adding the following constant to your `wp-config.php`:
+
+```php
+define( 'NEWSPACK_CORRECTIONS_ENABLED', true );
+```
+
+## Data
+
+Corrections are stored as `newspack_correction` custom post type. A correction consists of the following fields:
+
+| Name                          | Type     | Stored As      | Description                                                     |
+| ----------------------------- | -------- | -------------- | --------------------------------------------------------------- |
+| `title`                       | `string` | `post_title`   | The correction title. Defaults to 'Correction for [post title]' |
+| `content`                     | `string` | `post_content` | The correction text.                                            |
+| `newspack_correction_date`    | `string` | `post_meta`    | Correction date. Note this is different from the post date.     |
+| `newspack_correction-post-id` | `int`    | `post_meta`    | The ID of the post to which the correction is associated.       |
+
+In addition, some correction data is stored in the associated post as post meta:
+
+| Name                            | Type                    | Stored As   | Description                                                   |
+| ------------------------------- | ----------------------- | ----------- | ------------------------------------------------------------- |
+| `newspack_corrections_active`   | `bool`                  | `post_meta` | Whether the feature is enabled for the post.                  |
+| `newspack_corrections_location` | `string`                | `post_meta` | Where the correction should be displayed. (`top` or `bottom`) |
+| `newspack_corrections_ids`      | `array`                 | `post_meta` | An array of IDs of the corrections associated with the post.  |

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Newspack Corrections and Clarifications
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+/**
+ * Class to handle Corrections and Clarifications.
+ */
+class Corrections {
+	/**
+	 * Meta key for storing corrections.
+	 */
+	const CORRECTION_META = 'article-corrections';
+
+	/**
+	 * Meta key for storing whether corrections are active.
+	 */
+	const CORRECTION_ACTIVE_META = 'has_corrections';
+
+	/**
+	 * Initializes the class.
+	 */
+	public static function init() {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+		add_action( 'add_meta_boxes', [ __CLASS__, 'add_corrections_metabox' ] );
+		add_action( 'save_post', [ __CLASS__, 'save_corrections_metabox' ] );
+		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ] );
+		add_action( 'init', [ __CLASS__, 'add_corrections_shortcode' ] );
+	}
+
+	/**
+	 * Checks if the feature is enabled.
+	 *
+	 * True when:
+	 * - NEWSPACK_CORRECTIONS_ENABLED is defined and true.
+	 *
+	 * @return bool True if the feature is enabled, false otherwise.
+	 */
+	public static function is_enabled() {
+		return defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED;
+	}
+
+	/**
+	 * Adds the corrections shortcode.
+	 */
+	public static function add_corrections_shortcode() {
+		add_shortcode( 'corrections', [ __CLASS__, 'handle_corrections_shortcode' ] );
+	}
+
+	/**
+	 * Handles the corrections shortcode.
+	 *
+	 * @return string The shortcode output.
+	 */
+	public static function handle_corrections_shortcode() {
+		global $wpdb;
+
+		$post_ids = get_posts(
+			[
+				'posts_per_page' => -1,
+				'meta_key'       => self::CORRECTION_ACTIVE_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => 1, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'fields'         => 'ids',
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			]
+		);
+
+		ob_start();
+		foreach ( $post_ids as $post_id ) :
+			$corrections = get_post_meta( $post_id, self::CORRECTION_META, true );
+			if ( empty( $corrections ) ) {
+				continue;
+			}
+
+			?>
+			<!-- wp:group {"className":"is-style-default correction-shortcode-item"} -->
+			<div class="wp-block-group is-style-default correction-shortcode-item">
+				<div class="wp-block-group__inner-container">
+					<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showDate":false,"showAuthor":false,"mediaPosition":"left","specificPosts":["<?php echo intval( $post_id ); ?>"],"imageScale":2,"specificMode":true} /-->
+
+					<div class="correction-list">
+						<?php foreach ( $corrections as $correction ) : ?>
+							<?php $correction_heading = ! empty( $correction['date'] ) ? 'Correction on ' . gmdate( 'M j, Y', strtotime( $correction['date'] ) ) : 'Correction'; ?>
+							<p>
+								<span class="correction-date"><?php echo esc_html( $correction_heading ); ?><span>:</span></span>
+								<?php echo esc_html( $correction['correction'] ); ?>
+							</p>
+						<?php endforeach; ?>
+					</div>
+
+			</div></div>
+			<!-- /wp:group -->
+			<?php
+		endforeach;
+		return do_blocks( ob_get_clean() );
+	}
+
+	/**
+	 * Adds the corrections metabox.
+	 *
+	 * @param string $post_type The post type.
+	 */
+	public static function add_corrections_metabox( $post_type ) {
+		$valid_post_types = [ 'article_legacy', 'content_type_blog', 'post', 'press_release' ];
+		if ( in_array( $post_type, $valid_post_types, true ) ) {
+			add_meta_box(
+				'reveal_corrections',
+				'Corrections',
+				[ __CLASS__, 'render_corrections_metabox' ],
+				$post_type,
+				'advanced',
+				'high'
+			);
+		}
+	}
+
+	/**
+	 * Renders the corrections metabox.
+	 *
+	 * @param \WP_Post $post The post object.
+	 */
+	public static function render_corrections_metabox( $post ) {
+		$is_active            = (bool) get_post_meta( $post->ID, self::CORRECTION_ACTIVE_META, true );
+		$existing_corrections = get_post_meta( $post->ID, self::CORRECTION_META, true );
+		if ( ! is_array( $existing_corrections ) ) {
+			$existing_corrections = [];
+		}
+		?>
+		<style>
+			.activate-corrections {
+				padding-top: 1em;
+				padding-bottom: 1em;
+				border-bottom: 2px solid silver;
+				margin-bottom: 1em;
+			}
+
+			.reveal-correction {
+				position: relative;
+				border-bottom: 1px solid silver;
+				padding-top: 1em;
+				padding-bottom: 1em;
+			}
+
+			.delete-correction {
+				position: absolute;
+				top: 2em;
+				right: 2em;
+				font-weight: bold;
+				color: silver;
+				border: 1px solid silver;
+				padding-left: .25em;
+				padding-right: .25em;
+				cursor: pointer;
+			}
+
+			.delete-correction:hover {
+				color: red;
+			}
+
+			.add-correction {
+				margin-top: 2em;
+				cursor: pointer;
+			}
+		</style>
+
+		<div class="corrections-metabox-container">
+			<div class="activate-corrections">
+				<input type="hidden" value="0" name="<?php echo esc_attr( self::CORRECTION_ACTIVE_META ); ?>" />
+				<input type="checkbox" value="1" name="<?php echo esc_attr( self::CORRECTION_ACTIVE_META ); ?>" <?php checked( $is_active ); ?> />
+				Activate Corrections
+			</div>
+			<div class="manage-corrections">
+				<div class="existing-corrections">
+					<?php foreach ( $existing_corrections as $existing_correction ) : ?>
+						<div class="reveal-correction">
+							<p>Article Correction</p>
+							<textarea name="reveal_correction[]" rows="3" cols="60">
+								<?php echo esc_attr( sanitize_textarea_field( $existing_correction['correction'] ) ); ?>
+							</textarea><br/>
+								<p>Date: <input type="date" name="reveal_correction_date[]" value="<?php echo esc_attr( sanitize_text_field( $existing_correction['date'] ) ); ?>"></p>
+							<span class="delete-correction">X</span>
+						</div>
+					<?php endforeach; ?>
+				</div>
+				<button type="button" class="add-correction">Add new Correction</button>
+			</div>
+		</div>
+
+		<script>
+			( function($) {
+				if ( ! $( '.corrections-metabox-container' ).length ) {
+					return;
+				}
+
+				// Click handler for Add Correction button.
+				$( '.add-correction' ).click( function() {
+					$( '.existing-corrections' ).append( '<div class="reveal-correction"><p>Article Correction</p><textarea name="reveal_correction[]" rows="3" cols="60"></textarea><br/><p>Date: <input type="date" name="reveal_correction_date[]"></p><span class="delete-correction">X</span>' );
+				} );
+
+				// Click handler for Delete Correction button.
+				$( document ).on( 'click', '.delete-correction', function( evt ) {
+					$( evt.target ).parent().remove();
+				} );
+			} )( jQuery );
+		</script>
+
+		<?php
+	}
+
+	/**
+	 * Saves the corrections metabox.
+	 *
+	 * @param int $post_id The post ID.
+	 */
+	public static function save_corrections_metabox( $post_id ) {
+		if ( ! isset( $_POST[ self::CORRECTION_ACTIVE_META ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return;
+		}
+
+		$is_active = (bool) filter_input( INPUT_POST, self::CORRECTION_ACTIVE_META, FILTER_SANITIZE_NUMBER_INT );
+
+		$corrections_data = filter_input_array(
+			INPUT_POST,
+			[
+				'reveal_correction'      => [
+					'flags'  => FILTER_REQUIRE_ARRAY,
+					'filter' => FILTER_SANITIZE_STRING,
+				],
+				'reveal_correction_date' => [
+					'flags'  => FILTER_REQUIRE_ARRAY,
+					'filter' => FILTER_SANITIZE_STRING,
+				],
+			]
+		);
+
+		$corrections = [];
+		foreach ( $corrections_data['reveal_correction'] as $index => $correction_text ) {
+			$corrections[] = [
+				'correction' => sanitize_textarea_field( $correction_text ),
+				'date'       => ! empty( $corrections_data['reveal_correction_date'][ $index ] ) ? sanitize_text_field( $corrections_data['reveal_correction_date'][ $index ] ) : gmdate( 'Y-m-d' ),
+			];
+		}
+
+		update_post_meta( $post_id, self::CORRECTION_ACTIVE_META, $is_active );
+		update_post_meta( $post_id, self::CORRECTION_META, $corrections );
+	}
+
+	/**
+	 * Outputs corrections on the post content.
+	 *
+	 * @param string $content The post content.
+	 *
+	 * @return string The post content with corrections.
+	 */
+	public static function output_corrections_on_post( $content ) {
+		if ( is_admin() || ! is_single() ) {
+			return $content;
+		}
+
+		$corrections_active = get_post_meta( get_the_ID(), self::CORRECTION_ACTIVE_META, true );
+		if ( ! $corrections_active ) {
+			return $content;
+		}
+
+		$corrections          = get_post_meta( get_the_ID(), self::CORRECTION_META ) ?? [];
+		$has_valid_correction = false;
+		foreach ( $corrections as $correction ) {
+			if ( ! empty( trim( $correction['correction'] ) ) ) {
+				$has_valid_correction = true;
+				break;
+			}
+		}
+
+		if ( ! $has_valid_correction ) {
+			return $content;
+		}
+
+		ob_start();
+		?>
+		<!-- wp:group {"className":"correction-module","backgroundColor":"light-gray"} -->
+		<div class="wp-block-group correction-module has-light-gray-background-color has-background">
+			<div class="wp-block-group__inner-container">
+			<?php
+			foreach ( $corrections as $correction ) :
+				if ( empty( trim( $correction['correction'] ) ) ) {
+					continue;
+				}
+
+				$correction_heading = ! empty( $correction['date'] ) ? 'Correction on ' . gmdate( 'M j, Y', strtotime( $correction['date'] ) ) : 'Correction';
+				?>
+				<!-- wp:paragraph {"fontSize":"small"} -->
+				<p class="has-small-font-size correction-heading"><?php echo esc_html( $correction_heading ); ?></p>
+				<!-- /wp:paragraph -->
+
+				<!-- wp:paragraph {"fontSize":"normal"} -->
+				<p class="has-normal-font-size correction-body"><?php echo esc_html( $correction['correction'] ); ?></p>
+				<!-- /wp:paragraph -->
+			<?php endforeach; ?>
+			</div>
+		</div>
+		<!-- /wp:group -->
+		<?php
+		$markup = do_blocks( ob_get_clean() );
+		return $content . $markup;
+	}
+}
+Corrections::init();

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -14,17 +14,17 @@ class Corrections {
 	/**
 	 * Post type for corrections.
 	 */
-	const POST_TYPE = 'np_correction';
+	const POST_TYPE = 'newspack_correction';
 
 	/**
 	 * Meta key for storing corrections.
 	 */
-	const CORRECTION_META = 'article-corrections';
+	const POST_ID_META = 'newspack_correction-post-id';
 
 	/**
-	 * Meta key for storing whether corrections are active.
+	 * Meta key for corrections active postmeta.
 	 */
-	const CORRECTION_ACTIVE_META = 'has_corrections';
+	const CORRECTIONS_ACTIVE_META = 'newspack_corrections_active';
 
 	/**
 	 * Initializes the class.
@@ -38,6 +38,8 @@ class Corrections {
 		add_action( 'add_meta_boxes', [ __CLASS__, 'add_corrections_metabox' ] );
 		add_action( 'save_post', [ __CLASS__, 'save_corrections_metabox' ] );
 		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ] );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 	}
 
 	/**
@@ -52,6 +54,29 @@ class Corrections {
 		return defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED;
 	}
 
+
+	/**
+	 * Enqueue scripts and styles.
+	 */
+	public static function wp_enqueue_scripts() {
+		if ( ! is_admin() || ! isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return;
+		}
+		\wp_enqueue_script(
+			'newspack-corrections',
+			Newspack::plugin_url() . '/dist/other-scripts/corrections.js',
+			[],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+		\wp_enqueue_style(
+			'newspack-corrections',
+			Newspack::plugin_url() . '/dist/other-scripts/corrections.css',
+			[],
+			NEWSPACK_PLUGIN_VERSION
+		);
+	}
+
 	/**
 	 * Registers the corrections post type.
 	 *
@@ -63,6 +88,7 @@ class Corrections {
 			'editor',
 			'title',
 			'revisions',
+			'custom-fields',
 		];
 
 		$labels = [
@@ -115,6 +141,48 @@ class Corrections {
 	}
 
 	/**
+	 * Get corrections for post.
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return array The corrections.
+	 */
+	public static function get_corrections( $post_id ) {
+		return get_posts(
+			[
+				'posts_per_page' => -1,
+				'post_type'      => self::POST_TYPE,
+				'meta_key'       => self::POST_ID_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => $post_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			]
+		);
+	}
+
+	/**
+	 * Save corrections for post.
+	 *
+	 * @param int   $post_id     The post ID.
+	 * @param array $corrections The corrections.
+	 */
+	public static function save_corrections( $post_id, $corrections ) {
+		foreach ( $corrections as $correction ) {
+			$post_id = wp_insert_post(
+				[
+					'post_title'   => 'Correction for ' . get_the_title( $post_id ),
+					'post_content' => $correction,
+					'post_type'    => self::POST_TYPE,
+					'post_status'  => 'publish',
+					'meta_input'   => [
+						self::POST_ID_META => $post_id,
+					],
+				]
+			);
+		}
+	}
+
+	/**
 	 * Adds the corrections shortcode.
 	 */
 	public static function add_corrections_shortcode() {
@@ -132,7 +200,7 @@ class Corrections {
 		$post_ids = get_posts(
 			[
 				'posts_per_page' => -1,
-				'meta_key'       => self::CORRECTION_ACTIVE_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'       => self::CORRECTIONS_ACTIVE_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'     => 1, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'fields'         => 'ids',
 				'orderby'        => 'date',
@@ -142,7 +210,7 @@ class Corrections {
 
 		ob_start();
 		foreach ( $post_ids as $post_id ) :
-			$corrections = get_post_meta( $post_id, self::CORRECTION_META, true );
+			$corrections = self::get_corrections( $post_id );
 			if ( empty( $corrections ) ) {
 				continue;
 			}
@@ -195,53 +263,13 @@ class Corrections {
 	 * @param \WP_Post $post The post object.
 	 */
 	public static function render_corrections_metabox( $post ) {
-		$is_active            = (bool) get_post_meta( $post->ID, self::CORRECTION_ACTIVE_META, true );
-		$existing_corrections = get_post_meta( $post->ID, self::CORRECTION_META, true );
-		if ( ! is_array( $existing_corrections ) ) {
-			$existing_corrections = [];
-		}
+		$is_active            = (bool) get_post_meta( $post->ID, self::CORRECTIONS_ACTIVE_META, true );
+		$existing_corrections = self::get_corrections( $post->ID );
 		?>
-		<style>
-			.activate-corrections {
-				padding-top: 1em;
-				padding-bottom: 1em;
-				border-bottom: 2px solid silver;
-				margin-bottom: 1em;
-			}
-
-			.reveal-correction {
-				position: relative;
-				border-bottom: 1px solid silver;
-				padding-top: 1em;
-				padding-bottom: 1em;
-			}
-
-			.delete-correction {
-				position: absolute;
-				top: 2em;
-				right: 2em;
-				font-weight: bold;
-				color: silver;
-				border: 1px solid silver;
-				padding-left: .25em;
-				padding-right: .25em;
-				cursor: pointer;
-			}
-
-			.delete-correction:hover {
-				color: red;
-			}
-
-			.add-correction {
-				margin-top: 2em;
-				cursor: pointer;
-			}
-		</style>
-
 		<div class="corrections-metabox-container">
 			<div class="activate-corrections">
-				<input type="hidden" value="0" name="<?php echo esc_attr( self::CORRECTION_ACTIVE_META ); ?>" />
-				<input type="checkbox" value="1" name="<?php echo esc_attr( self::CORRECTION_ACTIVE_META ); ?>" <?php checked( $is_active ); ?> />
+				<input type="hidden" value="0" name="<?php echo esc_attr( self::CORRECTIONS_ACTIVE_META ); ?>" />
+				<input type="checkbox" value="1" name="<?php echo esc_attr( self::CORRECTIONS_ACTIVE_META ); ?>" <?php checked( $is_active ); ?> />
 				Activate Corrections
 			</div>
 			<div class="manage-corrections">
@@ -257,28 +285,9 @@ class Corrections {
 						</div>
 					<?php endforeach; ?>
 				</div>
-				<button type="button" class="add-correction">Add new Correction</button>
+				<button type="button" class="add-correction">Add new correction</button>
 			</div>
 		</div>
-
-		<script>
-			( function($) {
-				if ( ! $( '.corrections-metabox-container' ).length ) {
-					return;
-				}
-
-				// Click handler for Add Correction button.
-				$( '.add-correction' ).click( function() {
-					$( '.existing-corrections' ).append( '<div class="reveal-correction"><p>Article Correction</p><textarea name="reveal_correction[]" rows="3" cols="60"></textarea><br/><p>Date: <input type="date" name="reveal_correction_date[]"></p><span class="delete-correction">X</span>' );
-				} );
-
-				// Click handler for Delete Correction button.
-				$( document ).on( 'click', '.delete-correction', function( evt ) {
-					$( evt.target ).parent().remove();
-				} );
-			} )( jQuery );
-		</script>
-
 		<?php
 	}
 
@@ -288,20 +297,19 @@ class Corrections {
 	 * @param int $post_id The post ID.
 	 */
 	public static function save_corrections_metabox( $post_id ) {
-		if ( ! isset( $_POST[ self::CORRECTION_ACTIVE_META ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! isset( $_POST[ self::CORRECTIONS_ACTIVE_META ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 
-		$is_active = (bool) filter_input( INPUT_POST, self::CORRECTION_ACTIVE_META, FILTER_SANITIZE_NUMBER_INT );
-
+		$is_active        = (bool) filter_input( INPUT_POST, self::CORRECTIONS_ACTIVE_META, FILTER_SANITIZE_NUMBER_INT );
 		$corrections_data = filter_input_array(
 			INPUT_POST,
 			[
-				'reveal_correction'      => [
+				'correction'      => [
 					'flags'  => FILTER_REQUIRE_ARRAY,
 					'filter' => FILTER_SANITIZE_STRING,
 				],
-				'reveal_correction_date' => [
+				'correction_date' => [
 					'flags'  => FILTER_REQUIRE_ARRAY,
 					'filter' => FILTER_SANITIZE_STRING,
 				],
@@ -316,8 +324,8 @@ class Corrections {
 			];
 		}
 
-		update_post_meta( $post_id, self::CORRECTION_ACTIVE_META, $is_active );
-		update_post_meta( $post_id, self::CORRECTION_META, $corrections );
+		self::save_corrections( $post_id, $corrections );
+		update_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, true );
 	}
 
 	/**
@@ -332,12 +340,12 @@ class Corrections {
 			return $content;
 		}
 
-		$corrections_active = get_post_meta( get_the_ID(), self::CORRECTION_ACTIVE_META, true );
+		$corrections_active = get_post_meta( get_the_ID(), self::CORRECTIONS_ACTIVE_META, true );
 		if ( ! $corrections_active ) {
 			return $content;
 		}
 
-		$corrections          = get_post_meta( get_the_ID(), self::CORRECTION_META ) ?? [];
+		$corrections          = self::get_corrections( get_the_ID() );
 		$has_valid_correction = false;
 		foreach ( $corrections as $correction ) {
 			if ( ! empty( trim( $correction['correction'] ) ) ) {

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -64,9 +64,10 @@ class Corrections {
 	 * Enqueue scripts and styles.
 	 */
 	public static function wp_enqueue_scripts() {
-		if ( ! is_admin() || ! isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! is_admin() || ! filter_input( INPUT_GET, 'post', FILTER_VALIDATE_INT ) ) {
 			return;
 		}
+
 		\wp_enqueue_script(
 			'newspack-corrections',
 			Newspack::plugin_url() . '/dist/other-scripts/corrections.js',

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -239,11 +239,19 @@ class Corrections {
 					<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showDate":false,"showAuthor":false,"mediaPosition":"left","specificPosts":["<?php echo intval( $post_id ); ?>"],"imageScale":2,"specificMode":true} /-->
 
 					<div class="correction-list">
-						<?php foreach ( $corrections as $correction ) : ?>
-							<?php $correction_heading = ! empty( $correction['date'] ) ? 'Correction on ' . gmdate( 'M j, Y', strtotime( $correction['date'] ) ) : 'Correction'; ?>
+						<?php
+						foreach ( $corrections as $correction ) :
+							$correction_content = $correction->post_content;
+							$correction_date    = get_post_meta( $correction->ID, self::CORRECTION_DATE_META, true );
+							$correction_heading = sprintf(
+								// translators: %s: correction date.
+								__( 'Correction on %s', 'newspack-plugin' ),
+								gmdate( 'M j, Y', strtotime( $correction_date ) )
+							);
+							?>
 							<p>
 								<span class="correction-date"><?php echo esc_html( $correction_heading ); ?><span>:</span></span>
-								<?php echo esc_html( $correction['correction'] ); ?>
+								<?php echo esc_html( $correction_content ); ?>
 							</p>
 						<?php endforeach; ?>
 					</div>

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -17,12 +17,17 @@ class Corrections {
 	const POST_TYPE = 'newspack_correction';
 
 	/**
-	 * Meta key for storing corrections.
+	 * Meta key for correction date meta.
 	 */
-	const POST_ID_META = 'newspack_correction-post-id';
+	const CORRECTION_DATE_META = 'newspack_correction_date';
 
 	/**
-	 * Meta key for corrections active postmeta.
+	 * Meta key for correction post ID meta.
+	 */
+	const CORRECTION_POST_ID_META = 'newspack_correction-post-id';
+
+	/**
+	 * Meta key for post corrections active meta.
 	 */
 	const CORRECTIONS_ACTIVE_META = 'newspack_corrections_active';
 
@@ -152,7 +157,7 @@ class Corrections {
 			[
 				'posts_per_page' => -1,
 				'post_type'      => self::POST_TYPE,
-				'meta_key'       => self::POST_ID_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'       => self::CORRECTION_POST_ID_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'     => $post_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'orderby'        => 'date',
 				'order'          => 'DESC',
@@ -171,14 +176,26 @@ class Corrections {
 			$post_id = wp_insert_post(
 				[
 					'post_title'   => 'Correction for ' . get_the_title( $post_id ),
-					'post_content' => $correction,
+					'post_content' => $correction['content'],
 					'post_type'    => self::POST_TYPE,
 					'post_status'  => 'publish',
 					'meta_input'   => [
-						self::POST_ID_META => $post_id,
+						self::CORRECTION_POST_ID_META => $post_id,
+						self::CORRECTION_DATE_META    => $correction['date'],
 					],
 				]
 			);
+		}
+	}
+
+	/**
+	 * Delete corrections for post.
+	 *
+	 * @param array $correction_ids Correction IDs.
+	 */
+	public static function delete_corrections( $correction_ids ) {
+		foreach ( $correction_ids as $id ) {
+			wp_delete_post( $id, true );
 		}
 	}
 
@@ -247,7 +264,7 @@ class Corrections {
 		$valid_post_types = [ 'article_legacy', 'content_type_blog', 'post', 'press_release' ];
 		if ( in_array( $post_type, $valid_post_types, true ) ) {
 			add_meta_box(
-				'reveal_corrections',
+				'corrections',
 				'Corrections',
 				[ __CLASS__, 'render_corrections_metabox' ],
 				$post_type,
@@ -263,29 +280,37 @@ class Corrections {
 	 * @param \WP_Post $post The post object.
 	 */
 	public static function render_corrections_metabox( $post ) {
-		$is_active            = (bool) get_post_meta( $post->ID, self::CORRECTIONS_ACTIVE_META, true );
-		$existing_corrections = self::get_corrections( $post->ID );
+		$is_active   = (bool) get_post_meta( $post->ID, self::CORRECTIONS_ACTIVE_META, true );
+		$corrections = self::get_corrections( $post->ID );
 		?>
 		<div class="corrections-metabox-container">
 			<div class="activate-corrections">
 				<input type="hidden" value="0" name="<?php echo esc_attr( self::CORRECTIONS_ACTIVE_META ); ?>" />
 				<input type="checkbox" value="1" name="<?php echo esc_attr( self::CORRECTIONS_ACTIVE_META ); ?>" <?php checked( $is_active ); ?> />
-				Activate Corrections
+				<?php echo esc_html( __( 'Activate Corrections', 'newspack-plugin' ) ); ?>
 			</div>
 			<div class="manage-corrections">
-				<div class="existing-corrections">
-					<?php foreach ( $existing_corrections as $existing_correction ) : ?>
-						<div class="reveal-correction">
-							<p>Article Correction</p>
-							<textarea name="reveal_correction[]" rows="3" cols="60">
-								<?php echo esc_attr( sanitize_textarea_field( $existing_correction['correction'] ) ); ?>
-							</textarea><br/>
-								<p>Date: <input type="date" name="reveal_correction_date[]" value="<?php echo esc_attr( sanitize_text_field( $existing_correction['date'] ) ); ?>"></p>
-							<span class="delete-correction">X</span>
-						</div>
+				<fieldset name="existing-corrections[]" class="existing-corrections">
+					<?php
+					foreach ( $corrections as $correction ) :
+						$correction_content = $correction->post_content;
+						$correction_date    = get_post_meta( $correction->ID, self::CORRECTION_DATE_META, true );
+						?>
+						<fieldset name="existing-corrections[<?php echo esc_attr( $correction->ID ); ?>]" class="correction">
+							<p><?php echo esc_html( __( 'Article Correction', 'newspack-plugin' ) ); ?></p>
+							<textarea name="existing-corrections[<?php echo esc_attr( $correction->ID ); ?>][content]" rows="3" cols="60"><?php echo esc_html( $correction_content ); ?></textarea>
+							<br/>
+							<p>
+								<?php echo esc_html( __( 'Date:', 'newspack_plugin' ) ); ?>
+								<input name="existing-corrections[<?php echo esc_attr( $correction->ID ); ?>][date]" type="date" value="<?php echo esc_attr( sanitize_text_field( $correction_date ) ); ?>">
+							</p>
+							<button class="delete-correction">X</button>
+						</fieldset>
 					<?php endforeach; ?>
-				</div>
-				<button type="button" class="add-correction">Add new correction</button>
+				</fieldset>
+				<fieldset name="new-corrections[]" class="new-corrections"></fieldset>
+				<fieldset name="deleted-corrections[]" class="deleted-corrections"></fieldset>
+				<button type="button" class="add-correction"><?php echo esc_html( __( 'Add new correction', 'newspack-plugin' ) ); ?></button>
 			</div>
 		</div>
 		<?php
@@ -297,35 +322,53 @@ class Corrections {
 	 * @param int $post_id The post ID.
 	 */
 	public static function save_corrections_metabox( $post_id ) {
-		if ( ! isset( $_POST[ self::CORRECTIONS_ACTIVE_META ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		// Return early if we are saving a correction.
+		if ( self::POST_TYPE === get_post_type( $post_id ) ) {
 			return;
 		}
 
-		$is_active        = (bool) filter_input( INPUT_POST, self::CORRECTIONS_ACTIVE_META, FILTER_SANITIZE_NUMBER_INT );
 		$corrections_data = filter_input_array(
 			INPUT_POST,
 			[
-				'correction'      => [
+				'new-corrections'             => [
 					'flags'  => FILTER_REQUIRE_ARRAY,
 					'filter' => FILTER_SANITIZE_STRING,
 				],
-				'correction_date' => [
+				'deleted-corrections'         => [
 					'flags'  => FILTER_REQUIRE_ARRAY,
-					'filter' => FILTER_SANITIZE_STRING,
+					'filter' => FILTER_SANITIZE_NUMBER_INT,
 				],
+				self::CORRECTIONS_ACTIVE_META => FILTER_SANITIZE_NUMBER_INT,
 			]
 		);
-
-		$corrections = [];
-		foreach ( $corrections_data['reveal_correction'] as $index => $correction_text ) {
-			$corrections[] = [
-				'correction' => sanitize_textarea_field( $correction_text ),
-				'date'       => ! empty( $corrections_data['reveal_correction_date'][ $index ] ) ? sanitize_text_field( $corrections_data['reveal_correction_date'][ $index ] ) : gmdate( 'Y-m-d' ),
-			];
+		// Return early if there is no corrections data.
+		if ( ! $corrections_data ) {
+			return;
 		}
-
-		self::save_corrections( $post_id, $corrections );
-		update_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, true );
+		// Save new corrections if present.
+		if ( ! empty( $corrections_data['new-corrections'] ) ) {
+			$corrections = [];
+			foreach ( $corrections_data['new-corrections'] as $correction ) {
+				// Don't save empty corrections.
+				if ( empty( trim( $correction['content'] ) ) ) {
+					continue;
+				}
+				$corrections[] = [
+					'content' => sanitize_textarea_field( $correction['content'] ),
+					'date'    => ! empty( $correction['date'] ) ? sanitize_text_field( $correction['date'] ) : gmdate( 'Y-m-d' ),
+				];
+			}
+			self::save_corrections( $post_id, $corrections );
+		}
+		// Delete corrections if present.
+		if ( ! empty( $corrections_data['deleted-corrections'] ) ) {
+			$correction_ids = array_map( 'intval', $corrections_data['deleted-corrections'] );
+			self::delete_corrections( $correction_ids );
+		}
+		// Update active flag if present.
+		if ( isset( $corrections_data[ self::CORRECTIONS_ACTIVE_META ] ) ) {
+			update_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, (bool) $corrections_data[ self::CORRECTIONS_ACTIVE_META ] );
+		}
 	}
 
 	/**
@@ -340,21 +383,12 @@ class Corrections {
 			return $content;
 		}
 
-		$corrections_active = get_post_meta( get_the_ID(), self::CORRECTIONS_ACTIVE_META, true );
-		if ( ! $corrections_active ) {
+		if ( ! (bool) get_post_meta( get_the_ID(), self::CORRECTIONS_ACTIVE_META, true ) ) {
 			return $content;
 		}
 
-		$corrections          = self::get_corrections( get_the_ID() );
-		$has_valid_correction = false;
-		foreach ( $corrections as $correction ) {
-			if ( ! empty( trim( $correction['correction'] ) ) ) {
-				$has_valid_correction = true;
-				break;
-			}
-		}
-
-		if ( ! $has_valid_correction ) {
+		$corrections = self::get_corrections( get_the_ID() );
+		if ( empty( $corrections ) ) {
 			return $content;
 		}
 
@@ -365,18 +399,20 @@ class Corrections {
 			<div class="wp-block-group__inner-container">
 			<?php
 			foreach ( $corrections as $correction ) :
-				if ( empty( trim( $correction['correction'] ) ) ) {
-					continue;
-				}
-
-				$correction_heading = ! empty( $correction['date'] ) ? 'Correction on ' . gmdate( 'M j, Y', strtotime( $correction['date'] ) ) : 'Correction';
+				$correction_content = $correction->post_content;
+				$correction_date    = get_post_meta( $correction->ID, self::CORRECTION_DATE_META, true );
+				$correction_heading = sprintf(
+					// translators: %s: correction date.
+					__( 'Correction on %s', 'newspack-plugin' ),
+					gmdate( 'M j, Y', strtotime( $correction_date ) )
+				);
 				?>
 				<!-- wp:paragraph {"fontSize":"small"} -->
 				<p class="has-small-font-size correction-heading"><?php echo esc_html( $correction_heading ); ?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"fontSize":"normal"} -->
-				<p class="has-normal-font-size correction-body"><?php echo esc_html( $correction['correction'] ); ?></p>
+				<p class="has-normal-font-size correction-body"><?php echo esc_html( $correction_content ); ?></p>
 				<!-- /wp:paragraph -->
 			<?php endforeach; ?>
 			</div>

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -12,6 +12,11 @@ namespace Newspack;
  */
 class Corrections {
 	/**
+	 * Post type for corrections.
+	 */
+	const POST_TYPE = 'np_correction';
+
+	/**
 	 * Meta key for storing corrections.
 	 */
 	const CORRECTION_META = 'article-corrections';
@@ -28,10 +33,11 @@ class Corrections {
 		if ( ! self::is_enabled() ) {
 			return;
 		}
+		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
+		add_action( 'init', [ __CLASS__, 'add_corrections_shortcode' ] );
 		add_action( 'add_meta_boxes', [ __CLASS__, 'add_corrections_metabox' ] );
 		add_action( 'save_post', [ __CLASS__, 'save_corrections_metabox' ] );
 		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ] );
-		add_action( 'init', [ __CLASS__, 'add_corrections_shortcode' ] );
 	}
 
 	/**
@@ -44,6 +50,68 @@ class Corrections {
 	 */
 	public static function is_enabled() {
 		return defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED;
+	}
+
+	/**
+	 * Registers the corrections post type.
+	 *
+	 * @return void
+	 */
+	public static function register_post_type() {
+		$supports = [
+			'author',
+			'editor',
+			'title',
+			'revisions',
+		];
+
+		$labels = [
+			'name'                     => _x( 'Corrections', 'post type general name', 'newspack-plugin' ),
+			'singular_name'            => _x( 'Correction', 'post type singular name', 'newspack-plugin' ),
+			'menu_name'                => _x( 'Corrections', 'admin menu', 'newspack-plugin' ),
+			'name_admin_bar'           => _x( 'Correction', 'add new on admin bar', 'newspack-plugin' ),
+			'add_new'                  => _x( 'Add New', 'correction', 'newspack-plugin' ),
+			'add_new_item'             => __( 'Add New Correction', 'newspack-plugin' ),
+			'new_item'                 => __( 'New Correction', 'newspack-plugin' ),
+			'edit_item'                => __( 'Edit Correction', 'newspack-plugin' ),
+			'view_item'                => __( 'View Correction', 'newspack-plugin' ),
+			'view_items'               => __( 'View Correction', 'newspack-plugin' ),
+			'all_items'                => __( 'All Corrections', 'newspack-plugin' ),
+			'search_items'             => __( 'Search Corrections', 'newspack-plugin' ),
+			'parent_item_colon'        => __( 'Parent Correction:', 'newspack-plugin' ),
+			'not_found'                => __( 'No corrections found.', 'newspack-plugin' ),
+			'not_found_in_trash'       => __( 'No corrections found in Trash.', 'newspack-plugin' ),
+			'archives'                 => __( 'Correction Archives', 'newspack-plugin' ),
+			'attributes'               => __( 'Correction Attributes', 'newspack-plugin' ),
+			'insert_into_item'         => __( 'Insert into correction', 'newspack-plugin' ),
+			'uploaded_to_this_item'    => __( 'Uploaded to this correction', 'newspack-plugin' ),
+			'filter_items_list'        => __( 'Filter corrections list', 'newspack-plugin' ),
+			'items_list_navigation'    => __( 'Corrections list navigation', 'newspack-plugin' ),
+			'items_list'               => __( 'Corrections list', 'newspack-plugin' ),
+			'item_published'           => __( 'Correction published.', 'newspack-plugin' ),
+			'item_published_privately' => __( 'Correction published privately.', 'newspack-plugin' ),
+			'item_reverted_to_draft'   => __( 'Correction reverted to draft.', 'newspack-plugin' ),
+			'item_scheduled'           => __( 'Correction scheduled.', 'newspack-plugin' ),
+			'item_updated'             => __( 'Correction updated.', 'newspack-plugin' ),
+			'item_link'                => __( 'Correction Link', 'newspack-plugin' ),
+			'item_link_description'    => __( 'A link to a correction.', 'newspack-plugin' ),
+		];
+
+		$args = array(
+			'labels'           => $labels,
+			'description'      => 'Post type used to store corrections and clarifications.',
+			'has_archive'      => true,
+			'public'           => true,
+			'public_queryable' => true,
+			'query_var'        => true,
+			'rewrite'          => [ 'slug' => 'correction' ],
+			'show_ui'          => true,
+			'show_in_rest'     => true,
+			'supports'         => $supports,
+			'taxonomies'       => [],
+			'menu_icon'        => 'dashicons-edit',
+		);
+		\register_post_type( self::POST_TYPE, $args );
 	}
 
 	/**
@@ -94,8 +162,8 @@ class Corrections {
 							</p>
 						<?php endforeach; ?>
 					</div>
-
-			</div></div>
+				</div>
+			</div>
 			<!-- /wp:group -->
 			<?php
 		endforeach;

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -145,7 +145,7 @@ class Corrections {
 			'public_queryable' => true,
 			'query_var'        => true,
 			'rewrite'          => [ 'slug' => 'correction' ],
-			'show_ui'          => true,
+			'show_ui'          => false,
 			'show_in_rest'     => true,
 			'supports'         => $supports,
 			'taxonomies'       => [],
@@ -155,33 +155,12 @@ class Corrections {
 	}
 
 	/**
-	 * Get corrections for post.
-	 *
-	 * @param int $post_id The post ID.
-	 *
-	 * @return array The corrections.
-	 */
-	public static function get_corrections( $post_id ) {
-		$correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
-		if ( ! is_array( $correction_ids ) ) {
-			return [];
-		}
-		return get_posts(
-			[
-				'posts_per_page' => -1,
-				'post_type'      => self::POST_TYPE,
-				'include'        => $correction_ids,
-			]
-		);
-	}
-
-	/**
 	 * Save corrections for post.
 	 *
 	 * @param int   $post_id     The post ID.
 	 * @param array $corrections The corrections.
 	 */
-	public static function save_corrections( $post_id, $corrections ) {
+	public static function add_corrections( $post_id, $corrections ) {
 		$correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
 		if ( ! is_array( $correction_ids ) ) {
 			$correction_ids = [];
@@ -207,6 +186,27 @@ class Corrections {
 	}
 
 	/**
+	 * Get corrections for post.
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return array The corrections.
+	 */
+	public static function get_corrections( $post_id ) {
+		$correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
+		if ( ! is_array( $correction_ids ) ) {
+			return [];
+		}
+		return get_posts(
+			[
+				'posts_per_page' => -1,
+				'post_type'      => self::POST_TYPE,
+				'include'        => $correction_ids,
+			]
+		);
+	}
+
+	/**
 	 * Update correction.
 	 *
 	 * @param int   $correction_id the post id.
@@ -225,9 +225,10 @@ class Corrections {
 	/**
 	 * Delete corrections for post.
 	 *
+	 * @param int   $post_id        the post id.
 	 * @param array $correction_ids correction ids.
 	 */
-	public static function delete_corrections( $correction_ids ) {
+	public static function delete_corrections( $post_id, $correction_ids ) {
 		$stored_correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
 		if ( ! is_array( $stored_correction_ids ) ) {
 			$stored_correction_ids = [];
@@ -439,12 +440,12 @@ class Corrections {
 					'date'    => ! empty( $correction['date'] ) ? sanitize_text_field( $correction['date'] ) : gmdate( 'Y-m-d' ),
 				];
 			}
-			self::save_corrections( $post_id, $corrections );
+			self::add_corrections( $post_id, $corrections );
 		}
 		// delete corrections if present.
 		if ( ! empty( $corrections_data['deleted-corrections'] ) ) {
 			$correction_ids = array_map( 'intval', $corrections_data['deleted-corrections'] );
-			self::delete_corrections( $correction_ids );
+			self::delete_corrections( $post_id, $correction_ids );
 		}
 	}
 

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -32,6 +32,11 @@ class Corrections {
 	const CORRECTIONS_ACTIVE_META = 'newspack_corrections_active';
 
 	/**
+	 * Meta key for post corrections location meta.
+	 */
+	const CORRECTIONS_LOCATION_META = 'newspack_corrections_location';
+
+	/**
 	 * Meta key for post corrections ids meta.
 	 */
 	const CORRECTIONS_IDS_META = 'newspack_corrections_ids';
@@ -101,7 +106,6 @@ class Corrections {
 			'revisions',
 			'custom-fields',
 		];
-
 		$labels = [
 			'name'                     => _x( 'Corrections', 'post type general name', 'newspack-plugin' ),
 			'singular_name'            => _x( 'Correction', 'post type singular name', 'newspack-plugin' ),
@@ -133,7 +137,6 @@ class Corrections {
 			'item_link'                => __( 'Correction Link', 'newspack-plugin' ),
 			'item_link_description'    => __( 'A link to a correction.', 'newspack-plugin' ),
 		];
-
 		$args = array(
 			'labels'           => $labels,
 			'description'      => 'Post type used to store corrections and clarifications.',
@@ -206,8 +209,8 @@ class Corrections {
 	/**
 	 * Update correction.
 	 *
-	 * @param int   $correction_id The post ID.
-	 * @param array $correction    The correction.
+	 * @param int   $correction_id the post id.
+	 * @param array $correction    the correction.
 	 */
 	public static function update_correction( $correction_id, $correction ) {
 		wp_update_post(
@@ -222,7 +225,7 @@ class Corrections {
 	/**
 	 * Delete corrections for post.
 	 *
-	 * @param array $correction_ids Correction IDs.
+	 * @param array $correction_ids correction ids.
 	 */
 	public static function delete_corrections( $correction_ids ) {
 		$stored_correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
@@ -248,7 +251,7 @@ class Corrections {
 	/**
 	 * Handles the corrections shortcode.
 	 *
-	 * @return string The shortcode output.
+	 * @return string the shortcode output.
 	 */
 	public static function handle_corrections_shortcode() {
 		global $wpdb;
@@ -256,7 +259,7 @@ class Corrections {
 		$post_ids = get_posts(
 			[
 				'posts_per_page' => -1,
-				'meta_key'       => self::CORRECTIONS_ACTIVE_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'       => self::CORRECTIONS_ACTIVE_META,
 				'meta_value'     => 1, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'fields'         => 'ids',
 				'orderby'        => 'date',
@@ -305,7 +308,7 @@ class Corrections {
 	/**
 	 * Adds the corrections metabox.
 	 *
-	 * @param string $post_type The post type.
+	 * @param string $post_type the post type.
 	 */
 	public static function add_corrections_metabox( $post_type ) {
 		$valid_post_types = [ 'article_legacy', 'content_type_blog', 'post', 'press_release' ];
@@ -324,17 +327,25 @@ class Corrections {
 	/**
 	 * Renders the corrections metabox.
 	 *
-	 * @param \WP_Post $post The post object.
+	 * @param \WP_Post $post the post object.
 	 */
 	public static function render_corrections_metabox( $post ) {
 		$is_active   = (bool) get_post_meta( $post->ID, self::CORRECTIONS_ACTIVE_META, true );
+		$location    = get_post_meta( $post->ID, self::CORRECTIONS_LOCATION_META, true );
 		$corrections = self::get_corrections( $post->ID );
 		?>
 		<div class="corrections-metabox-container">
 			<div class="activate-corrections">
 				<input type="hidden" value="0" name="<?php echo esc_attr( self::CORRECTIONS_ACTIVE_META ); ?>" />
-				<input type="checkbox" value="1" name="<?php echo esc_attr( self::CORRECTIONS_ACTIVE_META ); ?>" <?php checked( $is_active ); ?> />
-				<?php echo esc_html( __( 'Activate Corrections', 'newspack-plugin' ) ); ?>
+				<input type="checkbox" class="activate-corrections-checkbox" value="1" name="<?php echo esc_attr( self::CORRECTIONS_ACTIVE_META ); ?>" <?php checked( $is_active ); ?> />
+				<?php echo esc_html( __( 'activate corrections', 'newspack-plugin' ) ); ?>
+			</div>
+			<div class="display-corrections">
+				<select name="<?php echo esc_attr( self::CORRECTIONS_LOCATION_META ); ?>" />
+					<option value=""><?php echo esc_html( __( 'Select Location', 'newspack-plugin' ) ); ?></option>
+					<option value="bottom" <?php selected( $location, 'bottom' ); ?>><?php echo esc_html( __( 'Bottom', 'newspack-plugin' ) ); ?></option>
+					<option value="top" <?php selected( $location, 'top' ); ?>><?php echo esc_html( __( 'Top', 'newspack-plugin' ) ); ?></option>
+				</select>
 			</div>
 			<div class="manage-corrections">
 				<fieldset name="existing-corrections[]" class="existing-corrections">
@@ -366,25 +377,26 @@ class Corrections {
 	/**
 	 * Saves the corrections metabox.
 	 *
-	 * @param int $post_id The post ID.
+	 * @param int $post_id the post id.
 	 */
 	public static function save_corrections_metabox( $post_id ) {
-		// Return early if we are saving a correction.
+		// return early if we are saving a correction.
 		if ( self::POST_TYPE === get_post_type( $post_id ) ) {
 			return;
 		}
 
-		$corrections_active = filter_input( INPUT_POST, self::CORRECTIONS_ACTIVE_META, FILTER_VALIDATE_BOOLEAN );
-		$corrections_data   = filter_input_array(
+		$corrections_active   = filter_input( INPUT_POST, self::CORRECTIONS_ACTIVE_META, FILTER_VALIDATE_BOOLEAN );
+		$corrections_location = filter_input( INPUT_POST, self::CORRECTIONS_LOCATION_META, FILTER_SANITIZE_STRING );
+		$corrections_data     = filter_input_array(
 			INPUT_POST,
 			[
 				'existing-corrections' => [
 					'flags'  => FILTER_REQUIRE_ARRAY,
-					'filter' => FILTER_SANITIZE_STRING,
+					'filter' => FILTER_DEFAULT,
 				],
 				'new-corrections'      => [
 					'flags'  => FILTER_REQUIRE_ARRAY,
-					'filter' => FILTER_SANITIZE_STRING,
+					'filter' => FILTER_DEFAULT,
 				],
 				'deleted-corrections'  => [
 					'flags'  => FILTER_REQUIRE_ARRAY,
@@ -392,29 +404,33 @@ class Corrections {
 				],
 			]
 		);
-		// Return early if there is no corrections data.
-		if ( false === $corrections_active && empty( $corrections_data ) ) {
+		// return early if there is no corrections data.
+		if ( false === $corrections_active && false === $corrections_location && empty( $corrections_data ) ) {
 			return;
 		}
-		// Update active flag if present.
+		// update active flag if present.
 		if ( (bool) $corrections_active !== (bool) get_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, true ) ) {
 			update_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, (bool) $corrections_active );
 		}
-		// Update existing corrections if present.
+		// update location flag if present.
+		if ( $corrections_location !== get_post_meta( $post_id, self::CORRECTIONS_LOCATION_META, true ) ) {
+			update_post_meta( $post_id, self::CORRECTIONS_LOCATION_META, sanitize_text_field( $corrections_location ) );
+		}
+		// update existing corrections if present.
 		if ( ! empty( $corrections_data['existing-corrections'] ) ) {
 			foreach ( $corrections_data['existing-corrections'] as $correction_id => $correction ) {
-				// Don't save empty corrections.
+				// don't save empty corrections.
 				if ( empty( trim( $correction['content'] ) ) ) {
 					continue;
 				}
 				self::update_correction( $correction_id, $correction );
 			}
 		}
-		// Save new corrections if present.
+		// save new corrections if present.
 		if ( ! empty( $corrections_data['new-corrections'] ) ) {
 			$corrections = [];
 			foreach ( $corrections_data['new-corrections'] as $correction ) {
-				// Don't save empty corrections.
+				// don't save empty corrections.
 				if ( empty( trim( $correction['content'] ) ) ) {
 					continue;
 				}
@@ -425,7 +441,7 @@ class Corrections {
 			}
 			self::save_corrections( $post_id, $corrections );
 		}
-		// Delete corrections if present.
+		// delete corrections if present.
 		if ( ! empty( $corrections_data['deleted-corrections'] ) ) {
 			$correction_ids = array_map( 'intval', $corrections_data['deleted-corrections'] );
 			self::delete_corrections( $correction_ids );
@@ -435,9 +451,9 @@ class Corrections {
 	/**
 	 * Outputs corrections on the post content.
 	 *
-	 * @param string $content The post content.
+	 * @param string $content the post content.
 	 *
-	 * @return string The post content with corrections.
+	 * @return string the post content with corrections.
 	 */
 	public static function output_corrections_on_post( $content ) {
 		if ( is_admin() || ! is_single() ) {
@@ -481,7 +497,7 @@ class Corrections {
 		<!-- /wp:group -->
 		<?php
 		$markup = do_blocks( ob_get_clean() );
-		return $content . $markup;
+		return 'top' === get_post_meta( get_the_ID(), self::CORRECTIONS_LOCATION_META, true ) ? $markup . $content : $content . $markup;
 	}
 }
 Corrections::init();

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -326,14 +326,14 @@ class Corrections {
 	 * @param \WP_Post $post the post object.
 	 */
 	public static function render_corrections_metabox( $post ) {
-		$is_active   = (bool) get_post_meta( $post->ID, self::CORRECTIONS_ACTIVE_META, true );
+		$is_active   = get_post_meta( $post->ID, self::CORRECTIONS_ACTIVE_META, true );
 		$location    = get_post_meta( $post->ID, self::CORRECTIONS_LOCATION_META, true );
 		$corrections = self::get_corrections( $post->ID );
 		?>
 		<div class="corrections-metabox-container">
 			<div class="activate-corrections">
 				<input type="hidden" value="0" name="<?php echo esc_attr( self::CORRECTIONS_ACTIVE_META ); ?>" />
-				<input type="checkbox" class="activate-corrections-checkbox" value="1" name="<?php echo esc_attr( self::CORRECTIONS_ACTIVE_META ); ?>" <?php checked( $is_active ); ?> />
+				<input type="checkbox" class="activate-corrections-checkbox" value="1" name="<?php echo esc_attr( self::CORRECTIONS_ACTIVE_META ); ?>" <?php checked( 0 != $is_active ); ?> />
 				<?php echo esc_html( __( 'activate corrections', 'newspack-plugin' ) ); ?>
 			</div>
 			<div class="display-corrections">
@@ -381,7 +381,7 @@ class Corrections {
 			return;
 		}
 
-		$corrections_active   = filter_input( INPUT_POST, self::CORRECTIONS_ACTIVE_META, FILTER_VALIDATE_BOOLEAN );
+		$corrections_active   = filter_input( INPUT_POST, self::CORRECTIONS_ACTIVE_META, FILTER_SANITIZE_NUMBER_INT );
 		$corrections_location = filter_input( INPUT_POST, self::CORRECTIONS_LOCATION_META, FILTER_SANITIZE_STRING );
 		$corrections_data     = filter_input_array(
 			INPUT_POST,
@@ -405,8 +405,8 @@ class Corrections {
 			return;
 		}
 		// update active flag if present.
-		if ( (bool) $corrections_active !== (bool) get_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, true ) ) {
-			update_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, (bool) $corrections_active );
+		if ( $corrections_active != get_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, true ) ) {
+			update_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, $corrections_active );
 		}
 		// update location flag if present.
 		if ( $corrections_location !== get_post_meta( $post_id, self::CORRECTIONS_LOCATION_META, true ) ) {
@@ -456,7 +456,7 @@ class Corrections {
 			return $content;
 		}
 
-		if ( ! (bool) get_post_meta( get_the_ID(), self::CORRECTIONS_ACTIVE_META, true ) ) {
+		if ( 0 == get_post_meta( get_the_ID(), self::CORRECTIONS_ACTIVE_META, true ) ) {
 			return $content;
 		}
 

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -17,11 +17,6 @@ class Corrections {
 	const POST_TYPE = 'newspack_correction';
 
 	/**
-	 * Meta key for correction date meta.
-	 */
-	const CORRECTION_DATE_META = 'newspack_correction_date';
-
-	/**
 	 * Meta key for correction post ID meta.
 	 */
 	const CORRECTION_POST_ID_META = 'newspack_correction-post-id';
@@ -170,11 +165,11 @@ class Corrections {
 				[
 					'post_title'   => 'Correction for ' . get_the_title( $post_id ),
 					'post_content' => $correction['content'],
+					'post_date'    => $correction['date'],
 					'post_type'    => self::POST_TYPE,
 					'post_status'  => 'publish',
 					'meta_input'   => [
 						self::CORRECTION_POST_ID_META => $post_id,
-						self::CORRECTION_DATE_META    => $correction['date'],
 					],
 				]
 			);
@@ -217,9 +212,9 @@ class Corrections {
 			[
 				'ID'           => $correction_id,
 				'post_content' => sanitize_textarea_field( $correction['content'] ),
+				'post_date'    => sanitize_text_field( $correction['date'] ),
 			]
 		);
-		update_post_meta( $correction_id, self::CORRECTION_DATE_META, sanitize_text_field( $correction['date'] ) );
 	}
 
 	/**
@@ -285,11 +280,11 @@ class Corrections {
 						<?php
 						foreach ( $corrections as $correction ) :
 							$correction_content = $correction->post_content;
-							$correction_date    = get_post_meta( $correction->ID, self::CORRECTION_DATE_META, true );
+							$correction_date    = \get_the_date( 'M j, Y', $correction->ID );
 							$correction_heading = sprintf(
 								// translators: %s: correction date.
 								__( 'Correction on %s', 'newspack-plugin' ),
-								gmdate( 'M j, Y', strtotime( $correction_date ) )
+								$correction_date
 							);
 							?>
 							<p>
@@ -353,7 +348,7 @@ class Corrections {
 					<?php
 					foreach ( $corrections as $correction ) :
 						$correction_content = $correction->post_content;
-						$correction_date    = get_post_meta( $correction->ID, self::CORRECTION_DATE_META, true );
+						$correction_date    = \get_the_date( 'Y-m-d', $correction->ID );
 						?>
 						<fieldset name="existing-corrections[<?php echo esc_attr( $correction->ID ); ?>]" class="correction">
 							<p><?php echo esc_html( __( 'Article Correction', 'newspack-plugin' ) ); ?></p>
@@ -478,11 +473,11 @@ class Corrections {
 			<?php
 			foreach ( $corrections as $correction ) :
 				$correction_content = $correction->post_content;
-				$correction_date    = get_post_meta( $correction->ID, self::CORRECTION_DATE_META, true );
+				$correction_date    = \get_the_date( 'M j, Y', $correction->ID );
 				$correction_heading = sprintf(
 					// translators: %s: correction date.
 					__( 'Correction on %s', 'newspack-plugin' ),
-					gmdate( 'M j, Y', strtotime( $correction_date ) )
+					$correction_date
 				);
 				?>
 				<!-- wp:paragraph {"fontSize":"small"} -->

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -32,6 +32,11 @@ class Corrections {
 	const CORRECTIONS_ACTIVE_META = 'newspack_corrections_active';
 
 	/**
+	 * Meta key for post corrections ids meta.
+	 */
+	const CORRECTIONS_IDS_META = 'newspack_corrections_ids';
+
+	/**
 	 * Initializes the class.
 	 */
 	public static function init() {
@@ -154,14 +159,15 @@ class Corrections {
 	 * @return array The corrections.
 	 */
 	public static function get_corrections( $post_id ) {
+		$correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
+		if ( ! is_array( $correction_ids ) ) {
+			return [];
+		}
 		return get_posts(
 			[
 				'posts_per_page' => -1,
 				'post_type'      => self::POST_TYPE,
-				'meta_key'       => self::CORRECTION_POST_ID_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value'     => $post_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-				'orderby'        => 'date',
-				'order'          => 'DESC',
+				'include'        => $correction_ids,
 			]
 		);
 	}
@@ -173,8 +179,12 @@ class Corrections {
 	 * @param array $corrections The corrections.
 	 */
 	public static function save_corrections( $post_id, $corrections ) {
+		$correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
+		if ( ! is_array( $correction_ids ) ) {
+			$correction_ids = [];
+		}
 		foreach ( $corrections as $correction ) {
-			$post_id = wp_insert_post(
+			$id = wp_insert_post(
 				[
 					'post_title'   => 'Correction for ' . get_the_title( $post_id ),
 					'post_content' => $correction['content'],
@@ -186,7 +196,27 @@ class Corrections {
 					],
 				]
 			);
+			if ( ! \is_wp_error( $id ) ) {
+				$correction_ids[] = $id;
+			}
 		}
+		update_post_meta( $post_id, self::CORRECTIONS_IDS_META, $correction_ids );
+	}
+
+	/**
+	 * Update correction.
+	 *
+	 * @param int   $correction_id The post ID.
+	 * @param array $correction    The correction.
+	 */
+	public static function update_correction( $correction_id, $correction ) {
+		wp_update_post(
+			[
+				'ID'           => $correction_id,
+				'post_content' => sanitize_textarea_field( $correction['content'] ),
+			]
+		);
+		update_post_meta( $correction_id, self::CORRECTION_DATE_META, sanitize_text_field( $correction['date'] ) );
 	}
 
 	/**
@@ -195,9 +225,17 @@ class Corrections {
 	 * @param array $correction_ids Correction IDs.
 	 */
 	public static function delete_corrections( $correction_ids ) {
+		$stored_correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
+		if ( ! is_array( $stored_correction_ids ) ) {
+			$stored_correction_ids = [];
+		}
 		foreach ( $correction_ids as $id ) {
 			wp_delete_post( $id, true );
+			if ( isset( $stored_correction_ids[ $id ] ) ) {
+				unset( $stored_correction_ids[ $id ] );
+			}
 		}
+		update_post_meta( $post_id, self::CORRECTIONS_IDS_META, $stored_correction_ids );
 	}
 
 	/**
@@ -336,23 +374,41 @@ class Corrections {
 			return;
 		}
 
-		$corrections_data = filter_input_array(
+		$corrections_active = filter_input( INPUT_POST, self::CORRECTIONS_ACTIVE_META, FILTER_VALIDATE_BOOLEAN );
+		$corrections_data   = filter_input_array(
 			INPUT_POST,
 			[
-				'new-corrections'             => [
+				'existing-corrections' => [
 					'flags'  => FILTER_REQUIRE_ARRAY,
 					'filter' => FILTER_SANITIZE_STRING,
 				],
-				'deleted-corrections'         => [
+				'new-corrections'      => [
+					'flags'  => FILTER_REQUIRE_ARRAY,
+					'filter' => FILTER_SANITIZE_STRING,
+				],
+				'deleted-corrections'  => [
 					'flags'  => FILTER_REQUIRE_ARRAY,
 					'filter' => FILTER_SANITIZE_NUMBER_INT,
 				],
-				self::CORRECTIONS_ACTIVE_META => FILTER_SANITIZE_NUMBER_INT,
 			]
 		);
 		// Return early if there is no corrections data.
-		if ( ! $corrections_data ) {
+		if ( false === $corrections_active && empty( $corrections_data ) ) {
 			return;
+		}
+		// Update active flag if present.
+		if ( (bool) $corrections_active !== (bool) get_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, true ) ) {
+			update_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, (bool) $corrections_active );
+		}
+		// Update existing corrections if present.
+		if ( ! empty( $corrections_data['existing-corrections'] ) ) {
+			foreach ( $corrections_data['existing-corrections'] as $correction_id => $correction ) {
+				// Don't save empty corrections.
+				if ( empty( trim( $correction['content'] ) ) ) {
+					continue;
+				}
+				self::update_correction( $correction_id, $correction );
+			}
 		}
 		// Save new corrections if present.
 		if ( ! empty( $corrections_data['new-corrections'] ) ) {
@@ -373,10 +429,6 @@ class Corrections {
 		if ( ! empty( $corrections_data['deleted-corrections'] ) ) {
 			$correction_ids = array_map( 'intval', $corrections_data['deleted-corrections'] );
 			self::delete_corrections( $correction_ids );
-		}
-		// Update active flag if present.
-		if ( isset( $corrections_data[ self::CORRECTIONS_ACTIVE_META ] ) ) {
-			update_post_meta( $post_id, self::CORRECTIONS_ACTIVE_META, (bool) $corrections_data[ self::CORRECTIONS_ACTIVE_META ] );
 		}
 	}
 

--- a/src/other-scripts/corrections/index.js
+++ b/src/other-scripts/corrections/index.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { domReady } from '../../utils';
+import './style.scss';
+
+domReady( () => {
+	// Handle admin metabox for article corrections.
+	const metaboxContainer = document.querySelector( '.corrections-metabox-container' );
+	if ( metaboxContainer ) {
+		metaboxContainer.querySelector( 'button.add-correction' ).addEventListener( 'click', () => {
+			const existingCorrections = metaboxContainer.querySelector( '.existing-corrections' );
+			const newCorrection = document.createElement( 'div' );
+			newCorrection.classList.add( 'reveal-correction' );
+			newCorrection.innerHTML = `
+				<p>${ __( 'Article Correction', 'newspack-plugin' ) }</p>
+				<textarea name="reveal_correction[]" rows="3" cols="60"></textarea>
+				<br/>
+				<p>${ __( 'Date:', 'newspack-plugin' ) } <input type="date" name="reveal_correction_date[]"></p>
+				<span class="delete-correction">X</span>
+			`;
+			existingCorrections.appendChild( newCorrection );
+			newCorrection.querySelector( 'span.delete-correction' ).addEventListener( 'click', () => {
+				newCorrection.remove();
+			} );
+		} );
+	}
+} );
+

--- a/src/other-scripts/corrections/index.js
+++ b/src/other-scripts/corrections/index.js
@@ -13,21 +13,46 @@ domReady( () => {
 	// Handle admin metabox for article corrections.
 	const metaboxContainer = document.querySelector( '.corrections-metabox-container' );
 	if ( metaboxContainer ) {
+		// Handle deletion of existing corrections.
+		metaboxContainer.querySelectorAll( '.existing-corrections button.delete-correction' )
+			.forEach( button => {
+				button.addEventListener( 'click', e => {
+					// Get the partent .correction element.
+					const correction = e.target.closest( '.correction' );
+					if ( correction ) {
+						correction.remove();
+						const correctionId = correction.getAttribute( 'name' ).replace( 'existing-corrections[', '' ).replace( ']', '' );
+						if ( correctionId ) {
+							const deletedCorrections = metaboxContainer.querySelector( '.deleted-corrections' );
+							const deletedCorrection = document.createElement( 'input' );
+							deletedCorrection.type = 'hidden';
+							deletedCorrection.name = 'deleted-corrections[]';
+							deletedCorrection.value = correctionId;
+							deletedCorrections.appendChild( deletedCorrection );
+						}
+					}
+				} );
+			} );
+		// Handle addition of new corrections.
+		let newCorrectionsCount = 0;
 		metaboxContainer.querySelector( 'button.add-correction' ).addEventListener( 'click', () => {
-			const existingCorrections = metaboxContainer.querySelector( '.existing-corrections' );
+			const newCorrections = metaboxContainer.querySelector( '.new-corrections' );
 			const newCorrection = document.createElement( 'div' );
-			newCorrection.classList.add( 'reveal-correction' );
+			newCorrection.classList.add( 'correction' );
 			newCorrection.innerHTML = `
+				<fieldset name="new-corrections[${newCorrectionsCount}]">
 				<p>${ __( 'Article Correction', 'newspack-plugin' ) }</p>
-				<textarea name="reveal_correction[]" rows="3" cols="60"></textarea>
+				<textarea name="new-corrections[${newCorrectionsCount}][content]" rows="3" cols="60"></textarea>
 				<br/>
-				<p>${ __( 'Date:', 'newspack-plugin' ) } <input type="date" name="reveal_correction_date[]"></p>
-				<span class="delete-correction">X</span>
+				<p>${ __( 'Date:', 'newspack-plugin' ) } <input type="date" name="new-corrections[${newCorrectionsCount}][date]"></p>
+				<button class="delete-correction">X</button>
+				</fieldset>
 			`;
-			existingCorrections.appendChild( newCorrection );
-			newCorrection.querySelector( 'span.delete-correction' ).addEventListener( 'click', () => {
+			newCorrections.appendChild( newCorrection );
+			newCorrection.querySelector( 'button.delete-correction' ).addEventListener( 'click', () => {
 				newCorrection.remove();
 			} );
+			newCorrectionsCount++;
 		} );
 	}
 } );

--- a/src/other-scripts/corrections/index.js
+++ b/src/other-scripts/corrections/index.js
@@ -13,6 +13,18 @@ domReady( () => {
 	// Handle admin metabox for article corrections.
 	const metaboxContainer = document.querySelector( '.corrections-metabox-container' );
 	if ( metaboxContainer ) {
+		// Handle displaying location select.
+		const activateCorrections = metaboxContainer.querySelector( 'input.activate-corrections-checkbox' );
+		const locationSelect = metaboxContainer.querySelector( '.display-corrections' );
+		locationSelect.style.display = activateCorrections.checked ? 'block' : 'none';
+		activateCorrections.addEventListener( 'change', () => {
+			if ( activateCorrections.checked ) {
+				locationSelect.style.display = 'block';
+			} else {
+				locationSelect.style.display = 'none';
+			}
+		} );
+
 		// Handle deletion of existing corrections.
 		metaboxContainer.querySelectorAll( '.existing-corrections button.delete-correction' )
 			.forEach( button => {

--- a/src/other-scripts/corrections/index.js
+++ b/src/other-scripts/corrections/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { select, subscribe } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -24,7 +25,6 @@ domReady( () => {
 				locationSelect.style.display = 'none';
 			}
 		} );
-
 		// Handle deletion of existing corrections.
 		metaboxContainer.querySelectorAll( '.existing-corrections button.delete-correction' )
 			.forEach( button => {
@@ -65,6 +65,26 @@ domReady( () => {
 				newCorrection.remove();
 			} );
 			newCorrectionsCount++;
+		} );
+		// Handle saving the post.
+		let hasSavedPost = false;
+		const unsubscribe = subscribe( () => {
+			// Return early if no new corrections have been added.
+			if ( ! newCorrectionsCount ) {
+				return;
+			}
+			const isSavingPost = select( 'core/editor' ).isSavingPost();
+			const isAutosavingPost = select('core/editor').isAutosavingPost();
+
+			if ( isSavingPost && ! isAutosavingPost && ! hasSavedPost ) {
+				hasSavedPost = true;
+			}
+
+			if ( ! isSavingPost && hasSavedPost ) {
+				// Unsubscribe from the store.
+				unsubscribe();
+				window.location.href = window.location.href;
+			}
 		} );
 	}
 } );

--- a/src/other-scripts/corrections/style.scss
+++ b/src/other-scripts/corrections/style.scss
@@ -1,0 +1,37 @@
+// Admin metabox styles
+.corrections-metabox-container {
+	.activate-corrections {
+		padding-top: 1em;
+		padding-bottom: 1em;
+		border-bottom: 2px solid silver;
+		margin-bottom: 1em;
+	}
+
+	.reveal-correction {
+		position: relative;
+		border-bottom: 1px solid silver;
+		padding-top: 1em;
+		padding-bottom: 1em;
+	}
+
+	.add-correction {
+		margin-top: 2em;
+		cursor: pointer;
+	}
+
+	.delete-correction {
+		position: absolute;
+		top: 2em;
+		right: 2em;
+		font-weight: bold;
+		color: silver;
+		border: 1px solid silver;
+		padding-left: 0.25em;
+		padding-right: 0.25em;
+		cursor: pointer;
+	}
+
+	.delete-correction:hover {
+		color: red;
+	}
+}

--- a/src/other-scripts/corrections/style.scss
+++ b/src/other-scripts/corrections/style.scss
@@ -7,7 +7,11 @@
 		margin-bottom: 1em;
 	}
 
-	.reveal-correction {
+	.deleted-corrections {
+		visibility: hidden;
+	}
+
+	.correction {
 		position: relative;
 		border-bottom: 1px solid silver;
 		padding-top: 1em;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208894036683495/1208945901567236 and https://app.asana.com/0/1208894036683495/1208945901567238

This PR adds the corrections feature behind the `NEWSPACK_CORRECTIONS_ENABLED` feature flag. Note this is a quick and simple implementation based on an already existing custom plugin strictly for the purpose of getting ready for a site migration. 

**Editor:**
![Screenshot 2025-01-08 at 16 35 44](https://github.com/user-attachments/assets/42878377-c358-4c71-868d-d2bfc40c5b11)

**Frontend:**
![Screenshot 2025-01-08 at 16 34 54](https://github.com/user-attachments/assets/f8c1d1bf-ec8f-45da-a520-b4d4133f0559)


### How to test the changes in this Pull Request:

1. Enable the corrections feature flag in wp-config (`NEWSPACK_CORRECTIONS_ENABLED`)
2. Edit any post as admin
3. Scroll to the bottom of the content editor and verify the corrections metabox is present
4. Select the activate corrections checkbox, select a location, and add some corrections
5. As a reader visit the post on the front end
6. Verify the corrections are added to the post
7. As admin again, select a different corrections location
8. As reader again, visit the post and verify the corrections have moved
9. As admin again, uncheck the activate corrections checkbox and save
10. As reader again, visit the post and verify the corrections are NOT added to the post
12. As admin, delete a revision and save
13. As reader, verify the revisions appear as expected on the frontend
14. As admin, remove the feature flag from wp-config and edit any post
15. Verify corrections are no longer present

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->