### PR TITLE
fix(esp-sync): get inactive subscriptions with failed or pending orders

### DIFF
--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -105,8 +105,17 @@ class WooCommerce {
 				$subscription = \wcs_get_subscription( $subscription_id );
 				if ( $subscription->has_status( WooCommerce_Connection::FORMER_SUBSCRIBER_STATUSES ) ) {
 
-					// Only subscriptions that have at least one order are considered.
-					if ( ! empty( $subscription->get_related_orders() ) ) {
+					// Only subscriptions that have at least one completed order are considered.
+					$completed_orders = array_values(
+						array_filter(
+							$subscription->get_related_orders(),
+							function( $order_id ) {
+								$order = \wc_get_order( $order_id );
+								return 'completed' === $order->get_status();
+							}
+						)
+					);
+					if ( ! empty( $completed_orders ) ) {
 						$acc[] = $subscription_id;
 					}
 				}

--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -108,7 +108,7 @@ class WooCommerce {
 					// Only subscriptions that have at least one completed order are considered.
 					$completed_orders = array_values(
 						array_filter(
-							$subscription->get_related_orders(),
+							array_keys( $subscription->get_related_orders() ),
 							function( $order_id ) {
 								$order = \wc_get_order( $order_id );
 								return 'completed' === $order->get_status();

--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -105,8 +105,8 @@ class WooCommerce {
 				$subscription = \wcs_get_subscription( $subscription_id );
 				if ( $subscription->has_status( WooCommerce_Connection::FORMER_SUBSCRIBER_STATUSES ) ) {
 
-					// Only subscriptions that had a completed order are considered.
-					if ( ! empty( $subscription->get_date( 'last_order_date_completed' ) ) ) {
+					// Only subscriptions that have at least one order are considered.
+					if ( ! empty( $subscription->get_related_orders() ) ) {
 						$acc[] = $subscription_id;
 					}
 				}

--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -106,15 +106,7 @@ class WooCommerce {
 				if ( $subscription->has_status( WooCommerce_Connection::FORMER_SUBSCRIBER_STATUSES ) ) {
 
 					// Only subscriptions that have at least one completed order are considered.
-					$related_orders  = $subscription->get_related_orders( 'all' );
-					$completed_order = false;
-					foreach ( $related_orders as $order_id => $order ) {
-						if ( $order->has_status( 'completed' ) ) {
-							$completed_order = $order;
-							break;
-						}
-					}
-					if ( ! empty( $completed_order ) ) {
+					if ( 0 < $subscription->get_payment_count() ) {
 						$acc[] = $subscription_id;
 					}
 				}

--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -266,7 +266,7 @@ class WooCommerce {
 				}
 
 				// If the subscription has moved to a cancelled or expired status.
-				if ( $current_subscription->has_status( [ 'cancelled', 'expired' ] ) ) {
+				if ( $current_subscription->has_status( [ 'cancelled', 'expired', 'on-hold' ] ) ) {
 					$donor_status = 'Ex-' . $donor_status;
 				}
 				$metadata['membership_status'] = $donor_status;

--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -106,7 +106,16 @@ class WooCommerce {
 				if ( $subscription->has_status( WooCommerce_Connection::FORMER_SUBSCRIBER_STATUSES ) ) {
 
 					// Only subscriptions that have at least one completed order are considered.
-					if ( 0 < $subscription->get_payment_count() ) {
+					$related_orders  = $subscription->get_related_orders();
+					$completed_order = false;
+					foreach ( $related_orders as $order_id ) {
+						$order = \wc_get_order( $order_id );
+						if ( $order->has_status( 'completed' ) ) {
+							$completed_order = $order_id;
+							break;
+						}
+					}
+					if ( ! empty( $completed_order ) ) {
 						$acc[] = $subscription_id;
 					}
 				}

--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -106,16 +106,15 @@ class WooCommerce {
 				if ( $subscription->has_status( WooCommerce_Connection::FORMER_SUBSCRIBER_STATUSES ) ) {
 
 					// Only subscriptions that have at least one completed order are considered.
-					$completed_orders = array_values(
-						array_filter(
-							array_keys( $subscription->get_related_orders() ),
-							function( $order_id ) {
-								$order = \wc_get_order( $order_id );
-								return 'completed' === $order->get_status();
-							}
-						)
-					);
-					if ( ! empty( $completed_orders ) ) {
+					$related_orders  = $subscription->get_related_orders( 'all' );
+					$completed_order = false;
+					foreach ( $related_orders as $order_id => $order ) {
+						if ( $order->has_status( 'completed' ) ) {
+							$completed_order = $order;
+							break;
+						}
+					}
+					if ( ! empty( $completed_order ) ) {
 						$acc[] = $subscription_id;
 					}
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue where `Newspack\Reader_Activation\Sync\WooCommerce::get_most_recent_cancelled_or_expired_subscription( $user_id )` fails to get subscriptions whose most recent order has a `failed` or `pending` status. This is because `$subscription->get_date( 'last_order_date_completed' )` will only return a value if the subscription's most recent order has a `completed` status.

### How to test the changes in this Pull Request:

1. As a new reader, purchase a subscription.
2. As an admin, edit the subscription and use the "Order actions" menu to create a pending renewal order for the subscription (this will put the subscription into "on hold" status"):

<img width="298" alt="Screenshot 2025-01-07 at 4 36 32 PM" src="https://github.com/user-attachments/assets/8fa30611-3cca-4c60-9bf8-bfc163d02a89" />

3. On `release`, using `wp shell`, run `\Newspack\Reader_Activation\Sync\WooCommerce::get_contact_from_customer( $user_id );` to get the contact data for the order. Observe that the contact data does not contain any info about the on-hold subscription:

```
> \Newspack\Reader_Activation\Sync\WooCommerce::get_contact_from_customer( 127 );

= [
    "email" => "test@test.co",
    "metadata" => [
      "account" => 127,
      "registration_date" => "2025-01-07 22:40:54",
      "total_paid" => "",
      "membership_status" => "",
      "payment_page" => "",
      "payment_page_utm" => "",
      "sub_start_date" => "",
      "sub_end_date" => "",
      "cancellation_reason" => "",
      "billing_cycle" => "",
      "recurring_payment" => "",
      "last_payment_date" => "",
      "last_payment_amount" => "",
      "product_name" => "",
      "next_payment_date" => "",
    ],
    "name" => "Test Contact",
  ]
```

4. Check out this branch, start a new `wp shell` session, and confirm that `\Newspack\Reader_Activation\Sync\WooCommerce::get_contact_from_customer( $user_id );` now contains info about the on-hold subscription:

```
> \Newspack\Reader_Activation\Sync\WooCommerce::get_contact_from_customer( 127 );
= [
    "email" => "test@test.co",
    "metadata" => [
      "payment_page" => "https://localhost/support/?utm_campaign=Newspack%202025&utm_content=testing",
      "payment_page_utm_campaign" => "Newspack 2025",
      "payment_page_utm_content" => "testing",
      "membership_status" => "on-hold",
      "sub_start_date" => "2025-01-07 22:40:55",
      "sub_end_date" => "",
      "billing_cycle" => "month",
      "recurring_payment" => "25.00",
      "last_payment_amount" => "25.00",
      "last_payment_date" => "2025-01-08 16:47:45",
      "next_payment_date" => "2025-02-07 22:40:55",
      "product_name" => "All Access - Monthly",
      "payment_page_utm_source" => "",
      "payment_page_utm_medium" => "",
      "payment_page_utm_term" => "",
      "cancellation_reason" => "",
      "total_paid" => "75.00",
      "account" => 127,
      "registration_date" => "2025-01-07 22:40:54",
    ],
    "name" => "Test Contact",
  ]
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209109673133239