### PR TITLE
fix: v2 widget in modal checkout

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -344,18 +344,6 @@ final class Recaptcha {
 			return false;
 		}
 
-		// Only use v2 if we are in modal checkout context.
-		// TODO: Remove this check once we have a way to enable v2 for non-modal checkouts.
-		if (
-			( 'v2' === $version || 'v2_invisible' === $settings['version'] ) &&
-			(
-				! method_exists( 'Newspack_Blocks\Modal_Checkout', 'is_modal_checkout' ) ||
-				! \Newspack_Blocks\Modal_Checkout::is_modal_checkout()
-			)
-		) {
-			return false;
-		}
-
 		if ( empty( self::get_site_key() ) || empty( self::get_site_secret() ) ) {
 			return false;
 		}
@@ -510,6 +498,20 @@ final class Recaptcha {
 	public static function verify_recaptcha_on_checkout() {
 		$url                   = \home_url( \add_query_arg( null, null ) );
 		$should_verify_captcha = apply_filters( 'newspack_recaptcha_verify_captcha', self::can_use_captcha(), $url );
+		$version               = self::get_setting( 'version' );
+
+		// Only use v2 if we are in modal checkout context.
+		// TODO: Remove this check once we have a way to enable v2 for non-modal checkouts.
+		if (
+			( 'v2' === $version || 'v2_invisible' === $version ) &&
+			(
+				! method_exists( 'Newspack_Blocks\Modal_Checkout', 'is_modal_checkout' ) ||
+				! \Newspack_Blocks\Modal_Checkout::is_modal_checkout()
+			)
+		) {
+			$should_verify_captcha = false;
+		}
+
 		if ( ! $should_verify_captcha ) {
 			return;
 		}

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -139,14 +139,18 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 		if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
 			return;
 		}
-		// Refresh widget if it already exists.
-		if ( button.hasAttribute( 'data-recaptcha-widget-id' ) ) {
-			refreshV2Widget( button );
-			return;
-		}
 		// Callback when reCAPTCHA passes validation or skip flag is present.
-		const successCallback = () => {
-			onSuccess?.()
+		const successCallback = token => {
+			onSuccess?.();
+			// Ensure the token gets submitted with the form submission.
+			let hiddenField = form.querySelector( '[name="g-recaptcha-response"]' );
+			if ( ! hiddenField ) {
+				hiddenField = document.createElement( 'input' );
+				hiddenField.type = 'hidden';
+				hiddenField.name = 'g-recaptcha-response';
+				form.appendChild( hiddenField );
+			}
+			hiddenField.value = token;
 			form.requestSubmit( button );
 			refreshV2Widget( button );
 		};
@@ -166,9 +170,40 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 				}
 			}
 		}
+		// Attach widget to form events.
+		const attachListeners = () => {
+			form.addEventListener( 'focusin', () => renderV2Widget( form, onSuccess, onError ) );
+			button.addEventListener( 'click', e => {
+				e.preventDefault();
+				e.stopImmediatePropagation();
+				// Empty error messages if present.
+				removeErrorMessages( form );
+				// Skip reCAPTCHA verification if the button has a data-skip-recaptcha attribute.
+				if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
+					successCallback();
+				} else {
+					grecaptcha.execute( widgetId ).then( () => {
+						// If we are in an iframe scroll to top.
+						if ( window?.location !== window?.parent?.location ) {
+							document.body.scrollIntoView( { behavior: 'smooth' } );
+						}
+					} );
+				}
+			} );
+		}
+		// Refresh reCAPTCHA widgets on Woo checkout update and error.
+		if ( jQuery ) {
+			jQuery( document ).on( 'updated_checkout', () => attachListeners );
+			jQuery( document.body ).on( 'checkout_error', () => attachListeners );
+		}
+		// Refresh widget if it already exists.
+		if ( button.hasAttribute( 'data-recaptcha-widget-id' ) ) {
+			refreshV2Widget( button );
+			return;
+		}
 		const container = document.createElement( 'div' );
 		container.classList.add( 'grecaptcha-container' );
-		button.parentElement.append( container );
+		document.body.append( container );
 		const widgetId = grecaptcha.render( container, {
 			...options,
 			callback: successCallback,
@@ -176,30 +211,7 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 			'expired-callback': errorCallback,
 		} );
 		button.setAttribute( 'data-recaptcha-widget-id', widgetId );
