### PR TITLE
fix: dont try to get orders if Woo is not active

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-duplicate-orders.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-duplicate-orders.php
@@ -44,6 +44,11 @@ class WooCommerce_Duplicate_Orders {
 	 * @param array  $results Results to be merged with new results.
 	 */
 	public static function get_order_duplicates( $cutoff_time, $current_page = 0, $results = [] ): array {
+
+		if ( ! function_exists( 'wc_get_orders' ) ) {
+			return [];
+		}
+
 		$per_page = 100;
 		$order_result = wc_get_orders(
 			[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids an error when the job is executed while Woo is not active

### How to test the changes in this Pull Request:

1. Read the code
2. on trunk run `wp newspack detect-order-duplicates` confirm it works
3. `wp plugin deactivate woocommerce`
4. Run again and confirm you see an error
5. Checkout this branch and confirm there are no errors
6. reactivate woo and confirm it works

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209007294965787