### PR TITLE
feat: add `/wp-admin/customize.php` as click destination for advanced settings cta

### DIFF
--- a/src/wizards/newspack/views/settings/display-settings/index.tsx
+++ b/src/wizards/newspack/views/settings/display-settings/index.tsx
@@ -170,7 +170,7 @@ export default function DisplaySettings() {
 			</WizardSection>
 			{ errorMessage && <Notice /> }
 			<div className="newspack-buttons-card">
-				<Button variant="tertiary">
+				<Button variant="tertiary" href="/wp-admin/customize.php">
 					{ __( 'Advanced Settings', 'newspack-plugin' ) }
 				</Button>
 				<Button variant="primary" onClick={ save }>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes broken CTA by adding `/wp-admin/customize.php` to click destination for Advanced Settings on Newspack > Settings > Display Settings.

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets `git checkout fix/ia-display-settings__advanced-settings && npm run build` 
2. Navigate to _/wp-admin/admin.php?page=newspack-settings#/display-settings_
3. Scroll to bottom of screen and click "Advanced Settings"
![Screenshot 2024-12-19 at 08 33 13](https://github.com/user-attachments/assets/2753502f-3aea-4786-b56d-628e7a99208f)
4. Confirm you're directed to _/wp-admin/customize.php_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->