### PR TITLE
feat(data-events): unique event key

### DIFF
--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -38,13 +38,20 @@ final class Data_Events {
 	private static $global_handlers = [];
 
 	/**
+	 * Dispatches queued for execution on shutdown.
+	 *
+	 * @var array[]
+	 */
+	private static $queued_dispatches = [];
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
 		\add_action( 'wp_ajax_' . self::ACTION, [ __CLASS__, 'maybe_handle' ] );
 		\add_action( 'wp_ajax_nopriv_' . self::ACTION, [ __CLASS__, 'maybe_handle' ] );
+		\add_action( 'shutdown', [ __CLASS__, 'execute_queued_dispatches' ] );
 	}
-
 
 	/**
 	 * Maybe handle an event.
@@ -57,16 +64,24 @@ final class Data_Events {
 			\wp_die();
 		}
 
-		$action_name = isset( $_POST['action_name'] ) ? \sanitize_text_field( \wp_unslash( $_POST['action_name'] ) ) : null;
-		if ( empty( $action_name ) || ! isset( self::$actions[ $action_name ] ) ) {
+		$dispatches = isset( $_POST['dispatches'] ) ? $_POST['dispatches'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		if ( empty( $dispatches ) || ! is_array( $dispatches ) ) {
 			\wp_die();
 		}
 
-		$timestamp = isset( $_POST['timestamp'] ) ? \sanitize_text_field( \wp_unslash( $_POST['timestamp'] ) ) : null;
-		$data      = isset( $_POST['data'] ) ? $_POST['data'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$client_id = isset( $_POST['client_id'] ) ? \sanitize_text_field( \wp_unslash( $_POST['client_id'] ) ) : null;
+		foreach ( $dispatches as $dispatch ) {
+			$action_name = isset( $dispatch['action_name'] ) ? \sanitize_text_field( $dispatch['action_name'] ) : null;
+			if ( empty( $action_name ) || ! isset( self::$actions[ $action_name ] ) ) {
+				continue;
+			}
 
-		self::handle( $action_name, $timestamp, $data, $client_id );
+			$timestamp = isset( $dispatch['timestamp'] ) ? \sanitize_text_field( $dispatch['timestamp'] ) : null;
+			$data      = isset( $dispatch['data'] ) ? $dispatch['data'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$client_id = isset( $dispatch['client_id'] ) ? \sanitize_text_field( $dispatch['client_id'] ) : null;
+
+			self::handle( $action_name, $timestamp, $data, $client_id );
+		}
 
 		\wp_die();
 	}
@@ -312,8 +327,21 @@ final class Data_Events {
 			return $body;
 		}
 
+		self::$queued_dispatches[] = $body;
+	}
+
+	/**
+	 * Execute queued dispatches.
+	 */
+	public static function execute_queued_dispatches() {
+		if ( empty( self::$queued_dispatches ) ) {
+			return;
+		}
+
+		$actions = array_column( self::$queued_dispatches, 'action_name' );
+
 		Logger::log(
-			sprintf( 'Dispatching action "%s".', $action_name ),
+			sprintf( 'Dispatching actions: "%s".', implode( ', ', $actions ) ),
 			self::LOGGER_HEADER
 		);
 
@@ -325,16 +353,24 @@ final class Data_Events {
 			\admin_url( 'admin-ajax.php' )
 		);
 
-		return \wp_remote_post(
+		$request = \wp_remote_post(
 			$url,
 			[
 				'timeout'   => 0.01,
 				'blocking'  => false,
-				'body'      => $body,
+				'body'      => [ 'dispatches' => self::$queued_dispatches ],
 				'cookies'   => $_COOKIE, // phpcs:ignore
 				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
 			]
 		);
+
+		/**
+		 * Fires after dispatching queued actions.
+		 *
+		 * @param WP_Error|WP_HTTP_Response $request           The request object.
+		 * @param array                     $queued_dispatches The queued dispatches.
+		 */
+		\do_action( 'newspack_data_events_dispatched', $request, self::$queued_dispatches );
 	}
 }
 Data_Events::init();

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -328,6 +328,11 @@ final class Data_Events {
 		}
 
 		self::$queued_dispatches[] = $body;
