### PR TITLE
fix: add max limit of 5 consecutive scheduled syncs

### DIFF
--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -112,6 +112,13 @@ class ESP_Sync extends Sync {
 
 		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context );
 
+		if ( ! \is_wp_error( $result ) ) {
+			$user = get_user_by( 'email', $contact['email'] );
+			if ( $user ) {
+				\delete_user_meta( $user->ID, 'newspack_sync_retries' );
+			}
+		}
+
 		return \is_wp_error( $result ) ? $result : true;
 	}
 
@@ -136,7 +143,7 @@ class ESP_Sync extends Sync {
 		static::log(
 			sprintf(
 				// Translators: %s is the email address of the contact to synced.
-				__( 'Scheduling secondary sync for contact %s.', 'newspack-plugin' ),
+				__( 'Scheduling sync for contact %s.', 'newspack-plugin' ),
 				$user->data->user_email
 			),
 			[
@@ -155,11 +162,31 @@ class ESP_Sync extends Sync {
 	 * @param string $context The context of the sync.
 	 */
 	public static function scheduled_sync( $user_id, $context ) {
+		$retries = (int) get_user_meta( $user_id, 'newspack_sync_retries', true );
+		$retries++;
+		if ( 5 < $retries ) {
+			static::log(
+				sprintf(
+					// Translators: %s is the email address of the contact to synced.
+					__( 'Failed to sync contact %s after 5 retries.', 'newspack-plugin' ),
+					$user_id
+				),
+				[
+					'user_id' => $user_id,
+					'context' => $context,
+				]
+			);
+			return;
+		}
+
 		$contact = Sync\WooCommerce::get_contact_from_customer( new \WC_Customer( $user_id ) );
 		if ( ! $contact ) {
 			return;
 		}
-		self::sync( $contact, $context );
+		$result = self::sync( $contact, $context );
+		if ( true !== $result ) {
+			update_user_meta( $user_id, 'newspack_sync_retries', $retries );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a mechanism to the `schedule_sync` method so that consecutive scheduled syncs for a single contact will only happen up to a max of five consecutive times. This is to avoid an infinite loop if a contact is scheduled to retry the sync after a failure, but the sync keeps failing.

The counter is reset upon a successful sync to the ESP.

### How to test the changes in this Pull Request:

Follow instructions in https://github.com/Automattic/newspack-newsletters/pull/1729.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->