-
-		// Refresh reCAPTCHA widgets on Woo checkout update and error.
-		if ( jQuery ) {
-			jQuery( document ).on( 'updated_checkout', () => renderV2Widget( form, onSuccess, onError ) );
-			jQuery( document.body ).on( 'checkout_error', () => renderV2Widget( form, onSuccess, onError ) );
-		}
-
-		button.addEventListener( 'click', e => {
-			e.preventDefault();
-			e.stopImmediatePropagation();
-			// Empty error messages if present.
-			removeErrorMessages( form );
-			// Skip reCAPTCHA verification if the button has a data-skip-recaptcha attribute.
-			if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
-				successCallback();
-			} else {
-				grecaptcha.execute( widgetId ).then( () => {
-					// If we are in an iframe scroll to top.
-					if ( window?.location !== window?.parent?.location ) {
-						document.body.scrollIntoView( { behavior: 'smooth' } );
-					}
-				} );
-			}
-		} );
+		attachListeners();
 	} );
 }
 
@@ -254,25 +266,14 @@ function render( forms = [], onSuccess = null, onError = null ) {
 		: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
 
 	formsToHandle.forEach( form => {
-		if ( ! form.hasAttribute( 'data-recaptcha-rendered' ) ) {
-			form.addEventListener( 'focusin', () => {
-				if ( isV2 ) {
-					renderV2Widget( form, onSuccess, onError );
-				}
-				if ( isV3 ) {
-					addHiddenV3Field( form );
-				}
-			} );
-			form.setAttribute( 'data-recaptcha-rendered', 'true' );
-		} else {
-			// Call render methods to trigger refresh.
+		form.addEventListener( 'focusin', () => {
 			if ( isV2 ) {
 				renderV2Widget( form, onSuccess, onError );
 			}
 			if ( isV3 ) {
 				addHiddenV3Field( form );
 			}
-		}
+		} );
 	} );
 }
 

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -1,28 +1,15 @@
 /* globals jQuery, grecaptcha, newspack_recaptcha_data */
 
+import {
+	addErrorMessage,
+	addHiddenV3Field,
+	destroyV3Field,
+	domReady,
+	getIntersectionObserver,
+	refreshV2Widget,
+	removeErrorMessages
+} from './utils';
 import './style.scss';
