### PR TITLE
fix(recaptcha): also verify v2 on checkout

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -344,18 +344,6 @@ final class Recaptcha {
 			return false;
 		}
 
-		// Only use v2 if we are in modal checkout context.
-		// TODO: Remove this check once we have a way to enable v2 for non-modal checkouts.
-		if (
-			( 'v2' === $version || 'v2_invisible' === $settings['version'] ) &&
-			(
-				! method_exists( 'Newspack_Blocks\Modal_Checkout', 'is_modal_checkout' ) ||
-				! \Newspack_Blocks\Modal_Checkout::is_modal_checkout()
-			)
-		) {
-			return false;
-		}
-
 		if ( empty( self::get_site_key() ) || empty( self::get_site_secret() ) ) {
 			return false;
 		}
@@ -510,6 +498,20 @@ final class Recaptcha {
 	public static function verify_recaptcha_on_checkout() {
 		$url                   = \home_url( \add_query_arg( null, null ) );
 		$should_verify_captcha = apply_filters( 'newspack_recaptcha_verify_captcha', self::can_use_captcha(), $url );
+		$version               = self::get_setting( 'version' );
+
+		// Only use v2 if we are in modal checkout context.
+		// TODO: Remove this check once we have a way to enable v2 for non-modal checkouts.
+		if (
+			( 'v2' === $version || 'v2_invisible' === $version ) &&
+			(
+				! method_exists( 'Newspack_Blocks\Modal_Checkout', 'is_modal_checkout' ) ||
+				! \Newspack_Blocks\Modal_Checkout::is_modal_checkout()
+			)
+		) {
+			$should_verify_captcha = false;
+		}
+
 		if ( ! $should_verify_captcha ) {
 			return;
 		}

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -497,7 +497,7 @@ final class Recaptcha {
 	 */
 	public static function verify_recaptcha_on_checkout() {
 		$url                   = \home_url( \add_query_arg( null, null ) );
-		$should_verify_captcha = apply_filters( 'newspack_recaptcha_verify_captcha', self::can_use_captcha( 'v3' ), $url );
+		$should_verify_captcha = apply_filters( 'newspack_recaptcha_verify_captcha', self::can_use_captcha(), $url );
 		if ( ! $should_verify_captcha ) {
 			return;
 		}

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -344,6 +344,18 @@ final class Recaptcha {
 			return false;
 		}
 
+		// Only use v2 if we are in modal checkout context.
+		// TODO: Remove this check once we have a way to enable v2 for non-modal checkouts.
+		if (
+			( 'v2' === $version || 'v2_invisible' === $settings['version'] ) &&
+			(
+				! method_exists( 'Newspack_Blocks\Modal_Checkout', 'is_modal_checkout' ) ||
+				! \Newspack_Blocks\Modal_Checkout::is_modal_checkout()
+			)
+		) {
+			return false;
+		}
+
 		if ( empty( self::get_site_key() ) || empty( self::get_site_secret() ) ) {
 			return false;
 		}

--- a/src/other-scripts/recaptcha/utils.js
+++ b/src/other-scripts/recaptcha/utils.js
@@ -1,0 +1,175 @@
+/* globals jQuery, grecaptcha, newspack_recaptcha_data */
+
+// The minimum continuous amount of time an element must be in the viewport before being considered visible.
+const MINIMUM_VISIBLE_TIME = 250;
+
+// The minimum percentage of an element that must be in the viewport before being considered visible.
+const MINIMUM_VISIBLE_PERCENTAGE = 0.5;
+
+/**
+ * Specify a function to execute when the DOM is fully loaded.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
+ *
+ * @param {Function} callback A function to execute after the DOM is ready.
+ * @return {void}
+ */
+export function domReady( callback ) {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+	if (
+		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+	) {
+		return void callback();
+	}
+	// DOMContentLoaded has not fired yet, delay callback until then.
+	document.addEventListener( 'DOMContentLoaded', callback );
+}
+
+/**
+ * Create an IntersectionObserver to execute function `handleEvent` when an element becomes visible.
+ *
+ * @param {Function} handleEvent
+ * @return {IntersectionObserver} Observer instance.
+ */
+export function getIntersectionObserver( handleEvent ) {
+	let timer;
+	const observer = new IntersectionObserver(
+		entries => {
+			entries.forEach( observerEntry => {
+				if ( observerEntry.isIntersecting ) {
+					if ( ! timer ) {
+						timer = setTimeout( () => {
+							handleEvent();
+							observer.unobserve( observerEntry.target );
+						}, MINIMUM_VISIBLE_TIME || 0 );
+					}
+				} else if ( timer ) {
+					clearTimeout( timer );
+					timer = false;
+				}
+			} );
+		},
+		{
+			threshold: MINIMUM_VISIBLE_PERCENTAGE,
+		}
+	);
+
+	return observer;
+};
+
+/**
+ * Destroy hidden reCAPTCHA v3 token fields to avoid unnecessary reCAPTCHA checks.
+ */
+export function destroyV3Field( forms = [] ) {
+	const formsToHandle = forms.length
+		? forms
+		: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
+
+	formsToHandle.forEach( form => {
+		removeHiddenV3Field( form );
+	} );
+}
+
+/**
+ * Append a hidden reCAPTCHA v3 token field to the given form.
+ *
+ * @param {HTMLElement} form The form element.
+ */
+export function addHiddenV3Field( form ) {
+	let field = form.querySelector( 'input[name="g-recaptcha-response"]' );
+	if ( ! field ) {
+		field = document.createElement( 'input' );
+		field.type = 'hidden';
+		field.name = 'g-recaptcha-response';
+		form.appendChild( field );
+
+		const action = form.getAttribute( 'data-newspack-recaptcha' ) || 'submit';
+		refreshV3Token( field, action );
+		setInterval( () => refreshV3Token( field, action ), 30000 ); // Refresh token every 30 seconds.
+
+		// Refresh reCAPTCHAs on Woo checkout update and error.
+		if ( jQuery ) {
+			jQuery( document ).on( 'updated_checkout', () => refreshV3Token( field, action ) );
+			jQuery( document.body ).on( 'checkout_error', () => refreshV3Token( field, action ) );
+		}
+	}
+}
+
+/**
+ * Refresh the reCAPTCHA v3 token for the given form and action.
+ *
+ * @param {HTMLElement} field  The hidden input field storing the token for a form.
+ * @param {string}      action The action name to pass to reCAPTCHA.
+ *
+ * @return {Promise<void>|void} A promise that resolves when the token is refreshed.
+ */
+function refreshV3Token( field, action = 'submit' ) {
+	if ( field ) {
+		const siteKey = newspack_recaptcha_data?.site_key;
+
+		// Get a token to pass to the server. See https://developers.google.com/recaptcha/docs/v3 for API reference.
+		return grecaptcha.execute( siteKey, { action } ).then( token => {
+			field.value = token;
+		} );
+	}
+}
+
+/**
+ * Remove the hidden reCAPTCHA v3 token field from the given form.
+ *
+ * @param {HTMLElement} form The form element.
+ */
+function removeHiddenV3Field( form ) {
+	const field = form.querySelector( 'input[name="g-recaptcha-response"]' );
+	if ( field ) {
+		field.parentElement.removeChild( field );
+	}
+}
+
+/**
+ * Refresh the reCAPTCHA v2 widget attached to the given element.
+ *
+ * @param {HTMLElement} el Element with the reCAPTCHA widget to refresh.
+ */
+export function refreshV2Widget( el ) {
+	const widgetId = parseInt( el.getAttribute( 'data-recaptcha-widget-id' ) );
+	if ( ! isNaN( widgetId ) ) {
+		grecaptcha.reset( widgetId );
+	}
+}
+
+/**
+ * Append a generic error message above the given form.
+ *
+ * @param {HTMLElement} form    The form element.
+ * @param {string}      message The error message to display.
+ */
+export function addErrorMessage( form, message ) {
+	const errorText = document.createElement( 'p' );
+	errorText.textContent = message;
+	const container = document.createElement( 'div' );
+	container.classList.add( 'newspack-recaptcha-error' );
+	container.appendChild( errorText );
+	// Newsletters block errors render below the form.
+	if ( form.parentElement.classList.contains( 'newspack-newsletters-subscribe' ) ) {
+		form.append( container );
+	} else {
+		container.classList.add( 'newspack-ui__notice', 'newspack-ui__notice--error' );
+		form.insertBefore( container, form.firstChild );
+	}
+}
+
+/**
+ * Remove generic error messages from form if present.
+ *
+ * @param {HTMLElement} form The form element.
+ */
+export function removeErrorMessages( form ) {
+	const errors = form.querySelectorAll( '.newspack-recaptcha-error' );
+	for ( const error of errors ) {
+		error.parentElement.removeChild( error );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1200550061930446/1209016713141551/f

This PR makes sure we are also verifying v2 recaptcha response on checkout requests.

### How to test the changes in this Pull Request:

1. Enable recaptcha v2
2. As a reader go through checkout
3. There should be no change in behavior, but you can add some logging here to confirm the recaptcha verification is happening in the backend: https://github.com/Automattic/newspack-plugin/blob/731535dc3c2439eadfccff46522a705db0f104be/includes/class-recaptcha.php#L504

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->