### PR TITLE
feat(esp-sync): queue data events sync to run once

### DIFF
--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -45,6 +45,13 @@ final class Data_Events {
 	private static $queued_dispatches = [];
 
 	/**
+	 * Current action event.
+	 *
+	 * @var string|null
+	 */
+	private static $current_event = null;
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -95,6 +102,9 @@ final class Data_Events {
 	 * @param string $client_id   Client ID.
 	 */
 	public static function handle( $action_name, $timestamp, $data, $client_id ) {
+		// Set current event.
+		self::set_current_event( $action_name );
+
 		// Execute global handlers.
 		Logger::log(
 			sprintf( 'Executing global action handlers for "%s".', $action_name ),
@@ -145,6 +155,27 @@ final class Data_Events {
 		 * @param string $client_id   Client ID.
 		 */
 		\do_action( 'newspack_data_event', $action_name, $timestamp, $data, $client_id );
+
+		// Unset current event.
+		self::set_current_event( null );
+	}
+
+	/**
+	 * Get the current event being handled.
+	 *
+	 * @return string|null Current event.
+	 */
+	public static function current_event() {
+		return self::$current_event;
+	}
+
+	/**
+	 * Set the current event being handled.
+	 *
+	 * @param string|null $name Event name.
+	 */
+	private static function set_current_event( $name ) {
+		self::$current_event = $name;
 	}
 
 	/**

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -108,7 +108,6 @@ class ESP_Sync extends Sync {
 			$context = static::$context;
 		}
 
-
 		// If we're running in a data event, queue the sync to run on shutdown.
 		if ( Data_Events::current_event() && ! did_action( 'shutdown' ) ) {
 			if ( ! isset( self::$queued_syncs[ $contact['email'] ] ) ) {
@@ -271,7 +270,7 @@ class ESP_Sync extends Sync {
 				continue;
 			}
 
-			self::sync( $contact, implode( ', ', $contexts ) );
+			self::sync( $contact, implode( '; ', $contexts ) );
 		}
 
 		self::$queued_syncs = [];

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -25,9 +25,9 @@ class ESP_Sync extends Sync {
 	protected static $context = 'ESP Sync';
 
 	/**
-	 * Queued syncs.
+	 * Queued syncs keyed by email address.
 	 *
-	 * @var string[]
+	 * @var array[]
 	 */
 	protected static $queued_syncs = [];
 

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -25,7 +25,7 @@ class ESP_Sync extends Sync {
 	protected static $context = 'ESP Sync';
 
 	/**
-	 * Queued syncs keyed by email address.
+	 * Queued syncs containing their contexts keyed by email address.
 	 *
 	 * @var array[]
 	 */
@@ -108,6 +108,16 @@ class ESP_Sync extends Sync {
 			$context = static::$context;
 		}
 
+
+		// If we're running in a data event, queue the sync to run on shutdown.
+		if ( Data_Events::current_event() && ! did_action( 'shutdown' ) ) {
+			if ( ! isset( self::$queued_syncs[ $contact['email'] ] ) ) {
+				self::$queued_syncs[ $contact['email'] ] = [];
+			}
+			self::$queued_syncs[ $contact['email'] ][] = $context;
+			return;
+		}
+
 		$master_list_id = Reader_Activation::get_esp_master_list_id();
 
 		/**
@@ -119,12 +129,6 @@ class ESP_Sync extends Sync {
 		$contact = \apply_filters( 'newspack_esp_sync_contact', $contact, $context );
 
 		$contact = Sync\Metadata::normalize_contact_data( $contact );
-
-		// If we're running in a data event, queue the sync to run on shutdown.
-		if ( Data_Events::current_event() ) {
-			self::$queued_syncs[ $contact['email'] ] = [ $contact, $master_list_id, $context ];
-			return;
-		}
 
 		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context );
 
@@ -179,24 +183,12 @@ class ESP_Sync extends Sync {
 	}
 
 	/**
-	 * Given a user ID or WooCommerce Order, sync that reader's contact data to
-	 * the connected ESP.
+	 * Get contact data for syncing.
 	 *
-	 * @param int|\WC_order $user_id_or_order User ID or WC_Order object.
-	 * @param bool          $is_dry_run       True if a dry run.
-	 *
-	 * @return true|\WP_Error True if the contact was synced successfully, WP_Error otherwise.
+	 * @param int $user_id The user ID.
 	 */
-	public static function sync_contact( $user_id_or_order, $is_dry_run = false ) {
-		$can_sync = static::can_esp_sync( true );
-		if ( ! $is_dry_run && $can_sync->has_errors() ) {
-			return $can_sync;
-		}
-
-		$is_order = $user_id_or_order instanceof \WC_Order;
-		$order    = $is_order ? $user_id_or_order : false;
-		$user_id  = $is_order ? $order->get_customer_id() : $user_id_or_order;
-		$user     = \get_userdata( $user_id );
+	protected static function get_contact_data( $user_id ) {
+		$user = \get_userdata( $user_id );
 
 		$customer = new \WC_Customer( $user_id );
 		if ( ! $customer || ! $customer->get_id() ) {
@@ -216,7 +208,29 @@ class ESP_Sync extends Sync {
 			$customer->save();
 		}
 
-		$contact = $is_order ? Sync\WooCommerce::get_contact_from_order( $order ) : Sync\WooCommerce::get_contact_from_customer( $customer );
+		return Sync\WooCommerce::get_contact_from_customer( $customer );
+	}
+
+	/**
+	 * Given a user ID or WooCommerce Order, sync that reader's contact data to
+	 * the connected ESP.
+	 *
+	 * @param int|\WC_order $user_id_or_order User ID or WC_Order object.
+	 * @param bool          $is_dry_run       True if a dry run.
+	 *
+	 * @return true|\WP_Error True if the contact was synced successfully, WP_Error otherwise.
+	 */
+	public static function sync_contact( $user_id_or_order, $is_dry_run = false ) {
+		$can_sync = static::can_esp_sync( true );
+		if ( ! $is_dry_run && $can_sync->has_errors() ) {
+			return $can_sync;
+		}
+
+		$is_order = $user_id_or_order instanceof \WC_Order;
+		$order    = $is_order ? $user_id_or_order : false;
+		$user_id  = $is_order ? $order->get_customer_id() : $user_id_or_order;
+
+		$contact = $is_order ? Sync\WooCommerce::get_contact_from_order( $order ) : self::get_contact_data( $user_id );
 		$result  = $is_dry_run ? true : self::sync( $contact );
 
 		if ( $result && ! \is_wp_error( $result ) ) {
@@ -246,8 +260,18 @@ class ESP_Sync extends Sync {
 			return;
 		}
 
-		foreach ( self::$queued_syncs as $sync ) {
-			\Newspack_Newsletters_Contacts::upsert( ...$sync );
+		foreach ( self::$queued_syncs as $email => $contexts ) {
+			$user = get_user_by( 'email', $email );
+			if ( ! $user ) {
+				continue;
+			}
+
+			$contact = self::get_contact_data( $user->ID );
+			if ( ! $contact ) {
+				continue;
+			}
+
+			self::sync( $contact, implode( ', ', $contexts ) );
 		}
 
 		self::$queued_syncs = [];

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -8,6 +8,7 @@
 namespace Newspack\Reader_Activation;
 
 use Newspack\Reader_Activation;
+use Newspack\Data_Events;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -22,11 +23,20 @@ class ESP_Sync extends Sync {
 	 * @var string
 	 */
 	protected static $context = 'ESP Sync';
+
+	/**
+	 * Queued syncs.
+	 *
+	 * @var string[]
+	 */
+	protected static $queued_syncs = [];
+
 	/**
 	 * Initialize hooks.
 	 */
 	public static function init_hooks() {
 		add_action( 'newspack_scheduled_esp_sync', [ __CLASS__, 'scheduled_sync' ], 10, 2 );
+		add_action( 'shutdown', [ __CLASS__, 'run_queued_syncs' ] );
 	}
 
 	/**
@@ -109,6 +119,12 @@ class ESP_Sync extends Sync {
 		$contact = \apply_filters( 'newspack_esp_sync_contact', $contact, $context );
 
 		$contact = Sync\Metadata::normalize_contact_data( $contact );
+
+		// If we're running in a data event, queue the sync to run on shutdown.
+		if ( Data_Events::current_event() ) {
+			self::$queued_syncs[ $contact['email'] ] = [ $contact, $master_list_id, $context ];
+			return;
+		}
 
 		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context );
 
@@ -218,6 +234,23 @@ class ESP_Sync extends Sync {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Run queued syncs.
+	 *
+	 * @return void
+	 */
+	public static function run_queued_syncs() {
+		if ( empty( self::$queued_syncs ) ) {
+			return;
+		}
+
+		foreach ( self::$queued_syncs as $sync ) {
+			self::sync( ...$sync );
+		}
+
+		self::$queued_syncs = [];
 	}
 }
 ESP_Sync::init_hooks();

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -247,7 +247,7 @@ class ESP_Sync extends Sync {
 		}
 
 		foreach ( self::$queued_syncs as $sync ) {
-			self::sync( ...$sync );
+			\Newspack_Newsletters_Contacts::upsert( ...$sync );
 		}
 
 		self::$queued_syncs = [];

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -269,4 +269,28 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 			$parsed_data
 		);
 	}
+
+	/**
+	 * Test the current event is set and available during handler execution.
+	 */
+	public function test_current_event() {
+		Data_Events::register_action( 'test_action' );
+		Data_Events::register_action( 'test_action2' );
+
+		$handler = function() {
+			$this->assertEquals( 'test_action', Data_Events::get_current_event(), 'Current event should be set and equal to the action name' );
+		};
+		Data_Events::register_handler( $handler, 'test_action' );
+		Data_Events::handle( 'test_action', time(), [], 'test-client-id' );
+
+		$this->assertNull( Data_Events::get_current_event(), 'Current event should be null after handling' );
+
+		$handler2 = function() {
+			$this->assertEquals( 'test_action2', Data_Events::get_current_event(), 'Current event should be set and equal to the action name' );
+		};
+		Data_Events::register_handler( $handler2, 'test_action2' );
+		Data_Events::handle( 'test_action2', time(), [], 'test-client-id' );
+
+		$this->assertNull( Data_Events::get_current_event(), 'Current event should be null after handling' );
+	}
 }

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -278,19 +278,19 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		Data_Events::register_action( 'test_action2' );
 
 		$handler = function() {
-			$this->assertEquals( 'test_action', Data_Events::get_current_event(), 'Current event should be set and equal to the action name' );
+			$this->assertEquals( 'test_action', Data_Events::current_event(), 'Current event should be set and equal to the action name' );
 		};
 		Data_Events::register_handler( $handler, 'test_action' );
 		Data_Events::handle( 'test_action', time(), [], 'test-client-id' );
 
-		$this->assertNull( Data_Events::get_current_event(), 'Current event should be null after handling' );
+		$this->assertNull( Data_Events::current_event(), 'Current event should be null after handling' );
 
 		$handler2 = function() {
-			$this->assertEquals( 'test_action2', Data_Events::get_current_event(), 'Current event should be set and equal to the action name' );
+			$this->assertEquals( 'test_action2', Data_Events::current_event(), 'Current event should be set and equal to the action name' );
 		};
 		Data_Events::register_handler( $handler2, 'test_action2' );
 		Data_Events::handle( 'test_action2', time(), [], 'test-client-id' );
 
-		$this->assertNull( Data_Events::get_current_event(), 'Current event should be null after handling' );
+		$this->assertNull( Data_Events::current_event(), 'Current event should be null after handling' );
 	}
 }

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -293,4 +293,23 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 
 		$this->assertNull( Data_Events::current_event(), 'Current event should be null after handling' );
 	}
+
+	/**
+	 * Test that the current event is set to null even if a handler throws an exception.
+	 */
+	public function test_current_event_exception() {
+		Data_Events::register_action( 'test_action' );
+
+		$handler = function() {
+			$this->assertEquals( 'test_action', Data_Events::current_event(), 'Current event should be set and equal to the action name' );
+			throw new Exception( 'Test exception' );
+		};
+		Data_Events::register_handler( $handler, 'test_action' );
+
+		try {
+			Data_Events::handle( 'test_action', time(), [], 'test-client-id' );
+		} catch ( Exception $e ) {
+			$this->assertNull( Data_Events::current_event(), 'Current event should be null after handling' );
+		}
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since #3616, data events are grouped and handled in the same execution. This PR leverages that change to also optimize multiple syncs that different data events may trigger.

To restrict that behavior to data events only, this PR implements the feature from #3383 so we can be aware of whether we're running under a data event or not.

Syncs performed under data events should now only run once per email, containing the latest payload.

For debugging, the sync contexts are grouped to be logged, which can look like this:

<img width="491" alt="image" src="https://github.com/user-attachments/assets/c2310ed5-7fba-4fbb-b16b-e174bf47649b" />

To ensure we always have the most recent data, when running on shutdown the most recent contact data is fetched using a new `get_contact_data()` method,  which was decoupled from the `sync_contact()` method.

### How to test the changes in this Pull Request:

1. Make sure you have a RAS setup with a membership plan and a subscription product activating it
2. In a fresh session, go through the Checkout Button flow and complete the subscription purchase
3. Confirm via logs that a bunch of data events gets dispatched (`membership_status_active`, `membership_saved`, `reader_registered`)
4. Confirm that only one `Newspack_Newsletters_Contacts::upsert` is logged
5. Confirm the contact is added to your ESP

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209092039483633