### PR TITLE
fix(wcs): migrate-expired-subscriptions handle manual subscriptions

### DIFF
--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -110,35 +110,43 @@ class WooCommerce_Subscriptions {
 					}
 					continue;
 				}
-				$last_retry = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $renewal_order, 'id' ) );
-				// No retries indicates the subscription was likely manually placed on hold.
-				if ( empty( $last_retry ) ) {
+				if ( ! $subscription->payment_method_supports( 'subscription_date_changes' ) ) {
 					if ( self::$verbose ) {
-						WP_CLI::line( 'No retries scheduled. Moving to next subscription...' );
+						WP_CLI::line( 'Subscription payment method does not support retries. Moving to next subscription...' );
 						WP_CLI::line( '' );
 					}
 					continue;
 				}
-				// A non failed status indicates the retry was either manually cancelled
-				// or was successful at one point but likely placed on hold for some other reason.
-				if ( 'failed' !== $last_retry->get_status() ) {
-					if ( self::$verbose ) {
-						WP_CLI::line( 'Last retry does not have a failed status. Moving to next subscription...' );
-						WP_CLI::line( '' );
-					}
-					continue;
-				} else {
-					if ( $subscription->is_manual() || ! $subscription->payment_method_supports( 'subscription_date_changes' ) ) {
+				$end_date      = $subscription->is_manual() ? $subscription->get_date( 'next_payment' ) : $last_retry->get_date();
+				$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
+				if ( $subscription->is_manual() ) {
+					if ( ! $should_expire ) {
 						if ( self::$verbose ) {
-							WP_CLI::line( 'Subscription does not support retries. Moving to next subscription...' );
+							WP_CLI::line( 'Subscription is within the on-hold duration. Moving to next subscription...' );
 							WP_CLI::line( '' );
 						}
 						continue;
 					}
-					$retry_date       = $last_retry->get_date();
-					$on_hold_duration = On_Hold_Duration::get_on_hold_duration();
-					// If the retry date is within the on-hold duration, schedule a final retry.
-					if ( wcs_date_to_time( $retry_date ) + ( $on_hold_duration * DAY_IN_SECONDS ) > time() ) {
+				} else {
+					$last_retry = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $renewal_order, 'id' ) );
+					// No retries indicates the subscription was likely manually placed on hold.
+					if ( empty( $last_retry ) ) {
+						if ( self::$verbose ) {
+							WP_CLI::line( 'No retries scheduled. Moving to next subscription...' );
+							WP_CLI::line( '' );
+						}
+						continue;
+					}
+					// A non failed status indicates the retry was either manually cancelled
+					// or was successful at one point but likely placed on hold for some other reason.
+					if ( 'failed' !== $last_retry->get_status() ) {
+						if ( self::$verbose ) {
+							WP_CLI::line( 'Last retry does not have a failed status. Moving to next subscription...' );
+							WP_CLI::line( '' );
+						}
+						continue;
+					}
+					if ( ! $should_expire ) {
 						if ( self::$verbose ) {
 							WP_CLI::line( 'Retry date is within the on-hold duration. Scheduling final retry...' );
 						}
@@ -162,19 +170,20 @@ class WooCommerce_Subscriptions {
 							}
 						}
 						++$scheduled;
-					} else {
-						// Otherwise, if the retry date is past the on-hold duration, update the subscription status to expired.
-						if ( self::$verbose ) {
-							WP_CLI::line( 'Updating subscription status to expired...' );
-						}
-						if ( self::$live ) {
-							$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
-							$subscription->set_end_date( $retry_date );
-							$subscription->update_meta_data( '_newspack_cli_status_updated', true );
-							$subscription->save();
-						}
-						++$updated;
 					}
+				}
+				if ( should_expire ) {
+					// Otherwise, if the retry date is past the on-hold duration, update the subscription status to expired.
+					if ( self::$verbose ) {
+						WP_CLI::line( 'Updating subscription status to expired...' );
+					}
+					if ( self::$live ) {
+						$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
+						$subscription->set_end_date( $end_date );
+						$subscription->update_meta_data( '_newspack_cli_status_updated', true );
+						$subscription->save();
+					}
+					++$updated;
 				}
 				if ( self::$verbose ) {
 					WP_CLI::line( 'Finished processing subscription ' . $id );
@@ -206,7 +215,7 @@ class WooCommerce_Subscriptions {
 					continue;
 				}
 				$subscription = wcs_get_subscription( $id );
-				if ( $subscription ) {
+				if ( $subscription && 'on-hold' === $subscription->get_status() ) {
 					$subscriptions[] = $subscription;
 				}
 			}

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -172,7 +172,7 @@ class WooCommerce_Subscriptions {
 						++$scheduled;
 					}
 				}
-				if ( should_expire ) {
+				if ( $should_expire ) {
 					// Otherwise, if the retry date is past the on-hold duration, update the subscription status to expired.
 					if ( self::$verbose ) {
 						WP_CLI::line( 'Updating subscription status to expired...' );

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -117,9 +117,11 @@ class WooCommerce_Subscriptions {
 					}
 					continue;
 				}
-				$end_date      = $subscription->is_manual() ? $subscription->get_date( 'next_payment' ) : $last_retry->get_date();
-				$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
+
 				if ( $subscription->is_manual() ) {
+					$end_date = $subscription->get_date( 'next_payment' );
+					$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
+
 					if ( ! $should_expire ) {
 						if ( self::$verbose ) {
 							WP_CLI::line( 'Subscription is within the on-hold duration. Moving to next subscription...' );
@@ -129,6 +131,7 @@ class WooCommerce_Subscriptions {
 					}
 				} else {
 					$last_retry = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $renewal_order, 'id' ) );
+
 					// No retries indicates the subscription was likely manually placed on hold.
 					if ( empty( $last_retry ) ) {
 						if ( self::$verbose ) {
@@ -137,6 +140,10 @@ class WooCommerce_Subscriptions {
 						}
 						continue;
 					}
+
+					$end_date = $last_retry->get_date();
+					$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
+
 					// A non failed status indicates the retry was either manually cancelled
 					// or was successful at one point but likely placed on hold for some other reason.
 					if ( 'failed' !== $last_retry->get_status() ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds support for manual subscriptions to the `migrate-expired-subscriptions` cli tool.

### How to test the changes in this Pull Request:

- Ensure you have a manual subscription that is on-hold because it has reached it's next payment date.
- Make sure the next payment date is within whatever you have set as the on-hold duration in WooCommerce > Settings > Subscriptions > Newspack Subscriptions Settings. If you need to, you can adjust this via `wp shell`:
```
$s = wcs_get_subscription(12345);
$s->update_dates(['next_payment' => "2025-01-09 20:51:28"]);
```
- Run the `wp newspack migrate-expired-subscriptions --verbose --ids=12345` command.
- Verify the output indicates the subscription is within the on-hold duration
- Now run the command with the `--live` flag
- Verify the subscription status has NOT changed in wp-admin
- Either test another manual subscription with a next payment date that is beyond the on-hold duration, or use `wp shell` to manually adjust the next payment date
- Repeat the command without the `--live` flag and verify the output says the status is updated to expired
- Repeat with the `--live` flag and verify the subscription status has actually changed in wp-admin

**BONUS**: If you have any subscriptions that are still around from before this feature was launched that are on-hold, and have retries, smoke test the command with these as well.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->