### PR TITLE
fix(recaptcha): validate on form submit, not button click

### DIFF
--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -30,6 +30,7 @@ const isInvisible = 'v2_invisible' === newspack_recaptcha_data.version;
  * @param {Function|null} onError   Callback to handle errors. Optional.
  */
 function renderV2Widget( form, onSuccess = null, onError = null ) {
+	form.removeAttribute( 'data-recapchta-validated' );
 	// Common render options for reCAPTCHA v2 widget. See https://developers.google.com/recaptcha/docs/invisible#render_param for supported params.
 	const options = {
 		sitekey: siteKey,
@@ -47,6 +48,7 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 		}
 		// Callback when reCAPTCHA passes validation or skip flag is present.
 		const successCallback = token => {
+			form.setAttribute( 'data-recapchta-validated', '1' );
 			onSuccess?.();
 			// Ensure the token gets submitted with the form submission.
 			let hiddenField = form.querySelector( '[name="g-recaptcha-response"]' );
@@ -62,6 +64,7 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 		};
 		// Callback when reCAPTCHA rendering fails or expires.
 		const errorCallback = () => {
+			form.removeAttribute( 'data-recapchta-validated' );
 			const retryCount = parseInt( button.getAttribute( 'data-recaptcha-retry-count' ) ) || 0;
 			if ( retryCount < 3 ) {
 				refreshV2Widget( button );
@@ -79,23 +82,25 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 		// Attach widget to form events.
 		const attachListeners = () => {
 			getIntersectionObserver( () => renderV2Widget( form, onSuccess, onError ) ).observe( form, { attributes: true } );
-			button.addEventListener( 'click', e => {
-				e.preventDefault();
-				e.stopImmediatePropagation();
-				// Empty error messages if present.
-				removeErrorMessages( form );
-				// Skip reCAPTCHA verification if the button has a data-skip-recaptcha attribute.
-				if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
-					successCallback();
-				} else {
-					grecaptcha.execute( widgetId ).then( () => {
-						// If we are in an iframe scroll to top.
-						if ( window?.location !== window?.parent?.location ) {
-							document.body.scrollIntoView( { behavior: 'smooth' } );
-						}
-					} );
+			form.addEventListener( 'submit', e => {
+				if ( ! form.hasAttribute( 'data-recapchta-validated' ) ) {
+					e.preventDefault();
+					e.stopPropagation();
+					// Empty error messages if present.
+					removeErrorMessages( form );
+					// Skip reCAPTCHA verification if the button has a data-skip-recaptcha attribute.
+					if ( button.hasAttribute( 'data-skip-recaptcha' ) ) {
+						successCallback();
+					} else {
+						grecaptcha.execute( widgetId ).then( () => {
+							// If we are in an iframe scroll to top.
+							if ( window?.location !== window?.parent?.location ) {
+								document.body.scrollIntoView( { behavior: 'smooth' } );
+							}
+						} );
+					}
 				}
-			} );
+			}, true );
 		}
 		// Refresh reCAPTCHA widgets on Woo checkout update and error.
 		if ( jQuery ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Moves the event handler to render the reCAPTCHA v2 challenge to form `submit` instead of submit button `click`. This allows us to validate the form interaction no matter how the form is submitted—whether via submit button click, "enter" keypress, or even programmatically via JS.

### How to test the changes in this Pull Request:

Test all protected flows protected by reCAPTCHA v2 by both clicking on the submit button and by hitting the "enter" key from the form inputs:

- Auth modal: registration
- Auth modal: login
- Registration block
- Newsletter Subscription Form block
- Checkout as an anonymous reader
- Checkout as a logged-in reader

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208992370784514