+
+		// If we're in shutdown, execute the dispatches immediately.
+		if ( did_action( 'shutdown' ) ) {
+			self::execute_queued_dispatches();
+		}
 	}
 
 	/**
@@ -371,6 +376,9 @@ final class Data_Events {
 		 * @param array                     $queued_dispatches The queued dispatches.
 		 */
 		\do_action( 'newspack_data_events_dispatched', $request, self::$queued_dispatches );
+
+		// Clear the queue in case of a retry.
+		self::$queued_dispatches = [];
 	}
 }
 Data_Events::init();

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -31,6 +31,13 @@ final class Data_Events {
 	private static $actions = [];
 
 	/**
+	 * Unique event keys, keyed by their action name.
+	 *
+	 * @var callable[]
+	 */
+	private static $actions_unique_event_keys = [];
+
+	/**
 	 * Registered global callable handlers to be executed on all actions.
 	 *
 	 * @var callable[]
@@ -150,15 +157,17 @@ final class Data_Events {
 	/**
 	 * Register a triggerable action.
 	 *
-	 * @param string $action_name Action name.
+	 * @param string $action_name      Action name.
+	 * @param string $unique_event_key Optional unique event key to ensure a single dispatch per event that matches the key.
 	 *
 	 * @return void|WP_Error Error if action already registered.
 	 */
-	public static function register_action( $action_name ) {
+	public static function register_action( $action_name, $unique_event_key = '' ) {
 		if ( isset( self::$actions[ $action_name ] ) ) {
 			return new WP_Error( 'action_already_registered', __( 'Action already registered.', 'newspack' ) );
 		}
 		self::$actions[ $action_name ] = [];
+		self::$actions_unique_event_keys[ $action_name ] = $unique_event_key;
 	}
 
 	/**
@@ -196,9 +205,10 @@ final class Data_Events {
 	 * @param callable|array $callable    Optional callable to filter the data
 	 *                                    passed to dispatch or an array of
 	 *                                    strings to map argument names.
+	 * @param string         $unique_event_key Optional unique event key to ensure a single dispatch per event that matches the key.
 	 */
-	public static function register_listener( $hook_name, $action_name, $callable = null ) {
-		self::register_action( $action_name );
+	public static function register_listener( $hook_name, $action_name, $callable = null, $unique_event_key = '' ) {
+		self::register_action( $action_name, $unique_event_key );
 		\add_action(
 			$hook_name,
 			function() use ( $action_name, $callable ) {
@@ -343,6 +353,24 @@ final class Data_Events {
 			return;
 		}
 
+		$dispatches = [];
+		// Run through actions unique event keys to prevent duplicate dispatches.
+		foreach ( self::$queued_dispatches as $dispatch ) {
+			$action_name = $dispatch['action_name'];
+
+			if ( ! isset( $dispatches[ $action_name ] ) ) {
+				$dispatches[ $action_name ] = [];
+			}
+
+			$unique_event_key = self::$actions_unique_event_keys[ $action_name ] ?? '';
+			if ( empty( $unique_event_key ) ) {
+				$dispatches[ $action_name ][] = $dispatch;
+			} else {
+				$dispatches[ $action_name ][ $dispatch['data'][ $unique_event_key ] ] = $dispatch;
+			}
+		}
+		$dispatches = array_merge( ...array_values( array_map( 'array_values', $dispatches ) ) );
+
 		$actions = array_column( self::$queued_dispatches, 'action_name' );
 
 		Logger::log(
@@ -363,7 +391,7 @@ final class Data_Events {
 			[
 				'timeout'   => 0.01,
 				'blocking'  => false,
-				'body'      => [ 'dispatches' => self::$queued_dispatches ],
+				'body'      => [ 'dispatches' => $dispatches ],
 				'cookies'   => $_COOKIE, // phpcs:ignore
 				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
 			]
@@ -372,10 +400,10 @@ final class Data_Events {
 		/**
 		 * Fires after dispatching queued actions.
 		 *
-		 * @param WP_Error|WP_HTTP_Response $request           The request object.
-		 * @param array                     $queued_dispatches The queued dispatches.
+		 * @param WP_Error|WP_HTTP_Response $request    The request object.
+		 * @param array                     $dispatches The executed dispatches.
 		 */
-		\do_action( 'newspack_data_events_dispatched', $request, self::$queued_dispatches );
+		\do_action( 'newspack_data_events_dispatched', $request, $dispatches );
 
 		// Clear the queue in case of a retry.
 		self::$queued_dispatches = [];

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -77,6 +77,32 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that executing queued dispatches triggers the dispatched action hook.
+	 */
+	public function test_execute_queued_dispatches() {
+		$action_name = 'test_action';
+		$data        = [ 'test' => 'data' ];
+
+		$hook_request = null;
+		$hook_queued_dispatches = null;
+
+		$hook = function( $request, $queued_dispatches ) use ( &$hook_request, &$hook_queued_dispatches ) {
+			$hook_request = $request;
+			$hook_queued_dispatches = $queued_dispatches;
+		};
+		add_action( 'newspack_data_events_dispatched', $hook, 10, 2 );
+
+		Data_Events::register_action( $action_name );
+		Data_Events::dispatch( $action_name, $data );
+		Data_Events::execute_queued_dispatches();
+
+		$this->assertIsArray( $hook_request );
+		$this->assertIsArray( $hook_queued_dispatches );
+		$this->assertEquals( $action_name, $hook_queued_dispatches[0]['action_name'] );
+		$this->assertEquals( $data, $hook_queued_dispatches[0]['data'] );
+	}
+
+	/**
 	 * Test triggering the handler.
 	 */
 	public function test_handler() {

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -74,10 +74,6 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 
 		// Assert the hook was called once.
 		$this->assertEquals( 1, $call_count );
-
-		// Assert it returns a WP_Http response.
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'http_response', $result );
 	}
 
 	/**

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -12,6 +12,15 @@ use Newspack\Data_Events;
  */
 class Newspack_Test_Data_Events extends WP_UnitTestCase {
 	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		// Ensure queue is empty for next test.
+		Data_Events::execute_queued_dispatches();
+	}
+
+	/**
 	 * Test registering an action.
 	 */
 	public function test_register_action() {
@@ -268,5 +277,33 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 			],
 			$parsed_data
 		);
+	}
+
+	/**
+	 * Test action unique event key.
+	 */
+	public function test_unique_event_key() {
+		$action_name      = 'test_unique_event_key';
+		$unique_event_key = 'email';
+		Data_Events::register_action( $action_name, $unique_event_key );
+
+		// Hook into the dispatch queue run.
+		$executed_dispatches = [];
+		$hook = function( $request, $dispatches ) use ( &$executed_dispatches ) {
+			$executed_dispatches = $dispatches;
+		};
+		add_action( 'newspack_data_events_dispatched', $hook, 10, 2 );
+
+		Data_Events::dispatch( $action_name, [ 'email' => 'test@test.com', 'foo' => 'bar' ] ); // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
+		Data_Events::dispatch( $action_name, [ 'email' => 'test@test.com', 'foo' => 'baz' ] ); // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
+
+		// Manually run queue.
+		Data_Events::execute_queued_dispatches();
+
+		// Assert only one dispatch was executed.
+		$this->assertEquals( 1, count( $executed_dispatches ) );
+
+		// Assert that the last dispatch was the one that was executed.
+		$this->assertEquals( [ 'email' => 'test@test.com', 'foo' => 'baz' ], $executed_dispatches[0]['data'] ); // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implement support for a unique event key to prevent multiple consecutive dispatches for events that always send the latest and complete payload in the same execution.

The key is determined when registering the action or listener:

```php
Data_Events::register_action( 'my_action', 'email' );
// or:
Data_Events::register_listener( 'my_hook', 'my_action', 'my_callback', 'email' );
```

In the example above, events dispatched matching the value in the property `email` of its payload data will only be executed once with the final payload data:

```php
Data_Events::dispatch( $action_name, [ 'email' => 'test@test.com', 'foo' => 'bar' ] );
Data_Events::dispatch( $action_name, [ 'email' => 'test@test.com', 'foo' => 'baz' ] );
```

Only 1 dispatch will be executed, containing `[ 'email' => 'test@test.com', 'foo' => 'baz' ]`.

This PR depends on #3616

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->