### PR TITLE
fix(cli): verify-reader CLI command

### DIFF
--- a/includes/cli/class-ras.php
+++ b/includes/cli/class-ras.php
@@ -55,14 +55,14 @@ class RAS {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--user=<user ID|email>]
+	 * [--user-id=<id|email>]
 	 * : The user ID or email address associated with the reader account to verify.
 	 *
 	 * @param array $args Positional args.
 	 * @param array $assoc_args Associative args.
 	 */
 	public static function cli_verify_reader( $args, $assoc_args ) {
-		$user_id_or_email = ! empty( $args ) ? reset( $args ) : false;
+		$user_id_or_email = ! empty( $assoc_args ) ? reset( $assoc_args ) : false;
 		if ( ! $user_id_or_email ) {
 			WP_CLI::error( __( 'Please provide a user ID or email address.', 'newspack-plugin' ) );
 			exit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the `wp newspack verify-reader` CLI command:

- Example parameter values cannot contain spaces in the docblock synopsis
- `--user` is a [global flag](https://make.wordpress.org/cli/handbook/references/config/#global-parameters) and can't be used as an associative arg for specific commands

### How to test the changes in this Pull Request:

1. On `trunk`, run `wp newspack verify-reader --user=<user ID or email address>` and observe that it fails with an error:

```
Warning: The `wp newspack verify-reader` command has an invalid synopsis part: [--user=<user
Warning: The `wp newspack verify-reader` command has an invalid synopsis part: ID|email>]
Error: Please provide a user ID or email address.
```

2. Check out this branch and test `wp newspack verify-reader --user-id=<user ID or email address>` with both a user ID and an email address and confirm that it works as expected. (Note the new flag name `--user-id` instead of `--user`)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->