### PR TITLE
feat(esp-sync): debounce successive sync requests

### DIFF
--- a/includes/data-events/connectors/class-esp-connector.php
+++ b/includes/data-events/connectors/class-esp-connector.php
@@ -162,22 +162,6 @@ class ESP_Connector extends Reader_Activation\ESP_Sync {
 		if ( empty( $data['subscription_id'] ) || empty( $data['user_id'] ) || empty( $data['email'] ) ) {
 			return;
 		}
-
-		/** 
-		* When a renewal happens, it triggers two syncs to the ESP, one setting the subscription as on hold, and a 
-		* second one setting it back to active. This sometimes creates a race condition on the ESP side. 
-		* This third request will make sure the ESP always has the correct and most up to date data about the reader.
-		*/
-		self::schedule_sync(
-			$data['user_id'],
-			sprintf(
-				// Translators: %d is the subscription ID and %s is the customer's email address.
-				'RAS Woo subscription %d for %s renewed.',
-				$data['subscription_id'],
-				$data['email']
-			),
-			120 // Schedule an ESP sync in 2 minutes.
-		);
 	}
 
 	/**

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -15,6 +15,22 @@ defined( 'ABSPATH' ) || exit;
  * ESP Sync Class.
  */
 class ESP_Sync extends Sync {
+	/**
+	 * Hook name for sync events.
+	 */
+	const SYNC_EVENT_HOOK = 'newspack_scheduled_esp_sync';
+
+	/**
+	 * User meta field prefix for contact data.
+	 */
+	const USER_META_PREFIX = 'newspack_sync_';
+
+	/**
+	 * The standard number of seconds to wait before syncing a contact to the ESP.
+	 * If multiple sync requests happen within this timeframe, the request data will be consolidated and synced all at once.
+	 * It's a unique number so that we can schedule one-off syncs outside of the regular sync method.
+	 */
+	const STANDARD_SYNC_DELAY = 123;
 
 	/**
 	 * Context of the sync.
@@ -26,7 +42,7 @@ class ESP_Sync extends Sync {
 	 * Initialize hooks.
 	 */
 	public static function init_hooks() {
-		add_action( 'newspack_scheduled_esp_sync', [ __CLASS__, 'scheduled_sync' ], 10, 2 );
+		add_action( self::SYNC_EVENT_HOOK, [ __CLASS__, 'scheduled_sync' ], 10, 2 );
 	}
 
 	/**
@@ -81,14 +97,33 @@ class ESP_Sync extends Sync {
 	}
 
 	/**
-	 * Sync contact to the ESP.
+	 * Reconcile contact data for a user with data stored in user meta.
+	 *
+	 * @param int   $user_id The user ID.
+	 * @param array $contact The new contact data.
+	 */
+	public static function reconcile_contact_data( $user_id, $contact ) {
+		$existing_contact = \get_user_meta( $user_id, self::USER_META_PREFIX . 'contact', true );
+
+		// Merge existing contact data with new data and update in user meta.
+		if ( ! empty( $existing_contact['metadata'] ) ) {
+			$contact['metadata'] = \wp_parse_args( $contact['metadata'], $existing_contact['metadata'] );
+			$contact             = \wp_parse_args( $contact, $existing_contact );
+		}
+
+		return $contact;
+	}
+
+	/**
+	 * Queue a request to sync a contact to the ESP.
 	 *
 	 * @param array  $contact The contact data to sync.
 	 * @param string $context The context of the sync. Defaults to static::$context.
+	 * @param int    $delay   The number of seconds to wait before syncing.
 	 *
 	 * @return true|\WP_Error True if succeeded or WP_Error.
 	 */
-	public static function sync( $contact, $context = '' ) {
+	public static function sync( $contact, $context = '', $delay = null ) {
 		$can_sync = static::can_esp_sync( true );
 		if ( $can_sync->has_errors() ) {
 			return $can_sync;
@@ -98,19 +133,95 @@ class ESP_Sync extends Sync {
 			$context = static::$context;
 		}
 
-		$master_list_id = Reader_Activation::get_esp_master_list_id();
+		if ( ! is_int( $delay ) ) {
+			$delay = self::STANDARD_SYNC_DELAY;
+		}
 
 		/**
-		 * Filters the contact data before normalizing and syncing to the ESP.
+		 * Filters the contact data before normalizing for syncing to the ESP.
+		 *
+		 * @param array  $contact The contact data to sync.
+		 * @param string $context The context of the sync.
+		 */
+		$contact = \apply_filters( 'newspack_esp_presync_contact', $contact, $context );
+		$contact = Sync\Metadata::normalize_contact_data( $contact );
+
+		$user    = \get_user_by( 'email', $contact['email'] );
+		$contact = self::reconcile_contact_data( $user->ID, $contact );
+
+		// Merge existing contexts with new context and update in user meta.
+		$existing_context = \get_user_meta( $user->ID, self::USER_META_PREFIX . 'context', true );
+		if ( empty( $existing_context ) ) {
+			$existing_context = [];
+		}
+		$existing_context[] = $context;
+
+		\update_user_meta( $user->ID, self::USER_META_PREFIX . 'contact', $contact );
+		\update_user_meta( $user->ID, self::USER_META_PREFIX . 'context', $existing_context );
+
+		// If there's an unprocessed sync event for this user, cancel it.
+		$cleared = \wp_clear_scheduled_hook( self::SYNC_EVENT_HOOK, [ $user->ID ] );
+		if ( ! empty( $cleared ) ) {
+			static::log(
+				__( 'Scheduled sync cancelled due to debounce', 'newspack-plugin' ),
+				[
+					'cancelled'    => $cleared,
+					'contact'      => $contact,
+					'new_context'  => $context,
+					'all_contexts' => $existing_context,
+					'user_id'      => $user->ID,
+				]
+			);
+		}
+
+		// Execute sync immediately or schedule it.
+		if ( 0 === $delay ) {
+			return self::execute_sync( $user->ID, $context );
+		}
+		return self::schedule_sync( $user->ID, $delay, $context );
+	}
+
+	/**
+	 * Execute a sync request with the connected ESP.
+	 *
+	 * @param int    $user_id The user ID for the contact to sync.
+	 * @param string $context The context of the sync.
+	 */
+	public static function execute_sync( $user_id, $context = '' ) {
+		$can_sync = static::can_esp_sync( true );
+		if ( $can_sync->has_errors() ) {
+			return $can_sync;
+		}
+
+		$contact = Sync\WooCommerce::get_contact_from_customer( new \WC_Customer( $user_id ) );
+
+		/**
+		 * Filters the contact data before normalizing for syncing to the ESP.
 		 *
 		 * @param array  $contact The contact data to sync.
 		 * @param string $context The context of the sync.
 		 */
 		$contact = \apply_filters( 'newspack_esp_sync_contact', $contact, $context );
-
 		$contact = Sync\Metadata::normalize_contact_data( $contact );
+		$contact = self::reconcile_contact_data( $user_id, $contact );
+
+		if ( empty( $context ) ) {
+			$stored_context = \get_user_meta( $user_id, self::USER_META_PREFIX . 'context', true );
+			if ( ! empty( $stored_context ) ) {
+				$context = end( $stored_context );
+			}
+		}
+
+		if ( empty( $context ) ) {
+			$context = static::$context;
+		}
+
+		$master_list_id = Reader_Activation::get_esp_master_list_id();
 
 		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context );
+		if ( ! \is_wp_error( $result ) ) {
+			\delete_user_meta( $user_id, self::USER_META_PREFIX . 'context' );
+		}
 
 		return \is_wp_error( $result ) ? $result : true;
 	}
@@ -119,47 +230,40 @@ class ESP_Sync extends Sync {
 	 * Schedule a future sync.
 	 *
 	 * @param int    $user_id The user ID for the contact to sync.
-	 * @param string $context The context of the sync.
 	 * @param int    $delay   The delay in seconds.
+	 * @param string $context The context of the sync.
+	 *
+	 * @return bool|\WP_Error True if the sync was scheduled, WP_Error otherwise.
 	 */
-	public static function schedule_sync( $user_id, $context, $delay ) {
+	public static function schedule_sync( $user_id, $delay, $context = '' ) {
 		// Schedule another sync in $delay number of seconds.
 		if ( ! is_int( $delay ) ) {
-			return;
+			return false;
 		}
 
 		$user = get_userdata( $user_id );
 		if ( ! $user ) {
-			return;
+			return false;
 		}
 
 		static::log(
-			sprintf(
-				// Translators: %s is the email address of the contact to synced.
-				__( 'Scheduling secondary sync for contact %s.', 'newspack-plugin' ),
-				$user->data->user_email
-			),
+			__( 'Scheduling ESP sync for user', 'newspack-plugin' ),
 			[
 				'user_email' => $user->data->user_email,
 				'user_id'    => $user_id,
 				'context'    => $context,
 			]
 		);
-		\wp_schedule_single_event( \time() + $delay, 'newspack_scheduled_esp_sync', [ $user_id, $context ] );
+		return \wp_schedule_single_event( \time() + $delay, self::SYNC_EVENT_HOOK, [ $user_id ], true );
 	}
 
 	/**
 	 * Handle a scheduled sync event.
 	 *
-	 * @param int    $user_id The user ID for the contact to sync.
-	 * @param string $context The context of the sync.
+	 * @param int $user_id The user ID for the contact to sync.
 	 */
-	public static function scheduled_sync( $user_id, $context ) {
-		$contact = Sync\WooCommerce::get_contact_from_customer( new \WC_Customer( $user_id ) );
-		if ( ! $contact ) {
-			return;
-		}
-		self::sync( $contact, $context );
+	public static function scheduled_sync( $user_id ) {
+		self::execute_sync( $user_id );
 	}
 
 	/**
@@ -201,7 +305,7 @@ class ESP_Sync extends Sync {
 		}
 
 		$contact = $is_order ? Sync\WooCommerce::get_contact_from_order( $order ) : Sync\WooCommerce::get_contact_from_customer( $customer );
-		$result  = $is_dry_run ? true : self::sync( $contact );
+		$result  = $is_dry_run ? true : self::sync( $contact, '', 0 );
 
 		if ( $result && ! \is_wp_error( $result ) ) {
 			static::log(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements [debounce](https://developer.mozilla.org/en-US/docs/Glossary/Debounce)-like behavior for ESP sync requests. 

Currently, ESP sync requests are fired to the connected ESP's API immediately. However, successive data events can trigger a rapid series of sync requests. Given a site using premium newsletters tied to memberships tied to subscriptions, the single act of renewing a reader subscription will result in the following events:

1. The reader's subscription gets put into `on-hold` status pending a successful payment
2. The reader's membership gets put into `paused` status, pending the subscription's reactivation
3. The reader's subscription(s) to the premium newsletter list(s) tied to the membership gets revoked
4. After payment is complete, the subscription gets put back into `active` status
5. The membership gets reactivated
6. The premium newsletter subscription(s) gets reinstated

Each of these data events triggers its own ESP sync, but ultimately only the last one matters. However, we can't just skip the prior steps as payment could fail along the way, which means we would want to sync the reader's change in membership status as a result.

Instead of immediately firing sync requests, this PR will store contact data as user meta which is continuously updated with each sync request, then schedule a sync with the ESP's API ~2 minutes in the future. If other sync requests come in before the scheduled sync happens, the scheduled sync is cancelled, the contact data in user meta is updated again, and another sync is scheduled ~2 minutes in the future. Once 2 minutes elapse without another sync request, the contact data is once again updated according to the user's current status (but reconciled with data stored in user meta—this is necessary to persist data that may only be available one time, such as signup UTM parameters) and then synced to the ESP. This should ensure that if multiple sync requests get triggered in rapid succession, only one sync is actually fired to the ESP's API, and always with the most up-to-date contact data that we have.

This should also solve for race conditions that might happen if two sync requests are fired simultaneously, as the contact data will be refreshed again at the moment the sync is sent to the ESP.

The PR also supports passing a `$delay` value of `0` to sync immediately, basically retaining the current non-debounced behavior. This is still used for sync requests triggered by an admin action (manual resync via the Users admin UI) or CLI script, as these bulk syncs should only result in one sync per user per action.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Purchase new subscriptions (preferably ones tied to memberships and premium newsletters) as two separate readers.
3. Using WP CLI's `wp cron event list`, confirm that there are two non-recurring cron jobs with the `newspack_scheduled_esp_sync` hook scheduled ~2 minutes after each completed transaction, and that the sync to the ESP doesn't actually happen before the scheduled cron jobs occur.
4. Wait until both jobs fire, or run `wp cron event run newspack_scheduled_esp_sync` to trigger them early, and confirm that both contacts are synced to the ESP.
5. As an admin, manually renew both subscriptions within two minutes and confirm again that both renewals trigger a series of sync requests moving through the subscription/membership status changes, but that in the end, only one `newspack_scheduled_esp_sync` cron job is scheduled for each.
6. Wait until both jobs fire, or run `wp cron event run newspack_scheduled_esp_sync` to trigger them early, and confirm that each contact is synced to the ESP only once with up-to-date data.
7. As an admin, use the Order Actions menu to create a pending renewal order (which will put the subscription in `on-hold` status and pause the membership)

<img width="298" alt="Screenshot 2025-01-07 at 4 36 32 PM" src="https://github.com/user-attachments/assets/20fe6f81-b107-4c28-801a-36f91341b4d4" />

8. ~[currently failing: needs a fix]~ _(EDIT: fixed by #3658)_ Wait ~2 minutes or run `wp cron event run newspack_scheduled_esp_sync` to trigger the job early, and confirm that the contact is correctly synced with a `NP_Membership Status` value of `on-hold`. Also confirm that the user is unsubscribed from any premium newsletter lists associated with the paused membership. (This tests that failed renewals still sync the non-active status correctly.) 
9. Smoke test manual resyncs via the admin Users UI and via WP CLI (`wp newspack esp sync` command).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->