-
-/**
- * Specify a function to execute when the DOM is fully loaded.
- *
- * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
- *
- * @param {Function} callback A function to execute after the DOM is ready.
- * @return {void}
- */
-function domReady( callback ) {
-	if ( typeof document === 'undefined' ) {
-		return;
-	}
-	if (
-		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
-		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
-	) {
-		return void callback();
-	}
-	// DOMContentLoaded has not fired yet, delay callback until then.
-	document.addEventListener( 'DOMContentLoaded', callback );
-}
 
 window.newspack_grecaptcha = window.newspack_grecaptcha || {
 	destroy: destroyV3Field,
@@ -34,87 +21,6 @@ const isV2 = 'v2' === newspack_recaptcha_data.version.substring( 0, 2 );
 const isV3 = 'v3' === newspack_recaptcha_data.version;
 const siteKey = newspack_recaptcha_data.site_key;
 const isInvisible = 'v2_invisible' === newspack_recaptcha_data.version;
-
-/**
- * Destroy hidden reCAPTCHA v3 token fields to avoid unnecessary reCAPTCHA checks.
- */
-function destroyV3Field( forms = [] ) {
-	if ( isV3 ) {
-		const formsToHandle = forms.length
-			? forms
-			: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
-
-		formsToHandle.forEach( form => {
-			removeHiddenV3Field( form );
-		} );
-	}
-}
-
-/**
- * Refresh the reCAPTCHA v3 token for the given form and action.
- *
- * @param {HTMLElement} field  The hidden input field storing the token for a form.
- * @param {string}      action The action name to pass to reCAPTCHA.
- *
- * @return {Promise<void>|void} A promise that resolves when the token is refreshed.
- */
-function refreshV3Token( field, action = 'submit' ) {
-	if ( field ) {
-		// Get a token to pass to the server. See https://developers.google.com/recaptcha/docs/v3 for API reference.
-		return grecaptcha.execute( siteKey, { action } ).then( token => {
-			field.value = token;
-		} );
-	}
-}
-
-/**
- * Append a hidden reCAPTCHA v3 token field to the given form.
- *
- * @param {HTMLElement} form The form element.
- */
-function addHiddenV3Field( form ) {
-	let field = form.querySelector( 'input[name="g-recaptcha-response"]' );
-	if ( ! field ) {
-		field = document.createElement( 'input' );
-		field.type = 'hidden';
-		field.name = 'g-recaptcha-response';
-		form.appendChild( field );
-
-		const action = form.getAttribute( 'data-newspack-recaptcha' ) || 'submit';
-		refreshV3Token( field, action );
-		setInterval( () => refreshV3Token( field, action ), 30000 ); // Refresh token every 30 seconds.
-
-		// Refresh reCAPTCHAs on Woo checkout update and error.
-		if ( jQuery ) {
-			jQuery( document ).on( 'updated_checkout', () => refreshV3Token( field, action ) );
-			jQuery( document.body ).on( 'checkout_error', () => refreshV3Token( field, action ) );
-		}
-	}
-}
-
-/**
- * Remove the hidden reCAPTCHA v3 token field from the given form.
- *
- * @param {HTMLElement} form The form element.
- */
-function removeHiddenV3Field( form ) {
-	const field = form.querySelector( 'input[name="g-recaptcha-response"]' );
-	if ( field ) {
-		field.parentElement.removeChild( field );
-	}
-}
-
-/**
- * Refresh the reCAPTCHA v2 widget attached to the given element.
- *
- * @param {HTMLElement} el Element with the reCAPTCHA widget to refresh.
- */
-function refreshV2Widget( el ) {
-	const widgetId = parseInt( el.getAttribute( 'data-recaptcha-widget-id' ) );
-	if ( ! isNaN( widgetId ) ) {
-		grecaptcha.reset( widgetId );
-	}
-}
 
 /**
  * Render reCAPTCHA v2 widget on the given form.
@@ -172,7 +78,7 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 		}
 		// Attach widget to form events.
 		const attachListeners = () => {
-			form.addEventListener( 'focusin', () => renderV2Widget( form, onSuccess, onError ) );
+			getIntersectionObserver( () => renderV2Widget( form, onSuccess, onError ) ).observe( form, { attributes: true } );
 			button.addEventListener( 'click', e => {
 				e.preventDefault();
 				e.stopImmediatePropagation();
@@ -216,39 +122,6 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 }
 
 /**
- * Append a generic error message above the given form.
- *
- * @param {HTMLElement} form    The form element.
- * @param {string}      message The error message to display.
- */
-function addErrorMessage( form, message ) {
-	const errorText = document.createElement( 'p' );
-	errorText.textContent = message;
-	const container = document.createElement( 'div' );
-	container.classList.add( 'newspack-recaptcha-error' );
-	container.appendChild( errorText );
-	// Newsletters block errors render below the form.
-	if ( form.parentElement.classList.contains( 'newspack-newsletters-subscribe' ) ) {
-		form.append( container );
-	} else {
-		container.classList.add( 'newspack-ui__notice', 'newspack-ui__notice--error' );
-		form.insertBefore( container, form.firstChild );
-	}
-}
-
-/**
- * Remove generic error messages from form if present.
- *
- * @param {HTMLElement} form The form element.
- */
-function removeErrorMessages( form ) {
-	const errors = form.querySelectorAll( '.newspack-recaptcha-error' );
-	for ( const error of errors ) {
-		error.parentElement.removeChild( error );
-	}
-}
-
-/**
  * Render reCAPTCHA elements.
  *
  * @param {Array}         forms     Array of form elements to render reCAPTCHA on.
@@ -266,14 +139,15 @@ function render( forms = [], onSuccess = null, onError = null ) {
 		: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
 
 	formsToHandle.forEach( form => {
-		form.addEventListener( 'focusin', () => {
+		const renderForm = () => {
 			if ( isV2 ) {
 				renderV2Widget( form, onSuccess, onError );
 			}
 			if ( isV3 ) {
 				addHiddenV3Field( form );
 			}
-		} );
+		};
+		getIntersectionObserver( renderForm ).observe( form, { attributes: true } );
 	} );
 }
 

--- a/src/other-scripts/recaptcha/utils.js
+++ b/src/other-scripts/recaptcha/utils.js
@@ -1,0 +1,175 @@
+/* globals jQuery, grecaptcha, newspack_recaptcha_data */
+
+// The minimum continuous amount of time an element must be in the viewport before being considered visible.
+const MINIMUM_VISIBLE_TIME = 250;
+
+// The minimum percentage of an element that must be in the viewport before being considered visible.
+const MINIMUM_VISIBLE_PERCENTAGE = 0.5;
+
+/**
+ * Specify a function to execute when the DOM is fully loaded.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
+ *
+ * @param {Function} callback A function to execute after the DOM is ready.
+ * @return {void}
+ */
+export function domReady( callback ) {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+	if (
+		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+	) {
+		return void callback();
+	}
+	// DOMContentLoaded has not fired yet, delay callback until then.
+	document.addEventListener( 'DOMContentLoaded', callback );
+}
+
+/**
+ * Create an IntersectionObserver to execute function `handleEvent` when an element becomes visible.
+ *
+ * @param {Function} handleEvent
+ * @return {IntersectionObserver} Observer instance.
+ */
+export function getIntersectionObserver( handleEvent ) {
+	let timer;
+	const observer = new IntersectionObserver(
+		entries => {
+			entries.forEach( observerEntry => {
+				if ( observerEntry.isIntersecting ) {
+					if ( ! timer ) {
+						timer = setTimeout( () => {
+							handleEvent();
+							observer.unobserve( observerEntry.target );
+						}, MINIMUM_VISIBLE_TIME || 0 );
+					}
+				} else if ( timer ) {
+					clearTimeout( timer );
+					timer = false;
+				}
+			} );
+		},
+		{
+			threshold: MINIMUM_VISIBLE_PERCENTAGE,
+		}
+	);
+
+	return observer;
+};
+
+/**
+ * Destroy hidden reCAPTCHA v3 token fields to avoid unnecessary reCAPTCHA checks.
+ */
+export function destroyV3Field( forms = [] ) {
+	const formsToHandle = forms.length
+		? forms
+		: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
+
+	formsToHandle.forEach( form => {
+		removeHiddenV3Field( form );
+	} );
+}
+
+/**
+ * Append a hidden reCAPTCHA v3 token field to the given form.
+ *
+ * @param {HTMLElement} form The form element.
+ */
+export function addHiddenV3Field( form ) {
+	let field = form.querySelector( 'input[name="g-recaptcha-response"]' );
+	if ( ! field ) {
+		field = document.createElement( 'input' );
+		field.type = 'hidden';
+		field.name = 'g-recaptcha-response';
+		form.appendChild( field );
+
+		const action = form.getAttribute( 'data-newspack-recaptcha' ) || 'submit';
+		refreshV3Token( field, action );
+		setInterval( () => refreshV3Token( field, action ), 30000 ); // Refresh token every 30 seconds.
+
+		// Refresh reCAPTCHAs on Woo checkout update and error.
+		if ( jQuery ) {
+			jQuery( document ).on( 'updated_checkout', () => refreshV3Token( field, action ) );
+			jQuery( document.body ).on( 'checkout_error', () => refreshV3Token( field, action ) );
+		}
+	}
+}
+
+/**
+ * Refresh the reCAPTCHA v3 token for the given form and action.
+ *
+ * @param {HTMLElement} field  The hidden input field storing the token for a form.
+ * @param {string}      action The action name to pass to reCAPTCHA.
+ *
+ * @return {Promise<void>|void} A promise that resolves when the token is refreshed.
+ */
+function refreshV3Token( field, action = 'submit' ) {
+	if ( field ) {
+		const siteKey = newspack_recaptcha_data?.site_key;
+
+		// Get a token to pass to the server. See https://developers.google.com/recaptcha/docs/v3 for API reference.
+		return grecaptcha.execute( siteKey, { action } ).then( token => {
+			field.value = token;
+		} );
+	}
+}
+
+/**
+ * Remove the hidden reCAPTCHA v3 token field from the given form.
+ *
+ * @param {HTMLElement} form The form element.
+ */
+function removeHiddenV3Field( form ) {
+	const field = form.querySelector( 'input[name="g-recaptcha-response"]' );
+	if ( field ) {
+		field.parentElement.removeChild( field );
+	}
+}
+
+/**
+ * Refresh the reCAPTCHA v2 widget attached to the given element.
+ *
+ * @param {HTMLElement} el Element with the reCAPTCHA widget to refresh.
+ */
+export function refreshV2Widget( el ) {
+	const widgetId = parseInt( el.getAttribute( 'data-recaptcha-widget-id' ) );
+	if ( ! isNaN( widgetId ) ) {
+		grecaptcha.reset( widgetId );
+	}
+}
+
+/**
+ * Append a generic error message above the given form.
+ *
+ * @param {HTMLElement} form    The form element.
+ * @param {string}      message The error message to display.
+ */
+export function addErrorMessage( form, message ) {
+	const errorText = document.createElement( 'p' );
+	errorText.textContent = message;
+	const container = document.createElement( 'div' );
+	container.classList.add( 'newspack-recaptcha-error' );
+	container.appendChild( errorText );
+	// Newsletters block errors render below the form.
+	if ( form.parentElement.classList.contains( 'newspack-newsletters-subscribe' ) ) {
+		form.append( container );
+	} else {
+		container.classList.add( 'newspack-ui__notice', 'newspack-ui__notice--error' );
+		form.insertBefore( container, form.firstChild );
+	}
+}
+
+/**
+ * Remove generic error messages from form if present.
+ *
+ * @param {HTMLElement} form The form element.
+ */
+export function removeErrorMessages( form ) {
+	const errors = form.querySelectorAll( '.newspack-recaptcha-error' );
+	for ( const error of errors ) {
+		error.parentElement.removeChild( error );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In Woo checkout, certain actions will trigger a Woo `updated_checkout` or `checkout_error` jQuery event, which will destroy and recreate DOM elements inside the checkout form, causing our reCAPTCHA v2-related event listeners to also be destroyed. When this happens, the checkout form is no longer protected by reCAPTCHA, but since #3644 does a server-side reCAPTCHA verification, it's missing the token required to verify and thus returns an error that makes it impossible to complete checkout.

This PR should fix the issue with the following changes:

- Move the check for modal checkouts to decide whether to verify the reCAPTCHA token server-side from the `Recaptcha::can_use_captcha()` method to `Recaptcha::verify_recaptcha_on_checkout()`: this ensures that our own RAS auth/registration forms + modal checkout forms all do a server-side reCAPTCHA check, but a standard non-modal checkout does not (we should fix this ASAP, though)
- Always render v2 widgets for every form we handle as direct children of the `document.body` element, instead of inside the form itself: this will ensure that the widget remains in the DOM after `updated_checkout` or `checkout_error` events
- Upon successfully completing a v2 widget challenge, ensure that the form data being submitted actually has the success token (it may not during checkout since the hidden input may have been destroyed or lost its value from a `updated_checkout` or `checkout_error` event between when the submit button is clicked and the data is posted to the server)

### How to test the changes in this Pull Request:

1. Enable/connect reCAPTCHA v2 and make sure the "Security preference" option in reCAPTCHA settings (in Google's dashboard) is turned all the way up to ensure you will always be challenged

<img width="646" alt="Screenshot 2024-12-20 at 5 50 29 PM" src="https://github.com/user-attachments/assets/3433bf44-2bb5-4018-8ab5-b7e12ec6ab15" />


3. Test auth modal (registration only), Newsletter Subscription Form, and Registration blocks: confirm all present a v2 widget challenge, and all submit the form after completing the challenge (successfully if required fields are filled out, with errors if not)
4. Test modal checkout: confirm that when submitting the payment details form (modal step 2), you are always presented with a v2 widget challenge, and that the form always submits after completing the challenge (successfully if checkout data passes validation, with errors if not)
5. Test modal checkout a few more times, making sure to submit the form with errors (e.g. without filling out required payment fields or with invalid values), after checking/unchecking the "cover fees" checkbox, after selecting different payment gateway options, etc. All of these actions will trigger a Woo `updated_checkout` or `checkout_error` jQuery event, which should now also trigger our JS to reattach reCAPTCHA-related event listeners to the form and its children.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->