### PR TITLE
fix(stripe): when adding new card, update subs of all statuses

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -35,6 +35,7 @@ class WooCommerce_My_Account {
 		\add_filter( 'woocommerce_billing_fields', [ __CLASS__, 'required_address_fields' ] );
 		\add_filter( 'woocommerce_get_checkout_url', [ __CLASS__, 'get_checkout_url' ] );
 		\add_filter( 'woocommerce_get_checkout_payment_url', [ __CLASS__, 'get_checkout_url' ] );
+		\add_filter( 'wc_stripe_update_subs_payment_method_card_statuses', [ __CLASS__, 'update_payment_methods_for_all_subs' ] );
 
 		// Reader Activation mods.
 		if ( Reader_Activation::is_enabled() ) {
@@ -744,6 +745,22 @@ class WooCommerce_My_Account {
 			unset( $columns['membership-next-bill-on'] );
 		}
 		return $columns;
+	}
+
+	/**
+	 * When adding a new payment method, apply to subscriptions of all statuses.
+	 * By default, this is only applied to subscriptions with an `active` status.
+	 * Applies to the Stripe payment gateway only.
+	 *
+	 * @return array Filtered array of statuses.
+	 */
+	public static function update_payment_methods_for_all_subs() {
+		return [
+			'active',
+			'pending',
+			'on-hold',
+			'pending-cancel',
+		];
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

By default, when a reader adds a new payment method to the Stripe gateway, the checkbox to "Update the payment method for all of my current subscriptions" is only shown if the reader has an _active_ subscription. If the reader only has non-active subscriptions (e.g. a subscription in `on-hold` status due to a failed payment), then those subscriptions' payment methods won't be updated automatically when a new payment method is added.

Since we visually hid this checkbox in #2934 so that it's always active when present, it was hard to tell that it wasn't always there.

### How to test the changes in this Pull Request:

1. On `release`, as a reader, purchase a subscription.
2. As an admin, set the subscription to "on hold" status (or select the "create pending renewal order", which simulates a subscription after a failed payment).

<img width="308" alt="Screenshot 2024-12-19 at 5 23 04 PM" src="https://github.com/user-attachments/assets/d691ddcf-3b5f-44e9-9077-64e181960825" />

3. As the reader, add a new different payment method in My Account.
4. As the admin, manually renew the subscription. Observe that the renewal order created charges the old card used in step 1, not the one added in step 3. Also observe in the reader's My Account > My Subscription page that the subscription is still set to use the old payment method.
5. Check out this branch.
6. Repeat 1–4 on this branch, but after renewing the subscription, confirm that it charges the new payment method and that in the reader's My Account > My Subscription page, the subscription is set to use the new payment method.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208948912819349